### PR TITLE
Keep some memory reserved for external allocations.

### DIFF
--- a/src/pool/binned.jl
+++ b/src/pool/binned.jl
@@ -205,7 +205,7 @@ function pool_alloc(dev, bytes)
     end
 
     @pool_timeit "9. try alloc" begin
-      block = actual_alloc(dev, bytes)
+      block = actual_alloc(dev, bytes, true)
     end
   end
 

--- a/src/pool/none.jl
+++ b/src/pool/none.jl
@@ -12,7 +12,7 @@ function pool_alloc(dev, sz)
         end
 
         @pool_timeit "$phase.1 alloc" begin
-            block = actual_alloc(dev, sz)
+            block = actual_alloc(dev, sz, phase==3)
         end
         block === nothing || break
     end

--- a/src/pool/simple.jl
+++ b/src/pool/simple.jl
@@ -94,7 +94,7 @@ function pool_alloc(dev, sz)
 
         @pool_timeit "$phase.4 reclaim + alloc" begin
             pool_reclaim(dev, sz)
-            block = actual_alloc(dev, sz)
+            block = actual_alloc(dev, sz, phase==3)
         end
         block === nothing || break
     end

--- a/src/pool/split.jl
+++ b/src/pool/split.jl
@@ -273,7 +273,7 @@ function pool_alloc(dev, sz)
             pool_reclaim_single(dev, pool_large[dev])
             pool_reclaim_single(dev, pool_small[dev])
         end
-        @pool_timeit "$phase.5b alloc" block = actual_alloc(dev, sz)
+        @pool_timeit "$phase.5b alloc" block = actual_alloc(dev, sz, phase==3)
     end
 
     if block !== nothing


### PR DESCRIPTION
This PR splits the memory limit into a 'soft' and 'hard' limit, where the soft limit tries to keep a chunk of memory available for external libraries like CUDNN or CUBLAS. This should reduce the change of running into bad error situations that are often caused by an OOM but not reported as such. If it isn't possible to stick to the soft memory limit (i.e, after calling the GC a couple of times) we'll use the hard limit which is allowed to eat into the memory reserve up to any user-imposed memory limit.