### PR TITLE
Rework memory pinning and speed up async ops on unpinned memory

### DIFF
--- a/lib/cudadrv/memory.jl
+++ b/lib/cudadrv/memory.jl
@@ -14,6 +14,8 @@ using Printf
 
 using Memoize
 
+using DataStructures
+
 
 #
 # buffers
@@ -599,24 +601,69 @@ end
 # auxiliary functionality
 #
 
-## memory pinning
-# TODO: PerDevice
-const __pinned_memory = Dict{Tuple{CuContext,Ptr{Cvoid}}, WeakRef}()
-function pin(a::Base.Array, flags=0)
-    ctx = context()
-    ptr = convert(Ptr{Cvoid}, pointer(a))
-    if haskey(__pinned_memory, (ctx,ptr)) && __pinned_memory[(ctx,ptr)].value !== nothing
-        return
-    end
+# given object, find base allocation
+# pin that, or increase refcount
+# finalizer, drop refcount, free if 0
 
-    buf = Mem.register(Mem.Host, pointer(a), sizeof(a), flags)
+## memory pinning
+
+function pin(a::AbstractArray)
+    __pin(a)
     finalizer(a) do _
-        CUDA.isvalid(ctx) || return
-        context!(ctx) do
-            Mem.unregister(buf)
+        __unpin(a)
+    end
+    a
+end
+
+__pin(a::Base.Array) = __pin(convert(Ptr{Cvoid}, pointer(a)), sizeof(a))
+__unpin(a::Base.Array) = __unpin(convert(Ptr{Cvoid}, pointer(a)))
+
+# derived arrays should always pin the parent memory range, because we may end up copying
+# from or to that parent range (containing the derived range), and partially-pinned ranges
+# are not supported:
+#
+# > Memory regions requested must be either entirely registered with CUDA, or in the case
+# > of host pageable transfers, not registered at all. Memory regions spanning over
+# > allocations that are both registered and not registered with CUDA are not supported and
+# > will return CUDA_ERROR_INVALID_VALUE.
+__pin(a::Union{SubArray, Base.ReinterpretArray, Base.ReshapedArray}) = __pin(parent(a))
+__unpin(a::Union{SubArray, Base.ReinterpretArray, Base.ReshapedArray}) = __unpin(parent(a))
+
+# refcount the pinning per context, since we can only pin a memory range once
+const __pin_lock = ReentrantLock()
+const __pins = Dict{Tuple{CuContext,Ptr{Cvoid}}, HostBuffer}()
+const __pin_count = DefaultDict{Tuple{CuContext,Ptr{Cvoid}}, Int}(0)
+function __pin(ptr::Ptr{Nothing}, sz::Int)
+    ctx = context()
+
+    @lock __pin_lock begin
+        pin_count = __pin_count[(ctx, ptr)] += 1
+        if pin_count == 1
+            buf = Mem.register(Mem.Host, ptr, sz)
+            __pins[(ctx,ptr)] = buf
+        elseif Base.JLOptions().debug_level >= 2
+            # make sure we're pinning the exact same range
+            buf = __pins[(ctx,ptr)]
+            @assert sz == sizeof(buf)
         end
     end
-    __pinned_memory[(ctx,ptr)] = WeakRef(a)
+
+    return
+end
+function __unpin(ptr::Ptr{Nothing})
+    ctx = context()
+    key = (ctx,ptr)
+
+    @spinlock __pin_lock begin
+        pin_count = @inbounds __pin_count[key] -= 1
+        if pin_count == 0 && CUDA.isvalid(ctx)
+            buf = @inbounds __pins[key]
+            Mem.unregister(buf)
+            delete!(__pins, key)
+            delete!(__pin_count, key)
+        end
+    end
+
     return
 end
 

--- a/lib/cudadrv/memory.jl
+++ b/lib/cudadrv/memory.jl
@@ -6,6 +6,7 @@ module Mem
 
 using ..CUDA
 using ..CUDA: @enum_without_prefix, CUstream, CUdevice, CuDim3, CUarray, CUarray_format
+using ..CUDA.APIUtils
 
 using Base: @deprecate_binding
 

--- a/lib/utils/APIUtils.jl
+++ b/lib/utils/APIUtils.jl
@@ -7,5 +7,6 @@ using Libdl
 # helpers that facilitate working with CUDA APIs
 include("call.jl")
 include("enum.jl")
+include("threading.jl")
 
 end

--- a/lib/utils/threading.jl
+++ b/lib/utils/threading.jl
@@ -1,0 +1,39 @@
+export NonReentrantLock, @spinlock, @lock
+
+const var"@lock" = Base.var"@lock"
+
+# a simple non-reentrant lock that errors when trying to reenter on the same task
+struct NonReentrantLock <: Threads.AbstractLock
+  rl::ReentrantLock
+  NonReentrantLock() = new(ReentrantLock())
+end
+
+function Base.lock(nrl::NonReentrantLock)
+  @assert !islocked(nrl.rl) || nrl.rl.locked_by !== current_task()
+  lock(nrl.rl)
+end
+
+function Base.trylock(nrl::NonReentrantLock)
+  @assert !islocked(nrl.rl) || nrl.rl.locked_by !== current_task()
+  trylock(nrl.rl)
+end
+
+Base.unlock(nrl::NonReentrantLock) = unlock(nrl.rl)
+
+# a safe way to acquire locks from finalizers, where we can't wait (which switches tasks)
+macro spinlock(l, ex)
+  quote
+    temp = $(esc(l))
+    while !trylock(temp)
+      ccall(:jl_cpu_pause, Cvoid, ())
+      # Temporary solution before we have gc transition support in codegen.
+      ccall(:jl_gc_safepoint, Cvoid, ())
+      # we can't yield here
+    end
+    try
+      $(esc(ex))
+    finally
+      unlock(temp)
+    end
+  end
+end

--- a/src/array.jl
+++ b/src/array.jl
@@ -289,7 +289,8 @@ Base.copyto!(dest::DenseCuArray{T}, src::DenseCuArray{T}) where {T} =
     copyto!(dest, 1, src, 1, length(src))
 
 function Base.unsafe_copyto!(dest::DenseCuArray{T}, doffs, src::Array{T}, soffs, n) where T
-  GC.@preserve src dest unsafe_copyto!(pointer(dest, doffs), pointer(src, soffs), n)
+  GC.@preserve src dest unsafe_copyto!(pointer(dest, doffs), pointer(src, soffs), n;
+                                       async=true)
   if Base.isbitsunion(T)
     # copy selector bytes
     error("Not implemented")
@@ -305,6 +306,7 @@ function Base.unsafe_copyto!(dest::Array{T}, doffs, src::DenseCuArray{T}, soffs,
     # copy selector bytes
     error("Not implemented")
   end
+  synchronize() # users expect values to be available after this call
   return dest
 end
 

--- a/src/array.jl
+++ b/src/array.jl
@@ -289,6 +289,11 @@ Base.copyto!(dest::DenseCuArray{T}, src::DenseCuArray{T}) where {T} =
     copyto!(dest, 1, src, 1, length(src))
 
 function Base.unsafe_copyto!(dest::DenseCuArray{T}, doffs, src::Array{T}, soffs, n) where T
+  if !is_pinned(pointer(src))
+    # operations on unpinned memory cannot be executed asynchronously, and synchronize
+    # without yielding back to the Julia scheduler. prevent that by eagerly synchronizing.
+    synchronize()
+  end
   GC.@preserve src dest unsafe_copyto!(pointer(dest, doffs), pointer(src, soffs), n;
                                        async=true)
   if Base.isbitsunion(T)
@@ -299,7 +304,11 @@ function Base.unsafe_copyto!(dest::DenseCuArray{T}, doffs, src::Array{T}, soffs,
 end
 
 function Base.unsafe_copyto!(dest::Array{T}, doffs, src::DenseCuArray{T}, soffs, n) where T
-  # TODO: pin the source memory so that it can actually execute asynchronously?
+  if !is_pinned(pointer(dest))
+    # operations on unpinned memory cannot be executed asynchronously, and synchronize
+    # without yielding back to the Julia scheduler. prevent that by eagerly synchronizing.
+    synchronize()
+  end
   GC.@preserve src dest unsafe_copyto!(pointer(dest, doffs), pointer(src, soffs), n;
                                        async=true)
   if Base.isbitsunion(T)

--- a/src/pool/binned.jl
+++ b/src/pool/binned.jl
@@ -5,8 +5,6 @@
 # - when requested memory, check the pool for unused memory, or allocate dynamically
 # - conversely, when released memory, put it in the appropriate pool for future use
 
-using .PoolUtils
-
 
 ## tunables
 

--- a/src/pool/none.jl
+++ b/src/pool/none.jl
@@ -1,7 +1,5 @@
 # dummy allocator that passes through any requests, calling into the GC if that fails.
 
-using .PoolUtils
-
 Base.@kwdef struct NoPool <: AbstractPool
     dev::CuDevice
     stream_ordered::Bool

--- a/src/pool/simple.jl
+++ b/src/pool/simple.jl
@@ -1,7 +1,5 @@
 # simple scan into a list of free buffers
 
-using .PoolUtils
-
 
 ## tunables
 

--- a/src/pool/split.jl
+++ b/src/pool/split.jl
@@ -1,7 +1,5 @@
 # scan into a sorted list of free buffers, splitting buffers along the way
 
-using .PoolUtils
-
 
 ## tunables
 

--- a/src/pool/utils.jl
+++ b/src/pool/utils.jl
@@ -12,49 +12,6 @@ export MEMDEBUG
 const MEMDEBUG = ccall(:jl_is_memdebug, Bool, ())
 
 
-## locking
-
-export NonReentrantLock, @spinlock, @lock
-
-const var"@lock" = Base.var"@lock"
-
-# a simple non-reentrant lock that errors when trying to reenter on the same task
-struct NonReentrantLock <: Threads.AbstractLock
-  rl::ReentrantLock
-  NonReentrantLock() = new(ReentrantLock())
-end
-
-function Base.lock(nrl::NonReentrantLock)
-  @assert !islocked(nrl.rl) || nrl.rl.locked_by !== current_task()
-  lock(nrl.rl)
-end
-
-function Base.trylock(nrl::NonReentrantLock)
-  @assert !islocked(nrl.rl) || nrl.rl.locked_by !== current_task()
-  trylock(nrl.rl)
-end
-
-Base.unlock(nrl::NonReentrantLock) = unlock(nrl.rl)
-
-# a safe way to acquire locks from finalizers, where we can't wait (which switches tasks)
-macro spinlock(l, ex)
-  quote
-    temp = $(esc(l))
-    while !trylock(temp)
-      ccall(:jl_cpu_pause, Cvoid, ())
-      # Temporary solution before we have gc transition support in codegen.
-      ccall(:jl_gc_safepoint, Cvoid, ())
-      # we can't yield here
-    end
-    try
-      $(esc(ex))
-    finally
-      unlock(temp)
-    end
-  end
-end
-
-
 ## block of memory
 
 export Block, INVALID, AVAILABLE, ALLOCATED, FREED, iswhole

--- a/test/cudadrv/memory.jl
+++ b/test/cudadrv/memory.jl
@@ -241,33 +241,14 @@ let
                        dstPitch=nx*sizeof(T), dstHeight=ny)
     @test all(check2[2,:,:] .== data)
 end
+
 # pinned memory with existing memory
 if attribute(device(), CUDA.DEVICE_ATTRIBUTE_HOST_REGISTER_SUPPORTED) != 0
-    let hA = rand(UInt8, 512), hB = rand(UInt8, 512)
+    hA = rand(UInt8, 512)
+    @test !CUDA.is_pinned(pointer(hA))
     Mem.pin(hA)
-    # no way to test if something is already registered, sadly...
-    # make sure this doesn't explode -- nothing should happen if we try
-    # to register twice
+    @test CUDA.is_pinned(pointer(hA))
+
+    # make sure we can double-pin
     Mem.pin(hA)
-    # by default pin doesn't use DEVICEMAP so we'd have to memcpy
-    # just test that some basic ops work without corrupting memory
-    dA = Mem.alloc(Mem.Device, sizeof(hA))
-    TA = eltype(hA)
-    unsafe_copyto!(typed_pointer(dA, TA), pointer(hA), 512)
-    Mem.set!(typed_pointer(dA, TA), zero(TA), 512)
-    unsafe_copyto!(pointer(hA), typed_pointer(dA, TA), 512)
-    @test all(hA .== zero(TA))
-    # test with a flag
-    Mem.pin(hB, Mem.HOSTREGISTER_DEVICEMAP)
-    Mem.pin(hB)
-    # by default pin doesn't use DEVICEMAP so we'd have to memcpy
-    # just test that some basic ops work without corrupting memory
-    dB = Mem.alloc(Mem.Device, sizeof(hB))
-    TB = eltype(hB)
-    # since pin doesn't return the buffer we can't directly set
-    unsafe_copyto!(typed_pointer(dB, TB), pointer(hB), 512)
-    Mem.set!(typed_pointer(dB, TB), zero(TB), 512)
-    unsafe_copyto!(pointer(hB), typed_pointer(dB, TB), 512)
-    @test all(hB .== zero(TB))
-    end
 end

--- a/test/cudadrv/memory.jl
+++ b/test/cudadrv/memory.jl
@@ -251,4 +251,9 @@ if attribute(device(), CUDA.DEVICE_ATTRIBUTE_HOST_REGISTER_SUPPORTED) != 0
 
     # make sure we can double-pin
     Mem.pin(hA)
+
+    # memory copies on pinned memory behave differently, so test that code path
+    dA = CUDA.rand(UInt8, 512)
+    copyto!(dA, hA)
+    copyto!(hA, dA)
 end


### PR DESCRIPTION
Closes https://github.com/JuliaGPU/CUDA.jl/issues/242, closes https://github.com/JuliaGPU/CUDA.jl/issues/735.

With the recent stream-per-task execution model, we can start executing a whole bunch of operations asynchronously (because synchronization is cheaper now that it can yield back to the Julia scheduler). There was one exception though: memory copies. Basically, when transferring memory to or from the CPU, that memory should not be paged out. You can avoid that from happening by pinning or page-locking memory. If you don't, the operation will still execute synchronously, and worse, it will do so without yielding back to the Julia scheduler.

Demo for the rest of this PR:

```julia
using CUDA, LinearAlgebra

# an expensive computation
function compute(a,b,c)
    mul!(c, a, b)         # library call
    broadcast!(sin, c, c) # Julia kernel
    c
end

# one "iteration", computing in two tasks
# and comparing the output.
function iteration(a,b,c)
    results = Vector{Any}(undef, 2)
    NVTX.@range "computation" @sync begin
        @async begin
            results[1] = Array(compute(a,b,c))
        end
        @async begin
            results[2] = Array(compute(a,b,c))
        end
    end
    NVTX.@range "comparison" results[1] == results[2]
end

function main(N=1024)
    a = CUDA.rand(N,N)
    b = CUDA.rand(N,N)
    c = CUDA.rand(N,N)

    # make sure this data can be used by other tasks!
    synchronize()

    # warm-up
    iteration(a,b,c)
    GC.gc(true)

    CUDA.@profile begin
        NVTX.@range "run" iteration(a,b,c)
    end
end

isinteractive() || main()
```

Similar example to https://github.com/JuliaGPU/CUDA.jl/pull/662, but with one crucial difference: a memory copy is performed within the computational task (`Array(compute(a,b,c))`). That's bad, and results in the following profile:

![image](https://user-images.githubusercontent.com/383068/110766798-d908dd80-8255-11eb-87d0-bafab088be13.png)

The copies behave synchronously, which results in the first task blocking outside of the scheduler so that the second task can't get scheduled. One solution, as sneakily used in https://github.com/JuliaGPU/CUDA.jl/pull/662, is to `synchronize()` in each task such that we can start work on the other task before we perform a memory operation. That results in the following trace:

![image](https://user-images.githubusercontent.com/383068/110767043-1a00f200-8256-11eb-98fe-89e534a7b48b.png)

Much better. The void before each memory copy is because of allocating memory. A better solution is to pre-allocate that memory and pin it (so `results[...] = Mem.pin(Array{eltype(c)}(undef, size(c)))` in the main task, and a `copyto!` on the results instead of just calling the `Array` constructor), not only avoiding that 'blank space' but also making sure the memory operations can happen asynchronously. That gives a best-case profile trace:

![image](https://user-images.githubusercontent.com/383068/110767350-7532e480-8256-11eb-80df-77b465f930b8.png)

Note that the copies themselves are also a lot faster. So you might think, why not eagerly pin every CPU buffer before a memory operation? Alas, pinning isn't free:

![image](https://user-images.githubusercontent.com/383068/110767485-985d9400-8256-11eb-9022-38a7eaddcf29.png)

So, that brings me to the final design of this PR, where we try and figure out whether a CPU buffer is pinned before a memory operation, and if it isn't, eagerly synchronize execution. By doing so, we can at least finish the current work on the GPU concurrently to work queued up by other Julia tasks, even though we'll still end up synchronizing in the driver afterwards:

![image](https://user-images.githubusercontent.com/383068/110767823-f25e5980-8256-11eb-9d25-2a7fa0d188bc.png)

The overhead of these operations are minimal, couple of 10s of ns is barely visible on the profiler trace.

cc @staticfloat 