### PR TITLE
Implement statistics functions: correlation and covariance

### DIFF
--- a/src/statistics.jl
+++ b/src/statistics.jl
@@ -1,5 +1,4 @@
 using Statistics
-using Base: require_one_based_indexing
 
 Statistics.varm(A::CuArray{<:Real},m::AbstractArray{<:Real}; dims, corrected::Bool=true) =
     sum((A .- m).^2, dims=dims)/(prod(size(A)[[dims...]])::Int-corrected)
@@ -24,12 +23,11 @@ function Statistics.covzm(x::CuMatrix, vardim::Int=1; corrected::Bool=true)
     T = promote_type(typeof(one(eltype(C)) / 1), eltype(C))
     A = convert(AbstractArray{T}, C)
     b = 1//(size(x, vardim) - corrected)
-    A .= A .* b
+    A .*= b
     return A
 end
 
 function Statistics.cov2cor!(C::CuMatrix{T}, xsd::CuArray) where T
-    require_one_based_indexing(C, xsd)
     nx = length(xsd)
     size(C) == (nx, nx) || throw(DimensionMismatch("inconsistent dimensions"))
     tril!(C, -1)
@@ -39,95 +37,7 @@ function Statistics.cov2cor!(C::CuMatrix{T}, xsd::CuArray) where T
     return C
 end
 
-function sqrt!(ret::CuDeviceMatrix{Complex{T}}, z::CuDeviceMatrix{Complex{T}}) where T
-    (lx, ly) = size(z)
-    index_x = (blockIdx().x - 1) * blockDim().x + threadIdx().x
-    index_y = (blockIdx().y - 1) * blockDim().y + threadIdx().y
-    stride_x = blockDim().x * gridDim().x
-    stride_y = blockDim().y * gridDim().y
-    for j = index_y:stride_y:ly
-        for i = index_x:stride_x:lx
-            x, y = reim(z[i, j])
-            if x == y == 0
-                ret[i] = zero(x) + y * im
-            end
-            ρ, k::Int32 = Base.ssqs(x, y)
-            if isfinite(x)
-                ρ = CUDA.ldexp(CUDA.abs(x), -k) + CUDA.sqrt(ρ)
-            end
-            if isodd(k)
-                k = div(k - 1, 2)
-            else
-                k = div(k, 2) - 1
-                ρ += ρ
-            end
-            ρ = CUDA.ldexp(CUDA.sqrt(ρ), k)
-            ξ = ρ
-            η = y
-            if ρ != 0
-                if CUDA.isfinite(η)
-                    η = (η / ρ) / 2
-                end
-                if x < 0
-                    ξ = CUDA.abs(η)
-                    η = CUDA.copysign(ρ, y)
-                end
-            end
-            ret[i, j] = ξ + η * im
-        end
-    end
-end
-
-function sqrt!(ret::CuDeviceVector{Complex{T}}, z::CuDeviceVector{Complex{T}}) where T
-    index = (blockIdx().x - 1) * blockDim().x + threadIdx().x
-    stride = blockDim().x * gridDim().x
-    for i = index:stride:length(z)
-        x, y = reim(z[i])
-        if x == y == 0
-            ret[i] = zero(x) + y * im
-        end
-        ρ, k::Int32 = Base.ssqs(x, y)
-        if isfinite(x)
-            ρ = CUDA.ldexp(CUDA.abs(x), -k) + CUDA.sqrt(ρ)
-        end
-        if isodd(k)
-            k = div(k - 1, 2)
-        else
-            k = div(k, 2) - 1
-            ρ += ρ
-        end
-        ρ = CUDA.ldexp(CUDA.sqrt(ρ), k)
-        ξ = ρ
-        η = y
-        if ρ != 0
-            if isfinite(η)
-                η = (η / ρ) / 2
-            end
-            if x < 0
-                ξ = CUDA.abs(η)
-                η = CUDA.copysign(ρ, y)
-            end
-        end
-        ret[i] = ξ + η * im
-    end
-end
-
-function sqrt(z::Union{CuVector{Complex{T}}, CuMatrix{Complex{T}}}) where T
-    function get_config(kernel)
-        fun = kernel.fun
-        config = launch_configuration(fun)
-        return (threads=config.threads, blocks=cld(length(z), config.threads))
-    end
-    ret = similar(z)
-    @cuda config=get_config sqrt!(ret, z)
-    ret
-end
-
-function sqrt(A::CuArray)
-    sqrt.(A)
-end
-
 function Statistics.corzm(x::CuMatrix, vardim::Int=1)
     c = Statistics.unscaled_covzm(x, vardim)
-    return Statistics.cov2cor!(c, sqrt(diag(c)))
+    return Statistics.cov2cor!(c, sqrt.(diag(c)))
 end

--- a/src/statistics.jl
+++ b/src/statistics.jl
@@ -47,15 +47,14 @@ function sqrt!(ret::CuDeviceMatrix{Complex{T}}, z::CuDeviceMatrix{Complex{T}}) w
     stride_y = blockDim().y * gridDim().y
     for j = index_y:stride_y:ly
         for i = index_x:stride_x:lx
-            rz = real(z[i, j])
-            iz = imag(z[i, j])
-            r = sqrt((hypot(rz, iz) + abs(rz)) / 2.0)
+            rz, iz = reim(z[i, j])
+            r = CUDA.sqrt((CUDA.hypot(rz, iz) + CUDA.abs(rz)) / 2.0)
             if r == 0
                 ret[i, j] = iz * im
             elseif rz >= 0
                 ret[i, j] = r + (iz / r / 2.0) * im
             else
-                ret[i, j] = (abs(iz) / r / 2.0) + copysign(r, iz)
+                ret[i, j] = (CUDA.abs(iz) / r / 2.0) + CUDA.copysign(r, iz)
             end
         end
     end
@@ -65,15 +64,14 @@ function sqrt!(ret::CuDeviceVector{Complex{T}}, z::CuDeviceVector{Complex{T}}) w
     index = (blockIdx().x - 1) * blockDim().x + threadIdx().x
     stride = blockDim().x * gridDim().x
     for i = index:stride:length(z)
-        rz = real(z[i])
-        iz = imag(z[i])
-        r = sqrt((hypot(rz, iz) + abs(rz)) / 2.0)
+        rz, iz = reim(z[i])
+        r = CUDA.sqrt((CUDA.hypot(rz, iz) + CUDA.abs(rz)) / 2.0)
         if r == 0
             ret[i] = iz * im
         elseif rz >= 0
             ret[i] = r + (iz / r / 2.0) * im
         else
-            ret[i] = (abs(iz) / r / 2.0) + copysign(r, iz)
+            ret[i] = (CUDA.abs(iz) / r / 2.0) + CUDA.copysign(r, iz)
         end
     end
 end

--- a/src/statistics.jl
+++ b/src/statistics.jl
@@ -21,9 +21,9 @@ Statistics._mean(f, A::CuArray, dims) = sum(f, A, dims=dims) / mapreduce(i -> si
 # TODO `cor`
 
 function Statistics.covzm(x::CuMatrix, vardim::Int=1; corrected::Bool=true)
-    # Compared to the CPU version, we assume that no type promotion is
-    # necessary.
-    A = Statistics.unscaled_covzm(x, vardim)
+    C = Statistics.unscaled_covzm(x, vardim)
+    T = promote_type(typeof(one(eltype(C)) / 1), eltype(C))
+    A = convert(AbstractArray{T}, C)
     b = 1//(size(x, vardim) - corrected)
     A .= A .* b
     return A

--- a/src/statistics.jl
+++ b/src/statistics.jl
@@ -17,3 +17,22 @@ Statistics._mean(A::CuArray, ::Colon)    = sum(A) / length(A)
 Statistics._mean(f, A::CuArray, ::Colon) = sum(f, A) / length(A)
 Statistics._mean(A::CuArray, dims)    = mean!(Base.reducedim_init(t -> t/2, +, A, dims), A)
 Statistics._mean(f, A::CuArray, dims) = sum(f, A, dims=dims) / mapreduce(i -> size(A, i), *, unique(dims); init=1)
+
+# TODO `cor`
+
+function Statistics.covzm(x::CuMatrix, vardim::Int=1; corrected::Bool=true)
+    # Compared to the CPU version, we assume that no type promotion is
+    # necessary.
+    A = Statistics.unscaled_covzm(x, vardim)
+    b = 1//(size(x, vardim) - corrected)
+    A .= A .* b
+    return A
+end
+
+
+# TODO `median` (scalar operation when dims is mentioned)
+# Statistics.median(A::CuArray, dims) = CuArray([median(row) for row in eachrow(reshape(A, dims, :))])
+
+# TODO `middle` (implement extrema function)
+
+# TODO `quantile` (probably need sort for this)

--- a/test/statistics.jl
+++ b/test/statistics.jl
@@ -26,3 +26,13 @@ end
     @test testf(x->mean(sin, x; dims=2), rand(2,2))
     @test testf(x->mean(sin, x; dims=[1,3]), rand(2,2,2))
 end
+
+@testset "cov" begin
+    s = 100
+    @test testf(cov, rand(s))
+    @test testf(cov, rand(Complex{Float64}, s))
+    @test testf(cov, rand(s, 2))
+    @test testf(cov, rand(Complex{Float64}, s, 2))
+    @test testf(cov, rand(s, 2); dims=2)
+    @test testf(cov, rand(Complex{Float64}, s, 2); dims=2)
+end

--- a/test/statistics.jl
+++ b/test/statistics.jl
@@ -35,7 +35,7 @@ end
     @test testf(cov, rand(Complex{Float64}, s, 2))
     @test testf(cov, rand(s, 2); dims=2)
     @test testf(cov, rand(Complex{Float64}, s, 2); dims=2)
-    @test testf(cov, rand(Int64, s))
+    @test testf(cov, rand(1:100, s))
 end
 
 @testset "cor" begin
@@ -46,5 +46,5 @@ end
     @test testf(cor, rand(Complex{Float64}, s, 2))
     @test testf(cor, rand(s, 2); dims=2)
     @test testf(cor, rand(Complex{Float64}, s, 2); dims=2)
-    @test testf(cor, rand(Int64, s))
+    @test testf(cor, rand(1:100, s))
 end

--- a/test/statistics.jl
+++ b/test/statistics.jl
@@ -41,10 +41,10 @@ end
 @testset "cor" begin
     s = 100
     @test testf(cor, rand(s))
-    # @test testf(cor, rand(Complex{Float64}, s))
+    @test testf(cor, rand(Complex{Float64}, s))
     @test testf(cor, rand(s, 2))
-    # @test testf(cor, rand(Complex{Float64}, s, 2))
+    @test testf(cor, rand(Complex{Float64}, s, 2))
     @test testf(cor, rand(s, 2); dims=2)
-    # @test testf(cor, rand(Complex{Float64}, s, 2); dims=2)
+    @test testf(cor, rand(Complex{Float64}, s, 2); dims=2)
     @test testf(cor, rand(Int64, s))
 end

--- a/test/statistics.jl
+++ b/test/statistics.jl
@@ -35,4 +35,16 @@ end
     @test testf(cov, rand(Complex{Float64}, s, 2))
     @test testf(cov, rand(s, 2); dims=2)
     @test testf(cov, rand(Complex{Float64}, s, 2); dims=2)
+    @test testf(cov, rand(Int64, s))
+end
+
+@testset "cor" begin
+    s = 100
+    @test testf(cor, rand(s))
+    # @test testf(cor, rand(Complex{Float64}, s))
+    @test testf(cor, rand(s, 2))
+    # @test testf(cor, rand(Complex{Float64}, s, 2))
+    @test testf(cor, rand(s, 2); dims=2)
+    # @test testf(cor, rand(Complex{Float64}, s, 2); dims=2)
+    @test testf(cor, rand(Int64, s))
 end


### PR DESCRIPTION
Part of the solution to #265 

Depending on how complicated correlation, median, middle, and quantile are, I might not include them in this PR.

The one function that needed to be changed for covariance was failing scalar iteration because of the `first` call in https://github.com/JuliaLang/Statistics.jl/blob/4b3ef9aaa79350510ca0be395458f66051c2f92d/src/Statistics.jl#L523. ~~Is type promotion necessary here?~~ Removing type promotion is incorrect, for example, when the vector contains `Int64`.