### PR TITLE
Bump CUDNN and CUTENSOR

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -49,10 +49,12 @@ cuda:11.0:
     - .test
   image: ubuntu:bionic
   variables:
+    CI_THOROUGH: 'true'
     JULIA_CUDA_VERSION: '11.0'
     JULIA_CUDA_USE_BINARYBUILDER: 'true'
   tags:
     - nvidia
+    - latest
     - cuda_11.0
 
 cuda:10.2:

--- a/Artifacts.toml
+++ b/Artifacts.toml
@@ -345,33 +345,96 @@ os = "windows"
 
 [[CUTENSOR_CUDA101]]
 arch = "x86_64"
-git-tree-sha1 = "e2c2c823b3cb5030389cab74001ae4371b3e6665"
+git-tree-sha1 = "16dcf8a61c4b9b3304a48e9f474bdc51f722bcfb"
 lazy = true
 libc = "glibc"
 os = "linux"
 
     [[CUTENSOR_CUDA101.download]]
-    sha256 = "6f6af02aa32d15be5019bfd47a28fafa785f47b5adee7b351a993a411cf1261d"
-    url = "https://github.com/JuliaBinaryWrappers/CUTENSOR_CUDA101_jll.jl/releases/download/CUTENSOR_CUDA101-v1.1.0+0/CUTENSOR_CUDA101.v1.1.0.x86_64-linux-gnu.tar.gz"
+    sha256 = "df9e79b72bd0e862443b485694a66f09811181e822b2ca5526a373ed7c18b632"
+    url = "https://github.com/JuliaBinaryWrappers/CUTENSOR_CUDA101_jll.jl/releases/download/CUTENSOR_CUDA101-v1.2.0+0/CUTENSOR_CUDA101.v1.2.0.x86_64-linux-gnu.tar.gz"
+
+[[CUTENSOR_CUDA101]]
+arch = "powerpc64le"
+git-tree-sha1 = "3cca8368bbe4965846a77d4be89914bd6f71e0d7"
+lazy = true
+libc = "glibc"
+os = "linux"
+
+    [[CUTENSOR_CUDA101.download]]
+    sha256 = "0f66003f90e2554622f7f1bcd50202b4cb6428de6cf8315cb65c29efd5f66c55"
+    url = "https://github.com/JuliaBinaryWrappers/CUTENSOR_CUDA101_jll.jl/releases/download/CUTENSOR_CUDA101-v1.2.0+0/CUTENSOR_CUDA101.v1.2.0.powerpc64le-linux-gnu.tar.gz"
+
+[[CUTENSOR_CUDA101]]
+arch = "x86_64"
+git-tree-sha1 = "48d1784fa4999a51262fd71d80963ea93018f4b7"
+lazy = true
+os = "windows"
+
+    [[CUTENSOR_CUDA101.download]]
+    sha256 = "5efce496c330cd9f6df38b93e605127977f0221ca023a4c864bb9e2bc48dd595"
+    url = "https://github.com/JuliaBinaryWrappers/CUTENSOR_CUDA101_jll.jl/releases/download/CUTENSOR_CUDA101-v1.2.0+0/CUTENSOR_CUDA101.v1.2.0.x86_64-w64-mingw32.tar.gz"
 
 [[CUTENSOR_CUDA102]]
 arch = "x86_64"
-git-tree-sha1 = "fbe34931d3c1bebd56fbc2edba0f8ece5295fed7"
+git-tree-sha1 = "22ae18c36ae1627644e3f7bf7bcf5ffc38f1139e"
 lazy = true
 libc = "glibc"
 os = "linux"
 
     [[CUTENSOR_CUDA102.download]]
-    sha256 = "ee3fa5d015ff1605b6d9997ae84d41182cd35beae4a0e738f74a34a3778aeeff"
-    url = "https://github.com/JuliaBinaryWrappers/CUTENSOR_CUDA102_jll.jl/releases/download/CUTENSOR_CUDA102-v1.1.0+0/CUTENSOR_CUDA102.v1.1.0.x86_64-linux-gnu.tar.gz"
+    sha256 = "086c7717d18632ba3027d37d3d0e2b27995996407474f2f0845b51e18ca34bde"
+    url = "https://github.com/JuliaBinaryWrappers/CUTENSOR_CUDA102_jll.jl/releases/download/CUTENSOR_CUDA102-v1.2.0+0/CUTENSOR_CUDA102.v1.2.0.x86_64-linux-gnu.tar.gz"
+
+[[CUTENSOR_CUDA102]]
+arch = "powerpc64le"
+git-tree-sha1 = "c7daacb1595742713af9785268bc3c938f259d11"
+lazy = true
+libc = "glibc"
+os = "linux"
+
+    [[CUTENSOR_CUDA102.download]]
+    sha256 = "1148373079d63cb4517259d65353a2f9e7f0d109bb05f219019caf80b75b1122"
+    url = "https://github.com/JuliaBinaryWrappers/CUTENSOR_CUDA102_jll.jl/releases/download/CUTENSOR_CUDA102-v1.2.0+0/CUTENSOR_CUDA102.v1.2.0.powerpc64le-linux-gnu.tar.gz"
+
+[[CUTENSOR_CUDA102]]
+arch = "x86_64"
+git-tree-sha1 = "d6605f4aac98265f0bc1e17d7b6442ffbdee6e9a"
+lazy = true
+os = "windows"
+
+    [[CUTENSOR_CUDA102.download]]
+    sha256 = "23830ae8da7eaaaef63b572ff19a47f3a86ca7124b8ce2c85bd76286cbf58014"
+    url = "https://github.com/JuliaBinaryWrappers/CUTENSOR_CUDA102_jll.jl/releases/download/CUTENSOR_CUDA102-v1.2.0+0/CUTENSOR_CUDA102.v1.2.0.x86_64-w64-mingw32.tar.gz"
 
 [[CUTENSOR_CUDA110]]
 arch = "x86_64"
-git-tree-sha1 = "5676355e1994b73b2f11b154e4b00780ac4c21d7"
+git-tree-sha1 = "12a771b8cabb526e7ca8a897e19b144d1f517079"
 lazy = true
 libc = "glibc"
 os = "linux"
 
     [[CUTENSOR_CUDA110.download]]
-    sha256 = "1402d11ee5f1c51ad270b4ac0001c4ef4e36e456b6d6078d90d52e1292f40685"
-    url = "https://github.com/JuliaBinaryWrappers/CUTENSOR_CUDA110_jll.jl/releases/download/CUTENSOR_CUDA110-v1.1.0+0/CUTENSOR_CUDA110.v1.1.0.x86_64-linux-gnu.tar.gz"
+    sha256 = "33d301405a4e6e10d3c44304c419b004f0cfc89a1e81cc483b4b2067b6f1b0bb"
+    url = "https://github.com/JuliaBinaryWrappers/CUTENSOR_CUDA110_jll.jl/releases/download/CUTENSOR_CUDA110-v1.2.0+0/CUTENSOR_CUDA110.v1.2.0.x86_64-linux-gnu.tar.gz"
+
+[[CUTENSOR_CUDA110]]
+arch = "powerpc64le"
+git-tree-sha1 = "8b5c5ccf3a2233b8a1730ee5160294caef91b1c0"
+lazy = true
+libc = "glibc"
+os = "linux"
+
+    [[CUTENSOR_CUDA110.download]]
+    sha256 = "5f0ce5d2d0f94c7d096bf6317d5425e66381ec9aa41942904570f982a03a4269"
+    url = "https://github.com/JuliaBinaryWrappers/CUTENSOR_CUDA110_jll.jl/releases/download/CUTENSOR_CUDA110-v1.2.0+0/CUTENSOR_CUDA110.v1.2.0.powerpc64le-linux-gnu.tar.gz"
+
+[[CUTENSOR_CUDA110]]
+arch = "x86_64"
+git-tree-sha1 = "804435c7dbe9d002d6caa0a8b3596d11a6faa778"
+lazy = true
+os = "windows"
+
+    [[CUTENSOR_CUDA110.download]]
+    sha256 = "a2ff02ca1003f6e96e63335e6296637173d02cf9d44892225815679dc9c13ee7"
+    url = "https://github.com/JuliaBinaryWrappers/CUTENSOR_CUDA110_jll.jl/releases/download/CUTENSOR_CUDA110-v1.2.0+0/CUTENSOR_CUDA110.v1.2.0.x86_64-w64-mingw32.tar.gz"

--- a/Artifacts.toml
+++ b/Artifacts.toml
@@ -169,6 +169,8 @@ os = "windows"
 
 # CUDNN
 
+## v7
+
 [[CUDNN_CUDA90]]
 arch = "x86_64"
 git-tree-sha1 = "64af5b057674c39b9feaac7ad55c77a35024b268"
@@ -273,27 +275,71 @@ os = "macos"
     sha256 = "b07de2ba0a454196d4f3706e85c66f9c5a0f5b0060574de0082229192581ab45"
     url = "https://github.com/JuliaBinaryWrappers/CUDNN_CUDA101_jll.jl/releases/download/CUDNN_CUDA101-v7.6.5+0/CUDNN_CUDA101.v7.6.5.x86_64-apple-darwin14.tar.gz"
 
+## v8
+
 [[CUDNN_CUDA102]]
 arch = "x86_64"
-git-tree-sha1 = "e2c3e0d624e434939d57d97c7496ea8b2d032bc0"
+git-tree-sha1 = "efde3d4177a633e8ad32d1c4b7e984b9c03ccad2"
 lazy = true
 libc = "glibc"
 os = "linux"
 
     [[CUDNN_CUDA102.download]]
-    sha256 = "74471356148c70be43a0c2976b6bf6dbdca760b727ba27cfed35b28b2d124732"
-    url = "https://github.com/JuliaBinaryWrappers/CUDNN_CUDA102_jll.jl/releases/download/CUDNN_CUDA102-v7.6.5+0/CUDNN_CUDA102.v7.6.5.x86_64-linux-gnu.tar.gz"
+    sha256 = "0739fa1e3df612e0b937226d00479ba8d9a4243ec6898e86c6d5f90d3e0705e9"
+    url = "https://github.com/JuliaBinaryWrappers/CUDNN_CUDA102_jll.jl/releases/download/CUDNN_CUDA102-v8.0.1+0/CUDNN_CUDA102.v8.0.1.x86_64-linux-gnu.tar.gz"
+
+[[CUDNN_CUDA102]]
+arch = "powerpc64le"
+git-tree-sha1 = "aa64967c29dc7a8bb58725a214c95bfa041ecbef"
+lazy = true
+libc = "glibc"
+os = "linux"
+
+    [[CUDNN_CUDA102.download]]
+    sha256 = "f4b41f4d2f716977b70b6d95c29e77c2f51e1a2bdd4238f961c7a94ba589eec0"
+    url = "https://github.com/JuliaBinaryWrappers/CUDNN_CUDA102_jll.jl/releases/download/CUDNN_CUDA102-v8.0.1+0/CUDNN_CUDA102.v8.0.1.powerpc64le-linux-gnu.tar.gz"
 
 [[CUDNN_CUDA102]]
 arch = "x86_64"
-git-tree-sha1 = "055670857790510de6b98f25390ddd0be213ba7e"
+git-tree-sha1 = "3869b0f2b71d915a971390b2ea465e1b5122b764"
 lazy = true
 os = "windows"
 
     [[CUDNN_CUDA102.download]]
-    sha256 = "4a057d49bd2e6139dfec71fa512f91b8f9181fa155e8def7f0b388b66dd2e59b"
-    url = "https://github.com/JuliaBinaryWrappers/CUDNN_CUDA102_jll.jl/releases/download/CUDNN_CUDA102-v7.6.5+0/CUDNN_CUDA102.v7.6.5.x86_64-w64-mingw32.tar.gz"
+    sha256 = "e78b7ba4293d7d021121373a81cd8731dbef059ef2b32527b6d04b1ac0dd196e"
+    url = "https://github.com/JuliaBinaryWrappers/CUDNN_CUDA102_jll.jl/releases/download/CUDNN_CUDA102-v8.0.1+0/CUDNN_CUDA102.v8.0.1.x86_64-w64-mingw32.tar.gz"
 
+[[CUDNN_CUDA110]]
+arch = "x86_64"
+git-tree-sha1 = "f4c5832285bd1c9e172b0a31347418b8650f851c"
+lazy = true
+libc = "glibc"
+os = "linux"
+
+    [[CUDNN_CUDA110.download]]
+    sha256 = "9a040740a3ccf1f8dcfac75ba38ca6ccefa2762b641c9274f03b9747f86b2512"
+    url = "https://github.com/JuliaBinaryWrappers/CUDNN_CUDA110_jll.jl/releases/download/CUDNN_CUDA110-v8.0.1+0/CUDNN_CUDA110.v8.0.1.x86_64-linux-gnu.tar.gz"
+
+[[CUDNN_CUDA110]]
+arch = "powerpc64le"
+git-tree-sha1 = "2c2fac843d001124c78122baaa6b12ade35a14ca"
+lazy = true
+libc = "glibc"
+os = "linux"
+
+    [[CUDNN_CUDA110.download]]
+    sha256 = "57593880ca0ba0433baa88112838900d0431e619ea9b8a0ae4a9f40274c3081a"
+    url = "https://github.com/JuliaBinaryWrappers/CUDNN_CUDA110_jll.jl/releases/download/CUDNN_CUDA110-v8.0.1+0/CUDNN_CUDA110.v8.0.1.powerpc64le-linux-gnu.tar.gz"
+
+[[CUDNN_CUDA110]]
+arch = "x86_64"
+git-tree-sha1 = "430f2638c1882d64e7673183c57b1564edaba69f"
+lazy = true
+os = "windows"
+
+    [[CUDNN_CUDA110.download]]
+    sha256 = "594fd7c6730a76581dafd6db6e205c1bc83a7a0be52fc128d167129b94f59454"
+    url = "https://github.com/JuliaBinaryWrappers/CUDNN_CUDA110_jll.jl/releases/download/CUDNN_CUDA110-v8.0.1+0/CUDNN_CUDA110.v8.0.1.x86_64-w64-mingw32.tar.gz"
 
 # CUTENSOR
 

--- a/deps/bindeps.jl
+++ b/deps/bindeps.jl
@@ -236,6 +236,7 @@ end
 # CUDNN
 
 const cudnn_artifacts = Dict(
+    v"11.0" => ()->artifact"CUDNN_CUDA110",
     v"10.2" => ()->artifact"CUDNN_CUDA102",
     v"10.1" => ()->artifact"CUDNN_CUDA101",
     v"10.0" => ()->artifact"CUDNN_CUDA100",

--- a/deps/discovery.jl
+++ b/deps/discovery.jl
@@ -27,6 +27,15 @@ function library_versioned_names(name::String, version::Union{Nothing,VersionNum
             push!(names, "$(name)$(Sys.WORD_SIZE)_$(version).$(Libdl.dlext)")
         end
         push!(names, "$(name)$(Sys.WORD_SIZE).$(Libdl.dlext)")
+
+        # some libraries (e.g. CUTENSOR) are shipped without the word size-prefix
+        if version isa VersionNumber
+            append!(names, ["$(name)_$(version.major)$(version.minor).$(Libdl.dlext)",
+                            "$(name)_$(version.major).$(Libdl.dlext)"])
+        elseif version isa String
+            push!(names, "$(name)_$(version).$(Libdl.dlext)")
+        end
+        push!(names, "$(name).$(Libdl.dlext)")
     elseif Sys.isunix()
         # most UNIX distributions ship versioned libraries (also see JuliaLang/julia#22828)
         if version isa VersionNumber

--- a/src/initialization.jl
+++ b/src/initialization.jl
@@ -127,8 +127,8 @@ function __runtime_init__()
 
     if has_cutensor()
         cutensor_release = VersionNumber(CUTENSOR.version().major, CUTENSOR.version().minor)
-        if !(v"1.0" <= cutensor_release <= v"1.1")
-            @warn "CUDA.jl only supports CUTENSOR 1.0 to 1.1"
+        if !(v"1.0" <= cutensor_release <= v"1.2")
+            @warn "CUDA.jl only supports CUTENSOR 1.0 to 1.2"
         end
     end
 

--- a/src/initialization.jl
+++ b/src/initialization.jl
@@ -120,8 +120,8 @@ function __runtime_init__()
 
     if has_cudnn()
         cudnn_release = VersionNumber(CUDNN.version().major, CUDNN.version().minor)
-        if cudnn_release != v"7.6"
-            @warn "CUDA.jl only supports CUDNN 7.6"
+        if !(v"7.6" <= cudnn_release <= v"8.0")
+            @warn "CUDA.jl only supports CUDNN 7.6 to 8.0"
         end
     end
 


### PR DESCRIPTION
CUDNN v8.0, for CUDA 11 compatibility
CUTENSOR 1.2, now also with Windows artifacts (cc @kshyatt, fixes https://github.com/JuliaGPU/CUDA.jl/issues/301)
Both with PPC artifacts, but we don't have CUDA itself for PPC packaged yet.