### PR TITLE
include potri and test

### DIFF
--- a/test/cusolver.jl
+++ b/test/cusolver.jl
@@ -40,6 +40,31 @@ k = 1
         @test_throws LinearAlgebra.PosDefException cholesky(d_A)
     end
 
+    CUDA.CUSOLVER.version() >= v"10.1" && @testset "Cholesky inverse (potri)" begin
+        # test lower
+        A    = rand(elty,n,n)
+        A    = A*A' #posdef
+        d_A  = CuArray(A)
+
+        LinearAlgebra.LAPACK.potrf!('L', A)
+        LinearAlgebra.LAPACK.potrf!('L', d_A)
+
+        LinearAlgebra.LAPACK.potri!('L', A)
+        LinearAlgebra.LAPACK.potri!('L', d_A)
+        @test A  ≈ collect(d_A)
+
+        # test upper
+        A    = rand(elty,n,n)
+        A    = A*A' #posdef
+        d_A  = CuArray(A)
+
+        LinearAlgebra.LAPACK.potrf!('U', A)
+        LinearAlgebra.LAPACK.potrf!('U', d_A)
+        LinearAlgebra.LAPACK.potri!('U', A)
+        LinearAlgebra.LAPACK.potri!('U', d_A)
+        @test A  ≈ collect(d_A)
+    end
+
     @testset "getrf!" begin
         A          = rand(elty,m,n)
         d_A        = CuArray(A)


### PR DESCRIPTION
This mirrors PR #730 from CuArrays

> This PR addes potri! and accompanying tests.
> Possibly an improvement to #440 (from CuArrays)