### PR TITLE
Support for 'delayed kernels'

### DIFF
--- a/examples/pairwise.jl
+++ b/examples/pairwise.jl
@@ -96,7 +96,7 @@ function pairwise_dist_gpu(lat::Vector{Float32}, lon::Vector{Float32})
     # calculate the amount of dynamic shared memory for a 2D block size
     get_shmem(threads) = 2 * sum(threads) * sizeof(Float32)
 
-    kernel = @cuda delayed=true pairwise_dist_kernel(lat_gpu, lon_gpu, rowresult_gpu, n)
+    kernel = @cuda launch=false pairwise_dist_kernel(lat_gpu, lon_gpu, rowresult_gpu, n)
     config = launch_configuration(kernel.fun, shmem=threads->get_shmem(get_threads(threads)))
 
     # convert to 2D block size and figure out appropriate grid size

--- a/examples/pairwise.jl
+++ b/examples/pairwise.jl
@@ -84,33 +84,27 @@ function pairwise_dist_gpu(lat::Vector{Float32}, lon::Vector{Float32})
     n = length(lat)
     rowresult_gpu = CuArray(zeros(Float32, n, n))
 
-    # calculate launch configuration
-    function get_config(kernel)
-        # calculate a 2D block size from the suggested 1D configuration
-        # NOTE: we want our launch configuration to be as square as possible,
-        #       because that minimizes shared memory usage
-        function get_threads(threads)
-            threads_x = floor(Int, sqrt(threads))
-            threads_y = threads ÷ threads_x
-            return (threads_x, threads_y)
-        end
-
-        # calculate the amount of dynamic shared memory for a 2D block size
-        get_shmem(threads) = 2 * sum(threads) * sizeof(Float32)
-
-        fun = kernel.fun
-        config = launch_configuration(fun, shmem=threads->get_shmem(get_threads(threads)))
-
-        # convert to 2D block size and figure out appropriate grid size
-        threads = get_threads(config.threads)
-        blocks = ceil.(Int, n ./ threads)
-        shmem = get_shmem(threads)
-
-        return (threads=threads, blocks=blocks, shmem=shmem)
+    # calculate a 2D block size from the suggested 1D configuration
+    # NOTE: we want our launch configuration to be as square as possible,
+    #       because that minimizes shared memory usage
+    function get_threads(threads)
+        threads_x = floor(Int, sqrt(threads))
+        threads_y = threads ÷ threads_x
+        return (threads_x, threads_y)
     end
 
-    @cuda config=get_config pairwise_dist_kernel(lat_gpu, lon_gpu, rowresult_gpu, n)
+    # calculate the amount of dynamic shared memory for a 2D block size
+    get_shmem(threads) = 2 * sum(threads) * sizeof(Float32)
 
+    kernel = @cuda delayed=true pairwise_dist_kernel(lat_gpu, lon_gpu, rowresult_gpu, n)
+    config = launch_configuration(kernel.fun, shmem=threads->get_shmem(get_threads(threads)))
+
+    # convert to 2D block size and figure out appropriate grid size
+    threads = get_threads(config.threads)
+    blocks = ceil.(Int, n ./ threads)
+    shmem = get_shmem(threads)
+
+    kernel(lat_gpu, lon_gpu, rowresult_gpu, n; threads=threads, blocks=blocks, shmem=shmem)
     return Array(rowresult_gpu)
 end
 

--- a/examples/peakflops.jl
+++ b/examples/peakflops.jl
@@ -37,7 +37,7 @@ function peakflops(n::Integer=5000, dev::CuDevice=CuDevice(0))
 
         len = prod(dims)
 
-        kernel = @cuda delayed=true kernel_100fma(d_a, d_b, d_c, d_out)
+        kernel = @cuda launch=false kernel_100fma(d_a, d_b, d_c, d_out)
         config = launch_configuration(kernel.fun)
         threads = Base.min(len, config.threads)
         blocks = cld(len, threads)

--- a/perf/kernel.jl
+++ b/perf/kernel.jl
@@ -4,15 +4,12 @@ dummy_kernel() = nothing
 group["launch"] = @benchmarkable @cuda dummy_kernel()
 
 wanted_threads = 10000
-function configurator(kernel)
+group["occupancy"] = @benchmarkable begin
+    kernel = @cuda delayed=true dummy_kernel()
     config = launch_configuration(kernel.fun)
-
-    threads = Base.min(wanted_threads, config.threads)
-    blocks = cld(wanted_threads, threads)
-
-    return (threads=threads, blocks=blocks)
+    threads = Base.min($wanted_threads, config.threads)
+    blocks = cld($wanted_threads, threads)
 end
-group["occupancy"] = @benchmarkable @cuda config=$configurator dummy_kernel()
 
 src = CUDA.rand(Float32, 512, 1000)
 dest = similar(src)

--- a/perf/kernel.jl
+++ b/perf/kernel.jl
@@ -5,7 +5,7 @@ group["launch"] = @benchmarkable @cuda dummy_kernel()
 
 wanted_threads = 10000
 group["occupancy"] = @benchmarkable begin
-    kernel = @cuda delayed=true dummy_kernel()
+    kernel = @cuda launch=false dummy_kernel()
     config = launch_configuration(kernel.fun)
     threads = Base.min($wanted_threads, config.threads)
     blocks = cld($wanted_threads, threads)

--- a/src/accumulate.jl
+++ b/src/accumulate.jl
@@ -145,7 +145,7 @@ function scan!(f::Function, output::AnyCuArray{T}, input::AnyCuArray;
     Rother = CartesianIndices((length(Rpre), length(Rpost)))
 
     # determine how many threads we can launch for the scan kernel
-    kernel = @cuda delayed=true partial_scan(f, output, input, Rdim, Rpre, Rpost, Rother, neutral, init, Val(true))
+    kernel = @cuda launch=false partial_scan(f, output, input, Rdim, Rpre, Rpost, Rother, neutral, init, Val(true))
     kernel_config = launch_configuration(kernel.fun; shmem=(threads)->2*threads*sizeof(T))
 
     # determine the grid layout to cover the other dimensions

--- a/src/accumulate.jl
+++ b/src/accumulate.jl
@@ -145,10 +145,7 @@ function scan!(f::Function, output::AnyCuArray{T}, input::AnyCuArray;
     Rother = CartesianIndices((length(Rpre), length(Rpost)))
 
     # determine how many threads we can launch for the scan kernel
-    args = (f, output, input, Rdim, Rpre, Rpost, Rother, neutral, init, Val(true))
-    kernel_args = cudaconvert.(args)
-    kernel_tt = Tuple{Core.Typeof.(kernel_args)...}
-    kernel = cufunction(partial_scan, kernel_tt)
+    kernel = @cuda delayed=true partial_scan(f, output, input, Rdim, Rpre, Rpost, Rother, neutral, init, Val(true))
     kernel_config = launch_configuration(kernel.fun; shmem=(threads)->2*threads*sizeof(T))
 
     # determine the grid layout to cover the other dimensions

--- a/src/compiler/execution.jl
+++ b/src/compiler/execution.jl
@@ -95,7 +95,6 @@ macro cuda(ex...)
         push!(code.args,
             quote
                 GC.@preserve $(vars...) begin
-                    # TODO: ensure inference if kernel_tt, since kernel_args is unused
                     local $kernel_args = map($cudaconvert, ($(var_exprs...),))
                     local $kernel_tt = Tuple{map(Core.Typeof, $kernel_args)...}
                     local $kernel = $cufunction($f, $kernel_tt; $(compiler_kwargs...))

--- a/src/gpuarrays.jl
+++ b/src/gpuarrays.jl
@@ -14,9 +14,7 @@ struct CuKernelContext <: AbstractKernelContext end
 
 @inline function GPUArrays.launch_heuristic(::CuArrayBackend, f::F, args::Vararg{Any,N};
                                             maximize_blocksize=false) where {F,N}
-    kernel_args = map(cudaconvert, args)
-    kernel_tt = Tuple{CuKernelContext, map(Core.Typeof, kernel_args)...}
-    kernel = cufunction(f, kernel_tt)
+    kernel = @cuda delayed=true f(CuKernelContext(), args...)
     if maximize_blocksize
         # some kernels benefit (algorithmically) from a large block size
         launch_configuration(kernel.fun)

--- a/src/gpuarrays.jl
+++ b/src/gpuarrays.jl
@@ -14,7 +14,7 @@ struct CuKernelContext <: AbstractKernelContext end
 
 @inline function GPUArrays.launch_heuristic(::CuArrayBackend, f::F, args::Vararg{Any,N};
                                             maximize_blocksize=false) where {F,N}
-    kernel = @cuda delayed=true f(CuKernelContext(), args...)
+    kernel = @cuda launch=false f(CuKernelContext(), args...)
     if maximize_blocksize
         # some kernels benefit (algorithmically) from a large block size
         launch_configuration(kernel.fun)

--- a/src/indexing.jl
+++ b/src/indexing.jl
@@ -29,7 +29,7 @@ function Base.getindex(xs::AnyCuArray{T}, bools::AnyCuArray{Bool}) where {T}
         return
     end
 
-    kernel = @cuda name="logical_getindex" delayed=true kernel(ys, xs, bools, indices)
+    kernel = @cuda name="logical_getindex" launch=false kernel(ys, xs, bools, indices)
     config = launch_configuration(kernel.fun)
     threads = Base.min(length(indices), config.threads)
     blocks = cld(length(indices), threads)
@@ -64,7 +64,7 @@ function Base.findall(bools::AnyCuArray{Bool})
             return
         end
 
-        kernel = @cuda name="findall" delayed=true kernel(ys, bools, indices)
+        kernel = @cuda name="findall" launch=false kernel(ys, bools, indices)
         config = launch_configuration(kernel.fun)
         threads = Base.min(length(indices), config.threads)
         blocks = cld(length(indices), threads)
@@ -98,7 +98,7 @@ function Base.findfirst(testf::Function, xs::AnyCuArray)
         return
     end
 
-    kernel = @cuda name="findfirst" delayed=true kernel(y, xs)
+    kernel = @cuda name="findfirst" launch=false kernel(y, xs)
     config = launch_configuration(kernel.fun)
     threads = Base.min(length(xs), config.threads)
     blocks = cld(length(xs), threads)
@@ -165,7 +165,7 @@ function findfirstval(vals::AnyCuArray, xs::AnyCuArray)
         return
     end
 
-    kernel = @cuda delayed=true kernel(xs, vals, indices)
+    kernel = @cuda launch=false kernel(xs, vals, indices)
     config = launch_configuration(kernel.fun)
     threads = Base.min(length(xs), config.threads)
     blocks = cld(length(xs), threads)

--- a/src/indexing.jl
+++ b/src/indexing.jl
@@ -29,16 +29,11 @@ function Base.getindex(xs::AnyCuArray{T}, bools::AnyCuArray{Bool}) where {T}
         return
     end
 
-    function configurator(kernel)
-        config = launch_configuration(kernel.fun)
-
-        threads = Base.min(length(indices), config.threads)
-        blocks = cld(length(indices), threads)
-
-        return (threads=threads, blocks=blocks)
-    end
-
-    @cuda name="logical_getindex" config=configurator kernel(ys, xs, bools, indices)
+    kernel = @cuda name="logical_getindex" delayed=true kernel(ys, xs, bools, indices)
+    config = launch_configuration(kernel.fun)
+    threads = Base.min(length(indices), config.threads)
+    blocks = cld(length(indices), threads)
+    kernel(ys, xs, bools, indices; threads=threads, blocks=blocks)
   end
 
   unsafe_free!(indices)
@@ -69,16 +64,11 @@ function Base.findall(bools::AnyCuArray{Bool})
             return
         end
 
-        function configurator(kernel)
-            config = launch_configuration(kernel.fun)
-
-            threads = Base.min(length(indices), config.threads)
-            blocks = cld(length(indices), threads)
-
-            return (threads=threads, blocks=blocks)
-        end
-
-        @cuda name="findall" config=configurator kernel(ys, bools, indices)
+        kernel = @cuda name="findall" delayed=true kernel(ys, bools, indices)
+        config = launch_configuration(kernel.fun)
+        threads = Base.min(length(indices), config.threads)
+        blocks = cld(length(indices), threads)
+        kernel(ys, bools, indices; threads=threads, blocks=blocks)
     end
 
     unsafe_free!(indices)
@@ -108,16 +98,11 @@ function Base.findfirst(testf::Function, xs::AnyCuArray)
         return
     end
 
-    function configurator(kernel)
-        config = launch_configuration(kernel.fun)
-
-        threads = Base.min(length(xs), config.threads)
-        blocks = cld(length(xs), threads)
-
-        return (threads=threads, blocks=blocks)
-    end
-
-    @cuda name="findfirst" config=configurator kernel(y, xs)
+    kernel = @cuda name="findfirst" delayed=true kernel(y, xs)
+    config = launch_configuration(kernel.fun)
+    threads = Base.min(length(xs), config.threads)
+    blocks = cld(length(xs), threads)
+    kernel(y, xs; threads=threads, blocks=blocks)
 
     first_i = @allowscalar y[1]
     return first_i == typemax(Int) ? nothing : keys(xs)[first_i]
@@ -180,16 +165,11 @@ function findfirstval(vals::AnyCuArray, xs::AnyCuArray)
         return
     end
 
-    function configurator(kernel)
-        config = launch_configuration(kernel.fun)
-
-        threads = Base.min(length(xs), config.threads)
-        blocks = cld(length(xs), threads)
-
-        return (threads=threads, blocks=blocks)
-    end
-
-    @cuda config=configurator kernel(xs, vals, indices)
+    kernel = @cuda delayed=true kernel(xs, vals, indices)
+    config = launch_configuration(kernel.fun)
+    threads = Base.min(length(xs), config.threads)
+    blocks = cld(length(xs), threads)
+    kernel(xs, vals, indices; threads=threads, blocks=blocks)
 
 
     ## convert the linear indices to an appropriate type

--- a/src/mapreduce.jl
+++ b/src/mapreduce.jl
@@ -189,7 +189,7 @@ function GPUArrays.mapreducedim!(f::F, op::OP, R::AnyCuArray{T},
     # we might not be able to launch all those threads to reduce each slice in one go.
     # that's why each threads also loops across their inputs, processing multiple values
     # so that we can span the entire reduction dimension using a single thread block.
-    kernel = @cuda delayed=true partial_mapreduce_grid(f, op, init, Rreduce, Rother, Val(shuffle), R′, A)
+    kernel = @cuda launch=false partial_mapreduce_grid(f, op, init, Rreduce, Rother, Val(shuffle), R′, A)
     compute_shmem(threads) = shuffle ? 0 : 2*threads*sizeof(T)
     kernel_config = launch_configuration(kernel.fun; shmem=compute_shmem∘compute_threads)
     reduce_threads = compute_threads(kernel_config.threads)

--- a/src/mapreduce.jl
+++ b/src/mapreduce.jl
@@ -189,10 +189,7 @@ function GPUArrays.mapreducedim!(f::F, op::OP, R::AnyCuArray{T},
     # we might not be able to launch all those threads to reduce each slice in one go.
     # that's why each threads also loops across their inputs, processing multiple values
     # so that we can span the entire reduction dimension using a single thread block.
-    args = (f, op, init, Rreduce, Rother, Val(shuffle), R′, A)
-    kernel_args = cudaconvert.(args)
-    kernel_tt = Tuple{Core.Typeof.(kernel_args)...}
-    kernel = cufunction(partial_mapreduce_grid, kernel_tt)
+    kernel = @cuda delayed=true partial_mapreduce_grid(f, op, init, Rreduce, Rother, Val(shuffle), R′, A)
     compute_shmem(threads) = shuffle ? 0 : 2*threads*sizeof(T)
     kernel_config = launch_configuration(kernel.fun; shmem=compute_shmem∘compute_threads)
     reduce_threads = compute_threads(kernel_config.threads)

--- a/test/execution.jl
+++ b/test/execution.jl
@@ -41,6 +41,17 @@ end
 end
 
 
+@testset "inference" begin
+    foo() = @cuda dummy()
+    @inferred foo()
+
+    # with arguments, we call cudaconvert
+    kernel(a) = return
+    bar(a) = @cuda kernel(a)
+    @inferred bar(CuArray([1]))
+end
+
+
 @testset "reflection" begin
     CUDA.code_lowered(dummy, Tuple{})
     CUDA.code_typed(dummy, Tuple{})

--- a/test/execution.jl
+++ b/test/execution.jl
@@ -8,8 +8,8 @@ dummy() = return
 @test_throws MethodError @cuda dummy(1)
 
 
-@testset "low-level interface" begin
-    k = cufunction(dummy)
+@testset "delayed kernel" begin
+    k = @cuda delayed=true dummy()
     k()
     k(; threads=1)
 
@@ -30,11 +30,6 @@ end
     @cuda blocks=1 dummy()
     @cuda blocks=(1,1) dummy()
     @cuda blocks=(1,1,1) dummy()
-
-    @cuda config=(kernel)->() dummy()
-    @cuda config=(kernel)->(threads=1,) dummy()
-    @cuda config=(kernel)->(blocks=1,) dummy()
-    @cuda config=(kernel)->(shmem=0,) dummy()
 end
 
 

--- a/test/execution.jl
+++ b/test/execution.jl
@@ -8,18 +8,6 @@ dummy() = return
 @test_throws MethodError @cuda dummy(1)
 
 
-@testset "delayed kernel" begin
-    k = @cuda delayed=true dummy()
-    k()
-    k(; threads=1)
-
-    CUDA.version(k)
-    CUDA.memory(k)
-    CUDA.registers(k)
-    CUDA.maxthreads(k)
-end
-
-
 @testset "launch configuration" begin
     @cuda dummy()
 
@@ -30,6 +18,18 @@ end
     @cuda blocks=1 dummy()
     @cuda blocks=(1,1) dummy()
     @cuda blocks=(1,1,1) dummy()
+end
+
+
+@testset "launch=false" begin
+    k = @cuda launch=false dummy()
+    k()
+    k(; threads=1)
+
+    CUDA.version(k)
+    CUDA.memory(k)
+    CUDA.registers(k)
+    CUDA.maxthreads(k)
 end
 
 

--- a/test/texture.jl
+++ b/test/texture.jl
@@ -27,7 +27,7 @@ function fetch_all(texture)
     dims = size(texture)
     d_out = CuArray{eltype(texture)}(undef, dims...)
 
-    kernel = @cuda delayed=true kernel_texture_warp_native(d_out, texture)
+    kernel = @cuda launch=false kernel_texture_warp_native(d_out, texture)
     config = launch_configuration(kernel.fun)
 
     dim_x, dim_y, dim_z = size(texture, 1), size(texture, 2), size(texture, 3)


### PR DESCRIPTION
When you need to introspect the compiled kernel, e.g. to determine a launch configuration, you either have to do the whole `cudaconvert` and `cufunction` dance manually, or use the hacky `config=callback` argument to `@cuda`. Both are pretty cumbersome, so here I introduce an alternative: `@cuda delayed=true kernel(args...)`, returning a callable object you can then just introspect and finally call using `kernel_object(args...; threads=..., blocks=..., shmem=...)`.

cc @vchuravy, as KA probably uses the lower-level interface.