### PR TITLE
CUDA quicksort

### DIFF
--- a/perf/array.jl
+++ b/perf/array.jl
@@ -90,3 +90,9 @@ let group = addgroup!(group, "random")
         #group["Int64"] = @async_benchmarkable CUDA.randn!($gpu_vec_ints)
     end
 end
+
+let group = addgroup!(group, "sorting")
+    group["1d"] = @async_benchmarkable sort($gpu_vec)
+    group["2d"] = @async_benchmarkable sort($gpu_mat; dims=1)
+    group["by"] = @async_benchmarkable sort($gpu_vec; by=sin)
+end

--- a/src/CUDA.jl
+++ b/src/CUDA.jl
@@ -84,6 +84,7 @@ include("nnlib.jl")
 include("iterator.jl")
 include("statistics.jl")
 include("random.jl")
+include("sorting.jl")
 
 # other libraries
 include("../lib/nvml/NVML.jl")

--- a/src/device/array.jl
+++ b/src/device/array.jl
@@ -59,6 +59,8 @@ Base.elsize(::Type{<:CuDeviceArray{T}}) where {T} = sizeof(T)
 Base.size(g::CuDeviceArray) = g.shape
 Base.length(g::CuDeviceArray) = prod(g.shape)
 
+Base.sizeof(x::CuDeviceArray) = Base.elsize(x) * length(x)
+
 
 ## conversions
 

--- a/src/device/intrinsics/output.jl
+++ b/src/device/intrinsics/output.jl
@@ -114,6 +114,7 @@ const cuprint_specifiers = Dict(
     # other
     Cchar       => "%c",
     Ptr{Cvoid}  => "%p",
+    Cstring     => "%s",
 )
 
 @generated function _cuprint(parts...)

--- a/src/sorting.jl
+++ b/src/sorting.jl
@@ -352,7 +352,7 @@ function qsort_kernel(vals::AbstractArray{T}, lo, hi, parity, sync::Val{S}, sync
     return
 end
 
-function quicksort!(c::AbstractArray{T}; lt=isless) where T
+function quicksort!(c::AbstractArray{T}; lt::F) where {T,F}
     MAX_DEPTH = CUDA.limit(CUDA.LIMIT_DEV_RUNTIME_SYNC_DEPTH)
     N = length(c)
 
@@ -376,7 +376,7 @@ end
 
 using .Quicksort
 
-function Base.sort!(c::CuArray{T}; dims::Integer, rev::Bool=false) where T
+function Base.sort!(c::CuArray{T}; dims::Integer, lt::F=isless, rev::Bool=false) where {T,F}
     nd = ndims(c)
     k = dims
     sz = size(c)
@@ -389,16 +389,16 @@ function Base.sort!(c::CuArray{T}; dims::Integer, rev::Bool=false) where T
         else
             v = view(c, ntuple(i -> i == k ? Colon() : idx[i], nd)...)
         end
-        quicksort!(v)
+        quicksort!(v; lt)
     end
     c
 end
 
-function Base.sort!(c::CuVector{T}; rev=false) where T
+function Base.sort!(c::CuVector{T}; lt::F=isless, rev=false) where {T,F}
     if rev
-        quicksort!(view(c, range(length(c), 1, step=-1)))
+        quicksort!(view(c, range(length(c), 1, step=-1)); lt)
     else
-        quicksort!(c)
+        quicksort!(c; lt)
     end
     c
 end

--- a/src/sorting.jl
+++ b/src/sorting.jl
@@ -31,17 +31,6 @@ using ..CUDA
 # Integer arithmetic
 
 """
-Returns smallest power of 2 < x
-"""
-function pow2_floor(x)
-    out = 1
-    while out * 2 <= x
-        out *= 2
-    end
-    out
-end
-
-"""
 For a batch of size `n` what is the lowest index of the batch `i` is in
 """
 function batch_floor(idx, n)
@@ -371,8 +360,7 @@ function quicksort!(c::AbstractArray{T}) where T
 
     get_shmem(threads) = threads * (sizeof(Int32) + max(4, sizeof(T)))
     config = launch_configuration(kernel.fun, shmem=threads->get_shmem(threads))
-    threads = pow2_floor(config.threads)
-    @assert threads <= config.threads
+    threads = prevpow(2, config.threads)
 
     kernel(c, 0, N, true, Val(MAX_DEPTH > 1), MAX_DEPTH, nothing;
            blocks=1, threads=threads, shmem=get_shmem(threads))

--- a/src/sorting.jl
+++ b/src/sorting.jl
@@ -400,6 +400,9 @@ function quicksort!(c::AbstractArray{T,N}; lt::F1, by::F2, dims::Int) where {T,N
     max_depth = CUDA.limit(CUDA.LIMIT_DEV_RUNTIME_SYNC_DEPTH)
     len = size(c, dims)
 
+    lt = CUDA.cufunc(lt)
+    by = CUDA.cufunc(by)
+
     1 <= dims <= N || throw(ArgumentError("dimension out of range"))
     otherdims = ntuple(i -> i == dims ? 1 : size(c, i), N)
 

--- a/src/sorting.jl
+++ b/src/sorting.jl
@@ -382,13 +382,14 @@ function Base.sort!(c::CuArray{T}; dims::Integer, lt::F=isless, rev::Bool=false)
     sz = size(c)
     1 <= k <= nd || throw(ArgumentError("dimension out of range"))
 
+    # for reverse sorting, invert the less-than function
+    if rev
+        lt = !lt
+    end
+
     remdims = ntuple(i -> i == k ? 1 : size(c, i), nd)
     for idx in CartesianIndices(remdims)
-        if rev
-            v = view(c, ntuple(i -> i == k ? range(sz[i], 1, step=-1) : idx[i], nd)...)
-        else
-            v = view(c, ntuple(i -> i == k ? Colon() : idx[i], nd)...)
-        end
+        v = view(c, ntuple(i -> i == k ? Colon() : idx[i], nd)...)
         quicksort!(v; lt)
     end
     c

--- a/src/sorting.jl
+++ b/src/sorting.jl
@@ -292,8 +292,9 @@ Partition batches in a loop using a single block
 """
 @inline function call_batch_partition(vals::AbstractArray{T}, pivot, swap, b_sums, lo, hi,
                                       parity, sync::Val{false}, lt::F1, by::F2) where {T, F1, F2}
-    for temp in lo:blockDim().x:hi
-        batch_partition(vals, pivot, swap, b_sums, temp, min(hi, temp + blockDim().x), parity, lt, by)
+    while lo <= hi
+        batch_partition(vals, pivot, swap, b_sums, lo, min(hi, lo + blockDim().x), parity, lt, by)
+        lo += blockDim().x
     end
 end
 

--- a/src/sorting.jl
+++ b/src/sorting.jl
@@ -1,0 +1,423 @@
+"""
+Quicksort!
+Alex Ellison
+@xaellison
+Usage:
+sort!(my_cuarray)
+The main quicksort kernel uses dynamic parallelism. Let's call blocksize M. The
+first part of the kernel bubble sorts M elements with maximal stride between
+lo and hi. If the sublist is <= M elements, stride = 1 and no recursion
+happens. Otherwise, we pick element lo + M ÷ 2 * stride as a pivot. This is
+an efficient choice for random lists and pre-sorted lists.
+
+Partition is done in stages:
+1. Merge-sort batches of M values using their comparison to pivot as a key. The
+   comparison alternates between < and <= with recursion depth. This makes no
+   difference when there are many unique values, but when there are many
+   duplicates, this effectively partitions into <, =, and >.
+2. Consolidate batches. This runs inside the quicksort kernel.
+
+Sublists (ranges of the list being sorted) are denoted by `lo` and one of
+    `L` and `hi`. `lo` is an exclusive lower bound, `hi` is an
+    inclusive upperboard, `L` is their difference.
+`b_sums` is "batch sums", the number of values in a batch which are >= pivot or
+    > pivot depending on the relevant `parity`
+"""
+module Sorting
+using ..CUDA
+
+#-------------------------------------------------------------------------------
+# Integer arithmetic
+
+"""
+Returns smallest power of 2 < x
+"""
+function pow2_floor(x)
+    out = 1
+    while out * 2 <= x
+        out *= 2
+    end
+    out
+end
+
+"""
+For a batch of size `n` what is the lowest index of the batch `i` is in
+"""
+function batch_floor(idx, n)
+    return idx - (idx - 1) % n
+end
+
+"""
+For a batch of size `n` what is the highest index of the batch `i` is in
+"""
+function batch_ceil(idx, n)
+    return idx + n - 1 - (idx - 1) % n
+end
+
+"""
+GPU friendly step function (step at `i` = 1)
+"""
+function Θ(i)
+    return 1 & (1 <= i)
+end
+
+"""
+Suppose we are merging two lists of size n, each of which has all falses before
+all trues. Together, they will be indexed 1:2n. This is a fast stepwise function
+for the destination index of a value at index `x` in the concatenated input,
+where `a` is the number of falses in the first half, b = n - a, and false is the
+number of falses in the second half.
+"""
+function step_swap(x, a, b, c)
+    return x + Θ(x - a) * b - Θ(x - (a + c)) * (b + c) + Θ(x - (a + b + c)) * c
+end
+
+"""
+Generalizes `step_swap` for when the floor index is not 1
+"""
+function batch_step_swap(x, n, a, b, c)
+    idx = (x - 1) % n + 1
+    return batch_floor(x, n) - 1 + step_swap(idx, a, b, c)
+end
+
+@inline function flex_lt(a, b, eq)# where T
+    eq ? a <= b : a < b
+end
+
+#-------------------------------------------------------------------------------
+# Batch partitioning
+"""
+For thread `idx` with current value `value`, merge two batches of size `n` and
+return the new value this thread takes. `sums` and `swap` are shared mem
+"""
+function merge_swap_shmem(value, idx, n, sums, swap)
+    @inbounds begin
+    sync_threads()
+    b = sums[batch_floor(idx, 2 * n)]
+    a = n - b
+    d = sums[batch_ceil(idx, 2 * n)]
+    c = n - d
+    swap[idx] = value
+    sync_threads()
+    sums[idx] = d + b
+    return swap[batch_step_swap(idx, 2 * n, a, b, c)]
+    end
+end
+
+"""
+Partition the region of `values` after index `lo` up to (inclusive) `hi` with
+respect to `pivot`. This is done by a 'binary' merge sort, where each the values
+are sorted by a boolean key: how they compare to `pivot`. The comparison is
+affected by `parity`. See `flex_lt`. `swap` is an array for exchanging values
+and `sums` is an array of Int32s used during the merge sort.
+
+Uses block index to decide which values to operate on.
+"""
+@inline function batch_partition(values, pivot, swap, sums, lo, hi, parity)
+    sync_threads()
+    idx0 = Int(lo) + (blockIdx().x - 1) * blockDim().x + threadIdx().x
+    if idx0 <= hi
+         swap[threadIdx().x] = values[idx0]
+         sums[threadIdx().x] = 1 & flex_lt(pivot, swap[threadIdx().x], parity)
+    else
+        @inbounds sums[threadIdx().x] = 1
+    end
+    sync_threads()
+    val = merge_swap_shmem(swap[threadIdx().x], threadIdx().x, 1, sums, swap)
+    temp = 2
+    while temp < blockDim().x
+        val = merge_swap_shmem(val, threadIdx().x, temp, sums, swap)
+        temp *= 2
+    end
+    sync_threads()
+
+    if idx0 <= hi
+         values[idx0] = val
+    end
+    sync_threads()
+end
+
+"""
+Each block evaluates `batch_partition` on consecutive regions of length blockDim().x
+from `lo` to `hi` of `values`.
+"""
+function partition_batches_kernel(values :: AbstractArray{T}, pivot, lo, hi, parity) where T
+    swap = @cuDynamicSharedMem(T, blockDim().x, 4 * blockDim().x)
+    sums = @cuDynamicSharedMem(Int32, blockDim().x)
+    batch_partition(values, pivot, swap, sums, lo, hi, parity)
+    return nothing
+end
+
+#-------------------------------------------------------------------------------
+# Batch consolidation
+"""
+Finds the index in `array` of the last value <= `pivot` if `parity` = true or the
+last value < `pivot` if `parity` = false.
+Searches after index `lo` up to (inclusive) index `hi`
+"""
+function find_partition(array, pivot, lo, hi, parity) :: Int32
+    low = lo + 1
+    high = hi
+    @inbounds while low <= high
+        mid = (low + high) ÷ 2
+        if flex_lt(pivot, array[mid], parity)
+            high = mid - 1
+        else
+            low = mid + 1
+        end
+    end
+    return low - 1
+end
+
+"""
+This assumes the region of `vals` of length `L` starting after `lo`
+has been batch partitioned with respect to `pivot`. Further, it assumes that
+these batches are of size `blockDim().x`.
+
+Using 1 step per batch, consolidate these partitioned batches such that the
+region is fully partitioned. Each step moves at most `blockDim().x` values.
+
+`b_sums`: either shared memory or a global array which serves as scratch space
+for storing the partition of each batch.
+
+`parity`: see top docstring
+
+Must only run on 1 SM.
+"""
+@inline function consolidate_batch_partition(vals :: AbstractArray{T}, pivot, lo, L, b_sums, parity) where T
+    sync_threads()
+    @inline N_b() = ceil(Int, L / blockDim().x)
+    @inline batch(k) :: Int32 = threadIdx().x + k * blockDim().x
+
+    my_iter = 0
+    a = 0
+    b = 0
+
+    @inbounds for batch_i in 1:N_b()
+        if batch_i % blockDim().x == 1
+            if batch(my_iter) <= N_b()
+                seek_lo = lo + (batch(my_iter) - 1) * blockDim().x
+                seek_hi = lo + min(L, batch(my_iter) * blockDim().x)
+                b_sums[threadIdx().x] = seek_hi - find_partition(vals, pivot, seek_lo, seek_hi, parity)
+            end
+            my_iter += 1
+        end
+
+        n_eff() = (batch_i != ceil(Int, L / blockDim().x) || L % blockDim().x == 0) ? blockDim().x : L % blockDim().x
+        sync_threads()
+        d = b_sums[batch_i - (my_iter - 1) * blockDim().x]
+        c = n_eff() - d
+        to_move = min(b, c)
+        sync_threads()
+        if threadIdx().x <= to_move
+            swap = vals[lo + a + threadIdx().x]
+        end
+        sync_threads()
+        if threadIdx().x <= to_move
+            vals[lo + a + threadIdx().x] = vals[lo + a + b + c - to_move + threadIdx().x]
+        end
+        sync_threads()
+        if threadIdx().x <= to_move
+            vals[lo + a + b + c - to_move + threadIdx().x] = swap
+        end
+        sync_threads()
+        a += c
+        b += d
+    end
+    sync_threads()
+    return lo + a
+end
+
+#-------------------------------------------------------------------------------
+# Sorting
+"""
+Performs bubble sort on `vals` starting after `lo` and going for min(`L`, `blockDim().x`)
+elements spaced by `stride`. Good for sampling pivot values as well as short
+sorts.
+"""
+@inline function bubble_sort(vals, swap, lo, L, stride)
+    sync_threads()
+    L = min(blockDim().x, L)
+    @inbounds begin
+    if threadIdx().x <= L
+        swap[threadIdx().x] = vals[lo + threadIdx().x * stride]
+    end
+    sync_threads()
+    for level in 0:L
+        # get left/right neighbor depending on even/odd level
+        buddy = threadIdx().x - 1 + 2 * (1 & (threadIdx().x % 2 != level % 2))
+        if 1 <= buddy <= L && threadIdx().x <= L
+            buddy_val = swap[buddy]
+        end
+        sync_threads()
+        if 1 <= buddy <= L && threadIdx().x <= L
+            if (threadIdx().x < buddy) != flex_lt(swap[threadIdx().x], buddy_val, false)
+                swap[threadIdx().x] = buddy_val
+            end
+        end
+        sync_threads()
+    end
+    if threadIdx().x <= L
+        vals[lo + threadIdx().x * stride] = swap[threadIdx().x]
+    end
+    end
+    sync_threads()
+end
+
+"""
+Launch batch partition kernel and sync
+"""
+@inline function call_batch_partition(vals :: AbstractArray{T}, pivot, swap, b_sums, lo, hi, parity, sync :: Val{true}) where T
+    L = hi - lo
+    if threadIdx().x == 1
+        @cuda blocks=ceil(Int, L / blockDim().x) threads=blockDim().x dynamic=true shmem=blockDim().x*(4+sizeof(T)) partition_batches_kernel(vals, pivot, lo, hi, parity)
+        CUDA.device_synchronize()
+    end
+end
+
+"""
+Partition batches in a loop using a single block
+"""
+@inline function call_batch_partition(vals :: AbstractArray{T}, pivot, swap, b_sums, lo, hi, parity, sync :: Val{false}) where T
+    for temp in lo:blockDim().x:hi
+        batch_partition(vals, pivot, swap, b_sums, temp, min(hi, temp + blockDim().x), parity)
+    end
+end
+
+"""
+Perform quicksort on `vals` for the region with `lo` as an exclusive floor and
+`hi` as an inclusive ceiling.
+`parity` is a Val{Bool} which says whether to partition by < or <= with respect
+to the pivot.
+`sync_depth` is how many (more) levels of recursion with `qsort_kernel`
+can be done before reaching `cudaLimitDevRuntimeSyncDepth`. From the host, this value
+must not exceed that limit.
+
+`sync` and enclosed type `S` determine how partition occurs:
+ If `sync` is `true`:
+This kernel partitions batches in a child kernel, synchronizes, and then
+consolidates the batches. The benefit of this kernel is that it distributes
+the work of partitioning batches across multiple SMs.
+If `sync` is `false`:
+This kernel partitions without launching any children kernels, then has recursive
+`qsort_async_kernel` children for left and right partitions. `device_synchronize`
+is never called from this kernel, so there is no practical limit on recursion.
+
+To detect the scenario of all values in the region being the same, we have two
+args: `prev_pivot` and `stuck`. If two consecutive partitions have the same pivot
+and both failed to split the region in two, that means all the values are equal.
+`stuck` is incremented when the pivot hasn't changed and partition = `lo` or `hi`.
+If `stuck` reaches 2, recursion ends. `stuck` is initialized at -1 because
+`prev_pivot` must be initialized to some value, and it's possible that the first
+pivot will be that value, which could lead to an incorrectly early end to recursion
+if we started `stuck` at 0.
+"""
+function qsort_kernel(vals :: AbstractArray{T}, lo, hi, parity , sync :: Val{S}, sync_depth, prev_pivot, stuck=-1) where {T, S}
+    b_sums = @cuDynamicSharedMem(Int32, blockDim().x, 0)
+    swap = @cuDynamicSharedMem(T, blockDim().x, 4 * blockDim().x)
+    L = hi - lo
+
+    #= step 1 bubble sort. It'll either finish sorting a subproblem or help
+    select a pivot value =#
+    bubble_sort(vals, swap, lo, L, L <= blockDim().x ? 1 : L ÷ blockDim().x)
+
+    if L <= blockDim().x
+        return
+    end
+
+    pivot = vals[lo + (blockDim().x ÷ 2) * (L ÷ blockDim().x)]
+
+    # step 2: use pivot to partition into batches
+    call_batch_partition(vals, pivot, swap, b_sums, lo, hi, parity, sync)
+
+    #= step 3: consolidate the partitioned batches so that the sublist from
+    [lo, hi) is partitioned, and the partition is stored in `partition`.
+    Dispatching on P cleaner and faster than an if statement=#
+
+    partition = consolidate_batch_partition(vals, pivot, lo, L, b_sums, parity)
+
+    #= step 4: recursion =#
+    if threadIdx().x == 1
+
+        stuck = (pivot == prev_pivot && partition == lo || partition == hi) ? stuck + 1 : 0
+
+        if stuck < 2 && partition > lo
+            s = CuDeviceStream()
+            if sync_depth > 1
+                @cuda threads=blockDim().x dynamic=true stream=s shmem=blockDim().x*(4+sizeof(T)) qsort_kernel(vals, lo, partition, !parity, Val(true), sync_depth - 1, pivot, stuck)
+            else
+                @cuda threads=blockDim().x dynamic=true stream=s shmem=blockDim().x*(4+sizeof(T)) qsort_kernel(vals, lo, partition, !parity, Val(false), sync_depth - 1, pivot, stuck)
+            end
+            CUDA.unsafe_destroy!(s)
+        end
+
+        if stuck < 2 && partition < hi
+            s = CuDeviceStream()
+            if sync_depth > 1
+                @cuda threads=blockDim().x dynamic=true stream=s shmem=blockDim().x*(4+sizeof(T)) qsort_kernel(vals, partition, hi, !parity, Val(true), sync_depth - 1, pivot, stuck)
+            else
+                @cuda threads=blockDim().x dynamic=true stream=s shmem=blockDim().x*(4+sizeof(T)) qsort_kernel(vals, partition, hi, !parity, Val(false), sync_depth - 1, pivot, stuck)
+            end
+            CUDA.unsafe_destroy!(s)
+        end
+    end
+
+    return nothing
+end
+
+function quicksort!(c :: AbstractArray{T}) where T
+    MAX_DEPTH = CUDA.limit(CUDA.LIMIT_DEV_RUNTIME_SYNC_DEPTH)
+    N = length(c)
+
+    function get_config(kernel)
+        get_shmem(threads) = threads * (sizeof(Int32) + max(4, sizeof(T)))
+        fun = kernel.fun
+        config = launch_configuration(fun, shmem=threads->get_shmem(threads))
+        threads = pow2_floor(config.threads)
+        @assert threads <= config.threads
+        return (blocks=1, threads=threads, shmem=get_shmem(threads))
+    end
+
+    @cuda config=get_config qsort_kernel(c, 0, N, true, Val(MAX_DEPTH > 1), MAX_DEPTH, nothing)
+    synchronize()
+    return c
+end
+
+function Base.sort!(c :: CuArray{T}; dims :: Integer, rev::Bool=false) where T
+    # TODO: is it best to create a stream per call to `quicksort!` and sync after?
+    nd = ndims(c)
+    k = dims
+    sz = size(c)
+
+    1 <= k <= nd || throw(ArgumentError("dimension out of range"))
+
+    remdims = ntuple(i -> i == k ? 1 : size(c, i), nd)
+    for idx in CartesianIndices(remdims)
+        if rev
+            v = view(c, ntuple(i -> i == k ? range(sz[i], 1, step=-1) : idx[i], nd)...)
+        else
+            v = view(c, ntuple(i -> i == k ? Colon() : idx[i], nd)...)
+        end
+        quicksort!(v)
+    end
+    c
+end
+
+function Base.sort!(c :: CuVector{T}; rev=false) where T
+    if rev
+        quicksort!(view(c, range(length(c), 1, step=-1)))
+    else
+        quicksort!(c)
+    end
+    c
+end
+
+function Base.sort(c :: CuArray; by=identity, kwargs...)
+    if by == identity
+        return sort!(copy(c); kwargs...)
+    else
+        return map(x -> x[2], sort!(map(x -> (by(x), x), c); kwargs...))
+    end
+end
+
+end

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -1,6 +1,7 @@
 [deps]
 Adapt = "79e6a3ab-5dfb-504d-930d-738a2a938a0e"
 BFloat16s = "ab4f0b2a-ad5b-11e8-123f-65d77653426b"
+DataStructures = "864edb3b-99cc-5e75-8d2d-829cb0a9cfe8"
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"
 Distributed = "8ba89e20-285c-5b6f-9357-94700520ee1b"
 FFTW = "7a1cc6ca-52ef-59f5-83cd-3a7055c09341"

--- a/test/sorting.jl
+++ b/test/sorting.jl
@@ -35,7 +35,7 @@ function test_batch_partition(T, N, lo, hi, seed, lt=isless, by=identity)
 
     kernel = @cuda launch=false partition_batches_kernel(A, pivot, lo, hi, true, lt, by)
 
-    get_shmem(threads) = threads * (sizeof(Int32) + sizeof(T))
+    get_shmem(threads) = threads * (sizeof(Int) + sizeof(T))
     config = launch_configuration(kernel.fun, shmem=threads->get_shmem(threads), max_threads=1024)
 
     threads = prevpow(2, config.threads)
@@ -106,11 +106,11 @@ function test_consolidate_partition(T, N, lo, hi, seed, block_dim, lt=isless, by
     pivot = rand(original[my_range])
 
     threads = blocks = -1
-    sums = CuArray(zeros(Int32, ceil(Int, hi - lo / block_dim)))
+    sums = CuArray(zeros(Int, ceil(Int, hi - lo / block_dim)))
 
     kernel = @cuda launch=false partition_batches_kernel(A, pivot, lo, hi, true, lt, by)
 
-    get_shmem(threads) = threads * (sizeof(Int32) + sizeof(T))
+    get_shmem(threads) = threads * (sizeof(Int) + sizeof(T))
     config = launch_configuration(kernel.fun, shmem=threads->get_shmem(threads), max_threads=1024)
 
     threads = isnothing(block_dim) ? prevpow(2, config.threads) : block_dim
@@ -118,7 +118,7 @@ function test_consolidate_partition(T, N, lo, hi, seed, block_dim, lt=isless, by
 
     kernel(A, pivot, lo, hi, true, lt, by; threads=threads, blocks=blocks, shmem=get_shmem(threads))
     synchronize()
-    dest = CuArray(zeros(Int32, 1))
+    dest = CuArray(zeros(Int, 1))
 
     @cuda threads=threads test_consolidate_kernel(A, pivot, lo, hi - lo, sums, dest, true, lt, by)
     synchronize()

--- a/test/sorting.jl
+++ b/test/sorting.jl
@@ -35,7 +35,7 @@ function test_batch_partition(T, N, lo, hi, seed, lt=isless, by=identity)
 
     kernel = @cuda launch=false partition_batches_kernel(A, pivot, lo, hi, true, lt, by)
 
-    get_shmem(threads) = threads * (sizeof(Int32) + max(4, sizeof(T)))
+    get_shmem(threads) = threads * (sizeof(Int32) + sizeof(T))
     config = launch_configuration(kernel.fun, shmem=threads->get_shmem(threads), max_threads=1024)
 
     threads = prevpow(2, config.threads)
@@ -110,7 +110,7 @@ function test_consolidate_partition(T, N, lo, hi, seed, block_dim, lt=isless, by
 
     kernel = @cuda launch=false partition_batches_kernel(A, pivot, lo, hi, true, lt, by)
 
-    get_shmem(threads) = threads * (sizeof(Int32) + max(4, sizeof(T)))
+    get_shmem(threads) = threads * (sizeof(Int32) + sizeof(T))
     config = launch_configuration(kernel.fun, shmem=threads->get_shmem(threads), max_threads=1024)
 
     threads = isnothing(block_dim) ? prevpow(2, config.threads) : block_dim

--- a/test/sorting.jl
+++ b/test/sorting.jl
@@ -1,33 +1,33 @@
-"""
-Unit tests for quicksort.
-"""
+using Random
+using DataStructures
 
-using DataStructures, Random, Test, CUDA.Sorting
-import CUDA.Sorting: pow2_floor, Θ, flex_lt, find_partition,
+@testset "quicksort" begin
+
+import CUDA.Quicksort: pow2_floor, Θ, flex_lt, find_partition,
         partition_batches_kernel, consolidate_batch_partition
 
-@testset "Quicksort Integer Functions" begin
-@test pow2_floor(1) == 1
-@test pow2_floor(2) == 2
-@test pow2_floor(3) == 2
-@test pow2_floor(5) == 4
-@test pow2_floor(8) == 8
+@testset "integer functions" begin
+    @test pow2_floor(1) == 1
+    @test pow2_floor(2) == 2
+    @test pow2_floor(3) == 2
+    @test pow2_floor(5) == 4
+    @test pow2_floor(8) == 8
 
-@test Θ(0) == 0
-@test Θ(1) == 1
-@test Θ(2) == 1
+    @test Θ(0) == 0
+    @test Θ(1) == 1
+    @test Θ(2) == 1
 
-@test flex_lt(1, 2, false) == true
-@test flex_lt(1, 2, true) == true
-@test flex_lt(2, 2, false) == false
-@test flex_lt(2, 2, true) == true
-@test flex_lt(3, 2, false) == false
-@test flex_lt(3, 2, true) == false
+    @test flex_lt(1, 2, false) == true
+    @test flex_lt(1, 2, true) == true
+    @test flex_lt(2, 2, false) == false
+    @test flex_lt(2, 2, true) == true
+    @test flex_lt(3, 2, false) == false
+    @test flex_lt(3, 2, true) == false
 
-@test find_partition([1, 2, 2, 3, 4, 1, 2, 2, 3, 4], 3, 0, 5, false) == 4
-@test find_partition([1, 2, 2, 3, 4, 1, 2, 2, 3, 4], 3, 5, 10, false) == 9
-@test find_partition([1, 2, 2, 3, 4, 1, 2, 2, 3, 4], 3, 0, 5, true) == 3
-@test find_partition([1, 2, 2, 3, 4, 1, 2, 2, 3, 4], 3, 5, 10, true) == 8
+    @test find_partition([1, 2, 2, 3, 4, 1, 2, 2, 3, 4], 3, 0, 5, false) == 4
+    @test find_partition([1, 2, 2, 3, 4, 1, 2, 2, 3, 4], 3, 5, 10, false) == 9
+    @test find_partition([1, 2, 2, 3, 4, 1, 2, 2, 3, 4], 3, 0, 5, true) == 3
+    @test find_partition([1, 2, 2, 3, 4, 1, 2, 2, 3, 4], 3, 5, 10, true) == 8
 end
 
 function test_batch_partition(T, N, lo, hi, seed)
@@ -61,8 +61,8 @@ function test_batch_partition(T, N, lo, hi, seed)
     for block in 1:block_N
         block_range = lo + 1 + (block - 1) * block_dim: min(hi, lo + block * block_dim)
         temp = original[block_range]
-        #= this shows that batch partitioning is a stable sort where key for
-        each value v is whether v > or <= pivot =#
+        # this shows that batch partitioning is a stable sort where key for each value v is
+        # whether v > or <= pivot
         expected_sort = vcat(filter(x -> x < pivot, temp), filter(x -> x >= pivot, temp))
         sort_match &= post_sort[block_range] == expected_sort
     end
@@ -70,27 +70,27 @@ function test_batch_partition(T, N, lo, hi, seed)
     @test sort_match
 end
 
-@testset "Quicksort batch partition" begin
-test_batch_partition(Int8, 10000, 2000, 6000, 0)
-test_batch_partition(Int8, 10000, 2000, 6000, 1)
-test_batch_partition(Int8, 10000000, 0, 10000000, 0)
-test_batch_partition(Int8, 10000000, 5000, 500000, 0)
-test_batch_partition(Int8, 10000, 0, 10000, 0)
-test_batch_partition(Int8, 10000, 2000, 6000, 0)
-test_batch_partition(Int8, 10000, 2000, 6000, 1)
-test_batch_partition(Int8, 10000000, 0, 10000000, 0)
-test_batch_partition(Int8, 10000000, 5000, 500000, 0)
+@testset "batch partition" begin
+    test_batch_partition(Int8, 10000, 2000, 6000, 0)
+    test_batch_partition(Int8, 10000, 2000, 6000, 1)
+    test_batch_partition(Int8, 10000000, 0, 10000000, 0)
+    test_batch_partition(Int8, 10000000, 5000, 500000, 0)
+    test_batch_partition(Int8, 10000, 0, 10000, 0)
+    test_batch_partition(Int8, 10000, 2000, 6000, 0)
+    test_batch_partition(Int8, 10000, 2000, 6000, 1)
+    test_batch_partition(Int8, 10000000, 0, 10000000, 0)
+    test_batch_partition(Int8, 10000000, 5000, 500000, 0)
 
-test_batch_partition(Float32, 10000, 0, 10000, 0)
-test_batch_partition(Float32, 10000, 2000, 6000, 0)
-test_batch_partition(Float32, 10000, 2000, 6000, 1)
-test_batch_partition(Float32, 10000000, 0, 10000000, 0)
-test_batch_partition(Float32, 10000000, 5000, 500000, 0)
-test_batch_partition(Float32, 10000, 0, 10000, 0)
-test_batch_partition(Float32, 10000, 2000, 6000, 0)
-test_batch_partition(Float32, 10000, 2000, 6000, 1)
-test_batch_partition(Float32, 10000000, 0, 10000000, 0)
-test_batch_partition(Float32, 10000000, 5000, 500000, 0)
+    test_batch_partition(Float32, 10000, 0, 10000, 0)
+    test_batch_partition(Float32, 10000, 2000, 6000, 0)
+    test_batch_partition(Float32, 10000, 2000, 6000, 1)
+    test_batch_partition(Float32, 10000000, 0, 10000000, 0)
+    test_batch_partition(Float32, 10000000, 5000, 500000, 0)
+    test_batch_partition(Float32, 10000, 0, 10000, 0)
+    test_batch_partition(Float32, 10000, 2000, 6000, 0)
+    test_batch_partition(Float32, 10000, 2000, 6000, 1)
+    test_batch_partition(Float32, 10000000, 0, 10000000, 0)
+    test_batch_partition(Float32, 10000000, 5000, 500000, 0)
 end
 
 function test_consolidate_kernel(vals, pivot, my_floor, L, b_sums, dest, parity)
@@ -132,46 +132,45 @@ function test_consolidate_partition(T, N, lo, hi, seed, block_dim)
     partition = Array(dest)[1]
     temp = original[my_range]
     post_sort = Array(A)
-    #= consolidation is a highly unstable sort (again, by pivot comparison as
-    the key) so we compare by counting each element =#
+    # consolidation is a highly unstable sort (again, by pivot comparison as the key) so we
+    # compare by counting each element
     cc(x) = x |> counter |> collect |> sort
     @test cc(original) == cc(post_sort)
     @test all(post_sort[lo + 1 : partition] |> cc .== filter(x -> x < pivot, temp) |> cc)
     @test all(post_sort[partition + 1 : hi] |> cc .== filter(x -> x >= pivot, temp) |> cc)
 end
 
-@testset "Quicksort consolidate partition" begin
-test_consolidate_partition(Int8, 10000, 0, 10000, 0, 16)
-test_consolidate_partition(Int8, 10000, 0, 10000, 0, 32)
-test_consolidate_partition(Int8, 10000, 0, 10000, 0, 64)
-test_consolidate_partition(Int8, 10000, 9, 6333, 0, 16)
-test_consolidate_partition(Int8, 10000, 9, 6333, 0, 32)
-test_consolidate_partition(Int8, 10000, 9, 6333, 0, 64)
-test_consolidate_partition(Int8, 10000, 129, 9999, 0, 16)
-test_consolidate_partition(Int8, 10000, 129, 9999, 0, 32)
-test_consolidate_partition(Int8, 10000, 129, 9999, 0, 64)
-test_consolidate_partition(Int8, 10000, 0, 10000, 1, 16)
-test_consolidate_partition(Int8, 10000, 0, 10000, 2, 32)
-test_consolidate_partition(Int8, 10000, 0, 10000, 3, 64)
-test_consolidate_partition(Int8, 10000, 9, 6333, 4, 16)
-test_consolidate_partition(Int8, 10000, 9, 6333, 5, 32)
-test_consolidate_partition(Int8, 10000, 9, 6333, 6, 64)
-test_consolidate_partition(Int8, 10000, 129, 9999, 7, 16)
-test_consolidate_partition(Int8, 10000, 129, 9999, 8, 32)
-test_consolidate_partition(Int8, 10000, 129, 9999, 9, 64)
-test_consolidate_partition(Int8, 10000, 3329, 9999, 10, 16)
-test_consolidate_partition(Int8, 10000, 3329, 9999, 11, 32)
-test_consolidate_partition(Int8, 10000, 3329, 9999, 12, 64)
-
+@testset "consolidate partition" begin
+    test_consolidate_partition(Int8, 10000, 0, 10000, 0, 16)
+    test_consolidate_partition(Int8, 10000, 0, 10000, 0, 32)
+    test_consolidate_partition(Int8, 10000, 0, 10000, 0, 64)
+    test_consolidate_partition(Int8, 10000, 9, 6333, 0, 16)
+    test_consolidate_partition(Int8, 10000, 9, 6333, 0, 32)
+    test_consolidate_partition(Int8, 10000, 9, 6333, 0, 64)
+    test_consolidate_partition(Int8, 10000, 129, 9999, 0, 16)
+    test_consolidate_partition(Int8, 10000, 129, 9999, 0, 32)
+    test_consolidate_partition(Int8, 10000, 129, 9999, 0, 64)
+    test_consolidate_partition(Int8, 10000, 0, 10000, 1, 16)
+    test_consolidate_partition(Int8, 10000, 0, 10000, 2, 32)
+    test_consolidate_partition(Int8, 10000, 0, 10000, 3, 64)
+    test_consolidate_partition(Int8, 10000, 9, 6333, 4, 16)
+    test_consolidate_partition(Int8, 10000, 9, 6333, 5, 32)
+    test_consolidate_partition(Int8, 10000, 9, 6333, 6, 64)
+    test_consolidate_partition(Int8, 10000, 129, 9999, 7, 16)
+    test_consolidate_partition(Int8, 10000, 129, 9999, 8, 32)
+    test_consolidate_partition(Int8, 10000, 129, 9999, 9, 64)
+    test_consolidate_partition(Int8, 10000, 3329, 9999, 10, 16)
+    test_consolidate_partition(Int8, 10000, 3329, 9999, 11, 32)
+    test_consolidate_partition(Int8, 10000, 3329, 9999, 12, 64)
 end
 
-function init_case(T, f, N :: Integer)
+function init_case(T, f, N::Integer)
     a = map(x -> T(f(x)), 1:N)
     c = CuArray(a)
     a, c
 end
 
-function init_case(T, f, N :: Tuple)
+function init_case(T, f, N::Tuple)
     a = map(f, rand(N...))
     c = CuArray(a)
     a, c
@@ -180,14 +179,14 @@ end
 """
 Tests if `c` is a valid sort of `a`
 """
-function test_equivalence(a :: Vector, c :: Vector; kwargs...)
+function test_equivalence(a::Vector, c::Vector; kwargs...)
     @test counter(a) == counter(c) && issorted(c; kwargs...)
 end
 
 """
 Tests if `c` is a valid sort of `a`
 """
-function test_equivalence(a :: Array, c :: Array; dims, kwargs...)
+function test_equivalence(a::Array, c::Array; dims, kwargs...)
     @assert size(a) == size(c)
     nd = ndims(c)
     k = dims
@@ -197,7 +196,8 @@ function test_equivalence(a :: Array, c :: Array; dims, kwargs...)
 
     remdims = ntuple(i -> i == k ? 1 : size(c, i), nd)
     v(a, idx) = view(a, ntuple(i -> i == k ? Colon() : idx[i], nd)...)
-    @test all(counter(v(a, idx)) == counter(v(c, idx)) && issorted(v(c, idx); kwargs...) for idx in CartesianIndices(remdims))
+    @test all(counter(v(a, idx)) == counter(v(c, idx)) && issorted(v(c, idx); kwargs...)
+              for idx in CartesianIndices(remdims))
 end
 
 """
@@ -208,9 +208,6 @@ end
 """
 function test_sort!(T, N, f=identity; kwargs...)
     original_arr, device_arr = init_case(T, f, N)
-    # if sort! fell back to Base implementation, CUDA would error over
-    # disallowed scalar indexing
-    CUDA.allowscalar(false)
     sort!(device_arr; kwargs...)
     host_result = Array(device_arr)
     test_equivalence(original_arr, host_result; kwargs...)
@@ -222,55 +219,49 @@ function test_sort(T, N, f=identity; kwargs...)
     test_equivalence(original_arr, host_result; kwargs...)
 end
 
-@testset "Quicksort" begin
-# test pre-sorted
-test_sort!(Int, 1000000)
-test_sort!(Int32, 1000000)
-test_sort!(Float64, 1000000)
-test_sort!(Float32, 1000000)
-test_sort!(Int32, 1000000; rev=true)
-test_sort!(Float32, 1000000; rev=true)
 
-# test reverse sorted
-test_sort!(Int32, 1000000, x -> -x)
-test_sort!(Float32, 1000000, x -> -x)
-test_sort!(Int32, 1000000, x -> -x; rev=true)
-test_sort!(Float32, 1000000, x -> -x; rev=true)
+@testset "interface" begin
+    # pre-sorted
+    test_sort!(Int, 1000000)
+    test_sort!(Int32, 1000000)
+    test_sort!(Float64, 1000000)
+    test_sort!(Float32, 1000000)
+    test_sort!(Int32, 1000000; rev=true)
+    test_sort!(Float32, 1000000; rev=true)
 
-# test random arrays
-Random.seed!(0)
+    # reverse sorted
+    test_sort!(Int32, 1000000, x -> -x)
+    test_sort!(Float32, 1000000, x -> -x)
+    test_sort!(Int32, 1000000, x -> -x; rev=true)
+    test_sort!(Float32, 1000000, x -> -x; rev=true)
 
-test_sort!(Int, 10000, x -> rand(Int))
-test_sort!(Int32, 10000, x -> rand(Int32))
-test_sort!(Int8, 10000, x -> rand(Int8))
-test_sort!(Float64, 10000, x -> rand(Float64))
-test_sort!(Float32, 10000, x -> rand(Float32))
-test_sort!(Float16, 10000, x -> rand(Float16))
+    test_sort!(Int, 10000, x -> rand(Int))
+    test_sort!(Int32, 10000, x -> rand(Int32))
+    test_sort!(Int8, 10000, x -> rand(Int8))
+    test_sort!(Float64, 10000, x -> rand(Float64))
+    test_sort!(Float32, 10000, x -> rand(Float32))
+    test_sort!(Float16, 10000, x -> rand(Float16))
 
-#test non-uniform distributions
-test_sort!(UInt8, 100000, x -> round(255 * rand() ^ 2))
-test_sort!(UInt8, 100000, x -> round(255 * rand() ^ 3))
+    # non-uniform distributions
+    test_sort!(UInt8, 100000, x -> round(255 * rand() ^ 2))
+    test_sort!(UInt8, 100000, x -> round(255 * rand() ^ 3))
 
-# test case when there are more copies of each value than fit in one block
-test_sort!(Int8, 4000000, x -> rand(Int8))
+    # more copies of each value than can fit in one block
+    test_sort!(Int8, 4000000, x -> rand(Int8))
 
-# test multiple dimensions
-test_sort!(Int32, (4, 50000, 4); dims=2)
-test_sort!(Int32, (4, 4, 50000); dims=3, rev=true)
+    # multiple dimensions
+    test_sort!(Int32, (4, 50000, 4); dims=2)
+    test_sort!(Int32, (4, 4, 50000); dims=3, rev=true)
 
-# test various sync depths
-CUDA.limit!(CUDA.LIMIT_DEV_RUNTIME_SYNC_DEPTH, 0)
-test_sort!(Int, 100000, x -> rand(Int))
-CUDA.limit!(CUDA.LIMIT_DEV_RUNTIME_SYNC_DEPTH, 1)
-test_sort!(Int, 100000, x -> rand(Int))
-CUDA.limit!(CUDA.LIMIT_DEV_RUNTIME_SYNC_DEPTH, 2)
-test_sort!(Int, 100000, x -> rand(Int))
-CUDA.limit!(CUDA.LIMIT_DEV_RUNTIME_SYNC_DEPTH, 3)
-test_sort!(Int, 100000, x -> rand(Int))
-CUDA.limit!(CUDA.LIMIT_DEV_RUNTIME_SYNC_DEPTH, 4)
-test_sort!(Int, 100000, x -> rand(Int))
+    # various sync depths
+    for depth in 0:4
+        CUDA.limit!(CUDA.LIMIT_DEV_RUNTIME_SYNC_DEPTH, depth)
+        test_sort!(Int, 100000, x -> rand(Int))
+    end
 
-# test using a `by` argument
-test_sort(Float32, 100000; by=x->abs(x - 0.5))
-test_sort(Float64, (4, 100000); by=x->cos(4 * pi * x), dims=2)
+    # using a `by` argument
+    test_sort(Float32, 100000; by=x->abs(x - 0.5))
+    test_sort(Float64, (4, 100000); by=x->cos(4 * pi * x), dims=2)
+end
+
 end

--- a/test/sorting.jl
+++ b/test/sorting.jl
@@ -1,0 +1,281 @@
+"""
+Unit tests for quicksort.
+"""
+
+using DataStructures, Random, Test, CUDA.Sorting
+import CUDA.Sorting: pow2_floor, Θ, flex_lt, find_partition,
+        partition_batches_kernel, consolidate_batch_partition
+
+@testset "Quicksort Integer Functions" begin
+@test pow2_floor(1) == 1
+@test pow2_floor(2) == 2
+@test pow2_floor(3) == 2
+@test pow2_floor(5) == 4
+@test pow2_floor(8) == 8
+
+@test Θ(0) == 0
+@test Θ(1) == 1
+@test Θ(2) == 1
+
+@test flex_lt(1, 2, false) == true
+@test flex_lt(1, 2, true) == true
+@test flex_lt(2, 2, false) == false
+@test flex_lt(2, 2, true) == true
+@test flex_lt(3, 2, false) == false
+@test flex_lt(3, 2, true) == false
+
+@test find_partition([1, 2, 2, 3, 4, 1, 2, 2, 3, 4], 3, 0, 5, false) == 4
+@test find_partition([1, 2, 2, 3, 4, 1, 2, 2, 3, 4], 3, 5, 10, false) == 9
+@test find_partition([1, 2, 2, 3, 4, 1, 2, 2, 3, 4], 3, 0, 5, true) == 3
+@test find_partition([1, 2, 2, 3, 4, 1, 2, 2, 3, 4], 3, 5, 10, true) == 8
+end
+
+function test_batch_partition(T, N, lo, hi, seed)
+    my_range = lo + 1 : hi
+    Random.seed!(seed)
+    original = rand(T, N)
+    A = CuArray(original)
+
+    pivot = rand(original[my_range])
+    block_N, block_dim = -1, -1
+
+    function get_config(kernel)
+        get_shmem(threads) = threads * (sizeof(Int32) + max(4, sizeof(T)))
+
+        fun = kernel.fun
+        config = launch_configuration(fun, shmem=threads->get_shmem(threads), max_threads=1024)
+
+        threads = pow2_floor(config.threads)
+        blocks = ceil(Int, (hi - lo) ./ threads)
+        block_N = blocks
+        block_dim = threads
+        @assert block_dim >= 32 "This test assumes block size can be >= 32"
+        shmem = get_shmem(threads)
+        return (threads=threads, blocks=blocks, shmem=shmem)
+    end
+    @cuda config=get_config partition_batches_kernel(A, pivot, lo, hi, true)
+    synchronize()
+
+    post_sort = Array(A)
+
+    sort_match = true
+
+    for block in 1:block_N
+        block_range = lo + 1 + (block - 1) * block_dim: min(hi, lo + block * block_dim)
+        temp = original[block_range]
+        #= this shows that batch partitioning is a stable sort where key for
+        each value v is whether v > or <= pivot =#
+        expected_sort = vcat(filter(x -> x < pivot, temp), filter(x -> x >= pivot, temp))
+        sort_match &= post_sort[block_range] == expected_sort
+    end
+
+    @test sort_match
+end
+
+@testset "Quicksort batch partition" begin
+test_batch_partition(Int8, 10000, 2000, 6000, 0)
+test_batch_partition(Int8, 10000, 2000, 6000, 1)
+test_batch_partition(Int8, 10000000, 0, 10000000, 0)
+test_batch_partition(Int8, 10000000, 5000, 500000, 0)
+test_batch_partition(Int8, 10000, 0, 10000, 0)
+test_batch_partition(Int8, 10000, 2000, 6000, 0)
+test_batch_partition(Int8, 10000, 2000, 6000, 1)
+test_batch_partition(Int8, 10000000, 0, 10000000, 0)
+test_batch_partition(Int8, 10000000, 5000, 500000, 0)
+
+test_batch_partition(Float32, 10000, 0, 10000, 0)
+test_batch_partition(Float32, 10000, 2000, 6000, 0)
+test_batch_partition(Float32, 10000, 2000, 6000, 1)
+test_batch_partition(Float32, 10000000, 0, 10000000, 0)
+test_batch_partition(Float32, 10000000, 5000, 500000, 0)
+test_batch_partition(Float32, 10000, 0, 10000, 0)
+test_batch_partition(Float32, 10000, 2000, 6000, 0)
+test_batch_partition(Float32, 10000, 2000, 6000, 1)
+test_batch_partition(Float32, 10000000, 0, 10000000, 0)
+test_batch_partition(Float32, 10000000, 5000, 500000, 0)
+end
+
+function test_consolidate_kernel(vals, pivot, my_floor, L, b_sums, dest, parity)
+    i = threadIdx().x
+    p = consolidate_batch_partition(vals, pivot, my_floor, L, b_sums, parity)
+    if i == 1
+        dest[1] = p
+    end
+    return nothing
+end
+
+function test_consolidate_partition(T, N, lo, hi, seed, block_dim)
+    # assuming partition_batches works, we can validate consolidate by
+    # checking that together they partition a large domain
+    my_range = lo + 1 : hi
+    Random.seed!(seed)
+    original = rand(T, N)
+    A = CuArray(original)
+    pivot = rand(original[my_range])
+
+    threads = blocks = -1
+    sums = CuArray(zeros(Int32, ceil(Int, hi - lo / block_dim)))
+
+    function get_config(kernel)
+        get_shmem(threads) = threads * (sizeof(Int32) + max(4, sizeof(T)))
+        config = launch_configuration(kernel.fun, shmem=threads->get_shmem(threads), max_threads=1024)
+
+        threads = isnothing(block_dim) ? pow2_floor(config.threads) : block_dim
+        blocks = ceil(Int, (hi - lo) ./ threads)
+
+        shmem = get_shmem(threads)
+        return (threads=threads, blocks=blocks, shmem=shmem)
+    end
+
+    @cuda config=get_config partition_batches_kernel(A, pivot, lo, hi, true)
+    synchronize()
+    dest = CuArray(zeros(Int32, 1))
+
+    @cuda threads=threads test_consolidate_kernel(A, pivot, lo, hi - lo, sums, dest, true)
+    synchronize()
+
+    partition = Array(dest)[1]
+    temp = original[my_range]
+    post_sort = Array(A)
+    #= consolidation is a highly unstable sort (again, by pivot comparison as
+    the key) so we compare by counting each element =#
+    cc(x) = x |> counter |> collect |> sort
+    @test cc(original) == cc(post_sort)
+    @test all(post_sort[lo + 1 : partition] |> cc .== filter(x -> x < pivot, temp) |> cc)
+    @test all(post_sort[partition + 1 : hi] |> cc .== filter(x -> x >= pivot, temp) |> cc)
+end
+
+@testset "Quicksort consolidate partition" begin
+test_consolidate_partition(Int8, 10000, 0, 10000, 0, 16)
+test_consolidate_partition(Int8, 10000, 0, 10000, 0, 32)
+test_consolidate_partition(Int8, 10000, 0, 10000, 0, 64)
+test_consolidate_partition(Int8, 10000, 9, 6333, 0, 16)
+test_consolidate_partition(Int8, 10000, 9, 6333, 0, 32)
+test_consolidate_partition(Int8, 10000, 9, 6333, 0, 64)
+test_consolidate_partition(Int8, 10000, 129, 9999, 0, 16)
+test_consolidate_partition(Int8, 10000, 129, 9999, 0, 32)
+test_consolidate_partition(Int8, 10000, 129, 9999, 0, 64)
+test_consolidate_partition(Int8, 10000, 0, 10000, 1, 16)
+test_consolidate_partition(Int8, 10000, 0, 10000, 2, 32)
+test_consolidate_partition(Int8, 10000, 0, 10000, 3, 64)
+test_consolidate_partition(Int8, 10000, 9, 6333, 4, 16)
+test_consolidate_partition(Int8, 10000, 9, 6333, 5, 32)
+test_consolidate_partition(Int8, 10000, 9, 6333, 6, 64)
+test_consolidate_partition(Int8, 10000, 129, 9999, 7, 16)
+test_consolidate_partition(Int8, 10000, 129, 9999, 8, 32)
+test_consolidate_partition(Int8, 10000, 129, 9999, 9, 64)
+test_consolidate_partition(Int8, 10000, 3329, 9999, 10, 16)
+test_consolidate_partition(Int8, 10000, 3329, 9999, 11, 32)
+test_consolidate_partition(Int8, 10000, 3329, 9999, 12, 64)
+
+end
+
+function init_case(T, f, N :: Integer)
+    a = map(x -> T(f(x)), 1:N)
+    c = CuArray(a)
+    a, c
+end
+
+function init_case(T, f, N :: Tuple)
+    a = map(f, rand(N...))
+    c = CuArray(a)
+    a, c
+end
+
+"""
+Tests if `c` is a valid sort of `a`
+"""
+function test_equivalence(a :: Vector, c :: Vector; kwargs...)
+    @test counter(a) == counter(c) && issorted(c; kwargs...)
+end
+
+"""
+Tests if `c` is a valid sort of `a`
+"""
+function test_equivalence(a :: Array, c :: Array; dims, kwargs...)
+    @assert size(a) == size(c)
+    nd = ndims(c)
+    k = dims
+    sz = size(c)
+
+    1 <= k <= nd || throw(ArgumentError("dimension out of range"))
+
+    remdims = ntuple(i -> i == k ? 1 : size(c, i), nd)
+    v(a, idx) = view(a, ntuple(i -> i == k ? Colon() : idx[i], nd)...)
+    @test all(counter(v(a, idx)) == counter(v(c, idx)) && issorted(v(c, idx); kwargs...) for idx in CartesianIndices(remdims))
+end
+
+"""
+`T` - Element type to test
+`N` - Either an integer for a vector length, or a tuple for array dimension
+`f` - For a vector, fill with, for each index i, `T(f(i))`. Facilitates testing orderings
+      For an array, fill with `f(rand(T))`. Facilitates testing distributions
+"""
+function test_sort!(T, N, f=identity; kwargs...)
+    original_arr, device_arr = init_case(T, f, N)
+    # if sort! fell back to Base implementation, CUDA would error over
+    # disallowed scalar indexing
+    CUDA.allowscalar(false)
+    sort!(device_arr; kwargs...)
+    host_result = Array(device_arr)
+    test_equivalence(original_arr, host_result; kwargs...)
+end
+
+function test_sort(T, N, f=identity; kwargs...)
+    original_arr, device_arr = init_case(T, f, N)
+    host_result = Array(sort(device_arr; kwargs...))
+    test_equivalence(original_arr, host_result; kwargs...)
+end
+
+@testset "Quicksort" begin
+# test pre-sorted
+test_sort!(Int, 1000000)
+test_sort!(Int32, 1000000)
+test_sort!(Float64, 1000000)
+test_sort!(Float32, 1000000)
+test_sort!(Int32, 1000000; rev=true)
+test_sort!(Float32, 1000000; rev=true)
+
+# test reverse sorted
+test_sort!(Int32, 1000000, x -> -x)
+test_sort!(Float32, 1000000, x -> -x)
+test_sort!(Int32, 1000000, x -> -x; rev=true)
+test_sort!(Float32, 1000000, x -> -x; rev=true)
+
+# test random arrays
+Random.seed!(0)
+
+test_sort!(Int, 10000, x -> rand(Int))
+test_sort!(Int32, 10000, x -> rand(Int32))
+test_sort!(Int8, 10000, x -> rand(Int8))
+test_sort!(Float64, 10000, x -> rand(Float64))
+test_sort!(Float32, 10000, x -> rand(Float32))
+test_sort!(Float16, 10000, x -> rand(Float16))
+
+#test non-uniform distributions
+test_sort!(UInt8, 100000, x -> round(255 * rand() ^ 2))
+test_sort!(UInt8, 100000, x -> round(255 * rand() ^ 3))
+
+# test case when there are more copies of each value than fit in one block
+test_sort!(Int8, 4000000, x -> rand(Int8))
+
+# test multiple dimensions
+test_sort!(Int32, (4, 50000, 4); dims=2)
+test_sort!(Int32, (4, 4, 50000); dims=3, rev=true)
+
+# test various sync depths
+CUDA.limit!(CUDA.LIMIT_DEV_RUNTIME_SYNC_DEPTH, 0)
+test_sort!(Int, 100000, x -> rand(Int))
+CUDA.limit!(CUDA.LIMIT_DEV_RUNTIME_SYNC_DEPTH, 1)
+test_sort!(Int, 100000, x -> rand(Int))
+CUDA.limit!(CUDA.LIMIT_DEV_RUNTIME_SYNC_DEPTH, 2)
+test_sort!(Int, 100000, x -> rand(Int))
+CUDA.limit!(CUDA.LIMIT_DEV_RUNTIME_SYNC_DEPTH, 3)
+test_sort!(Int, 100000, x -> rand(Int))
+CUDA.limit!(CUDA.LIMIT_DEV_RUNTIME_SYNC_DEPTH, 4)
+test_sort!(Int, 100000, x -> rand(Int))
+
+# test using a `by` argument
+test_sort(Float32, 100000; by=x->abs(x - 0.5))
+test_sort(Float64, (4, 100000); by=x->cos(4 * pi * x), dims=2)
+end

--- a/test/sorting.jl
+++ b/test/sorting.jl
@@ -11,20 +11,20 @@ import CUDA.Quicksort: Θ, flex_lt, find_partition,
     @test Θ(1) == 1
     @test Θ(2) == 1
 
-    @test flex_lt(1, 2, false, isless) == true
-    @test flex_lt(1, 2, true, isless) == true
-    @test flex_lt(2, 2, false, isless) == false
-    @test flex_lt(2, 2, true, isless) == true
-    @test flex_lt(3, 2, false, isless) == false
-    @test flex_lt(3, 2, true, isless) == false
+    @test flex_lt(1, 2, false, isless, identity) == true
+    @test flex_lt(1, 2, true, isless, identity) == true
+    @test flex_lt(2, 2, false, isless, identity) == false
+    @test flex_lt(2, 2, true, isless, identity) == true
+    @test flex_lt(3, 2, false, isless, identity) == false
+    @test flex_lt(3, 2, true, isless, identity) == false
 
-    @test find_partition([1, 2, 2, 3, 4, 1, 2, 2, 3, 4], 3, 0, 5, false, isless) == 4
-    @test find_partition([1, 2, 2, 3, 4, 1, 2, 2, 3, 4], 3, 5, 10, false, isless) == 9
-    @test find_partition([1, 2, 2, 3, 4, 1, 2, 2, 3, 4], 3, 0, 5, true, isless) == 3
-    @test find_partition([1, 2, 2, 3, 4, 1, 2, 2, 3, 4], 3, 5, 10, true, isless) == 8
+    @test find_partition([1, 2, 2, 3, 4, 1, 2, 2, 3, 4], 3, 0, 5, false, isless, identity) == 4
+    @test find_partition([1, 2, 2, 3, 4, 1, 2, 2, 3, 4], 3, 5, 10, false, isless, identity) == 9
+    @test find_partition([1, 2, 2, 3, 4, 1, 2, 2, 3, 4], 3, 0, 5, true, isless, identity) == 3
+    @test find_partition([1, 2, 2, 3, 4, 1, 2, 2, 3, 4], 3, 5, 10, true, isless, identity) == 8
 end
 
-function test_batch_partition(T, N, lo, hi, seed, lt=isless)
+function test_batch_partition(T, N, lo, hi, seed, lt=isless, by=identity)
     my_range = lo + 1 : hi
     Random.seed!(seed)
     original = rand(T, N)
@@ -33,7 +33,7 @@ function test_batch_partition(T, N, lo, hi, seed, lt=isless)
     pivot = rand(original[my_range])
     block_N, block_dim = -1, -1
 
-    kernel = @cuda launch=false partition_batches_kernel(A, pivot, lo, hi, true, lt)
+    kernel = @cuda launch=false partition_batches_kernel(A, pivot, lo, hi, true, lt, by)
 
     get_shmem(threads) = threads * (sizeof(Int32) + max(4, sizeof(T)))
     config = launch_configuration(kernel.fun, shmem=threads->get_shmem(threads), max_threads=1024)
@@ -87,16 +87,16 @@ end
     test_batch_partition(Float32, 10000000, 5000, 500000, 0)
 end
 
-function test_consolidate_kernel(vals, pivot, my_floor, L, b_sums, dest, parity, lt)
+function test_consolidate_kernel(vals, pivot, my_floor, L, b_sums, dest, parity, lt, by)
     i = threadIdx().x
-    p = consolidate_batch_partition(vals, pivot, my_floor, L, b_sums, parity, lt)
+    p = consolidate_batch_partition(vals, pivot, my_floor, L, b_sums, parity, lt, by)
     if i == 1
         dest[1] = p
     end
     return nothing
 end
 
-function test_consolidate_partition(T, N, lo, hi, seed, block_dim, lt=isless)
+function test_consolidate_partition(T, N, lo, hi, seed, block_dim, lt=isless, by=identity)
     # assuming partition_batches works, we can validate consolidate by
     # checking that together they partition a large domain
     my_range = lo + 1 : hi
@@ -108,7 +108,7 @@ function test_consolidate_partition(T, N, lo, hi, seed, block_dim, lt=isless)
     threads = blocks = -1
     sums = CuArray(zeros(Int32, ceil(Int, hi - lo / block_dim)))
 
-    kernel = @cuda launch=false partition_batches_kernel(A, pivot, lo, hi, true, lt)
+    kernel = @cuda launch=false partition_batches_kernel(A, pivot, lo, hi, true, lt, by)
 
     get_shmem(threads) = threads * (sizeof(Int32) + max(4, sizeof(T)))
     config = launch_configuration(kernel.fun, shmem=threads->get_shmem(threads), max_threads=1024)
@@ -116,11 +116,11 @@ function test_consolidate_partition(T, N, lo, hi, seed, block_dim, lt=isless)
     threads = isnothing(block_dim) ? prevpow(2, config.threads) : block_dim
     blocks = ceil(Int, (hi - lo) ./ threads)
 
-    kernel(A, pivot, lo, hi, true, lt; threads=threads, blocks=blocks, shmem=get_shmem(threads))
+    kernel(A, pivot, lo, hi, true, lt, by; threads=threads, blocks=blocks, shmem=get_shmem(threads))
     synchronize()
     dest = CuArray(zeros(Int32, 1))
 
-    @cuda threads=threads test_consolidate_kernel(A, pivot, lo, hi - lo, sums, dest, true, lt)
+    @cuda threads=threads test_consolidate_kernel(A, pivot, lo, hi - lo, sums, dest, true, lt, by)
     synchronize()
 
     partition = Array(dest)[1]

--- a/test/sorting.jl
+++ b/test/sorting.jl
@@ -45,7 +45,7 @@ function test_batch_partition(T, N, lo, hi, seed, lt=isless, by=identity)
     @assert block_dim >= 32 "This test assumes block size can be >= 32"
 
     kernel(A, pivot, lo, hi, true, lt;
-           threads=threads, blocks=blocks, shmem=get_shmem(threads))
+           threads=threads, blocks=(1,blocks), shmem=get_shmem(threads))
     synchronize()
 
     post_sort = Array(A)
@@ -116,7 +116,7 @@ function test_consolidate_partition(T, N, lo, hi, seed, block_dim, lt=isless, by
     threads = isnothing(block_dim) ? prevpow(2, config.threads) : block_dim
     blocks = ceil(Int, (hi - lo) ./ threads)
 
-    kernel(A, pivot, lo, hi, true, lt, by; threads=threads, blocks=blocks, shmem=get_shmem(threads))
+    kernel(A, pivot, lo, hi, true, lt, by; threads=threads, blocks=(1,blocks), shmem=get_shmem(threads))
     synchronize()
     dest = CuArray(zeros(Int, 1))
 

--- a/test/sorting.jl
+++ b/test/sorting.jl
@@ -3,16 +3,10 @@ using DataStructures
 
 @testset "quicksort" begin
 
-import CUDA.Quicksort: pow2_floor, Θ, flex_lt, find_partition,
+import CUDA.Quicksort: Θ, flex_lt, find_partition,
         partition_batches_kernel, consolidate_batch_partition
 
 @testset "integer functions" begin
-    @test pow2_floor(1) == 1
-    @test pow2_floor(2) == 2
-    @test pow2_floor(3) == 2
-    @test pow2_floor(5) == 4
-    @test pow2_floor(8) == 8
-
     @test Θ(0) == 0
     @test Θ(1) == 1
     @test Θ(2) == 1
@@ -44,7 +38,7 @@ function test_batch_partition(T, N, lo, hi, seed)
     get_shmem(threads) = threads * (sizeof(Int32) + max(4, sizeof(T)))
     config = launch_configuration(kernel.fun, shmem=threads->get_shmem(threads), max_threads=1024)
 
-    threads = pow2_floor(config.threads)
+    threads = prevpow(2, config.threads)
     blocks = ceil(Int, (hi - lo) ./ threads)
     block_N = blocks
     block_dim = threads
@@ -119,7 +113,7 @@ function test_consolidate_partition(T, N, lo, hi, seed, block_dim)
     get_shmem(threads) = threads * (sizeof(Int32) + max(4, sizeof(T)))
     config = launch_configuration(kernel.fun, shmem=threads->get_shmem(threads), max_threads=1024)
 
-    threads = isnothing(block_dim) ? pow2_floor(config.threads) : block_dim
+    threads = isnothing(block_dim) ? prevpow(2, config.threads) : block_dim
     blocks = ceil(Int, (hi - lo) ./ threads)
 
     kernel(A, pivot, lo, hi, true; threads=threads, blocks=blocks, shmem=get_shmem(threads))

--- a/test/sorting.jl
+++ b/test/sorting.jl
@@ -165,7 +165,7 @@ function init_case(T, f, N::Integer)
 end
 
 function init_case(T, f, N::Tuple)
-    a = map(f, rand(N...))
+    a = map(f, rand(T, N...))
     c = CuArray(a)
     a, c
 end


### PR DESCRIPTION
An implementation of quicksort to address: https://github.com/JuliaGPU/CUDA.jl/issues/93

The performance is solid, see `src/sorting/usage.jl` for quick performance tests. I intend to later include handling lists with a large number of duplicates, which currently can stymie the method for partitioning.

Hopefully the tests included can help clarify the inner workings. Be warned that this is likely not the most "Julian" code that's ever been written in Julia.