### PR TITLE
Separate CURAND wrappers from Random impl.

### DIFF
--- a/Manifest.toml
+++ b/Manifest.toml
@@ -59,8 +59,8 @@ version = "0.1.1"
 
 [[GPUArrays]]
 deps = ["AbstractFFTs", "Adapt", "LinearAlgebra", "Printf", "Random", "Serialization"]
-git-tree-sha1 = "7e9f3423e539e04858b065a5afa0a5622db4bf08"
-repo-rev = "dc9f6bb"
+git-tree-sha1 = "5e7d7fe1eaf4da0b820c11e9be5d0c057b54e000"
+repo-rev = "56bc004aa3a61ca71003ca11c8e0ef3345a5436e"
 repo-url = "https://github.com/JuliaGPU/GPUArrays.jl.git"
 uuid = "0c68f7d7-f131-5f86-a1c3-88cf8149b2d7"
 version = "4.0.1"

--- a/src/CUDA.jl
+++ b/src/CUDA.jl
@@ -79,6 +79,7 @@ include("linalg.jl")
 include("nnlib.jl")
 include("iterator.jl")
 include("statistics.jl")
+include("random.jl")
 
 # other libraries
 include("../lib/nvml/NVML.jl")

--- a/src/gpuarrays.jl
+++ b/src/gpuarrays.jl
@@ -5,11 +5,6 @@
 # Device functionality
 #
 
-## device properties
-
-GPUArrays.threads(dev::CuDevice) =
-    attribute(dev, DEVICE_ATTRIBUTE_MAX_THREADS_PER_BLOCK)
-
 
 ## execution
 

--- a/src/random.jl
+++ b/src/random.jl
@@ -1,0 +1,77 @@
+# random functions that dispatch either to CURAND or GPUArrays' generic RNG
+
+using Random
+
+export rand_logn!, rand_poisson!
+
+# the interface is split in two levels:
+# - functions that extend the Random standard library, and take an RNG as first argument,
+#   will only ever dispatch to CURAND and as a result are limited in the types they support.
+# - functions that take an array will dispatch to either CURAND or GPUArrays
+# - non-exported functions are provided for constructing GPU arrays from only an eltype
+
+const curand_rng = CURAND.default_rng
+gpuarrays_rng() = GPUArrays.default_rng(CuArray)
+
+function seed!(seed=Base.rand(UInt64))
+    Random.seed!(curand_rng(), seed)
+    Random.seed!(gpuarrays_rng(), seed)
+end
+
+# CURAND in-place
+Random.rand!(A::CURAND.UniformArray) = Random.rand!(curand_rng(), A)
+Random.randn!(A::CURAND.NormalArray; kwargs...) = Random.randn!(curand_rng(), A; kwargs...)
+rand_logn!(A::CURAND.LognormalArray; kwargs...) = CURAND.rand_logn!(curand_rng(), A; kwargs...)
+rand_poisson!(A::CURAND.PoissonArray; kwargs...) = CURAND.rand_poisson!(curand_rng(), A; kwargs...)
+
+# CURAND out-of-place
+rand(T::CURAND.UniformType, dims::Dims) = Random.rand(curand_rng(), T, dims)
+randn(T::CURAND.NormalType, dims::Dims; kwargs...) = Random.randn(curand_rng(), T, dims; kwargs...)
+rand_logn(T::CURAND.LognormalType, dims::Dims; kwargs...) = CURAND.rand_logn(curand_rng(), T, dims; kwargs...)
+rand_poisson(T::CURAND.PoissonType, dims::Dims; kwargs...) = CURAND.rand_poisson(curand_rng(), T, dims; kwargs...)
+
+# support all dimension specifications
+rand(T::CURAND.UniformType, dim1::Integer, dims::Integer...) =
+    Random.rand(curand_rng(), T, Dims((dim1, dims...)))
+randn(T::CURAND.NormalType, dim1::Integer, dims::Integer...; kwargs...) =
+    Random.randn(curand_rng(), T, Dims((dim1, dims...)); kwargs...)
+rand_logn(T::CURAND.LognormalType, dim1::Integer, dims::Integer...; kwargs...) =
+    CURAND.rand_logn(curand_rng(), T, Dims((dim1, dims...)); kwargs...)
+rand_poisson(T::CURAND.PoissonType, dim1::Integer, dims::Integer...; kwargs...) =
+    CURAND.rand_poisson(curand_rng(), T, Dims((dim1, dims...)); kwargs...)
+
+# GPUArrays in-place
+Random.rand!(A::CuArray) = Random.rand!(gpuarrays_rng(), A)
+Random.randn!(A::CuArray; kwargs...) =
+    error("CUDA.jl does not support generating normally-distrubyted random numbers of type $(eltype(A))")
+# FIXME: GPUArrays.jl has a randn! nowadays, but it doesn't work with e.g. Cuint
+rand_logn!(A::CuArray; kwargs...) =
+    error("CUDA.jl does not support generating lognormally-distributed random numbers of type $(eltype(A))")
+rand_poisson!(A::CuArray; kwargs...) =
+    error("CUDA.jl does not support generating Poisson-distributed random numbers of type $(eltype(A))")
+
+# GPUArrays out-of-place
+rand(T::Type, dims::Dims) = Random.rand!(CuArray{T}(undef, dims...))
+randn(T::Type, dims::Dims; kwargs...) = Random.randn!(CuArray{T}(undef, dims...); kwargs...)
+rand_logn(T::Type, dims::Dims; kwargs...) = rand_logn!(CuArray{T}(undef, dims...); kwargs...)
+rand_poisson(T::Type, dims::Dims; kwargs...) = rand_poisson!(CuArray{T}(undef, dims...); kwargs...)
+
+# support all dimension specifications
+rand(T::Type, dim1::Integer, dims::Integer...) =
+    Random.rand!(CuArray{T}(undef, dim1, dims...))
+randn(T::Type, dim1::Integer, dims::Integer...; kwargs...) =
+    Random.randn!(CuArray{T}(undef, dim1, dims...); kwargs...)
+rand_logn(T::Type, dim1::Integer, dims::Integer...; kwargs...) =
+    rand_logn!(CuArray{T}(undef, dim1, dims...); kwargs...)
+rand_poisson(T::Type, dim1::Integer, dims::Integer...; kwargs...) =
+    rand_poisson!(CuArray{T}(undef, dim1, dims...); kwargs...)
+
+# untyped out-of-place
+rand(dim1::Integer, dims::Integer...) =
+    Random.rand(curand_rng(), Dims((dim1, dims...)))
+randn(dim1::Integer, dims::Integer...; kwargs...) =
+    Random.randn(curand_rng(), Dims((dim1, dims...)); kwargs...)
+rand_logn(dim1::Integer, dims::Integer...; kwargs...) =
+    CURAND.rand_logn(curand_rng(), Dims((dim1, dims...)); kwargs...)
+rand_poisson(dim1::Integer, dims::Integer...; kwargs...) =
+    CURAND.rand_poisson(curand_rng(), Dims((dim1, dims...)); kwargs...)

--- a/test/curand.jl
+++ b/test/curand.jl
@@ -2,73 +2,8 @@ using CUDA.CURAND
 
 @test CURAND.version() isa VersionNumber
 
-rng = CURAND.generator()
+rng = CURAND.default_rng()
 Random.seed!(rng)
 Random.seed!(rng, nothing)
 Random.seed!(rng, 1)
 Random.seed!(rng, 1, 0)
-
-# NOTE: tests should cover both pow2 and non-pow2 dims
-
-# in-place
-for (f,T) in ((rand!,Float32),
-              (rand!,Cuint),
-              (randn!,Float32),
-              (rand_logn!,Float32),
-              (rand_poisson!,Cuint)),
-    d in (2, (2,2), (2,2,2), 3, (3,3), (3,3,3))
-    A = CuArray{T}(undef, d)
-    f(A)
-end
-
-# out-of-place, with implicit type
-for (f,T) in ((CUDA.rand,Float32), (CUDA.randn,Float32),
-              (CUDA.rand_logn,Float32), (CUDA.rand_poisson,Cuint),
-              (rand,Float64), (randn,Float64)),
-    args in ((2,), (2, 2), (3,), (3, 3))
-    A = f(args...)
-    @test eltype(A) == T
-end
-
-# out-of-place, with type specified
-for (f,T) in ((CUDA.rand,Float32), (CUDA.randn,Float32), (CUDA.rand_logn,Float32),
-              (CUDA.rand,Float64), (CUDA.randn,Float64), (CUDA.rand_logn,Float64),
-              (CUDA.rand_poisson,Cuint),
-              (rand,Float32), (randn,Float32),
-              (rand,Float64), (randn,Float64)),
-    args in ((T, 2), (T, 2, 2), (T, (2, 2)), (T, 3), (T, 3, 3), (T, (3, 3)))
-    A = f(args...)
-    @test eltype(A) == T
-end
-
-# unsupported types that fall back to GPUArrays
-for (f,T) in ((CUDA.rand,Int64),),
-    args in ((T, 2), (T, 2, 2), (T, (2, 2)), (T, 3), (T, 3, 3), (T, (3, 3)))
-    A = f(args...)
-    @test eltype(A) == T
-end
-for (f,T) in ((rand!,Int64),),
-    d in (2, (2,2), (2,2,2), 3, (3,3), (3,3,3))
-    A = CuArray{T}(undef, d)
-    f(A)
-end
-
-@test_throws ErrorException randn!(CuArray{Cuint}(undef, 10))
-@test_throws ErrorException rand_logn!(CuArray{Cuint}(undef, 10))
-@test_throws ErrorException rand_poisson!(CuArray{Float64}(undef, 10))
-
-# seeding of both generators
-CURAND.seed!()
-CURAND.seed!(1)
-## CUDA CURAND
-CURAND.seed!(1)
-A = CUDA.rand(Float32, 1)
-CURAND.seed!(1)
-B = CUDA.rand(Float32, 1)
-@test all(A .== B)
-## GPUArrays fallback
-CURAND.seed!(1)
-A = CUDA.rand(Int64, 1)
-CURAND.seed!(1)
-B = CUDA.rand(Int64, 1)
-@test all(A .== B)

--- a/test/random.jl
+++ b/test/random.jl
@@ -1,0 +1,64 @@
+# NOTE: tests should cover both pow2 and non-pow2 dims
+
+# in-place
+for (f,T) in ((rand!,Float32),
+              (rand!,Cuint),
+              (randn!,Float32),
+              (rand_logn!,Float32),
+              (rand_poisson!,Cuint)),
+    d in (2, (2,2), (2,2,2), 3, (3,3), (3,3,3))
+    A = CuArray{T}(undef, d)
+    f(A)
+end
+
+# out-of-place, with implicit type
+for (f,T) in ((CUDA.rand,Float32), (CUDA.randn,Float32),
+              (CUDA.rand_logn,Float32), (CUDA.rand_poisson,Cuint),
+              (rand,Float64), (randn,Float64)),
+    args in ((2,), (2, 2), (3,), (3, 3))
+    A = f(args...)
+    @test eltype(A) == T
+end
+
+# out-of-place, with type specified
+for (f,T) in ((CUDA.rand,Float32), (CUDA.randn,Float32), (CUDA.rand_logn,Float32),
+              (CUDA.rand,Float64), (CUDA.randn,Float64), (CUDA.rand_logn,Float64),
+              (CUDA.rand_poisson,Cuint),
+              (rand,Float32), (randn,Float32),
+              (rand,Float64), (randn,Float64)),
+    args in ((T, 2), (T, 2, 2), (T, (2, 2)), (T, 3), (T, 3, 3), (T, (3, 3)))
+    A = f(args...)
+    @test eltype(A) == T
+end
+
+# unsupported types that fall back to GPUArrays
+for (f,T) in ((CUDA.rand,Int64),),
+    args in ((T, 2), (T, 2, 2), (T, (2, 2)), (T, 3), (T, 3, 3), (T, (3, 3)))
+    A = f(args...)
+    @test eltype(A) == T
+end
+for (f,T) in ((rand!,Int64),),
+    d in (2, (2,2), (2,2,2), 3, (3,3), (3,3,3))
+    A = CuArray{T}(undef, d)
+    f(A)
+end
+
+@test_throws ErrorException randn!(CuArray{Cuint}(undef, 10))
+@test_throws ErrorException rand_logn!(CuArray{Cuint}(undef, 10))
+@test_throws ErrorException rand_poisson!(CuArray{Float64}(undef, 10))
+
+# seeding of both generators
+CUDA.seed!()
+CUDA.seed!(1)
+## CUDA CURAND
+CUDA.seed!(1)
+A = CUDA.rand(Float32, 1)
+CUDA.seed!(1)
+B = CUDA.rand(Float32, 1)
+@test all(A .== B)
+## GPUArrays fallback
+CUDA.seed!(1)
+A = CUDA.rand(Int64, 1)
+CUDA.seed!(1)
+B = CUDA.rand(Int64, 1)
+@test all(A .== B)


### PR DESCRIPTION
Makes the design a little clearer: the CURAND wrappers, and https://github.com/JuliaGPU/GPUArrays.jl/pull/304 now only implement wrappers on a specific RNG, while `src/random.jl` ties it all together and makes everything dispatch properly.

Also makes the GPUArrays RNG objects context-aware in preparation of https://github.com/JuliaGPU/CUDA.jl/pull/253 (can't have global arrays that are device specific, they should respect the context in case we reset the device).