### PR TITLE
fix bounds check for reverse kwarg and add tests

### DIFF
--- a/src/reverse.jl
+++ b/src/reverse.jl
@@ -85,8 +85,8 @@ end
 
 # in-place
 function Base.reverse!(data::AnyCuArray{T, N}; dims::Integer) where {T, N}
-    if !(1 ≤ dims ≤ length(size(data)))
-      ArgumentError("dimension $dims is not 1 ≤ $dims ≤ $length(size(input))")
+    if !(1 ≤ dims ≤ ndims(data))
+        throw(ArgumentError("dimension $dims is not 1 ≤ $dims ≤ $(ndims(data))"))
     end
 
     _reverse(data; dims=dims)
@@ -96,8 +96,8 @@ end
 
 # out-of-place
 function Base.reverse(input::AnyCuArray{T, N}; dims::Integer) where {T, N}
-    if !(1 ≤ dims ≤ length(size(input)))
-      ArgumentError("dimension $dims is not 1 ≤ $dims ≤ $length(size(input))")
+    if !(1 ≤ dims ≤ ndims(input))
+        throw(ArgumentError("dimension $dims is not 1 ≤ $dims ≤ $(ndims(input))"))
     end
 
     output = similar(input)

--- a/test/array.jl
+++ b/test/array.jl
@@ -419,6 +419,14 @@ end
 
     # wrapped array
     @test testf(x->reverse(x), reshape(rand(2,2), 4))
+
+    # error throwing
+    cpu = rand(1,2,3,4)
+    gpu = CuArray(cpu)
+    @test_throws ArgumentError reverse!(gpu, dims=5)
+    @test_throws ArgumentError reverse!(gpu, dims=0)
+    @test_throws ArgumentError reverse(gpu, dims=5)
+    @test_throws ArgumentError reverse(gpu, dims=0)
 end
 
 @testset "findall" begin


### PR DESCRIPTION
why not just use `ndims`? Also this wasn't throwing earlier and now does without progressing to the underscored methods.