### PR TITLE
CompatHelper: only instantiate `/Manifest.toml` (the manifest file in the root of the repository)

### DIFF
--- a/.github/workflows/CompatHelper.yml
+++ b/.github/workflows/CompatHelper.yml
@@ -25,4 +25,4 @@ jobs:
       - name: CompatHelper.main()
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: julia -e 'using CompatHelper; CompatHelper.main()'
+        run: julia -e 'using CompatHelper; CompatHelper.main( (; registries) -> CompatHelper._update_manifests(String[pwd()]; registries = registries, delete_old_manifests = false) )'


### PR DESCRIPTION
This is based on the example here: https://github.com/JuliaRegistries/CompatHelper.jl/blob/master/README.md#example-3-only-update-the-manifesttoml-in-the-root-of-the-repository

cc: @maleadt 