### PR TITLE
Support all combinations of datatypes and transposes/adjoints in LinearAlgebra

### DIFF
--- a/lib/cusparse/generic.jl
+++ b/lib/cusparse/generic.jl
@@ -100,8 +100,10 @@ function mv!(transa::SparseChar, alpha::Number, A::CuSparseMatrixCSC{T}, X::Dens
     ctransa = 'N'
     if transa == 'N'
         ctransa = 'T'
+    elseif transa == 'C' && T <: Complex
+        throw(ArgumentError("Matrix-vector multiplication with the adjoint of a CSC matrix" *
+                            " is not supported. Use a CSR matrix instead."))
     end
-    # TODO: conjugate transpose?
 
     n,m = size(A)
 
@@ -163,8 +165,10 @@ function mm!(transa::SparseChar, transb::SparseChar, alpha::Number, A::CuSparseM
     ctransa = 'N'
     if transa == 'N'
         ctransa = 'T'
+    elseif transa == 'C' && T <: Complex
+        throw(ArgumentError("Matrix-matrix multiplication with the adjoint of a CSC matrix" *
+                            " is not supported. Use a CSR matrix instead."))
     end
-    # TODO: conjugate transpose?
 
     k,m = size(A)
     n = size(C)[2]

--- a/lib/cusparse/interfaces.jl
+++ b/lib/cusparse/interfaces.jl
@@ -10,8 +10,8 @@ end
 
 function mm_wrapper(transa::SparseChar, transb::SparseChar, alpha::Number,
                     A::CuSparseMatrix{T}, B::CuMatrix{T}, beta::Number, C::CuMatrix{T}) where {T}
-    if version() < v"10.3.1" && A isa CuSparseMatrixCSR
-        # generic mm! doesn't work on CUDA 10.1 with CSC matrices
+    if version() <= v"10.3.1"
+        # Generic mm! doesn't support transposed B on CUDA10
         return mm2!(transa, transb, alpha, A, B, beta, C, 'O')
     end
     mm!(transa, transb, alpha, A, B, beta, C, 'O')

--- a/lib/cusparse/level3.jl
+++ b/lib/cusparse/level3.jl
@@ -53,6 +53,11 @@ for (fname,elty) in ((:cusparseScsrmm2, :Float32),
                       beta::Number,
                       C::CuMatrix{$elty},
                       index::SparseChar)
+            if transb == 'C'
+                throw(ArgumentError("B^H is not supported"))
+            elseif transb == 'T' && transa != 'N'
+                throw(ArgumentError("When using B^T, A can be neither transposed nor adjointed"))
+            end
             desc = CuMatrixDescriptor(CUSPARSE_MATRIX_TYPE_GENERAL, CUSPARSE_FILL_MODE_LOWER, CUSPARSE_DIAG_TYPE_NON_UNIT, index)
             m,k = A.dims
             n = size(C)[2]
@@ -80,6 +85,11 @@ for (fname,elty) in ((:cusparseScsrmm2, :Float32),
                       beta::Number,
                       C::CuMatrix{$elty},
                       index::SparseChar)
+            if transb == 'C'
+                throw(ArgumentError("B^H is not supported"))
+            elseif transb == 'T' && transa != 'N'
+                throw(ArgumentError("When using B^T, A can be neither transposed nor adjointed"))
+            end
             ctransa = 'N'
             if transa == 'N'
                 ctransa = 'T'

--- a/test/cusparse.jl
+++ b/test/cusparse.jl
@@ -681,10 +681,6 @@ end
             h_z = collect(d_y)
             z = alpha * A * x + beta * y
             @test z ≈ h_z
-            mul!(d_y, d_A, d_x)
-            h_y = collect(d_y)
-            z = A * x
-            @test z ≈ h_y
             if d_A isa CuSparseMatrixCSR
                 @test d_y' * (d_A * d_x) ≈ (d_y' * d_A) * d_x
             end
@@ -717,11 +713,6 @@ end
             h_D = collect(d_C)
             D = alpha * A * B + beta * C
             @test D ≈ h_D
-            d_C = CuArray(C)
-            mul!(d_C, d_A, d_B)
-            h_C = collect(d_C)
-            D = A * B
-            @test D ≈ h_C
         end
     end
 

--- a/test/cusparse.jl
+++ b/test/cusparse.jl
@@ -707,7 +707,12 @@ end
             end
             @test_throws DimensionMismatch mm!('N','T',alpha,d_A,d_B,beta,d_C,'O')
             @test_throws DimensionMismatch mm!('T','N',alpha,d_A,d_B,beta,d_C,'O')
-            @test_throws DimensionMismatch mm!('T','T',alpha,d_A,d_B,beta,d_C,'O')
+            if CUSPARSE.version() < v"10.3.1" && d_A isa CuSparseMatrixCSR
+                # A^T is not supported with B^T
+                @test_throws ArgumentError mm!('T','T',alpha,d_A,d_B,beta,d_C,'O')
+            else
+                @test_throws DimensionMismatch mm!('T','T',alpha,d_A,d_B,beta,d_C,'O')
+            end
             @test_throws DimensionMismatch mm!('N','N',alpha,d_A,d_B,beta,d_B,'O')
             mm!('N','N',alpha,d_A,d_B,beta,d_C,'O')
             h_D = collect(d_C)

--- a/test/cusparse/interfaces.jl
+++ b/test/cusparse/interfaces.jl
@@ -1,0 +1,59 @@
+using CUDA.CUSPARSE
+using LinearAlgebra, SparseArrays
+
+@testset "LinearAlgebra" begin
+    @testset "$f(A)*b $elty" for elty in [Float32, Float64, ComplexF32, ComplexF64],
+                                 f in (identity, transpose, adjoint)
+        n = 10
+        alpha = rand()
+        beta = rand()
+        A = sprand(elty, n, n, rand())
+        b = rand(elty, n)
+        c = rand(elty, n)
+        alpha = beta = 1.0
+        c = zeros(elty, n)
+
+        dA = CuSparseMatrixCSR(A)
+        db = CuArray(b)
+        dc = CuArray(c)
+
+        mul!(c, f(A), b, alpha, beta)
+        mul!(dc, f(dA), db, alpha, beta)
+        @test c ≈ collect(dc)
+
+        A = A + transpose(A)
+        dA = CuSparseMatrixCSR(A)
+
+        @assert issymmetric(A)
+        mul!(c, f(Symmetric(A)), b, alpha, beta)
+        mul!(dc, f(Symmetric(dA)), db, alpha, beta)
+        @test c ≈ collect(dc)
+    end
+
+    @testset "$f(A)*$h(B) $elty" for elty in [Float32, Float64, ComplexF32, ComplexF64],
+                                     f in (identity, transpose, adjoint),
+                                     h in (identity, transpose, adjoint),
+        n = 10
+        alpha = rand()
+        beta = rand()
+        A = sprand(elty, n, n, rand())
+        B = rand(elty, n, n)
+        C = rand(elty, n, n)
+
+        dA = CuSparseMatrixCSR(A)
+        dB = CuArray(B)
+        dC = CuArray(C)
+
+        mul!(C, f(A), h(B), alpha, beta)
+        mul!(dC, f(dA), h(dB), alpha, beta)
+        @test C ≈ collect(dC)
+
+        A = A + transpose(A)
+        dA = CuSparseMatrixCSR(A)
+
+        @assert issymmetric(A)
+        mul!(C, f(Symmetric(A)), h(B), alpha, beta)
+        mul!(dC, f(Symmetric(dA)), h(dB), alpha, beta)
+        @test C ≈ collect(dC)
+    end
+end

--- a/test/cusparse/interfaces.jl
+++ b/test/cusparse/interfaces.jl
@@ -32,7 +32,14 @@ using LinearAlgebra, SparseArrays
 
     @testset "$f(A)*$h(B) $elty" for elty in [Float32, Float64, ComplexF32, ComplexF64],
                                      f in (identity, transpose, adjoint),
-                                     h in (identity, transpose, adjoint),
+                                     h in (identity, transpose, adjoint)
+        if CUSPARSE.version() <= v"10.3.1" &&
+            (h ∈ (transpose, adjoint) && f != identity) ||
+            (h == adjoint && elty <: Complex)
+            # These combinations are not implemented in CUDA10
+            continue
+        end
+
         n = 10
         alpha = rand()
         beta = rand()


### PR DESCRIPTION
This PR generalizes the LinearAlgebra integration of CUSPARSE from a handpicked list of common types to a large list of combinations of linear algebra types.The definitions are automatically generated to avoid "holes" in the methods.

I ran into this today when I was using Flux with Zygote. The pullback of matrix multiplication is defined as `A' * \Delta` which was not defined in CUDA.jl previously.

Do I need to register the new test file somewhere so that it runs in the CI? The `runtests.jl` is pretty elaborate and I could not figure out if it would pick up the file on its own or not.