### PR TITLE
Don't use mod from libdevice.

### DIFF
--- a/src/device/intrinsics/math.jl
+++ b/src/device/intrinsics/math.jl
@@ -237,8 +237,9 @@ using SpecialFunctions
 
 ## division and remainder
 
-@device_override Base.mod(x::Float64, y::Float64) = ccall("extern __nv_fmod", llvmcall, Cdouble, (Cdouble, Cdouble), x, y)
-@device_override Base.mod(x::Float32, y::Float32) = ccall("extern __nv_fmodf", llvmcall, Cfloat, (Cfloat, Cfloat), x, y)
+# NOTE: CUDA follows fmod, which behaves differently than Base.mod for negative numbers
+#@device_override Base.mod(x::Float64, y::Float64) = ccall("extern __nv_fmod", llvmcall, Cdouble, (Cdouble, Cdouble), x, y)
+#@device_override Base.mod(x::Float32, y::Float32) = ccall("extern __nv_fmodf", llvmcall, Cfloat, (Cfloat, Cfloat), x, y)
 
 @device_override Base.rem(x::Float64, y::Float64) = ccall("extern __nv_remainder", llvmcall, Cdouble, (Cdouble, Cdouble), x, y)
 @device_override Base.rem(x::Float32, y::Float32) = ccall("extern __nv_remainderf", llvmcall, Cfloat, (Cfloat, Cfloat), x, y)

--- a/test/device/intrinsics.jl
+++ b/test/device/intrinsics.jl
@@ -31,7 +31,9 @@ end
 ############################################################################################
 
 @testset "math" begin
-    @test testf(a->log10.(a), Float32[100])
+    @testset "log10" begin
+        @test testf(a->log10.(a), Float32[100])
+    end
 
     @testset "pow" begin
         for T in (Float32, Float64, ComplexF32, ComplexF64)
@@ -70,6 +72,13 @@ end
                 @test testf(x->op.(x), -rand(T, 1))
             end
 
+        end
+    end
+    @testset "mod and rem" begin
+        # CUDA follows C's fmod, which behaves differently than Julia on negative numbers
+        for op in (mod, rem), T in (Float32, Float64)
+            @test testf(a->op.(a, T(2)), T[1])
+            @test testf(a->op.(a, T(2)), T[-1])
         end
     end
 end


### PR DESCRIPTION
It behaves differently than Base.mod on negative numbers. Fixes https://github.com/JuliaGPU/CUDA.jl/issues/748.