### PR TITLE
Use the correct CUDNN scaling parameter type.

### DIFF
--- a/lib/cudnn/activation.jl
+++ b/lib/cudnn/activation.jl
@@ -24,8 +24,8 @@ function cudnnActivationForward(x::DenseCuArray{T,N}, y::DenseCuArray{T,N}=x;
                                 mode=CUDNN_ACTIVATION_RELU, # CUDNN_ACTIVATION_IDENTITY will not work
                                 coeff=0.0, reluNanOpt=CUDNN_NOT_PROPAGATE_NAN, alpha=1, beta=0) where {T,N}
     cudnnActivationForward(handle(), ActivationDesc(mode, T(coeff), reluNanOpt),
-                           Ref(T(alpha)), TensorDesc(x), x,
-                           Ref(T(beta )), TensorDesc(y), y)
+                           scalingParameter(T, alpha), TensorDesc(x), x,
+                           scalingParameter(T, beta ), TensorDesc(y), y)
     return  y
 end
 
@@ -33,9 +33,9 @@ function cudnnActivationBackward(x::DenseCuArray{T,N}, dx::DenseCuArray{T,N}, y:
                                  mode=CUDNN_ACTIVATION_RELU, # CUDNN_ACTIVATION_IDENTITY will not work
                                  coeff=0.0, reluNanOpt=CUDNN_NOT_PROPAGATE_NAN, alpha=1, beta=0) where {T,N}
     cudnnActivationBackward(handle(), ActivationDesc(mode, T(coeff), reluNanOpt),
-                            Ref(T(alpha)), TensorDesc( y),  y,
+                            scalingParameter(T, alpha), TensorDesc( y),  y,
                             TensorDesc(dy), dy,
                             TensorDesc( x),  x,
-                            Ref(T(beta )), TensorDesc(dx), dx)
+                            scalingParameter(T, beta ), TensorDesc(dx), dx)
     return dx
 end

--- a/lib/cudnn/batchnorm.jl
+++ b/lib/cudnn/batchnorm.jl
@@ -50,14 +50,14 @@ function cudnnBNForward!(y::DenseCuArray{T}, g::DenseCuArray{T}, b::DenseCuArray
       ivar = CU_NULL
     end
 
-    cudnnBatchNormalizationForwardTraining(handle(), CUDNN_BATCHNORM_SPATIAL, Ref{T}(alpha), Ref{T}(beta), xd, x, yd, y, gd, g, b, momentum, running_mean, running_var, eps, mean, ivar)
+    cudnnBatchNormalizationForwardTraining(handle(), CUDNN_BATCHNORM_SPATIAL, scalingParameter(T, alpha), scalingParameter(T, beta), xd, x, yd, y, gd, g, b, momentum, running_mean, running_var, eps, mean, ivar)
 
     if cache !== nothing
       cache.mean = mean
       cache.ivar = ivar
     end
   else
-    cudnnBatchNormalizationForwardInference(handle(), CUDNN_BATCHNORM_SPATIAL, Ref{T}(alpha), Ref{T}(beta), xd, x, yd, y, gd, g, b, running_mean, running_var, eps)
+    cudnnBatchNormalizationForwardInference(handle(), CUDNN_BATCHNORM_SPATIAL, scalingParameter(T, alpha), scalingParameter(T, beta), xd, x, yd, y, gd, g, b, running_mean, running_var, eps)
   end
   return y
 end
@@ -106,7 +106,7 @@ function cudnnBNBackward!(dg::DenseCuArray{T}, g::DenseCuArray{T}, db::DenseCuAr
       eps = CUDNN_BN_MIN_EPSILON
     end
 
-    cudnnBatchNormalizationBackward(handle(), CUDNN_BATCHNORM_SPATIAL, Ref{T}(alpha), Ref{T}(beta), Ref{T}(dalpha), Ref{T}(dbeta), xd, x, dyd, dy, dxd, dx, gd, g, dg, db, eps, mean, ivar)
+    cudnnBatchNormalizationBackward(handle(), CUDNN_BATCHNORM_SPATIAL, scalingParameter(T, alpha), scalingParameter(T, beta), scalingParameter(T, dalpha), scalingParameter(T, dbeta), xd, x, dyd, dy, dxd, dx, gd, g, dg, db, eps, mean, ivar)
   else
     ivar = 1 ./ sqrt.(reshape(running_var, _wsize(x)) .+ eps)
     dx .= dy .* reshape(g, _wsize(x)) .* ivar

--- a/lib/cudnn/conv.jl
+++ b/lib/cudnn/conv.jl
@@ -151,9 +151,9 @@ function cudnnConvolutionForward(y::DenseCuArray{T,N}, x::DenseCuArray{T,N}, w::
                 out(Ref{Csize_t}()))
         )[] workspace->begin
             cudnnConvolutionForward(
-                handle(), Ref{T}(alpha), TensorDesc(x), x, FilterDesc(w), w,
+                handle(), scalingParameter(T, alpha), TensorDesc(x), x, FilterDesc(w), w,
                 ConvDesc(T,cdims), cudnnConvolutionFwdAlgo_t(algo), workspace,
-                sizeof(workspace), Ref{T}(beta), TensorDesc(y), y)
+                sizeof(workspace), scalingParameter(T, beta), TensorDesc(y), y)
         end
     return y
 end
@@ -170,9 +170,9 @@ function cudnnConvolutionBiasActivationForward(y::DenseCuArray{T,N}, x::DenseCuA
                 out(Ref{Csize_t}()))
         )[] workspace->begin
             cudnnConvolutionBiasActivationForward(
-                handle(), Ref(T(alpha1)), TensorDesc(x), x, FilterDesc(w), w,
+                handle(), scalingParameter(T, alpha1), TensorDesc(x), x, FilterDesc(w), w,
                 ConvDesc(T, cdims), cudnnConvolutionFwdAlgo_t(algo), workspace,
-                sizeof(workspace), Ref(T(alpha2)), TensorDesc(z), z, TensorDesc(bias), bias, ActivationDesc(activationMode, activationCoeff, activationReluNanOpt), TensorDesc(y),y)
+                sizeof(workspace), scalingParameter(T, alpha2), TensorDesc(z), z, TensorDesc(bias), bias, ActivationDesc(activationMode, activationCoeff, activationReluNanOpt), TensorDesc(y),y)
         end
     return y
 end
@@ -262,11 +262,11 @@ function cudnnConvolutionBackwardData(dx::DenseCuArray{T,N}, w::DenseCuArray{T,N
                 out(Ref{Csize_t}()))
         )[] workspace->begin
             cudnnConvolutionBackwardData(
-                handle(), Ref{T}(alpha), FilterDesc(w), w,
+                handle(), scalingParameter(T, alpha), FilterDesc(w), w,
                 TensorDesc(dy), dy, ConvDesc(T, cdims),
                 cudnnConvolutionBwdDataAlgo_t(algo),
                 workspace, sizeof(workspace),
-                Ref{T}(beta), TensorDesc(dx), dx)
+                scalingParameter(T, beta), TensorDesc(dx), dx)
         end
     return dx
 end
@@ -360,10 +360,10 @@ function cudnnConvolutionBackwardFilter(dw::DenseCuArray{T,N}, x::DenseCuArray{T
                 out(Ref{Csize_t}()))
         )[] workspace->begin
             cudnnConvolutionBackwardFilter(
-                handle(), Ref{T}(alpha), TensorDesc(x), x,
+                handle(), scalingParameter(T, alpha), TensorDesc(x), x,
                 TensorDesc(dy), dy, ConvDesc(T, cdims),
                 cudnnConvolutionBwdFilterAlgo_t(algo), workspace,
-                sizeof(workspace), Ref{T}(beta), FilterDesc(dw), dw)
+                sizeof(workspace), scalingParameter(T, beta), FilterDesc(dw), dw)
         end
     return dw
 end
@@ -372,7 +372,7 @@ end
 
 function cudnnConvolutionBackwardBias(db::DenseCuArray{T,N}, dy::DenseCuArray{T,N}; alpha=1, beta=0) where {T,N}
     cudnnConvolutionBackwardBias(handle(),
-                                 Ref(T(alpha)), TensorDesc(dy), dy,
-                                 Ref(T(beta )), TensorDesc(db), db)
+                                 scalingParameter(T, alpha), TensorDesc(dy), dy,
+                                 scalingParameter(T, beta),  TensorDesc(db), db)
     return db
 end

--- a/lib/cudnn/pooling.jl
+++ b/lib/cudnn/pooling.jl
@@ -35,8 +35,8 @@ end
 function cudnnPoolingForward(y::DenseCuArray{T,N}, x::DenseCuArray{T,N}, pdims::PoolDims;
                              alpha=1, beta=0, mode=0) where {T,N}
     cudnnPoolingForward(handle(), PoolDesc(pdims, mode),
-                        Ref(T(alpha)), TensorDesc(x), x,
-                        Ref(T(beta )), TensorDesc(y), y)
+                        scalingParameter(T, alpha), TensorDesc(x), x,
+                        scalingParameter(T, beta ), TensorDesc(y), y)
     return y
 end
 
@@ -45,9 +45,9 @@ function cudnnPoolingBackward(dx::DenseCuArray{T,N}, dy::DenseCuArray{T,N}, x::D
     if alpha!=1 && mode==0; error("Gradient of pool(alpha!=1,mode=0) broken in CUDNN"); end
     beta = 0
     cudnnPoolingBackward(handle(), PoolDesc(pdims, mode),
-                         Ref(T(alpha)), TensorDesc( y),  y,
+                         scalingParameter(T, alpha), TensorDesc( y),  y,
                          TensorDesc(dy), dy,
                          TensorDesc( x),  x,
-                         Ref(T(beta )), TensorDesc(dx), dx)
+                         scalingParameter(T, beta ), TensorDesc(dx), dx)
     return dx
 end

--- a/lib/cudnn/softmax.jl
+++ b/lib/cudnn/softmax.jl
@@ -5,8 +5,8 @@ function cudnnSoftmaxForward(x::DenseCuArray{T,4}, y::DenseCuArray{T,4}=x;
                              mode=CUDNN_SOFTMAX_MODE_INSTANCE, # or CUDNN_SOFTMAX_MODE_CHANNEL
                              alpha=1.0, beta=0.0) where T
     cudnnSoftmaxForward(handle(), algo, mode,
-                        Ref(T(alpha)), TensorDesc(x), x,
-                        Ref(T(beta )), TensorDesc(y), y)
+                        scalingParameter(T, alpha), TensorDesc(x), x,
+                        scalingParameter(T, beta ), TensorDesc(y), y)
     return y
 end
 
@@ -15,8 +15,8 @@ function cudnnSoftmaxBackward(y::DenseCuArray{T,4}, dy::DenseCuArray{T,4}, dx::D
                               mode=CUDNN_SOFTMAX_MODE_INSTANCE, # or CUDNN_SOFTMAX_MODE_CHANNEL
                               alpha=1.0, beta=0.0) where T
     cudnnSoftmaxBackward(handle(), algo, mode,
-                         Ref(T(alpha)), TensorDesc(y), y,
+                         scalingParameter(T, alpha), TensorDesc(y), y,
                          TensorDesc(dy), dy,
-                         Ref(T(beta )), TensorDesc(dx), dx)
+                         scalingParameter(T, beta ), TensorDesc(dx), dx)
     return dx
 end

--- a/lib/cudnn/tensor.jl
+++ b/lib/cudnn/tensor.jl
@@ -28,8 +28,8 @@ TensorDesc(a::DenseCuArray) = TensorDesc(eltype(a), size(a), strides(a))
 function cudnnAddTensor(C::DenseCuArray{T,N}, A::DenseCuArray{T,N};
                         alpha=1, beta=1) where {T,N}
     cudnnAddTensor(handle(),
-                   Ref(T(alpha)), TensorDesc(A), A,
-                   Ref(T(beta )), TensorDesc(C), C)
+                   scalingParameter(T, alpha), TensorDesc(A), A,
+                   scalingParameter(T, beta ), TensorDesc(C), C)
     return C
 end
 
@@ -64,9 +64,9 @@ function cudnnOpTensor(op::cudnnOpTensorOp_t,
                        A::DenseCuArray{T,N}, B::DenseCuArray{T,N}, C::DenseCuArray{T,N};
                        alpha1=1, alpha2=1, beta=0) where {T,N}
     cudnnOpTensor(handle(), OpTensorDesc(op, T),
-                  Ref(T(alpha1)), TensorDesc(A), A,
-                  Ref(T(alpha2)), TensorDesc(B), B,
-                  Ref(T(beta  )), TensorDesc(C), C)
+                  scalingParameter(T, alpha1), TensorDesc(A), A,
+                  scalingParameter(T, alpha2), TensorDesc(B), B,
+                  scalingParameter(T, beta  ), TensorDesc(C), C)
     return C
 end
 
@@ -125,8 +125,8 @@ function cudnnReduceTensor(op::cudnnReduceTensorOp_t,
             cudnnReduceTensor(handle(), ReduceTensorDesc(op, A),
                               C_NULL, indicesSizeInBytes,
                               workspace, sizeof(workspace),
-                              Ref(T(alpha)), TensorDesc(A), A,
-                              Ref(T(beta )), TensorDesc(C), C)
+                              scalingParameter(T, alpha), TensorDesc(A), A,
+                              scalingParameter(T, beta ), TensorDesc(C), C)
         end
     return C
 end

--- a/lib/cudnn/util.jl
+++ b/lib/cudnn/util.jl
@@ -18,3 +18,11 @@ function _strides(out::NTuple{M,Int}, A::Tuple) where M
     Base.@_inline_meta
     _strides((out..., out[M]*A[M]), A)
 end
+
+# The storage data types for alpha and beta are:
+#     float for HALF and FLOAT tensors, and
+#     double for DOUBLE tensors.
+scalingParameter(T, val) = error("Unknown tensor type $T")
+scalingParameter(::Type{Float16}, val) = Ref{Float32}(val)
+scalingParameter(::Type{Float32}, val) = Ref{Float32}(val)
+scalingParameter(::Type{Float64}, val) = Ref{Float64}(val)


### PR DESCRIPTION
Fixes https://github.com/JuliaGPU/CUDA.jl/issues/92

cc @ DrChainsaw  @hgt312

@DhairyaLGandhi Could you test this with Flux? There's very few CUDNN tests here, and we're close to release. FWIW, Flux' tests still pass, or at least throw the same errors as they did before this PR (`UndefVarError: ALL_LOSSES not defined`).