### PR TITLE
README: document how to find out the compute capabilities for your GPUs

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,11 +37,7 @@ or higher, and an accompanying NVIDIA driver with support for **CUDA 10.1** or n
 requirements are not enforced by the Julia package manager when installing CUDA.jl.
 Depending on your system and GPU, you may need to install an older version of the package.
 
-You can print the compute capability for all of your GPUS by running the following in Julia:
-```julia
-julia> [CUDA.capability(dev) for dev in CUDA.devices()]
-```
-
+You can view the compute capabilities of your devices, as well as the supported CUDA versions, by running `CUDA.versioninfo()`.
 
 ## Quick start
 

--- a/README.md
+++ b/README.md
@@ -37,6 +37,11 @@ or higher, and an accompanying NVIDIA driver with support for **CUDA 10.1** or n
 requirements are not enforced by the Julia package manager when installing CUDA.jl.
 Depending on your system and GPU, you may need to install an older version of the package.
 
+You can print the compute capability for all of your GPUS by running the following in Julia:
+```julia
+julia> [CUDA.capability(dev) for dev in CUDA.devices()]
+```
+
 
 ## Quick start
 


### PR DESCRIPTION
The README currently says:
> CUDA.jl currently also requires a CUDA-capable GPU with **compute capability 5.0** (Maxwell) or higher, and an accompanying NVIDIA driver with support for **CUDA 10.1** or newer. These requirements are not enforced by the Julia package manager when installing CUDA.jl. Depending on your system and GPU, you may need to install an older version of the package.

If users are anything like me, their first question will be: what is the compute capability of my GPU? After all, if the package manager is not going to enforce this requirement, I should probably verify it myself.

This PR adds a brief snippet to the README (right below the aforementioned section) that shows users how they can print the compute capabilities for all of their GPUs.

---

The second requirement is:
> an accompanying NVIDIA driver with support for **CUDA 10.1** or newer

@maleadt Is there a way that users can use CUDA.jl to verify that they meet this requirement? That is, is there a function in CUDA.jl that will print the versions of CUDA that are supported by the user's NVIDIA driver?