### PR TITLE
do not open the file twice when reading the libdevice bitcode

### DIFF
--- a/src/device/runtime.jl
+++ b/src/device/runtime.jl
@@ -66,9 +66,7 @@ function load_libdevice(cap)
     path = libdevice()
 
     get!(libcache, path) do
-        open(path) do io
-            parse(LLVM.Module, read(path), JuliaContext())
-        end
+        parse(LLVM.Module, read(path), JuliaContext())
     end
 end
 


### PR DESCRIPTION
Might help with #293 with the shared pvfs (GPFS) we are using on the cluster.