### PR TITLE
Default to per-thread stream semantics

### DIFF
--- a/lib/cublas/CUBLAS.jl
+++ b/lib/cublas/CUBLAS.jl
@@ -32,6 +32,7 @@ function handle()
         ctx = context()
         thread_handles[tid] = get!(task_local_storage(), (:CUBLAS, ctx)) do
             handle = cublasCreate()
+            cublasSetStream_v2(handle, CuStreamPerThread())
             finalizer(current_task()) do task
                 CUDA.isvalid(ctx) || return
                 context!(ctx) do

--- a/lib/cudadrv/context.jl
+++ b/lib/cudadrv/context.jl
@@ -49,12 +49,16 @@ function invalidate!(ctx::CuContext)
 end
 
 function Base.show(io::IO, ctx::CuContext)
-    fields = [@sprintf("%p", ctx.handle), @sprintf("instance %x", objectid(ctx))]
-    if !isvalid(ctx)
-        push!(fields, "invalidated")
-    end
+    if ctx.handle != C_NULL
+        fields = [@sprintf("%p", ctx.handle), @sprintf("instance %x", objectid(ctx))]
+        if !isvalid(ctx)
+            push!(fields, "invalidated")
+        end
 
-    print(io, "CuContext(", join(fields, ", "), ")")
+        print(io, "CuContext(", join(fields, ", "), ")")
+    else
+        print(io, "CuContext(NULL)")
+    end
 end
 
 """

--- a/lib/cudadrv/libcuda.jl
+++ b/lib/cudadrv/libcuda.jl
@@ -487,105 +487,105 @@ end
 
 @checked function cuMemcpy(dst, src, ByteCount)
     initialize_api()
-    @runtime_ccall((:cuMemcpy, libcuda()), CUresult,
+    @runtime_ccall((:cuMemcpy_ptds, libcuda()), CUresult,
                    (CUdeviceptr, CUdeviceptr, Csize_t),
                    dst, src, ByteCount)
 end
 
 @checked function cuMemcpyPeer(dstDevice, dstContext, srcDevice, srcContext, ByteCount)
     initialize_api()
-    @runtime_ccall((:cuMemcpyPeer, libcuda()), CUresult,
+    @runtime_ccall((:cuMemcpyPeer_ptds, libcuda()), CUresult,
                    (CUdeviceptr, CUcontext, CUdeviceptr, CUcontext, Csize_t),
                    dstDevice, dstContext, srcDevice, srcContext, ByteCount)
 end
 
 @checked function cuMemcpyHtoD_v2(dstDevice, srcHost, ByteCount)
     initialize_api()
-    @runtime_ccall((:cuMemcpyHtoD_v2, libcuda()), CUresult,
+    @runtime_ccall((:cuMemcpyHtoD_v2_ptds, libcuda()), CUresult,
                    (CUdeviceptr, Ptr{Cvoid}, Csize_t),
                    dstDevice, srcHost, ByteCount)
 end
 
 @checked function cuMemcpyDtoH_v2(dstHost, srcDevice, ByteCount)
     initialize_api()
-    @runtime_ccall((:cuMemcpyDtoH_v2, libcuda()), CUresult,
+    @runtime_ccall((:cuMemcpyDtoH_v2_ptds, libcuda()), CUresult,
                    (Ptr{Cvoid}, CUdeviceptr, Csize_t),
                    dstHost, srcDevice, ByteCount)
 end
 
 @checked function cuMemcpyDtoD_v2(dstDevice, srcDevice, ByteCount)
     initialize_api()
-    @runtime_ccall((:cuMemcpyDtoD_v2, libcuda()), CUresult,
+    @runtime_ccall((:cuMemcpyDtoD_v2_ptds, libcuda()), CUresult,
                    (CUdeviceptr, CUdeviceptr, Csize_t),
                    dstDevice, srcDevice, ByteCount)
 end
 
 @checked function cuMemcpyDtoA_v2(dstArray, dstOffset, srcDevice, ByteCount)
     initialize_api()
-    @runtime_ccall((:cuMemcpyDtoA_v2, libcuda()), CUresult,
+    @runtime_ccall((:cuMemcpyDtoA_v2_ptds, libcuda()), CUresult,
                    (CUarray, Csize_t, CUdeviceptr, Csize_t),
                    dstArray, dstOffset, srcDevice, ByteCount)
 end
 
 @checked function cuMemcpyAtoD_v2(dstDevice, srcArray, srcOffset, ByteCount)
     initialize_api()
-    @runtime_ccall((:cuMemcpyAtoD_v2, libcuda()), CUresult,
+    @runtime_ccall((:cuMemcpyAtoD_v2_ptds, libcuda()), CUresult,
                    (CUdeviceptr, CUarray, Csize_t, Csize_t),
                    dstDevice, srcArray, srcOffset, ByteCount)
 end
 
 @checked function cuMemcpyHtoA_v2(dstArray, dstOffset, srcHost, ByteCount)
     initialize_api()
-    @runtime_ccall((:cuMemcpyHtoA_v2, libcuda()), CUresult,
+    @runtime_ccall((:cuMemcpyHtoA_v2_ptds, libcuda()), CUresult,
                    (CUarray, Csize_t, Ptr{Cvoid}, Csize_t),
                    dstArray, dstOffset, srcHost, ByteCount)
 end
 
 @checked function cuMemcpyAtoH_v2(dstHost, srcArray, srcOffset, ByteCount)
     initialize_api()
-    @runtime_ccall((:cuMemcpyAtoH_v2, libcuda()), CUresult,
+    @runtime_ccall((:cuMemcpyAtoH_v2_ptds, libcuda()), CUresult,
                    (Ptr{Cvoid}, CUarray, Csize_t, Csize_t),
                    dstHost, srcArray, srcOffset, ByteCount)
 end
 
 @checked function cuMemcpyAtoA_v2(dstArray, dstOffset, srcArray, srcOffset, ByteCount)
     initialize_api()
-    @runtime_ccall((:cuMemcpyAtoA_v2, libcuda()), CUresult,
+    @runtime_ccall((:cuMemcpyAtoA_v2_ptds, libcuda()), CUresult,
                    (CUarray, Csize_t, CUarray, Csize_t, Csize_t),
                    dstArray, dstOffset, srcArray, srcOffset, ByteCount)
 end
 
 @checked function cuMemcpy2D_v2(pCopy)
     initialize_api()
-    @runtime_ccall((:cuMemcpy2D_v2, libcuda()), CUresult,
+    @runtime_ccall((:cuMemcpy2D_v2_ptds, libcuda()), CUresult,
                    (Ptr{CUDA_MEMCPY2D},),
                    pCopy)
 end
 
 @checked function cuMemcpy2DUnaligned_v2(pCopy)
     initialize_api()
-    @runtime_ccall((:cuMemcpy2DUnaligned_v2, libcuda()), CUresult,
+    @runtime_ccall((:cuMemcpy2DUnaligned_v2_ptds, libcuda()), CUresult,
                    (Ptr{CUDA_MEMCPY2D},),
                    pCopy)
 end
 
 @checked function cuMemcpy3D_v2(pCopy)
     initialize_api()
-    @runtime_ccall((:cuMemcpy3D_v2, libcuda()), CUresult,
+    @runtime_ccall((:cuMemcpy3D_v2_ptds, libcuda()), CUresult,
                    (Ptr{CUDA_MEMCPY3D},),
                    pCopy)
 end
 
 @checked function cuMemcpy3DPeer(pCopy)
     initialize_api()
-    @runtime_ccall((:cuMemcpy3DPeer, libcuda()), CUresult,
+    @runtime_ccall((:cuMemcpy3DPeer_ptds, libcuda()), CUresult,
                    (Ptr{CUDA_MEMCPY3D_PEER},),
                    pCopy)
 end
 
 @checked function cuMemcpyAsync(dst, src, ByteCount, hStream)
     initialize_api()
-    @runtime_ccall((:cuMemcpyAsync, libcuda()), CUresult,
+    @runtime_ccall((:cuMemcpyAsync_ptsz, libcuda()), CUresult,
                    (CUdeviceptr, CUdeviceptr, Csize_t, CUstream),
                    dst, src, ByteCount, hStream)
 end
@@ -593,147 +593,147 @@ end
 @checked function cuMemcpyPeerAsync(dstDevice, dstContext, srcDevice, srcContext,
                                     ByteCount, hStream)
     initialize_api()
-    @runtime_ccall((:cuMemcpyPeerAsync, libcuda()), CUresult,
+    @runtime_ccall((:cuMemcpyPeerAsync_ptsz, libcuda()), CUresult,
                    (CUdeviceptr, CUcontext, CUdeviceptr, CUcontext, Csize_t, CUstream),
                    dstDevice, dstContext, srcDevice, srcContext, ByteCount, hStream)
 end
 
 @checked function cuMemcpyHtoDAsync_v2(dstDevice, srcHost, ByteCount, hStream)
     initialize_api()
-    @runtime_ccall((:cuMemcpyHtoDAsync_v2, libcuda()), CUresult,
+    @runtime_ccall((:cuMemcpyHtoDAsync_v2_ptsz, libcuda()), CUresult,
                    (CUdeviceptr, Ptr{Cvoid}, Csize_t, CUstream),
                    dstDevice, srcHost, ByteCount, hStream)
 end
 
 @checked function cuMemcpyDtoHAsync_v2(dstHost, srcDevice, ByteCount, hStream)
     initialize_api()
-    @runtime_ccall((:cuMemcpyDtoHAsync_v2, libcuda()), CUresult,
+    @runtime_ccall((:cuMemcpyDtoHAsync_v2_ptsz, libcuda()), CUresult,
                    (Ptr{Cvoid}, CUdeviceptr, Csize_t, CUstream),
                    dstHost, srcDevice, ByteCount, hStream)
 end
 
 @checked function cuMemcpyDtoDAsync_v2(dstDevice, srcDevice, ByteCount, hStream)
     initialize_api()
-    @runtime_ccall((:cuMemcpyDtoDAsync_v2, libcuda()), CUresult,
+    @runtime_ccall((:cuMemcpyDtoDAsync_v2_ptsz, libcuda()), CUresult,
                    (CUdeviceptr, CUdeviceptr, Csize_t, CUstream),
                    dstDevice, srcDevice, ByteCount, hStream)
 end
 
 @checked function cuMemcpyHtoAAsync_v2(dstArray, dstOffset, srcHost, ByteCount, hStream)
     initialize_api()
-    @runtime_ccall((:cuMemcpyHtoAAsync_v2, libcuda()), CUresult,
+    @runtime_ccall((:cuMemcpyHtoAAsync_v2_ptsz, libcuda()), CUresult,
                    (CUarray, Csize_t, Ptr{Cvoid}, Csize_t, CUstream),
                    dstArray, dstOffset, srcHost, ByteCount, hStream)
 end
 
 @checked function cuMemcpyAtoHAsync_v2(dstHost, srcArray, srcOffset, ByteCount, hStream)
     initialize_api()
-    @runtime_ccall((:cuMemcpyAtoHAsync_v2, libcuda()), CUresult,
+    @runtime_ccall((:cuMemcpyAtoHAsync_v2_ptsz, libcuda()), CUresult,
                    (Ptr{Cvoid}, CUarray, Csize_t, Csize_t, CUstream),
                    dstHost, srcArray, srcOffset, ByteCount, hStream)
 end
 
 @checked function cuMemcpy2DAsync_v2(pCopy, hStream)
     initialize_api()
-    @runtime_ccall((:cuMemcpy2DAsync_v2, libcuda()), CUresult,
+    @runtime_ccall((:cuMemcpy2DAsync_v2_ptsz, libcuda()), CUresult,
                    (Ptr{CUDA_MEMCPY2D}, CUstream),
                    pCopy, hStream)
 end
 
 @checked function cuMemcpy3DAsync_v2(pCopy, hStream)
     initialize_api()
-    @runtime_ccall((:cuMemcpy3DAsync_v2, libcuda()), CUresult,
+    @runtime_ccall((:cuMemcpy3DAsync_v2_ptsz, libcuda()), CUresult,
                    (Ptr{CUDA_MEMCPY3D}, CUstream),
                    pCopy, hStream)
 end
 
 @checked function cuMemcpy3DPeerAsync(pCopy, hStream)
     initialize_api()
-    @runtime_ccall((:cuMemcpy3DPeerAsync, libcuda()), CUresult,
+    @runtime_ccall((:cuMemcpy3DPeerAsync_ptsz, libcuda()), CUresult,
                    (Ptr{CUDA_MEMCPY3D_PEER}, CUstream),
                    pCopy, hStream)
 end
 
 @checked function cuMemsetD8_v2(dstDevice, uc, N)
     initialize_api()
-    @runtime_ccall((:cuMemsetD8_v2, libcuda()), CUresult,
+    @runtime_ccall((:cuMemsetD8_v2_ptds, libcuda()), CUresult,
                    (CUdeviceptr, Cuchar, Csize_t),
                    dstDevice, uc, N)
 end
 
 @checked function cuMemsetD16_v2(dstDevice, us, N)
     initialize_api()
-    @runtime_ccall((:cuMemsetD16_v2, libcuda()), CUresult,
+    @runtime_ccall((:cuMemsetD16_v2_ptds, libcuda()), CUresult,
                    (CUdeviceptr, UInt16, Csize_t),
                    dstDevice, us, N)
 end
 
 @checked function cuMemsetD32_v2(dstDevice, ui, N)
     initialize_api()
-    @runtime_ccall((:cuMemsetD32_v2, libcuda()), CUresult,
+    @runtime_ccall((:cuMemsetD32_v2_ptds, libcuda()), CUresult,
                    (CUdeviceptr, UInt32, Csize_t),
                    dstDevice, ui, N)
 end
 
 @checked function cuMemsetD2D8_v2(dstDevice, dstPitch, uc, Width, Height)
     initialize_api()
-    @runtime_ccall((:cuMemsetD2D8_v2, libcuda()), CUresult,
+    @runtime_ccall((:cuMemsetD2D8_v2_ptds, libcuda()), CUresult,
                    (CUdeviceptr, Csize_t, Cuchar, Csize_t, Csize_t),
                    dstDevice, dstPitch, uc, Width, Height)
 end
 
 @checked function cuMemsetD2D16_v2(dstDevice, dstPitch, us, Width, Height)
     initialize_api()
-    @runtime_ccall((:cuMemsetD2D16_v2, libcuda()), CUresult,
+    @runtime_ccall((:cuMemsetD2D16_v2_ptds, libcuda()), CUresult,
                    (CUdeviceptr, Csize_t, UInt16, Csize_t, Csize_t),
                    dstDevice, dstPitch, us, Width, Height)
 end
 
 @checked function cuMemsetD2D32_v2(dstDevice, dstPitch, ui, Width, Height)
     initialize_api()
-    @runtime_ccall((:cuMemsetD2D32_v2, libcuda()), CUresult,
+    @runtime_ccall((:cuMemsetD2D32_v2_ptds, libcuda()), CUresult,
                    (CUdeviceptr, Csize_t, UInt32, Csize_t, Csize_t),
                    dstDevice, dstPitch, ui, Width, Height)
 end
 
 @checked function cuMemsetD8Async(dstDevice, uc, N, hStream)
     initialize_api()
-    @runtime_ccall((:cuMemsetD8Async, libcuda()), CUresult,
+    @runtime_ccall((:cuMemsetD8Async_ptsz, libcuda()), CUresult,
                    (CUdeviceptr, Cuchar, Csize_t, CUstream),
                    dstDevice, uc, N, hStream)
 end
 
 @checked function cuMemsetD16Async(dstDevice, us, N, hStream)
     initialize_api()
-    @runtime_ccall((:cuMemsetD16Async, libcuda()), CUresult,
+    @runtime_ccall((:cuMemsetD16Async_ptsz, libcuda()), CUresult,
                    (CUdeviceptr, UInt16, Csize_t, CUstream),
                    dstDevice, us, N, hStream)
 end
 
 @checked function cuMemsetD32Async(dstDevice, ui, N, hStream)
     initialize_api()
-    @runtime_ccall((:cuMemsetD32Async, libcuda()), CUresult,
+    @runtime_ccall((:cuMemsetD32Async_ptsz, libcuda()), CUresult,
                    (CUdeviceptr, UInt32, Csize_t, CUstream),
                    dstDevice, ui, N, hStream)
 end
 
 @checked function cuMemsetD2D8Async(dstDevice, dstPitch, uc, Width, Height, hStream)
     initialize_api()
-    @runtime_ccall((:cuMemsetD2D8Async, libcuda()), CUresult,
+    @runtime_ccall((:cuMemsetD2D8Async_ptsz, libcuda()), CUresult,
                    (CUdeviceptr, Csize_t, Cuchar, Csize_t, Csize_t, CUstream),
                    dstDevice, dstPitch, uc, Width, Height, hStream)
 end
 
 @checked function cuMemsetD2D16Async(dstDevice, dstPitch, us, Width, Height, hStream)
     initialize_api()
-    @runtime_ccall((:cuMemsetD2D16Async, libcuda()), CUresult,
+    @runtime_ccall((:cuMemsetD2D16Async_ptsz, libcuda()), CUresult,
                    (CUdeviceptr, Csize_t, UInt16, Csize_t, Csize_t, CUstream),
                    dstDevice, dstPitch, us, Width, Height, hStream)
 end
 
 @checked function cuMemsetD2D32Async(dstDevice, dstPitch, ui, Width, Height, hStream)
     initialize_api()
-    @runtime_ccall((:cuMemsetD2D32Async, libcuda()), CUresult,
+    @runtime_ccall((:cuMemsetD2D32Async_ptsz, libcuda()), CUresult,
                    (CUdeviceptr, Csize_t, UInt32, Csize_t, Csize_t, CUstream),
                    dstDevice, dstPitch, ui, Width, Height, hStream)
 end
@@ -899,7 +899,7 @@ end
 
 @checked function cuMemPrefetchAsync(devPtr, count, dstDevice, hStream)
     initialize_api()
-    @runtime_ccall((:cuMemPrefetchAsync, libcuda()), CUresult,
+    @runtime_ccall((:cuMemPrefetchAsync_ptsz, libcuda()), CUresult,
                    (CUdeviceptr, Csize_t, CUdevice, CUstream),
                    devPtr, count, dstDevice, hStream)
 end
@@ -957,42 +957,42 @@ end
 
 @checked function cuStreamGetPriority(hStream, priority)
     initialize_api()
-    @runtime_ccall((:cuStreamGetPriority, libcuda()), CUresult,
+    @runtime_ccall((:cuStreamGetPriority_ptsz, libcuda()), CUresult,
                    (CUstream, Ptr{Cint}),
                    hStream, priority)
 end
 
 @checked function cuStreamGetFlags(hStream, flags)
     initialize_api()
-    @runtime_ccall((:cuStreamGetFlags, libcuda()), CUresult,
+    @runtime_ccall((:cuStreamGetFlags_ptsz, libcuda()), CUresult,
                    (CUstream, Ptr{UInt32}),
                    hStream, flags)
 end
 
 @checked function cuStreamGetCtx(hStream, pctx)
     initialize_api()
-    @runtime_ccall((:cuStreamGetCtx, libcuda()), CUresult,
+    @runtime_ccall((:cuStreamGetCtx_ptsz, libcuda()), CUresult,
                    (CUstream, Ptr{CUcontext}),
                    hStream, pctx)
 end
 
 @checked function cuStreamWaitEvent(hStream, hEvent, Flags)
     initialize_api()
-    @runtime_ccall((:cuStreamWaitEvent, libcuda()), CUresult,
+    @runtime_ccall((:cuStreamWaitEvent_ptsz, libcuda()), CUresult,
                    (CUstream, CUevent, UInt32),
                    hStream, hEvent, Flags)
 end
 
 @checked function cuStreamAddCallback(hStream, callback, userData, flags)
     initialize_api()
-    @runtime_ccall((:cuStreamAddCallback, libcuda()), CUresult,
+    @runtime_ccall((:cuStreamAddCallback_ptsz, libcuda()), CUresult,
                    (CUstream, CUstreamCallback, Ptr{Cvoid}, UInt32),
                    hStream, callback, userData, flags)
 end
 
 @checked function cuStreamBeginCapture_v2(hStream, mode)
     initialize_api()
-    @runtime_ccall((:cuStreamBeginCapture_v2, libcuda()), CUresult,
+    @runtime_ccall((:cuStreamBeginCapture_v2_ptsz, libcuda()), CUresult,
                    (CUstream, CUstreamCaptureMode),
                    hStream, mode)
 end
@@ -1006,42 +1006,42 @@ end
 
 @checked function cuStreamEndCapture(hStream, phGraph)
     initialize_api()
-    @runtime_ccall((:cuStreamEndCapture, libcuda()), CUresult,
+    @runtime_ccall((:cuStreamEndCapture_ptsz, libcuda()), CUresult,
                    (CUstream, Ptr{CUgraph}),
                    hStream, phGraph)
 end
 
 @checked function cuStreamIsCapturing(hStream, captureStatus)
     initialize_api()
-    @runtime_ccall((:cuStreamIsCapturing, libcuda()), CUresult,
+    @runtime_ccall((:cuStreamIsCapturing_ptsz, libcuda()), CUresult,
                    (CUstream, Ptr{CUstreamCaptureStatus}),
                    hStream, captureStatus)
 end
 
 @checked function cuStreamGetCaptureInfo(hStream, captureStatus, id)
     initialize_api()
-    @runtime_ccall((:cuStreamGetCaptureInfo, libcuda()), CUresult,
+    @runtime_ccall((:cuStreamGetCaptureInfo_ptsz, libcuda()), CUresult,
                    (CUstream, Ptr{CUstreamCaptureStatus}, Ptr{cuuint64_t}),
                    hStream, captureStatus, id)
 end
 
 @checked function cuStreamAttachMemAsync(hStream, dptr, length, flags)
     initialize_api()
-    @runtime_ccall((:cuStreamAttachMemAsync, libcuda()), CUresult,
+    @runtime_ccall((:cuStreamAttachMemAsync_ptsz, libcuda()), CUresult,
                    (CUstream, CUdeviceptr, Csize_t, UInt32),
                    hStream, dptr, length, flags)
 end
 
 @checked function cuStreamQuery(hStream)
     initialize_api()
-    @runtime_ccall((:cuStreamQuery, libcuda()), CUresult,
+    @runtime_ccall((:cuStreamQuery_ptsz, libcuda()), CUresult,
                    (CUstream,),
                    hStream)
 end
 
 @checked function cuStreamSynchronize(hStream)
     initialize_api()
-    @runtime_ccall((:cuStreamSynchronize, libcuda()), CUresult,
+    @runtime_ccall((:cuStreamSynchronize_ptsz, libcuda()), CUresult,
                    (CUstream,),
                    hStream)
 end
@@ -1055,21 +1055,21 @@ end
 
 @checked function cuStreamCopyAttributes(dst, src)
     initialize_api()
-    @runtime_ccall((:cuStreamCopyAttributes, libcuda()), CUresult,
+    @runtime_ccall((:cuStreamCopyAttributes_ptsz, libcuda()), CUresult,
                    (CUstream, CUstream),
                    dst, src)
 end
 
 @checked function cuStreamGetAttribute(hStream, attr, value_out)
     initialize_api()
-    @runtime_ccall((:cuStreamGetAttribute, libcuda()), CUresult,
+    @runtime_ccall((:cuStreamGetAttribute_ptsz, libcuda()), CUresult,
                    (CUstream, CUstreamAttrID, Ptr{CUstreamAttrValue}),
                    hStream, attr, value_out)
 end
 
 @checked function cuStreamSetAttribute(hStream, attr, value)
     initialize_api()
-    @runtime_ccall((:cuStreamSetAttribute, libcuda()), CUresult,
+    @runtime_ccall((:cuStreamSetAttribute_ptsz, libcuda()), CUresult,
                    (CUstream, CUstreamAttrID, Ptr{CUstreamAttrValue}),
                    hStream, attr, value)
 end
@@ -1083,7 +1083,7 @@ end
 
 @checked function cuEventRecord(hEvent, hStream)
     initialize_api()
-    @runtime_ccall((:cuEventRecord, libcuda()), CUresult,
+    @runtime_ccall((:cuEventRecord_ptsz, libcuda()), CUresult,
                    (CUevent, CUstream),
                    hEvent, hStream)
 end
@@ -1156,7 +1156,7 @@ end
 @checked function cuSignalExternalSemaphoresAsync(extSemArray, paramsArray, numExtSems,
                                                   stream)
     initialize_api()
-    @runtime_ccall((:cuSignalExternalSemaphoresAsync, libcuda()), CUresult,
+    @runtime_ccall((:cuSignalExternalSemaphoresAsync_ptsz, libcuda()), CUresult,
                    (Ptr{CUexternalSemaphore}, Ptr{CUDA_EXTERNAL_SEMAPHORE_SIGNAL_PARAMS},
                     UInt32, CUstream),
                    extSemArray, paramsArray, numExtSems, stream)
@@ -1164,7 +1164,7 @@ end
 
 @checked function cuWaitExternalSemaphoresAsync(extSemArray, paramsArray, numExtSems, stream)
     initialize_api()
-    @runtime_ccall((:cuWaitExternalSemaphoresAsync, libcuda()), CUresult,
+    @runtime_ccall((:cuWaitExternalSemaphoresAsync_ptsz, libcuda()), CUresult,
                    (Ptr{CUexternalSemaphore}, Ptr{CUDA_EXTERNAL_SEMAPHORE_WAIT_PARAMS},
                     UInt32, CUstream),
                    extSemArray, paramsArray, numExtSems, stream)
@@ -1179,28 +1179,28 @@ end
 
 @checked function cuStreamWaitValue32(stream, addr, value, flags)
     initialize_api()
-    @runtime_ccall((:cuStreamWaitValue32, libcuda()), CUresult,
+    @runtime_ccall((:cuStreamWaitValue32_ptsz, libcuda()), CUresult,
                    (CUstream, CUdeviceptr, cuuint32_t, UInt32),
                    stream, addr, value, flags)
 end
 
 @checked function cuStreamWaitValue64(stream, addr, value, flags)
     initialize_api()
-    @runtime_ccall((:cuStreamWaitValue64, libcuda()), CUresult,
+    @runtime_ccall((:cuStreamWaitValue64_ptsz, libcuda()), CUresult,
                    (CUstream, CUdeviceptr, cuuint64_t, UInt32),
                    stream, addr, value, flags)
 end
 
 @checked function cuStreamWriteValue32(stream, addr, value, flags)
     initialize_api()
-    @runtime_ccall((:cuStreamWriteValue32, libcuda()), CUresult,
+    @runtime_ccall((:cuStreamWriteValue32_ptsz, libcuda()), CUresult,
                    (CUstream, CUdeviceptr, cuuint32_t, UInt32),
                    stream, addr, value, flags)
 end
 
 @checked function cuStreamWriteValue64(stream, addr, value, flags)
     initialize_api()
-    @runtime_ccall((:cuStreamWriteValue64, libcuda()), CUresult,
+    @runtime_ccall((:cuStreamWriteValue64_ptsz, libcuda()), CUresult,
                    (CUstream, CUdeviceptr, cuuint64_t, UInt32),
                    stream, addr, value, flags)
 end
@@ -1236,7 +1236,7 @@ end
 @checked function cuLaunchKernel(f, gridDimX, gridDimY, gridDimZ, blockDimX, blockDimY,
                                  blockDimZ, sharedMemBytes, hStream, kernelParams, extra)
     initialize_api()
-    @runtime_ccall((:cuLaunchKernel, libcuda()), CUresult,
+    @runtime_ccall((:cuLaunchKernel_ptsz, libcuda()), CUresult,
                    (CUfunction, UInt32, UInt32, UInt32, UInt32, UInt32, UInt32, UInt32,
                     CUstream, Ptr{Ptr{Cvoid}}, Ptr{Ptr{Cvoid}}),
                    f, gridDimX, gridDimY, gridDimZ, blockDimX, blockDimY, blockDimZ,
@@ -1247,7 +1247,7 @@ end
                                             blockDimY, blockDimZ, sharedMemBytes, hStream,
                                             kernelParams)
     initialize_api()
-    @runtime_ccall((:cuLaunchCooperativeKernel, libcuda()), CUresult,
+    @runtime_ccall((:cuLaunchCooperativeKernel_ptsz, libcuda()), CUresult,
                    (CUfunction, UInt32, UInt32, UInt32, UInt32, UInt32, UInt32, UInt32,
                     CUstream, Ptr{Ptr{Cvoid}}),
                    f, gridDimX, gridDimY, gridDimZ, blockDimX, blockDimY, blockDimZ,
@@ -1263,7 +1263,7 @@ end
 
 @checked function cuLaunchHostFunc(hStream, fn, userData)
     initialize_api()
-    @runtime_ccall((:cuLaunchHostFunc, libcuda()), CUresult,
+    @runtime_ccall((:cuLaunchHostFunc_ptsz, libcuda()), CUresult,
                    (CUstream, CUhostFn, Ptr{Cvoid}),
                    hStream, fn, userData)
 end
@@ -1574,7 +1574,7 @@ end
 
 @checked function cuGraphLaunch(hGraphExec, hStream)
     initialize_api()
-    @runtime_ccall((:cuGraphLaunch, libcuda()), CUresult,
+    @runtime_ccall((:cuGraphLaunch_ptsz, libcuda()), CUresult,
                    (CUgraphExec, CUstream),
                    hGraphExec, hStream)
 end
@@ -1996,14 +1996,14 @@ end
 
 @checked function cuGraphicsMapResources(count, resources, hStream)
     initialize_api()
-    @runtime_ccall((:cuGraphicsMapResources, libcuda()), CUresult,
+    @runtime_ccall((:cuGraphicsMapResources_ptsz, libcuda()), CUresult,
                    (UInt32, Ptr{CUgraphicsResource}, CUstream),
                    count, resources, hStream)
 end
 
 @checked function cuGraphicsUnmapResources(count, resources, hStream)
     initialize_api()
-    @runtime_ccall((:cuGraphicsUnmapResources, libcuda()), CUresult,
+    @runtime_ccall((:cuGraphicsUnmapResources_ptsz, libcuda()), CUresult,
                    (UInt32, Ptr{CUgraphicsResource}, CUstream),
                    count, resources, hStream)
 end

--- a/lib/cudadrv/stream.jl
+++ b/lib/cudadrv/stream.jl
@@ -1,7 +1,8 @@
 # Stream management
 
 export
-    CuStream, CuDefaultStream, priority, priority_range, synchronize
+    CuStream, CuDefaultStream, CuStreamLegacy, CuStreamPerThread,
+    priority, priority_range, synchronize
 
 
 mutable struct CuStream
@@ -49,6 +50,20 @@ end
 Return the default stream.
 """
 @inline CuDefaultStream() = CuStream(convert(CUstream, C_NULL), CuContext(C_NULL))
+
+"""
+    CuStreamLegacy()
+
+Return a special object to use use an implicit stream with legacy synchronization behavior.
+"""
+@inline CuStreamLegacy() = CuStream(convert(CUstream, 1), CuContext(C_NULL))
+
+"""
+    CuStreamPerThread()
+
+Return a special object to use an implicit stream with per-thread synchronization behavior.
+"""
+@inline CuStreamPerThread() = CuStream(convert(CUstream, 2), CuContext(C_NULL))
 
 """
     synchronize(s::CuStream)

--- a/lib/cudnn/CUDNN.jl
+++ b/lib/cudnn/CUDNN.jl
@@ -42,6 +42,7 @@ function handle()
         ctx = context()
         thread_handles[tid] = get!(task_local_storage(), (:CUDNN, ctx)) do
             handle = cudnnCreate()
+            cudnnSetStream(handle, CuStreamPerThread())
             finalizer(current_task()) do task
                 CUDA.isvalid(ctx) || return
                 context!(ctx) do

--- a/lib/cufft/fft.jl
+++ b/lib/cufft/fft.jl
@@ -93,8 +93,6 @@ function Base.show(io::IO, p::CuFFTPlan{T,K,inplace}) where {T,K,inplace}
     showfftdims(io, p.sz, T)
 end
 
-set_stream(plan::CuFFTPlan, stream::CuStream) = cufftSetStream(plan, stream)
-
 Base.size(p::CuFFTPlan) = p.sz
 
 
@@ -112,6 +110,7 @@ function create_plan(xtype, xdims, region)
     handle_ref = Ref{cufftHandle}()
     cufftCreate(handle_ref)
     handle = handle_ref[]
+    cufftSetStream(handle, CuStreamPerThread())
     cufftSetAutoAllocation(handle, 0)
 
     # make the plan

--- a/lib/curand/random.jl
+++ b/lib/curand/random.jl
@@ -12,6 +12,7 @@ mutable struct RNG <: Random.AbstractRNG
 
     function RNG(typ=CURAND_RNG_PSEUDO_DEFAULT)
         handle = curandCreateGenerator(typ)
+        curandSetStream(handle, CuStreamPerThread())
         obj = new(handle, context(), typ)
         finalizer(unsafe_destroy!, obj)
         return obj

--- a/lib/cusolver/CUSOLVER.jl
+++ b/lib/cusolver/CUSOLVER.jl
@@ -33,6 +33,7 @@ function dense_handle()
         ctx = context()
         thread_dense_handles[tid] = get!(task_local_storage(), (:CUSOLVER, :dense, ctx)) do
             handle = cusolverDnCreate()
+            cusolverDnSetStream(handle, CuStreamPerThread())
             finalizer(current_task()) do task
                 CUDA.isvalid(ctx) || return
                 context!(ctx) do
@@ -52,6 +53,7 @@ function sparse_handle()
         ctx = context()
         thread_sparse_handles[tid] = get!(task_local_storage(), (:CUSOLVER, :sparse, ctx)) do
             handle = cusolverSpCreate()
+            cusolverSpSetStream(handle, CuStreamPerThread())
             finalizer(current_task()) do task
                 CUDA.isvalid(ctx) || return
                 context!(ctx) do

--- a/lib/cusparse/CUSPARSE.jl
+++ b/lib/cusparse/CUSPARSE.jl
@@ -42,6 +42,7 @@ function handle()
         ctx = context()
         thread_handles[tid] = get!(task_local_storage(), (:CUSPARSE, ctx)) do
             handle = cusparseCreate()
+            cusparseSetStream(handle, CuStreamPerThread())
             finalizer(current_task()) do task
                 CUDA.isvalid(ctx) || return
                 context!(ctx) do

--- a/lib/cutensor/libcutensor.jl
+++ b/lib/cutensor/libcutensor.jl
@@ -28,11 +28,12 @@ end
     initialize_api()
     @runtime_ccall((:cutensorElementwiseTrinary, libcutensor()), cutensorStatus_t,
                    (Ptr{cutensorHandle_t}, Ptr{Cvoid}, PtrOrCuPtr{Cvoid},
-                    Ptr{cutensorTensorDescriptor_t}, Ptr{Int32}, Ptr{Cvoid}, PtrOrCuPtr{Cvoid},
-                    Ptr{cutensorTensorDescriptor_t}, Ptr{Int32}, Ptr{Cvoid}, PtrOrCuPtr{Cvoid},
-                    Ptr{cutensorTensorDescriptor_t}, Ptr{Int32}, PtrOrCuPtr{Cvoid},
-                    Ptr{cutensorTensorDescriptor_t}, Ptr{Int32}, cutensorOperator_t,
-                    cutensorOperator_t, cudaDataType_t, CUstream),
+                    Ptr{cutensorTensorDescriptor_t}, Ptr{Int32}, Ptr{Cvoid},
+                    PtrOrCuPtr{Cvoid}, Ptr{cutensorTensorDescriptor_t}, Ptr{Int32},
+                    Ptr{Cvoid}, PtrOrCuPtr{Cvoid}, Ptr{cutensorTensorDescriptor_t},
+                    Ptr{Int32}, PtrOrCuPtr{Cvoid}, Ptr{cutensorTensorDescriptor_t},
+                    Ptr{Int32}, cutensorOperator_t, cutensorOperator_t, cudaDataType_t,
+                    CUstream),
                    handle, alpha, A, descA, modeA, beta, B, descB, modeB, gamma, C, descC,
                    modeC, D, descD, modeD, opAB, opABC, typeScalar, stream)
 end
@@ -43,10 +44,10 @@ end
     initialize_api()
     @runtime_ccall((:cutensorElementwiseBinary, libcutensor()), cutensorStatus_t,
                    (Ptr{cutensorHandle_t}, Ptr{Cvoid}, PtrOrCuPtr{Cvoid},
-                    Ptr{cutensorTensorDescriptor_t}, Ptr{Int32}, Ptr{Cvoid}, PtrOrCuPtr{Cvoid},
-                    Ptr{cutensorTensorDescriptor_t}, Ptr{Int32}, PtrOrCuPtr{Cvoid},
-                    Ptr{cutensorTensorDescriptor_t}, Ptr{Int32}, cutensorOperator_t,
-                    cudaDataType_t, CUstream),
+                    Ptr{cutensorTensorDescriptor_t}, Ptr{Int32}, Ptr{Cvoid},
+                    PtrOrCuPtr{Cvoid}, Ptr{cutensorTensorDescriptor_t}, Ptr{Int32},
+                    PtrOrCuPtr{Cvoid}, Ptr{cutensorTensorDescriptor_t}, Ptr{Int32},
+                    cutensorOperator_t, cudaDataType_t, CUstream),
                    handle, alpha, A, descA, modeA, gamma, C, descC, modeC, D, descD, modeD,
                    opAC, typeScalar, stream)
 end
@@ -127,10 +128,11 @@ end
     initialize_api()
     @runtime_ccall((:cutensorReduction, libcutensor()), cutensorStatus_t,
                    (Ptr{cutensorHandle_t}, Ptr{Cvoid}, PtrOrCuPtr{Cvoid},
-                    Ptr{cutensorTensorDescriptor_t}, Ptr{Int32}, Ptr{Cvoid}, PtrOrCuPtr{Cvoid},
-                    Ptr{cutensorTensorDescriptor_t}, Ptr{Int32}, PtrOrCuPtr{Cvoid},
-                    Ptr{cutensorTensorDescriptor_t}, Ptr{Int32}, cutensorOperator_t,
-                    cutensorComputeType_t, PtrOrCuPtr{Cvoid}, UInt64, CUstream),
+                    Ptr{cutensorTensorDescriptor_t}, Ptr{Int32}, Ptr{Cvoid},
+                    PtrOrCuPtr{Cvoid}, Ptr{cutensorTensorDescriptor_t}, Ptr{Int32},
+                    PtrOrCuPtr{Cvoid}, Ptr{cutensorTensorDescriptor_t}, Ptr{Int32},
+                    cutensorOperator_t, cutensorComputeType_t, PtrOrCuPtr{Cvoid}, UInt64,
+                    CUstream),
                    handle, alpha, A, descA, modeA, beta, C, descC, modeC, D, descD, modeD,
                    opReduce, minTypeCompute, workspace, workspaceSize, stream)
 end
@@ -140,10 +142,11 @@ end
                                                 workspaceSize)
     initialize_api()
     @runtime_ccall((:cutensorReductionGetWorkspace, libcutensor()), cutensorStatus_t,
-                   (Ptr{cutensorHandle_t}, PtrOrCuPtr{Cvoid}, Ptr{cutensorTensorDescriptor_t},
-                    Ptr{Int32}, PtrOrCuPtr{Cvoid}, Ptr{cutensorTensorDescriptor_t}, Ptr{Int32},
-                    PtrOrCuPtr{Cvoid}, Ptr{cutensorTensorDescriptor_t}, Ptr{Int32},
-                    cutensorOperator_t, cutensorComputeType_t, Ptr{UInt64}),
+                   (Ptr{cutensorHandle_t}, PtrOrCuPtr{Cvoid},
+                    Ptr{cutensorTensorDescriptor_t}, Ptr{Int32}, PtrOrCuPtr{Cvoid},
+                    Ptr{cutensorTensorDescriptor_t}, Ptr{Int32}, PtrOrCuPtr{Cvoid},
+                    Ptr{cutensorTensorDescriptor_t}, Ptr{Int32}, cutensorOperator_t,
+                    cutensorComputeType_t, Ptr{UInt64}),
                    handle, A, descA_, modeA, C, descC_, modeC, D, descD_, modeD, opReduce,
                    typeCompute, workspaceSize)
 end
@@ -151,8 +154,8 @@ end
 @checked function cutensorGetAlignmentRequirement(handle, ptr, desc, alignmentRequirement)
     initialize_api()
     @runtime_ccall((:cutensorGetAlignmentRequirement, libcutensor()), cutensorStatus_t,
-                   (Ptr{cutensorHandle_t}, PtrOrCuPtr{Cvoid}, Ptr{cutensorTensorDescriptor_t},
-                    Ptr{UInt32}),
+                   (Ptr{cutensorHandle_t}, PtrOrCuPtr{Cvoid},
+                    Ptr{cutensorTensorDescriptor_t}, Ptr{UInt32}),
                    handle, ptr, desc, alignmentRequirement)
 end
 

--- a/lib/cutensor/wrappers.jl
+++ b/lib/cutensor/wrappers.jl
@@ -48,7 +48,7 @@ function elementwiseTrinary!(
     beta::Number,  B::CuArray, Binds::ModeType, opB::cutensorOperator_t,
     gamma::Number, C::CuArray{T}, Cinds::ModeType, opC::cutensorOperator_t,
     D::CuArray{T}, Dinds::ModeType, opAB::cutensorOperator_t,
-    opABC::cutensorOperator_t; stream::CuStream=CuDefaultStream()) where {T}
+    opABC::cutensorOperator_t; stream::CuStream=CuStreamPerThread()) where {T}
 
     !is_unary(opA)    && throw(ArgumentError("opA must be a unary op!"))
     !is_unary(opB)    && throw(ArgumentError("opB must be a unary op!"))
@@ -78,7 +78,7 @@ function elementwiseTrinary!(
     beta::Number, B::Array, Binds::ModeType, opB::cutensorOperator_t,
     gamma::Number, C::Array{T}, Cinds::ModeType, opC::cutensorOperator_t,
     D::Array{T}, Dinds::ModeType, opAB::cutensorOperator_t,
-    opABC::cutensorOperator_t; stream::CuStream=CuDefaultStream()) where {T}
+    opABC::cutensorOperator_t; stream::CuStream=CuStreamPerThread()) where {T}
 
     !is_unary(opA)    && throw(ArgumentError("opA must be a unary op!"))
     !is_unary(opB)    && throw(ArgumentError("opB must be a unary op!"))
@@ -107,7 +107,7 @@ function elementwiseBinary!(
     alpha::Number, A::CuArray, Ainds::ModeType, opA::cutensorOperator_t,
     gamma::Number, C::CuArray{T}, Cinds::ModeType, opC::cutensorOperator_t,
     D::CuArray{T}, Dinds::ModeType, opAC::cutensorOperator_t;
-    stream::CuStream=CuDefaultStream()) where {T}
+    stream::CuStream=CuStreamPerThread()) where {T}
 
     !is_unary(opA)    && throw(ArgumentError("opA must be a unary op!"))
     !is_unary(opC)    && throw(ArgumentError("opC must be a unary op!"))
@@ -131,7 +131,7 @@ function elementwiseBinary!(
     alpha::Number, A::Array, Ainds::ModeType, opA::cutensorOperator_t,
     gamma::Number, C::Array{T}, Cinds::ModeType, opC::cutensorOperator_t,
     D::Array{T}, Dinds::ModeType, opAC::cutensorOperator_t;
-    stream::CuStream=CuDefaultStream()) where {T}
+    stream::CuStream=CuStreamPerThread()) where {T}
 
     !is_unary(opA)    && throw(ArgumentError("opA must be a unary op!"))
     !is_unary(opC)    && throw(ArgumentError("opC must be a unary op!"))
@@ -152,7 +152,7 @@ function elementwiseBinary!(
 end
 
 function elementwiseBinary!(
-    alpha::Number, A::CuTensor, opA::cutensorOperator_t, gamma::Number, C::CuTensor{T}, opC::cutensorOperator_t, D::CuTensor{T}, opAC::cutensorOperator_t; stream::CuStream=CuDefaultStream()) where {T}
+    alpha::Number, A::CuTensor, opA::cutensorOperator_t, gamma::Number, C::CuTensor{T}, opC::cutensorOperator_t, D::CuTensor{T}, opAC::cutensorOperator_t; stream::CuStream=CuStreamPerThread()) where {T}
 
     !is_unary(opA)    && throw(ArgumentError("opA must be a unary op!"))
     !is_unary(opC)    && throw(ArgumentError("opC must be a unary op!"))
@@ -170,7 +170,7 @@ function elementwiseBinary!(
 end
 
 function permutation!(alpha::Number, A::CuArray, Ainds::ModeType,
-                      B::CuArray, Binds::ModeType; stream::CuStream=CuDefaultStream())
+                      B::CuArray, Binds::ModeType; stream::CuStream=CuStreamPerThread())
     #!is_unary(opPsi)    && throw(ArgumentError("opPsi must be a unary op!"))
     descA = CuTensorDescriptor(A)
     descB = CuTensorDescriptor(B)
@@ -182,7 +182,7 @@ function permutation!(alpha::Number, A::CuArray, Ainds::ModeType,
     return B
 end
 function permutation!(alpha::Number, A::Array, Ainds::ModeType,
-                      B::Array, Binds::ModeType; stream::CuStream=CuDefaultStream())
+                      B::Array, Binds::ModeType; stream::CuStream=CuStreamPerThread())
     #!is_unary(opPsi)    && throw(ArgumentError("opPsi must be a unary op!"))
     descA = CuTensorDescriptor(A)
     descB = CuTensorDescriptor(B)
@@ -200,7 +200,7 @@ function contraction!(
     beta::Number,  C::Union{Array, CuArray}, Cinds::ModeType, opC::cutensorOperator_t,
                                                 opOut::cutensorOperator_t;
     pref::cutensorWorksizePreference_t=CUTENSOR_WORKSPACE_RECOMMENDED,
-    algo::cutensorAlgo_t=CUTENSOR_ALGO_DEFAULT, stream::CuStream=CuDefaultStream(),
+    algo::cutensorAlgo_t=CUTENSOR_ALGO_DEFAULT, stream::CuStream=CuStreamPerThread(),
     compute_type::Type=eltype(C), plan::Union{cutensorContractionPlan_t, Nothing}=nothing)
 
     !is_unary(opA)    && throw(ArgumentError("opA must be a unary op!"))
@@ -302,7 +302,7 @@ end
 function reduction!(
     alpha::Number, A::Union{Array, CuArray}, Ainds::ModeType, opA::cutensorOperator_t,
     beta::Number,  C::Union{Array, CuArray}, Cinds::ModeType, opC::cutensorOperator_t,
-    opReduce::cutensorOperator_t; stream::CuStream=CuDefaultStream())
+    opReduce::cutensorOperator_t; stream::CuStream=CuStreamPerThread())
 
     !is_unary(opA)    && throw(ArgumentError("opA must be a unary op!"))
     !is_unary(opC)    && throw(ArgumentError("opC must be a unary op!"))

--- a/res/wrap/patches/cublas/computetype.patch
+++ b/res/wrap/patches/cublas/computetype.patch
@@ -1,5 +1,5 @@
---- a/lib/cublas/libcublas.jl
-+++ b/lib/cublas/libcublas.jl
+--- a/libcublas.jl
++++ b/libcublas.jl
 @@ -1414,7 +1414,7 @@ end
                     (cublasHandle_t, cublasOperation_t, cublasOperation_t, Cint, Cint,
                      Cint, PtrOrCuPtr{Cvoid}, CuPtr{Cvoid}, cudaDataType, Cint,

--- a/res/wrap/patches/cudadrv/batched_memop.patch
+++ b/res/wrap/patches/cudadrv/batched_memop.patch
@@ -3,7 +3,7 @@
 @@ -937,7 +937,0 @@
 -@checked function cuStreamBatchMemOp(stream, count, paramArray, flags)
 -    initialize_api()
--    @runtime_ccall((:cuStreamBatchMemOp, libcuda()), CUresult,
+-    @runtime_ccall((:cuStreamBatchMemOp_ptsz, libcuda()), CUresult,
 -                   (CUstream, UInt32, Ptr{CUstreamBatchMemOpParams}, UInt32),
 -                   stream, count, paramArray, flags)
 -end

--- a/res/wrap/pointers.json
+++ b/res/wrap/pointers.json
@@ -5283,7 +5283,7 @@
         "modeD": "Ptr",
         "opReduce": null,
         "minTypeCompute": null,
-        "workspace": "CuPtr",
+        "workspace": "PtrOrCuPtr",
         "workspaceSize": null,
         "stream": null
     },
@@ -16088,7 +16088,7 @@
     },
     "cutensorGetAlignmentRequirement": {
         "handle": "Ptr",
-        "ptr": "CuPtr",
+        "ptr": "PtrOrCuPtr",
         "desc": "Ptr",
         "alignmentRequirement": "Ptr"
     },

--- a/test/cufft.jl
+++ b/test/cufft.jl
@@ -298,5 +298,4 @@ end
     X = rand(N1)
     d_X = CuArray(X)
     p = plan_fft(d_X)
-    CUFFT.set_stream(p, CUDA.CuDefaultStream())
 end


### PR DESCRIPTION
This PR changes two things threading and stream-related:
- call the PTDS/PTSZ variants of CUDA driver methods, which automatically select a per-thread stream when you (implicitly) requested the default one (handle 0x0)
- for libraries, explicitly use the special per-thread stream (handle 0x2)

As a result, we get the new default stream semantics where operations on streams don't get synchronized by the global default stream anymore:

```julia
using CUDA

N = 1 << 20

function kernel(x, n)
    tid = threadIdx().x + (blockIdx().x-1) * blockDim().x
    for i = tid:blockDim().x*gridDim().x:n
        x[i] = CUDA.sqrt(CUDA.pow(3.14159f0, i))
    end
    return
end

num_streams = 8

for i in 1:num_streams
    stream = CuStream()

    data = CuArray{Float32}(undef, N)

    @cuda blocks=1 threads=64 stream=stream kernel(data, N)

    @cuda kernel(data,0)
end
```

Before:
![multistream_before](https://user-images.githubusercontent.com/383068/91302554-f89f5380-e7a6-11ea-9954-857c7367506b.png)

After:
![multistream_after](https://user-images.githubusercontent.com/383068/91302563-fb01ad80-e7a6-11ea-93aa-a91a9d87bcde.png)

Another, maybe more important consequence is that we automatically get concurrent execution on different threads:

```julia
using CUDA

N = 1 << 20

function kernel(x, n)
    tid = threadIdx().x + (blockIdx().x-1) * blockDim().x
    for i = tid:blockDim().x*gridDim().x:n
        x[i] = CUDA.sqrt(CUDA.pow(3.14159f0, i))
    end
    return
end

Threads.@threads for i in 1:Threads.nthreads()
    data = CuArray{Float32}(undef, N)
    @cuda blocks=1 threads=64 kernel(data, N)
    synchronize(CuDefaultStream())
end
```

Before:
![multithread_before](https://user-images.githubusercontent.com/383068/91302654-1967a900-e7a7-11ea-842a-0ffd945d00e8.png)

After:
![multithread_after](https://user-images.githubusercontent.com/383068/91302660-1a98d600-e7a7-11ea-96ee-f60b5ade3bc2.png)

Thanks to @marius311 for making me read https://developer.nvidia.com/blog/gpu-pro-tip-cuda-7-streams-simplify-concurrency/ again (this time implementing its features) :-)

cc @vchuravy @kshyatt 