### PR TITLE
Fix broadcasting with Base.angle

### DIFF
--- a/src/broadcast.jl
+++ b/src/broadcast.jl
@@ -25,7 +25,7 @@ Broadcast.broadcasted(::CuArrayStyle{N}, f, args...) where {N} =
 
 const device_intrinsics = :[
   cos, cospi, sin, sinpi, tan, acos, asin, atan,
-  cosh, sinh, tanh, acosh, asinh, atanh,
+  cosh, sinh, tanh, acosh, asinh, atanh, angle,
   log, log10, log1p, log2, logb, ilogb,
   exp, exp2, exp10, expm1, ldexp,
   erf, erfinv, erfc, erfcinv, erfcx,


### PR DESCRIPTION
Before this change (Julia 1.5.3, CUDA 2.3.0):

```julia
julia> using CUDA

julia> x = cu(rand(10,10));

julia> angle.(x)
┌ Warning: calls to Base intrinsics might be GPU incompatible
│   exception =
│    You called atan(y::T, x::T) where T<:Union{Float32, Float64} in Base.Math at special/trig.jl:567, maybe you intended to call atan(x::Float32, y::Float32) in CUDA at /home/marius/.julia/packages/CUDA/YeS8q/src/device/intrinsics/math.jl:39 instead?
```