### PR TITLE
Dynamically choose versioned libcuda

### DIFF
--- a/src/initialization.jl
+++ b/src/initialization.jl
@@ -59,7 +59,9 @@ end
 
 ## deferred initialization API
 
-const __libcuda = Sys.iswindows() ? "nvcuda" : "libcuda.so.1"
+import Libdl.find_library
+# Use libcuda.so -> libcuda.so.1 symlink if exists, some systems don't have this. 
+const __libcuda = Sys.iswindows() ? "nvcuda" : (find_library(["libcuda.so"]) == "" ? "libcuda.so.1" : "libcuda" )
 libcuda() = @after_init(__libcuda)
 
 # load-time initialization: only perform mininal checks here

--- a/src/initialization.jl
+++ b/src/initialization.jl
@@ -61,7 +61,7 @@ end
 
 import Libdl.find_library
 # Use libcuda.so -> libcuda.so.1 symlink if exists, some systems don't have this. 
-const __libcuda = Sys.iswindows() ? "nvcuda" : (find_library(["libcuda.so"]) == "" ? "libcuda.so.1" : "libcuda" )
+const __libcuda = Sys.iswindows() ? "nvcuda" : (find_library(["libcuda.so"]) == "" ? "libcuda.so.1" : "libcuda.so" )
 libcuda() = @after_init(__libcuda)
 
 # load-time initialization: only perform mininal checks here

--- a/src/initialization.jl
+++ b/src/initialization.jl
@@ -59,7 +59,7 @@ end
 
 ## deferred initialization API
 
-const __libcuda = Sys.iswindows() ? :nvcuda : :libcuda
+const __libcuda = Sys.iswindows() ? "nvcuda" : "libcuda.so.1"
 libcuda() = @after_init(__libcuda)
 
 # load-time initialization: only perform mininal checks here

--- a/src/initialization.jl
+++ b/src/initialization.jl
@@ -61,7 +61,7 @@ end
 
 import Libdl.find_library
 # Use libcuda.so -> libcuda.so.1 symlink if exists, some systems don't have this. 
-const __libcuda = Sys.iswindows() ? "nvcuda" : (find_library(["libcuda.so"]) == "" ? "libcuda.so.1" : "libcuda.so" )
+const __libcuda = Sys.iswindows() ? "nvcuda" : (find_library(["libcuda"]) == "" ? "libcuda.so.1" : "libcuda" )
 libcuda() = @after_init(__libcuda)
 
 # load-time initialization: only perform mininal checks here

--- a/src/initialization.jl
+++ b/src/initialization.jl
@@ -59,9 +59,7 @@ end
 
 ## deferred initialization API
 
-import Libdl.find_library
-# Use libcuda.so -> libcuda.so.1 symlink if exists, some systems don't have this. 
-const __libcuda = Sys.iswindows() ? "nvcuda" : (find_library(["libcuda"]) == "" ? "libcuda.so.1" : "libcuda" )
+const __libcuda = Sys.iswindows() ? "nvcuda" : ( Sys.islinux() ? "libcuda.so.1" : "libcuda" )
 libcuda() = @after_init(__libcuda)
 
 # load-time initialization: only perform mininal checks here


### PR DESCRIPTION
In reference to discussion on #502 , we don't necessarily want to always use `libcuda.so.1`. Dynamically check if `libcuda` can already be found using `Libdl`, and if we don't find it then try `libcuda.so.1`. If this doesn't exist an error will be thrown to the user, as previously was, except saying `libcuda.so.1 not found`.