### PR TITLE
Track external globals, use it to avoid needless exception flags

### DIFF
--- a/src/compiler/exceptions.jl
+++ b/src/compiler/exceptions.jl
@@ -11,73 +11,16 @@ function Base.showerror(io::IO, err::KernelException)
 end
 
 
-## exception codegen
-
-# emit a global variable for storing the current exception status
-#
-# since we don't actually support globals, access to this variable is done by calling the
-# julia_exception_flag function (lowered here to actual accesses of the variable)
-function emit_exception_flag!(mod::LLVM.Module)
-    @assert !haskey(globals(mod), "exception_flag")
-    ctx = LLVM.context(mod)
-
-    # add the global variable
-    T_ptr = convert(LLVMType, Ptr{Cvoid}, ctx)
-    gv = GlobalVariable(mod, T_ptr, "exception_flag")
-    initializer!(gv, LLVM.ConstantInt(T_ptr, 0))
-    linkage!(gv, LLVM.API.LLVMWeakAnyLinkage)
-    extinit!(gv, true)
-    set_used!(mod, gv)
-
-    # lower uses of the getter
-    if haskey(functions(mod), "julia_exception_flag")
-        buf_getter = functions(mod)["julia_exception_flag"]
-        @assert return_type(eltype(llvmtype(buf_getter))) == eltype(llvmtype(gv))
-
-        # find uses
-        worklist = Vector{LLVM.CallInst}()
-        for use in uses(buf_getter)
-            call = user(use)::LLVM.CallInst
-            push!(worklist, call)
-        end
-
-        # replace uses by a load from the global variable
-        for call in worklist
-            Builder(ctx) do builder
-                position!(builder, call)
-                ptr = load!(builder, gv)
-                replace_uses!(call, ptr)
-            end
-            unsafe_delete!(LLVM.parent(call), call)
-        end
-    end
-end
-
-
 ## exception handling
 
 const exception_flags = Dict{CuContext, Mem.HostBuffer}()
 
 # create a CPU/GPU exception flag for error signalling, and put it in the module
-#
-# also see compiler/irgen.jl::emit_exception_flag!
 function create_exceptions!(mod::CuModule)
-    if VERSION >= v"1.5" && !(v"1.6-" <= VERSION < v"1.6.0-DEV.90")
-        flag_ptr = CuGlobal{Ptr{Cvoid}}(mod, "exception_flag")
-        exception_flag = get!(exception_flags, mod.ctx,
-                            Mem.alloc(Mem.Host, sizeof(Int), Mem.HOSTALLOC_DEVICEMAP))
-        flag_ptr[] = reinterpret(Ptr{Cvoid}, convert(CuPtr{Cvoid}, exception_flag))
-    else
-        ctx = mod.ctx
-        try
-            flag_ptr = CuGlobal{Ptr{Cvoid}}(mod, "exception_flag")
-            exception_flag = get!(exception_flags, ctx, Mem.alloc(Mem.Host, sizeof(Int),
-                                Mem.HOSTALLOC_DEVICEMAP))
-            flag_ptr[] = reinterpret(Ptr{Cvoid}, convert(CuPtr{Cvoid}, exception_flag))
-        catch err
-            (isa(err, CuError) && err.code == ERROR_NOT_FOUND) || rethrow()
-        end
-    end
+    flag_ptr = CuGlobal{Ptr{Cvoid}}(mod, "exception_flag")
+    exception_flag = get!(exception_flags, mod.ctx,
+                          Mem.alloc(Mem.Host, sizeof(Int), Mem.HOSTALLOC_DEVICEMAP))
+    flag_ptr[] = reinterpret(Ptr{Cvoid}, convert(CuPtr{Cvoid}, exception_flag))
 
     return
 end

--- a/src/compiler/execution.jl
+++ b/src/compiler/execution.jl
@@ -362,8 +362,11 @@ function cufunction_link(@nospecialize(source::FunctionSpec), compiled; kwargs..
     mod = CuModule(image, jit_options)
     fun = CuFunction(mod, compiled.entry)
 
-    # initialize and register the exception flag
-    create_exceptions!(mod)
+    # initialize and register the exception flag, if any
+    if "exception_flag" in compiled.external_gvars
+        create_exceptions!(mod)
+        filter!(isequal("exception_flag"), compiled.external_gvars)
+    end
 
     return HostKernel{source.f,source.tt}(ctx, mod, fun)
 end

--- a/src/compiler/gpucompiler.jl
+++ b/src/compiler/gpucompiler.jl
@@ -30,13 +30,6 @@ GPUCompiler.isintrinsic(job::CUDACompilerJob, fn::String) =
            job, fn) ||
     fn == "__nvvm_reflect" || startswith(fn, "cuda")
 
-function GPUCompiler.finish_module!(job::CUDACompilerJob, mod::LLVM.Module)
-    invoke(GPUCompiler.finish_module!,
-           Tuple{CompilerJob{PTXCompilerTarget}, typeof(mod)},
-           job, mod)
-    emit_exception_flag!(mod)
-end
-
 function GPUCompiler.link_libraries!(job::CUDACompilerJob, mod::LLVM.Module,
                                      undefined_fns::Vector{String})
     invoke(GPUCompiler.link_libraries!,

--- a/src/compiler/reflection.jl
+++ b/src/compiler/reflection.jl
@@ -56,7 +56,11 @@ function code_sass(io::IO, job::CUDACompilerJob; verbose::Bool=false)
         error("Can only generate SASS code for kernel functions")
     end
 
-    asm = GPUCompiler.codegen(:asm, job)
+    # FIXME: don't have cufunction_compile use the compile hook
+    hook = GPUCompiler.compile_hook[]
+    GPUCompiler.compile_hook[] = nothing
+    compiled = cufunction_compile(job)
+    GPUCompiler.compile_hook[] = hook
 
     cubin = Ref{Any}()
     callback = @cfunction(code_sass_callback, Cvoid,
@@ -74,7 +78,7 @@ function code_sass(io::IO, job::CUDACompilerJob; verbose::Bool=false)
     subscriber = subscriber_ref[]
     try
         CUPTI.cuptiEnableDomain(1, subscriber, CUPTI.CUPTI_CB_DOMAIN_RESOURCE)
-        cufunction_link(job.source, asm)
+        cufunction_link(job.source, compiled)
     finally
         CUPTI.cuptiUnsubscribe(subscriber)
     end


### PR DESCRIPTION
While thinking about a better design for https://github.com/JuliaGPU/CUDA.jl/pull/552, and making sure external globals now survive (https://github.com/JuliaGPU/GPUCompiler.jl/pull/138, https://github.com/JuliaLang/julia/pull/39387), I figured we need to make it easier to pick those globals up and initialize them.

Probably needs https://github.com/JuliaLang/julia/pull/39387, although we do handle the case where the symbol disappeared here (it's not like we care that the unused global has disappeared, but we should probably restore the linkage to external).