### PR TITLE
Fix wrong initialisation error message

### DIFF
--- a/src/initialization.jl
+++ b/src/initialization.jl
@@ -30,7 +30,7 @@ const configure_lock = ReentrantLock()
                 __configure__()
                 configured[] = 1
                 __runtime_init__()
-            catch
+            catch ex
                 show_reason && @error("Error during initialization of CUDA.jl", exception=(ex,catch_backtrace()))
                 configured[] = 0
             end


### PR DESCRIPTION
Attempt to fix #603

Before fix:
```julia
Error: Exception while generating log record in module CUDA at 
/home/qyu/.julia/dev/CUDA/src/initialization.jl:34
│   exception =
│    UndefVarError: ex not defined
│    Stacktrace:
...
```

After fix:
```julia
┌ Error: Recursion during initialization of CUDA.jl
└ @ CUDA ~/.julia/dev/CUDA/src/initialization.jl:38
┌ Error: Error during initialization of CUDA.jl
│   exception =
│    CUDA error (code 999, CUDA_ERROR_UNKNOWN)
│    Stacktrace:
...
```