### PR TITLE
fix address calculation for ldg

### DIFF
--- a/src/device/pointer.jl
+++ b/src/device/pointer.jl
@@ -116,12 +116,15 @@ for T in LDGTypes
         :f
     end
     # TODO: p class
-    width = sizeof(T)*8
+    width = sizeof(T)*8 # in bits
     typ = Symbol(class, width)
 
     intr = "llvm.nvvm.ldg.global.$class.$typ.p1$typ"
-    @eval @inline pointerref_ldg(ptr::LLVMPtr{$T,AS.Global}, i::Int, ::Val{align}) where align =
-        @typed_ccall($intr, llvmcall, $T, (LLVMPtr{$T,AS.Global}, Int32), ptr+i-1, align)
+    @eval @inline function pointerref_ldg(base_ptr::LLVMPtr{$T,AS.Global}, i::Int, ::Val{align}) where align
+        offset = i-1 # in elements
+        ptr = base_ptr + offset*sizeof($T)
+        @typed_ccall($intr, llvmcall, $T, (LLVMPtr{$T,AS.Global}, Int32), ptr, align)
+    end
 end
 
 # interface

--- a/test/device/ldg.jl
+++ b/test/device/ldg.jl
@@ -36,6 +36,22 @@ end
 
     asm = String(take!(copy(buf)))
     @test occursin("ld.global.nc", asm)
+
+    function copy_const(A, _B)
+        B = Base.Experimental.Const(_B)
+        i = threadIdx().x
+        if i <= length(A)
+            @inbounds A[i] = B[i]
+        end
+        return nothing
+    end
+
+    x = CUDA.zeros(Float64, 32)
+    y = CUDA.ones(Float64, length(x))
+
+    @cuda threads=(length(x),) copy_const(x, y)
+    CUDA.synchronize()
+    @test x == y
 end
 
 end


### PR DESCRIPTION
Should fix #548 

The issue was that we forwarded the address calculation to `unsafe_cached_load` which should operate in bytes.

