### PR TITLE
Improve context switching

### DIFF
--- a/lib/cudadrv/context.jl
+++ b/lib/cudadrv/context.jl
@@ -117,6 +117,24 @@ function Base.pop!(::Type{CuContext})
     CuContext(handle_ref[])
 end
 
+# perform some finalizer actions in a context
+macro finalize_in_ctx(ctx, body)
+    # XXX: should this not integrate with the high-level context management from state.jl?
+    #      it might be good that the driver API wrappers don't need that runtime-esque
+    #      state management, but it might be confusing that `context()` doesn't work here.
+    quote
+        ctx = $(esc(ctx))
+        if isvalid(ctx)
+            push!(CuContext, ctx)
+            try
+                $(esc(body))
+            finally
+                pop!(CuContext)
+            end
+        end
+    end
+end
+
 """
     activate(ctx::CuContext)
 

--- a/lib/cudadrv/events.jl
+++ b/lib/cudadrv/events.jl
@@ -26,9 +26,7 @@ mutable struct CuEvent
 end
 
 function unsafe_destroy!(e::CuEvent)
-    if isvalid(e.ctx)
-        cuEventDestroy_v2(e)
-    end
+    @finalize_in_ctx e.ctx cuEventDestroy_v2(e)
 end
 
 Base.unsafe_convert(::Type{CUevent}, e::CuEvent) = e.handle

--- a/lib/cudadrv/memory.jl
+++ b/lib/cudadrv/memory.jl
@@ -5,7 +5,7 @@ export Mem, attribute, attribute!, memory_type, is_managed
 module Mem
 
 using ..CUDA
-using ..CUDA: @enum_without_prefix, CUstream, CUdevice, CuDim3, CUarray, CUarray_format
+using ..CUDA: @enum_without_prefix, CUstream, CUdevice, CuDim3, CUarray, CUarray_format, @finalize_in_ctx
 using ..CUDA.APIUtils
 
 using Base: @deprecate_binding
@@ -656,9 +656,9 @@ function __unpin(ptr::Ptr{Nothing})
 
     @spinlock __pin_lock begin
         pin_count = @inbounds __pin_count[key] -= 1
-        if pin_count == 0 && CUDA.isvalid(ctx)
+        if pin_count == 0
             buf = @inbounds __pins[key]
-            Mem.unregister(buf)
+            @finalize_in_ctx ctx Mem.unregister(buf)
             delete!(__pins, key)
             delete!(__pin_count, key)
         end

--- a/lib/cudadrv/module.jl
+++ b/lib/cudadrv/module.jl
@@ -65,9 +65,7 @@ mutable struct CuModule
 end
 
 function unsafe_unload!(mod::CuModule)
-    if isvalid(mod.ctx)
-        cuModuleUnload(mod)
-    end
+    @finalize_in_ctx mod.ctx cuModuleUnload(mod)
 end
 
 Base.unsafe_convert(::Type{CUmodule}, mod::CuModule) = mod.handle

--- a/lib/cudadrv/module/linker.jl
+++ b/lib/cudadrv/module/linker.jl
@@ -44,9 +44,7 @@ mutable struct CuLink
 end
 
 function unsafe_destroy!(link::CuLink)
-    if isvalid(link.ctx)
-        cuLinkDestroy(link)
-    end
+    @finalize_in_ctx link.ctx cuLinkDestroy(link)
 end
 
 Base.unsafe_convert(::Type{CUlinkState}, link::CuLink) = link.handle

--- a/lib/cudadrv/pool.jl
+++ b/lib/cudadrv/pool.jl
@@ -28,9 +28,7 @@ function CuMemoryPool(dev::CuDevice)
 end
 
 function unsafe_destroy!(pool::CuMemoryPool)
-    if isvalid(pool.ctx)
-        cuMemPoolDestroy(pool)
-    end
+    @finalize_in_ctx pool.ctx cuMemPoolDestroy(pool)
 end
 
 Base.unsafe_convert(::Type{CUmemoryPool}, pool::CuMemoryPool) = pool.handle

--- a/lib/cudadrv/stream.jl
+++ b/lib/cudadrv/stream.jl
@@ -39,9 +39,7 @@ function CuStream(; flags::CUstream_flags=STREAM_DEFAULT,
 end
 
 function unsafe_destroy!(s::CuStream)
-    if isvalid(s.ctx)
-        cuStreamDestroy_v2(s)
-    end
+    @finalize_in_ctx s.ctx cuStreamDestroy_v2(s)
 end
 
 function Base.show(io::IO, stream::CuStream)

--- a/lib/curand/random.jl
+++ b/lib/curand/random.jl
@@ -23,10 +23,7 @@ mutable struct RNG <: Random.AbstractRNG
 end
 
 function unsafe_destroy!(rng::RNG)
-    CUDA.isvalid(rng.ctx) || return
-    context!(rng.ctx) do
-        curandDestroyGenerator(rng)
-    end
+    CUDA.@context! skip_destroyed=true rng.ctx curandDestroyGenerator(rng)
 end
 
 Base.unsafe_convert(::Type{curandGenerator_t}, rng::RNG) = rng.handle

--- a/src/pool/binned.jl
+++ b/src/pool/binned.jl
@@ -23,7 +23,6 @@ const MAX_DELAY = 5.0
 ## infrastructure
 
 Base.@kwdef struct BinnedPool <: AbstractPool
-  dev::CuDevice
   stream_ordered::Bool
 
   # TODO: npools
@@ -74,7 +73,7 @@ function reclaim(pool::BinnedPool, target_bytes::Int=typemax(Int))
         for i in 1:bufcount
           block = pop!(cache)
 
-          actual_free(pool.dev, block; pool.stream_ordered)
+          actual_free(block; pool.stream_ordered)
 
           freed_bytes += bytes
           if freed_bytes >= target_bytes
@@ -145,7 +144,7 @@ function alloc(pool::BinnedPool, bytes)
 
   if block === nothing
     @pool_timeit "1. try alloc" begin
-      block = actual_alloc(pool.dev, bytes; pool.stream_ordered)
+      block = actual_alloc(bytes; pool.stream_ordered)
     end
   end
 
@@ -174,7 +173,7 @@ function alloc(pool::BinnedPool, bytes)
     end
 
     @pool_timeit "4. try alloc" begin
-      block = actual_alloc(pool.dev, bytes; pool.stream_ordered)
+      block = actual_alloc(bytes; pool.stream_ordered)
     end
   end
 
@@ -200,7 +199,7 @@ function alloc(pool::BinnedPool, bytes)
     end
 
     @pool_timeit "7. try alloc" begin
-      block = actual_alloc(pool.dev, bytes; pool.stream_ordered)
+      block = actual_alloc(bytes; pool.stream_ordered)
     end
   end
 
@@ -210,7 +209,7 @@ function alloc(pool::BinnedPool, bytes)
     end
 
     @pool_timeit "9. try alloc" begin
-      block = actual_alloc(pool.dev, bytes, true; pool.stream_ordered)
+      block = actual_alloc(bytes, true; pool.stream_ordered)
     end
   end
 
@@ -231,7 +230,7 @@ function free(pool::BinnedPool, block)
   # was this a pooled buffer?
   bytes = sizeof(block)
   if bytes > MAX_POOL
-    actual_free(pool.dev, block; pool.stream_ordered)
+    actual_free(block; pool.stream_ordered)
     return
   end
 

--- a/src/pool/none.jl
+++ b/src/pool/none.jl
@@ -1,7 +1,6 @@
 # dummy allocator that passes through any requests, calling into the GC if that fails.
 
 Base.@kwdef struct NoPool <: AbstractPool
-    dev::CuDevice
     stream_ordered::Bool
 end
 
@@ -15,7 +14,7 @@ function alloc(pool::NoPool, sz)
         end
 
         @pool_timeit "$phase.1 alloc" begin
-            block = actual_alloc(pool.dev, sz, phase==3; pool.stream_ordered)
+            block = actual_alloc(sz, phase==3; pool.stream_ordered)
         end
         block === nothing || break
     end
@@ -24,7 +23,7 @@ function alloc(pool::NoPool, sz)
 end
 
 function free(pool::NoPool, block)
-    actual_free(pool.dev, block; pool.stream_ordered)
+    actual_free(block; pool.stream_ordered)
     return
 end
 

--- a/src/state.jl
+++ b/src/state.jl
@@ -163,14 +163,14 @@ Note that the contexts used with this call should be previously acquired by call
 [`context`](@ref), and not arbitrary contexts created by calling the `CuContext` constructor.
 """
 function context!(ctx::CuContext)
-    detect_task_switches()  # we got a CuDevice, so CUDA is initialized already
+    detect_task_switches()
     tid = Threads.threadid()
 
     # update the thread-local state
     state = @inbounds thread_state[tid]
     if state === nothing || state.ctx != ctx
         activate(ctx)
-        dev = CuCurrentDevice()
+        dev = CuCurrentDevice()::CuDevice
         thread_state[tid] = (;ctx=ctx, dev=dev)
         _atdeviceswitch()
     end
@@ -181,43 +181,55 @@ function context!(ctx::CuContext)
     return
 end
 
-"""
-    context!(f, ctx)
+macro context!(ex...)
+    body = ex[end]
+    ctx = ex[end-1]
+    kwargs = ex[1:end-2]
 
-Sets the active context for the duration of `f`.
-"""
-function context!(f::Function, ctx::CuContext)
-    @assert isvalid(ctx)
-    old_ctx = CuCurrentContext()
-    if ctx != old_ctx
-        context!(ctx)
+    skip_destroyed = false
+    for kwarg in kwargs
+        Meta.isexpr(kwarg, :(=)) || throw(ArgumentError("non-keyword argument like option '$kwarg'"))
+        key, val = kwarg.args
+        isa(key, Symbol) || throw(ArgumentError("non-symbolic keyword '$key'"))
+
+        if key == :skip_destroyed
+            skip_destroyed = val
+        else
+            throw(ArgumentError("unrecognized keyword argument '$kwarg'"))
+        end
     end
-    try
-        f()
-    finally
-        if ctx !== old_ctx && old_ctx !== nothing
-            context!(old_ctx)
+
+    quote
+        ctx = $(esc(ctx))
+        if isvalid(ctx)
+            detect_task_switches()
+            tid = Threads.threadid()
+
+            # NOTE: we don't use `context()` here, since that initializes
+            old_state = @inbounds thread_state[tid]
+            if old_state === nothing || old_state.ctx != ctx
+                context!(ctx)   # XXX: context! performs a lot of the same checks...
+            end
+            try
+                $(esc(body))
+            finally
+                if old_state !== nothing && ctx != old_state.ctx
+                    context!(old_state.ctx)
+                end
+            end
+        elseif !$(esc(skip_destroyed))
+            error("Cannot switch to an invalidated context.")
         end
     end
 end
 
-# macro version for maximal performance (avoiding closures)
-macro context!(ctx_expr, expr)
-    quote
-        ctx = $(esc(ctx_expr))
-        @assert isvalid(ctx)
-        old_ctx = CuCurrentContext()
-        if ctx != old_ctx
-            context!(ctx)
-        end
-        try
-            $(esc(expr))
-        finally
-            if ctx !== old_ctx && old_ctx !== nothing
-                context!(old_ctx)
-            end
-        end
-    end
+"""
+    context!(f, ctx; [skip_destroyed=false])
+
+Sets the active context for the duration of `f`.
+"""
+@inline function context!(f::Function, ctx::CuContext; skip_destroyed::Bool=false)
+    @context! skip_destroyed=skip_destroyed ctx f()
 end
 
 
@@ -304,6 +316,13 @@ function device!(dev::CuDevice, flags=nothing)
     context!(ctx)
 end
 
+macro device!(dev, body)
+    quote
+        ctx = context($(esc(dev)))
+        @context! ctx $(esc(body))
+    end
+end
+
 """
     device!(f, dev)
 
@@ -312,17 +331,8 @@ Sets the active device for the duration of `f`.
 Note that this call is intended for temporarily switching devices, and does not change the
 default device used to initialize new threads or tasks.
 """
-function device!(f::Function, dev::CuDevice)
-    ctx = context(dev)
-    context!(f, ctx)
-end
-
-macro device!(dev_expr, expr)
-    quote
-        dev = $(esc(dev_expr))
-        ctx = context(dev)
-        @context! ctx $(esc(expr))
-    end
+@inline function device!(f::Function, dev::CuDevice)
+    @device! dev f()
 end
 
 """

--- a/src/state.jl
+++ b/src/state.jl
@@ -5,7 +5,9 @@
 # multiple threads), using a GPU of your choice (with the ability to reset that device, or
 # use different devices on different threads).
 
-export context, context!, device, device!, device_reset!, deviceid, stream, stream!, pool
+# XXX: a task switch hook would make much of this complexity go away...
+
+export context, context!, device, device!, device_reset!, deviceid, stream, stream!
 
 
 ## hooks

--- a/src/texture.jl
+++ b/src/texture.jl
@@ -45,9 +45,7 @@ mutable struct CuTextureArray{T,N}
 end
 
 function unsafe_destroy!(t::CuTextureArray)
-    if isvalid(t.ctx)
-        Mem.free(t.buf)
-    end
+    @context! skip_destroyed=true t.ctx Mem.free(t.buf)
 end
 
 Base.unsafe_convert(T::Type{CUarray}, t::CuTextureArray) = Base.unsafe_convert(T, t.buf)
@@ -262,9 +260,7 @@ Base.unsafe_convert(::Type{Ptr{CUDA_RESOURCE_DESC}}, ref::Base.RefValue{T}) wher
     convert(Ptr{CUDA_RESOURCE_DESC}, Base.unsafe_convert(Ptr{T}, ref))
 
 function unsafe_destroy!(t::CuTexture)
-    if isvalid(t.ctx)
-        cuTexObjectDestroy(t)
-    end
+    @context! skip_destroyed=true t.ctx cuTexObjectDestroy(t)
 end
 
 Base.convert(::Type{CUtexObject}, t::CuTexture) = t.handle

--- a/test/cudadrv/module.jl
+++ b/test/cudadrv/module.jl
@@ -24,7 +24,7 @@ let
     @test md != md2
 end
 
-@not_if_sanitize @test_throws_cuerror CUDA.ERROR_INVALID_IMAGE CuModule("foobar")
+@test_throws_cuerror CUDA.ERROR_INVALID_IMAGE CuModule("foobar")
 
 @testset "globals" begin
     md = CuModuleFile(joinpath(@__DIR__, "ptx/global.ptx"))
@@ -54,11 +54,11 @@ end
     # TODO: test with valid object code
     # NOTE: apparently, on Windows cuLinkAddData! _does_ accept object data containing \0
     if !Sys.iswindows()
-        @not_if_sanitize @test_throws_cuerror CUDA.ERROR_UNKNOWN add_data!(link, "vadd_parent", UInt8[0])
+        @test_throws_cuerror CUDA.ERROR_UNKNOWN add_data!(link, "vadd_parent", UInt8[0])
     end
 end
 
-@not_if_sanitize @testset "error log" begin
+@testset "error log" begin
     @test_throws_message contains("ptxas fatal") CuError CuModule(".version 3.1")
 
     link = CuLink()

--- a/test/cudadrv/pool.jl
+++ b/test/cudadrv/pool.jl
@@ -1,14 +1,12 @@
-@not_if_sanitize let
-    dev = device()
+dev = device()
 
-    pool = memory_pool(dev)
+pool = memory_pool(dev)
 
-    pool2 = CuMemoryPool(dev)
-    @test pool2 != pool
-    memory_pool!(dev, pool2)
-    @test pool2 == memory_pool(dev)
-    @test pool2 != default_memory_pool(dev)
+pool2 = CuMemoryPool(dev)
+@test pool2 != pool
+memory_pool!(dev, pool2)
+@test pool2 == memory_pool(dev)
+@test pool2 != default_memory_pool(dev)
 
-    memory_pool!(dev, pool)
-    @test pool == memory_pool(dev)
-end
+memory_pool!(dev, pool)
+@test pool == memory_pool(dev)

--- a/test/cutensor/contractions.jl
+++ b/test/cutensor/contractions.jl
@@ -2,9 +2,6 @@ using CUDA.CUTENSOR
 using CUDA
 using LinearAlgebra
 
-# these tests perform a lot of harmless-but-invalid API calls, poluting sanitizer logs
-@not_if_sanitize begin
-
 eltypes = ( (Float32, Float32, Float32, Float32),
             (Float32, Float32, Float32, Float16),
             (ComplexF32, ComplexF32, ComplexF32, ComplexF32),
@@ -198,6 +195,4 @@ can_pin = !Sys.iswindows()
             end
         end
     end
-end
-
 end

--- a/test/cutensor/elementwise_binary.jl
+++ b/test/cutensor/elementwise_binary.jl
@@ -2,8 +2,9 @@ using CUDA.CUTENSOR
 using CUDA
 using LinearAlgebra
 
-# using host memory with CUTENSOR doesn't work on Windows
-can_pin = !Sys.iswindows()
+# using host memory with CUTENSOR doesn't work on Windows,
+# and occasionally causes failures under compute-sanitizer.
+can_pin = !Sys.iswindows() && !sanitize
 
 eltypes = ((Float16, Float16),
             #(Float16, Float32),

--- a/test/cutensor/elementwise_trinary.jl
+++ b/test/cutensor/elementwise_trinary.jl
@@ -2,8 +2,9 @@ using CUDA.CUTENSOR
 using CUDA
 using LinearAlgebra
 
-# using host memory with CUTENSOR doesn't work on Windows
-can_pin = !Sys.iswindows()
+# using host memory with CUTENSOR doesn't work on Windows,
+# and occasionally causes failures under compute-sanitizer.
+can_pin = !Sys.iswindows() && !sanitize
 
 eltypes = ((Float16, Float16, Float16),
             #(Float16, Float32, Float32),

--- a/test/execution.jl
+++ b/test/execution.jl
@@ -36,7 +36,7 @@ end
 @testset "compilation params" begin
     @cuda dummy()
 
-    @not_if_sanitize @test_throws CuError @cuda threads=2 maxthreads=1 dummy()
+    @test_throws CuError @cuda threads=2 maxthreads=1 dummy()
     @cuda threads=2 dummy()
 end
 

--- a/test/initialization.jl
+++ b/test/initialization.jl
@@ -3,7 +3,7 @@
 
 # the API shouldn't have been initialized
 @test CuCurrentContext() == nothing
-@not_if_sanitize @test CuCurrentDevice() == nothing
+@test CuCurrentDevice() == nothing
 
 task_cb = Any[nothing for tid in 1:Threads.nthreads()]
 CUDA.attaskswitch() do

--- a/test/initialization.jl
+++ b/test/initialization.jl
@@ -55,14 +55,12 @@ dev = device()
 @test device_switch_cb[1] == nothing
 
 device!(CuDevice(0))
-device!(CuDevice(0)) do
-    nothing
-end
+@test device!(()->true, CuDevice(0))
+@inferred device!(()->42, CuDevice(0))
 
 context!(ctx)
-context!(ctx) do
-    nothing
-end
+@test context!(()->true, ctx)
+@inferred context!(()->42, ctx)
 
 @test_throws ErrorException device!(0, CUDA.CU_CTX_SCHED_YIELD)
 

--- a/test/pool.jl
+++ b/test/pool.jl
@@ -1,6 +1,6 @@
 CUDA.alloc(0)
 
-@not_if_sanitize @test_throws OutOfGPUMemoryError CuArray{Int}(undef, 10^20)
+@test_throws OutOfGPUMemoryError CuArray{Int}(undef, 10^20)
 
 @testset "@allocated" begin
     @test (CUDA.@allocated CuArray{Int32}(undef,1)) == 4

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -208,7 +208,7 @@ function addworker(X; kwargs...)
         sanitizer = CUDA.compute_sanitizer()
         @info "Running under $(readchomp(`$sanitizer --version`))"
         # NVIDIA bug 3263616: compute-sanitizer crashes when generating host backtraces
-        `$sanitizer --tool $sanitize_tool --launch-timeout=0 --show-backtrace=no --target-processes=all $test_exename`
+        `$sanitizer --tool $sanitize_tool --launch-timeout=0 --show-backtrace=no --target-processes=all --report-api-errors=no $test_exename`
     else
         test_exename
     end

--- a/test/setup.jl
+++ b/test/setup.jl
@@ -12,8 +12,9 @@ using Random
 
 # detect compute-sanitizer, to disable incompatible tests (e.g. using CUPTI),
 # and to skip tests that are known to generate innocuous API errors
+const sanitize = any(contains("NV_SANITIZER"), keys(ENV))
 macro not_if_sanitize(ex)
-    any(contains("NV_SANITIZER"), keys(ENV)) || return esc(ex)
+    sanitize || return esc(ex)
     quote
         @test_skip $ex
     end


### PR DESCRIPTION
Some performance (inferability) fixes, but also some bug fixes where we didn't switch to the appropriate context from finalizers. This would only surface in a multi-device setting (cc @marius311, in case you're still trying to do multi-device work in a single process).