### PR TITLE
 Add speciatization functions f(ctx, x) = f(x) for GPUArrays randn! function

### DIFF
--- a/Manifest.toml
+++ b/Manifest.toml
@@ -8,18 +8,18 @@ version = "0.5.0"
 
 [[Adapt]]
 deps = ["LinearAlgebra"]
-git-tree-sha1 = "c88cfc7f9c1f9f8633cddf0b56e86302b70f64c5"
+git-tree-sha1 = "fd04049c7dd78cfef0b06cdc1f0f181467655712"
 uuid = "79e6a3ab-5dfb-504d-930d-738a2a938a0e"
-version = "1.0.1"
+version = "1.1.0"
 
 [[Base64]]
 uuid = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"
 
 [[BinaryProvider]]
 deps = ["Libdl", "Logging", "SHA"]
-git-tree-sha1 = "428e9106b1ff27593cbd979afac9b45b82372b8c"
+git-tree-sha1 = "ecdec412a9abc8db54c0efc5548c64dfce072058"
 uuid = "b99e7846-7c00-51b0-8f62-c81ae34c0232"
-version = "0.5.9"
+version = "0.5.10"
 
 [[CEnum]]
 git-tree-sha1 = "1b77a77c3b28e0b3f413f7567c9bb8dd9bdccd14"
@@ -28,9 +28,9 @@ version = "0.3.0"
 
 [[DataStructures]]
 deps = ["InteractiveUtils", "OrderedCollections"]
-git-tree-sha1 = "6166ecfaf2b8bbf2b68d791bc1d54501f345d314"
+git-tree-sha1 = "af6d9c86e191c917c2276fbede1137e8ea20157f"
 uuid = "864edb3b-99cc-5e75-8d2d-829cb0a9cfe8"
-version = "0.17.15"
+version = "0.17.17"
 
 [[Dates]]
 deps = ["Printf"]
@@ -43,9 +43,11 @@ version = "0.1.1"
 
 [[GPUArrays]]
 deps = ["AbstractFFTs", "Adapt", "LinearAlgebra", "Printf", "Random", "Serialization"]
-git-tree-sha1 = "5f90fd4385ae86ab56cdd9bd4717f7bd2ff2acdf"
+git-tree-sha1 = "913e085e50a72b24dff205b8c2f2f4cd1d993cda"
+repo-rev = "0ef389c8ff29b6629d9e5d155a44defd6796c9ef"
+repo-url = "https://github.com/JuliaGPU/GPUArrays.jl.git"
 uuid = "0c68f7d7-f131-5f86-a1c3-88cf8149b2d7"
-version = "3.4.0"
+version = "3.4.1"
 
 [[GPUCompiler]]
 deps = ["DataStructures", "InteractiveUtils", "LLVM", "Libdl", "TimerOutputs", "UUIDs"]

--- a/src/gpuarrays.jl
+++ b/src/gpuarrays.jl
@@ -49,6 +49,13 @@ GPUArrays.blockdim(ctx::CuKernelContext) = CUDA.blockDim().x
 GPUArrays.threadidx(ctx::CuKernelContext) = CUDA.threadIdx().x
 GPUArrays.griddim(ctx::CuKernelContext) = CUDA.gridDim().x
 
+# math
+
+@inline GPUArrays.cos(ctx::CuKernelContext, x) = CUDA.cos(x)
+@inline GPUArrays.sin(ctx::CuKernelContext, x) = CUDA.sin(x)
+@inline GPUArrays.sqrt(ctx::CuKernelContext, x) = CUDA.sqrt(x)
+@inline GPUArrays.log(ctx::CuKernelContext, x) = CUDA.log(x)
+
 # memory
 
 @inline function GPUArrays.LocalMemory(::CuKernelContext, ::Type{T}, ::Val{dims}, ::Val{id}


### PR DESCRIPTION
To implement [#280 ](https://github.com/JuliaGPU/GPUArrays.jl/pull/280)from GPUArrays.jl 

Currently adds cos, sin, sqrt and log. 
Maybe add a macro to import everything from `cuda/math.jl` in the future.