### PR TITLE
New findmin/max implementation using single-pass reduction

### DIFF
--- a/src/indexing.jl
+++ b/src/indexing.jl
@@ -83,107 +83,96 @@ function Base.findall(f::Function, A::AnyCuArray)
     return ys
 end
 
-function Base.findfirst(testf::Function, xs::AnyCuArray)
-    I = keytype(xs)
-
-    y = CuArray([typemax(Int)])
-
-    function kernel(y::CuDeviceArray, xs::CuDeviceArray)
-        i = threadIdx().x + (blockIdx().x - 1) * blockDim().x
-
-        @inbounds if i <= length(xs) && testf(xs[i])
-            @atomic y[1] = Base.min(y[1], i)
+function Base.findfirst(f::Function, xs::AnyCuArray)
+    indx = ndims(xs) == 1 ? (eachindex(xs), 1) : 
+    (CartesianIndices(xs), CartesianIndex{ndims(xs)}())
+    function g(t1, t2)
+        (x, i), (y, j) = t1, t2
+        if i > j
+            t1, t2 = t2, t1
+            (x, i), (y, j) = t1, t2
         end
-
-        return
+        x && return t1
+        y && return t2
+        return (false, indx[2])
     end
 
-    kernel = @cuda name="findfirst" launch=false kernel(y, xs)
-    config = launch_configuration(kernel.fun)
-    threads = Base.min(length(xs), config.threads)
-    blocks = cld(length(xs), threads)
-    kernel(y, xs; threads=threads, blocks=blocks)
-
-    first_i = @allowscalar y[1]
-    return first_i == typemax(Int) ? nothing : keys(xs)[first_i]
+    res = mapreduce((x, y)->(f(x), y), g, xs, indx[1]; init = (false, indx[2]))
+    res[1] === true && return res[2]
+    return nothing
 end
 
 Base.findfirst(xs::AnyCuArray{Bool}) = findfirst(identity, xs)
 
 function Base.findmin(a::AnyCuArray; dims=:)
+    function f(t1::T, t2::T) where T <: Tuple{AbstractFloat, I} where I
+        (x, i), (y, j) = t1, t2
+        if i > j
+            t1, t2 = t2, t1
+            (x, i), (y, j) = t1, t2
+        end
+        
+        # Check for NaN first because NaN == NaN is false
+        isnan(x) && return t1
+        isnan(y) && return t2
+        min(x, y) == x && return t1
+        return t2
+    end
+
+    function f(t1, t2)
+        (x, i), (y, j) = t1, t2
+
+        x < y && return t1
+        x == y && return (x, min(i, j))
+        return t2
+    end
+
+    indx = ndims(a) == 1 ? (eachindex(a), 1) : 
+                           (CartesianIndices(a), CartesianIndex{ndims(a)}())
     if dims == Colon()
-        m = minimum(a)
-        i = findfirst(x->x==m, a)
-        return m,i
+        mapreduce(tuple, f, a, indx[1]; init = (typemax(eltype(a)), indx[2]))
     else
-        minima = minimum(a; dims=dims)
-        i = findfirstval(minima, a)
-        return minima,i
+        res = mapreduce(tuple, f, a, indx[1]; 
+                        init = (typemax(eltype(a)),indx[2]), dims=dims)
+        vals = map(x->x[1], res)
+        inds = map(x->x[2], res)
+        return (vals, inds)
     end
 end
+
 
 function Base.findmax(a::AnyCuArray; dims=:)
+    function f(t1::T, t2::T) where T <: Tuple{AbstractFloat, I} where I
+        (x, i), (y, j) = t1, t2
+        if i > j
+            t1, t2 = t2, t1
+            (x, i), (y, j) = t1, t2
+        end
+
+        # Check for NaN first because NaN == NaN is false
+        isnan(x) && return t1
+        isnan(y) && return t2
+        max(x, y) == x && return t1
+        return t2
+    end
+
+    function f(t1, t2)
+        (x, i), (y, j) = t1, t2
+
+        x < y && return t2
+        x == y && return (x, min(i, j))
+        return t1
+    end
+
+    indx = ndims(a) == 1 ? (eachindex(a), 1) : 
+                           (CartesianIndices(a), CartesianIndex{ndims(a)}())
     if dims == Colon()
-        m = maximum(a)
-        i = findfirst(x->x==m, a)
-        return m,i
+        mapreduce(tuple, f, a, indx[1]; init = (typemin(eltype(a)), indx[2]))
     else
-        maxima = maximum(a; dims=dims)
-        i = findfirstval(maxima, a)
-        return maxima,i
-    end
-end
-
-function findfirstval(vals::AnyCuArray, xs::AnyCuArray)
-    ## find the first matching element
-
-    # NOTE: this kernel performs global atomic operations for the sake of simplicity.
-    #       if this turns out to be a bottleneck, we will need to cache in local memory.
-    #       that requires the dimension-under-reduction to be iterated in first order.
-    #       this can be done by splitting the iteration domain eagerly; see the
-    #       accumulate kernel for an example, or git history from before this comment.
-
-    indices = fill(typemax(Int), size(vals))
-
-    function kernel(xs, vals, indices)
-        i = (blockIdx().x-1) * blockDim().x + threadIdx().x
-
-        R = CartesianIndices(xs)
-
-        if i <= length(R)
-            I = R[i]
-            Jmax = last(CartesianIndices(vals))
-            J = Base.min(I, Jmax)
-
-            @inbounds if xs[I] == vals[J]
-                I′ = LinearIndices(xs)[I]      # atomic_min only works with integers
-                J′ = LinearIndices(indices)[J] # FIXME: @atomic doesn't handle array ref with CartesianIndices
-                @atomic indices[J′] = Base.min(indices[J′], I′)
-            end
-        end
-
-        return
-    end
-
-    kernel = @cuda launch=false kernel(xs, vals, indices)
-    config = launch_configuration(kernel.fun)
-    threads = Base.min(length(xs), config.threads)
-    blocks = cld(length(xs), threads)
-    kernel(xs, vals, indices; threads=threads, blocks=blocks)
-
-
-    ## convert the linear indices to an appropriate type
-
-    kt = keytype(xs)
-
-    if kt == Int
-        return indices
-    else
-        indices′ = CuArray{kt}(undef, size(indices))
-        broadcast!(indices′, indices, Ref(keys(xs))) do index, keys
-            keys[index]
-        end
-
-        return indices′
+        res = mapreduce(tuple, f, a, indx[1]; 
+                        init = (typemin(eltype(a)), indx[2]), dims=dims)
+        vals = map(x->x[1], res)
+        inds = map(x->x[2], res)
+        return (vals, inds)
     end
 end

--- a/test/array.jl
+++ b/test/array.jl
@@ -276,33 +276,63 @@ end
   let x = rand(Float32, 100)
       @test findmax(x) == findmax(CuArray(x))
       @test findmax(x; dims=1) == Array.(findmax(CuArray(x); dims=1))
+      
+      x[32] = x[33] = x[55] = x[66] = NaN32
+      @test isequal(findmax(x), findmax(CuArray(x)))
+      @test isequal(findmax(x; dims=1), Array.(findmax(CuArray(x); dims=1)))
   end
   let x = rand(Float32, 10, 10)
       @test findmax(x) == findmax(CuArray(x))
       @test findmax(x; dims=1) == Array.(findmax(CuArray(x); dims=1))
       @test findmax(x; dims=2) == Array.(findmax(CuArray(x); dims=2))
+
+      x[rand(CartesianIndices((10, 10)), 10)] .= NaN
+      @test isequal(findmax(x), findmax(CuArray(x)))
+      @test isequal(findmax(x; dims=1), Array.(findmax(CuArray(x); dims=1)))
   end
   let x = rand(Float32, 10, 10, 10)
       @test findmax(x) == findmax(CuArray(x))
       @test findmax(x; dims=1) == Array.(findmax(CuArray(x); dims=1))
       @test findmax(x; dims=2) == Array.(findmax(CuArray(x); dims=2))
       @test findmax(x; dims=3) == Array.(findmax(CuArray(x); dims=3))
+
+      x[rand(CartesianIndices((10, 10, 10)), 20)] .= NaN
+      @test isequal(findmax(x), findmax(CuArray(x)))
+      @test isequal(findmax(x; dims=1), Array.(findmax(CuArray(x); dims=1)))
+      @test isequal(findmax(x; dims=2), Array.(findmax(CuArray(x); dims=2)))
+      @test isequal(findmax(x; dims=3), Array.(findmax(CuArray(x); dims=3)))
   end
 
   let x = rand(Float32, 100)
       @test findmin(x) == findmin(CuArray(x))
       @test findmin(x; dims=1) == Array.(findmin(CuArray(x); dims=1))
+
+      x[32] = x[33] = x[55] = x[66] = NaN32
+      @test isequal(findmin(x), findmin(CuArray(x)))
+      @test isequal(findmin(x; dims=1), Array.(findmin(CuArray(x); dims=1)))
   end
   let x = rand(Float32, 10, 10)
       @test findmin(x) == findmin(CuArray(x))
       @test findmin(x; dims=1) == Array.(findmin(CuArray(x); dims=1))
       @test findmin(x; dims=2) == Array.(findmin(CuArray(x); dims=2))
+
+      x[rand(CartesianIndices((10, 10)), 10)] .= NaN
+      @test isequal(findmin(x), findmin(CuArray(x)))
+      @test isequal(findmin(x; dims=1), Array.(findmin(CuArray(x); dims=1)))
+      @test isequal(findmin(x; dims=2), Array.(findmin(CuArray(x); dims=2)))
+      @test isequal(findmin(x; dims=3), Array.(findmin(CuArray(x); dims=3)))
   end
   let x = rand(Float32, 10, 10, 10)
       @test findmin(x) == findmin(CuArray(x))
       @test findmin(x; dims=1) == Array.(findmin(CuArray(x); dims=1))
       @test findmin(x; dims=2) == Array.(findmin(CuArray(x); dims=2))
       @test findmin(x; dims=3) == Array.(findmin(CuArray(x); dims=3))
+
+      x[rand(CartesianIndices((10, 10, 10)), 20)] .= NaN
+      @test isequal(findmin(x), findmin(CuArray(x)))
+      @test isequal(findmin(x; dims=1), Array.(findmin(CuArray(x); dims=1)))
+      @test isequal(findmin(x; dims=2), Array.(findmin(CuArray(x); dims=2)))
+      @test isequal(findmin(x; dims=3), Array.(findmin(CuArray(x); dims=3)))
   end
 end
 


### PR DESCRIPTION
This PR replaces the two-kernel findminmax implementation to a single-pass one by @tkf, https://github.com/JuliaGPU/CUDA.jl/issues/484#issue-718741136, as proposed by @Ellipse0934, https://github.com/JuliaGPU/CUDA.jl/issues/320#issuecomment-719291478. I only rebased it and cleaned-up a little.

Performance is about as @Ellipse0934 reported, i.e. massive improvements in some cases, and a small regression in others (which was much less pronounced with my GPU). As the implementation also fixes a bug, I'd say that's worth it. FWIW, I don't think the performance penalty comes from not using warp intrinsics, but due to the bloaty code generated by a tuple-heavy reduce closure. And recent/beefy GPUs like mine are often less sensitive to that.

Fixes https://github.com/JuliaGPU/CUDA.jl/issues/553, fixes https://github.com/JuliaGPU/CUDA.jl/issues/320#issuecomment-719291478