### PR TITLE
fixed gels_batched! issue

### DIFF
--- a/lib/cublas/wrappers.jl
+++ b/lib/cublas/wrappers.jl
@@ -1743,7 +1743,7 @@ for (fname, elty) in
         function gels_batched(trans::Char,
                              A::Vector{<:CuMatrix{$elty}},
                              C::Vector{<:CuMatrix{$elty}})
-            gels_batched!(trans, copy(A), copy(C))
+            gels_batched!(trans, deepcopy(A), deepcopy(C))
         end
     end
 end

--- a/lib/cublas/wrappers.jl
+++ b/lib/cublas/wrappers.jl
@@ -1709,14 +1709,14 @@ for (fname, elty) in
             end
             m,n = size(A[1])
             mC,nC = size(C[1])
-            if mC ≠ m
-                throw(DimensionMismatch(""))
+            if mC != m
+                throw(DimensionMismatch("Leading dimensions of arrays must match"))
             end
             for (As,Cs) in zip(A,C)
                 ms,ns = size(As)
                 mCs,nCs = size(Cs)
-                if (ms≠m) || (mCs≠mC) || (ns≠n) || (nCs≠nC)
-                    throw(DimensionMismatch("dimensions of arrays must be the same"))
+                if (size(As) != (m, n)) || (size(Cs) != (mC, nC))
+                    throw(DimensionMismatch("Dimensions of batched array entries must be invariant"))
                 end
             end
             if m < n

--- a/lib/cublas/wrappers.jl
+++ b/lib/cublas/wrappers.jl
@@ -1707,14 +1707,18 @@ for (fname, elty) in
             if length(A) != length(C)
                 throw(DimensionMismatch(""))
             end
+            m,n = size(A[1])
+            mC,nC = size(C[1])
+            if mC ≠ m
+                throw(DimensionMismatch(""))
+            end
             for (As,Cs) in zip(A,C)
-                m,n = size(As)
-                mC,nC = size(Cs)
-                if n != mC
-                    throw(DimensionMismatch(""))
+                ms,ns = size(As)
+                mCs,nCs = size(Cs)
+                if (ms≠m) || (mCs≠mC) || (ns≠n) || (nCs≠nC)
+                    throw(DimensionMismatch("dimensions of arrays must be the same"))
                 end
             end
-            m,n = size(A[1])
             if m < n
                 throw(ArgumentError("System must be overdetermined"))
             end

--- a/test/cublas.jl
+++ b/test/cublas.jl
@@ -1466,7 +1466,7 @@ end # level 1 testset
 
         @testset "gels_batched!" begin
             # generate matrices
-            A = [rand(elty,n,n) for i in 1:10]
+            A = [rand(elty,n,k) for i in 1:10]
             C = [rand(elty,n,k) for i in 1:10]
             # move to device
             d_A = CuArray{elty, 2}[]
@@ -1478,13 +1478,15 @@ end # level 1 testset
             d_A, d_C, info = CUBLAS.gels_batched!('N',d_A, d_C)
             for Cs in 1:length(d_C)
                 X = A[Cs]\C[Cs]
-                h_C = Array(d_C[Cs])
+                h_C = Array(d_C[Cs])[1:k,1:k]
                 @test X ≈ h_C rtol=1e-2
             end
-            push!(d_C,CuArray(rand(elty,n,k)))
+            push!(d_C,CuArray(rand(elty,n,k-1)))
             @test_throws DimensionMismatch CUBLAS.gels_batched!('N',d_A, d_C)
-            A = [rand(elty,n-1,n) for i in 1:10]
-            C = [rand(elty,n,k) for i in 1:10]
+            push!(d_A,CuArray(rand(elty,n,k-1)))
+            @test_throws DimensionMismatch CUBLAS.gels_batched!('N',d_A, d_C)
+            A = [rand(elty,k-1,k) for i in 1:10]
+            C = [rand(elty,k-1,k) for i in 1:10]
             # move to device
             d_A = CuArray{elty, 2}[]
             d_C = CuArray{elty, 2}[]
@@ -1498,7 +1500,7 @@ end # level 1 testset
 
         @testset "gels_batched" begin
             # generate matrices
-            A = [rand(elty,n,n) for i in 1:10]
+            A = [rand(elty,n,k) for i in 1:10]
             C = [rand(elty,n,k) for i in 1:10]
             # move to device
             d_A = CuArray{elty, 2}[]
@@ -1510,7 +1512,7 @@ end # level 1 testset
             d_B, d_D, info = CUBLAS.gels_batched('N',d_A, d_C)
             for Ds in 1:length(d_D)
                 X = A[Ds]\C[Ds]
-                h_D = Array(d_D[Ds])
+                h_D = Array(d_D[Ds])[1:k,1:k]
                 @test X ≈ h_D rtol=1e-2
             end
         end


### PR DESCRIPTION
First, I believe there is a typo in the CUDA docs here [https://docs.nvidia.com/cuda/cublas/index.html](url). Specifically, for the overdetermined system `Ax=C`, the number of rows of C should equal the number of **rows** of A, not the number of columns. 

See [https://discourse.julialang.org/t/accelerate-solving-many-matrix-problems/40500/7](url) for the use case and some details.

Second, I added a check to make sure that the arrays of matrices all have the same dimensions.

As an aside, I've never done a PR before, so hopefully it's not too atrocious.