### PR TITLE
fix CUDA error on macos 10.13

### DIFF
--- a/deps/discovery.jl
+++ b/deps/discovery.jl
@@ -41,10 +41,10 @@ function library_versioned_names(name::String, version::Union{Nothing,VersionNum
     elseif Sys.isunix()
         # most UNIX distributions ship versioned libraries (also see JuliaLang/julia#22828)
         if version isa VersionNumber
-            append!(names, ["lib$(name).$(Libdl.dlext).$(version.major).$(version.minor)",
-                            "lib$(name).$(Libdl.dlext).$(version.major)"])
+            append!(names, ["lib$(name).$(version.major).$(version.minor).$(Libdl.dlext)",
+                            "lib$(name).$(version.major).$(Libdl.dlext)"])
         elseif version isa String
-            push!(names, "lib$(name).$(Libdl.dlext).$(version)")
+            push!(names, "lib$(name).$(version).$(Libdl.dlext)")
         elseif version === nothing
             push!(names, "lib$(name).$(Libdl.dlext)")
         end


### PR DESCRIPTION
ENV:
macOS High Sierra
10.13.6

CUDA:
/usr/local/cuda/bin/nvcc --version
nvcc: NVIDIA (R) Cuda compiler driver
Copyright (c) 2005-2019 NVIDIA Corporation
Built on Sun_Jul_28_19:14:47_PDT_2019
Cuda compilation tools, release 10.1, V10.1.243

Before Changed:
```
Could not find nvToolsExt (libnvToolsExt.dylib.1.0 or libnvToolsExt.dylib.1) in /Users/imac/.julia/artifacts/b502baf54095dff4a69fd6aba8667124583f6929/lib
```

After Change
```
┌ Info: System information:
│ CUDA toolkit 10.1.243, artifact installation
│ CUDA driver 10.1.0
│ 
│ Libraries: 
│ - CUBLAS: 10.2.1
│ - CURAND: 10.1.1
│ - CUFFT: 10.1.1
│ - CUSOLVER: 10.2.0
│ - CUSPARSE: 10.3.0
│ - CUPTI: 12.0.0
│ - NVML: missing
│ - CUDNN: missing
│ - CUTENSOR: missing
```
