### PR TITLE
add CuSparseMatrixCOO

### DIFF
--- a/lib/cusparse/conversions.jl
+++ b/lib/cusparse/conversions.jl
@@ -122,6 +122,23 @@ for (fname,elty) in ((:cusparseSbsr2csr, :Float32),
     end
 end
 
+## CSR to COO and vice-versa
+
+function CuSparseMatrixCSR(coo::CuSparseMatrixCOO{Tv}, ind::SparseChar='O') where {Tv}
+    m,n = coo.dims
+    nnz = coo.nnz
+    csrRowPtr = CUDA.zeros(Cint, nnz)
+    cusparseXcoo2csr(handle(), coo.rowInd, nnz, m, csrRowPtr, ind)
+    CuSparseMatrixCSR{Tv}(csrRowPtr, coo.colInd, coo.nzVal, coo.dims)
+end
+
+function CuSparseMatrixCOO(csr::CuSparseMatrixCSR{Tv}, ind::SparseChar='O') where {Tv}
+    m,n = csr.dims
+    nnz = csr.nnz
+    cooRowInd = CUDA.zeros(Cint, nnz)
+    cusparseXcsr2coo(handle(), csr.rowPtr, nnz, m, cooRowInd, ind)
+    CuSparseMatrixCOO{Tv}(cooRowInd, csr.colVal, csr.nzVal, csr.dims, nnz)
+end
 
 ## sparse to dense, and vice-versa
 

--- a/test/cusparse.jl
+++ b/test/cusparse.jl
@@ -144,10 +144,18 @@ end
             @test collect(d_x) ≈ x
         end
 
-        @testset "CSR(CSC)" begin
+        @testset "CSR(::CSC)" begin
             x = sprand(elty,m,n, 0.2)
             d_x = CuSparseMatrixCSC(x)
             d_x = CuSparseMatrixCSR(d_x)
+            @test collect(d_x) == collect(x)
+        end
+
+        @testset "COO ↔ CSR" begin
+            x = sprand(elty,m,n, 0.2)
+            d_x = CuSparseMatrixCSR(x);
+            d_x = CuSparseMatrixCOO(d_x);
+            d_x = CuSparseMatrixCSR(d_x);
             @test collect(d_x) == collect(x)
         end
 
@@ -158,7 +166,7 @@ end
             @test h_x ≈ Array(x)
         end
 
-        @testset "Dense(CSC)" begin
+        @testset "Dense(::CSC)" begin
             x = sprand(elty,m,n, 0.2)
             d_x = CuSparseMatrixCSC(x)
             h_x = collect(d_x)

--- a/test/cusparse.jl
+++ b/test/cusparse.jl
@@ -118,6 +118,12 @@ end
             d_x  = CuSparseMatrixBSR(x, blockdim)
             @test collect(d_x) == collect(x)
         end
+
+        @testset "BSR" begin
+            x = sprand(elty,m,n, 0.2)
+            d_x  = CuSparseMatrixCOO(x)
+            @test collect(d_x) == collect(x)
+        end
     end
 end
 
@@ -130,12 +136,20 @@ end
             @test collect(d_x) == collect(x)
         end
 
+        @testset "CSR(::CSC)" begin
+            x = sprand(elty,m,n, 0.2)
+            d_x = CuSparseMatrixCSC(x)
+            d_x = CuSparseMatrixCSR(d_x)
+            @test collect(d_x) == collect(x)
+        end
+
         @testset "BSR(::CSR)" begin
             x = sprand(elty,m,n, 0.2)
             d_x = CuSparseMatrixCSR(x)
             d_x = CuSparseMatrixBSR(d_x, blockdim)
             @test collect(d_x) == collect(x)
         end
+        # CSR(::BSR) already covered by the non-direct collect
 
         @testset "BSR(::Dense)" begin
             x = rand(elty,m,n)
@@ -144,20 +158,13 @@ end
             @test collect(d_x) ≈ x
         end
 
-        @testset "CSR(::CSC)" begin
+        @testset "COO(::CSR)" begin
             x = sprand(elty,m,n, 0.2)
-            d_x = CuSparseMatrixCSC(x)
-            d_x = CuSparseMatrixCSR(d_x)
+            d_x = CuSparseMatrixCSR(x)
+            d_x = CuSparseMatrixCOO(d_x)
             @test collect(d_x) == collect(x)
         end
-
-        @testset "COO ↔ CSR" begin
-            x = sprand(elty,m,n, 0.2)
-            d_x = CuSparseMatrixCSR(x);
-            d_x = CuSparseMatrixCOO(d_x);
-            d_x = CuSparseMatrixCSR(d_x);
-            @test collect(d_x) == collect(x)
-        end
+        # CSR(::COO) already covered by the non-direct collect
 
         @testset "Dense(::CSR)" begin
             x = sprand(elty,m,n, 0.2)


### PR DESCRIPTION
Adds a simple `CuSparseMatrixCOO` matrix type and implements conversion to/from CSR. The motivation is that COO is often the easiest format to construct a matrix in, so its nice to be able to do that then convert to the other formats entirely on GPU. Essentially no other functionality is implemented but this alone I think should help. If other stuff is desired, let me know the minimum other functionality you'd  need before accepting this PR. 

Fixes https://github.com/JuliaGPU/CUDA.jl/issues/220