### PR TITLE
Use versioned libcuda

### DIFF
--- a/src/initialization.jl
+++ b/src/initialization.jl
@@ -59,7 +59,7 @@ end
 
 ## deferred initialization API
 
-const __libcuda = Sys.iswindows() ? :nvcuda : :libcuda
+const __libcuda = Sys.iswindows() ? "nvcuda" : "libcuda.so.1"
 libcuda() = @after_init(__libcuda)
 
 # load-time initialization: only perform mininal checks here


### PR DESCRIPTION
Some systems don't have the `libcuda.so.1` -> `libcuda.so` symlink.