### PR TITLE
Automatic task-based concurrency using local streams

### DIFF
--- a/lib/cublas/CUBLAS.jl
+++ b/lib/cublas/CUBLAS.jl
@@ -70,6 +70,13 @@ function math_mode!(handle, mode)
     return
 end
 
+function set_stream(s::CuStream)
+    ctx = context()
+    if haskey(task_local_storage(), (:CUBLAS, ctx))
+        cublasSetStream_v2(handle(), s)
+    end
+end
+
 function handle()
     tid = Threads.threadid()
     if @inbounds thread_handles[tid] === nothing
@@ -83,7 +90,7 @@ function handle()
                 end
             end
 
-            cublasSetStream_v2(handle, CuStreamPerThread())
+            cublasSetStream_v2(handle, CUDA.stream_per_thread())
 
             if version(handle) >= v"11.2"
                 workspace = CuArray{UInt8}(undef, 4*1024*1024)  # TODO: 256-byte aligned

--- a/lib/cublas/CUBLAS.jl
+++ b/lib/cublas/CUBLAS.jl
@@ -94,7 +94,7 @@ function handle()
             handle
         end
 
-        cublasSetStream_v2(thread_handles[tid], stream(per_thread=true))
+        cublasSetStream_v2(thread_handles[tid], stream())
     end
     something(@inbounds thread_handles[tid])
 end

--- a/lib/cublas/CUBLAS.jl
+++ b/lib/cublas/CUBLAS.jl
@@ -77,7 +77,7 @@ function math_mode!(handle, mode)
 end
 
 function handle()
-    CUDA.detect_task_switch()
+    CUDA.detect_state_changes()
     tid = Threads.threadid()
     if @inbounds thread_handles[tid] === nothing
         ctx = context()
@@ -105,7 +105,7 @@ function handle()
 end
 
 function xt_handle()
-    CUDA.detect_task_switch()
+    CUDA.detect_state_changes()
     tid = Threads.threadid()
     if @inbounds thread_xt_handles[tid] === nothing
         ctxs = [context(dev) for dev in devices()]

--- a/lib/cublas/CUBLAS.jl
+++ b/lib/cublas/CUBLAS.jl
@@ -70,13 +70,6 @@ function math_mode!(handle, mode)
     return
 end
 
-function set_stream(s::CuStream)
-    ctx = context()
-    if haskey(task_local_storage(), (:CUBLAS, ctx))
-        cublasSetStream_v2(handle(), s)
-    end
-end
-
 function handle()
     tid = Threads.threadid()
     if @inbounds thread_handles[tid] === nothing
@@ -90,8 +83,6 @@ function handle()
                 end
             end
 
-            cublasSetStream_v2(handle, CUDA.stream_per_thread())
-
             if version(handle) >= v"11.2"
                 workspace = CuArray{UInt8}(undef, 4*1024*1024)  # TODO: 256-byte aligned
                 cublasSetWorkspace_v2(handle, workspace, sizeof(workspace))
@@ -102,6 +93,8 @@ function handle()
 
             handle
         end
+
+        cublasSetStream_v2(thread_handles[tid], CUDA.stream_per_thread())
     end
     something(@inbounds thread_handles[tid])
 end
@@ -128,6 +121,13 @@ function xt_handle()
         end
     end
     something(@inbounds thread_xt_handles[tid])
+end
+
+function reset_stream()
+    # NOTE: we 'abuse' the thread cache here, as switching streams doesn't invalidate it,
+    #       but we (re-)apply the current stream when populating that cache.
+    tid = Threads.threadid()
+    thread_handles[tid] = nothing
 end
 
 function __init__()

--- a/lib/cublas/CUBLAS.jl
+++ b/lib/cublas/CUBLAS.jl
@@ -94,7 +94,7 @@ function handle()
             handle
         end
 
-        cublasSetStream_v2(thread_handles[tid], CUDA.stream_per_thread())
+        cublasSetStream_v2(thread_handles[tid], stream(per_thread=true))
     end
     something(@inbounds thread_handles[tid])
 end

--- a/lib/cublas/CUBLAS.jl
+++ b/lib/cublas/CUBLAS.jl
@@ -77,6 +77,7 @@ function math_mode!(handle, mode)
 end
 
 function handle()
+    CUDA.detect_task_switch()
     tid = Threads.threadid()
     if @inbounds thread_handles[tid] === nothing
         ctx = context()
@@ -104,6 +105,7 @@ function handle()
 end
 
 function xt_handle()
+    CUDA.detect_task_switch()
     tid = Threads.threadid()
     if @inbounds thread_xt_handles[tid] === nothing
         ctxs = [context(dev) for dev in devices()]

--- a/lib/cublas/error.jl
+++ b/lib/cublas/error.jl
@@ -48,7 +48,7 @@ end
 end
 
 function initialize_api()
-    CUDA.prepare_cuda_call()
+    CUDA.initialize_cuda_context()
 end
 
 macro check(ex)

--- a/lib/cudadrv/context.jl
+++ b/lib/cudadrv/context.jl
@@ -2,7 +2,7 @@
 
 export
     CuContext, CuCurrentContext, activate,
-    synchronize, CuCurrentDevice
+    synchronize_all, CuCurrentDevice
 
 
 ## construction and destruction
@@ -166,11 +166,13 @@ function CuDevice(ctx::CuContext)
 end
 
 """
-    synchronize()
+    synchronize_all()
 
-Block for the current context's tasks to complete.
+Block for the current device's tasks to complete.
 """
-synchronize() = cuCtxSynchronize()
+synchronize_all() = cuCtxSynchronize()
+
+# TODO: rename to device_synchronize when we can differentiate between the on-device call.
 
 
 ## cache config

--- a/lib/cudadrv/context.jl
+++ b/lib/cudadrv/context.jl
@@ -170,7 +170,10 @@ end
 
 Block for the current device's tasks to complete.
 """
-synchronize_all() = cuCtxSynchronize()
+function synchronize_all()
+    cuCtxSynchronize()
+    check_exceptions()
+end
 
 # TODO: rename to device_synchronize when we can differentiate between the on-device call.
 

--- a/lib/cudadrv/error.jl
+++ b/lib/cudadrv/error.jl
@@ -76,21 +76,9 @@ Base.show(io::IO, ::MIME"text/plain", err::CuError) = print(io, "CuError($(err.c
 
 ## API call wrapper
 
-"""
-    initializer(f::Function)
-
-Register a function to be called before making a CUDA API call that requires an initialized
-context.
-"""
-initializer(f::Function) = (api_initializer[] = f; nothing)
-const api_initializer = Union{Nothing,Function}[nothing]
-
 # outlined functionality to avoid GC frame allocation
 @noinline function initialize_api()
-    hook = @inbounds api_initializer[]
-    if hook !== nothing
-        hook()
-    end
+    initialize_cuda_context()
     return
 end
 @noinline function throw_api_error(res)

--- a/lib/cudadrv/events.jl
+++ b/lib/cudadrv/events.jl
@@ -89,24 +89,18 @@ function elapsed(start::CuEvent, stop::CuEvent)
 end
 
 """
-    @elapsed stream ex
     @elapsed ex
 
 A macro to evaluate an expression, discarding the resulting value, instead returning the
 number of seconds it took to execute on the GPU, as a floating-point number.
 """
-macro elapsed(stream, ex)
-    quote
-        t0, t1 = CuEvent(), CuEvent()
-        record(t0, $(esc(stream)))
-        $(esc(ex))
-        record(t1, $(esc(stream)))
-        synchronize(t1)
-        elapsed(t0, t1)
-    end
-end
 macro elapsed(ex)
     quote
-        @elapsed(stream(), $(esc(ex)))
+        t0, t1 = CuEvent(), CuEvent()
+        record(t0)
+        $(esc(ex))
+        record(t1)
+        synchronize(t1)
+        elapsed(t0, t1)
     end
 end

--- a/lib/cudadrv/events.jl
+++ b/lib/cudadrv/events.jl
@@ -41,7 +41,7 @@ Base.hash(e::CuEvent, h::UInt) = hash(e.handle, h)
 
 Record an event on a stream.
 """
-record(e::CuEvent, stream::CuStream=CUDA.stream()) =
+record(e::CuEvent, stream::CuStream=stream()) =
     cuEventRecord(e, stream)
 
 """
@@ -74,7 +74,7 @@ end
 Make a stream wait on a event. This only makes the stream wait, and not the host; use
 [`synchronize(::CuEvent)`](@ref) for that.
 """
-wait(e::CuEvent, stream::CuStream=CUDA.stream()) =
+wait(e::CuEvent, stream::CuStream=stream()) =
     cuStreamWaitEvent(stream, e, 0)
 
 """

--- a/lib/cudadrv/events.jl
+++ b/lib/cudadrv/events.jl
@@ -37,11 +37,11 @@ Base.:(==)(a::CuEvent, b::CuEvent) = a.handle == b.handle
 Base.hash(e::CuEvent, h::UInt) = hash(e.handle, h)
 
 """
-    record(e::CuEvent, stream=CuDefaultStream())
+    record(e::CuEvent, [stream::CuStream])
 
 Record an event on a stream.
 """
-record(e::CuEvent, stream::CuStream=CuDefaultStream()) =
+record(e::CuEvent, stream::CuStream=CUDA.stream()) =
     cuEventRecord(e, stream)
 
 """
@@ -69,12 +69,12 @@ function query(e::CuEvent)
 end
 
 """
-    wait(e::CuEvent, stream=CuDefaultStream())
+    wait(e::CuEvent, [stream::CuStream])
 
 Make a stream wait on a event. This only makes the stream wait, and not the host; use
 [`synchronize(::CuEvent)`](@ref) for that.
 """
-wait(e::CuEvent, stream::CuStream=CuDefaultStream()) =
+wait(e::CuEvent, stream::CuStream=CUDA.stream()) =
     cuStreamWaitEvent(stream, e, 0)
 
 """
@@ -107,6 +107,6 @@ macro elapsed(stream, ex)
 end
 macro elapsed(ex)
     quote
-        @elapsed(CuDefaultStream(), $(esc(ex)))
+        @elapsed(stream(), $(esc(ex)))
     end
 end

--- a/lib/cudadrv/execution.jl
+++ b/lib/cudadrv/execution.jl
@@ -38,7 +38,7 @@ end
 
 """
     launch(f::CuFunction; args...; blocks::CuDim=1, threads::CuDim=1,
-           cooperative=false, shmem=0, stream=CUDA.stream())
+           cooperative=false, shmem=0, stream=stream())
 
 Low-level call to launch a CUDA function `f` on the GPU, using `blocks` and `threads` as
 respectively the grid and block configuration. Dynamic shared memory is allocated according
@@ -51,7 +51,7 @@ This is a low-level call, prefer to use [`cudacall`](@ref) instead.
 """
 function launch(f::CuFunction, args::Vararg{Any,N}; blocks::CuDim=1, threads::CuDim=1,
                 cooperative::Bool=false, shmem::Integer=0,
-                stream::CuStream=CUDA.stream()) where {N}
+                stream::CuStream=stream()) where {N}
     blockdim = CuDim3(blocks)
     threaddim = CuDim3(threads)
     (blockdim.x>0 && blockdim.y>0 && blockdim.z>0) ||
@@ -103,7 +103,7 @@ end
 
 """
     cudacall(f::CuFunction, types, values...; blocks::CuDim, threads::CuDim,
-             cooperative=false, shmem=0, stream=CUDA.stream())
+             cooperative=false, shmem=0, stream=stream())
 
 `ccall`-like interface for launching a CUDA function `f` on a GPU.
 
@@ -144,7 +144,7 @@ end
 
 async_send(data::Ptr{Cvoid}) = ccall(:uv_async_send, Cint, (Ptr{Cvoid},), data)
 
-function launch(f::Base.Callable; stream::CuStream=CUDA.stream())
+function launch(f::Base.Callable; stream::CuStream=stream())
     cond = Base.AsyncCondition() do async_cond
         f()
         close(async_cond)

--- a/lib/cudadrv/execution.jl
+++ b/lib/cudadrv/execution.jl
@@ -38,7 +38,7 @@ end
 
 """
     launch(f::CuFunction; args...; blocks::CuDim=1, threads::CuDim=1,
-           cooperative=false, shmem=0, stream=CuDefaultStream())
+           cooperative=false, shmem=0, stream=CUDA.stream())
 
 Low-level call to launch a CUDA function `f` on the GPU, using `blocks` and `threads` as
 respectively the grid and block configuration. Dynamic shared memory is allocated according
@@ -51,7 +51,7 @@ This is a low-level call, prefer to use [`cudacall`](@ref) instead.
 """
 function launch(f::CuFunction, args::Vararg{Any,N}; blocks::CuDim=1, threads::CuDim=1,
                 cooperative::Bool=false, shmem::Integer=0,
-                stream::CuStream=CuDefaultStream()) where {N}
+                stream::CuStream=CUDA.stream()) where {N}
     blockdim = CuDim3(blocks)
     threaddim = CuDim3(threads)
     (blockdim.x>0 && blockdim.y>0 && blockdim.z>0) ||
@@ -103,7 +103,7 @@ end
 
 """
     cudacall(f::CuFunction, types, values...; blocks::CuDim, threads::CuDim,
-             cooperative=false, shmem=0, stream=CuDefaultStream())
+             cooperative=false, shmem=0, stream=CUDA.stream())
 
 `ccall`-like interface for launching a CUDA function `f` on a GPU.
 
@@ -144,7 +144,7 @@ end
 
 async_send(data::Ptr{Cvoid}) = ccall(:uv_async_send, Cint, (Ptr{Cvoid},), data)
 
-function launch(f::Base.Callable; stream::CuStream=CuDefaultStream())
+function launch(f::Base.Callable; stream::CuStream=CUDA.stream())
     cond = Base.AsyncCondition() do async_cond
         f()
         close(async_cond)

--- a/lib/cudadrv/libcuda.jl
+++ b/lib/cudadrv/libcuda.jl
@@ -475,105 +475,105 @@ end
 
 @checked function cuMemcpy(dst, src, ByteCount)
     initialize_api()
-    ccall((:cuMemcpy_ptds, libcuda()), CUresult,
+    ccall((:cuMemcpy, libcuda()), CUresult,
                    (CUdeviceptr, CUdeviceptr, Csize_t),
                    dst, src, ByteCount)
 end
 
 @checked function cuMemcpyPeer(dstDevice, dstContext, srcDevice, srcContext, ByteCount)
     initialize_api()
-    ccall((:cuMemcpyPeer_ptds, libcuda()), CUresult,
+    ccall((:cuMemcpyPeer, libcuda()), CUresult,
                    (CUdeviceptr, CUcontext, CUdeviceptr, CUcontext, Csize_t),
                    dstDevice, dstContext, srcDevice, srcContext, ByteCount)
 end
 
 @checked function cuMemcpyHtoD_v2(dstDevice, srcHost, ByteCount)
     initialize_api()
-    ccall((:cuMemcpyHtoD_v2_ptds, libcuda()), CUresult,
+    ccall((:cuMemcpyHtoD_v2, libcuda()), CUresult,
                    (CUdeviceptr, Ptr{Cvoid}, Csize_t),
                    dstDevice, srcHost, ByteCount)
 end
 
 @checked function cuMemcpyDtoH_v2(dstHost, srcDevice, ByteCount)
     initialize_api()
-    ccall((:cuMemcpyDtoH_v2_ptds, libcuda()), CUresult,
+    ccall((:cuMemcpyDtoH_v2, libcuda()), CUresult,
                    (Ptr{Cvoid}, CUdeviceptr, Csize_t),
                    dstHost, srcDevice, ByteCount)
 end
 
 @checked function cuMemcpyDtoD_v2(dstDevice, srcDevice, ByteCount)
     initialize_api()
-    ccall((:cuMemcpyDtoD_v2_ptds, libcuda()), CUresult,
+    ccall((:cuMemcpyDtoD_v2, libcuda()), CUresult,
                    (CUdeviceptr, CUdeviceptr, Csize_t),
                    dstDevice, srcDevice, ByteCount)
 end
 
 @checked function cuMemcpyDtoA_v2(dstArray, dstOffset, srcDevice, ByteCount)
     initialize_api()
-    ccall((:cuMemcpyDtoA_v2_ptds, libcuda()), CUresult,
+    ccall((:cuMemcpyDtoA_v2, libcuda()), CUresult,
                    (CUarray, Csize_t, CUdeviceptr, Csize_t),
                    dstArray, dstOffset, srcDevice, ByteCount)
 end
 
 @checked function cuMemcpyAtoD_v2(dstDevice, srcArray, srcOffset, ByteCount)
     initialize_api()
-    ccall((:cuMemcpyAtoD_v2_ptds, libcuda()), CUresult,
+    ccall((:cuMemcpyAtoD_v2, libcuda()), CUresult,
                    (CUdeviceptr, CUarray, Csize_t, Csize_t),
                    dstDevice, srcArray, srcOffset, ByteCount)
 end
 
 @checked function cuMemcpyHtoA_v2(dstArray, dstOffset, srcHost, ByteCount)
     initialize_api()
-    ccall((:cuMemcpyHtoA_v2_ptds, libcuda()), CUresult,
+    ccall((:cuMemcpyHtoA_v2, libcuda()), CUresult,
                    (CUarray, Csize_t, Ptr{Cvoid}, Csize_t),
                    dstArray, dstOffset, srcHost, ByteCount)
 end
 
 @checked function cuMemcpyAtoH_v2(dstHost, srcArray, srcOffset, ByteCount)
     initialize_api()
-    ccall((:cuMemcpyAtoH_v2_ptds, libcuda()), CUresult,
+    ccall((:cuMemcpyAtoH_v2, libcuda()), CUresult,
                    (Ptr{Cvoid}, CUarray, Csize_t, Csize_t),
                    dstHost, srcArray, srcOffset, ByteCount)
 end
 
 @checked function cuMemcpyAtoA_v2(dstArray, dstOffset, srcArray, srcOffset, ByteCount)
     initialize_api()
-    ccall((:cuMemcpyAtoA_v2_ptds, libcuda()), CUresult,
+    ccall((:cuMemcpyAtoA_v2, libcuda()), CUresult,
                    (CUarray, Csize_t, CUarray, Csize_t, Csize_t),
                    dstArray, dstOffset, srcArray, srcOffset, ByteCount)
 end
 
 @checked function cuMemcpy2D_v2(pCopy)
     initialize_api()
-    ccall((:cuMemcpy2D_v2_ptds, libcuda()), CUresult,
+    ccall((:cuMemcpy2D_v2, libcuda()), CUresult,
                    (Ptr{CUDA_MEMCPY2D},),
                    pCopy)
 end
 
 @checked function cuMemcpy2DUnaligned_v2(pCopy)
     initialize_api()
-    ccall((:cuMemcpy2DUnaligned_v2_ptds, libcuda()), CUresult,
+    ccall((:cuMemcpy2DUnaligned_v2, libcuda()), CUresult,
                    (Ptr{CUDA_MEMCPY2D},),
                    pCopy)
 end
 
 @checked function cuMemcpy3D_v2(pCopy)
     initialize_api()
-    ccall((:cuMemcpy3D_v2_ptds, libcuda()), CUresult,
+    ccall((:cuMemcpy3D_v2, libcuda()), CUresult,
                    (Ptr{CUDA_MEMCPY3D},),
                    pCopy)
 end
 
 @checked function cuMemcpy3DPeer(pCopy)
     initialize_api()
-    ccall((:cuMemcpy3DPeer_ptds, libcuda()), CUresult,
+    ccall((:cuMemcpy3DPeer, libcuda()), CUresult,
                    (Ptr{CUDA_MEMCPY3D_PEER},),
                    pCopy)
 end
 
 @checked function cuMemcpyAsync(dst, src, ByteCount, hStream)
     initialize_api()
-    ccall((:cuMemcpyAsync_ptsz, libcuda()), CUresult,
+    ccall((:cuMemcpyAsync, libcuda()), CUresult,
                    (CUdeviceptr, CUdeviceptr, Csize_t, CUstream),
                    dst, src, ByteCount, hStream)
 end
@@ -581,147 +581,147 @@ end
 @checked function cuMemcpyPeerAsync(dstDevice, dstContext, srcDevice, srcContext,
                                     ByteCount, hStream)
     initialize_api()
-    ccall((:cuMemcpyPeerAsync_ptsz, libcuda()), CUresult,
+    ccall((:cuMemcpyPeerAsync, libcuda()), CUresult,
                    (CUdeviceptr, CUcontext, CUdeviceptr, CUcontext, Csize_t, CUstream),
                    dstDevice, dstContext, srcDevice, srcContext, ByteCount, hStream)
 end
 
 @checked function cuMemcpyHtoDAsync_v2(dstDevice, srcHost, ByteCount, hStream)
     initialize_api()
-    ccall((:cuMemcpyHtoDAsync_v2_ptsz, libcuda()), CUresult,
+    ccall((:cuMemcpyHtoDAsync_v2, libcuda()), CUresult,
                    (CUdeviceptr, Ptr{Cvoid}, Csize_t, CUstream),
                    dstDevice, srcHost, ByteCount, hStream)
 end
 
 @checked function cuMemcpyDtoHAsync_v2(dstHost, srcDevice, ByteCount, hStream)
     initialize_api()
-    ccall((:cuMemcpyDtoHAsync_v2_ptsz, libcuda()), CUresult,
+    ccall((:cuMemcpyDtoHAsync_v2, libcuda()), CUresult,
                    (Ptr{Cvoid}, CUdeviceptr, Csize_t, CUstream),
                    dstHost, srcDevice, ByteCount, hStream)
 end
 
 @checked function cuMemcpyDtoDAsync_v2(dstDevice, srcDevice, ByteCount, hStream)
     initialize_api()
-    ccall((:cuMemcpyDtoDAsync_v2_ptsz, libcuda()), CUresult,
+    ccall((:cuMemcpyDtoDAsync_v2, libcuda()), CUresult,
                    (CUdeviceptr, CUdeviceptr, Csize_t, CUstream),
                    dstDevice, srcDevice, ByteCount, hStream)
 end
 
 @checked function cuMemcpyHtoAAsync_v2(dstArray, dstOffset, srcHost, ByteCount, hStream)
     initialize_api()
-    ccall((:cuMemcpyHtoAAsync_v2_ptsz, libcuda()), CUresult,
+    ccall((:cuMemcpyHtoAAsync_v2, libcuda()), CUresult,
                    (CUarray, Csize_t, Ptr{Cvoid}, Csize_t, CUstream),
                    dstArray, dstOffset, srcHost, ByteCount, hStream)
 end
 
 @checked function cuMemcpyAtoHAsync_v2(dstHost, srcArray, srcOffset, ByteCount, hStream)
     initialize_api()
-    ccall((:cuMemcpyAtoHAsync_v2_ptsz, libcuda()), CUresult,
+    ccall((:cuMemcpyAtoHAsync_v2, libcuda()), CUresult,
                    (Ptr{Cvoid}, CUarray, Csize_t, Csize_t, CUstream),
                    dstHost, srcArray, srcOffset, ByteCount, hStream)
 end
 
 @checked function cuMemcpy2DAsync_v2(pCopy, hStream)
     initialize_api()
-    ccall((:cuMemcpy2DAsync_v2_ptsz, libcuda()), CUresult,
+    ccall((:cuMemcpy2DAsync_v2, libcuda()), CUresult,
                    (Ptr{CUDA_MEMCPY2D}, CUstream),
                    pCopy, hStream)
 end
 
 @checked function cuMemcpy3DAsync_v2(pCopy, hStream)
     initialize_api()
-    ccall((:cuMemcpy3DAsync_v2_ptsz, libcuda()), CUresult,
+    ccall((:cuMemcpy3DAsync_v2, libcuda()), CUresult,
                    (Ptr{CUDA_MEMCPY3D}, CUstream),
                    pCopy, hStream)
 end
 
 @checked function cuMemcpy3DPeerAsync(pCopy, hStream)
     initialize_api()
-    ccall((:cuMemcpy3DPeerAsync_ptsz, libcuda()), CUresult,
+    ccall((:cuMemcpy3DPeerAsync, libcuda()), CUresult,
                    (Ptr{CUDA_MEMCPY3D_PEER}, CUstream),
                    pCopy, hStream)
 end
 
 @checked function cuMemsetD8_v2(dstDevice, uc, N)
     initialize_api()
-    ccall((:cuMemsetD8_v2_ptds, libcuda()), CUresult,
+    ccall((:cuMemsetD8_v2, libcuda()), CUresult,
                    (CUdeviceptr, Cuchar, Csize_t),
                    dstDevice, uc, N)
 end
 
 @checked function cuMemsetD16_v2(dstDevice, us, N)
     initialize_api()
-    ccall((:cuMemsetD16_v2_ptds, libcuda()), CUresult,
+    ccall((:cuMemsetD16_v2, libcuda()), CUresult,
                    (CUdeviceptr, UInt16, Csize_t),
                    dstDevice, us, N)
 end
 
 @checked function cuMemsetD32_v2(dstDevice, ui, N)
     initialize_api()
-    ccall((:cuMemsetD32_v2_ptds, libcuda()), CUresult,
+    ccall((:cuMemsetD32_v2, libcuda()), CUresult,
                    (CUdeviceptr, UInt32, Csize_t),
                    dstDevice, ui, N)
 end
 
 @checked function cuMemsetD2D8_v2(dstDevice, dstPitch, uc, Width, Height)
     initialize_api()
-    ccall((:cuMemsetD2D8_v2_ptds, libcuda()), CUresult,
+    ccall((:cuMemsetD2D8_v2, libcuda()), CUresult,
                    (CUdeviceptr, Csize_t, Cuchar, Csize_t, Csize_t),
                    dstDevice, dstPitch, uc, Width, Height)
 end
 
 @checked function cuMemsetD2D16_v2(dstDevice, dstPitch, us, Width, Height)
     initialize_api()
-    ccall((:cuMemsetD2D16_v2_ptds, libcuda()), CUresult,
+    ccall((:cuMemsetD2D16_v2, libcuda()), CUresult,
                    (CUdeviceptr, Csize_t, UInt16, Csize_t, Csize_t),
                    dstDevice, dstPitch, us, Width, Height)
 end
 
 @checked function cuMemsetD2D32_v2(dstDevice, dstPitch, ui, Width, Height)
     initialize_api()
-    ccall((:cuMemsetD2D32_v2_ptds, libcuda()), CUresult,
+    ccall((:cuMemsetD2D32_v2, libcuda()), CUresult,
                    (CUdeviceptr, Csize_t, UInt32, Csize_t, Csize_t),
                    dstDevice, dstPitch, ui, Width, Height)
 end
 
 @checked function cuMemsetD8Async(dstDevice, uc, N, hStream)
     initialize_api()
-    ccall((:cuMemsetD8Async_ptsz, libcuda()), CUresult,
+    ccall((:cuMemsetD8Async, libcuda()), CUresult,
                    (CUdeviceptr, Cuchar, Csize_t, CUstream),
                    dstDevice, uc, N, hStream)
 end
 
 @checked function cuMemsetD16Async(dstDevice, us, N, hStream)
     initialize_api()
-    ccall((:cuMemsetD16Async_ptsz, libcuda()), CUresult,
+    ccall((:cuMemsetD16Async, libcuda()), CUresult,
                    (CUdeviceptr, UInt16, Csize_t, CUstream),
                    dstDevice, us, N, hStream)
 end
 
 @checked function cuMemsetD32Async(dstDevice, ui, N, hStream)
     initialize_api()
-    ccall((:cuMemsetD32Async_ptsz, libcuda()), CUresult,
+    ccall((:cuMemsetD32Async, libcuda()), CUresult,
                    (CUdeviceptr, UInt32, Csize_t, CUstream),
                    dstDevice, ui, N, hStream)
 end
 
 @checked function cuMemsetD2D8Async(dstDevice, dstPitch, uc, Width, Height, hStream)
     initialize_api()
-    ccall((:cuMemsetD2D8Async_ptsz, libcuda()), CUresult,
+    ccall((:cuMemsetD2D8Async, libcuda()), CUresult,
                    (CUdeviceptr, Csize_t, Cuchar, Csize_t, Csize_t, CUstream),
                    dstDevice, dstPitch, uc, Width, Height, hStream)
 end
 
 @checked function cuMemsetD2D16Async(dstDevice, dstPitch, us, Width, Height, hStream)
     initialize_api()
-    ccall((:cuMemsetD2D16Async_ptsz, libcuda()), CUresult,
+    ccall((:cuMemsetD2D16Async, libcuda()), CUresult,
                    (CUdeviceptr, Csize_t, UInt16, Csize_t, Csize_t, CUstream),
                    dstDevice, dstPitch, us, Width, Height, hStream)
 end
 
 @checked function cuMemsetD2D32Async(dstDevice, dstPitch, ui, Width, Height, hStream)
     initialize_api()
-    ccall((:cuMemsetD2D32Async_ptsz, libcuda()), CUresult,
+    ccall((:cuMemsetD2D32Async, libcuda()), CUresult,
                    (CUdeviceptr, Csize_t, UInt32, Csize_t, Csize_t, CUstream),
                    dstDevice, dstPitch, ui, Width, Height, hStream)
 end
@@ -887,7 +887,7 @@ end
 
 @checked function cuMemPrefetchAsync(devPtr, count, dstDevice, hStream)
     initialize_api()
-    ccall((:cuMemPrefetchAsync_ptsz, libcuda()), CUresult,
+    ccall((:cuMemPrefetchAsync, libcuda()), CUresult,
                    (CUdeviceptr, Csize_t, CUdevice, CUstream),
                    devPtr, count, dstDevice, hStream)
 end
@@ -945,42 +945,42 @@ end
 
 @checked function cuStreamGetPriority(hStream, priority)
     initialize_api()
-    ccall((:cuStreamGetPriority_ptsz, libcuda()), CUresult,
+    ccall((:cuStreamGetPriority, libcuda()), CUresult,
                    (CUstream, Ptr{Cint}),
                    hStream, priority)
 end
 
 @checked function cuStreamGetFlags(hStream, flags)
     initialize_api()
-    ccall((:cuStreamGetFlags_ptsz, libcuda()), CUresult,
+    ccall((:cuStreamGetFlags, libcuda()), CUresult,
                    (CUstream, Ptr{UInt32}),
                    hStream, flags)
 end
 
 @checked function cuStreamGetCtx(hStream, pctx)
     initialize_api()
-    ccall((:cuStreamGetCtx_ptsz, libcuda()), CUresult,
+    ccall((:cuStreamGetCtx, libcuda()), CUresult,
                    (CUstream, Ptr{CUcontext}),
                    hStream, pctx)
 end
 
 @checked function cuStreamWaitEvent(hStream, hEvent, Flags)
     initialize_api()
-    ccall((:cuStreamWaitEvent_ptsz, libcuda()), CUresult,
+    ccall((:cuStreamWaitEvent, libcuda()), CUresult,
                    (CUstream, CUevent, UInt32),
                    hStream, hEvent, Flags)
 end
 
 @checked function cuStreamAddCallback(hStream, callback, userData, flags)
     initialize_api()
-    ccall((:cuStreamAddCallback_ptsz, libcuda()), CUresult,
+    ccall((:cuStreamAddCallback, libcuda()), CUresult,
                    (CUstream, CUstreamCallback, Ptr{Cvoid}, UInt32),
                    hStream, callback, userData, flags)
 end
 
 @checked function cuStreamBeginCapture_v2(hStream, mode)
     initialize_api()
-    ccall((:cuStreamBeginCapture_v2_ptsz, libcuda()), CUresult,
+    ccall((:cuStreamBeginCapture_v2, libcuda()), CUresult,
                    (CUstream, CUstreamCaptureMode),
                    hStream, mode)
 end
@@ -994,42 +994,42 @@ end
 
 @checked function cuStreamEndCapture(hStream, phGraph)
     initialize_api()
-    ccall((:cuStreamEndCapture_ptsz, libcuda()), CUresult,
+    ccall((:cuStreamEndCapture, libcuda()), CUresult,
                    (CUstream, Ptr{CUgraph}),
                    hStream, phGraph)
 end
 
 @checked function cuStreamIsCapturing(hStream, captureStatus)
     initialize_api()
-    ccall((:cuStreamIsCapturing_ptsz, libcuda()), CUresult,
+    ccall((:cuStreamIsCapturing, libcuda()), CUresult,
                    (CUstream, Ptr{CUstreamCaptureStatus}),
                    hStream, captureStatus)
 end
 
 @checked function cuStreamGetCaptureInfo(hStream, captureStatus, id)
     initialize_api()
-    ccall((:cuStreamGetCaptureInfo_ptsz, libcuda()), CUresult,
+    ccall((:cuStreamGetCaptureInfo, libcuda()), CUresult,
                    (CUstream, Ptr{CUstreamCaptureStatus}, Ptr{cuuint64_t}),
                    hStream, captureStatus, id)
 end
 
 @checked function cuStreamAttachMemAsync(hStream, dptr, length, flags)
     initialize_api()
-    ccall((:cuStreamAttachMemAsync_ptsz, libcuda()), CUresult,
+    ccall((:cuStreamAttachMemAsync, libcuda()), CUresult,
                    (CUstream, CUdeviceptr, Csize_t, UInt32),
                    hStream, dptr, length, flags)
 end
 
 @checked function cuStreamQuery(hStream)
     initialize_api()
-    ccall((:cuStreamQuery_ptsz, libcuda()), CUresult,
+    ccall((:cuStreamQuery, libcuda()), CUresult,
                    (CUstream,),
                    hStream)
 end
 
 @checked function cuStreamSynchronize(hStream)
     initialize_api()
-    ccall((:cuStreamSynchronize_ptsz, libcuda()), CUresult,
+    ccall((:cuStreamSynchronize, libcuda()), CUresult,
                    (CUstream,),
                    hStream)
 end
@@ -1043,21 +1043,21 @@ end
 
 @checked function cuStreamCopyAttributes(dst, src)
     initialize_api()
-    ccall((:cuStreamCopyAttributes_ptsz, libcuda()), CUresult,
+    ccall((:cuStreamCopyAttributes, libcuda()), CUresult,
                    (CUstream, CUstream),
                    dst, src)
 end
 
 @checked function cuStreamGetAttribute(hStream, attr, value_out)
     initialize_api()
-    ccall((:cuStreamGetAttribute_ptsz, libcuda()), CUresult,
+    ccall((:cuStreamGetAttribute, libcuda()), CUresult,
                    (CUstream, CUstreamAttrID, Ptr{CUstreamAttrValue}),
                    hStream, attr, value_out)
 end
 
 @checked function cuStreamSetAttribute(hStream, attr, value)
     initialize_api()
-    ccall((:cuStreamSetAttribute_ptsz, libcuda()), CUresult,
+    ccall((:cuStreamSetAttribute, libcuda()), CUresult,
                    (CUstream, CUstreamAttrID, Ptr{CUstreamAttrValue}),
                    hStream, attr, value)
 end
@@ -1071,7 +1071,7 @@ end
 
 @checked function cuEventRecord(hEvent, hStream)
     initialize_api()
-    ccall((:cuEventRecord_ptsz, libcuda()), CUresult,
+    ccall((:cuEventRecord, libcuda()), CUresult,
                    (CUevent, CUstream),
                    hEvent, hStream)
 end
@@ -1144,7 +1144,7 @@ end
 @checked function cuSignalExternalSemaphoresAsync(extSemArray, paramsArray, numExtSems,
                                                   stream)
     initialize_api()
-    ccall((:cuSignalExternalSemaphoresAsync_ptsz, libcuda()), CUresult,
+    ccall((:cuSignalExternalSemaphoresAsync, libcuda()), CUresult,
                    (Ptr{CUexternalSemaphore}, Ptr{CUDA_EXTERNAL_SEMAPHORE_SIGNAL_PARAMS},
                     UInt32, CUstream),
                    extSemArray, paramsArray, numExtSems, stream)
@@ -1152,7 +1152,7 @@ end
 
 @checked function cuWaitExternalSemaphoresAsync(extSemArray, paramsArray, numExtSems, stream)
     initialize_api()
-    ccall((:cuWaitExternalSemaphoresAsync_ptsz, libcuda()), CUresult,
+    ccall((:cuWaitExternalSemaphoresAsync, libcuda()), CUresult,
                    (Ptr{CUexternalSemaphore}, Ptr{CUDA_EXTERNAL_SEMAPHORE_WAIT_PARAMS},
                     UInt32, CUstream),
                    extSemArray, paramsArray, numExtSems, stream)
@@ -1167,28 +1167,28 @@ end
 
 @checked function cuStreamWaitValue32(stream, addr, value, flags)
     initialize_api()
-    ccall((:cuStreamWaitValue32_ptsz, libcuda()), CUresult,
+    ccall((:cuStreamWaitValue32, libcuda()), CUresult,
                    (CUstream, CUdeviceptr, cuuint32_t, UInt32),
                    stream, addr, value, flags)
 end
 
 @checked function cuStreamWaitValue64(stream, addr, value, flags)
     initialize_api()
-    ccall((:cuStreamWaitValue64_ptsz, libcuda()), CUresult,
+    ccall((:cuStreamWaitValue64, libcuda()), CUresult,
                    (CUstream, CUdeviceptr, cuuint64_t, UInt32),
                    stream, addr, value, flags)
 end
 
 @checked function cuStreamWriteValue32(stream, addr, value, flags)
     initialize_api()
-    ccall((:cuStreamWriteValue32_ptsz, libcuda()), CUresult,
+    ccall((:cuStreamWriteValue32, libcuda()), CUresult,
                    (CUstream, CUdeviceptr, cuuint32_t, UInt32),
                    stream, addr, value, flags)
 end
 
 @checked function cuStreamWriteValue64(stream, addr, value, flags)
     initialize_api()
-    ccall((:cuStreamWriteValue64_ptsz, libcuda()), CUresult,
+    ccall((:cuStreamWriteValue64, libcuda()), CUresult,
                    (CUstream, CUdeviceptr, cuuint64_t, UInt32),
                    stream, addr, value, flags)
 end
@@ -1224,7 +1224,7 @@ end
 @checked function cuLaunchKernel(f, gridDimX, gridDimY, gridDimZ, blockDimX, blockDimY,
                                  blockDimZ, sharedMemBytes, hStream, kernelParams, extra)
     initialize_api()
-    ccall((:cuLaunchKernel_ptsz, libcuda()), CUresult,
+    ccall((:cuLaunchKernel, libcuda()), CUresult,
                    (CUfunction, UInt32, UInt32, UInt32, UInt32, UInt32, UInt32, UInt32,
                     CUstream, Ptr{Ptr{Cvoid}}, Ptr{Ptr{Cvoid}}),
                    f, gridDimX, gridDimY, gridDimZ, blockDimX, blockDimY, blockDimZ,
@@ -1235,7 +1235,7 @@ end
                                             blockDimY, blockDimZ, sharedMemBytes, hStream,
                                             kernelParams)
     initialize_api()
-    ccall((:cuLaunchCooperativeKernel_ptsz, libcuda()), CUresult,
+    ccall((:cuLaunchCooperativeKernel, libcuda()), CUresult,
                    (CUfunction, UInt32, UInt32, UInt32, UInt32, UInt32, UInt32, UInt32,
                     CUstream, Ptr{Ptr{Cvoid}}),
                    f, gridDimX, gridDimY, gridDimZ, blockDimX, blockDimY, blockDimZ,
@@ -1251,7 +1251,7 @@ end
 
 @checked function cuLaunchHostFunc(hStream, fn, userData)
     initialize_api()
-    ccall((:cuLaunchHostFunc_ptsz, libcuda()), CUresult,
+    ccall((:cuLaunchHostFunc, libcuda()), CUresult,
                    (CUstream, CUhostFn, Ptr{Cvoid}),
                    hStream, fn, userData)
 end
@@ -1562,7 +1562,7 @@ end
 
 @checked function cuGraphLaunch(hGraphExec, hStream)
     initialize_api()
-    ccall((:cuGraphLaunch_ptsz, libcuda()), CUresult,
+    ccall((:cuGraphLaunch, libcuda()), CUresult,
                    (CUgraphExec, CUstream),
                    hGraphExec, hStream)
 end
@@ -1984,14 +1984,14 @@ end
 
 @checked function cuGraphicsMapResources(count, resources, hStream)
     initialize_api()
-    ccall((:cuGraphicsMapResources_ptsz, libcuda()), CUresult,
+    ccall((:cuGraphicsMapResources, libcuda()), CUresult,
                    (UInt32, Ptr{CUgraphicsResource}, CUstream),
                    count, resources, hStream)
 end
 
 @checked function cuGraphicsUnmapResources(count, resources, hStream)
     initialize_api()
-    ccall((:cuGraphicsUnmapResources_ptsz, libcuda()), CUresult,
+    ccall((:cuGraphicsUnmapResources, libcuda()), CUresult,
                    (UInt32, Ptr{CUgraphicsResource}, CUstream),
                    count, resources, hStream)
 end

--- a/lib/cudadrv/memory.jl
+++ b/lib/cudadrv/memory.jl
@@ -62,12 +62,15 @@ Allocate `bytesize` bytes of memory on the device. This memory is only accessibl
 GPU, and requires explicit calls to `unsafe_copyto!`, which wraps `cuMemcpy`,
 for access on the CPU.
 """
-function alloc(::Type{DeviceBuffer}, bytesize::Integer; async::Bool=false)
+function alloc(::Type{DeviceBuffer}, bytesize::Integer;
+               async::Bool=false, stream::CuStream=stream())
     bytesize == 0 && return DeviceBuffer(CU_NULL, 0)
 
     ptr_ref = Ref{CUDA.CUdeviceptr}()
-    if async
-        CUDA.cuMemAllocAsync(ptr_ref, bytesize, CUDA.stream())
+    # FIXME: async allocator never frees memory?
+    if false && CUDA.version() >= v"11.2"
+        CUDA.cuMemAllocAsync(ptr_ref, bytesize, stream)
+        async || synchronize(stream)
     else
         CUDA.cuMemAlloc_v2(ptr_ref, bytesize)
     end
@@ -76,11 +79,13 @@ function alloc(::Type{DeviceBuffer}, bytesize::Integer; async::Bool=false)
 end
 
 
-function free(buf::DeviceBuffer; async::Bool=false)
+function free(buf::DeviceBuffer; async::Bool=false, stream::CuStream=stream())
     pointer(buf) == CU_NULL && return
 
-    if async
-        CUDA.cuMemFreeAsync(buf, CUDA.stream())
+    # FIXME: async allocator never frees memory?
+    if false && CUDA.version() >= v"11.2"
+        CUDA.cuMemFreeAsync(buf, stream)
+        async || synchronize(stream)
     else
         CUDA.cuMemFree_v2(buf)
     end
@@ -249,7 +254,7 @@ end
 Prefetches memory to the specified destination device.
 """
 function prefetch(buf::UnifiedBuffer, bytes::Integer=sizeof(buf);
-                  device::CuDevice=device(), stream::CuStream=CUDA.stream())
+                  device::CuDevice=device(), stream::CuStream=stream())
     bytes > sizeof(buf) && throw(BoundsError(buf, bytes))
     CUDA.cuMemPrefetchAsync(buf, bytes, device, stream)
 end
@@ -361,69 +366,51 @@ const Array   = ArrayBuffer
              async::Bool=false, stream::CuStream)
 
 Initialize device memory by copying `val` for `len` times. Executed asynchronously if
-`async` is true, in which case a valid `stream` is required.
+`async` is true, otherwise `stream` is synchronized.
 """
 set!
 
 for T in [UInt8, UInt16, UInt32]
     bits = 8*sizeof(T)
-    fn_sync = Symbol("cuMemsetD$(bits)_v2")
-    fn_async = Symbol("cuMemsetD$(bits)Async")
+    fn = Symbol("cuMemsetD$(bits)Async")
     @eval function set!(ptr::CuPtr{$T}, value::$T, len::Integer;
-                        async::Bool=false, stream::Union{Nothing,CuStream}=nothing)
-        if async
-            $(getproperty(CUDA, fn_async))(ptr, value, len, something(stream, CUDA.stream()))
-        else
-          stream===nothing ||
-              throw(ArgumentError("Synchronous memory operations cannot be issues on a stream."))
-            $(getproperty(CUDA, fn_sync))(ptr, value, len)
-        end
+                        async::Bool=false, stream::CuStream=stream())
+        $(getproperty(CUDA, fn))(ptr, value, len, stream)
+        async || synchronize(stream)
+        return
     end
 end
 
 
 ## copy operations
 
-for (f, fa, srcPtrTy, dstPtrTy) in (("cuMemcpyDtoH_v2", "cuMemcpyDtoHAsync_v2", CuPtr, Ptr),
-                                    ("cuMemcpyHtoD_v2", "cuMemcpyHtoDAsync_v2", Ptr,   CuPtr),
-                                    ("cuMemcpyDtoD_v2", "cuMemcpyDtoDAsync_v2", CuPtr, CuPtr),
-                                   )
+for (fn, srcPtrTy, dstPtrTy) in (("cuMemcpyDtoHAsync_v2", CuPtr, Ptr),
+                                 ("cuMemcpyHtoDAsync_v2", Ptr,   CuPtr),
+                                 ("cuMemcpyDtoDAsync_v2", CuPtr, CuPtr),
+                                 )
     @eval function Base.unsafe_copyto!(dst::$dstPtrTy{T}, src::$srcPtrTy{T}, N::Integer;
-                                       stream::Union{Nothing,CuStream}=nothing,
+                                       stream::CuStream=stream(),
                                        async::Bool=false) where T
-        if async
-            $(getproperty(CUDA, Symbol(fa)))(dst, src, N*sizeof(T), something(stream, CUDA.stream()))
-        else
-            stream===nothing ||
-                throw(ArgumentError("Synchronous memory operations cannot be issued on a stream."))
-            $(getproperty(CUDA, Symbol(f)))(dst, src, N*sizeof(T))
-        end
+        $(getproperty(CUDA, Symbol(fn)))(dst, src, N*sizeof(T), stream)
+        async || synchronize(stream)
         return dst
     end
 end
 
 function Base.unsafe_copyto!(dst::CuArrayPtr{T}, doffs::Integer, src::Ptr{T}, N::Integer;
-                             stream::Union{Nothing,CuStream}=nothing,
+                             stream::CuStream=stream(),
                              async::Bool=false) where T
-    if async
-        CUDA.cuMemcpyHtoAAsync_v2(dst, doffs, src, N*sizeof(T), something(stream, CUDA.stream()))
-    else
-        stream===nothing ||
-            throw(ArgumentError("Synchronous memory operations cannot be issued on a stream."))
-        CUDA.cuMemcpyHtoA_v2(dst, doffs, src, N*sizeof(T))
-    end
+    CUDA.cuMemcpyHtoAAsync_v2(dst, doffs, src, N*sizeof(T), stream)
+    async || synchronize(stream)
+    return dst
 end
 
 function Base.unsafe_copyto!(dst::Ptr{T}, src::CuArrayPtr{T}, soffs::Integer, N::Integer;
-                             stream::Union{Nothing,CuStream}=nothing,
+                             stream::CuStream=stream(),
                              async::Bool=false) where T
-    if async
-        CUDA.cuMemcpyAtoHAsync_v2(dst, src, soffs, N*sizeof(T), something(stream, CUDA.stream()))
-    else
-        stream===nothing ||
-            throw(ArgumentError("Synchronous memory operations cannot be issued on a stream."))
-        CUDA.cuMemcpyAtoH_v2(dst, src, soffs, N*sizeof(T))
-    end
+    CUDA.cuMemcpyAtoHAsync_v2(dst, src, soffs, N*sizeof(T), stream)
+    async || synchronize(stream)
+    return dst
 end
 
 Base.unsafe_copyto!(dst::CuArrayPtr{T}, doffs::Integer, src::CuPtr{T}, N::Integer) where {T} =
@@ -443,7 +430,7 @@ function unsafe_copy2d!(dst::Union{Ptr{T},CuPtr{T},CuArrayPtr{T}}, dstTyp::Type{
                         width::Integer, height::Integer=1;
                         dstPos::CuDim=(1,1), srcPos::CuDim=(1,1),
                         dstPitch::Integer=0, srcPitch::Integer=0,
-                        async::Bool=false, stream::Union{Nothing,CuStream}=nothing) where T
+                        async::Bool=false, stream::CuStream=stream()) where T
     srcPos = CUDA.CuDim3(srcPos)
     @assert srcPos.z == 1
     dstPos = CUDA.CuDim3(dstPos)
@@ -505,13 +492,9 @@ function unsafe_copy2d!(dst::Union{Ptr{T},CuPtr{T},CuArrayPtr{T}}, dstTyp::Type{
         # extent
         width*sizeof(T), height
     ))
-    if async
-        CUDA.cuMemcpy2DAsync_v2(params_ref, something(stream, CUDA.stream()))
-    else
-        stream===nothing ||
-            throw(ArgumentError("Synchronous memory operations cannot be issued on a stream."))
-        CUDA.cuMemcpy2D_v2(params_ref)
-    end
+    CUDA.cuMemcpy2DAsync_v2(params_ref, stream)
+    async || synchronize(stream)
+    return dst
 end
 
 """
@@ -523,7 +506,7 @@ end
 Perform a 3D memory copy between pointers `src` and `dst`, at respectively position `srcPos`
 and `dstPos` (1-indexed). Both pitch and destination can be specified for both the source
 and destination; consult the CUDA documentation for more details. This call is executed
-asynchronously if `async` is set, in which case `stream` needs to be a valid CuStream.
+asynchronously if `async` is set, otherwise `stream` is synchronized.
 """
 function unsafe_copy3d!(dst::Union{Ptr{T},CuPtr{T},CuArrayPtr{T}}, dstTyp::Type{<:AbstractBuffer},
                         src::Union{Ptr{T},CuPtr{T},CuArrayPtr{T}}, srcTyp::Type{<:AbstractBuffer},
@@ -531,7 +514,7 @@ function unsafe_copy3d!(dst::Union{Ptr{T},CuPtr{T},CuArrayPtr{T}}, dstTyp::Type{
                         dstPos::CuDim=(1,1,1), srcPos::CuDim=(1,1,1),
                         dstPitch::Integer=0, dstHeight::Integer=0,
                         srcPitch::Integer=0, srcHeight::Integer=0,
-                        async::Bool=false, stream::Union{Nothing,CuStream}=nothing) where T
+                        async::Bool=false, stream::CuStream=stream()) where T
     srcPos = CUDA.CuDim3(srcPos)
     dstPos = CUDA.CuDim3(dstPos)
 
@@ -595,13 +578,9 @@ function unsafe_copy3d!(dst::Union{Ptr{T},CuPtr{T},CuArrayPtr{T}}, dstTyp::Type{
         # extent
         width*sizeof(T), height, depth
     ))
-    if async
-        CUDA.cuMemcpy3DAsync_v2(params_ref, something(stream, CUDA.stream()))
-    else
-        stream===nothing ||
-            throw(ArgumentError("Synchronous memory operations cannot be issued on a stream."))
-        CUDA.cuMemcpy3D_v2(params_ref)
-    end
+    CUDA.cuMemcpy3DAsync_v2(params_ref, stream)
+    async || synchronize(stream)
+    return dst
 end
 
 

--- a/lib/cudadrv/stream.jl
+++ b/lib/cudadrv/stream.jl
@@ -83,11 +83,11 @@ versions of their APIs (i.e. without a `ptsz` or `ptds` suffix).
 @inline CuStreamPerThread() = CuStream(convert(CUstream, 2), CuContext(C_NULL))
 
 """
-    synchronize(s::CuStream)
+    synchronize([s::CuStream])
 
 Wait until a stream's tasks are completed.
 """
-synchronize(s::CuStream) = cuStreamSynchronize(s)
+synchronize(s::CuStream=stream()) = cuStreamSynchronize(s)
 
 """
     query(s::CuStream)

--- a/lib/cudadrv/stream.jl
+++ b/lib/cudadrv/stream.jl
@@ -57,7 +57,7 @@ Return the default stream.
 Return a special object to use use an implicit stream with legacy synchronization behavior.
 
 You can use this stream to perform operations that should block on all streams (with the
-exception of streams created with `CU_STREAM_NON_BLOCKING`). This matches the old pre-CUDA 7
+exception of streams created with `STREAM_NON_BLOCKING`). This matches the old pre-CUDA 7
 global stream behavior.
 """
 @inline CuStreamLegacy() = CuStream(convert(CUstream, 1), CuContext(C_NULL))

--- a/lib/cudadrv/stream.jl
+++ b/lib/cudadrv/stream.jl
@@ -83,13 +83,6 @@ versions of their APIs (i.e. without a `ptsz` or `ptds` suffix).
 @inline CuStreamPerThread() = CuStream(convert(CUstream, 2), CuContext(C_NULL))
 
 """
-    synchronize([s::CuStream])
-
-Wait until a stream's tasks are completed.
-"""
-synchronize(s::CuStream=stream()) = cuStreamSynchronize(s)
-
-"""
     query(s::CuStream)
 
 Return `false` if a stream is busy (has task running or queued)
@@ -103,6 +96,19 @@ function query(s::CuStream)
         return true
     else
         throw_api_error(res)
+    end
+end
+
+"""
+    synchronize([s::CuStream]; blocking=true)
+
+Wait until a stream's tasks are completed. If `blocking` is true (the default), Julia will
+be asked to yield to any other scheduled task.
+"""
+function synchronize(s::CuStream=stream(); blocking::Bool=true)
+    # TODO: exponential back-off and sleep?
+    while !query(s)
+        blocking && yield()
     end
 end
 

--- a/lib/cudadrv/stream.jl
+++ b/lib/cudadrv/stream.jl
@@ -110,6 +110,10 @@ function synchronize(s::CuStream=stream(); blocking::Bool=true)
     while !query(s)
         blocking && yield()
     end
+
+    # FIXME: this is expensive. Maybe kernels should return a `wait`able object, a la KA.jl,
+    #        which then performs the necessary checks. Or only check when launching kernels.
+    check_exceptions()
 end
 
 """

--- a/lib/cudadrv/stream.jl
+++ b/lib/cudadrv/stream.jl
@@ -111,8 +111,6 @@ function synchronize(s::CuStream=stream(); blocking::Bool=true)
         blocking && yield()
     end
 
-    # FIXME: this is expensive. Maybe kernels should return a `wait`able object, a la KA.jl,
-    #        which then performs the necessary checks. Or only check when launching kernels.
     check_exceptions()
 end
 

--- a/lib/cudadrv/stream.jl
+++ b/lib/cudadrv/stream.jl
@@ -48,6 +48,11 @@ end
     CuDefaultStream()
 
 Return the default stream.
+
+!!! note
+
+    It is generally better to use `stream()` to get a stream object that's local to the
+    current task. That way, operations scheduled in other tasks can overlap.
 """
 @inline CuDefaultStream() = CuStream(convert(CUstream, C_NULL), CuContext(C_NULL))
 
@@ -66,11 +71,14 @@ global stream behavior.
     CuStreamPerThread()
 
 Return a special object to use an implicit stream with per-thread synchronization behavior.
+This stream object is normally meant to be used with APIs that do not have per-thread
+versions of their APIs (i.e. without a `ptsz` or `ptds` suffix).
 
-This should generally only be used with compiled libraries, which cannot be switched to the
-per-thread API calls. For all other uses, it be libraries compiled with `nvcc
---default-stream per-thread` or any CUDA API call using CUDA.jl (which defaults to the
-per-thread variants) you can just use the default `CuDefaultStream` object.
+!!! note
+
+    It is generally not needed to use this type of stream. With CUDA.jl, each task already
+    gets its own non-blocking stream, and multithreading in Julia is typically
+    accomplished using tasks.
 """
 @inline CuStreamPerThread() = CuStream(convert(CUstream, 2), CuContext(C_NULL))
 

--- a/lib/cudnn/CUDNN.jl
+++ b/lib/cudnn/CUDNN.jl
@@ -60,6 +60,7 @@ const thread_handles = Vector{Union{Nothing,cudnnHandle_t}}()
 const old_handles = DefaultDict{CuContext,Vector{cudnnHandle_t}}(()->cudnnHandle_t[])
 
 function handle()
+    CUDA.detect_task_switch()
     tid = Threads.threadid()
     if @inbounds thread_handles[tid] === nothing
         ctx = context()

--- a/lib/cudnn/CUDNN.jl
+++ b/lib/cudnn/CUDNN.jl
@@ -60,7 +60,7 @@ const thread_handles = Vector{Union{Nothing,cudnnHandle_t}}()
 const old_handles = DefaultDict{CuContext,Vector{cudnnHandle_t}}(()->cudnnHandle_t[])
 
 function handle()
-    CUDA.detect_task_switch()
+    CUDA.detect_state_changes()
     tid = Threads.threadid()
     if @inbounds thread_handles[tid] === nothing
         ctx = context()

--- a/lib/cudnn/CUDNN.jl
+++ b/lib/cudnn/CUDNN.jl
@@ -69,7 +69,7 @@ function handle()
 
             handle
         end
-        cudnnSetStream(thread_handles[tid], CUDA.stream_per_thread())
+        cudnnSetStream(thread_handles[tid], stream(per_thread=true))
     end
     something(@inbounds thread_handles[tid])
 end

--- a/lib/cudnn/CUDNN.jl
+++ b/lib/cudnn/CUDNN.jl
@@ -69,7 +69,7 @@ function handle()
 
             handle
         end
-        cudnnSetStream(thread_handles[tid], stream(per_thread=true))
+        cudnnSetStream(thread_handles[tid], stream())
     end
     something(@inbounds thread_handles[tid])
 end

--- a/lib/cudnn/error.jl
+++ b/lib/cudnn/error.jl
@@ -20,7 +20,7 @@ name(err::CUDNNError) = unsafe_string(cudnnGetErrorString(err))
 end
 
 function initialize_api()
-    CUDA.prepare_cuda_call()
+    CUDA.initialize_cuda_context()
 end
 
 macro check(ex)

--- a/lib/cufft/CUFFT.jl
+++ b/lib/cufft/CUFFT.jl
@@ -25,7 +25,7 @@ include("wrappers.jl")
 # high-level integrations
 include("fft.jl")
 
-function reset_stream()
+function set_stream(s)
     # CUFFT associates streams to plan objects
 end
 

--- a/lib/cufft/CUFFT.jl
+++ b/lib/cufft/CUFFT.jl
@@ -25,4 +25,8 @@ include("wrappers.jl")
 # high-level integrations
 include("fft.jl")
 
+function reset_stream()
+    # CUFFT associates streams to plan objects
+end
+
 end

--- a/lib/cufft/error.jl
+++ b/lib/cufft/error.jl
@@ -62,7 +62,7 @@ end
 end
 
 function initialize_api()
-    CUDA.prepare_cuda_call()
+    CUDA.initialize_cuda_context()
 end
 
 macro check(ex)

--- a/lib/cufft/fft.jl
+++ b/lib/cufft/fft.jl
@@ -110,7 +110,7 @@ function create_plan(xtype, xdims, region)
     handle_ref = Ref{cufftHandle}()
     cufftCreate(handle_ref)
     handle = handle_ref[]
-    cufftSetStream(handle, CuStreamPerThread())
+    cufftSetStream(handle, CUDA.stream_per_thread())
     cufftSetAutoAllocation(handle, 0)
 
     # make the plan

--- a/lib/cufft/fft.jl
+++ b/lib/cufft/fft.jl
@@ -110,7 +110,7 @@ function create_plan(xtype, xdims, region)
     handle_ref = Ref{cufftHandle}()
     cufftCreate(handle_ref)
     handle = handle_ref[]
-    cufftSetStream(handle, stream(per_thread=true))
+    cufftSetStream(handle, stream())
     cufftSetAutoAllocation(handle, 0)
 
     # make the plan

--- a/lib/cufft/fft.jl
+++ b/lib/cufft/fft.jl
@@ -110,7 +110,7 @@ function create_plan(xtype, xdims, region)
     handle_ref = Ref{cufftHandle}()
     cufftCreate(handle_ref)
     handle = handle_ref[]
-    cufftSetStream(handle, CUDA.stream_per_thread())
+    cufftSetStream(handle, stream(per_thread=true))
     cufftSetAutoAllocation(handle, 0)
 
     # make the plan

--- a/lib/cupti/error.jl
+++ b/lib/cupti/error.jl
@@ -112,7 +112,7 @@ end
 end
 
 function initialize_api()
-    CUDA.prepare_cuda_call()
+    CUDA.initialize_cuda_context()
 end
 
 macro check(ex)

--- a/lib/curand/CURAND.jl
+++ b/lib/curand/CURAND.jl
@@ -35,7 +35,7 @@ function default_rng()
             Random.seed!(rng)
             rng
         end
-        curandSetStream(CURAND_THREAD_RNGs[tid], stream(per_thread=true))
+        curandSetStream(CURAND_THREAD_RNGs[tid], stream())
     end
     something(@inbounds CURAND_THREAD_RNGs[tid])
 end

--- a/lib/curand/CURAND.jl
+++ b/lib/curand/CURAND.jl
@@ -33,6 +33,7 @@ const old_curand_rngs = DefaultDict{CuContext,Vector{RNG}}(()->RNG[])
 const old_gpuarray_rngs = DefaultDict{CuContext,Vector{GPUArrays.RNG}}(()->GPUArrays.RNG[])
 
 function default_rng()
+    CUDA.detect_task_switch()
     tid = Threads.threadid()
     if @inbounds CURAND_THREAD_RNGs[tid] === nothing
         ctx = context()
@@ -58,6 +59,7 @@ function default_rng()
 end
 
 function GPUArrays.default_rng(::Type{<:CuArray})
+    CUDA.detect_task_switch()
     tid = Threads.threadid()
     if @inbounds GPUARRAY_THREAD_RNGs[tid] === nothing
         ctx = context()

--- a/lib/curand/CURAND.jl
+++ b/lib/curand/CURAND.jl
@@ -10,6 +10,8 @@ using CEnum
 
 using Memoize
 
+using DataStructures
+
 
 # core library
 include("libcurand_common.jl")
@@ -26,12 +28,26 @@ include("random.jl")
 const CURAND_THREAD_RNGs = Vector{Union{Nothing,RNG}}()
 const GPUARRAY_THREAD_RNGs = Vector{Union{Nothing,GPUArrays.RNG}}()
 
+# cache for created, but unused handles
+const old_curand_rngs = DefaultDict{CuContext,Vector{RNG}}(()->RNG[])
+const old_gpuarray_rngs = DefaultDict{CuContext,Vector{GPUArrays.RNG}}(()->GPUArrays.RNG[])
+
 function default_rng()
     tid = Threads.threadid()
     if @inbounds CURAND_THREAD_RNGs[tid] === nothing
         ctx = context()
         CURAND_THREAD_RNGs[tid] = get!(task_local_storage(), (:CURAND, ctx)) do
-            rng = RNG()
+            rng = if isempty(old_curand_rngs[ctx])
+                RNG()
+            else
+                pop!(old_curand_rngs[ctx])
+            end
+
+            finalizer(current_task()) do task
+                push!(old_curand_rngs[ctx], rng)
+            end
+            # TODO: curandDestroyGenerator to preserve memory, or at exit?
+
             Random.seed!(rng)
             rng
         end
@@ -45,10 +61,21 @@ function GPUArrays.default_rng(::Type{<:CuArray})
     if @inbounds GPUARRAY_THREAD_RNGs[tid] === nothing
         ctx = context()
         GPUARRAY_THREAD_RNGs[tid] = get!(task_local_storage(), (:GPUArraysRNG, ctx)) do
-            dev = device()
-            N = attribute(dev, DEVICE_ATTRIBUTE_MAX_THREADS_PER_BLOCK)
-            state = CuArray{NTuple{4, UInt32}}(undef, N)
-            rng = GPUArrays.RNG(state)
+            if isempty(old_gpuarray_rngs[ctx])
+                dev = device()
+                N = attribute(dev, DEVICE_ATTRIBUTE_MAX_THREADS_PER_BLOCK)
+                state = CuArray{NTuple{4, UInt32}}(undef, N)
+                rng = GPUArrays.RNG(state)
+                Random.seed!(rng)
+            else
+                rng = pop!(old_gpuarray_rngs[ctx])
+            end
+
+            finalizer(current_task()) do task
+                push!(old_gpuarray_rngs[ctx], rng)
+            end
+            # TODO: destroy to preserve memory, or at exit?
+
             Random.seed!(rng)
             rng
         end

--- a/lib/curand/CURAND.jl
+++ b/lib/curand/CURAND.jl
@@ -26,6 +26,13 @@ include("random.jl")
 const CURAND_THREAD_RNGs = Vector{Union{Nothing,RNG}}()
 const GPUARRAY_THREAD_RNGs = Vector{Union{Nothing,GPUArrays.RNG}}()
 
+function set_stream(s::CuStream)
+    ctx = context()
+    if haskey(task_local_storage(), (:CURAND, ctx))
+        curandSetStream(default_rng(), s)
+    end
+end
+
 function default_rng()
     tid = Threads.threadid()
     if @inbounds CURAND_THREAD_RNGs[tid] === nothing

--- a/lib/curand/CURAND.jl
+++ b/lib/curand/CURAND.jl
@@ -33,7 +33,7 @@ const old_curand_rngs = DefaultDict{CuContext,Vector{RNG}}(()->RNG[])
 const old_gpuarray_rngs = DefaultDict{CuContext,Vector{GPUArrays.RNG}}(()->GPUArrays.RNG[])
 
 function default_rng()
-    CUDA.detect_task_switch()
+    CUDA.detect_state_changes()
     tid = Threads.threadid()
     if @inbounds CURAND_THREAD_RNGs[tid] === nothing
         ctx = context()
@@ -59,7 +59,7 @@ function default_rng()
 end
 
 function GPUArrays.default_rng(::Type{<:CuArray})
-    CUDA.detect_task_switch()
+    CUDA.detect_state_changes()
     tid = Threads.threadid()
     if @inbounds GPUARRAY_THREAD_RNGs[tid] === nothing
         ctx = context()

--- a/lib/curand/CURAND.jl
+++ b/lib/curand/CURAND.jl
@@ -35,7 +35,7 @@ function default_rng()
             Random.seed!(rng)
             rng
         end
-        curandSetStream(CURAND_THREAD_RNGs[tid], CUDA.stream_per_thread())
+        curandSetStream(CURAND_THREAD_RNGs[tid], stream(per_thread=true))
     end
     something(@inbounds CURAND_THREAD_RNGs[tid])
 end

--- a/lib/curand/error.jl
+++ b/lib/curand/error.jl
@@ -54,7 +54,7 @@ end
 end
 
 function initialize_api()
-    CUDA.prepare_cuda_call()
+    CUDA.initialize_cuda_context()
 end
 
 macro check(ex)

--- a/lib/curand/random.jl
+++ b/lib/curand/random.jl
@@ -12,11 +12,14 @@ mutable struct RNG <: Random.AbstractRNG
 
     function RNG(typ=CURAND_RNG_PSEUDO_DEFAULT)
         handle = curandCreateGenerator(typ)
-        curandSetStream(handle, CUDA.stream_per_thread())
+        curandSetStream(handle, CUDA.stream_per_thread())   # XXX: duplicate with default_rng
         obj = new(handle, context(), typ)
         finalizer(unsafe_destroy!, obj)
         return obj
     end
+
+    # TODO: this design doesn't work nicely in the presence of streams.
+    #       if the user switches streams, a local RNG object won't be updated.
 end
 
 function unsafe_destroy!(rng::RNG)

--- a/lib/curand/random.jl
+++ b/lib/curand/random.jl
@@ -12,7 +12,7 @@ mutable struct RNG <: Random.AbstractRNG
 
     function RNG(typ=CURAND_RNG_PSEUDO_DEFAULT)
         handle = curandCreateGenerator(typ)
-        curandSetStream(handle, stream(per_thread=true))   # XXX: duplicate with default_rng
+        curandSetStream(handle, stream())   # XXX: duplicate with default_rng
         obj = new(handle, context(), typ)
         finalizer(unsafe_destroy!, obj)
         return obj

--- a/lib/curand/random.jl
+++ b/lib/curand/random.jl
@@ -12,7 +12,7 @@ mutable struct RNG <: Random.AbstractRNG
 
     function RNG(typ=CURAND_RNG_PSEUDO_DEFAULT)
         handle = curandCreateGenerator(typ)
-        curandSetStream(handle, CUDA.stream_per_thread())   # XXX: duplicate with default_rng
+        curandSetStream(handle, stream(per_thread=true))   # XXX: duplicate with default_rng
         obj = new(handle, context(), typ)
         finalizer(unsafe_destroy!, obj)
         return obj

--- a/lib/curand/random.jl
+++ b/lib/curand/random.jl
@@ -12,7 +12,7 @@ mutable struct RNG <: Random.AbstractRNG
 
     function RNG(typ=CURAND_RNG_PSEUDO_DEFAULT)
         handle = curandCreateGenerator(typ)
-        curandSetStream(handle, CuStreamPerThread())
+        curandSetStream(handle, CUDA.stream_per_thread())
         obj = new(handle, context(), typ)
         finalizer(unsafe_destroy!, obj)
         return obj

--- a/lib/cusolver/CUSOLVER.jl
+++ b/lib/cusolver/CUSOLVER.jl
@@ -45,7 +45,7 @@ function dense_handle()
 
             handle
         end
-        cusolverDnSetStream(thread_dense_handles[tid], stream(per_thread=true))
+        cusolverDnSetStream(thread_dense_handles[tid], stream())
     end
     something(@inbounds thread_dense_handles[tid])
 end
@@ -65,7 +65,7 @@ function sparse_handle()
 
             handle
         end
-        cusolverSpSetStream(thread_sparse_handles[tid], stream(per_thread=true))
+        cusolverSpSetStream(thread_sparse_handles[tid], stream())
     end
     something(@inbounds thread_sparse_handles[tid])
 end

--- a/lib/cusolver/CUSOLVER.jl
+++ b/lib/cusolver/CUSOLVER.jl
@@ -37,7 +37,7 @@ const old_dense_handles = DefaultDict{CuContext,Vector{cusolverDnHandle_t}}(()->
 const old_sparse_handles = DefaultDict{CuContext,Vector{cusolverSpHandle_t}}(()->cusolverSpHandle_t[])
 
 function dense_handle()
-    CUDA.detect_task_switch()
+    CUDA.detect_state_changes()
     tid = Threads.threadid()
     if @inbounds thread_dense_handles[tid] === nothing
         ctx = context()
@@ -62,7 +62,7 @@ function dense_handle()
 end
 
 function sparse_handle()
-    CUDA.detect_task_switch()
+    CUDA.detect_state_changes()
     tid = Threads.threadid()
     if @inbounds thread_sparse_handles[tid] === nothing
         ctx = context()

--- a/lib/cusolver/CUSOLVER.jl
+++ b/lib/cusolver/CUSOLVER.jl
@@ -45,7 +45,7 @@ function dense_handle()
 
             handle
         end
-        cusolverDnSetStream(thread_dense_handles[tid], CUDA.stream_per_thread())
+        cusolverDnSetStream(thread_dense_handles[tid], stream(per_thread=true))
     end
     something(@inbounds thread_dense_handles[tid])
 end
@@ -65,7 +65,7 @@ function sparse_handle()
 
             handle
         end
-        cusolverSpSetStream(thread_sparse_handles[tid], CUDA.stream_per_thread())
+        cusolverSpSetStream(thread_sparse_handles[tid], stream(per_thread=true))
     end
     something(@inbounds thread_sparse_handles[tid])
 end

--- a/lib/cusolver/CUSOLVER.jl
+++ b/lib/cusolver/CUSOLVER.jl
@@ -30,23 +30,12 @@ include("linalg.jl")
 const thread_dense_handles = Vector{Union{Nothing,cusolverDnHandle_t}}()
 const thread_sparse_handles = Vector{Union{Nothing,cusolverSpHandle_t}}()
 
-function set_stream(s::CuStream)
-    ctx = context()
-    if haskey(task_local_storage(), (:CUSOLVER, :dense, ctx))
-        cusolverDnSetStream(dense_handle(), s)
-    end
-    if haskey(task_local_storage(), (:CUSOLVER, :sparse, ctx))
-        cusolverSpSetStream(sparse_handle(), s)
-    end
-end
-
 function dense_handle()
     tid = Threads.threadid()
     if @inbounds thread_dense_handles[tid] === nothing
         ctx = context()
         thread_dense_handles[tid] = get!(task_local_storage(), (:CUSOLVER, :dense, ctx)) do
             handle = cusolverDnCreate()
-            cusolverDnSetStream(handle, CUDA.stream_per_thread())
             finalizer(current_task()) do task
                 CUDA.isvalid(ctx) || return
                 context!(ctx) do
@@ -56,6 +45,7 @@ function dense_handle()
 
             handle
         end
+        cusolverDnSetStream(thread_dense_handles[tid], CUDA.stream_per_thread())
     end
     something(@inbounds thread_dense_handles[tid])
 end
@@ -66,7 +56,6 @@ function sparse_handle()
         ctx = context()
         thread_sparse_handles[tid] = get!(task_local_storage(), (:CUSOLVER, :sparse, ctx)) do
             handle = cusolverSpCreate()
-            cusolverSpSetStream(handle, CUDA.stream_per_thread())
             finalizer(current_task()) do task
                 CUDA.isvalid(ctx) || return
                 context!(ctx) do
@@ -76,8 +65,17 @@ function sparse_handle()
 
             handle
         end
+        cusolverSpSetStream(thread_sparse_handles[tid], CUDA.stream_per_thread())
     end
     something(@inbounds thread_sparse_handles[tid])
+end
+
+function reset_stream()
+    # NOTE: we 'abuse' the thread cache here, as switching streams doesn't invalidate it,
+    #       but we (re-)apply the current stream when populating that cache.
+    tid = Threads.threadid()
+    thread_dense_handles[tid] = nothing
+    thread_sparse_handles[tid] = nothing
 end
 
 function __init__()

--- a/lib/cusolver/CUSOLVER.jl
+++ b/lib/cusolver/CUSOLVER.jl
@@ -37,6 +37,7 @@ const old_dense_handles = DefaultDict{CuContext,Vector{cusolverDnHandle_t}}(()->
 const old_sparse_handles = DefaultDict{CuContext,Vector{cusolverSpHandle_t}}(()->cusolverSpHandle_t[])
 
 function dense_handle()
+    CUDA.detect_task_switch()
     tid = Threads.threadid()
     if @inbounds thread_dense_handles[tid] === nothing
         ctx = context()
@@ -61,6 +62,7 @@ function dense_handle()
 end
 
 function sparse_handle()
+    CUDA.detect_task_switch()
     tid = Threads.threadid()
     if @inbounds thread_sparse_handles[tid] === nothing
         ctx = context()

--- a/lib/cusolver/error.jl
+++ b/lib/cusolver/error.jl
@@ -44,7 +44,7 @@ end
 end
 
 function initialize_api()
-    CUDA.prepare_cuda_call()
+    CUDA.initialize_cuda_context()
 end
 
 macro check(ex)

--- a/lib/cusparse/CUSPARSE.jl
+++ b/lib/cusparse/CUSPARSE.jl
@@ -52,6 +52,7 @@ const thread_handles = Vector{Union{Nothing,cusparseHandle_t}}()
 const old_handles = DefaultDict{CuContext,Vector{cusparseHandle_t}}(()->cusparseHandle_t[])
 
 function handle()
+    CUDA.detect_task_switch()
     tid = Threads.threadid()
     if @inbounds thread_handles[tid] === nothing
         ctx = context()

--- a/lib/cusparse/CUSPARSE.jl
+++ b/lib/cusparse/CUSPARSE.jl
@@ -52,7 +52,7 @@ const thread_handles = Vector{Union{Nothing,cusparseHandle_t}}()
 const old_handles = DefaultDict{CuContext,Vector{cusparseHandle_t}}(()->cusparseHandle_t[])
 
 function handle()
-    CUDA.detect_task_switch()
+    CUDA.detect_state_changes()
     tid = Threads.threadid()
     if @inbounds thread_handles[tid] === nothing
         ctx = context()

--- a/lib/cusparse/CUSPARSE.jl
+++ b/lib/cusparse/CUSPARSE.jl
@@ -61,7 +61,7 @@ function handle()
 
             handle
         end
-        cusparseSetStream(thread_handles[tid], stream(per_thread=true))
+        cusparseSetStream(thread_handles[tid], stream())
     end
     something(@inbounds thread_handles[tid])
 end

--- a/lib/cusparse/CUSPARSE.jl
+++ b/lib/cusparse/CUSPARSE.jl
@@ -61,7 +61,7 @@ function handle()
 
             handle
         end
-        cusparseSetStream(thread_handles[tid], CUDA.stream_per_thread())
+        cusparseSetStream(thread_handles[tid], stream(per_thread=true))
     end
     something(@inbounds thread_handles[tid])
 end

--- a/lib/cusparse/error.jl
+++ b/lib/cusparse/error.jl
@@ -22,7 +22,7 @@ description(err::CUSPARSEError) = unsafe_string(cusparseGetErrorString(err))
 end
 
 function initialize_api()
-    CUDA.prepare_cuda_call()
+    CUDA.initialize_cuda_context()
 end
 
 macro check(ex)

--- a/lib/cutensor/CUTENSOR.jl
+++ b/lib/cutensor/CUTENSOR.jl
@@ -56,8 +56,9 @@ function handle()
     something(@inbounds thread_handles[tid])
 end
 
-function reset_stream()
+@inline function set_stream(stream::CuStream)
     # CUTENSOR uses stream arguments per operation
+    return
 end
 
 function __init__()

--- a/lib/cutensor/CUTENSOR.jl
+++ b/lib/cutensor/CUTENSOR.jl
@@ -10,6 +10,8 @@ using CEnum
 
 using Memoize
 
+using DataStructures
+
 
 const cudaDataType_t = cudaDataType
 
@@ -28,13 +30,26 @@ include("interfaces.jl")
 # thread cache for task-local library handles
 const thread_handles = Vector{Union{Nothing,Base.RefValue{cutensorHandle_t}}}()
 
+# cache for created, but unused handles
+const old_handles = DefaultDict{CuContext,Vector{Base.RefValue{cutensorHandle_t}}}(()->Base.RefValue{cutensorHandle_t}[])
+
 function handle()
     tid = Threads.threadid()
     if @inbounds thread_handles[tid] === nothing
         ctx = context()
         thread_handles[tid] = get!(task_local_storage(), (:CUTENSOR, ctx)) do
-            handle = Ref{cutensorHandle_t}()
-            cutensorInit(handle)
+            if isempty(old_handles[ctx])
+                handle = Ref{cutensorHandle_t}()
+                cutensorInit(handle)
+            else
+                handle = pop!(old_handles[ctx])
+            end
+
+            finalizer(current_task()) do task
+                push!(old_handles[ctx], handle)
+            end
+            # TODO: destroy to preserve memory, or at exit?
+
             handle
         end
     end

--- a/lib/cutensor/CUTENSOR.jl
+++ b/lib/cutensor/CUTENSOR.jl
@@ -41,6 +41,10 @@ function handle()
     something(@inbounds thread_handles[tid])
 end
 
+function reset_stream()
+    # CUTENSOR uses stream arguments per operation
+end
+
 function __init__()
     resize!(thread_handles, Threads.nthreads())
     fill!(thread_handles, nothing)

--- a/lib/cutensor/CUTENSOR.jl
+++ b/lib/cutensor/CUTENSOR.jl
@@ -34,7 +34,7 @@ const thread_handles = Vector{Union{Nothing,Base.RefValue{cutensorHandle_t}}}()
 const old_handles = DefaultDict{CuContext,Vector{Base.RefValue{cutensorHandle_t}}}(()->Base.RefValue{cutensorHandle_t}[])
 
 function handle()
-    CUDA.detect_task_switch()
+    CUDA.detect_state_changes()
     tid = Threads.threadid()
     if @inbounds thread_handles[tid] === nothing
         ctx = context()

--- a/lib/cutensor/CUTENSOR.jl
+++ b/lib/cutensor/CUTENSOR.jl
@@ -34,6 +34,7 @@ const thread_handles = Vector{Union{Nothing,Base.RefValue{cutensorHandle_t}}}()
 const old_handles = DefaultDict{CuContext,Vector{Base.RefValue{cutensorHandle_t}}}(()->Base.RefValue{cutensorHandle_t}[])
 
 function handle()
+    CUDA.detect_task_switch()
     tid = Threads.threadid()
     if @inbounds thread_handles[tid] === nothing
         ctx = context()

--- a/lib/cutensor/error.jl
+++ b/lib/cutensor/error.jl
@@ -56,7 +56,7 @@ end
 end
 
 function initialize_api()
-    CUDA.prepare_cuda_call()
+    CUDA.initialize_cuda_context()
 end
 
 macro check(ex)

--- a/lib/cutensor/wrappers.jl
+++ b/lib/cutensor/wrappers.jl
@@ -80,7 +80,7 @@ function elementwiseTrinary!(
                                 Ref{scalar_type}(beta),  B, descB, modeB,
                                 Ref{scalar_type}(gamma), C, descC, modeC,
                                 D, descD, modeD,
-                                opAB, opABC, scalar_type, stream)
+                                opAB, opABC, scalar_type, stream_per_thread())
     return D
 end
 
@@ -92,7 +92,7 @@ function elementwiseTrinary!(
         @nospecialize(gamma::Number),
         @nospecialize(C::Array), Cinds::ModeType, opC::cutensorOperator_t,
         @nospecialize(D::Array), Dinds::ModeType, opAB::cutensorOperator_t,
-        opABC::cutensorOperator_t; stream::CuStream=CUDA.stream_per_thread())
+        opABC::cutensorOperator_t)
     !is_unary(opA)    && throw(ArgumentError("opA must be a unary op!"))
     !is_unary(opB)    && throw(ArgumentError("opB must be a unary op!"))
     !is_unary(opC)    && throw(ArgumentError("opC must be a unary op!"))
@@ -113,7 +113,7 @@ function elementwiseTrinary!(
                                Ref{scalar_type}(beta),  B, descB, modeB,
                                Ref{scalar_type}(gamma), C, descC, modeC,
                                D, descD, modeD,
-                               opAB, opABC, scalar_type, stream)
+                               opAB, opABC, scalar_type, stream_per_thread())
     return D
 end
 
@@ -122,8 +122,7 @@ function elementwiseBinary!(
         @nospecialize(A::DenseCuArray), Ainds::ModeType, opA::cutensorOperator_t,
         @nospecialize(gamma::Number),
         @nospecialize(C::DenseCuArray), Cinds::ModeType, opC::cutensorOperator_t,
-        @nospecialize(D::DenseCuArray), Dinds::ModeType, opAC::cutensorOperator_t;
-        stream::CuStream=CUDA.stream_per_thread())
+        @nospecialize(D::DenseCuArray), Dinds::ModeType, opAC::cutensorOperator_t)
     !is_unary(opA)    && throw(ArgumentError("opA must be a unary op!"))
     !is_unary(opC)    && throw(ArgumentError("opC must be a unary op!"))
     !is_binary(opAC)  && throw(ArgumentError("opAC must be a binary op!"))
@@ -139,7 +138,7 @@ function elementwiseBinary!(
                               Ref{scalar_type}(alpha), A, descA, modeA,
                               Ref{scalar_type}(gamma), C, descC, modeC,
                               D, descD, modeD,
-                              opAC, scalar_type, stream)
+                              opAC, scalar_type, stream_per_thread())
     return D
 end
 
@@ -148,8 +147,7 @@ function elementwiseBinary!(
         @nospecialize(A::Array), Ainds::ModeType, opA::cutensorOperator_t,
         @nospecialize(gamma::Number),
         @nospecialize(C::Array), Cinds::ModeType, opC::cutensorOperator_t,
-        @nospecialize(D::Array), Dinds::ModeType, opAC::cutensorOperator_t;
-        stream::CuStream=CUDA.stream_per_thread())
+        @nospecialize(D::Array), Dinds::ModeType, opAC::cutensorOperator_t)
     !is_unary(opA)    && throw(ArgumentError("opA must be a unary op!"))
     !is_unary(opC)    && throw(ArgumentError("opC must be a unary op!"))
     !is_binary(opAC)  && throw(ArgumentError("opAC must be a binary op!"))
@@ -165,7 +163,7 @@ function elementwiseBinary!(
                               Ref{scalar_type}(alpha), A, descA, modeA,
                               Ref{scalar_type}(gamma), C, descC, modeC,
                               D, descD, modeD,
-                              opAC, scalar_type, stream)
+                              opAC, scalar_type, stream_per_thread())
     return D
 end
 
@@ -174,8 +172,7 @@ function elementwiseBinary!(
         @nospecialize(A::CuTensor), opA::cutensorOperator_t,
         @nospecialize(gamma::Number),
         @nospecialize(C::CuTensor), opC::cutensorOperator_t,
-        @nospecialize(D::CuTensor), opAC::cutensorOperator_t;
-        stream::CuStream=CUDA.stream_per_thread())
+        @nospecialize(D::CuTensor), opAC::cutensorOperator_t)
     !is_unary(opA)    && throw(ArgumentError("opA must be a unary op!"))
     !is_unary(opC)    && throw(ArgumentError("opC must be a unary op!"))
     !is_binary(opAC)  && throw(ArgumentError("opAC must be a binary op!"))
@@ -191,15 +188,14 @@ function elementwiseBinary!(
                               Ref{scalar_type}(alpha), A.data, descA, modeA,
                               Ref{scalar_type}(gamma), C.data, descC, modeC,
                               D.data, descD, modeD,
-                              opAC, scalar_type, stream)
+                              opAC, scalar_type, stream_per_thread())
     return D
 end
 
 function permutation!(
         @nospecialize(alpha::Number),
         @nospecialize(A::DenseCuArray), Ainds::ModeType,
-        @nospecialize(B::DenseCuArray), Binds::ModeType;
-        stream::CuStream=CUDA.stream_per_thread())
+        @nospecialize(B::DenseCuArray), Binds::ModeType)
     #!is_unary(opPsi)    && throw(ArgumentError("opPsi must be a unary op!"))
     descA = CuTensorDescriptor(A)
     descB = CuTensorDescriptor(B)
@@ -210,14 +206,13 @@ function permutation!(
                         Ref{scalar_type}(alpha),
                         A, descA, modeA,
                         B, descB, modeB,
-                        scalar_type, stream)
+                        scalar_type, stream_per_thread())
     return B
 end
 function permutation!(
         @nospecialize(alpha::Number),
         @nospecialize(A::Array), Ainds::ModeType,
-        @nospecialize(B::Array), Binds::ModeType;
-        stream::CuStream=CUDA.stream_per_thread())
+        @nospecialize(B::Array), Binds::ModeType)
     #!is_unary(opPsi)    && throw(ArgumentError("opPsi must be a unary op!"))
     descA = CuTensorDescriptor(A)
     descB = CuTensorDescriptor(B)
@@ -228,7 +223,7 @@ function permutation!(
                         Ref{scalar_type}(alpha),
                         A, descA, modeA,
                         B, descB, modeB,
-                        scalar_type, stream)
+                        scalar_type, stream_per_thread())
     return B
 end
 
@@ -240,7 +235,7 @@ function contraction!(
         @nospecialize(C::Union{Array, CuArray}), Cinds::ModeType, opC::cutensorOperator_t,
         opOut::cutensorOperator_t;
         pref::cutensorWorksizePreference_t=CUTENSOR_WORKSPACE_RECOMMENDED,
-        algo::cutensorAlgo_t=CUTENSOR_ALGO_DEFAULT, stream::CuStream=CUDA.stream_per_thread(),
+        algo::cutensorAlgo_t=CUTENSOR_ALGO_DEFAULT,
         compute_type::Type=eltype(C), plan::Union{cutensorContractionPlan_t, Nothing}=nothing)
     !is_unary(opA)    && throw(ArgumentError("opA must be a unary op!"))
     !is_unary(opB)    && throw(ArgumentError("opB must be a unary op!"))
@@ -286,7 +281,7 @@ function contraction!(
             cutensorContraction(handle(), plan_ref,
                                 Ref{scalar_type}(alpha), A, B,
                                 Ref{scalar_type}(beta),  C, C,
-                                workspace, sizeof(workspace), stream)
+                                workspace, sizeof(workspace), stream_per_thread())
         end
     return C
 end
@@ -342,7 +337,7 @@ function reduction!(
         @nospecialize(A::Union{Array, CuArray}), Ainds::ModeType, opA::cutensorOperator_t,
         @nospecialize(beta::Number),
         @nospecialize(C::Union{Array, CuArray}), Cinds::ModeType, opC::cutensorOperator_t,
-        opReduce::cutensorOperator_t; stream::CuStream=CUDA.stream_per_thread())
+        opReduce::cutensorOperator_t)
     !is_unary(opA)    && throw(ArgumentError("opA must be a unary op!"))
     !is_unary(opC)    && throw(ArgumentError("opC must be a unary op!"))
     !is_binary(opReduce)  && throw(ArgumentError("opReduce must be a binary op!"))
@@ -367,7 +362,7 @@ function reduction!(
                 Ref{T}(beta),  C, descC, modeC,
                         C, descC, modeC,
                 opReduce, typeCompute,
-                workspace, sizeof(workspace), stream)
+                workspace, sizeof(workspace), stream_per_thread())
         end
 
     return C

--- a/lib/cutensor/wrappers.jl
+++ b/lib/cutensor/wrappers.jl
@@ -59,7 +59,7 @@ function elementwiseTrinary!(
         @nospecialize(gamma::Number),
         @nospecialize(C::DenseCuArray), Cinds::ModeType, opC::cutensorOperator_t,
         @nospecialize(D::DenseCuArray), Dinds::ModeType, opAB::cutensorOperator_t,
-        opABC::cutensorOperator_t; stream::CuStream=CuStreamPerThread())
+        opABC::cutensorOperator_t; stream::CuStream=CUDA.stream_per_thread())
     !is_unary(opA)    && throw(ArgumentError("opA must be a unary op!"))
     !is_unary(opB)    && throw(ArgumentError("opB must be a unary op!"))
     !is_unary(opC)    && throw(ArgumentError("opC must be a unary op!"))
@@ -92,7 +92,7 @@ function elementwiseTrinary!(
         @nospecialize(gamma::Number),
         @nospecialize(C::Array), Cinds::ModeType, opC::cutensorOperator_t,
         @nospecialize(D::Array), Dinds::ModeType, opAB::cutensorOperator_t,
-        opABC::cutensorOperator_t; stream::CuStream=CuStreamPerThread())
+        opABC::cutensorOperator_t; stream::CuStream=CUDA.stream_per_thread())
     !is_unary(opA)    && throw(ArgumentError("opA must be a unary op!"))
     !is_unary(opB)    && throw(ArgumentError("opB must be a unary op!"))
     !is_unary(opC)    && throw(ArgumentError("opC must be a unary op!"))
@@ -123,7 +123,7 @@ function elementwiseBinary!(
         @nospecialize(gamma::Number),
         @nospecialize(C::DenseCuArray), Cinds::ModeType, opC::cutensorOperator_t,
         @nospecialize(D::DenseCuArray), Dinds::ModeType, opAC::cutensorOperator_t;
-        stream::CuStream=CuStreamPerThread())
+        stream::CuStream=CUDA.stream_per_thread())
     !is_unary(opA)    && throw(ArgumentError("opA must be a unary op!"))
     !is_unary(opC)    && throw(ArgumentError("opC must be a unary op!"))
     !is_binary(opAC)  && throw(ArgumentError("opAC must be a binary op!"))
@@ -149,7 +149,7 @@ function elementwiseBinary!(
         @nospecialize(gamma::Number),
         @nospecialize(C::Array), Cinds::ModeType, opC::cutensorOperator_t,
         @nospecialize(D::Array), Dinds::ModeType, opAC::cutensorOperator_t;
-        stream::CuStream=CuStreamPerThread())
+        stream::CuStream=CUDA.stream_per_thread())
     !is_unary(opA)    && throw(ArgumentError("opA must be a unary op!"))
     !is_unary(opC)    && throw(ArgumentError("opC must be a unary op!"))
     !is_binary(opAC)  && throw(ArgumentError("opAC must be a binary op!"))
@@ -175,7 +175,7 @@ function elementwiseBinary!(
         @nospecialize(gamma::Number),
         @nospecialize(C::CuTensor), opC::cutensorOperator_t,
         @nospecialize(D::CuTensor), opAC::cutensorOperator_t;
-        stream::CuStream=CuStreamPerThread())
+        stream::CuStream=CUDA.stream_per_thread())
     !is_unary(opA)    && throw(ArgumentError("opA must be a unary op!"))
     !is_unary(opC)    && throw(ArgumentError("opC must be a unary op!"))
     !is_binary(opAC)  && throw(ArgumentError("opAC must be a binary op!"))
@@ -199,7 +199,7 @@ function permutation!(
         @nospecialize(alpha::Number),
         @nospecialize(A::DenseCuArray), Ainds::ModeType,
         @nospecialize(B::DenseCuArray), Binds::ModeType;
-        stream::CuStream=CuStreamPerThread())
+        stream::CuStream=CUDA.stream_per_thread())
     #!is_unary(opPsi)    && throw(ArgumentError("opPsi must be a unary op!"))
     descA = CuTensorDescriptor(A)
     descB = CuTensorDescriptor(B)
@@ -217,7 +217,7 @@ function permutation!(
         @nospecialize(alpha::Number),
         @nospecialize(A::Array), Ainds::ModeType,
         @nospecialize(B::Array), Binds::ModeType;
-        stream::CuStream=CuStreamPerThread())
+        stream::CuStream=CUDA.stream_per_thread())
     #!is_unary(opPsi)    && throw(ArgumentError("opPsi must be a unary op!"))
     descA = CuTensorDescriptor(A)
     descB = CuTensorDescriptor(B)
@@ -240,7 +240,7 @@ function contraction!(
         @nospecialize(C::Union{Array, CuArray}), Cinds::ModeType, opC::cutensorOperator_t,
         opOut::cutensorOperator_t;
         pref::cutensorWorksizePreference_t=CUTENSOR_WORKSPACE_RECOMMENDED,
-        algo::cutensorAlgo_t=CUTENSOR_ALGO_DEFAULT, stream::CuStream=CuStreamPerThread(),
+        algo::cutensorAlgo_t=CUTENSOR_ALGO_DEFAULT, stream::CuStream=CUDA.stream_per_thread(),
         compute_type::Type=eltype(C), plan::Union{cutensorContractionPlan_t, Nothing}=nothing)
     !is_unary(opA)    && throw(ArgumentError("opA must be a unary op!"))
     !is_unary(opB)    && throw(ArgumentError("opB must be a unary op!"))
@@ -342,7 +342,7 @@ function reduction!(
         @nospecialize(A::Union{Array, CuArray}), Ainds::ModeType, opA::cutensorOperator_t,
         @nospecialize(beta::Number),
         @nospecialize(C::Union{Array, CuArray}), Cinds::ModeType, opC::cutensorOperator_t,
-        opReduce::cutensorOperator_t; stream::CuStream=CuStreamPerThread())
+        opReduce::cutensorOperator_t; stream::CuStream=CUDA.stream_per_thread())
     !is_unary(opA)    && throw(ArgumentError("opA must be a unary op!"))
     !is_unary(opC)    && throw(ArgumentError("opC must be a unary op!"))
     !is_binary(opReduce)  && throw(ArgumentError("opReduce must be a binary op!"))

--- a/lib/cutensor/wrappers.jl
+++ b/lib/cutensor/wrappers.jl
@@ -80,7 +80,7 @@ function elementwiseTrinary!(
                                 Ref{scalar_type}(beta),  B, descB, modeB,
                                 Ref{scalar_type}(gamma), C, descC, modeC,
                                 D, descD, modeD,
-                                opAB, opABC, scalar_type, stream(per_thread=true))
+                                opAB, opABC, scalar_type, stream())
     return D
 end
 
@@ -113,7 +113,7 @@ function elementwiseTrinary!(
                                Ref{scalar_type}(beta),  B, descB, modeB,
                                Ref{scalar_type}(gamma), C, descC, modeC,
                                D, descD, modeD,
-                               opAB, opABC, scalar_type, stream(per_thread=true))
+                               opAB, opABC, scalar_type, stream())
     return D
 end
 
@@ -138,7 +138,7 @@ function elementwiseBinary!(
                               Ref{scalar_type}(alpha), A, descA, modeA,
                               Ref{scalar_type}(gamma), C, descC, modeC,
                               D, descD, modeD,
-                              opAC, scalar_type, stream(per_thread=true))
+                              opAC, scalar_type, stream())
     return D
 end
 
@@ -163,7 +163,7 @@ function elementwiseBinary!(
                               Ref{scalar_type}(alpha), A, descA, modeA,
                               Ref{scalar_type}(gamma), C, descC, modeC,
                               D, descD, modeD,
-                              opAC, scalar_type, stream(per_thread=true))
+                              opAC, scalar_type, stream())
     return D
 end
 
@@ -188,7 +188,7 @@ function elementwiseBinary!(
                               Ref{scalar_type}(alpha), A.data, descA, modeA,
                               Ref{scalar_type}(gamma), C.data, descC, modeC,
                               D.data, descD, modeD,
-                              opAC, scalar_type, stream(per_thread=true))
+                              opAC, scalar_type, stream())
     return D
 end
 
@@ -206,7 +206,7 @@ function permutation!(
                         Ref{scalar_type}(alpha),
                         A, descA, modeA,
                         B, descB, modeB,
-                        scalar_type, stream(per_thread=true))
+                        scalar_type, stream())
     return B
 end
 function permutation!(
@@ -223,7 +223,7 @@ function permutation!(
                         Ref{scalar_type}(alpha),
                         A, descA, modeA,
                         B, descB, modeB,
-                        scalar_type, stream(per_thread=true))
+                        scalar_type, stream())
     return B
 end
 
@@ -281,7 +281,7 @@ function contraction!(
             cutensorContraction(handle(), plan_ref,
                                 Ref{scalar_type}(alpha), A, B,
                                 Ref{scalar_type}(beta),  C, C,
-                                workspace, sizeof(workspace), stream(per_thread=true))
+                                workspace, sizeof(workspace), stream())
         end
     return C
 end
@@ -362,7 +362,7 @@ function reduction!(
                 Ref{T}(beta),  C, descC, modeC,
                         C, descC, modeC,
                 opReduce, typeCompute,
-                workspace, sizeof(workspace), stream(per_thread=true))
+                workspace, sizeof(workspace), stream())
         end
 
     return C

--- a/lib/cutensor/wrappers.jl
+++ b/lib/cutensor/wrappers.jl
@@ -59,7 +59,7 @@ function elementwiseTrinary!(
         @nospecialize(gamma::Number),
         @nospecialize(C::DenseCuArray), Cinds::ModeType, opC::cutensorOperator_t,
         @nospecialize(D::DenseCuArray), Dinds::ModeType, opAB::cutensorOperator_t,
-        opABC::cutensorOperator_t; stream::CuStream=CUDA.stream_per_thread())
+        opABC::cutensorOperator_t)
     !is_unary(opA)    && throw(ArgumentError("opA must be a unary op!"))
     !is_unary(opB)    && throw(ArgumentError("opB must be a unary op!"))
     !is_unary(opC)    && throw(ArgumentError("opC must be a unary op!"))
@@ -80,7 +80,7 @@ function elementwiseTrinary!(
                                 Ref{scalar_type}(beta),  B, descB, modeB,
                                 Ref{scalar_type}(gamma), C, descC, modeC,
                                 D, descD, modeD,
-                                opAB, opABC, scalar_type, stream_per_thread())
+                                opAB, opABC, scalar_type, stream(per_thread=true))
     return D
 end
 
@@ -113,7 +113,7 @@ function elementwiseTrinary!(
                                Ref{scalar_type}(beta),  B, descB, modeB,
                                Ref{scalar_type}(gamma), C, descC, modeC,
                                D, descD, modeD,
-                               opAB, opABC, scalar_type, stream_per_thread())
+                               opAB, opABC, scalar_type, stream(per_thread=true))
     return D
 end
 
@@ -138,7 +138,7 @@ function elementwiseBinary!(
                               Ref{scalar_type}(alpha), A, descA, modeA,
                               Ref{scalar_type}(gamma), C, descC, modeC,
                               D, descD, modeD,
-                              opAC, scalar_type, stream_per_thread())
+                              opAC, scalar_type, stream(per_thread=true))
     return D
 end
 
@@ -163,7 +163,7 @@ function elementwiseBinary!(
                               Ref{scalar_type}(alpha), A, descA, modeA,
                               Ref{scalar_type}(gamma), C, descC, modeC,
                               D, descD, modeD,
-                              opAC, scalar_type, stream_per_thread())
+                              opAC, scalar_type, stream(per_thread=true))
     return D
 end
 
@@ -188,7 +188,7 @@ function elementwiseBinary!(
                               Ref{scalar_type}(alpha), A.data, descA, modeA,
                               Ref{scalar_type}(gamma), C.data, descC, modeC,
                               D.data, descD, modeD,
-                              opAC, scalar_type, stream_per_thread())
+                              opAC, scalar_type, stream(per_thread=true))
     return D
 end
 
@@ -206,7 +206,7 @@ function permutation!(
                         Ref{scalar_type}(alpha),
                         A, descA, modeA,
                         B, descB, modeB,
-                        scalar_type, stream_per_thread())
+                        scalar_type, stream(per_thread=true))
     return B
 end
 function permutation!(
@@ -223,7 +223,7 @@ function permutation!(
                         Ref{scalar_type}(alpha),
                         A, descA, modeA,
                         B, descB, modeB,
-                        scalar_type, stream_per_thread())
+                        scalar_type, stream(per_thread=true))
     return B
 end
 
@@ -281,7 +281,7 @@ function contraction!(
             cutensorContraction(handle(), plan_ref,
                                 Ref{scalar_type}(alpha), A, B,
                                 Ref{scalar_type}(beta),  C, C,
-                                workspace, sizeof(workspace), stream_per_thread())
+                                workspace, sizeof(workspace), stream(per_thread=true))
         end
     return C
 end
@@ -362,7 +362,7 @@ function reduction!(
                 Ref{T}(beta),  C, descC, modeC,
                         C, descC, modeC,
                 opReduce, typeCompute,
-                workspace, sizeof(workspace), stream_per_thread())
+                workspace, sizeof(workspace), stream(per_thread=true))
         end
 
     return C

--- a/src/array.jl
+++ b/src/array.jl
@@ -306,7 +306,7 @@ end
 
 function Base.unsafe_copyto!(dest::DenseCuArray{T}, doffs, src::DenseCuArray{T}, soffs, n) where T
   GC.@preserve src dest unsafe_copyto!(pointer(dest, doffs), pointer(src, soffs), n;
-                                       async=true, stream=CuDefaultStream())
+                                       async=true, stream=CUDA.stream())
   if Base.isbitsunion(T)
     # copy selector bytes
     error("Not implemented")

--- a/src/array.jl
+++ b/src/array.jl
@@ -296,6 +296,7 @@ function Base.unsafe_copyto!(dest::DenseCuArray{T}, doffs, src::Array{T}, soffs,
 end
 
 function Base.unsafe_copyto!(dest::Array{T}, doffs, src::DenseCuArray{T}, soffs, n) where T
+  # TODO: pin the source memory so that it can actually execute asynchronously?
   GC.@preserve src dest unsafe_copyto!(pointer(dest, doffs), pointer(src, soffs), n;
                                        async=true)
   if Base.isbitsunion(T)

--- a/src/array.jl
+++ b/src/array.jl
@@ -296,7 +296,8 @@ function Base.unsafe_copyto!(dest::DenseCuArray{T}, doffs, src::Array{T}, soffs,
 end
 
 function Base.unsafe_copyto!(dest::Array{T}, doffs, src::DenseCuArray{T}, soffs, n) where T
-  GC.@preserve src dest unsafe_copyto!(pointer(dest, doffs), pointer(src, soffs), n)
+  GC.@preserve src dest unsafe_copyto!(pointer(dest, doffs), pointer(src, soffs), n;
+                                       async=true)
   if Base.isbitsunion(T)
     # copy selector bytes
     error("Not implemented")

--- a/src/array.jl
+++ b/src/array.jl
@@ -306,7 +306,7 @@ end
 
 function Base.unsafe_copyto!(dest::DenseCuArray{T}, doffs, src::DenseCuArray{T}, soffs, n) where T
   GC.@preserve src dest unsafe_copyto!(pointer(dest, doffs), pointer(src, soffs), n;
-                                       async=true, stream=CUDA.stream())
+                                       async=true)
   if Base.isbitsunion(T)
     # copy selector bytes
     error("Not implemented")
@@ -362,8 +362,7 @@ const MemsetCompatTypes = Union{UInt8, Int8,
 function Base.fill!(A::DenseCuArray{T}, x) where T <: MemsetCompatTypes
   U = memsettype(T)
   y = reinterpret(U, convert(T, x))
-  Mem.set!(convert(CuPtr{U}, pointer(A)), y, length(A);
-           async=true, stream=CuDefaultStream())
+  Mem.set!(convert(CuPtr{U}, pointer(A)), y, length(A); async=true)
   A
 end
 

--- a/src/initialization.jl
+++ b/src/initialization.jl
@@ -87,7 +87,7 @@ function __init__()
         thread_streams[tid] = nothing
     end
 
-    initializer(prepare_cuda_call)
+    initializer(initialize_cuda_context)
 
     @require ForwardDiff="f6369f11-7733-5829-9624-2563aa707210" include("forwarddiff.jl")
 end

--- a/src/initialization.jl
+++ b/src/initialization.jl
@@ -74,6 +74,19 @@ function __init__()
     resize!(thread_tasks, Threads.nthreads())
     fill!(thread_tasks, nothing)
 
+    resize!(thread_streams, Threads.nthreads())
+    fill!(thread_streams, nothing)
+
+    atdeviceswitch() do
+        tid = Threads.threadid()
+        thread_streams[tid] = nothing
+    end
+
+    attaskswitch() do
+        tid = Threads.threadid()
+        thread_streams[tid] = nothing
+    end
+
     initializer(prepare_cuda_call)
 
     @require ForwardDiff="f6369f11-7733-5829-9624-2563aa707210" include("forwarddiff.jl")

--- a/src/initialization.jl
+++ b/src/initialization.jl
@@ -87,8 +87,6 @@ function __init__()
         thread_streams[tid] = nothing
     end
 
-    initializer(initialize_cuda_context)
-
     @require ForwardDiff="f6369f11-7733-5829-9624-2563aa707210" include("forwarddiff.jl")
 end
 

--- a/src/pool.jl
+++ b/src/pool.jl
@@ -534,7 +534,7 @@ macro timed(ex)
         while false; end # compiler heuristic: compile this block (alter this if the heuristic changes)
 
         # @time(d) might surround an application, so be sure to initialize CUDA before that
-        CUDA.prepare_cuda_call()
+        CUDA.initialize_cuda_context()
 
         # coarse synchronization to exclude effects from previously-executed code
         synchronize()

--- a/src/precompile.jl
+++ b/src/precompile.jl
@@ -2,7 +2,7 @@ function _precompile_()
     ccall(:jl_generating_output, Cint, ()) == 1 || return nothing
     @assert precompile(Tuple{CUDA.HostKernel{identity, Tuple{Nothing}},Nothing})
     @assert precompile(Tuple{Type{CuModule},String,Dict{CUDA.CUjit_option_enum, Any}})
-    @assert precompile(Tuple{typeof(CUDA.prepare_cuda_call)})
+    @assert precompile(Tuple{typeof(CUDA.initialize_cuda_context)})
     @assert precompile(Tuple{typeof(GPUCompiler.load_runtime),GPUCompiler.CompilerJob{GPUCompiler.PTXCompilerTarget, CUDA.CUDACompilerParams},LLVM.Context})
     @assert precompile(Tuple{typeof(cufunction),typeof(identity),Type{Tuple{Nothing}}})
     @assert precompile(Tuple{typeof(which(CUDA.pack_arguments,(Function,Vararg{Any, N} where N,)).generator.gen),Any,Any,Any})

--- a/src/state.jl
+++ b/src/state.jl
@@ -488,7 +488,7 @@ such that the default stream will be `CuStreamPerThread()`.`
     if haskey(tls, :CuStream)
         tls[:CuStream]::CuStream
     else
-        per_thread ? CuStreamPerThread() : CuDefaultStream()
+        tls[:CuStream] = CuStream(; flags=STREAM_NON_BLOCKING)
     end
 end
 

--- a/src/state.jl
+++ b/src/state.jl
@@ -481,7 +481,14 @@ Get the CUDA stream that should be used as the default one for the currently exe
     if @inbounds thread_streams[tid] === nothing
         ctx = context()
         thread_streams[tid] = get!(task_local_storage(), (:CuStream, ctx)) do
-            CuStream(; flags=STREAM_NON_BLOCKING)
+            stream = CuStream(; flags=STREAM_NON_BLOCKING)
+
+            t = current_task()
+            tptr = pointer_from_objref(current_task())
+            tptrstr = string(convert(UInt, tptr), base=16, pad=Sys.WORD_SIZE>>2)
+            NVTX.nvtxNameCuStreamA(stream, "Task(0x$tptrstr)")
+
+            stream
         end
     end
     something(@inbounds thread_streams[tid])

--- a/src/state.jl
+++ b/src/state.jl
@@ -5,7 +5,7 @@
 # multiple threads), using a GPU of your choice (with the ability to reset that device, or
 # use different devices on different threads).
 
-export context, context!, device, device!, device_reset!, deviceid
+export context, context!, device, device!, device_reset!, deviceid, stream, stream_per_thread
 
 
 ## hooks

--- a/src/state.jl
+++ b/src/state.jl
@@ -5,7 +5,7 @@
 # multiple threads), using a GPU of your choice (with the ability to reset that device, or
 # use different devices on different threads).
 
-export context, context!, device, device!, device_reset!, deviceid, stream
+export context, context!, device, device!, device_reset!, deviceid, stream, stream!
 
 
 ## hooks

--- a/src/state.jl
+++ b/src/state.jl
@@ -472,16 +472,11 @@ math_precision() =
 const thread_streams = Vector{Union{Nothing,CuStream}}()
 
 """
-    stream([per_thread=false])
+    stream()
 
-Get the active stream for the currently executing task. This returns any stream explicitly
-set by the user, or the default global stream `CuDefaultStream()`.
-
-If you need the default stream to be different per-thread, for use with libraries that do
-not use per-thread APIs (i.e. without `ptsz` or `ptds` suffixes), set `per_thread` to `true`
-such that the default stream will be `CuStreamPerThread()`.`
+Get the CUDA stream that should be used as the default one for the currently executing task.
 """
-@inline function stream(; per_thread::Bool=false)
+@inline function stream()
     tid = Threads.threadid()
     if @inbounds thread_streams[tid] === nothing
         ctx = context()

--- a/src/utilities.jl
+++ b/src/utilities.jl
@@ -3,10 +3,9 @@
 
 Run expression `ex` and synchronize the GPU afterwards. By default, this is a CPU-friendly
 synchronization, i.e. it performs a blocking synchronization without increasing CPU load
-As such, this operation is preferred over implicit synchronization (e.g. when performing a
-memory copy) for high-performance applications.
-
 It is also useful for timing code that executes asynchronously.
+
+See also: [`synchronize`](@ref).
 """
 macro sync(ex...)
     # destructure the `@sync` expression
@@ -25,16 +24,9 @@ macro sync(ex...)
         end
     end
 
-    flags = EVENT_DISABLE_TIMING
-    if blocking
-        flags |= EVENT_BLOCKING_SYNC
-    end
-
     quote
-        local e = CuEvent($flags)
         local ret = $(esc(code))
-        record(e)
-        synchronize(e)
+        synchronize(; blocking=$(esc(blocking)))
         ret
     end
 end

--- a/test/cudadrv/context.jl
+++ b/test/cudadrv/context.jl
@@ -24,7 +24,7 @@ let global_ctx2 = nothing
 
     @test CuDevice(ctx) == dev
     @test CuCurrentDevice() == dev
-    synchronize()
+    synchronize_all()
 end
 
 end

--- a/test/cudadrv/events.jl
+++ b/test/cudadrv/events.jl
@@ -12,8 +12,6 @@ end
 
 @test (CUDA.@elapsed begin end) > 0
 
-@test (CUDA.@elapsed CuDefaultStream() begin end) > 0
-
 CuEvent(CUDA.EVENT_BLOCKING_SYNC)
 CuEvent(CUDA.EVENT_BLOCKING_SYNC | CUDA.EVENT_DISABLE_TIMING)
 
@@ -30,9 +28,4 @@ end
 @testset "event query" begin
     event  = CuEvent()
     @test CUDA.query(event) == true
-end
-
-@testset "elapsed stream" begin
-    stream = CuStream()
-    @test (CUDA.@elapsed stream begin end) > 0
 end

--- a/test/cudadrv/execution.jl
+++ b/test/cudadrv/execution.jl
@@ -28,18 +28,18 @@ let
     cudacall(dummy, Tuple{}; threads=1)
     cudacall(dummy, Tuple{}; threads=1, blocks=1)
     cudacall(dummy, Tuple{}; threads=1, blocks=1, shmem=0)
-    cudacall(dummy, Tuple{}; threads=1, blocks=1, shmem=0, stream=CuDefaultStream())
-    cudacall(dummy, Tuple{}; threads=1, blocks=1, shmem=0, stream=CuDefaultStream(), cooperative=false)
+    cudacall(dummy, Tuple{}; threads=1, blocks=1, shmem=0, stream=stream())
+    cudacall(dummy, Tuple{}; threads=1, blocks=1, shmem=0, stream=stream(), cooperative=false)
     cudacall(dummy, ())
-    cudacall(dummy, (); threads=1, blocks=1, shmem=0, stream=CuDefaultStream(), cooperative=false)
+    cudacall(dummy, (); threads=1, blocks=1, shmem=0, stream=stream(), cooperative=false)
 
     # different launch syntaxes
     CUDA.launch(dummy)
     CUDA.launch(dummy; threads=1)
     CUDA.launch(dummy; threads=1, blocks=1)
     CUDA.launch(dummy; threads=1, blocks=1, shmem=0)
-    CUDA.launch(dummy; threads=1, blocks=1, shmem=0, stream=CuDefaultStream())
-    CUDA.launch(dummy; threads=1, blocks=1, shmem=0, stream=CuDefaultStream(), cooperative=false)
+    CUDA.launch(dummy; threads=1, blocks=1, shmem=0, stream=stream())
+    CUDA.launch(dummy; threads=1, blocks=1, shmem=0, stream=stream(), cooperative=false)
 end
 
 let

--- a/test/cudadrv/memory.jl
+++ b/test/cudadrv/memory.jl
@@ -80,8 +80,7 @@ end
 let
     src = Mem.alloc(Mem.Device, nb)
 
-    @test_throws ArgumentError unsafe_copyto!(typed_pointer(src, T), pointer(data), N; async=true)
-    unsafe_copyto!(typed_pointer(src, T), pointer(data), N; async=true, stream=CuDefaultStream())
+    unsafe_copyto!(typed_pointer(src, T), pointer(data), N; async=true)
 
     Mem.set!(typed_pointer(src, T), zero(T), N; async=true, stream=CuDefaultStream())
 

--- a/test/cudadrv/memory.jl
+++ b/test/cudadrv/memory.jl
@@ -82,7 +82,7 @@ let
 
     unsafe_copyto!(typed_pointer(src, T), pointer(data), N; async=true)
 
-    Mem.set!(typed_pointer(src, T), zero(T), N; async=true, stream=CuDefaultStream())
+    Mem.set!(typed_pointer(src, T), zero(T), N; async=true, stream=stream())
 
     Mem.free(src)
 end

--- a/test/cudadrv/stream.jl
+++ b/test/cudadrv/stream.jl
@@ -20,4 +20,7 @@ let s = CuStream(; priority=last(prio))
     @test priority(s) == last(prio)
 end
 
+synchronize()
+synchronize(; blocking=false)
 synchronize(stream())
+synchronize(stream(); blocking=false)

--- a/test/cudadrv/stream.jl
+++ b/test/cudadrv/stream.jl
@@ -20,4 +20,4 @@ let s = CuStream(; priority=last(prio))
     @test priority(s) == last(prio)
 end
 
-synchronize(CuDefaultStream())
+synchronize(stream())

--- a/test/cufft.jl
+++ b/test/cufft.jl
@@ -303,10 +303,3 @@ end
 end
 
 end
-
-
-@testset "streams" begin
-    X = rand(N1)
-    d_X = CuArray(X)
-    p = plan_fft(d_X)
-end

--- a/test/exceptions.jl
+++ b/test/exceptions.jl
@@ -12,7 +12,7 @@ script = """
     cpu = zeros(Int)
     gpu = CuArray(cpu)
     @cuda kernel(gpu, 1.2)
-    Array(gpu)
+    synchronize()
 
     # FIXME: on some platforms (Windows...), for some users, the exception flag change
     # doesn't immediately propagate to the host, and gets caught during finalization.
@@ -20,26 +20,35 @@ script = """
     # https://stackoverflow.com/questions/16417346/cuda-pinned-memory-flushing-from-the-device
     sleep(1)
     synchronize()
-    Array(gpu)
 """
+
+# NOTE: kernel exceptions aren't always caught on the CPU as a KernelException.
+#       on older devices, we emit a `trap` which causes a CUDA error...
+#
 
 let (code, out, err) = julia_script(script, `-g0`)
     @test code == 1
-    @test  occursin("ERROR: KernelException: exception thrown during kernel execution on device", err)
+    @test  occursin("ERROR: KernelException: exception thrown during kernel execution on device", err) ||
+           occursin("ERROR: CUDA error: an illegal instruction was encountered", err) ||
+           occursin("ERROR: CUDA error: unspecified launch failure", err)
     @test !occursin(r"ERROR: a \w+ was thrown during kernel execution", out)
     # NOTE: stdout sometimes contain a failure to free the CuArray with ILLEGAL_ACCESS
 end
 
 let (code, out, err) = julia_script(script, `-g1`)
     @test code == 1
-    @test occursin("ERROR: KernelException: exception thrown during kernel execution on device", err)
+    @test occursin("ERROR: KernelException: exception thrown during kernel execution on device", err) ||
+          occursin("ERROR: CUDA error: an illegal instruction was encountered", err) ||
+          occursin("ERROR: CUDA error: unspecified launch failure", err)
     @test occursin(r"ERROR: a \w+ was thrown during kernel execution", out)
     @test occursin("Run Julia on debug level 2 for device stack traces", out)
 end
 
 let (code, out, err) = julia_script(script, `-g2`)
     @test code == 1
-    @test occursin("ERROR: KernelException: exception thrown during kernel execution on device", err)
+    @test occursin("ERROR: KernelException: exception thrown during kernel execution on device", err) ||
+          occursin("ERROR: CUDA error: an illegal instruction was encountered", err) ||
+          occursin("ERROR: CUDA error: unspecified launch failure", err)
     @test occursin(r"ERROR: a \w+ was thrown during kernel execution", out)
     if VERSION < v"1.3.0-DEV.270"
         @test occursin("[1] Type at float.jl", out)
@@ -65,7 +74,9 @@ script = """
 
 let (code, out, err) = julia_script(script, `-g2`)
     @test code == 1
-    @test occursin("ERROR: KernelException: exception thrown during kernel execution on device", err)
+    @test occursin("ERROR: KernelException: exception thrown during kernel execution on device", err) ||
+          occursin("ERROR: CUDA error: an illegal instruction was encountered", err) ||
+          occursin("ERROR: CUDA error: unspecified launch failure", err)
     @test occursin(r"ERROR: a \w+ was thrown during kernel execution", out)
     @test occursin("foo at none:4", out)
     @test occursin("bar at none:5", out)

--- a/test/initialization.jl
+++ b/test/initialization.jl
@@ -146,3 +146,37 @@ end
 if length(devices()) > 1
     @test deviceid(CuDevice(1)) == 1
 end
+
+
+## default streams
+
+default_s = stream()
+s = CuStream()
+@test s != default_s
+
+# test stream switching
+let
+    stream!(s)
+    @test stream() == s
+    stream!(default_s)
+    @test stream() == default_s
+end
+stream!(s) do
+    @test stream() == s
+end
+@test stream() == default_s
+
+# default stream in task
+task = @async begin
+    stream()
+end
+@test fetch(task) != default_s
+@test stream() == default_s
+
+# test stream switching in tasks
+task = @async begin
+    stream!(s)
+    stream()
+end
+@test fetch(task) == s
+@test stream() == default_s

--- a/test/setup.jl
+++ b/test/setup.jl
@@ -125,6 +125,9 @@ macro grab_output(ex)
             open(fname, "w") do fout
                 redirect_stdout(fout) do
                     ret = $(esc(ex))
+
+                    # NOTE: CUDA requires a 'proper' sync to flush its printf buffer
+                    synchronize_all()
                 end
             end
             ret, read(fname, String)
@@ -184,7 +187,7 @@ macro test_throws_macro(ty, ex)
     end
 end
 
-# Run some code on-device, returning captured standard output
+# Run some code on-device
 macro on_device(ex)
     @gensym kernel
     esc(quote


### PR DESCRIPTION
This is the next big step (after https://github.com/JuliaGPU/CUDAnative.jl/pull/609 and https://github.com/JuliaGPU/CUDA.jl/pull/395) in marrying Julia's task-based parallelism with the CUDA APIs. By managing our own default stream, and using that instead of CUDA's default stream objects, we can ensure that all operations (kernel launches, library calls, etc) happen using the stream that's active for the current task. That should make it much easier to isolate independent operations. For example:

```julia
# operation that both executes a kernel and calls a library function
julia> run(a,b,c) = (mul!(c, a, b); broadcast!(sin, c))

julia> function main(N=1024)
       a = CUDA.rand(N,N)
       b = CUDA.rand(N,N)
       c = CUDA.rand(N,N)
       NVTX.@range "warmup" run(a,b,c)
       synchronize()
       NVTX.@range "global" x = run(a,b,c)
       NVTX.@range "local" y = CUDA.stream!(CuStream()) do
           run(a,b,c)
       end
       synchronize()
       x == y
       end
```

![image](https://user-images.githubusercontent.com/383068/104914100-ebba1100-598e-11eb-98bd-1e50f41c8dc6.png)

As you can see, the operations in the global stream are independent from the ones executed in a local stream context :tada: Here, that results in overlapping execution, which is great for performance.

Remains to be done/decided:
- should `synchronize` now default to synchronizing the current stream, or should it still be a device-wide sync?
- we can further improve this by using CUDA 11.2's async allocation features.