### PR TITLE
Remove 'view' implementation.

### DIFF
--- a/src/device/array.jl
+++ b/src/device/array.jl
@@ -140,12 +140,6 @@ Base.show(io::IO, a::CuDeviceArray) =
 
 Base.show(io::IO, mime::MIME"text/plain", a::CuDeviceArray) = show(io, a)
 
-@inline function Base.unsafe_view(A::CuDeviceVector{T}, I::Vararg{Base.ViewIndex,1}) where {T}
-    ptr = pointer(A, I[1].start)
-    len = I[1].stop - I[1].start + 1
-    return CuDeviceArray(len, ptr)
-end
-
 @inline function Base.iterate(A::CuDeviceArray, i=1)
     if (i % UInt) - 1 < length(A)
         (@inbounds A[i], i + 1)


### PR DESCRIPTION
SubArray works fine on GPU, and the existing override broke 'view(x, :)' due to nonexisting '.start'.

Fixes https://discourse.julialang.org/t/error-when-calling-2d-dynamic-kernel-with-view-argument/47647