### PR TITLE
Implement task local storage

### DIFF
--- a/src/device/intrinsics.jl
+++ b/src/device/intrinsics.jl
@@ -34,3 +34,6 @@ include("intrinsics/libcudadevrt_common.jl")
 include("intrinsics/libcudadevrt.jl")
 include("intrinsics/cooperative_groups.jl")
 include("intrinsics/dynamic_parallelism.jl")
+
+# TLS
+include("intrinsics/memory_local.jl")

--- a/src/device/intrinsics/memory_local.jl
+++ b/src/device/intrinsics/memory_local.jl
@@ -44,7 +44,7 @@ Allocates a `CuDeviceArray` backed by a global variable in local memory.
     Calls to `alloc_local` with the same `name` will alias within
     a kernel. This allows for the implmentation of thread local global state.
 """
-@inline function alloc_local(name::Symbol, ::Type{T}, dims=(0,))
+@inline function alloc_local(name::Symbol, ::Type{T}, dims=(0,)) where T
     ptr = emit_localmem(Val(name), T, Val(prod(dims)))
     CuDeviceArray(dims, ptr)
 end

--- a/src/device/intrinsics/memory_local.jl
+++ b/src/device/intrinsics/memory_local.jl
@@ -1,0 +1,35 @@
+# get a pointer to shared memory, with known (static) or zero length (dynamic shared memory)
+@generated function emit_localmem(::Val{name}, ::Type{T}, ::Val{len}=Val(0)) where {name,T,len}
+    JuliaContext() do ctx
+        eltyp = convert(LLVMType, T, ctx)
+        T_ptr = convert(LLVMType, LLVMPtr{T, AS.Local}, ctx)
+
+        # create a function
+        llvm_f, _ = create_function(T_ptr)
+
+        # create the global variable
+        mod = LLVM.parent(llvm_f)
+        gv_typ = LLVM.ArrayType(eltyp, len)
+        gv = GlobalVariable(mod, gv_typ, GPUCompiler.safe_name(string(name)), AS.Local)
+        if len > 0
+            # linkage!(gv, LLVM.API.LLVMInternalLinkage)
+            linkage!(gv.LLVM.API.LLVMLinkOnceODRLinkage)
+            initializer!(gv, null(gv_typ))
+        end
+        alignment!(gv, Base.datatype_alignment(T))
+
+        # generate IR
+        Builder(ctx) do builder
+            entry = BasicBlock(llvm_f, "entry", ctx)
+            position!(builder, entry)
+
+            ptr = gep!(builder, gv, [ConstantInt(0, ctx), ConstantInt(0, ctx)])
+
+            untyped_ptr = bitcast!(builder, ptr, T_ptr)
+
+            ret!(builder, untyped_ptr)
+        end
+
+        call_function(llvm_f, LLVMPtr{T,AS.Local})
+    end
+end

--- a/test/device/intrinsics.jl
+++ b/test/device/intrinsics.jl
@@ -1313,4 +1313,26 @@ end
     @test Array(a) == [16]
 end
 
+@testset "local memory" begin
+    @noinline function get_tls()
+        buf = alloc_local(:ptls, Int, 1)
+        buf[1]
+    end
+
+    @noinline function set_tls(val)
+        buf = alloc_local(:ptls, Int, 1)
+        buf[1] = val
+    end
+
+    function kernel(a)
+        set_tls(42)
+        @inbounds a[1] = get_tls()
+        return
+    end
+
+    a = CuArray([0])
+    @cuda kernel(a)
+    @test Array(a) == [42]
+end
+
 end

--- a/test/device/intrinsics.jl
+++ b/test/device/intrinsics.jl
@@ -1316,12 +1316,12 @@ end
 @testset "local memory" begin
     @noinline function get_tls()
         buf = alloc_local(:ptls, Int, 1)
-        buf[1]
+        @inbounds buf[1]
     end
 
     @noinline function set_tls(val)
         buf = alloc_local(:ptls, Int, 1)
-        buf[1] = val
+        @inbounds buf[1] = val
     end
 
     function kernel(a)


### PR DESCRIPTION
Discussions with @jpsamaroo made me think about how/if we could have "tls" in the sense of having global pointers that are local to each thread.

```
using CUDA

@noinline function get()
    ptr = CUDA.emit_localmem(Val(:tls), Int, Val(1))
    unsafe_load(ptr, 1)
end

function test(a)
    ptr = CUDA.emit_localmem(Val(:tls), Int, Val(1))
    unsafe_store!(ptr, 42, 1)
    val = get()
    @inbounds a[1] = val
    nothing
end
```

`linkonce_odr` is cool since it allows LLVM to turn `get` into:

```
define internal fastcc i64 @julia_get_4657() unnamed_addr #0 {
top:
;  @ REPL[4]:3 within `get'
; ┌ @ /home/vchuravy/.julia/packages/LLVM/AGEVG/src/interop/pointer.jl:79 within `unsafe_load' @ /home/vchuravy/.julia/packages/LLVM/AGEVG/src/interop/pointer.jl:79
; │┌ @ /home/vchuravy/.julia/packages/LLVM/AGEVG/src/interop/pointer.jl:7 within `pointerref'
; ││┌ @ /home/vchuravy/.julia/packages/LLVM/AGEVG/src/interop/pointer.jl:7 within `macro expansion' @ /home/vchuravy/.julia/packages/LLVM/AGEVG/src/interop/base.jl:80
     %.b = load i1, i1 addrspace(5)* @tls.0
     %0 = select i1 %.b, i64 42, i64 0
; └└└
  ret i64 %0
}
```

replacing the `tls` GV with a bit that indicates if it has been set.

A quick smoke test to make sure that things are indeed local
```
function test(a)
         ptr = CUDA.emit_localmem(Val(:tls), Int, Val(1))
         unsafe_store!(ptr, threadIdx().x, 1)
         val = get()
         @inbounds a[threadIdx().x] = val
         nothing
end
```

```
data = CUDA.zeros(Int, 128)
@cuda threads=(128,) test(data)

julia> all(data .== 1:128)
true
```
