### PR TITLE
Run the tests from the current directory.

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -215,9 +215,8 @@ function addworker(X; kwargs...)
     end
 
     withenv("JULIA_NUM_THREADS" => 1, "OPENBLAS_NUM_THREADS" => 1) do
-        procs = addprocs(X; exename=exename, exeflags=test_exeflags,
-                            dir=@__DIR__, kwargs...)
-        @everywhere procs include("setup.jl")
+        procs = addprocs(X; exename=exename, exeflags=test_exeflags, kwargs...)
+        @everywhere procs include($(joinpath(@__DIR__, "setup.jl")))
         procs
     end
 end


### PR DESCRIPTION
Otherwise the --project argument isn't guarantueed to work.
Makes it possible to do `julia --project=test test/runtests.jl`.