### PR TITLE
Streamline use of retry_reclaim.

### DIFF
--- a/lib/cublas/error.jl
+++ b/lib/cublas/error.jl
@@ -51,13 +51,20 @@ function initialize_api()
     CUDA.initialize_cuda_context()
 end
 
-macro check(ex)
+macro check(ex, errs...)
+    check = :(isequal(err, CUBLAS_STATUS_ALLOC_FAILED))
+    for err in errs
+        check = :($check || isequal(err, $(esc(err))))
+    end
+
     quote
-        res = @retry_reclaim isequal(CUBLAS_STATUS_ALLOC_FAILED) $(esc(ex))
-        if res != CUBLAS_STATUS_SUCCESS
+        res = @retry_reclaim err->$check $(esc(ex))
+        if res == CUBLAS_STATUS_ALLOC_FAILED
+            throw(OutOfGPUMemoryError())
+        elseif res != CUBLAS_STATUS_SUCCESS
             throw_api_error(res)
         end
 
-        return
+        nothing
     end
 end

--- a/lib/cublas/wrappers.jl
+++ b/lib/cublas/wrappers.jl
@@ -5,25 +5,13 @@
 
 function cublasCreate()
   handle_ref = Ref{cublasHandle_t}()
-  res = @retry_reclaim err->isequal(err, CUBLAS_STATUS_ALLOC_FAILED) ||
-                            isequal(err, CUBLAS_STATUS_NOT_INITIALIZED) begin
-    unsafe_cublasCreate_v2(handle_ref)
-  end
-  if res != CUBLAS_STATUS_SUCCESS
-    throw_api_error(res)
-  end
+  @check unsafe_cublasCreate_v2(handle_ref) CUBLAS_STATUS_NOT_INITIALIZED
   handle_ref[]
 end
 
 function cublasXtCreate()
   handle_ref = Ref{cublasXtHandle_t}()
-  res = @retry_reclaim err->isequal(err, CUBLAS_STATUS_ALLOC_FAILED) ||
-                            isequal(err, CUBLAS_STATUS_NOT_INITIALIZED) begin
-    unsafe_cublasXtCreate(handle_ref)
-  end
-  if res != CUBLAS_STATUS_SUCCESS
-    throw_api_error(res)
-  end
+  @check unsafe_cublasXtCreate(handle_ref) CUBLAS_STATUS_NOT_INITIALIZED
   handle_ref[]
 end
 

--- a/lib/cudadrv/error.jl
+++ b/lib/cudadrv/error.jl
@@ -92,6 +92,6 @@ macro check(ex)
             throw_api_error(res)
         end
 
-        return
+        nothing
     end
 end

--- a/lib/cudnn/base.jl
+++ b/lib/cudnn/base.jl
@@ -1,13 +1,6 @@
 function cudnnCreate()
     handle_ref = Ref{cudnnHandle_t}()
-    res = @retry_reclaim err->isequal(err, CUDNN_STATUS_ALLOC_FAILED) ||
-                              isequal(err, CUDNN_STATUS_NOT_INITIALIZED) ||
-                              isequal(err, CUDNN_STATUS_INTERNAL_ERROR) begin
-        unsafe_cudnnCreate(handle_ref)
-    end
-    if res != CUDNN_STATUS_SUCCESS
-         throw_api_error(res)
-    end
+    @check unsafe_cudnnCreate(handle_ref) CUDNN_STATUS_NOT_INITIALIZED CUDNN_STATUS_INTERNAL_ERROR
     return handle_ref[]
 end
 

--- a/lib/cudnn/dropout.jl
+++ b/lib/cudnn/dropout.jl
@@ -41,8 +41,7 @@ function cudnnDropoutForwardWithDefaults(
         dropout, states, seed = cudnnGetDropoutDescriptor(dropoutDesc)
         hstate = cudnnDropoutState[handle()]
         @assert states == pointer(hstate)
-        @retry_reclaim(isequal(CUDNN_STATUS_ALLOC_FAILED),
-                       cudnnSetDropoutDescriptor(dropoutDesc, handle(), dropout, hstate, sizeof(hstate), cudnnDropoutSeed[]))
+        cudnnSetDropoutDescriptor(dropoutDesc, handle(), dropout, hstate, sizeof(hstate), cudnnDropoutSeed[])
     end
     cudnnDropoutForwardAD(x; xDesc, y, yDesc, dropoutDesc, reserveSpace)
 end
@@ -84,8 +83,7 @@ function cudnnSetDropoutDescriptorFromFloat(ptr::cudnnDropoutDescriptor_t, dropo
         cudnnTempSpace(cudnnDropoutGetStatesSize())
     end
     seed = floor(Culonglong,time())
-    @retry_reclaim(isequal(CUDNN_STATUS_ALLOC_FAILED),
-                   cudnnSetDropoutDescriptor(ptr, handle(), Cfloat(dropout), hstate, sizeof(hstate), seed))
+    cudnnSetDropoutDescriptor(ptr, handle(), Cfloat(dropout), hstate, sizeof(hstate), seed)
 end
 
 

--- a/lib/cudnn/error.jl
+++ b/lib/cudnn/error.jl
@@ -23,13 +23,20 @@ function initialize_api()
     CUDA.initialize_cuda_context()
 end
 
-macro check(ex)
+macro check(ex, errs...)
+    check = :(isequal(err, CUDNN_STATUS_ALLOC_FAILED))
+    for err in errs
+        check = :($check || isequal(err, $(esc(err))))
+    end
+
     quote
-        res = @retry_reclaim isequal(CUDNN_STATUS_ALLOC_FAILED) $(esc(ex))
-        if res != CUDNN_STATUS_SUCCESS
+        res = @retry_reclaim err->$check $(esc(ex))
+        if res == CUDNN_STATUS_ALLOC_FAILED
+            throw(OutOfGPUMemoryError())
+        elseif res != CUDNN_STATUS_SUCCESS
             throw_api_error(res)
         end
 
-        return
+        nothing
     end
 end

--- a/lib/cufft/CUFFT.jl
+++ b/lib/cufft/CUFFT.jl
@@ -4,7 +4,7 @@ using ..APIUtils
 
 using ..CUDA
 using ..CUDA: CUstream, cuComplex, cuDoubleComplex, libraryPropertyType
-import ..CUDA: libcufft, unsafe_free!, @retry_reclaim
+using ..CUDA: libcufft, unsafe_free!, @retry_reclaim
 
 using CEnum
 

--- a/lib/cufft/fft.jl
+++ b/lib/cufft/fft.jl
@@ -24,7 +24,7 @@ Base.unsafe_convert(::Type{cufftHandle}, p::CuFFTPlan) = p.handle
 # for some reason, cufftHandle is an integer and not a pointer...
 Base.convert(::Type{cufftHandle}, p::CuFFTPlan) = Base.unsafe_convert(cufftHandle, p)
 
-function unsafe_free!(plan::CuFFTPlan)
+function CUDA.unsafe_free!(plan::CuFFTPlan)
     cufftDestroy(plan)
     unsafe_free!(plan.workarea)
 end

--- a/lib/cupti/CUPTI.jl
+++ b/lib/cupti/CUPTI.jl
@@ -3,7 +3,7 @@ module CUPTI
 using ..APIUtils
 
 using ..CUDA
-using ..CUDA: libcupti
+using ..CUDA: libcupti, @retry_reclaim
 using ..CUDA: CUuuid, CUcontext, CUstream, CUdevice, CUdevice_attribute,
               CUgraph, CUgraphNode, CUgraphNodeType, CUgraphExec, CUaccessPolicyWindow
 

--- a/lib/curand/random.jl
+++ b/lib/curand/random.jl
@@ -37,13 +37,7 @@ Base.unsafe_convert(::Type{curandGenerator_t}, rng::RNG) = rng.handle
 function Random.seed!(rng::RNG, seed=Base.rand(UInt64), offset=0)
     curandSetPseudoRandomGeneratorSeed(rng, seed)
     curandSetGeneratorOffset(rng, offset)
-    res = @retry_reclaim err->isequal(err, CURAND_STATUS_ALLOCATION_FAILED) ||
-                              isequal(err, CURAND_STATUS_PREEXISTING_FAILURE) begin
-        unsafe_curandGenerateSeeds(rng)
-    end
-    if res != CURAND_STATUS_SUCCESS
-        throw_api_error(res)
-    end
+    @check unsafe_curandGenerateSeeds(rng) CURAND_STATUS_PREEXISTING_FAILURE
     return
 end
 

--- a/lib/curand/wrappers.jl
+++ b/lib/curand/wrappers.jl
@@ -2,13 +2,7 @@
 
 function curandCreateGenerator(typ)
   handle_ref = Ref{curandGenerator_t}()
-  res = @retry_reclaim err->isequal(err, CURAND_STATUS_ALLOCATION_FAILED) ||
-                            isequal(err, CURAND_STATUS_INITIALIZATION_FAILED) begin
-    unsafe_curandCreateGenerator(handle_ref, typ)
-  end
-  if res != CURAND_STATUS_SUCCESS
-    throw_api_error(res)
-  end
+  @check unsafe_curandCreateGenerator(handle_ref, typ) CURAND_STATUS_INITIALIZATION_FAILED
   handle_ref[]
 end
 

--- a/lib/cusolver/wrappers.jl
+++ b/lib/cusolver/wrappers.jl
@@ -24,13 +24,7 @@ using ..CUSPARSE: CuSparseMatrixCSR, CuSparseMatrixCSC,
 
 function cusolverSpCreate()
   handle_ref = Ref{cusolverSpHandle_t}()
-  res = @retry_reclaim err->isequal(err, CUSOLVER_STATUS_ALLOC_FAILED) ||
-                            isequal(err, CUSOLVER_STATUS_NOT_INITIALIZED) begin
-    unsafe_cusolverSpCreate(handle_ref)
-  end
-  if res != CUSOLVER_STATUS_SUCCESS
-    throw_api_error(res)
-  end
+  @check unsafe_cusolverSpCreate(handle_ref) CUSOLVER_STATUS_NOT_INITIALIZED
   return handle_ref[]
 end
 
@@ -256,13 +250,7 @@ using ..CUBLAS: unsafe_batch
 
 function cusolverDnCreate()
   handle_ref = Ref{cusolverDnHandle_t}()
-  res = @retry_reclaim err->isequal(err, CUSOLVER_STATUS_ALLOC_FAILED) ||
-                            isequal(err, CUSOLVER_STATUS_NOT_INITIALIZED) begin
-    unsafe_cusolverDnCreate(handle_ref)
-  end
-  if res != CUSOLVER_STATUS_SUCCESS
-    throw_api_error(res)
-  end
+  @check unsafe_cusolverDnCreate(handle_ref) CUSOLVER_STATUS_NOT_INITIALIZED
   return handle_ref[]
 end
 

--- a/lib/cusparse/error.jl
+++ b/lib/cusparse/error.jl
@@ -25,13 +25,20 @@ function initialize_api()
     CUDA.initialize_cuda_context()
 end
 
-macro check(ex)
+macro check(ex, errs...)
+    check = :(isequal(err, CUSPARSE_STATUS_ALLOC_FAILED))
+    for err in errs
+        check = :($check || isequal(err, $(esc(err))))
+    end
+
     quote
-        res = @retry_reclaim isequal(CUSPARSE_STATUS_ALLOC_FAILED) $(esc(ex))
-        if res != CUSPARSE_STATUS_SUCCESS
+        res = @retry_reclaim err->$check $(esc(ex))
+        if res == CUSPARSE_STATUS_ALLOC_FAILED
+            throw(OutOfGPUMemoryError())
+        elseif res != CUSPARSE_STATUS_SUCCESS
             throw_api_error(res)
         end
 
-        return
+        nothing
     end
 end

--- a/lib/cusparse/management.jl
+++ b/lib/cusparse/management.jl
@@ -2,13 +2,7 @@
 
 function cusparseCreate()
     handle = Ref{cusparseHandle_t}()
-    res = @retry_reclaim err->isequal(err, CUSPARSE_STATUS_ALLOC_FAILED) ||
-                              isequal(err, CUSPARSE_STATUS_NOT_INITIALIZED) begin
-        unsafe_cusparseCreate(handle)
-    end
-    if res != CUSPARSE_STATUS_SUCCESS
-         throw_api_error(res)
-    end
+    @check unsafe_cusparseCreate(handle) CUSPARSE_STATUS_NOT_INITIALIZED
     handle[]
 end
 

--- a/lib/cutensor/error.jl
+++ b/lib/cutensor/error.jl
@@ -59,13 +59,20 @@ function initialize_api()
     CUDA.initialize_cuda_context()
 end
 
-macro check(ex)
+macro check(ex, errs...)
+    check = :(isequal(err, CUTENSOR_STATUS_ALLOC_FAILED))
+    for err in errs
+        check = :($check || isequal(err, $(esc(err))))
+    end
+
     quote
-        res = @retry_reclaim isequal(CUTENSOR_STATUS_ALLOC_FAILED) $(esc(ex))
-        if res != CUTENSOR_STATUS_SUCCESS
+        res = @retry_reclaim err->$check $(esc(ex))
+        if res == CUTENSOR_STATUS_ALLOC_FAILED
+            throw(OutOfGPUMemoryError())
+        elseif res != CUTENSOR_STATUS_SUCCESS
             throw_api_error(res)
         end
 
-        return
+        nothing
     end
 end

--- a/lib/nvml/error.jl
+++ b/lib/nvml/error.jl
@@ -40,6 +40,6 @@ macro check(ex)
             throw_api_error(res)
         end
 
-        return
+        nothing
     end
 end

--- a/src/CUDA.jl
+++ b/src/CUDA.jl
@@ -45,6 +45,8 @@ include("device/llvm.jl")
 include("device/runtime.jl")
 include("device/texture.jl")
 
+include("pool.jl")
+
 # compiler libraries
 include("../lib/cupti/CUPTI.jl")
 include("../lib/nvtx/NVTX.jl")
@@ -57,7 +59,6 @@ include("compiler/exceptions.jl")
 include("compiler/reflection.jl")
 
 # array abstraction
-include("pool.jl")
 include("array.jl")
 include("gpuarrays.jl")
 include("utilities.jl")

--- a/src/pool.jl
+++ b/src/pool.jl
@@ -295,10 +295,16 @@ handle properly.
 """
 struct OutOfGPUMemoryError <: Exception
   sz::Int
+
+  OutOfGPUMemoryError(sz::Integer=0) = new(sz)
 end
 
 function Base.showerror(io::IO, err::OutOfGPUMemoryError)
-    println(io, "Out of GPU memory trying to allocate $(Base.format_bytes(err.sz))")
+    print(io, "Out of GPU memory")
+    if err.sz > 0
+      print(io, " trying to allocate $(Base.format_bytes(err.sz))")
+    end
+    println(io)
     memory_status(io)
 end
 


### PR DESCRIPTION
Try to throw OutOfGPUMemoryError more often, and reuse the check macro. Should result in less confusing error messages as seen by @jonathan-laurent or in https://github.com/JuliaGPU/CUDA.jl/issues/706#issuecomment-778264044.