### PR TITLE
Prefer a local CUDA installation when running on CI, reinstate Julia 1.3.

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -24,17 +24,17 @@ julia:1.4:
   tags:
     - nvidia
 
-julia:1.4-debug:
-  extends:
-    - .julia:source
-    - .test
-  tags:
-    - nvidia
-    - sm_70
-  variables:
-    CI_CLONE_ARGS: '-b v1.4.0'
-    CI_BUILD_ARGS: 'BINARYBUILDER_LLVM_ASSERTS=1 debug'
-  allow_failure: true
+# julia:1.4-debug:
+#   extends:
+#     - .julia:source
+#     - .test
+#   tags:
+#     - nvidia
+#     - sm_70
+#   variables:
+#     CI_CLONE_ARGS: '-b v1.4.0'
+#     CI_BUILD_ARGS: 'BINARYBUILDER_LLVM_ASSERTS=1 debug'
+#   allow_failure: true
 
 julia:1.5:
   extends:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -10,6 +10,13 @@ variables:
 
 # Julia versions
 
+julia:1.3:
+  extends:
+    - .julia:1.3
+    - .test
+  tags:
+    - nvidia
+
 julia:1.4:
   extends:
     - .julia:1.4

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -6,7 +6,6 @@ variables:
   CI_APT_INSTALL: 'libgomp1'
   NVIDIA_VISIBLE_DEVICES: 'all'
   NVIDIA_DRIVER_CAPABILITIES: 'compute,utility'
-  JULIA_CUDA_USE_BINARYBUILDER: 'false' # reduce CI network traffic
 
 
 # Julia versions

--- a/Manifest.toml
+++ b/Manifest.toml
@@ -38,6 +38,10 @@ version = "0.17.17"
 deps = ["Printf"]
 uuid = "ade2ca70-3891-5945-98fb-dc099432e06a"
 
+[[Distributed]]
+deps = ["Random", "Serialization", "Sockets"]
+uuid = "8ba89e20-285c-5b6f-9357-94700520ee1b"
+
 [[ExprTools]]
 git-tree-sha1 = "6f0517056812fd6aa3af23d4b70d5325a2ae4e95"
 uuid = "e2ba6199-217a-4e67-a87a-7c52f15ade04"
@@ -53,8 +57,8 @@ version = "3.4.1"
 
 [[GPUCompiler]]
 deps = ["DataStructures", "InteractiveUtils", "LLVM", "Libdl", "TimerOutputs", "UUIDs"]
-git-tree-sha1 = "6256dcf3d134bf836ae2b15259dcb128138e2cf8"
-repo-rev = "4a259d30df4d69ea7b75432ea6779a34960306e1"
+git-tree-sha1 = "89e9a56cca53f3bf704902205037ba1a3d10eab5"
+repo-rev = "4f4d3bbe253a92280e0084f776f7893b936560ea"
 repo-url = "https://github.com/JuliaGPU/GPUCompiler.jl.git"
 uuid = "61eb1bfa-7361-4325-ad38-22787b887f55"
 version = "0.4.0"
@@ -70,7 +74,6 @@ uuid = "929cbde3-209d-540e-8aea-75f648917ca0"
 version = "1.5.1"
 
 [[LibGit2]]
-deps = ["Printf"]
 uuid = "76f85450-5226-5b5a-8eaa-529ad045b433"
 
 [[Libdl]]
@@ -105,7 +108,7 @@ uuid = "bac558e1-5e72-5ebc-8fee-abe8a469f55d"
 version = "1.2.0"
 
 [[Pkg]]
-deps = ["Dates", "LibGit2", "Libdl", "Logging", "Markdown", "Printf", "REPL", "Random", "SHA", "UUIDs"]
+deps = ["Dates", "LibGit2", "Libdl", "Logging", "Markdown", "Printf", "REPL", "Random", "SHA", "Test", "UUIDs"]
 uuid = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
 
 [[Printf]]
@@ -148,6 +151,10 @@ uuid = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 [[Statistics]]
 deps = ["LinearAlgebra", "SparseArrays"]
 uuid = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
+
+[[Test]]
+deps = ["Distributed", "InteractiveUtils", "Logging", "Random"]
+uuid = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [[TimerOutputs]]
 deps = ["Printf"]

--- a/Project.toml
+++ b/Project.toml
@@ -41,7 +41,7 @@ NNlib = "0.6.5"
 Reexport = "0.2"
 Requires = "0.5, 1.0"
 TimerOutputs = "0.5"
-julia = "1.4"
+julia = "1.3"
 
 [extras]
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"

--- a/deps/bindeps.jl
+++ b/deps/bindeps.jl
@@ -291,7 +291,12 @@ end
 function __init_dependencies__()
     found = false
 
-    if parse(Bool, get(ENV, "JULIA_CUDA_USE_BINARYBUILDER", "true"))
+    # CI runs in a well-defined environment, so prefer a local CUDA installation there
+    if parse(Bool, get(ENV, "CI", "false")) && !haskey(ENV, "JULIA_CUDA_USE_BINARYBUILDER")
+        found = use_local_cuda()
+    end
+
+    if !found && parse(Bool, get(ENV, "JULIA_CUDA_USE_BINARYBUILDER", "true"))
         found = use_artifact_cuda()
     end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -124,7 +124,7 @@ else
 end
 pick = last(candidates)
 pick.cap >= v"2.0" || error("The CUDA.jl test suite requires a CUDA device with compute capability 2.0 or higher")
-@info("Testing using device $(name(pick.dev)) (compute capability $(pick.cap), $(Base.format_bytes(pick.mem)) available memory) on CUDA driver $(CUDA.version()) and toolkit $(CUDA.version())")
+@info("Testing using device $(name(pick.dev)) (compute capability $(pick.cap), $(Base.format_bytes(pick.mem)) available memory) on CUDA driver $(CUDA.version()) and toolkit $(CUDA.toolkit_version())")
 
 # determine tests to skip
 const skip_tests = []

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -99,7 +99,7 @@ end
 
 # check that CI is using the requested toolkit
 toolkit_release = CUDA.toolkit_release() # ensure artifacts are downloaded
-if haskey(ENV, "CI") && haskey(ENV, "JULIA_CUDA_VERSION")
+if parse(Bool, get(ENV, "CI", "false")) && haskey(ENV, "JULIA_CUDA_VERSION")
   @test toolkit_release == VersionNumber(ENV["JULIA_CUDA_VERSION"])
 end
 


### PR DESCRIPTION
Now that the CI runners have reverted to using a CUDA-based image, we can have all jobs prefer non-BB provided CUDA to cut down on network traffic.