### PR TITLE
Force specialization for dynamic_cudacall to support more arguments.

### DIFF
--- a/src/compiler/execution.jl
+++ b/src/compiler/execution.jl
@@ -360,9 +360,9 @@ end
     dynamic_cudacall(kernel.fun, tt, args...; kwargs...)
 
 # FIXME: duplication with cudacall
-@generated function dynamic_cudacall(f::Ptr{Cvoid}, tt::Type, args...;
+@generated function dynamic_cudacall(f::Ptr{Cvoid}, tt::Type{T}, args::Vararg{Any,N};
                                      blocks=UInt32(1), threads=UInt32(1), shmem=UInt32(0),
-                                     stream=CuDefaultStream())
+                                     stream=CuDefaultStream()) where {T,N}
     types = tt.parameters[1].parameters     # the type of `tt` is Type{Tuple{<:DataType...}}
 
     ex = quote

--- a/test/execution.jl
+++ b/test/execution.jl
@@ -972,6 +972,32 @@ end
     end
 end
 
+@testset "many arguments" begin
+    # JuliaGPU/CUDA.jl#401
+    function dp_5arg_kernel(v1, v2, v3, v4, v5)
+        return nothing
+    end
+
+    function dp_6arg_kernel(v1, v2, v3, v4, v5, v6)
+        return nothing
+    end
+
+    function main_5arg_kernel()
+        @cuda threads=1 dynamic=true dp_5arg_kernel(1, 1, 1, 1, 1)
+        return nothing
+    end
+
+    function main_6arg_kernel()
+        @cuda threads=1 dynamic=true dp_6arg_kernel(1, 1, 1, 1, 1, 1)
+        return nothing
+    end
+
+    @cuda threads=1 dp_5arg_kernel(1, 1, 1, 1, 1)
+    @cuda threads=1 dp_6arg_kernel(1, 1, 1, 1, 1, 1)
+    @cuda threads=1 main_5arg_kernel()
+    @cuda threads=1 main_6arg_kernel()
+end
+
 end
 
 ############################################################################################


### PR DESCRIPTION
Fixes https://github.com/JuliaGPU/CUDA.jl/issues/401