### PR TITLE
Optimize array construction and allocation

### DIFF
--- a/lib/cufft/fft.jl
+++ b/lib/cufft/fft.jl
@@ -24,12 +24,12 @@ Base.unsafe_convert(::Type{cufftHandle}, p::CuFFTPlan) = p.handle
 # for some reason, cufftHandle is an integer and not a pointer...
 Base.convert(::Type{cufftHandle}, p::CuFFTPlan) = Base.unsafe_convert(cufftHandle, p)
 
-function CUDA.unsafe_free!(plan::CuFFTPlan, finalizer::Bool=false)
+function CUDA.unsafe_free!(plan::CuFFTPlan, stream::CuStream=stream())
     @context! skip_destroyed=true plan.workarea.ctx cufftDestroy(plan)
-    unsafe_free!(plan.workarea, finalizer)
+    unsafe_free!(plan.workarea, stream)
 end
 
-unsafe_finalize!(plan::CuFFTPlan) = unsafe_free!(plan, true)
+unsafe_finalize!(plan::CuFFTPlan) = unsafe_free!(plan, CuDefaultStream())
 
 mutable struct cCuFFTPlan{T<:cufftNumber,K,inplace,N} <: CuFFTPlan{T,K,inplace}
     handle::cufftHandle

--- a/src/pool.jl
+++ b/src/pool.jl
@@ -118,7 +118,7 @@ function hard_limit(dev::CuDevice)
 end
 
 function actual_alloc(bytes::Integer, last_resort::Bool=false;
-                      stream_ordered::Bool=false, stream::CuStream=stream())
+                      stream_ordered::Bool=false, stream::Union{CuStream,Nothing}=nothing)
   dev = device()
 
   # check the memory allocation limit
@@ -148,7 +148,7 @@ function actual_alloc(bytes::Integer, last_resort::Bool=false;
   return Block(buf, bytes; state=AVAILABLE)
 end
 
-function actual_free(block::Block; stream_ordered::Bool=false, stream::CuStream=stream())
+function actual_free(block::Block; stream_ordered::Bool=false, stream::Union{CuStream,Nothing}=nothing)
   dev = device()
 
   @assert iswhole(block) "Cannot free $block: block is not whole"


### PR DESCRIPTION
For 8 bytes, from 1.8 us to around 1 us, closer to the 800ns from before. For reference, before the stream-ordered allocator an 8-byte allocation only took around 500ns when it hit the pool. Base allocates in 20ns or so...