### PR TITLE
Remove duplicate comment

### DIFF
--- a/docs/src/tutorials/introduction.jl
+++ b/docs/src/tutorials/introduction.jl
@@ -57,7 +57,6 @@ sequential_add!(y, x)
 
 # And now a parallel implementation:
 
-# parallel implementation
 function parallel_add!(y, x)
     Threads.@threads for i in eachindex(y, x)
         @inbounds y[i] += x[i]


### PR DESCRIPTION
In the doc: https://juliagpu.gitlab.io/CUDA.jl/tutorials/introduction/, the same comment appear twice:
> And now a parallel implementation:
> 
> parallel implementation