### PR TITLE
Optimize element-wise operations

### DIFF
--- a/Manifest.toml
+++ b/Manifest.toml
@@ -59,8 +59,8 @@ version = "0.1.1"
 
 [[GPUArrays]]
 deps = ["AbstractFFTs", "Adapt", "LinearAlgebra", "Printf", "Random", "Serialization"]
-git-tree-sha1 = "6f9511424de3cccbf7024dffe9cd7eea2a95b6e8"
-repo-rev = "b988cdcc81011ded7223f250d127a1e544ea2d2a"
+git-tree-sha1 = "3c45f3a204bb5155debc5337bf79ea2a14e1935c"
+repo-rev = "52baee9"
 repo-url = "https://github.com/JuliaGPU/GPUArrays.jl.git"
 uuid = "0c68f7d7-f131-5f86-a1c3-88cf8149b2d7"
 version = "4.0.1"

--- a/lib/cudadrv/execution.jl
+++ b/lib/cudadrv/execution.jl
@@ -49,9 +49,9 @@ internal kernel parameter buffer, or a pointer to device memory.
 
 This is a low-level call, prefer to use [`cudacall`](@ref) instead.
 """
-function launch(f::CuFunction, args...; blocks::CuDim=1, threads::CuDim=1,
+function launch(f::CuFunction, args::Vararg{Any,N}; blocks::CuDim=1, threads::CuDim=1,
                 cooperative::Bool=false, shmem::Integer=0,
-                stream::CuStream=CuDefaultStream())
+                stream::CuStream=CuDefaultStream()) where {N}
     blockdim = CuDim3(blocks)
     threaddim = CuDim3(threads)
     (blockdim.x>0 && blockdim.y>0 && blockdim.z>0) ||

--- a/src/gpuarrays.jl
+++ b/src/gpuarrays.jl
@@ -17,7 +17,8 @@ struct CuArrayBackend <: AbstractGPUBackend end
 
 struct CuKernelContext <: AbstractKernelContext end
 
-function GPUArrays.launch_heuristic(::CuArrayBackend, f, args...; maximize_blocksize=false)
+function GPUArrays.launch_heuristic(::CuArrayBackend, f::F, args::Vararg{Any,N};
+                                    maximize_blocksize=false) where {F,N}
     kernel_args = map(cudaconvert, args)
     kernel_tt = Tuple{CuKernelContext, map(Core.Typeof, kernel_args)...}
     kernel = cufunction(f, kernel_tt)

--- a/src/gpuarrays.jl
+++ b/src/gpuarrays.jl
@@ -42,29 +42,29 @@ end
 
 # indexing
 
-GPUArrays.blockidx(ctx::CuKernelContext) = CUDA.blockIdx().x
-GPUArrays.blockdim(ctx::CuKernelContext) = CUDA.blockDim().x
-GPUArrays.threadidx(ctx::CuKernelContext) = CUDA.threadIdx().x
-GPUArrays.griddim(ctx::CuKernelContext) = CUDA.gridDim().x
+GPUArrays.blockidx(ctx::CuKernelContext) = blockIdx().x
+GPUArrays.blockdim(ctx::CuKernelContext) = blockDim().x
+GPUArrays.threadidx(ctx::CuKernelContext) = threadIdx().x
+GPUArrays.griddim(ctx::CuKernelContext) = gridDim().x
 
 # math
 
-@inline GPUArrays.cos(ctx::CuKernelContext, x) = CUDA.cos(x)
-@inline GPUArrays.sin(ctx::CuKernelContext, x) = CUDA.sin(x)
-@inline GPUArrays.sqrt(ctx::CuKernelContext, x) = CUDA.sqrt(x)
-@inline GPUArrays.log(ctx::CuKernelContext, x) = CUDA.log(x)
+@inline GPUArrays.cos(ctx::CuKernelContext, x) = cos(x)
+@inline GPUArrays.sin(ctx::CuKernelContext, x) = sin(x)
+@inline GPUArrays.sqrt(ctx::CuKernelContext, x) = sqrt(x)
+@inline GPUArrays.log(ctx::CuKernelContext, x) = log(x)
 
 # memory
 
 @inline function GPUArrays.LocalMemory(::CuKernelContext, ::Type{T}, ::Val{dims}, ::Val{id}
                                       ) where {T, dims, id}
-    ptr = CUDA._shmem(Val(id), T, Val(prod(dims)))
-    CuDeviceArray(dims, DevicePtr{T, CUDA.AS.Shared}(ptr))
+    ptr = emit_shmem(Val(id), T, Val(prod(dims)))
+    CuDeviceArray(dims, DevicePtr{T, AS.Shared}(ptr))
 end
 
 # synchronization
 
-@inline GPUArrays.synchronize_threads(::CuKernelContext) = CUDA.sync_threads()
+@inline GPUArrays.synchronize_threads(::CuKernelContext) = sync_threads()
 
 
 

--- a/src/gpuarrays.jl
+++ b/src/gpuarrays.jl
@@ -17,8 +17,8 @@ struct CuArrayBackend <: AbstractGPUBackend end
 
 struct CuKernelContext <: AbstractKernelContext end
 
-function GPUArrays.launch_heuristic(::CuArrayBackend, f::F, args::Vararg{Any,N};
-                                    maximize_blocksize=false) where {F,N}
+@inline function GPUArrays.launch_heuristic(::CuArrayBackend, f::F, args::Vararg{Any,N};
+                                            maximize_blocksize=false) where {F,N}
     kernel_args = map(cudaconvert, args)
     kernel_tt = Tuple{CuKernelContext, map(Core.Typeof, kernel_args)...}
     kernel = cufunction(f, kernel_tt)
@@ -32,8 +32,8 @@ function GPUArrays.launch_heuristic(::CuArrayBackend, f::F, args::Vararg{Any,N};
     end
 end
 
-function GPUArrays.gpu_call(::CuArrayBackend, f, args, threads::Int, blocks::Int;
-                            name::Union{String,Nothing})
+@inline function GPUArrays.gpu_call(::CuArrayBackend, f::F, args::TT, threads::Int,
+                                    blocks::Int; name::Union{String,Nothing}) where {F,TT}
     @cuda threads=threads blocks=blocks name=name f(CuKernelContext(), args...)
 end
 


### PR DESCRIPTION
Fixes https://github.com/JuliaGPU/CUDA.jl/issues/307

For `lmul!`:

```julia
function main(N=10784)
    println("Knet.jl")
    display(@benchmark(CUDA.@sync(blocking=false, lmul!(2,a)),
                       setup=(a=KnetArray(rand(Float32,$N))),
                       teardown=(Knet.freeKnetPtrCu(a.ptr))
                       ))

    println()

    println("CUDA.jl")
    display(@benchmark(CUDA.@sync(blocking=false, custom_lmul!(2,a)),
                       setup=(a=CuArray(rand(Float32,$N))),
                       teardown=(CUDA.unsafe_free!(a))
                                 ))

    return
end
```

```
Knet.jl
BenchmarkTools.Trial: 
  memory estimate:  288 bytes
  allocs estimate:  12
  --------------
  minimum time:     5.923 μs (0.00% GC)
  median time:      6.115 μs (0.00% GC)
  mean time:        6.142 μs (0.00% GC)
  maximum time:     24.955 μs (0.00% GC)
  --------------
  samples:          10000
  evals/sample:     6

CUDA.jl
BenchmarkTools.Trial: 
  memory estimate:  928 bytes
  allocs estimate:  35
  --------------
  minimum time:     6.281 μs (0.00% GC)
  median time:      6.510 μs (0.00% GC)
  mean time:        6.620 μs (0.83% GC)
  maximum time:     783.503 μs (69.80% GC)
  --------------
  samples:          10000
  evals/sample:     5
```

@denizyuret, do note that for these operations (N=10,784 as you mentioned) actual GPU execution time is only about 600ns, so you should queue up sufficient work (in which case the difference would not have mattered, since the kernels take equal time).