### PR TITLE
Update introduction.jl

### DIFF
--- a/docs/src/tutorials/introduction.jl
+++ b/docs/src/tutorials/introduction.jl
@@ -328,10 +328,7 @@ end
 
 function gpu_add3!(y, x)
     index = (blockIdx().x - 1) * blockDim().x + threadIdx().x
-    stride = blockDim().x * gridDim().x
-    for i = index:stride:length(y)
-        @inbounds y[i] += x[i]
-    end
+    @inbounds y[index] += x[index]
     return
 end
 


### PR DESCRIPTION
stride isn't needed in gpu_add3!, since we're creating a thread for every index, and the for loop slows the computation down ~5x. C.f. https://discourse.julialang.org/t/cuda-jl-tutorial-code-kernel-slower-than-broadcast/58242/5