### PR TITLE
Flip exception_flag filter! predicate

### DIFF
--- a/src/compiler/execution.jl
+++ b/src/compiler/execution.jl
@@ -355,7 +355,7 @@ function cufunction_link(@nospecialize(job::CompilerJob), compiled)
     # initialize and register the exception flag, if any
     if "exception_flag" in compiled.external_gvars
         create_exceptions!(mod)
-        filter!(isequal("exception_flag"), compiled.external_gvars)
+        filter!(!isequal("exception_flag"), compiled.external_gvars)
     end
 
     return HostKernel{job.source.f,job.source.tt}(ctx, mod, fun)


### PR DESCRIPTION
```
julia> external_gvars = ["exception_flag", "other_flag", "another_flag"]
3-element Vector{String}:
 "exception_flag"
 "other_flag"
 "another_flag"

julia> filter!(isequal("exception_flag"), external_gvars)
1-element Vector{String}:
 "exception_flag"

julia> external_gvars = ["exception_flag", "other_flag", "another_flag"]
3-element Vector{String}:
 "exception_flag"
 "other_flag"
 "another_flag"

julia> filter!(x -> x != "exception_flag", external_gvars)
2-element Vector{String}:
 "other_flag"
 "another_flag"
```

Noticed this while adding other externally initialized global variables. It was very confusing to not see them show up in `external_gvars`.