### PR TITLE
Support separate compilation of device functions

### DIFF
--- a/Manifest.toml
+++ b/Manifest.toml
@@ -85,7 +85,9 @@ version = "6.2.0"
 
 [[GPUCompiler]]
 deps = ["DataStructures", "InteractiveUtils", "LLVM", "Libdl", "Logging", "Scratch", "Serialization", "TimerOutputs", "UUIDs"]
-git-tree-sha1 = "6ab1bc883bc13919c25acc0fe0dea707f61ae39c"
+git-tree-sha1 = "c9d93cd26de19743cabc03cc36ef9b474430e586"
+repo-rev = "9ce2e6b"
+repo-url = "https://github.com/JuliaGPU/GPUCompiler.jl.git"
 uuid = "61eb1bfa-7361-4325-ad38-22787b887f55"
 version = "0.9.1"
 

--- a/docs/src/api/compiler.md
+++ b/docs/src/api/compiler.md
@@ -13,7 +13,7 @@ If needed, you can use a lower-level API that lets you inspect the compiler kern
 ```@docs
 cudaconvert
 cufunction
-CUDA.HostKernel
+CUDA.Kernel
 CUDA.version
 CUDA.maxthreads
 CUDA.registers

--- a/docs/src/api/kernel.md
+++ b/docs/src/api/kernel.md
@@ -144,7 +144,7 @@ well:
 
 ```@docs
 dynamic_cufunction
-CUDA.DeviceKernel
+CUDA.DynamicKernel
 ```
 
 

--- a/src/precompile.jl
+++ b/src/precompile.jl
@@ -1,6 +1,6 @@
 function _precompile_()
     ccall(:jl_generating_output, Cint, ()) == 1 || return nothing
-    @assert precompile(Tuple{CUDA.HostKernel{identity, Tuple{Nothing}},Nothing})
+    @assert precompile(Tuple{CUDA.Kernel{identity, Tuple{Nothing}},Nothing})
     @assert precompile(Tuple{Type{CuModule},String,Dict{CUDA.CUjit_option_enum, Any}})
     @assert precompile(Tuple{typeof(CUDA.prepare_cuda_call)})
     @assert precompile(Tuple{typeof(GPUCompiler.load_runtime),GPUCompiler.CompilerJob{GPUCompiler.PTXCompilerTarget, CUDA.CUDACompilerParams},LLVM.Context})

--- a/src/precompile.jl
+++ b/src/precompile.jl
@@ -1,6 +1,6 @@
 function _precompile_()
     ccall(:jl_generating_output, Cint, ()) == 1 || return nothing
-    @assert precompile(Tuple{CUDA.Kernel{identity, Tuple{Nothing}},Nothing})
+    @assert precompile(Tuple{Type{CUDA.Kernel{typeof(Base.identity), Tuple{Nothing}}}, Function, CUDA.CuContext, CUDA.CuModule, CUDA.CuFunction})
     @assert precompile(Tuple{Type{CuModule},String,Dict{CUDA.CUjit_option_enum, Any}})
     @assert precompile(Tuple{typeof(CUDA.prepare_cuda_call)})
     @assert precompile(Tuple{typeof(GPUCompiler.load_runtime),GPUCompiler.CompilerJob{GPUCompiler.PTXCompilerTarget, CUDA.CUDACompilerParams},LLVM.Context})


### PR DESCRIPTION
~WIP towards https://github.com/JuliaGPU/CUDA.jl/issues/75.~

First step, depends on https://github.com/JuliaGPU/GPUCompiler.jl/pull/129: make it possible to compile device functions in isolation and get a reference to them (like `cudaMemcpyFromSymbol`):

```julia
julia> kernel = nothing

julia> @device_code_ptx kernel = cufunction(identity, Tuple{Nothing}; kernel=false)
// PTX CompilerJob of function identity(Nothing) for sm_75

//
// Generated by LLVM NVPTX Back-End
//

.version 6.3
.target sm_75
.address_size 64

        // .globl       julia_identity_1335     // -- Begin function julia_identity_1335
.visible .func julia_identity_1335
()
;
.weak .global .align 8 .u64 julia_identity_1335_slot = julia_identity_1335;
.weak .global .align 8 .u64 exception_flag;
                                        // @julia_identity_1335
.visible .func julia_identity_1335()
{


// %bb.0:                               // %top
        ret;
                                        // -- End function
}

julia> kernel
CUDA.DeviceFunction{typeof(identity), Tuple{Nothing}}(CuContext(0x0000000002d6a100, instance 3a6919012dc68ea7), CuModule(Ptr{Nothing} @0x0000000004e9e6b0, CuContext(0x0000000002d6a100, instance 3a6919012dc68ea7)), CuPtr{Nothing}(0x0000000000000001))
```

IIUC, we'll be able to pass these into the CUFFT callback setter (although it isn't clear to me how that handles the owning module, etc).