### PR TITLE
Use callback APIs to get library debug logs.

### DIFF
--- a/lib/cublas/CUBLAS.jl
+++ b/lib/cublas/CUBLAS.jl
@@ -4,7 +4,7 @@ using ..APIUtils
 
 using ..CUDA
 using ..CUDA: CUstream, cuComplex, cuDoubleComplex, libraryPropertyType, cudaDataType
-using ..CUDA: libcublas, unsafe_free!, @retry_reclaim
+using ..CUDA: libcublas, unsafe_free!, @retry_reclaim, isdebug
 
 using LinearAlgebra
 
@@ -92,6 +92,22 @@ function __init__()
         tid = Threads.threadid()
         thread_handles[tid] = nothing
         thread_xt_handles[tid] = nothing
+    end
+end
+
+function log_message(cstr)
+    str = unsafe_string(cstr)
+    print(str)
+    # NOTE: we can't `@debug` these messages, because the logging function is called for
+    #       every line... also not sure what the i!/I! prefixes mean (info?)
+    return
+end
+
+function __runtime_init__()
+    # enable library logging when launched with JULIA_DEBUG=CUBLAS
+    if isdebug(:init, CUBLAS)
+        callback = @cfunction(log_message, Nothing, (Cstring,))
+        cublasSetLoggerCallback(callback)
     end
 end
 

--- a/lib/cudnn/CUDNN.jl
+++ b/lib/cudnn/CUDNN.jl
@@ -4,7 +4,7 @@ using ..APIUtils
 
 using ..CUDA
 using ..CUDA: CUstream, libraryPropertyType
-using ..CUDA: libcudnn, @retry_reclaim
+using ..CUDA: libcudnn, @retry_reclaim, isdebug
 
 using CEnum
 
@@ -67,6 +67,36 @@ function __init__()
     CUDA.attaskswitch() do
         tid = Threads.threadid()
         thread_handles[tid] = nothing
+    end
+end
+
+function log_message(sev, udata, dbg_ptr, cstr)
+    # "Each line of this message is terminated by \0, and the end of the message is
+    # terminated by \0\0"
+    len = 0
+    while true
+        if unsafe_load(cstr, len+1) == '\0' && unsafe_load(cstr, len+2)
+            break
+        end
+        len += 1
+    end
+    str = unsafe_string(cstr, len)
+    lines = split(str, '\0')
+    msg = join(str, '\n')
+
+    # TODO: inspect `sev` to generate an appropriate message (@debug, @info, etc)
+    dbg = unsafe_load(dbg_ptr)
+    println(msg)
+    return
+end
+
+function __runtime_init__()
+    # enable library logging when launched with JULIA_DEBUG=CUDNN
+    # FIXME: this doesn't work, and the mask remains 0 (as observed with cudnnGetCallback)
+    if isdebug(:init, CUDNN)
+        callback = @cfunction(log_message, Nothing,
+                              (cudnnSeverity_t, Ptr{Cvoid}, Ptr{cudnnDebug_t}, Cstring))
+        cudnnSetCallback(typemax(UInt32), C_NULL, callback)
     end
 end
 

--- a/src/CUDA.jl
+++ b/src/CUDA.jl
@@ -25,6 +25,7 @@ include("../lib/cudadrv/CUDAdrv.jl")
 # essential stuff
 include("initialization.jl")
 include("state.jl")
+include("debug.jl")
 
 # binary dependencies
 include("../deps/discovery.jl")
@@ -87,6 +88,5 @@ const has_nvml = NVML.has_nvml
 export NVML, has_nvml
 
 include("deprecated.jl")
-include("debug.jl")
 
 end

--- a/src/debug.jl
+++ b/src/debug.jl
@@ -7,3 +7,6 @@ Enable the recording of debug timings.
 """
 enable_timings() = (TimerOutputs.enable_debug_timings(CUDA); return)
 disable_timings() = (TimerOutputs.disable_debug_timings(CUDA); return)
+
+isdebug(group, mod=CUDA) =
+    Base.CoreLogging.current_logger_for_env(Base.CoreLogging.Debug, group, mod) !== nothing

--- a/src/initialization.jl
+++ b/src/initialization.jl
@@ -137,6 +137,9 @@ function __runtime_init__()
 
     __init_pool__()
 
+    CUBLAS.__runtime_init__()
+    has_cudnn() && CUDNN.__runtime_init__()
+
     return
 end
 


### PR DESCRIPTION
Fixes https://github.com/JuliaGPU/CUDA.jl/issues/366

Couldn't get it to work for CUDNN though.