### PR TITLE
Add fast getri_strided_batch

### DIFF
--- a/lib/cublas/wrappers.jl
+++ b/lib/cublas/wrappers.jl
@@ -1516,10 +1516,6 @@ for (fname, elty) in
          (:cublasZgetriBatched, :ComplexF64),
          (:cublasCgetriBatched, :ComplexF32))
     @eval begin
-        # cublasStatus_t cublasDgetriBatched(
-        #   cublasHandle_t handle, int n, double **A,
-        #   int lda, int *PivotArray, double **C,
-        #   int ldc, int *info, int batchSize)
         function getri_batched!(A::Vector{<:CuMatrix{$elty}},
                               C::Vector{<:CuMatrix{$elty}},
                               pivotArray::CuMatrix{Cint})

--- a/lib/cublas/wrappers.jl
+++ b/lib/cublas/wrappers.jl
@@ -1496,18 +1496,14 @@ for (fname, elty) in
      (:cublasZgetriBatched, :ComplexF64),
      (:cublasCgetriBatched, :ComplexF32))
     @eval begin
-    # cublasStatus_t cublasDgetriBatched(
-    #   cublasHandle_t handle, int n, double **A,
-    #   int lda, int *PivotArray, double **C,
-    #   int ldc, int *info, int batchSize)
         function getri_batched!(n, Aptrs::CuVector{CuPtr{$elty}},
                           lda, Cptrs::CuVector{CuPtr{$elty}},ldc,
                           pivotArray::CuArray{Cint})
             batchSize = length(Aptrs)
             info = CuArray{Cint}(undef, batchSize)
-            CUBLAS.$fname(CUBLAS.handle(), n, Aptrs, lda, pivotArray, Cptrs, ldc, info, batchSize)
-            CUBLAS.unsafe_free!(Cptrs)
-            CUBLAS.unsafe_free!(Aptrs)
+            $fname(handle(), n, Aptrs, lda, pivotArray, Cptrs, ldc, info, batchSize)
+            unsafe_free!(Cptrs)
+            unsafe_free!(Aptrs)
             return info
         end
     end
@@ -1530,12 +1526,12 @@ for (fname, elty) in
             n = size(A[1])[1]
             lda = max(1, stride(A[1], 2))
             ldc = max(1, stride(C[1], 2))
-            Aptrs = CUBLAS.unsafe_batch(A)
-            Cptrs = CUBLAS.unsafe_batch(C)
+            Aptrs = unsafe_batch(A)
+            Cptrs = unsafe_batch(C)
             info = CuArrays.zeros(Cint, length(A))
-            CUBLAS.$fname(CUBLAS.handle(), n, Aptrs, lda, pivotArray, Cptrs, ldc, info, length(A))
-            CUBLAS.unsafe_free!(Cptrs)
-            CUBLAS.unsafe_free!(Aptrs)
+            $fname(handle(), n, Aptrs, lda, pivotArray, Cptrs, ldc, info, length(A))
+            unsafe_free!(Cptrs)
+            unsafe_free!(Aptrs)
 
             return info
         end
@@ -1550,8 +1546,8 @@ function getri_strided_batched!(A::CuArray{<:Any,3}, C::CuArray{<:Any,3}, pivot:
     end
     ldc = max(1, stride(C, 2))
     lda = max(1, stride(A, 2))
-    Cptrs = CUBLAS.unsafe_strided_batch(C)
-    Aptrs = CUBLAS.unsafe_strided_batch(A)
+    Cptrs = unsafe_strided_batch(C)
+    Aptrs = unsafe_strided_batch(A)
     return getri_batched!(n, Aptrs, lda, Cptrs, ldc, pivot)
 end
 

--- a/lib/cublas/wrappers.jl
+++ b/lib/cublas/wrappers.jl
@@ -1489,6 +1489,71 @@ for (fname, elty) in
         end
     end
 end
+## getriBatched - performs batched matrix inversion, no allocations inside
+for (fname, elty) in
+    ((:cublasDgetriBatched, :Float64),
+     (:cublasSgetriBatched, :Float32),
+     (:cublasZgetriBatched, :ComplexF64),
+     (:cublasCgetriBatched, :ComplexF32))
+    @eval begin
+    # cublasStatus_t cublasDgetriBatched(
+    #   cublasHandle_t handle, int n, double **A,
+    #   int lda, int *PivotArray, double **C,
+    #   int ldc, int *info, int batchSize)
+        function getri_batched!(n, Aptrs::CuVector{CuPtr{$elty}},
+                          lda, Cptrs::CuVector{CuPtr{$elty}},ldc,
+                          pivotArray::CuArray{Cint})
+            batchSize = length(Aptrs)
+            info = CuArray{Cint}(undef, batchSize)
+            CUBLAS.$fname(CUBLAS.handle(), n, Aptrs, lda, pivotArray, Cptrs, ldc, info, batchSize)
+            CUBLAS.unsafe_free!(Cptrs)
+            CUBLAS.unsafe_free!(Aptrs)
+            return info
+        end
+    end
+end
+
+
+for (fname, elty) in
+        ((:cublasDgetriBatched, :Float64),
+         (:cublasSgetriBatched, :Float32),
+         (:cublasZgetriBatched, :ComplexF64),
+         (:cublasCgetriBatched, :ComplexF32))
+    @eval begin
+        # cublasStatus_t cublasDgetriBatched(
+        #   cublasHandle_t handle, int n, double **A,
+        #   int lda, int *PivotArray, double **C,
+        #   int ldc, int *info, int batchSize)
+        function getri_batched!(A::Vector{<:CuMatrix{$elty}},
+                              C::Vector{<:CuMatrix{$elty}},
+                              pivotArray::CuMatrix{Cint})
+            n = size(A[1])[1]
+            lda = max(1, stride(A[1], 2))
+            ldc = max(1, stride(C[1], 2))
+            Aptrs = CUBLAS.unsafe_batch(A)
+            Cptrs = CUBLAS.unsafe_batch(C)
+            info = CuArrays.zeros(Cint, length(A))
+            CUBLAS.$fname(CUBLAS.handle(), n, Aptrs, lda, pivotArray, Cptrs, ldc, info, length(A))
+            CUBLAS.unsafe_free!(Cptrs)
+            CUBLAS.unsafe_free!(Aptrs)
+
+            return info
+        end
+    end
+end
+
+# CUDA has no strided batched getri, but we can at least avoid constructing costly views (based on getrf_strided_batch)
+function getri_strided_batched!(A::CuArray{<:Any,3}, C::CuArray{<:Any,3}, pivot::CuArray{Cint})
+    m, n = size(A, 1), size(A, 2)
+    if m != n
+        throw(DimensionMismatch("All matrices must be square!"))
+    end
+    ldc = max(1, stride(C, 2))
+    lda = max(1, stride(A, 2))
+    Cptrs = CUBLAS.unsafe_strided_batch(C)
+    Aptrs = CUBLAS.unsafe_strided_batch(A)
+    return getri_batched!(n, Aptrs, lda, Cptrs, ldc, pivot)
+end
 
 ## matinvBatched - performs batched matrix inversion
 

--- a/test/cublas.jl
+++ b/test/cublas.jl
@@ -1598,10 +1598,10 @@ end
         @testset "getrf_strided_batched" begin
             local k
             # generate strided matrix
-            A = rand(elty,m,m,10);
+            A = rand(elty,m,m,10)
             # move to device
-            d_A = CuArray(A);
-            pivot, info, d_B = CUBLAS.getrf_strided_batched(d_A, false);
+            d_A = CuArray(A)
+            pivot, info, d_B = CUBLAS.getrf_strided_batched(d_A, false)
             h_info = Array(info)
 
             for Cs in 1:length(h_info)

--- a/test/cublas.jl
+++ b/test/cublas.jl
@@ -1632,6 +1632,7 @@ end
             A = rand(elty,m,m,10)
             # move to device
             d_A = CuArray(A)
+            d_B = similar(d_A)
             pivot, info = CUBLAS.getrf_strided_batched!(d_A, true)
             info = CUBLAS.getri_strided_batched!(d_A, d_B, pivot)
             h_info = Array(info)

--- a/test/cublas.jl
+++ b/test/cublas.jl
@@ -1601,9 +1601,7 @@ end
             A = rand(elty,m,m,10);
             # move to device
             d_A = CuArray(A);
-            d_B = similar(d_A);
             pivot, info, d_B = CUBLAS.getrf_strided_batched(d_A, false);
-            info = CUBLAS.getri_strided_batched!(d_A, d_B, pivot);
             h_info = Array(info)
 
             for Cs in 1:length(h_info)


### PR DESCRIPTION
Add getri_strided_batch (similar to getrf_strided_batch). Allocation free inside, easier to use getrf_strided_batch and getri_strided_batch for fast batched matrix inversion now