### PR TITLE
Quicksort performance update

### DIFF
--- a/test/sorting.jl
+++ b/test/sorting.jl
@@ -3,14 +3,10 @@ using DataStructures
 
 @testset "quicksort" begin
 
-import CUDA.Quicksort: Θ, flex_lt, find_partition,
-        partition_batches_kernel, consolidate_batch_partition
+import CUDA.Quicksort: flex_lt, find_partition,
+        partition_batches_kernel, consolidate_batch_partition, bubble_sort
 
 @testset "integer functions" begin
-    @test Θ(0) == 0
-    @test Θ(1) == 1
-    @test Θ(2) == 1
-
     @test flex_lt(1, 2, false, isless, identity) == true
     @test flex_lt(1, 2, true, isless, identity) == true
     @test flex_lt(2, 2, false, isless, identity) == false
@@ -256,7 +252,7 @@ end
 
     # using a `by` argument
     @test check_sort(Float32, 100000; by=x->abs(x - 0.5))
-    @test check_sort(Float64, (4, 100000); by=x->cos(4 * pi * x), dims=2)
+    @test check_sort(Float64, (4, 100000); by=x->8*x-round(8*x), dims=2)
 end
 
 end


### PR DESCRIPTION
Modest speed up to quicksort by optimizing two separate parts: batch partition, and small array sorting. Batch partition no longer uses merge sort; it uses a cumsum to count how many values left of an index are > pivot, then does a single data movement based on that. For small arrays, bubble/brick sort is replaced with bitonic sort. 

The relative runtime between this branch and master is shown below, for 1D arrays on two different GPUs. For the graphs, lower is better, 100% would mean no difference. 

![image](https://user-images.githubusercontent.com/25183646/110835456-d1a0fe80-826c-11eb-923e-3cc5c2a5987a.png)

![image](https://user-images.githubusercontent.com/25183646/110835696-204e9880-826d-11eb-839c-970259e4ab3b.png)


