### PR TITLE
Fix CUDNN-optimized activation broadcasts

### DIFF
--- a/lib/cudnn/activation.jl
+++ b/lib/cudnn/activation.jl
@@ -22,16 +22,19 @@ end
 
 function cudnnActivationForward(x::DenseCuArray{T,N}, y::DenseCuArray{T,N}=x;
                                 mode=CUDNN_ACTIVATION_RELU, # CUDNN_ACTIVATION_IDENTITY will not work
-                                coeff=0.0, reluNanOpt=CUDNN_NOT_PROPAGATE_NAN, alpha=1, beta=0) where {T,N}
+                                coeff=false, reluNanOpt=CUDNN_NOT_PROPAGATE_NAN, alpha=true,
+                                beta=false) where {T,N}
     cudnnActivationForward(handle(), ActivationDesc(mode, T(coeff), reluNanOpt),
                            scalingParameter(T, alpha), TensorDesc(x), x,
                            scalingParameter(T, beta ), TensorDesc(y), y)
     return  y
 end
 
-function cudnnActivationBackward(x::DenseCuArray{T,N}, dx::DenseCuArray{T,N}, y::DenseCuArray{T,N}, dy::DenseCuArray{T,N}=dx;
+function cudnnActivationBackward(x::DenseCuArray{T,N}, dx::DenseCuArray{T,N},
+                                 y::DenseCuArray{T,N}, dy::DenseCuArray{T,N}=dx;
                                  mode=CUDNN_ACTIVATION_RELU, # CUDNN_ACTIVATION_IDENTITY will not work
-                                 coeff=0.0, reluNanOpt=CUDNN_NOT_PROPAGATE_NAN, alpha=1, beta=0) where {T,N}
+                                 coeff=false, reluNanOpt=CUDNN_NOT_PROPAGATE_NAN, alpha=1,
+                                 beta=false) where {T,N}
     cudnnActivationBackward(handle(), ActivationDesc(mode, T(coeff), reluNanOpt),
                             scalingParameter(T, alpha), TensorDesc( y),  y,
                             TensorDesc(dy), dy,

--- a/lib/cudnn/tensor.jl
+++ b/lib/cudnn/tensor.jl
@@ -62,7 +62,7 @@ OpTensorDesc(op::cudnnOpTensorOp_t, a::DenseCuArray) = OpTensorDesc(op, eltype(a
 
 function cudnnOpTensor(op::cudnnOpTensorOp_t,
                        A::DenseCuArray{T,N}, B::DenseCuArray{T,N}, C::DenseCuArray{T,N};
-                       alpha1=1, alpha2=1, beta=0) where {T,N}
+                       alpha1=true, alpha2=true, beta=false) where {T,N}
     cudnnOpTensor(handle(), OpTensorDesc(op, T),
                   scalingParameter(T, alpha1), TensorDesc(A), A,
                   scalingParameter(T, alpha2), TensorDesc(B), B,
@@ -113,7 +113,7 @@ end
 
 function cudnnReduceTensor(op::cudnnReduceTensorOp_t,
                            A::DenseCuArray{T,N}, C::DenseCuArray{T,N};
-                           alpha=1, beta=0) where {T,N}
+                           alpha=true, beta=false) where {T,N}
     # indices = Array{UInt64, 1}(undef, N)
     indicesSizeInBytes = cudnnGetReductionIndicesSize(op, A, C)
     @workspace size=@argout(

--- a/test/cudnn.jl
+++ b/test/cudnn.jl
@@ -82,9 +82,24 @@ end
       @test testf(x -> f.(x), rand(Float64, dims))
     end
   end
+
   # softplus does not give `Inf` for large arguments
   x = CuArray([1000.])
   @test all(softplus.(x) .== x)
+
+  # optimized activation overwrote inputs
+  let
+    x = CUDA.ones(1)
+    @test Array(x) == [1f0]
+    tanh.(x)
+    @test Array(x) == [1f0]
+    y = tanh.(x)
+    @test Array(x) == [1f0]
+    @test Array(y) == [tanh(1f0)]
+    x .= tanh.(y)
+    @test Array(y) == [tanh(1f0)]
+    @test Array(x) == [tanh(tanh(1f0))]
+  end
 end
 
 @testset "Batchnorm" begin


### PR DESCRIPTION
Fixes:

```julia
julia> x = CUDA.ones(1); tanh.(x); x
1-element CuArray{Float32,1}:
 0.7615942

julia> x = CUDA.ones(1); tan.(x); x
1-element CuArray{Float32,1}:
 1.0
```

Introduced by https://github.com/JuliaGPU/CUDA.jl/pull/321, discovered while debugging https://github.com/FluxML/Flux.jl/pull/1367