### PR TITLE
Use legacy streams from finalizers to block on other streams

### DIFF
--- a/src/pool.jl
+++ b/src/pool.jl
@@ -8,6 +8,9 @@ using DataStructures
 include("pool/utils.jl")
 using .PoolUtils
 
+# TODO: simple/binned/split allocators ignore stream arguments; is that safe?
+#       should we bother fixing this (on CUDA 11.2 we have a stream-ordered allocator)?
+
 
 ## allocation statistics
 
@@ -115,7 +118,7 @@ function hard_limit(dev::CuDevice)
 end
 
 function actual_alloc(bytes::Integer, last_resort::Bool=false;
-                      stream_ordered::Bool=false)
+                      stream_ordered::Bool=false, stream::CuStream=stream())
   dev = device()
 
   # check the memory allocation limit
@@ -127,7 +130,7 @@ function actual_alloc(bytes::Integer, last_resort::Bool=false;
   buf = try
     time = Base.@elapsed begin
       @timeit_debug alloc_to "alloc" begin
-        buf = Mem.alloc(Mem.Device, bytes; async=true, stream_ordered)
+        buf = Mem.alloc(Mem.Device, bytes; async=true, stream_ordered, stream)
       end
     end
 
@@ -145,7 +148,7 @@ function actual_alloc(bytes::Integer, last_resort::Bool=false;
   return Block(buf, bytes; state=AVAILABLE)
 end
 
-function actual_free(block::Block; stream_ordered::Bool=false)
+function actual_free(block::Block; stream_ordered::Bool=false, stream::CuStream=stream())
   dev = device()
 
   @assert iswhole(block) "Cannot free $block: block is not whole"
@@ -155,7 +158,7 @@ function actual_free(block::Block; stream_ordered::Bool=false)
   # free the memory
   @timeit_debug alloc_to "free" begin
     time = Base.@elapsed begin
-      Mem.free(block.buf; async=true, stream_ordered)
+      Mem.free(block.buf; async=true, stream_ordered, stream)
     end
     block.state = INVALID
 
@@ -268,7 +271,7 @@ end
 Allocate a number of bytes `sz` from the memory pool. Returns a `CuPtr{Nothing}`; may throw
 a [`OutOfGPUMemoryError`](@ref) if the allocation request cannot be satisfied.
 """
-@inline function alloc(sz)
+@inline function alloc(sz; stream::CuStream=stream())
   # 0-byte allocations shouldn't hit the pool
   sz == 0 && return CU_NULL
 
@@ -276,7 +279,7 @@ a [`OutOfGPUMemoryError`](@ref) if the allocation request cannot be satisfied.
   pool = pools[dev]
 
   time = Base.@elapsed begin
-    @pool_timeit "pooled alloc" block = alloc(pool, sz)::Union{Nothing,Block}
+    @pool_timeit "pooled alloc" block = alloc(pool, sz; stream)::Union{Nothing,Block}
   end
   block === nothing && throw(OutOfGPUMemoryError(sz))
 
@@ -333,7 +336,7 @@ end
 
 Releases a buffer pointed to by `ptr` to the memory pool.
 """
-@inline function free(ptr::CuPtr{Nothing})
+@inline function free(ptr::CuPtr{Nothing}; stream::CuStream=stream())
   # 0-byte allocations shouldn't hit the pool
   ptr == CU_NULL && return
 
@@ -370,7 +373,7 @@ Releases a buffer pointed to by `ptr` to the memory pool.
     end
 
     time = Base.@elapsed begin
-      @pool_timeit "pooled free" free(pool, block)
+      @pool_timeit "pooled free" free(pool, block; stream)
     end
 
     alloc_stats.pool_time += time

--- a/src/pool.jl
+++ b/src/pool.jl
@@ -329,17 +329,11 @@ multiple calls to `free` before this buffer is put back into the memory pool.
 end
 
 """
-    free(ptr; [stream_ordered::Bool=true])
+    free(ptr)
 
 Releases a buffer pointed to by `ptr` to the memory pool.
-
-The optional keyword argument `stream_ordered` indicates whether this free may execute
-asynchronously, ordered against the task-local stream. This is not safe when performing the
-operation from a finalizer, which operates in its own task, using its own task-local stream.
-This may result in the free being executed before all uses, or even the allocation itself,
-have been executed on their respective stream.
 """
-@inline function free(ptr::CuPtr{Nothing}; stream_ordered::Bool=true)
+@inline function free(ptr::CuPtr{Nothing})
   # 0-byte allocations shouldn't hit the pool
   ptr == CU_NULL && return
 
@@ -376,7 +370,7 @@ have been executed on their respective stream.
     end
 
     time = Base.@elapsed begin
-      @pool_timeit "pooled free" free(pool, block; stream_ordered)
+      @pool_timeit "pooled free" free(pool, block)
     end
 
     alloc_stats.pool_time += time

--- a/src/pool/binned.jl
+++ b/src/pool/binned.jl
@@ -226,7 +226,7 @@ function alloc(pool::BinnedPool, bytes)
   return block
 end
 
-function free(pool::BinnedPool, block; stream_ordered::Bool)
+function free(pool::BinnedPool, block)
   # was this a pooled buffer?
   bytes = sizeof(block)
   if bytes > MAX_POOL
@@ -239,9 +239,6 @@ function free(pool::BinnedPool, block; stream_ordered::Bool)
   @spinlock pool.freed_lock begin
     push!(pool.freed, block)
   end
-
-  # NOTE: we can ignore the stream_ordered keyword, as this pool is never stream-ordered
-  @assert !pool.stream_ordered
 end
 
 function cached_memory(pool::BinnedPool)

--- a/src/pool/binned.jl
+++ b/src/pool/binned.jl
@@ -112,7 +112,7 @@ function pool_repopulate(pool::BinnedPool)
   return
 end
 
-function alloc(pool::BinnedPool, bytes)
+function alloc(pool::BinnedPool, bytes; stream::CuStream)
   if bytes <= MAX_POOL
     pid = poolidx(bytes)
     create_pools(pool, pid)
@@ -226,7 +226,7 @@ function alloc(pool::BinnedPool, bytes)
   return block
 end
 
-function free(pool::BinnedPool, block)
+function free(pool::BinnedPool, block; stream::CuStream)
   # was this a pooled buffer?
   bytes = sizeof(block)
   if bytes > MAX_POOL

--- a/src/pool/none.jl
+++ b/src/pool/none.jl
@@ -22,8 +22,8 @@ function alloc(pool::NoPool, sz)
     return block
 end
 
-function free(pool::NoPool, block; stream_ordered::Bool)
-    actual_free(block; stream_ordered = pool.stream_ordered && stream_ordered)
+function free(pool::NoPool, block)
+    actual_free(block; stream_ordered = pool.stream_ordered)
     return
 end
 

--- a/src/pool/none.jl
+++ b/src/pool/none.jl
@@ -4,7 +4,7 @@ Base.@kwdef struct NoPool <: AbstractPool
     stream_ordered::Bool
 end
 
-function alloc(pool::NoPool, sz)
+function alloc(pool::NoPool, sz; stream::CuStream)
     block = nothing
     for phase in 1:3
         if phase == 2
@@ -14,7 +14,7 @@ function alloc(pool::NoPool, sz)
         end
 
         @pool_timeit "$phase.1 alloc" begin
-            block = actual_alloc(sz, phase==3; pool.stream_ordered)
+            block = actual_alloc(sz, phase==3; pool.stream_ordered, stream)
         end
         block === nothing || break
     end
@@ -22,8 +22,8 @@ function alloc(pool::NoPool, sz)
     return block
 end
 
-function free(pool::NoPool, block)
-    actual_free(block; stream_ordered = pool.stream_ordered)
+function free(pool::NoPool, block; stream::CuStream)
+    actual_free(block; pool.stream_ordered, stream)
     return
 end
 

--- a/src/pool/simple.jl
+++ b/src/pool/simple.jl
@@ -71,7 +71,7 @@ function reclaim(pool::SimplePool, sz::Int=typemax(Int))
     end
 end
 
-function alloc(pool::SimplePool, sz)
+function alloc(pool::SimplePool, sz; stream::CuStream)
     block = nothing
     for phase in 1:3
         if phase == 2
@@ -102,7 +102,7 @@ function alloc(pool::SimplePool, sz)
     return block
 end
 
-function free(pool::SimplePool, block)
+function free(pool::SimplePool, block; stream::CuStream)
     # we don't do any work here to reduce pressure on the GC (spending time in finalizers)
     # and to simplify locking (preventing concurrent access during GC interventions)
     @spinlock pool.freed_lock begin

--- a/src/pool/simple.jl
+++ b/src/pool/simple.jl
@@ -102,15 +102,12 @@ function alloc(pool::SimplePool, sz)
     return block
 end
 
-function free(pool::SimplePool, block; stream_ordered::Bool)
+function free(pool::SimplePool, block)
     # we don't do any work here to reduce pressure on the GC (spending time in finalizers)
     # and to simplify locking (preventing concurrent access during GC interventions)
     @spinlock pool.freed_lock begin
         push!(pool.freed, block)
     end
-
-  # NOTE: we can ignore the stream_ordered keyword, as this pool is never stream-ordered
-  @assert !pool.stream_ordered
 end
 
 function cached_memory(pool::SimplePool)

--- a/src/pool/split.jl
+++ b/src/pool/split.jl
@@ -307,7 +307,7 @@ function alloc(pool::SplitPool, sz)
     return block
 end
 
-function free(pool::SplitPool, block; stream_ordered::Bool)
+function free(pool::SplitPool, block)
     # we don't do any work here to reduce pressure on the GC (spending time in finalizers)
     # and to simplify locking (preventing concurrent access during GC interventions)
     block.state == ALLOCATED || error("Cannot free a $(block.state) block")
@@ -315,9 +315,6 @@ function free(pool::SplitPool, block; stream_ordered::Bool)
     @spinlock pool.freed_lock begin
         push!(pool.freed, block)
     end
-
-  # NOTE: we can ignore the stream_ordered keyword, as this pool is never stream-ordered
-  @assert !pool.stream_ordered
 end
 
 function reclaim(pool::SplitPool, sz::Int=typemax(Int))

--- a/src/pool/split.jl
+++ b/src/pool/split.jl
@@ -214,7 +214,7 @@ end
     end
 end
 
-function alloc(pool::SplitPool, sz)
+function alloc(pool::SplitPool, sz; stream::CuStream)
     szclass = size_class(sz)
 
     # round off the block size
@@ -307,7 +307,7 @@ function alloc(pool::SplitPool, sz)
     return block
 end
 
-function free(pool::SplitPool, block)
+function free(pool::SplitPool, block; stream::CuStream)
     # we don't do any work here to reduce pressure on the GC (spending time in finalizers)
     # and to simplify locking (preventing concurrent access during GC interventions)
     block.state == ALLOCATED || error("Cannot free a $(block.state) block")

--- a/src/state.jl
+++ b/src/state.jl
@@ -518,7 +518,7 @@ Get the CUDA stream that should be used as the default one for the currently exe
     if @inbounds thread_streams[tid] === nothing
         ctx = context()
         thread_streams[tid] = get!(task_local_storage(), (:CuStream, ctx)) do
-            stream = CuStream(; flags=STREAM_NON_BLOCKING)
+            stream = CuStream()
 
             t = current_task()
             tptr = pointer_from_objref(current_task())


### PR DESCRIPTION
Reading https://github.com/JuliaGPU/CUDA.jl/issues/780#issuecomment-804255663, I realized that we can't ever safely free from finalizers without synchronizing the entire device: I previously assumed that calling the synchronizing `cuMemFree` would suffice, but I'm guessing now that's not true, and we first need to make sure any operation on this memory have finished.

And again, to avoid this sync you can call `unsafe_free!` early, in which case we won't sync but will use the task-local stream to perform the free on.

Also happens to work around https://github.com/JuliaGPU/CUDA.jl/issues/780.