### PR TITLE
More OOM fixes for the stream-ordered allocator

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -232,8 +232,6 @@ steps:
     plugins:
       - JuliaCI/julia#v1:
           version: 1.6-nightly
-    env:
-      JULIA_CUDA_MEMORY_POOL: 'none'  # CUDA.jl#794
     command: |
       julia --project -e '
         println("--- :julia: Instantiating project")

--- a/src/pool.jl
+++ b/src/pool.jl
@@ -141,7 +141,7 @@ function actual_alloc(bytes::Integer, last_resort::Bool=false;
 
     buf
   catch err
-    (isa(err, CuError) && err.code == ERROR_OUT_OF_MEMORY) || rethrow()
+    isa(err, OutOfGPUMemoryError) || rethrow()
     return nothing
   end
 

--- a/src/pool.jl
+++ b/src/pool.jl
@@ -616,7 +616,7 @@ function memory_status(io::IO=stdout)
   alloc_used_bytes = used_memory(dev)
   alloc_cached_bytes = cached_memory(pool)
   alloc_total_bytes = alloc_used_bytes + alloc_cached_bytes
-  @printf(io, "Memory pool '%s' usage: %s (%s allocated, %s cached)\n", string(pool),
+  @printf(io, "Memory pool usage: %s (%s allocated, %s cached)\n",
               Base.format_bytes(alloc_total_bytes), Base.format_bytes(alloc_used_bytes),
               Base.format_bytes(alloc_cached_bytes))
 

--- a/src/pool/none.jl
+++ b/src/pool/none.jl
@@ -6,11 +6,13 @@ end
 
 function alloc(pool::NoPool, sz; stream::CuStream)
     block = nothing
-    for phase in 1:3
+    for phase in 1:4
         if phase == 2
             @pool_timeit "$phase.0 gc (incremental)" GC.gc(false)
         elseif phase == 3
             @pool_timeit "$phase.0 gc (full)" GC.gc(true)
+        elseif phase == 4 && pool.stream_ordered
+            @pool_timeit "$phase.0 synchronize" device_synchronize()
         end
 
         @pool_timeit "$phase.1 alloc" begin


### PR DESCRIPTION
Should fix https://github.com/JuliaGPU/CUDA.jl/issues/794. Corrects a bug from https://github.com/JuliaGPU/CUDA.jl/pull/809, where we were now matching the wrong exception.