### PR TITLE
Specialize Base.to_index for AnyCuArray{Bool}

### DIFF
--- a/src/indexing.jl
+++ b/src/indexing.jl
@@ -8,6 +8,8 @@ using Base.Cartesian
 
 ## logical indexing
 
+# TODO: A more performant solution is to remove this specialization and write a custom
+# kernel in GPUArrays.jl for `setindex!` when the indices are `::LogicalIndex`.
 Base.to_index(I::AnyCuArray{Bool}) = findall(I)
 
 Base.getindex(xs::AnyCuArray, bools::AbstractArray{Bool}) = getindex(xs, CuArray(bools))

--- a/src/indexing.jl
+++ b/src/indexing.jl
@@ -8,6 +8,8 @@ using Base.Cartesian
 
 ## logical indexing
 
+Base.to_index(I::AnyCuArray{Bool}) = findall(I)
+
 Base.getindex(xs::AnyCuArray, bools::AbstractArray{Bool}) = getindex(xs, CuArray(bools))
 
 function Base.getindex(xs::AnyCuArray{T}, bools::AnyCuArray{Bool}) where {T}

--- a/test/array.jl
+++ b/test/array.jl
@@ -253,6 +253,13 @@ end
   @test testf(x -> filter(y->y .> 0.5, x), rand(2))
   @test testf(x -> filter(y->y .> 0.5, x), rand(2,2))
   @test testf(x -> filter(y->y .> 0.5, x), rand(2,2,2))
+
+  A = CuArray([1 2; 3 4; 5 6])
+  @test Array(A[CuArray([true, false, true]), :]) == [1 2; 5 6]
+
+  x = CuArray([0.0, 0.25, 0.5, 1.0])
+  x[x .> 0] .= 0
+  @test Array(x) == zeros(4)
 end
 
 @testset "reverse" begin


### PR DESCRIPTION
Fixes #106 and fixes #131. It is not he most performant solution as discussed in #131.

Probably a better solution would be to revert this `Base.to_index` specialization, check if there are `LogicalIndex`es among the results of `to_indicices` in `setindex!(::CuArray, ...)`, and have a specialized kernel for `_setindex!` and `LogicalIndex` in GPUArrays.jl, but I guess that can be improved later.

@maleadt 