### PR TITLE
specify Cchar rather than char in the doc for @cuprint

### DIFF
--- a/src/device/intrinsics/output.jl
+++ b/src/device/intrinsics/output.jl
@@ -163,7 +163,7 @@ end
 Print a textual representation of values `xs` to standard output from the GPU. The
 functionality builds on `@cuprintf`, and is intended as a more use friendly alternative of
 that API. However, that also means there's only limited support for argument types, handling
-16/32/64 signed and unsigned integers, 32 and 64-bit floating point numbers, chars and
+16/32/64 signed and unsigned integers, 32 and 64-bit floating point numbers, `Cchar`s and
 pointers. For more complex output, use `@cuprintf` directly.
 
 Limited string interpolation is also possible:


### PR DESCRIPTION
Just to clear up a little confusion because `Char` is not supported, `Cchar` is. 