### PR TITLE
Allow use of strided vectors with mul! (gemv! and gemm!)

### DIFF
--- a/lib/cublas/linalg.jl
+++ b/lib/cublas/linalg.jl
@@ -1,6 +1,6 @@
 # interfacing with LinearAlgebra standard library
 
-cublas_size(t::Char, M::CuVecOrMat) = (size(M, t=='N' ? 1 : 2), size(M, t=='N' ? 2 : 1))
+cublas_size(t::Char, M::StridedCuVecOrMat) = (size(M, t=='N' ? 1 : 2), size(M, t=='N' ? 2 : 1))
 
 
 
@@ -74,7 +74,7 @@ end
 
 # GEMV
 
-function gemv_wrapper!(y::CuVector{T}, tA::Char, A::CuMatrix{T}, x::CuVector{T},
+function gemv_wrapper!(y::CuVector{T}, tA::Char, A::StridedCuMatrix{T}, x::StridedCuVector{T},
                        alpha::Number = true, beta::Number = false) where T<:CublasFloat
     mA, nA = cublas_size(tA, A)
     if nA != length(x)
@@ -89,24 +89,25 @@ function gemv_wrapper!(y::CuVector{T}, tA::Char, A::CuMatrix{T}, x::CuVector{T},
     if nA == 0
         return rmul!(y, 0)
     end
+
     gemv!(tA, alpha, A, x, beta, y)
 end
 
-LinearAlgebra.mul!(Y::CuVector{T}, A::CuMatrix{T}, B::CuVector{T}, a::Number, b::Number) where T<:CublasFloat =
+LinearAlgebra.mul!(Y::CuVector{T}, A::StridedCuMatrix{T}, B::StridedCuVector{T}, a::Number, b::Number) where T<:CublasFloat =
     gemv_wrapper!(Y, 'N', A, B, a, b)
-LinearAlgebra.mul!(Y::CuVector{T}, A::Transpose{<:Any, <:CuVecOrMat{T}}, B::CuVector{T}, a::Number, b::Number) where T<:CublasFloat =
+LinearAlgebra.mul!(Y::CuVector{T}, A::Transpose{<:Any, <:StridedCuVecOrMat{T}}, B::StridedCuVector{T}, a::Number, b::Number) where T<:CublasFloat =
     gemv_wrapper!(Y, 'T', A.parent, B, a, b)
-LinearAlgebra.mul!(Y::CuVector{T}, A::Adjoint{<:Any, <:CuVecOrMat{T}}, B::CuVector{T}, a::Real, b::Real) where T<:CublasReal =
+LinearAlgebra.mul!(Y::CuVector{T}, A::Adjoint{<:Any, <:StridedCuVecOrMat{T}}, B::StridedCuVector{T}, a::Real, b::Real) where T<:CublasReal =
     gemv_wrapper!(Y, 'T', A.parent, B, a, b)
-LinearAlgebra.mul!(Y::CuVector{T}, A::Adjoint{<:Any, <:CuVecOrMat{T}}, B::CuVector{T}, a::Number, b::Number) where T<:CublasComplex =
+LinearAlgebra.mul!(Y::CuVector{T}, A::Adjoint{<:Any, <:StridedCuVecOrMat{T}}, B::StridedCuVector{T}, a::Number, b::Number) where T<:CublasComplex =
     gemv_wrapper!(Y, 'C', A.parent, B, a, b)
 
 # ambiguity hacks: Base and GPUArrays has mul! with a::Real, b::Real
-LinearAlgebra.mul!(Y::CuVector{T}, A::CuMatrix{T}, B::CuVector{T}, a::Real, b::Real) where T<:CublasFloat =
+LinearAlgebra.mul!(Y::CuVector{T}, A::StridedCuMatrix{T}, B::StridedCuVector{T}, a::Real, b::Real) where T<:CublasFloat =
     gemv_wrapper!(Y, 'N', A, B, a, b)
-LinearAlgebra.mul!(Y::CuVector{T}, A::Transpose{<:Any, <:CuVecOrMat{T}}, B::CuVector{T}, a::Real, b::Real) where T<:CublasFloat =
+LinearAlgebra.mul!(Y::CuVector{T}, A::Transpose{<:Any, <:StridedCuVecOrMat{T}}, B::StridedCuVector{T}, a::Real, b::Real) where T<:CublasFloat =
     gemv_wrapper!(Y, 'T', A.parent, B, a, b)
-LinearAlgebra.mul!(Y::CuVector{T}, A::Adjoint{<:Any, <:CuVecOrMat{T}}, B::CuVector{T}, a::Real, b::Real) where T<:CublasComplex =
+LinearAlgebra.mul!(Y::CuVector{T}, A::Adjoint{<:Any, <:StridedCuVecOrMat{T}}, B::StridedCuVector{T}, a::Real, b::Real) where T<:CublasComplex =
     gemv_wrapper!(Y, 'C', A.parent, B, a, b)
 
 # TRSV

--- a/lib/cublas/wrappers.jl
+++ b/lib/cublas/wrappers.jl
@@ -284,7 +284,7 @@ for (fname, elty) in ((:cublasDgemv_v2,:Float64),
                        A::StridedCuMatrix{$elty},
                        X::StridedCuVector{$elty},
                        beta::Number,
-                       Y::CuVector{$elty})
+                       Y::DenseCuVector{$elty})
             # handle trans
             m,n = size(A)
             # check dimensions
@@ -708,10 +708,10 @@ for (fname, elty) in
         function gemm!(transA::Char,
                        transB::Char,
                        alpha::Number,
-                       A::CuVecOrMat{$elty},
-                       B::CuVecOrMat{$elty},
+                       A::DenseCuVecOrMat{$elty},
+                       B::DenseCuVecOrMat{$elty},
                        beta::Number,
-                       C::CuVecOrMat{$elty})
+                       C::DenseCuVecOrMat{$elty})
             m = size(A, transA == 'N' ? 1 : 2)
             k = size(A, transA == 'N' ? 2 : 1)
             n = size(B, transB == 'N' ? 2 : 1)
@@ -727,16 +727,16 @@ for (fname, elty) in
         function gemm(transA::Char,
                       transB::Char,
                       alpha::Number,
-                      A::CuMatrix{$elty},
-                      B::CuMatrix{$elty})
+                      A::DenseCuMatrix{$elty},
+                      B::DenseCuMatrix{$elty})
             gemm!(transA, transB, alpha, A, B, zero($elty),
                   similar(B, $elty, (size(A, transA == 'N' ? 1 : 2),
                                      size(B, transB == 'N' ? 2 : 1))))
         end
         function gemm(transA::Char,
                       transB::Char,
-                      A::CuMatrix{$elty},
-                      B::CuMatrix{$elty})
+                      A::DenseCuMatrix{$elty},
+                      B::DenseCuMatrix{$elty})
             gemm(transA, transB, one($elty), A, B)
         end
     end
@@ -810,10 +810,10 @@ end
 
 function gemmEx!(transA::Char, transB::Char,
                  @nospecialize(alpha::Number),
-                 @nospecialize(A::CuVecOrMat),
-                 @nospecialize(B::CuVecOrMat),
+                 @nospecialize(A::DenseCuVecOrMat),
+                 @nospecialize(B::DenseCuVecOrMat),
                  @nospecialize(beta::Number),
-                 @nospecialize(C::CuVecOrMat);
+                 @nospecialize(C::DenseCuVecOrMat);
                  algo::cublasGemmAlgo_t=CUBLAS_GEMM_DEFAULT)
     m = size(A, transA == 'N' ? 1 : 2)
     k = size(A, transA == 'N' ? 2 : 1)

--- a/lib/cublas/wrappers.jl
+++ b/lib/cublas/wrappers.jl
@@ -281,8 +281,8 @@ for (fname, elty) in ((:cublasDgemv_v2,:Float64),
     @eval begin
         function gemv!(trans::Char,
                        alpha::Number,
-                       A::CuMatrix{$elty},
-                       X::CuVector{$elty},
+                       A::StridedCuMatrix{$elty},
+                       X::StridedCuVector{$elty},
                        beta::Number,
                        Y::CuVector{$elty})
             # handle trans
@@ -296,10 +296,10 @@ for (fname, elty) in ((:cublasDgemv_v2,:Float64),
             $fname(handle(), trans, m, n, alpha, A, lda, X, incx, beta, Y, incy)
             Y
         end
-        function gemv(trans::Char, alpha::Number, A::CuMatrix{$elty}, X::CuVector{$elty})
+        function gemv(trans::Char, alpha::Number, A::StridedCuMatrix{$elty}, X::StridedCuVector{$elty})
             gemv!(trans, alpha, A, X, zero($elty), similar(X, $elty, size(A, (trans == 'N' ? 1 : 2))))
         end
-        function gemv(trans::Char, A::CuMatrix{$elty}, X::CuVector{$elty})
+        function gemv(trans::Char, A::StridedCuMatrix{$elty}, X::StridedCuVector{$elty})
             gemv!(trans, one($elty), A, X, zero($elty), similar(X, $elty, size(A, (trans == 'N' ? 1 : 2))))
         end
     end

--- a/src/pointer.jl
+++ b/src/pointer.jl
@@ -70,6 +70,11 @@ function Base.unsafe_convert(::Type{CuPtr{T}}, V::SubArray{T,N,P,<:Tuple{Vararg{
            Base._memory_offset(V.parent, map(first, V.indices)...)
 end
 
+# from reshaped subarrays
+function Base.unsafe_convert(::Type{CuPtr{T}}, V::SubArray{T,N,P,<:Tuple{Vararg{Union{Base.RangeIndex,Base.ReshapedUnitRange}}}}) where {T,N,P}
+   return Base. unsafe_convert(CuPtr{T}, parent(V)) +
+          (Base.first_index(V)-1)*sizeof(T)
+end
 
 ## limited pointer arithmetic & comparison
 

--- a/test/cublas.jl
+++ b/test/cublas.jl
@@ -78,12 +78,6 @@ end
             A = rand(elty, m + 1, m )
             dA = CuArray(A)
             @test_throws DimensionMismatch mul!(dy, dA, dx)
-
-            # JuliaGPU/CUDA.jl#445: strided inputs
-            testf(rand(16), rand(4)) do p, b
-                W = @view p[reshape(1:(16),4,4)]
-                W*b
-            end
         end
 
         @testset "mul! y = $f(A) * x * $Ts(a) + y * $Ts(b)" for f in (identity, transpose, adjoint), Ts in (Int, elty)
@@ -424,6 +418,13 @@ end
                 hB = triu(hB)
                 @test B ≈ hB
             end
+        end
+    end
+
+    @testset "gemv! with strided inputs" begin  # JuliaGPU/CUDA.jl#445
+        testf(rand(16), rand(4)) do p, b
+            W = @view p[reshape(1:(16),4,4)]
+            W*b
         end
     end
 end
@@ -1289,6 +1290,14 @@ end
 
             rtol = Base.rtoldefault(AT, BT, 0)
             @test C ≈ Array(dC) rtol=rtol
+        end
+    end
+
+    @testset "gemm! with strided inputs" begin # JuliaGPU/CUDA.jl#78
+        inn = 784; out = 32
+        testf(randn(784*100), rand(Float32, 784, 100)) do p, x
+            p[reshape(1:(out*inn),out,inn)] * x
+            @view(p[reshape(1:(out*inn),out,inn)]) * x
         end
     end
 end

--- a/test/cublas.jl
+++ b/test/cublas.jl
@@ -78,7 +78,14 @@ end
             A = rand(elty, m + 1, m )
             dA = CuArray(A)
             @test_throws DimensionMismatch mul!(dy, dA, dx)
+
+            # JuliaGPU/CUDA.jl#445: strided inputs
+            testf(rand(16), rand(4)) do p, b
+                W = @view p[reshape(1:(16),4,4)]
+                W*b
+            end
         end
+
         @testset "mul! y = $f(A) * x * $Ts(a) + y * $Ts(b)" for f in (identity, transpose, adjoint), Ts in (Int, elty)
             y, A, x = rand(elty, 5), rand(elty, 5, 5), rand(elty, 5)
             dy, dA, dx = CuArray(y), CuArray(A), CuArray(x)


### PR DESCRIPTION
Fixes https://github.com/JuliaGPU/CUDA.jl/issues/78, fixes https://github.com/JuliaGPU/CUDA.jl/issues/448

Not fully generalized, and simplified some of the signatures, because using the `AnyCuArray` union everywhere makes package import time regress from ~5 to ~25 seconds.

cc @ChrisRackauckas 
