### PR TITLE
Emphasize rebooting option.

### DIFF
--- a/docs/src/installation/troubleshooting.md
+++ b/docs/src/installation/troubleshooting.md
@@ -15,7 +15,7 @@ location.
 If you encounter this error, there are several known issues that may be causing it:
 
 - a mismatch between the CUDA driver and driver library: on Linux, look for clues in `dmesg`
-- the CUDA driver is in a bad state: this can happen after resume. Try rebooting.
+- the CUDA driver is in a bad state: this can happen after resume. **Try rebooting**.
 
 Generally though, it's impossible to say what's the reason for the error, but Julia is
 likely not to blame. Make sure your set-up works (e.g., try executing `nvidia-smi`, a CUDA C


### PR DESCRIPTION
A second glance was required to find the workaround for failing to initialize CUDA.