### PR TITLE
Global math mode for easy use of lower-precision functionality

### DIFF
--- a/lib/cublas/libcublas.jl
+++ b/lib/cublas/libcublas.jl
@@ -76,14 +76,14 @@ end
 @checked function cublasGetMathMode(handle, mode)
     initialize_api()
     @runtime_ccall((:cublasGetMathMode, libcublas()), cublasStatus_t,
-                   (cublasHandle_t, Ref{cublasMath_t}),
+                   (cublasHandle_t, Ref{UInt32}),
                    handle, mode)
 end
 
 @checked function cublasSetMathMode(handle, mode)
     initialize_api()
     @runtime_ccall((:cublasSetMathMode, libcublas()), cublasStatus_t,
-                   (cublasHandle_t, cublasMath_t),
+                   (cublasHandle_t, UInt32),
                    handle, mode)
 end
 

--- a/lib/cublas/wrappers.jl
+++ b/lib/cublas/wrappers.jl
@@ -45,9 +45,9 @@ function cublasGetProperty(property::libraryPropertyType)
   value_ref[]
 end
 
-function version()
+function version(handle=handle())
   version_ref = Ref{Cint}()
-  cublasGetVersion_v2(handle(), version_ref)
+  cublasGetVersion_v2(handle, version_ref)
   major, rem = divrem(version_ref[], 1000)
   minor, patch = divrem(rem, 100)
   VersionNumber(major, minor, patch)
@@ -755,8 +755,7 @@ for (fname, elty) in
     end
 end
 
-function gemmExComputeType(TA, TB, TC, m, k, n; pedantic=false, fast=false)
-    @assert !(pedantic || fast) || (pedantic ⊻ fast)
+function gemmExComputeType(TA, TB, TC, m, k, n)
     if TA !== TB
         return nothing
     end
@@ -768,22 +767,32 @@ function gemmExComputeType(TA, TB, TC, m, k, n; pedantic=false, fast=false)
         return nothing
     end
 
+    math_mode = CUDA.math_mode()
+    reduced_precision = CUDA.math_precision()
+
     if sig === (Float16, Float16)
         # NOTE: Float16=Float16*Float16 can also happen in 32-bit compute
-        return pedantic ? CUBLAS_COMPUTE_16F_PEDANTIC : CUBLAS_COMPUTE_16F
+        return math_mode==CUDA.PEDANTIC_MATH ? CUBLAS_COMPUTE_16F_PEDANTIC : CUBLAS_COMPUTE_16F
     end
 
     if m%4 == 0 && n%4 == 0 && k%4 == 0 && sig === (Int8, Int32)
         # Int32=Int8*Int8 requires m,n,k to be multiples of 4
         # https://forums.developer.nvidia.com/t/cublasgemmex-cant-use-cuda-r-8i-compute-type-on-gtx1080/58100/2
-        return pedantic ? CUBLAS_COMPUTE_32I_PEDANTIC : CUBLAS_COMPUTE_32I
+        return math_mode==CUDA.PEDANTIC_MATH ? CUBLAS_COMPUTE_32I_PEDANTIC : CUBLAS_COMPUTE_32I
     end
 
-    if fast
+    if math_mode == CUDA.FAST_MATH
         if sig === (Float32, Float32) ||
-           sig === (Complex{Float32}, Complex{Float32}) ||
-            # TODO: select between 16F, 16BF and TF32
-            return CUBLAS_COMPUTE_32F_FAST_16F
+           sig === (Complex{Float32}, Complex{Float32})
+            if reduced_precision === :Float16
+                return CUBLAS_COMPUTE_32F_FAST_16F
+            elseif reduced_precision === :BFloat16
+                return CUBLAS_COMPUTE_32F_FAST_16BF
+            elseif reduced_precision === :TensorFloat32
+                return CUBLAS_COMPUTE_32F_FAST_TF32
+            else
+                throw(ArgumentError("Unknown reduced precision type $reduced_precision"))
+            end
         end
     end
 
@@ -793,19 +802,19 @@ function gemmExComputeType(TA, TB, TC, m, k, n; pedantic=false, fast=false)
        sig === (Float32,  Float32) ||
        sig === (Complex{Int8},    Complex{Float32}) ||
        sig === (Complex{Float32}, Complex{Float32})
-        return pedantic ? CUBLAS_COMPUTE_32F_PEDANTIC : CUBLAS_COMPUTE_32F
+        return math_mode==CUDA.PEDANTIC_MATH ? CUBLAS_COMPUTE_32F_PEDANTIC : CUBLAS_COMPUTE_32F
     end
 
     if sig === (Float64, Float64) ||
        sig === (Complex{Float64}, Complex{Float64})
-        return pedantic ? CUBLAS_COMPUTE_64F_PEDANTIC : CUBLAS_COMPUTE_64F
+        return math_mode==CUDA.PEDANTIC_MATH ? CUBLAS_COMPUTE_64F_PEDANTIC : CUBLAS_COMPUTE_64F
     end
 
     # BFloat16 support was added in CUDA 11
     if version() >= v"11"
         if sig === (BFloat16, BFloat16) ||
            sig === (BFloat16, Float32)
-            return pedantic ? CUBLAS_COMPUTE_32F_PEDANTIC : CUBLAS_COMPUTE_32F
+            return math_mode==CUDA.PEDANTIC_MATH ? CUBLAS_COMPUTE_32F_PEDANTIC : CUBLAS_COMPUTE_32F
         end
     end
 

--- a/src/state.jl
+++ b/src/state.jl
@@ -439,6 +439,12 @@ function math_mode!(mode::MathMode; precision=nothing)
         default_math_precision[] = precision
     end
 
+    # reapply the CUBLAS math mode if it had been set already
+    cublas_handle = get(tls, (:CUBLAS, ctx), nothing)
+    if cublas_handle !== nothing
+        CUBLAS.math_mode!(cublas_handle, mode)
+    end
+
     return
 end
 

--- a/src/state.jl
+++ b/src/state.jl
@@ -405,3 +405,49 @@ Base.size(x::PerDevice) = size(x.inner)
 function Base.show(io::IO, mime::MIME"text/plain", x::PerDevice{T}) where {T}
     print(io, "PerDevice{$T} with $(length(x)) entries")
 end
+
+
+## math mode
+
+@enum MathMode begin
+    # use prescribed precision and standardized arithmetic for all calculations.
+    # this may serialize operations, and reduce performance.
+    PEDANTIC_MATH
+
+    # use at least the required precision, and allow reordering operations for performance.
+    DEFAULT_MATH
+
+    # additionally allow downcasting operations for better use of hardware resources.
+    # whenever possible the `precision` flag passed to `math_mode!` will be used
+    # to constrain those downcasts.
+    FAST_MATH
+end
+
+# math mode and precision are sticky (once set on a task, inherit to newly created tasks)
+const default_math_mode = Ref{Union{Nothing,MathMode}}(nothing)
+const default_math_precision = Ref{Union{Nothing,Symbol}}(nothing)
+
+function math_mode!(mode::MathMode; precision=nothing)
+    # make sure we initialize first, or recursion might overwrite the math mode
+    ctx = context()
+
+    tls = task_local_storage()
+    tls[(:CUDA, :math_mode)] = mode
+    default_math_mode[] = mode
+    if precision !== nothing
+        tls[(:CUDA, :math_precision)] = precision
+        default_math_precision[] = precision
+    end
+
+    return
+end
+
+math_mode() =
+    get!(task_local_storage(), (:CUDA, :math_mode)) do
+        something(default_math_mode[],
+                  Base.JLOptions().fast_math==1 ? FAST_MATH : DEFAULT_MATH)
+    end
+math_precision() =
+    get!(task_local_storage(), (:CUDA, :math_precision)) do
+        something(default_math_precision[], :TensorFloat32)
+    end


### PR DESCRIPTION
Fixes https://github.com/JuliaGPU/CUDA.jl/issues/354:

- 3 possible math modes: pedantic (like a CPU), default (use tensor cores), fast (tensor cores + lower precision calculations). This means the default now changes to using tensor cores.
- per-task value, 'inherited' when creating new tasks
- CUDA-level API that configures all submodules:

```julia
julia> CUDA.math_mode!(CUDA.FAST_MATH; precision=:Float16)
I! cuBLAS (v11.0) function cublasStatus_t cublasSetMathMode(cublasHandle_t, cublasMath_t) called:
i!  handle: type=cublasHandle_t; val=POINTER (IN HEX:0x0xb87b3d0)
i!  mode: type=cublasMath_t; val=CUBLAS_TENSOR_OP_MATH | CUBLAS_MATH_DISALLOW_REDUCED_PRECISION_REDUCTION(17)
i! Time: 2020-09-14T13:54:41 elapsed from start 2.783333 minutes or 167.000000 seconds
i!Process=107610; Thread=139770769617472; GPU=0; Handle=POINTER (IN HEX:0x0xb87b3d0); StreamId=POINTER (IN HEX:0x0x2); MathMode=CUBLAS_DEFAULT_MATH | CUBLAS_MATH_DISALLOW_REDUCED_PRECISION_REDUCTION
i! COMPILED WITH: GNU GCC/G++ / 5.3.1 20160406 (Red Hat 5.3.1-6)

julia> mul!(CuArray(zeros(Float32,2,2)), CuArray(rand(Float32,2,2)), CuArray(rand(Float32,2,2)))
I! cuBLAS (v11.0) function cublasStatus_t cublasGemmEx(cublasHandle_t, cublasOperation_t, cublasOperation_t, int, int, int, const void*, const void*, cudaDataType_t, int, const void*, cudaDataType_t, int, const void*, void*, cudaDataType_t, int, cublasComputeType_t, cublasGemmAlgo_t) called:
i!  handle: type=cublasHandle_t; val=POINTER (IN HEX:0x0xb87b3d0)
i!  transa: type=cublasOperation_t; val=CUBLAS_OP_N(0)
i!  transb: type=cublasOperation_t; val=CUBLAS_OP_N(0)
i!  m: type=int; val=2
i!  n: type=int; val=2
i!  k: type=int; val=2
i!  alpha: type=void; val=POINTER (IN HEX:0x0x7f1ea78a7370)
i!  A: type=void; val=POINTER (IN HEX:0x0x7f1dc6c00200)
i!  Atype: type=cudaDataType_t; val=CUDA_R_32F(0)
i!  lda: type=int; val=2
i!  B: type=void; val=POINTER (IN HEX:0x0x7f1dc6c20e00)
i!  Btype: type=cudaDataType_t; val=CUDA_R_32F(0)
i!  ldb: type=int; val=2
i!  beta: type=void; val=POINTER (IN HEX:0x0x7f1ea78a7380)
i!  C: type=void; val=POINTER (IN HEX:0x0x7f1dc6c42400)
i!  Ctype: type=cudaDataType_t; val=CUDA_R_32F(0)
i!  ldc: type=int; val=2
i!  computeType: type=cublasComputeType_t; val=CUBLAS_COMPUTE_32F_FAST_16F(74)
i!  algo: type=SOME TYPE; val=CUBLAS_GEMM_DEFAULT(-1)
i! Time: 2020-09-14T13:54:45 elapsed from start 2.850000 minutes or 171.000000 seconds
i!Process=107610; Thread=139770769617472; GPU=0; Handle=POINTER (IN HEX:0x0xb87b3d0); StreamId=POINTER (IN HEX:0x0x2); MathMode=CUBLAS_TENSOR_OP_MATH | CUBLAS_MATH_DISALLOW_REDUCED_PRECISION_REDUCTION
i! COMPILED WITH: GNU GCC/G++ / 5.3.1 20160406 (Red Hat 5.3.1-6)
2×2 CuArray{Float32,2}:
 0.175258  0.226159
 0.511893  0.331351
```

Note the `CUBLAS_COMPUTE_32F_FAST_16F`

TODO: same treatment for CUDNN