### PR TITLE
Use a memory pool per device.

### DIFF
--- a/lib/cudadrv/pool.jl
+++ b/lib/cudadrv/pool.jl
@@ -50,7 +50,7 @@ function memory_pool(dev::CuDevice)
     handle_ref = Ref{CUmemoryPool}()
     cuDeviceGetMemPool(handle_ref, dev)
 
-    ctx = CuCurrentContext()
+    ctx = CuCurrentContext()::CuContext
     CuMemoryPool(handle_ref[], ctx)
 end
 

--- a/lib/cudadrv/stream.jl
+++ b/lib/cudadrv/stream.jl
@@ -32,7 +32,7 @@ function CuStream(; flags::CUstream_flags=STREAM_DEFAULT,
         cuStreamCreateWithPriority(handle_ref, flags, priority)
     end
 
-    ctx = CuCurrentContext()
+    ctx = CuCurrentContext()::CuContext
     obj = CuStream(handle_ref[], ctx)
     finalizer(unsafe_destroy!, obj)
     return obj

--- a/lib/cudnn/CUDNN.jl
+++ b/lib/cudnn/CUDNN.jl
@@ -118,17 +118,17 @@ function __init__()
     end
 end
 
-function log_message(sev, udata, dbg_ptr, cstr)
+function log_message(sev, udata, dbg_ptr, ptr)
     # "Each line of this message is terminated by \0, and the end of the message is
     # terminated by \0\0"
     len = 0
     while true
-        if unsafe_load(cstr, len+1) == '\0' && unsafe_load(cstr, len+2)
+        if unsafe_load(ptr, len+1) == '\0' && unsafe_load(ptr, len+2) == '\0'
             break
         end
         len += 1
     end
-    str = unsafe_string(cstr, len)
+    str = unsafe_string(ptr, len)
     lines = split(str, '\0')
     msg = join(str, '\n')
 
@@ -143,7 +143,7 @@ function __runtime_init__()
     # FIXME: this doesn't work, and the mask remains 0 (as observed with cudnnGetCallback)
     if isdebug(:init, CUDNN)
         callback = @cfunction(log_message, Nothing,
-                              (cudnnSeverity_t, Ptr{Cvoid}, Ptr{cudnnDebug_t}, Cstring))
+                              (cudnnSeverity_t, Ptr{Cvoid}, Ptr{cudnnDebug_t}, Ptr{UInt8}))
         cudnnSetCallback(typemax(UInt32), C_NULL, callback)
     end
 end

--- a/src/pool.jl
+++ b/src/pool.jl
@@ -3,6 +3,7 @@
 using Printf
 using Logging
 using TimerOutputs
+using DataStructures
 
 include("pool/utils.jl")
 using .PoolUtils
@@ -64,9 +65,6 @@ end
 const usage_limit = PerDevice{Int}() do dev
   if haskey(ENV, "JULIA_CUDA_MEMORY_LIMIT")
     parse(Int, ENV["JULIA_CUDA_MEMORY_LIMIT"])
-  elseif haskey(ENV, "CUARRAYS_MEMORY_LIMIT")
-    Base.depwarn("The CUARRAYS_MEMORY_LIMIT environment flag is deprecated, please use JULIA_CUDA_MEMORY_LIMIT instead.", :__init_pool__)
-    parse(Int, ENV["CUARRAYS_MEMORY_LIMIT"])
   else
     typemax(Int)
   end
@@ -116,7 +114,8 @@ function hard_limit(dev::CuDevice)
   usage_limit[dev]
 end
 
-function actual_alloc(dev::CuDevice, bytes::Integer, last_resort::Bool=false)
+function actual_alloc(dev::CuDevice, bytes::Integer, last_resort::Bool=false;
+                      stream_ordered::Bool=false)
   buf = @device! dev begin
     # check the memory allocation limit
     if usage[dev][] + bytes > (last_resort ? hard_limit(dev) : soft_limit(dev))
@@ -127,7 +126,7 @@ function actual_alloc(dev::CuDevice, bytes::Integer, last_resort::Bool=false)
     try
       time = Base.@elapsed begin
         @timeit_debug alloc_to "alloc" begin
-          buf = Mem.alloc(Mem.Device, bytes; async=true)
+          buf = Mem.alloc(Mem.Device, bytes; async=true, stream_ordered)
         end
       end
 
@@ -146,7 +145,7 @@ function actual_alloc(dev::CuDevice, bytes::Integer, last_resort::Bool=false)
   return Block(buf, bytes; state=AVAILABLE)
 end
 
-function actual_free(dev::CuDevice, block::Block)
+function actual_free(dev::CuDevice, block::Block; stream_ordered::Bool=false)
   @assert iswhole(block) "Cannot free $block: block is not whole"
   @assert block.off == 0
   @assert block.state == AVAILABLE "Cannot free $block: block is not available"
@@ -155,7 +154,7 @@ function actual_free(dev::CuDevice, block::Block)
     # free the memory
     @timeit_debug alloc_to "free" begin
       time = Base.@elapsed begin
-        Mem.free(block.buf; async=true)
+        Mem.free(block.buf; async=true, stream_ordered)
       end
       block.state = INVALID
 
@@ -181,40 +180,41 @@ Show the timings of the currently active memory pool. Assumes
 pool_timings() = (show(PoolUtils.to; allocations=false, sortby=:name); println())
 
 # pool API:
-# - init()
-# - alloc(::CuDevice, sz)::Block
-# - free(::CuDevice, ::Block)
-# - reclaim(::CuDevice, nb::Int=typemax(Int))::Int
-# - cached_memory()
+# - constructor taking a CuDevice
+# - alloc(::AbstractPool, sz)::Block
+# - free(::AbstractPool, ::Block)
+# - reclaim(::AbstractPool, nb::Int=typemax(Int))::Int
+# - cached_memory(::AbstractPool)
 
 module Pool
 @enum MemoryPool None Simple Binned Split
 end
-const active_pool = Ref{Pool.MemoryPool}()
-const async_alloc = Ref{Bool}()
 
-macro pooled(ex)
-    @assert Meta.isexpr(ex, :call)
-    f, args... = ex.args
-    quote
-      if active_pool[] == Pool.None
-        NoPool.$(f)($(map(esc, args)...))
-      elseif active_pool[] == Pool.Simple
-        SimplePool.$(f)($(map(esc, args)...))
-      elseif active_pool[] == Pool.Binned
-        BinnedPool.$(f)($(map(esc, args)...))
-      elseif active_pool[] == Pool.Split
-        SplitPool.$(f)($(map(esc, args)...))
-      else
-        error("unreachable")
-      end
-    end
-end
-
+abstract type AbstractPool end
 include("pool/none.jl")
 include("pool/simple.jl")
 include("pool/binned.jl")
 include("pool/split.jl")
+
+const pools = PerDevice{AbstractPool}(dev->begin
+  default_pool = version() >= v"11.2" ? "cuda" : "binned"
+  pool_name = get(ENV, "JULIA_CUDA_MEMORY_POOL", default_pool)
+  pool = if pool_name == "none"
+      NoPool(; dev, stream_ordered=false)
+  elseif pool_name == "simple"
+      SimplePool(; dev, stream_ordered=false)
+  elseif pool_name == "binned"
+      BinnedPool(; dev, stream_ordered=false)
+  elseif pool_name == "split"
+      SplitPool(; dev, stream_ordered=false)
+  elseif pool_name == "cuda"
+      @assert version() >= v"11.2" "The CUDA memory pool is only supported on CUDA 11.2+"
+      NoPool(; dev, stream_ordered=true)
+  else
+      error("Invalid memory pool '$pool_name'")
+  end
+  pool
+end)
 
 
 ## interface
@@ -263,11 +263,11 @@ a [`OutOfGPUMemoryError`](@ref) if the allocation request cannot be satisfied.
   sz == 0 && return CU_NULL
 
   dev = device()
+  pool = pools[dev]
 
   time = Base.@elapsed begin
-    @pool_timeit "pooled alloc" block = @pooled alloc(dev, sz)
+    @pool_timeit "pooled alloc" block = alloc(pool, sz)::Union{Nothing,Block}
   end
-  block::Union{Nothing,Block}
   block === nothing && throw(OutOfGPUMemoryError(sz))
 
   # record the memory block
@@ -328,6 +328,7 @@ Releases a buffer pointed to by `ptr` to the memory pool.
   ptr == CU_NULL && return
 
   dev = device()
+  pool = pools[dev]
   last_use[dev] = time()
 
   if MEMDEBUG && ptr == CuPtr{Cvoid}(0xbbbbbbbbbbbbbbbb)
@@ -359,7 +360,7 @@ Releases a buffer pointed to by `ptr` to the memory pool.
     end
 
     time = Base.@elapsed begin
-      @pool_timeit "pooled free" @pooled free(dev, block)
+      @pool_timeit "pooled free" free(pool, block)
     end
 
     alloc_stats.pool_time += time
@@ -382,7 +383,8 @@ actually reclaimed.
 """
 function reclaim(sz::Int=typemax(Int))
   dev = device()
-  @pooled reclaim(dev, sz)
+  pool = pools[dev]
+  reclaim(pool, sz)
 end
 
 """
@@ -403,6 +405,9 @@ macro retry_reclaim(isfailed, ex)
       ret = $(esc(ex))
       $(esc(isfailed))(ret) || break
 
+      dev = device()
+      pool = pools[dev]
+
       # incrementally more costly reclaim of cached memory
       if phase == 1
         reclaim()
@@ -412,11 +417,10 @@ macro retry_reclaim(isfailed, ex)
       elseif phase == 3
         GC.gc(true)
         reclaim()
-      elseif phase == 4 && async_alloc[]
+      elseif phase == 4 && pool.stream_ordered
         # this phase is unique to retry_reclaim, as regular allocations come from the pool
         # so are assumed to never need to trim its contents.
-        pool = memory_pool(device())
-        trim(pool)
+        trim(memory_pool(device()))
       end
     end
     ret
@@ -445,7 +449,8 @@ function pool_cleanup()
 
       if t1-t0 > 300
         # the pool hasn't been used for a while, so reclaim unused buffers
-        @pooled reclaim(dev)
+        pool = pools[dev]
+        reclaim(pool)
       end
     end
 
@@ -561,7 +566,10 @@ macro timed(ex)
     end
 end
 
-cached_memory() = @pooled cached_memory()
+function cached_memory(dev::CuDevice=device())
+  pool = pools[dev]
+  cached_memory(pool)
+end
 
 """
     memory_status([io=stdout])
@@ -584,10 +592,11 @@ function memory_status(io::IO=stdout)
   end
   println(io)
 
-  alloc_used_bytes = used_memory()
-  alloc_cached_bytes = cached_memory()
+  pool = pools[dev]
+  alloc_used_bytes = used_memory(dev)
+  alloc_cached_bytes = cached_memory(pool)
   alloc_total_bytes = alloc_used_bytes + alloc_cached_bytes
-  @printf(io, "Memory pool '%s' usage: %s (%s allocated, %s cached)\n", string(active_pool[]),
+  @printf(io, "Memory pool '%s' usage: %s (%s allocated, %s cached)\n", string(pool),
               Base.format_bytes(alloc_total_bytes), Base.format_bytes(alloc_used_bytes),
               Base.format_bytes(alloc_cached_bytes))
 
@@ -627,24 +636,8 @@ function __init_pool__()
   initialize!(allocated, ndevices())
   initialize!(requested, ndevices())
 
-  # memory pool configuration
-  default_pool = version() >= v"11.2" ? "cuda" : "binned"
-  pool_name = get(ENV, "JULIA_CUDA_MEMORY_POOL", default_pool)
-  active_pool[], async_alloc[] = if pool_name == "none"
-      Pool.None, false
-  elseif pool_name == "simple"
-      Pool.Simple, false
-  elseif pool_name == "binned"
-      Pool.Binned, false
-  elseif pool_name == "split"
-      Pool.Split, false
-  elseif pool_name == "cuda"
-      @assert version() >= v"11.2" "The CUDA memory pool is only supported on CUDA 11.2+"
-      Pool.None, true
-  else
-      error("Invalid memory pool '$pool_name'")
-  end
-  @pooled init()
+  # memory pools
+  initialize!(pools, ndevices())
 
   TimerOutputs.reset_timer!(alloc_to)
   TimerOutputs.reset_timer!(PoolUtils.to)
@@ -660,6 +653,6 @@ function __init_pool__()
   end
 
   if isinteractive()
-    @async @pooled pool_cleanup()
+    @async pool_cleanup()
   end
 end

--- a/src/pool/binned.jl
+++ b/src/pool/binned.jl
@@ -1,5 +1,3 @@
-module BinnedPool
-
 # binned memory pool allocator
 #
 # the core design is a pretty simple:
@@ -7,10 +5,7 @@ module BinnedPool
 # - when requested memory, check the pool for unused memory, or allocate dynamically
 # - conversely, when released memory, put it in the appropriate pool for future use
 
-using ..CUDA
-import ..CUDA: actual_alloc, actual_free, PerDevice, initialize!
-
-using ..PoolUtils
+using .PoolUtils
 
 
 ## tunables
@@ -29,26 +24,34 @@ const MAX_DELAY = 5.0
 
 ## infrastructure
 
-# TODO: npools
-const pool_lock = ReentrantLock()
-const pools_used = PerDevice{Vector{Set{Block}}}((dev)->Vector{Set{Block}}())
-const pools_avail = PerDevice{Vector{Vector{Block}}}((dev)->Vector{Vector{Block}}())
+Base.@kwdef struct BinnedPool <: AbstractPool
+  dev::CuDevice
+  stream_ordered::Bool
+
+  # TODO: npools
+  lock::ReentrantLock = ReentrantLock()
+  active::Vector{Set{Block}} = Vector{Set{Block}}()
+  cache::Vector{Vector{Block}} = Vector{Vector{Block}}()
+
+  freed_lock::NonReentrantLock = NonReentrantLock()
+  freed::Vector{Block} = Vector{Block}()
+end
 
 poolidx(n) = Base.ceil(Int, Base.log2(n))+1
 poolsize(idx) = 2^(idx-1)
 
 @assert poolsize(poolidx(MAX_POOL)) <= MAX_POOL "MAX_POOL cutoff should close a pool"
 
-function create_pools(dev, idx)
-  if length(pools_avail[dev]) >= idx
+function create_pools(pool::BinnedPool, idx)
+  if length(pool.cache) >= idx
     # fast-path without taking a lock
     return
   end
 
-  @lock pool_lock begin
-    while length(pools_avail[dev]) < idx
-      push!(pools_used[dev], Set{Block}())
-      push!(pools_avail[dev], Vector{Block}())
+  @lock pool.lock begin
+    while length(pool.cache) < idx
+      push!(pool.active, Set{Block}())
+      push!(pool.cache, Vector{Block}())
     end
   end
 end
@@ -56,27 +59,24 @@ end
 
 ## pooling
 
-const freed_lock = NonReentrantLock()
-const freed = PerDevice{Vector{Block}}((dev)->Vector{Block}())
-
 # reclaim unused buffers
-function reclaim(dev, target_bytes::Int=typemax(Int))
-  pool_repopulate(dev)
+function reclaim(pool::BinnedPool, target_bytes::Int=typemax(Int))
+  pool_repopulate(pool)
 
-  @lock pool_lock begin
+  @lock pool.lock begin
     @pool_timeit "reclaim" begin
       freed_bytes = 0
 
       # process pools in reverse, to discard largest buffers first
-      for pid in reverse(1:length(pools_avail[dev]))
+      for pid in reverse(1:length(pool.cache))
         bytes = poolsize(pid)
-        avail = pools_avail[dev][pid]
+        cache = pool.cache[pid]
 
-        bufcount = length(avail)
+        bufcount = length(cache)
         for i in 1:bufcount
-          block = pop!(avail)
+          block = pop!(cache)
 
-          actual_free(dev, block)
+          actual_free(pool.dev, block; pool.stream_ordered)
 
           freed_bytes += bytes
           if freed_bytes >= target_bytes
@@ -91,34 +91,34 @@ function reclaim(dev, target_bytes::Int=typemax(Int))
 end
 
 # repopulate the "available" pools from the list of freed blocks
-function pool_repopulate(dev)
-  blocks = @lock freed_lock begin
-    isempty(freed[dev]) && return
-    blocks = Set(freed[dev])
-    empty!(freed[dev])
+function pool_repopulate(pool::BinnedPool)
+  blocks = @lock pool.freed_lock begin
+    isempty(pool.freed) && return
+    blocks = Set(pool.freed)
+    empty!(pool.freed)
     blocks
   end
 
-  @lock pool_lock begin
+  @lock pool.lock begin
     for block in blocks
       pid = poolidx(sizeof(block))
 
-      @inbounds used = pools_used[dev][pid]
-      @inbounds avail = pools_avail[dev][pid]
+      @inbounds active = pool.active[pid]
+      @inbounds cache = pool.cache[pid]
 
       # mark the buffer as available
-      delete!(used, block)
-      push!(avail, block)
+      delete!(active, block)
+      push!(cache, block)
     end
   end
 
   return
 end
 
-function alloc(dev, bytes)
+function alloc(pool::BinnedPool, bytes)
   if bytes <= MAX_POOL
     pid = poolidx(bytes)
-    create_pools(dev, pid)
+    create_pools(pool, pid)
     bytes = poolsize(pid)
   else
     pid = -1
@@ -127,27 +127,27 @@ function alloc(dev, bytes)
   block = nothing
 
   # NOTE: checking the pool is really fast, and not included in the timings
-  @lock pool_lock begin
-    if pid != -1 && !isempty(pools_avail[dev][pid])
-      block = pop!(pools_avail[dev][pid])
+  @lock pool.lock begin
+    if pid != -1 && !isempty(pool.cache[pid])
+      block = pop!(pool.cache[pid])
     end
   end
 
   if block === nothing
     @pool_timeit "0. repopulate" begin
-      pool_repopulate(dev)
+      pool_repopulate(pool)
     end
 
-    @lock pool_lock begin
-      if pid != -1 && !isempty(pools_avail[dev][pid])
-        block = pop!(pools_avail[dev][pid])
+    @lock pool.lock begin
+      if pid != -1 && !isempty(pool.cache[pid])
+        block = pop!(pool.cache[pid])
       end
     end
   end
 
   if block === nothing
     @pool_timeit "1. try alloc" begin
-      block = actual_alloc(dev, bytes)
+      block = actual_alloc(pool.dev, bytes; pool.stream_ordered)
     end
   end
 
@@ -157,12 +157,12 @@ function alloc(dev, bytes)
     end
 
     @pool_timeit "2b. repopulate" begin
-      pool_repopulate(dev)
+      pool_repopulate(pool)
     end
 
-    @lock pool_lock begin
-      if pid != -1 && !isempty(pools_avail[dev][pid])
-        block = pop!(pools_avail[dev][pid])
+    @lock pool.lock begin
+      if pid != -1 && !isempty(pool.cache[pid])
+        block = pop!(pool.cache[pid])
       end
     end
   end
@@ -172,11 +172,11 @@ function alloc(dev, bytes)
 
   if block === nothing
     @pool_timeit "3. reclaim" begin
-      reclaim(dev, bytes)
+      reclaim(pool, bytes)
     end
 
     @pool_timeit "4. try alloc" begin
-      block = actual_alloc(dev, bytes)
+      block = actual_alloc(pool.dev, bytes; pool.stream_ordered)
     end
   end
 
@@ -186,78 +186,69 @@ function alloc(dev, bytes)
     end
 
     @pool_timeit "5b. repopulate" begin
-      pool_repopulate(dev)
+      pool_repopulate(pool)
     end
 
-    @lock pool_lock begin
-      if pid != -1 && !isempty(pools_avail[dev][pid])
-        block = pop!(pools_avail[dev][pid])
+    @lock pool.lock begin
+      if pid != -1 && !isempty(pool.cache[pid])
+        block = pop!(pool.cache[pid])
       end
     end
   end
 
   if block === nothing
     @pool_timeit "6. reclaim" begin
-      reclaim(dev, bytes)
+      reclaim(pool, bytes)
     end
 
     @pool_timeit "7. try alloc" begin
-      block = actual_alloc(dev, bytes)
+      block = actual_alloc(pool.dev, bytes; pool.stream_ordered)
     end
   end
 
   if block === nothing
     @pool_timeit "8. reclaim everything" begin
-      reclaim(dev, typemax(Int))
+      reclaim(pool, typemax(Int))
     end
 
     @pool_timeit "9. try alloc" begin
-      block = actual_alloc(dev, bytes, true)
+      block = actual_alloc(pool.dev, bytes, true; pool.stream_ordered)
     end
   end
 
   if block !== nothing && pid != -1
-    @lock pool_lock begin
-      @inbounds used = pools_used[dev][pid]
-      @inbounds avail = pools_avail[dev][pid]
+    @lock pool.lock begin
+      @inbounds active = pool.active[pid]
+      @inbounds cache = pool.cache[pid]
 
-      # mark the buffer as used
-      push!(used, block)
+      # mark the buffer as active
+      push!(active, block)
     end
   end
 
   return block
 end
 
-function free(dev, block)
+function free(pool::BinnedPool, block)
   # was this a pooled buffer?
   bytes = sizeof(block)
   if bytes > MAX_POOL
-    actual_free(dev, block)
+    actual_free(pool.dev, block; pool.stream_ordered)
     return
   end
 
   # we don't do any work here to reduce pressure on the GC (spending time in finalizers)
   # and to simplify locking (preventing concurrent access during GC interventions)
-  @spinlock freed_lock begin
-    push!(freed[dev], block)
+  @spinlock pool.freed_lock begin
+    push!(pool.freed, block)
   end
 end
 
-function init()
-  initialize!(freed, ndevices())
-
-  initialize!(pools_used, ndevices())
-  initialize!(pools_avail, ndevices())
-end
-
-function cached_memory(dev=device())
-  sz = @lock freed_lock mapreduce(sizeof, +, freed[dev]; init=0)
-  @lock pool_lock for (pid, pl) in enumerate(pools_avail[dev])
+function cached_memory(pool::BinnedPool)
+  sz = @lock pool.freed_lock mapreduce(sizeof, +, pool.freed; init=0)
+  @lock pool.lock for (pid, pl) in enumerate(pool.cache)
     bytes = poolsize(pid)
     sz += bytes * length(pl)
   end
   return sz
-end
-
 end

--- a/src/state.jl
+++ b/src/state.jl
@@ -344,7 +344,8 @@ so it is generally not needed to subscribe to the reset hook specifically.
     this package.
 """
 function device_reset!(dev::CuDevice=device())
-    if async_alloc[] # NVIDIA bug #3240770
+    stream_ordered = any(dev->pools[dev].stream_ordered, devices())
+    if stream_ordered # NVIDIA bug #3240770
         @error """Due to a bug in CUDA, resetting the device is not possible on CUDA 11.2 when using the stream-ordered memory allocator.
 
                   If you are calling this function to free memory, that may not be required anymore

--- a/src/utilities.jl
+++ b/src/utilities.jl
@@ -57,11 +57,6 @@ function versioninfo(io::IO=stdout)
     println(io, "- Device support: $(join(map(ver->"sm_$(ver.major)$(ver.minor)", __target_support[]), ", "))")
     println(io)
 
-    println(io, "Preferences:")
-    println(io, "- Memory pool: $(active_pool[])")
-    println(io, "- Async allocation: $(async_alloc[])")
-    println(io)
-
     env = filter(var->startswith(var, "JULIA_CUDA"), keys(ENV))
     if !isempty(env)
         println(io, "Environment:")

--- a/test/cudadrv/pool.jl
+++ b/test/cudadrv/pool.jl
@@ -1,4 +1,4 @@
-let
+@not_if_memcheck let
     dev = device()
 
     pool = memory_pool(dev)

--- a/test/examples.jl
+++ b/test/examples.jl
@@ -1,5 +1,5 @@
 # these tests spawn subprocesses, so reset the current context to conserve memory
-CUDA.async_alloc[] || CUDA.device_reset!()
+CUDA.release() == v"11.2" || CUDA.device_reset!()
 
 function find_sources(path::String, sources=String[])
     if isdir(path)

--- a/test/exceptions.jl
+++ b/test/exceptions.jl
@@ -1,5 +1,5 @@
 # these tests spawn subprocesses, so reset the current context to conserve memory
-CUDA.async_alloc[] || CUDA.device_reset!()
+CUDA.release() == v"11.2" || CUDA.device_reset!()
 
 @testset "stack traces at different debug levels" begin
 

--- a/test/initialization.jl
+++ b/test/initialization.jl
@@ -68,7 +68,7 @@ end
 
 reset_cb()
 
-if !CUDA.async_alloc[]
+if CUDA.release() != v"11.2"
     # NVIDIA bug #3240770
     device_reset!()
 

--- a/test/setup.jl
+++ b/test/setup.jl
@@ -102,7 +102,7 @@ function runtests(f, name, time_source=:cuda, snoop=nothing)
         end
         res = vcat(collect(data), cpu_rss, gpu_rss)
 
-        if !CUDA.async_alloc[] # NVIDIA bug #3240770
+        if CUDA.release() != v"11.2" # NVIDIA bug #3240770
             device_reset!()
         end
         res


### PR DESCRIPTION
Fixes https://github.com/JuliaGPU/CUDA.jl/issues/742. Doesn't seem to impact allocation time, e.g. comparing to https://github.com/JuliaGPU/CUDA.jl/issues/137#issuecomment-788867996:

```
Memory pool timings:
 ────────────────────────────────────────────────
                                   Time          
                           ──────────────────────
     Tot / % measured:           786s / 5.78%    

 Section           ncalls     time   %tot     avg
 ────────────────────────────────────────────────
 pooled alloc       8.79M    31.0s  68.2%  3.52μs
   1.1 alloc        8.79M    21.3s  47.0%  2.42μs
     pooled free    55.6k   81.3ms  0.18%  1.46μs
   pooled free       115k    169ms  0.37%  1.47μs
 pooled free        8.62M    14.4s  31.8%  1.68μs
 ────────────────────────────────────────────────
Allocator timings:
 ────────────────────────────────────────
                           Time          
                   ──────────────────────
 Tot / % measured:       786s / 3.22%    

 Section   ncalls     time   %tot     avg
 ────────────────────────────────────────
 alloc      8.79M    14.8s  58.5%  1.68μs
 free       8.79M    10.5s  41.5%  1.19μs
 ────────────────────────────────────────
```

A very small difference. Either way, there's still 50% of execution time being left on the table (comparing the time it takes to do the pool allocation vs the time spent calling the CUDA allocator).