### PR TITLE
Retry CuModule creation when OOM.

### DIFF
--- a/lib/cudadrv/module.jl
+++ b/lib/cudadrv/module.jl
@@ -30,9 +30,14 @@ mutable struct CuModule
         end
         optionKeys, optionVals = encode(options)
 
-        res = GC.@preserve data unsafe_cuModuleLoadDataEx(handle_ref, pointer(data),
-                                                          length(optionKeys),
-                                                          optionKeys, optionVals)
+        # FIXME: maybe all CUDA API calls need to run under retry_reclaim?
+        #        that would require a redesign of the memory pool,
+        #        so maybe do so when we replace it with CUDA 11.2's pool.
+        res = GC.@preserve data retry_reclaim(isequal(ERROR_OUT_OF_MEMORY)) do
+            unsafe_cuModuleLoadDataEx(handle_ref, pointer(data),
+                                      length(optionKeys),
+                                      optionKeys, optionVals)
+        end
         if res == ERROR_NO_BINARY_FOR_GPU ||
            res == ERROR_INVALID_IMAGE ||
            res == ERROR_INVALID_PTX

--- a/src/pool.jl
+++ b/src/pool.jl
@@ -423,6 +423,11 @@ macro retry_reclaim(isfailed, ex)
   end
 end
 
+# XXX: function version for use in CUDAdrv where we haven't loaded pool.jl yet
+function retry_reclaim(f, check)
+  @retry_reclaim check f()
+end
+
 
 ## management
 


### PR DESCRIPTION
Although we need a better (and cheaper) way to retry many more API calls, CuModule creation is one that seems to fail fairly often, e.g. in the benchmarks of https://github.com/JuliaGPU/CUDA.jl/pull/431.