### PR TITLE
Add p-norm functionality.

### DIFF
--- a/lib/cublas/linalg.jl
+++ b/lib/cublas/linalg.jl
@@ -41,10 +41,10 @@ function LinearAlgebra.norm(x::DenseCuArray{<:CublasFloat}, p::Integer)
     if p==1
         return CUBLAS.asum(length(x),x)
     end
-    if p==2
+    else if p==2
         return LinearAlgebra.norm(x)
     end
-    if p>2
+    else
         return LinearAlgebra.tr(LinearAlgebra.Diagonal(abs.(x))^p)^(1/p)
     end
 end

--- a/lib/cublas/linalg.jl
+++ b/lib/cublas/linalg.jl
@@ -37,6 +37,18 @@ end
 LinearAlgebra.norm(x::DenseCuArray{<:CublasFloat}) = nrm2(x)
 LinearAlgebra.BLAS.asum(x::StridedCuArray{<:CublasFloat}) = asum(length(x), x)
 
+function LinearAlgebra.norm(x::DenseCuArray{<:CublasFloat}, p::Integer)
+    if p==1
+        return CUBLAS.asum(length(x),x)
+    end
+    if p==2
+        return LinearAlgebra.norm(x)
+    end
+    if p>2
+        return LinearAlgebra.tr(LinearAlgebra.Diagonal(abs.(x))^p)^(1/p)
+    end
+end
+
 function LinearAlgebra.axpy!(alpha::Number, x::StridedCuArray{T}, y::StridedCuArray{T}) where T<:CublasFloat
     length(x)==length(y) || throw(DimensionMismatch("axpy arguments have lengths $(length(x)) and $(length(y))"))
     axpy!(length(x), alpha, x, y)

--- a/lib/cublas/linalg.jl
+++ b/lib/cublas/linalg.jl
@@ -40,10 +40,8 @@ LinearAlgebra.BLAS.asum(x::StridedCuArray{<:CublasFloat}) = asum(length(x), x)
 function LinearAlgebra.norm(x::DenseCuArray{<:CublasFloat}, p::Integer)
     if p==1
         return CUBLAS.asum(length(x),x)
-    end
     else if p==2
         return LinearAlgebra.norm(x)
-    end
     else
         return LinearAlgebra.tr(LinearAlgebra.Diagonal(abs.(x))^p)^(1/p)
     end

--- a/lib/cublas/linalg.jl
+++ b/lib/cublas/linalg.jl
@@ -40,7 +40,7 @@ LinearAlgebra.BLAS.asum(x::StridedCuArray{<:CublasFloat}) = asum(length(x), x)
 function LinearAlgebra.norm(x::DenseCuArray{<:CublasFloat}, p::Integer)
     if p==1
         return CUBLAS.asum(length(x),x)
-    else if p==2
+    elseif p==2
         return LinearAlgebra.norm(x)
     else
         return LinearAlgebra.tr(LinearAlgebra.Diagonal(abs.(x))^p)^(1/p)

--- a/test/cublas.jl
+++ b/test/cublas.jl
@@ -86,10 +86,12 @@ end
         end
 
         @testset "norm" begin
-            x, y, z = CUDA.rand(elty, 1), CUDA.rand(elty, 2), CUDA.rand(elty, m)
-            @test typeof(norm(x,1)) <: Real
-            @test typeof(norm(y,2)) <: Real
-            @test typeof(norm(z,m)) <: Real
+            CUDA.allowscalar(false) do
+                x, y, z = CUDA.rand(elty, 1), CUDA.rand(elty, 2), CUDA.rand(elty, m)
+                @test typeof(norm(x,1)) <: Real
+                @test typeof(norm(y,2)) <: Real
+                @test typeof(norm(z,m)) <: Real
+            end
         end
 
         @testset "banded methods" begin

--- a/test/cublas.jl
+++ b/test/cublas.jl
@@ -84,6 +84,14 @@ end
             mul!(y, f(A), x, Ts(1), Ts(2))
             @test Array(dy) ≈ y
         end
+
+        @testset "norm" begin
+            x, y, z = CUDA.rand(elty, 1), CUDA.rand(elty, 2), CUDA.rand(elty, m)
+            @test typeof(norm(x,1)) <: Real
+            @test typeof(norm(y,2)) <: Real
+            @test typeof(norm(z,m)) <: Real
+        end
+
         @testset "banded methods" begin
             # bands
             ku = 2

--- a/test/cublas.jl
+++ b/test/cublas.jl
@@ -1,5 +1,6 @@
 using CUDA.CUBLAS
 using CUDA.CUBLAS: band, bandex
+using GPUArrays
 
 using LinearAlgebra
 
@@ -86,12 +87,10 @@ end
         end
 
         @testset "norm" begin
-            CUDA.allowscalar(false) do
-                x, y, z = CUDA.rand(elty, 1), CUDA.rand(elty, 2), CUDA.rand(elty, m)
-                @test typeof(norm(x,1)) <: Real
-                @test typeof(norm(y,2)) <: Real
-                @test typeof(norm(z,m)) <: Real
-            end
+            x, y, z = CUDA.rand(elty, 1), CUDA.rand(elty, 2), CUDA.rand(elty, m)
+            @disallowscalar @test typeof(norm(x,1)) <: Real
+            @disallowscalar @test typeof(norm(y,2)) <: Real
+            @disallowscalar @test typeof(norm(z,m)) <: Real
         end
 
         @testset "banded methods" begin


### PR DESCRIPTION
What does this PR do?
- [x] Addresses issue #84 by adding a `norm(x::CuArray, p::Integer)`
- [x] As it says, it adds p-norm functionality.

I will add the coming modifications over here.

Another aspect I should point out, it still does not work for `norm(x::CuArray, p::Inf)`, gives us the same old scalar getindex error. Might have to think of something much better for this, because `LinearAlgebra.opnorm()` also has not been implemented for `CUDA.jl`.