### PR TITLE
Only run benchmarks on the master branch.

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -212,6 +212,9 @@ pages:
   interruptible: true
   tags:
     - nvidia-benchmark
+  only:
+    refs:
+      - master
   variables:
     JULIA_LOAD_PATH: "$CI_PROJECT_DIR:$CI_PROJECT_DIR/perf::"
     CODESPEED_ENVIRONMENT: "$CI_RUNNER_DESCRIPTION"


### PR DESCRIPTION
Apparently DiffEq benchmarks can take >12h, blocking CI on PRs.