### PR TITLE
Replace slash by path separator to properly skip tests on Windows.

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -151,6 +151,9 @@ if haskey(ENV, "CI_THOROUGH")
     filter!(!in(skip_tests), tests)
 else
     if !isempty(skip_tests)
+        for (i, test) in enumerate(skip_tests)
+            skip_tests[i] = replace(test, '/'=>Base.Filesystem.path_separator)
+        end
         @info "Skipping the following tests: $(join(skip_tests, ", "))"
         filter!(!in(skip_tests), tests)
     end


### PR DESCRIPTION
Fixes https://github.com/JuliaGPU/CUDA.jl/issues/236

@finmod this fixes your issues with the `device/wmma` tests. I think you had other failures though, please open another issue for those.