### PR TITLE
Don't free memory asynchronously from finalizers.

### DIFF
--- a/lib/cudadrv/CUDAdrv.jl
+++ b/lib/cudadrv/CUDAdrv.jl
@@ -31,3 +31,6 @@ include("events.jl")
 include("execution.jl")
 include("profile.jl")
 include("occupancy.jl")
+
+# TODO: figure out if these wrappers may use the runtime-esque state (stream(), context()).
+#       it's inconsitent now: @finalize_in_ctx doesn't, memory.jl does use stream(), etc.

--- a/src/pool/binned.jl
+++ b/src/pool/binned.jl
@@ -226,7 +226,7 @@ function alloc(pool::BinnedPool, bytes)
   return block
 end
 
-function free(pool::BinnedPool, block)
+function free(pool::BinnedPool, block; stream_ordered::Bool)
   # was this a pooled buffer?
   bytes = sizeof(block)
   if bytes > MAX_POOL
@@ -239,6 +239,9 @@ function free(pool::BinnedPool, block)
   @spinlock pool.freed_lock begin
     push!(pool.freed, block)
   end
+
+  # NOTE: we can ignore the stream_ordered keyword, as this pool is never stream-ordered
+  @assert !pool.stream_ordered
 end
 
 function cached_memory(pool::BinnedPool)

--- a/src/pool/none.jl
+++ b/src/pool/none.jl
@@ -22,8 +22,8 @@ function alloc(pool::NoPool, sz)
     return block
 end
 
-function free(pool::NoPool, block)
-    actual_free(block; pool.stream_ordered)
+function free(pool::NoPool, block; stream_ordered::Bool)
+    actual_free(block; stream_ordered = pool.stream_ordered && stream_ordered)
     return
 end
 

--- a/src/pool/simple.jl
+++ b/src/pool/simple.jl
@@ -102,12 +102,15 @@ function alloc(pool::SimplePool, sz)
     return block
 end
 
-function free(pool::SimplePool, block)
+function free(pool::SimplePool, block; stream_ordered::Bool)
     # we don't do any work here to reduce pressure on the GC (spending time in finalizers)
     # and to simplify locking (preventing concurrent access during GC interventions)
     @spinlock pool.freed_lock begin
         push!(pool.freed, block)
     end
+
+  # NOTE: we can ignore the stream_ordered keyword, as this pool is never stream-ordered
+  @assert !pool.stream_ordered
 end
 
 function cached_memory(pool::SimplePool)

--- a/src/pool/split.jl
+++ b/src/pool/split.jl
@@ -307,7 +307,7 @@ function alloc(pool::SplitPool, sz)
     return block
 end
 
-function free(pool::SplitPool, block)
+function free(pool::SplitPool, block; stream_ordered::Bool)
     # we don't do any work here to reduce pressure on the GC (spending time in finalizers)
     # and to simplify locking (preventing concurrent access during GC interventions)
     block.state == ALLOCATED || error("Cannot free a $(block.state) block")
@@ -315,6 +315,9 @@ function free(pool::SplitPool, block)
     @spinlock pool.freed_lock begin
         push!(pool.freed, block)
     end
+
+  # NOTE: we can ignore the stream_ordered keyword, as this pool is never stream-ordered
+  @assert !pool.stream_ordered
 end
 
 function reclaim(pool::SplitPool, sz::Int=typemax(Int))


### PR DESCRIPTION
Finalizers are executed from different tasks, so they use a different stream. That may result in early-free, because it doesn't order against any of the memory's uses, or even the allocation. Basically:

```julia
a = CuArray(...)
@cuda long_running_kernel(a)
a = nothing
GC.gc()
# finalizer kicks in here, freeing the memory immediately (since it executes
# on an otherwise idle stream in a different task) while the kernel is still running
```

Keeping track of the allocation stream in each CuArray doesn't help, since it's legal to `synchronize()` and use the array in a different task. Keeping track of all of the streams involved in operations on each CuArray seems too expensive.

@vchuravy suggested enqueueing a hostcall that marks the memory as free'able, but that seems fragile (what with array wrappers?) and costly.

So I've opted for making the free from finalizer synchronous again. Eager `unsafe_free!` can remain asynchronous, since it's assumed this is executed from the stream that's being used for other operations with the array. If we ever do lifetime tracking and insert early free operations, the same applies, so the cost of this approach may go down in the future.

Finally, this should also fix some of the CONTEXT_IS_DESTROYED errors we were seeing on CI, since those happened when an asynchronous free executed during task or process cleanup when the task-local stream had already been destroyed (the error message is inaccurate). We could track validity of streams like we do with contexts, but with this PR not freeing asynchronously (and thus not needing a stream) we solve the issue too.