### PR TITLE
Fix initialization of global state

### DIFF
--- a/src/initialization.jl
+++ b/src/initialization.jl
@@ -134,8 +134,8 @@ function __runtime_init__()
         end
     end
 
-    resize!(device_contexts, ndevices())
-    fill!(device_contexts, nothing)
+    resize!(__device_contexts, ndevices())
+    fill!(__device_contexts, nothing)
 
     __init_compatibility__()
 


### PR DESCRIPTION
Fixes https://github.com/JuliaGPU/CUDA.jl/issues/468, where a `CuDevice` was passed to a process which resulted in global state being accessed before any actual API call.