### PR TITLE
Define Base.deepcopy rather than Base.deepcopy_internal to avoid invalidations

### DIFF
--- a/src/array.jl
+++ b/src/array.jl
@@ -314,11 +314,10 @@ function Base.unsafe_copyto!(dest::DenseCuArray{T}, doffs, src::DenseCuArray{T},
   return dest
 end
 
-function Base.deepcopy_internal(x::CuArray, dict::IdDict)
-  haskey(dict, x) && return dict[x]::typeof(x)
+function Base.deepcopy(x::CuArray) # define deepcopy rather than deepcopy_internal to avoid invalidations in Base
+  dict = IdDict()
   return dict[x] = copy(x)
 end
-
 
 ## Float32-preferring conversion
 


### PR DESCRIPTION
Defining `Base.deepcopy` directly rather than `Base.deepcopy_internal` seems like it would fix the 2nd biggest source of invalidations associated with `using CUDA`

It's the 2nd from the bottom in the full report below, which this PR eliminates
```
 inserting deepcopy_internal(x::CuArray, dict::IdDict) in CUDA at /Users/ian/Documents/GitHub/CUDA.jl/src/array.jl:317 invalidated:
   backedges: 1: superseding deepcopy_internal(x, stackdict::IdDict) in Base at deepcopy.jl:53 with MethodInstance for Base.deepcopy_internal(::Any, ::IdDict{Any, Any}) (242 children)
   5 mt_cache
```
I think the `@nospecialize` on `Base.deepcopy_internal` is the reason for all the invalidations, but I'm not sure..

Note! I haven't run any tests locally due to lack of an available gpu.

The list is sorted with most resulting invalidations at the bottom. (I recommend running this to get the proper highlighted report)

Master
```
julia> using SnoopCompileCore

julia> invalidations = @snoopr using CUDA;

julia> using SnoopCompile

julia> trees = invalidation_trees(invalidations)
insert_backedges for MethodInstance for Core.Compiler.setindex!(::GPUCompiler.CodeCache, ::Core.CodeInstance, ::Core.MethodInstance)
insert_backedges for MethodInstance for LLVM.call!(::LLVM.Builder, ::GPUCompiler.Runtime.RuntimeMethodInstance, ::Vector{LLVM.Value})
insert_backedges for MethodInstance for GPUCompiler.lower_throw!(::LLVM.Module)
21-element Vector{SnoopCompile.MethodInvalidations}:
 inserting convert(::Type{var"#s4"} where var"#s4"<:Tuple, comp::ChainRulesCore.Composite{var"#s3", var"#s2"} where var"#s2"<:Tuple where var"#s3") in ChainRulesCore at /Users/ian/.julia/dev/ChainRulesCore/src/differentials/composite.jl:68 invalidated:
   mt_backedges: 1: signature Tuple{typeof(convert), Type{Tuple{DataType, DataType, DataType}}, Any} triggered MethodInstance for Pair{DataType, Tuple{DataType, DataType, DataType}}(::Any, ::Any) (0 children)
                 2: signature Tuple{typeof(convert), Type{NTuple{8, DataType}}, Any} triggered MethodInstance for Pair{DataType, NTuple{8, DataType}}(::Any, ::Any) (0 children)
                 3: signature Tuple{typeof(convert), Type{NTuple{7, DataType}}, Any} triggered MethodInstance for Pair{DataType, NTuple{7, DataType}}(::Any, ::Any) (0 children)
                 4: signature Tuple{typeof(convert), Type{Tuple{Symbol, Any, Symbol, Symbol}}, Any} triggered MethodInstance for setindex!(::Vector{Tuple{Symbol, Any, Symbol, Symbol}}, ::Any, ::Int64) (0 children)
                 5: signature Tuple{typeof(convert), Type{Tuple{Any, String}}, Any} triggered MethodInstance for setindex!(::Vector{Tuple{Any, String}}, ::Any, ::Int64) (0 children)

 inserting *(s, comp::ChainRulesCore.Composite) in ChainRulesCore at /Users/ian/.julia/dev/ChainRulesCore/src/differential_arithmetic.jl:138 invalidated:
   mt_backedges: 1: signature Tuple{typeof(*), Union{Regex, String}, Any} triggered MethodInstance for *(::Any, ::Char, ::Any) (0 children)

 inserting may_discard_trees(ni::GPUCompiler.GPUInterpreter) in GPUCompiler at /Users/ian/.julia/packages/GPUCompiler/9oa8s/src/jlgen.jl:118 invalidated:

 inserting code_cache(ni::GPUCompiler.GPUInterpreter) in GPUCompiler at /Users/ian/.julia/packages/GPUCompiler/9oa8s/src/jlgen.jl:155 invalidated:

 inserting may_optimize(ni::GPUCompiler.GPUInterpreter) in GPUCompiler at /Users/ian/.julia/packages/GPUCompiler/9oa8s/src/jlgen.jl:116 invalidated:

 inserting get_world_counter(ni::GPUCompiler.GPUInterpreter) in GPUCompiler at /Users/ian/.julia/packages/GPUCompiler/9oa8s/src/jlgen.jl:112 invalidated:

 inserting may_compress(ni::GPUCompiler.GPUInterpreter) in GPUCompiler at /Users/ian/.julia/packages/GPUCompiler/9oa8s/src/jlgen.jl:117 invalidated:

 inserting get_inference_cache(ni::GPUCompiler.GPUInterpreter) in GPUCompiler at /Users/ian/.julia/packages/GPUCompiler/9oa8s/src/jlgen.jl:113 invalidated:

 inserting Core.Compiler.InferenceParams(ni::GPUCompiler.GPUInterpreter) in GPUCompiler at /Users/ian/.julia/packages/GPUCompiler/9oa8s/src/jlgen.jl:114 invalidated:

 inserting Core.Compiler.OptimizationParams(ni::GPUCompiler.GPUInterpreter) in GPUCompiler at /Users/ian/.julia/packages/GPUCompiler/9oa8s/src/jlgen.jl:115 invalidated:

 inserting isnan(x::BFloat16s.BFloat16) in BFloat16s at /Users/ian/.julia/packages/BFloat16s/rVeFv/src/bfloat16.jl:16 invalidated:
   backedges: 1: superseding isnan(x::AbstractFloat) in Base at float.jl:473 with MethodInstance for isnan(::AbstractFloat) (1 children)
   21 mt_cache

 inserting lock(nrl::CUDA.NonReentrantLock) in CUDA at /Users/ian/Documents/GitHub/CUDA.jl/src/pool.jl:15 invalidated:
   mt_backedges: 1: signature Tuple{typeof(lock), Base.AbstractLock} triggered MethodInstance for lock(::Base.GenericCondition) (0 children)
                 2: signature Tuple{typeof(lock), Base.AbstractLock} triggered MethodInstance for Base.relockall(::Base.AbstractLock, ::Nothing) (0 children)
                 3: signature Tuple{typeof(lock), Base.AbstractLock} triggered MethodInstance for lock(::Base.LibuvStream) (2 children)

 inserting Base.IteratorSize(::Type{T} where T<:Union{DataStructures.SortedDict, DataStructures.SortedMultiDict, DataStructures.SortedSet}) in DataStructures at /Users/ian/.julia/packages/DataStructures/5hvIb/src/container_loops.jl:86 invalidated:
   backedges: 1: superseding Base.IteratorSize(::Type) in Base at generator.jl:92 with MethodInstance for Base.IteratorSize(::Type{var"#s445"} where var"#s445"<:LinearAlgebra.Factorization{T} where T) (3 children)
   56 mt_cache

 inserting unlock(nrl::CUDA.NonReentrantLock) in CUDA at /Users/ian/Documents/GitHub/CUDA.jl/src/pool.jl:25 invalidated:
   mt_backedges: 1: signature Tuple{typeof(unlock), Base.AbstractLock} triggered MethodInstance for unlock(::Base.GenericCondition) (0 children)
                 2: signature Tuple{typeof(unlock), Base.AbstractLock} triggered MethodInstance for Base.unlockall(::Base.AbstractLock) (1 children)
                 3: signature Tuple{typeof(unlock), Base.AbstractLock} triggered MethodInstance for unlock(::Base.LibuvStream) (2 children)

 inserting runtime_module(::GPUCompiler.CompilerJob{GPUCompiler.PTXCompilerTarget, CUDA.CUDACompilerParams}) in CUDA at /Users/ian/Documents/GitHub/CUDA.jl/src/compiler/gpucompiler.jl:5 invalidated:
   backedges: 1: superseding runtime_module(::GPUCompiler.CompilerJob) in GPUCompiler at /Users/ian/.julia/packages/GPUCompiler/9oa8s/src/interface.jl:107 with MethodInstance for GPUCompiler.runtime_module(::GPUCompiler.CompilerJob) (10 children)
   36 mt_cache

 inserting *(::ChainRulesCore.One, b) in ChainRulesCore at /Users/ian/.julia/dev/ChainRulesCore/src/differential_arithmetic.jl:98 invalidated:
   mt_backedges: 1: signature Tuple{typeof(*), Any, Char} triggered MethodInstance for *(::Any, ::Char, ::Any) (16 children)
   8 mt_cache

 inserting unsafe_convert(::Type{Int32}, p::CUDA.CUFFT.CuFFTPlan) in CUDA.CUFFT at /Users/ian/Documents/GitHub/CUDA.jl/lib/cufft/fft.jl:22 invalidated:
   mt_backedges: 1: signature Tuple{typeof(Base.unsafe_convert), Type{Int32}, Any} triggered MethodInstance for LibCURL.curl_multi_socket_action(::Ptr{Nothing}, ::Int32, ::Any, ::Base.RefValue{Int32}) (17 children)

 inserting convert(::Type{var"#s4"} where var"#s4"<:Dict, comp::ChainRulesCore.Composite{var"#s3", var"#s2"} where var"#s2"<:Dict where var"#s3"<:Dict) in ChainRulesCore at /Users/ian/.julia/dev/ChainRulesCore/src/differentials/composite.jl:69 invalidated:
   mt_backedges: 1: signature Tuple{typeof(convert), Type{Dict{String, Any}}, Any} triggered MethodInstance for setindex!(::Dict{Base.BinaryPlatforms.AbstractPlatform, Dict{String, Any}}, ::Any, ::Base.BinaryPlatforms.Platform) (0 children)
                 2: signature Tuple{typeof(convert), Type{Dict{Symbol, Any}}, Any} triggered MethodInstance for setindex!(::IdDict{Function, Dict{Symbol, Any}}, ::Any, ::Any) (8 children)
                 3: signature Tuple{typeof(convert), Type{Dict{Char, Any}}, Any} triggered MethodInstance for REPL.LineEdit.Prompt(::Any, ::Any, ::Any, ::Any, ::Any, ::Any, ::Any, ::Any, ::Any, ::Any) (18 children)

 inserting broadcasted(::CUDA.CuArrayStyle{N}, f, args...) where N in CUDA at /Users/ian/Documents/GitHub/CUDA.jl/src/broadcast.jl:23 invalidated:
   backedges: 1: superseding broadcasted(::S, f, args...) where S<:Base.Broadcast.BroadcastStyle in Base.Broadcast at broadcast.jl:1314 with MethodInstance for Base.Broadcast.broadcasted(::Base.Broadcast.BroadcastStyle, ::typeof(something), ::Any) (39 children)

 inserting deepcopy_internal(x::CuArray, dict::IdDict) in CUDA at /Users/ian/Documents/GitHub/CUDA.jl/src/array.jl:317 invalidated:
   backedges: 1: superseding deepcopy_internal(x, stackdict::IdDict) in Base at deepcopy.jl:53 with MethodInstance for Base.deepcopy_internal(::Any, ::IdDict{Any, Any}) (242 children)
   5 mt_cache

 inserting convert(::Type{Type}, T::CUDA.CUSPARSE.cusparseIndexType_t) in CUDA.CUSPARSE at /Users/ian/Documents/GitHub/CUDA.jl/lib/cusparse/types.jl:17 invalidated:
   mt_backedges: 1: signature Tuple{typeof(convert), Type{Type}, Any} triggered MethodInstance for LoweredCodeUtils.signature(::Function, ::JuliaInterpreter.Frame, ::Expr, ::Int64) (0 children)
                 2: signature Tuple{typeof(convert), Type{Type}, Any} triggered MethodInstance for Revise._precompile_() (0 children)
                 3: signature Tuple{typeof(convert), Type{Type}, Any} triggered MethodInstance for Revise.var"#methods_by_execution!#24"(::Symbol, ::Bool, ::typeof(Revise.methods_by_execution!), ::Function, ::Revise.CodeTrackingMethodInfo, ::Dict{Module, Vector{Expr}}, ::JuliaInterpreter.Frame, ::Vector{Bool}) (0 children)
                 4: signature Tuple{typeof(convert), Type{Type}, Any} triggered MethodInstance for JuliaInterpreter.DispatchableMethod(::Nothing, ::JuliaInterpreter.FrameInstance, ::Any) (4 children)
                 5: signature Tuple{typeof(convert), Type{Type}, Any} triggered MethodInstance for JuliaInterpreter.DispatchableMethod(::Nothing, ::JuliaInterpreter.Compiled, ::Any) (352 children)
```