### PR TITLE
Make CUDNN tests eagerly invoke at-test for better error reporting.

### DIFF
--- a/test/cudnn/activation.jl
+++ b/test/cudnn/activation.jl
@@ -1,5 +1,4 @@
-using CUDA, Test, Random
-using CUDA.CUDNN: 
+using CUDA.CUDNN:
     cudnnActivationForward,
     cudnnActivationForward!,
     cudnnActivationBackward,
@@ -18,12 +17,10 @@ using CUDA.CUDNN:
         CUDNN_ACTIVATION_IDENTITY,     # 5
     cudnnNanPropagation_t,
         CUDNN_NOT_PROPAGATE_NAN, # 0
-        CUDNN_PROPAGATE_NAN,     # 1
-    handle
+        CUDNN_PROPAGATE_NAN      # 1
 
 
 @testset "cudnn/activation" begin
-
     @test cudnnActivationDescriptor(C_NULL) isa cudnnActivationDescriptor
     @test Base.unsafe_convert(Ptr, cudnnActivationDescriptor(C_NULL)) isa Ptr
     @test cudnnActivationDescriptor(CUDNN_ACTIVATION_RELU,CUDNN_NOT_PROPAGATE_NAN,0) isa cudnnActivationDescriptor
@@ -31,8 +28,8 @@ using CUDA.CUDNN:
     (ax,ay) = randn.((10,10))
     (cx,cy) = CuArray.((ax,ay))
 
-    function activationtest(
-        ;mode=CUDNN_ACTIVATION_SIGMOID,
+    function activationtest(;
+        mode=CUDNN_ACTIVATION_SIGMOID,
         nanOpt=CUDNN_NOT_PROPAGATE_NAN,
         coef=1,
         alpha=1,
@@ -47,20 +44,20 @@ using CUDA.CUDNN:
         d = cudnnActivationDescriptor(mode,nanOpt,Cfloat(coef))
         y0 = alpha * fx
         y1 = y0 .+ beta * ay
-        ((y0 ≈ cudnnActivationForward(cx; mode, nanOpt, coef, alpha) |> Array) &&
-         (y0 ≈ cudnnActivationForward(cx, d; alpha) |> Array) &&
-         (y1 ≈ cudnnActivationForward!(copy(cy), cx; mode, nanOpt, coef, alpha, beta) |> Array) &&
-         (y1 ≈ cudnnActivationForward!(copy(cy), cx, d; alpha, beta) |> Array))
+        @test y0 ≈ cudnnActivationForward(cx; mode, nanOpt, coef, alpha) |> Array
+        @test y0 ≈ cudnnActivationForward(cx, d; alpha) |> Array
+        @test y1 ≈ cudnnActivationForward!(copy(cy), cx; mode, nanOpt, coef, alpha, beta) |> Array
+        @test y1 ≈ cudnnActivationForward!(copy(cy), cx, d; alpha, beta) |> Array
     end
-    
-    @test activationtest(mode=CUDNN_ACTIVATION_SIGMOID)
-    @test activationtest(mode=CUDNN_ACTIVATION_RELU)
-    @test activationtest(mode=CUDNN_ACTIVATION_TANH)
-    @test activationtest(mode=CUDNN_ACTIVATION_CLIPPED_RELU)
-    @test activationtest(mode=CUDNN_ACTIVATION_ELU)
-    @test activationtest(nanOpt=CUDNN_PROPAGATE_NAN)
-    @test activationtest(coef=2,mode=CUDNN_ACTIVATION_CLIPPED_RELU)
-    @test activationtest(coef=2,mode=CUDNN_ACTIVATION_ELU)
-    @test activationtest(alpha=2)
-    @test activationtest(beta=2)
+
+    activationtest(mode=CUDNN_ACTIVATION_SIGMOID)
+    activationtest(mode=CUDNN_ACTIVATION_RELU)
+    activationtest(mode=CUDNN_ACTIVATION_TANH)
+    activationtest(mode=CUDNN_ACTIVATION_CLIPPED_RELU)
+    activationtest(mode=CUDNN_ACTIVATION_ELU)
+    activationtest(nanOpt=CUDNN_PROPAGATE_NAN)
+    activationtest(coef=2,mode=CUDNN_ACTIVATION_CLIPPED_RELU)
+    activationtest(coef=2,mode=CUDNN_ACTIVATION_ELU)
+    activationtest(alpha=2)
+    activationtest(beta=2)
 end

--- a/test/cudnn/dropout.jl
+++ b/test/cudnn/dropout.jl
@@ -1,5 +1,5 @@
-using Test, CUDA, Statistics
-using CUDA.CUDNN: 
+using Statistics
+using CUDA.CUDNN:
     cudnnDropoutForward,
     cudnnDropoutForward!,
     cudnnDropoutBackward,
@@ -12,11 +12,9 @@ using CUDA.CUDNN:
         cudnnRestoreDropoutDescriptor,
         cudnnDestroyDropoutDescriptor,
     cudnnDropoutGetStatesSize,
-    cudnnDropoutGetReserveSpaceSize,
-    handle
+    cudnnDropoutGetReserveSpaceSize
 
 @testset "cudnn/dropout" begin
-
     @test cudnnDropoutDescriptor(C_NULL) isa cudnnDropoutDescriptor
     @test Base.unsafe_convert(Ptr, cudnnDropoutDescriptor(C_NULL)) isa Ptr
     @test cudnnDropoutDescriptor(0.5) isa cudnnDropoutDescriptor
@@ -31,5 +29,4 @@ using CUDA.CUDNN:
     @test y == cudnnDropoutForward!(similar(x), x; dropout = P)
     @test y == cudnnDropoutForward!(similar(x), x, d)
     cudnnDropoutSeed[] = -1
-
 end

--- a/test/cudnn/inplace.jl
+++ b/test/cudnn/inplace.jl
@@ -1,4 +1,3 @@
-using Test, CUDA, Random
 import CUDA.CUDNN:
     cudnnSetTensor!,
     cudnnScaleTensor!,
@@ -6,7 +5,6 @@ import CUDA.CUDNN:
     cudnnAddTensor!,
     cudnnAddTensor,
     CUDNN_TENSOR_NHWC
-
 
 @testset "cudnn/inplace" begin
     x = CUDA.rand(10)

--- a/test/cudnn/softmax.jl
+++ b/test/cudnn/softmax.jl
@@ -1,4 +1,3 @@
-using Test, CUDA
 using CUDA.CUDNN:
     cudnnSoftmaxForward,
     cudnnSoftmaxForward!,
@@ -9,16 +8,14 @@ using CUDA.CUDNN:
         CUDNN_SOFTMAX_LOG,      # 2
     cudnnSoftmaxMode_t,
         CUDNN_SOFTMAX_MODE_INSTANCE, # 0, /* compute the softmax over all C, H, W for each N */
-        CUDNN_SOFTMAX_MODE_CHANNEL,  # 1  /* compute the softmax over all C for each H, W, N */
-    handle
-
+        CUDNN_SOFTMAX_MODE_CHANNEL   # 1  /* compute the softmax over all C for each H, W, N */
 
 @testset "cudnn/softmax" begin
     ax,ay = randn(Float32,10,10),randn(Float32,10,10)
     cx,cy = CuArray.((ax,ay))
 
-    function softmaxtest(
-        ; alpha=1,
+    function softmaxtest(;
+        alpha=1,
         beta=0,
         mode=CUDNN_SOFTMAX_MODE_INSTANCE,
         algo=CUDNN_SOFTMAX_FAST
@@ -35,16 +32,16 @@ using CUDA.CUDNN:
         end
         y0 = alpha * y
         y1 = y0 .+ beta * ay
-        ((y0 ≈ cudnnSoftmaxForward(cx1; algo, mode, alpha) |> Array) &&
-         (y1 ≈ cudnnSoftmaxForward!(copy(cy1), cx1; algo, mode, alpha, beta) |> Array))
+        @test y0 ≈ cudnnSoftmaxForward(cx1; algo, mode, alpha) |> Array
+        @test y1 ≈ cudnnSoftmaxForward!(copy(cy1), cx1; algo, mode, alpha, beta) |> Array
     end
 
-    @test softmaxtest()
-    @test softmaxtest(alpha=2)
-    @test softmaxtest(beta=2)
-    @test softmaxtest(mode=CUDNN_SOFTMAX_MODE_INSTANCE)
-    @test softmaxtest(mode=CUDNN_SOFTMAX_MODE_CHANNEL)
-    @test softmaxtest(algo=CUDNN_SOFTMAX_FAST)
-    @test softmaxtest(algo=CUDNN_SOFTMAX_ACCURATE)
-    @test softmaxtest(algo=CUDNN_SOFTMAX_LOG)
+    softmaxtest()
+    softmaxtest(alpha=2)
+    softmaxtest(beta=2)
+    softmaxtest(mode=CUDNN_SOFTMAX_MODE_INSTANCE)
+    softmaxtest(mode=CUDNN_SOFTMAX_MODE_CHANNEL)
+    softmaxtest(algo=CUDNN_SOFTMAX_FAST)
+    softmaxtest(algo=CUDNN_SOFTMAX_ACCURATE)
+    softmaxtest(algo=CUDNN_SOFTMAX_LOG)
 end

--- a/test/cudnn/tensor.jl
+++ b/test/cudnn/tensor.jl
@@ -1,6 +1,4 @@
-using Test, CUDA
-using Base: unsafe_convert
-using CUDA.CUDNN: 
+using CUDA.CUDNN:
     cudnnTensorDescriptor,
     cudnnCreateTensorDescriptor,
     cudnnFilterDescriptor,
@@ -8,12 +6,9 @@ using CUDA.CUDNN:
     cudnnDataType_t,
     CUDNN_TENSOR_NCHW,
     CUDNN_STATUS_SUCCESS,
-    @retry_reclaim,
-    handle
-
+    @retry_reclaim
 
 @testset "cudnn/tensor" begin
-
     x = CUDA.rand(1,1,1,2)
 
     TD = cudnnTensorDescriptor
@@ -24,16 +19,15 @@ using CUDA.CUDNN:
     @test TD(CUDNN_TENSOR_NCHW, DT(eltype(x)), Cint(ndims(x)), Cint[reverse(size(x))...]) isa TD
     td = TD(x)
     @test TD(td.ptr) isa TD
-    @test unsafe_convert(Ptr, TD(td.ptr)) isa Ptr
+    @test Base.unsafe_convert(Ptr, TD(td.ptr)) isa Ptr
 
     @test FD(x) isa FD
     @test FD(DT(eltype(x)),CUDNN_TENSOR_NCHW,Cint(ndims(x)),Cint[reverse(size(x))...]) isa FD
     fd = FD(x)
     @test FD(fd.ptr) isa FD
-    @test unsafe_convert(Ptr, FD(fd.ptr)) isa Ptr
+    @test Base.unsafe_convert(Ptr, FD(fd.ptr)) isa Ptr
 
     @test DT(Float32) isa cudnnDataType_t
 
     @test (@retry_reclaim(x->(x!==CUDNN_STATUS_SUCCESS),cudnnCreateTensorDescriptor(Ref{Ptr{Cvoid}}(C_NULL)))) isa Nothing
-
 end


### PR DESCRIPTION
Test failures were pretty vague now, with the `@test` on the outside:

```
cudnn/convolution: Test Failed at /var/lib/buildkite-agent/builds/rtx2080-hydor-elis-ugent-be/julialang/cuda-dot-jl/test/cudnn/convolution.jl:167
  Expression: convtest(bias = cb, group = 2)
```

This should reveal which comparison exactly fails. Meanwhile, I've also seen:

```
Error in testset cudnn/convolution:
Error During Test at /home/tim/Julia/pkg/CUDA/test/cudnn/convolution.jl:142
  Test threw exception
  Expression: ay1 ≈ cudnnConvolutionForward(cw0, cx; bias, activation, mode, padding, stride, dilation, group, mathType, reorderType, alpha) |> Array
  CUDNNError: CUDNN_STATUS_BAD_PARAM (code 3)
  Stacktrace:
    [3] cudnnConvolutionForward(handle::Ptr{Nothing}, alpha::Base.RefValue{Float32}, xDesc::CUDA.CUDNN.cudnnTensorDescriptor, x::CuArray{Float32, 4}, wDesc::CUDA.CUDNN.cudnnFilterDescriptor, w::CuArray{Float32, 4}, convDesc::cudnnConvolutionDescriptor, algo::cudnnConvolutionFwdAlgo_t, workSpace::CuArray{UInt8, 1}, workSpaceSizeInBytes::Int64, beta::Base.RefValue{Float32}, yDesc::CUDA.CUDNN.cudnnTensorDescriptor, y::CuArray{Float32, 4})
      @ CUDA.CUDNN ~/Julia/pkg/CUDA/lib/utils/call.jl:26
    [4] macro expansion
      @ ~/Julia/pkg/CUDA/lib/cudnn/convolution.jl:105 [inlined]
    [5] macro expansion
      @ ~/Julia/pkg/CUDA/lib/utils/call.jl:144 [inlined]
    [6] cudnnConvolutionForwardAD(w::CuArray{Float32, 4}, x::CuArray{Float32, 4}, bias::Nothing, z::Nothing; y::CuArray{Float32, 4}, activation::cudnnActivationMode_t, convDesc::cudnnConvolutionDescriptor, wDesc::CUDA.CUDNN.cudnnFilterDescriptor, xDesc::CUDA.CUDNN.cudnnTensorDescriptor, yDesc::CUDA.CUDNN.cudnnTensorDescriptor, zDesc::Nothing, biasDesc::Nothing, alpha::Base.RefValue{Float32}, beta::Base.RefValue{Float32}, dw::Base.RefValue{Any}, dx::Base.RefValue{Any}, dz::Base.RefValue{Any}, dbias::Base.RefValue{Any}, dready::Base.RefValue{Bool})
      @ CUDA.CUDNN ~/Julia/pkg/CUDA/lib/cudnn/convolution.jl:103
    [7] cudnnConvolutionForwardWithDefaults(w::CuArray{Float32, 4}, x::CuArray{Float32, 4}; padding::Int64, stride::Int64, dilation::Int64, mode::cudnnConvolutionMode_t, mathType::cudnnMathType_t, reorderType::cudnnReorderType_t, group::Int64, format::cudnnTensorFormat_t, convDesc::cudnnConvolutionDescriptor, xDesc::CUDA.CUDNN.cudnnTensorDescriptor, wDesc::CUDA.CUDNN.cudnnFilterDescriptor, y::CuArray{Float32, 4}, yDesc::CUDA.CUDNN.cudnnTensorDescriptor, alpha::Int64, beta::Int64, bias::Nothing, z::Nothing, biasDesc::Nothing, zDesc::Nothing, activation::cudnnActivationMode_t, dw::Base.RefValue{Any}, dx::Base.RefValue{Any}, dz::Base.RefValue{Any}, dbias::Base.RefValue{Any})
      @ CUDA.CUDNN ~/Julia/pkg/CUDA/lib/cudnn/convolution.jl:96
    [8] #cudnnConvolutionForward#104
      @ ~/Julia/pkg/CUDA/lib/cudnn/convolution.jl:50 [inlined]
    [9] (::var"#convtest#6"{var"#convtest#4#7"{CuArray{Float32, 4}, CuArray{Float32, 4}, Array{Float32, 4}, Array{Float32, 4}, DataType}, CuArray{Float32, 4}})(; blendz::Bool, bias::Nothing, activation::cudnnActivationMode_t, mode::cudnnConvolutionMode_t, padding::Int64, stride::Int64, dilation::Int64, group::Int64, dataType::Type, mathType::cudnnMathType_t, reorderType::cudnnReorderType_t, alpha::Int64, beta::Int64)
      @ Main ~/Julia/pkg/CUDA/test/cudnn/convolution.jl:142
   [10] macro expansion
      @ ~/Julia/pkg/CUDA/test/cudnn/convolution.jl:161 [inlined]

Error in testset cudnn/convolution:
Error During Test at /home/tim/Julia/pkg/CUDA/test/cudnn/convolution.jl:145
  Test threw exception
  Expression: ay1 ≈ cudnnConvolutionForward(cw0, cx, d; bias, activation, alpha) |> Array
  CUDNNError: CUDNN_STATUS_BAD_PARAM (code 3)
  Stacktrace:
    [3] cudnnConvolutionForward(handle::Ptr{Nothing}, alpha::Base.RefValue{Float32}, xDesc::CUDA.CUDNN.cudnnTensorDescriptor, x::CuArray{Float32, 4}, wDesc::CUDA.CUDNN.cudnnFilterDescriptor, w::CuArray{Float32, 4}, convDesc::cudnnConvolutionDescriptor, algo::cudnnConvolutionFwdAlgo_t, workSpace::CuArray{UInt8, 1}, workSpaceSizeInBytes::Int64, beta::Base.RefValue{Float32}, yDesc::CUDA.CUDNN.cudnnTensorDescriptor, y::CuArray{Float32, 4})
      @ CUDA.CUDNN ~/Julia/pkg/CUDA/lib/utils/call.jl:26
    [4] macro expansion
      @ ~/Julia/pkg/CUDA/lib/cudnn/convolution.jl:105 [inlined]
    [5] macro expansion
      @ ~/Julia/pkg/CUDA/lib/utils/call.jl:144 [inlined]
    [6] cudnnConvolutionForwardAD(w::CuArray{Float32, 4}, x::CuArray{Float32, 4}, bias::Nothing, z::Nothing; y::CuArray{Float32, 4}, activation::cudnnActivationMode_t, convDesc::cudnnConvolutionDescriptor, wDesc::CUDA.CUDNN.cudnnFilterDescriptor, xDesc::CUDA.CUDNN.cudnnTensorDescriptor, yDesc::CUDA.CUDNN.cudnnTensorDescriptor, zDesc::Nothing, biasDesc::Nothing, alpha::Base.RefValue{Float32}, beta::Base.RefValue{Float32}, dw::Base.RefValue{Any}, dx::Base.RefValue{Any}, dz::Base.RefValue{Any}, dbias::Base.RefValue{Any}, dready::Base.RefValue{Bool})
      @ CUDA.CUDNN ~/Julia/pkg/CUDA/lib/cudnn/convolution.jl:103
    [7] cudnnConvolutionForwardWithDefaults(w::CuArray{Float32, 4}, x::CuArray{Float32, 4}; padding::Int64, stride::Int64, dilation::Int64, mode::cudnnConvolutionMode_t, mathType::cudnnMathType_t, reorderType::cudnnReorderType_t, group::Int64, format::cudnnTensorFormat_t, convDesc::cudnnConvolutionDescriptor, xDesc::CUDA.CUDNN.cudnnTensorDescriptor, wDesc::CUDA.CUDNN.cudnnFilterDescriptor, y::CuArray{Float32, 4}, yDesc::CUDA.CUDNN.cudnnTensorDescriptor, alpha::Int64, beta::Int64, bias::Nothing, z::Nothing, biasDesc::Nothing, zDesc::Nothing, activation::cudnnActivationMode_t, dw::Base.RefValue{Any}, dx::Base.RefValue{Any}, dz::Base.RefValue{Any}, dbias::Base.RefValue{Any})
      @ CUDA.CUDNN ~/Julia/pkg/CUDA/lib/cudnn/convolution.jl:96
    [8] #cudnnConvolutionForward#106
      @ ~/Julia/pkg/CUDA/lib/cudnn/convolution.jl:52 [inlined]
    [9] (::var"#convtest#6"{var"#convtest#4#7"{CuArray{Float32, 4}, CuArray{Float32, 4}, Array{Float32, 4}, Array{Float32, 4}, DataType}, CuArray{Float32, 4}})(; blendz::Bool, bias::Nothing, activation::cudnnActivationMode_t, mode::cudnnConvolutionMode_t, padding::Int64, stride::Int64, dilation::Int64, group::Int64, dataType::Type, mathType::cudnnMathType_t, reorderType::cudnnReorderType_t, alpha::Int64, beta::Int64)
      @ Main ~/Julia/pkg/CUDA/test/cudnn/convolution.jl:145
   [10] macro expansion
      @ ~/Julia/pkg/CUDA/test/cudnn/convolution.jl:161 [inlined]

Error in testset cudnn/convolution:
Error During Test at /home/tim/Julia/pkg/CUDA/test/cudnn/convolution.jl:146
  Test threw exception
  Expression: ay2 ≈ cudnnConvolutionForward!(cy0, cw0, cx; z = cz0, bias, activation, mode, padding, stride, dilation, group, mathType, reorderType, alpha, beta) |> Array
  CUDNNError: CUDNN_STATUS_BAD_PARAM (code 3)
  Stacktrace:
    [3] cudnnConvolutionForward(handle::Ptr{Nothing}, alpha::Base.RefValue{Float32}, xDesc::CUDA.CUDNN.cudnnTensorDescriptor, x::CuArray{Float32, 4}, wDesc::CUDA.CUDNN.cudnnFilterDescriptor, w::CuArray{Float32, 4}, convDesc::cudnnConvolutionDescriptor, algo::cudnnConvolutionFwdAlgo_t, workSpace::CuArray{UInt8, 1}, workSpaceSizeInBytes::Int64, beta::Base.RefValue{Float32}, yDesc::CUDA.CUDNN.cudnnTensorDescriptor, y::CuArray{Float32, 4})
      @ CUDA.CUDNN ~/Julia/pkg/CUDA/lib/utils/call.jl:26
    [4] macro expansion
      @ ~/Julia/pkg/CUDA/lib/cudnn/convolution.jl:105 [inlined]
    [5] macro expansion
      @ ~/Julia/pkg/CUDA/lib/utils/call.jl:144 [inlined]
    [6] cudnnConvolutionForwardAD(w::CuArray{Float32, 4}, x::CuArray{Float32, 4}, bias::Nothing, z::CuArray{Float32, 4}; y::CuArray{Float32, 4}, activation::cudnnActivationMode_t, convDesc::cudnnConvolutionDescriptor, wDesc::CUDA.CUDNN.cudnnFilterDescriptor, xDesc::CUDA.CUDNN.cudnnTensorDescriptor, yDesc::CUDA.CUDNN.cudnnTensorDescriptor, zDesc::CUDA.CUDNN.cudnnTensorDescriptor, biasDesc::Nothing, alpha::Base.RefValue{Float32}, beta::Base.RefValue{Float32}, dw::Base.RefValue{Any}, dx::Base.RefValue{Any}, dz::Base.RefValue{Any}, dbias::Base.RefValue{Any}, dready::Base.RefValue{Bool})
      @ CUDA.CUDNN ~/Julia/pkg/CUDA/lib/cudnn/convolution.jl:103
    [7] #cudnnConvolutionForwardWithDefaults#108
      @ ~/Julia/pkg/CUDA/lib/cudnn/convolution.jl:96 [inlined]
    [8] #cudnnConvolutionForward!#105
      @ ~/Julia/pkg/CUDA/lib/cudnn/convolution.jl:51 [inlined]
    [9] (::var"#convtest#6"{var"#convtest#4#7"{CuArray{Float32, 4}, CuArray{Float32, 4}, Array{Float32, 4}, Array{Float32, 4}, DataType}, CuArray{Float32, 4}})(; blendz::Bool, bias::Nothing, activation::cudnnActivationMode_t, mode::cudnnConvolutionMode_t, padding::Int64, stride::Int64, dilation::Int64, group::Int64, dataType::Type, mathType::cudnnMathType_t, reorderType::cudnnReorderType_t, alpha::Int64, beta::Int64)
      @ Main ~/Julia/pkg/CUDA/test/cudnn/convolution.jl:146
   [10] macro expansion
      @ ~/Julia/pkg/CUDA/test/cudnn/convolution.jl:161 [inlined]

Error in testset cudnn/convolution:
Error During Test at /home/tim/Julia/pkg/CUDA/test/cudnn/convolution.jl:149
  Test threw exception
  Expression: ay2 ≈ cudnnConvolutionForward!(cy1, cw0, cx, d; z = cz1, bias, activation, alpha, beta) |> Array
  CUDNNError: CUDNN_STATUS_BAD_PARAM (code 3)
  Stacktrace:
    [3] cudnnConvolutionForward(handle::Ptr{Nothing}, alpha::Base.RefValue{Float32}, xDesc::CUDA.CUDNN.cudnnTensorDescriptor, x::CuArray{Float32, 4}, wDesc::CUDA.CUDNN.cudnnFilterDescriptor, w::CuArray{Float32, 4}, convDesc::cudnnConvolutionDescriptor, algo::cudnnConvolutionFwdAlgo_t, workSpace::CuArray{UInt8, 1}, workSpaceSizeInBytes::Int64, beta::Base.RefValue{Float32}, yDesc::CUDA.CUDNN.cudnnTensorDescriptor, y::CuArray{Float32, 4})
      @ CUDA.CUDNN ~/Julia/pkg/CUDA/lib/utils/call.jl:26
    [4] macro expansion
      @ ~/Julia/pkg/CUDA/lib/cudnn/convolution.jl:105 [inlined]
    [5] macro expansion
      @ ~/Julia/pkg/CUDA/lib/utils/call.jl:144 [inlined]
    [6] cudnnConvolutionForwardAD(w::CuArray{Float32, 4}, x::CuArray{Float32, 4}, bias::Nothing, z::CuArray{Float32, 4}; y::CuArray{Float32, 4}, activation::cudnnActivationMode_t, convDesc::cudnnConvolutionDescriptor, wDesc::CUDA.CUDNN.cudnnFilterDescriptor, xDesc::CUDA.CUDNN.cudnnTensorDescriptor, yDesc::CUDA.CUDNN.cudnnTensorDescriptor, zDesc::CUDA.CUDNN.cudnnTensorDescriptor, biasDesc::Nothing, alpha::Base.RefValue{Float32}, beta::Base.RefValue{Float32}, dw::Base.RefValue{Any}, dx::Base.RefValue{Any}, dz::Base.RefValue{Any}, dbias::Base.RefValue{Any}, dready::Base.RefValue{Bool})
      @ CUDA.CUDNN ~/Julia/pkg/CUDA/lib/cudnn/convolution.jl:103
    [7] #cudnnConvolutionForwardWithDefaults#108
      @ ~/Julia/pkg/CUDA/lib/cudnn/convolution.jl:96 [inlined]
    [8] #cudnnConvolutionForward!#107
      @ ~/Julia/pkg/CUDA/lib/cudnn/convolution.jl:53 [inlined]
    [9] (::var"#convtest#6"{var"#convtest#4#7"{CuArray{Float32, 4}, CuArray{Float32, 4}, Array{Float32, 4}, Array{Float32, 4}, DataType}, CuArray{Float32, 4}})(; blendz::Bool, bias::Nothing, activation::cudnnActivationMode_t, mode::cudnnConvolutionMode_t, padding::Int64, stride::Int64, dilation::Int64, group::Int64, dataType::Type, mathType::cudnnMathType_t, reorderType::cudnnReorderType_t, alpha::Int64, beta::Int64)
      @ Main ~/Julia/pkg/CUDA/test/cudnn/convolution.jl:149
   [10] macro expansion
      @ ~/Julia/pkg/CUDA/test/cudnn/convolution.jl:161 [inlined]
```

cc @denizyuret; looks like there's still something wrong with the CUDNN convolution wrappers.