### PR TITLE
Specialization fixes for mapreducedim.

### DIFF
--- a/Manifest.toml
+++ b/Manifest.toml
@@ -59,8 +59,8 @@ version = "0.1.1"
 
 [[GPUArrays]]
 deps = ["AbstractFFTs", "Adapt", "LinearAlgebra", "Printf", "Random", "Serialization"]
-git-tree-sha1 = "3c45f3a204bb5155debc5337bf79ea2a14e1935c"
-repo-rev = "52baee9"
+git-tree-sha1 = "7e9f3423e539e04858b065a5afa0a5622db4bf08"
+repo-rev = "dc9f6bb"
 repo-url = "https://github.com/JuliaGPU/GPUArrays.jl.git"
 uuid = "0c68f7d7-f131-5f86-a1c3-88cf8149b2d7"
 version = "4.0.1"


### PR DESCRIPTION
Fixes https://github.com/JuliaGPU/CUDA.jl/issues/302

```
julia> k = KnetArray{Float32}(rand(10,100));

julia> c = CuArray{Float32}(rand(10,100));

julia> @benchmark sum(k)
BenchmarkTools.Trial: 
  memory estimate:  32 bytes
  allocs estimate:  2
  --------------
  minimum time:     8.516 μs (0.00% GC)
  median time:      8.788 μs (0.00% GC)
  mean time:        8.817 μs (0.00% GC)
  maximum time:     23.335 μs (0.00% GC)
  --------------
  samples:          10000
  evals/sample:     3

julia> @benchmark sum(c)
BenchmarkTools.Trial: 
  memory estimate:  1.08 KiB
  allocs estimate:  37
  --------------
  minimum time:     12.593 μs (0.00% GC)
  median time:      19.867 μs (0.00% GC)
  mean time:        19.804 μs (0.00% GC)
  maximum time:     325.308 μs (0.00% GC)
  --------------
  samples:          10000
  evals/sample:     1

julia> @benchmark sum(k,dims=1)
BenchmarkTools.Trial: 
  memory estimate:  288 bytes
  allocs estimate:  11
  --------------
  minimum time:     2.899 μs (0.00% GC)
  median time:      3.016 μs (0.00% GC)
  mean time:        3.072 μs (0.00% GC)
  maximum time:     163.371 μs (0.00% GC)
  --------------
  samples:          10000
  evals/sample:     9

julia> @benchmark sum(c,dims=1)
BenchmarkTools.Trial: 
  memory estimate:  960 bytes
  allocs estimate:  33
  --------------
  minimum time:     3.236 μs (0.00% GC)
  median time:      3.493 μs (0.00% GC)
  mean time:        4.332 μs (4.12% GC)
  maximum time:     5.562 ms (32.07% GC)
  --------------
  samples:          10000
  evals/sample:     8

julia> @benchmark sum(abs2, k)
BenchmarkTools.Trial: 
  memory estimate:  32 bytes
  allocs estimate:  2
  --------------
  minimum time:     8.926 μs (0.00% GC)
  median time:      9.180 μs (0.00% GC)
  mean time:        9.288 μs (0.00% GC)
  maximum time:     128.632 μs (0.00% GC)
  --------------
  samples:          10000
  evals/sample:     3

julia> @benchmark sum(abs2, c)
BenchmarkTools.Trial: 
  memory estimate:  1.08 KiB
  allocs estimate:  37
  --------------
  minimum time:     13.336 μs (0.00% GC)
  median time:      20.882 μs (0.00% GC)
  mean time:        20.743 μs (0.00% GC)
  maximum time:     66.558 μs (0.00% GC)
  --------------
  samples:          10000
  evals/sample:     1
```


From x10 to less than 50% overhead.

@denizyuret at this point the largest issues are gone, and it would be good to port over some over the tricks that Knet does. For example, I think the scalar reductions here avoid allocating an output container (I couldn't see a `cudaMalloc` in the profiler), which might account for the remaining overhead.