### PR TITLE
fix bug in CURAND.jl's set_stream function.

### DIFF
--- a/lib/curand/CURAND.jl
+++ b/lib/curand/CURAND.jl
@@ -91,7 +91,7 @@ end
     tls = task_local_storage()
     rng = get(tls, (:CURAND, ctx), nothing)
     if rng !== nothing
-        curandSetStream(rng, stream())
+        curandSetStream(rng, stream)
     end
     return
 end


### PR DESCRIPTION
root cause: the parameter stream is not a callable.