### PR TITLE
Add a wrapper to cusolverRF in CUSOLVER

### DIFF
--- a/lib/cusolver/CUSOLVER.jl
+++ b/lib/cusolver/CUSOLVER.jl
@@ -22,6 +22,7 @@ include("base.jl")
 include("sparse.jl")
 include("dense.jl")
 include("multigpu.jl")
+include("cusolverRF.jl")
 
 # high-level integrations
 include("linalg.jl")

--- a/lib/cusolver/cusolverRF.jl
+++ b/lib/cusolver/cusolverRF.jl
@@ -1,0 +1,436 @@
+
+import CUDA.CUBLAS: unsafe_batch, unsafe_strided_batch
+
+function cusolverRfCreate()
+    handle_ref = Ref{cusolverRfHandle_t}()
+    cusolverRfCreate(handle_ref)
+    return handle_ref[]
+end
+
+function cusolverRfFree(handle)
+    if handle != C_NULL
+        cusolverRfDestroy(handle)
+        handle = C_NULL
+    end
+end
+
+mutable struct RfHandle
+    handle::Ptr{cusolverRfHandle_t}
+end
+
+function sparse_rf_handle(;
+    fast_mode=true, nzero=0.0, nboost=0.0,
+    factorization_algo=CUSOLVERRF_FACTORIZATION_ALG0,
+    triangular_algo=CUSOLVERRF_TRIANGULAR_SOLVE_ALG1,
+)
+    # Create handle
+    gH = cusolverRfCreate()
+    if fast_mode
+        cusolverRfSetResetValuesFastMode(gH, CUSOLVERRF_RESET_VALUES_FAST_MODE_ON)
+    else
+        cusolverRfSetResetValuesFastMode(gH, CUSOLVERRF_RESET_VALUES_FAST_MODE_OFF)
+    end
+    cusolverRfSetNumericProperties(gH, nzero, nboost)
+    cusolverRfSetMatrixFormat(
+        gH,
+        CUSOLVERRF_MATRIX_FORMAT_CSR,
+        CUSOLVERRF_UNIT_DIAGONAL_ASSUMED_L
+    )
+    cusolverRfSetAlgs(
+        gH, factorization_algo, triangular_algo,
+    )
+    handle = RfHandle(gH)
+    finalizer(rf_free!, handle)
+    return handle
+end
+
+rf_free!(rf::RfHandle) = cusolverRfFree(rf.handle)
+
+Base.unsafe_convert(::Type{cusolverRfHandle_t}, rf::RfHandle) = rf.handle
+
+struct RfHostLU{T}
+    nnzA::Cint
+    rowsA::Vector{Cint}
+    colsA::Vector{Cint}
+    valsA::Vector{T}
+    nnzL::Cint
+    rowsL::Vector{Cint}
+    colsL::Vector{Cint}
+    valsL::Vector{T}
+    nnzU::Cint
+    rowsU::Vector{Cint}
+    colsU::Vector{Cint}
+    valsU::Vector{T}
+    P::Vector{Cint}
+    Q::Vector{Cint}
+end
+
+function RfHostLU(
+    A::CuSparseMatrixCSR{T, Ti};
+    ordering=:AMD, tol=1e-8, check=true,
+) where {T, Ti}
+    m, n = size(A)
+    @assert m == n # only squared matrices are supported
+    nnzA = nnz(A)
+
+    # Transfer data to host
+    h_rowsA = A.rowPtr |> Vector{Cint}
+    h_colsA = A.colVal |> Vector{Cint}
+    h_valsA = A.nzVal |> Vector{T}
+
+    # cusolverRf is 0-based
+    h_rowsA .-= Cint(1)
+    h_colsA .-= Cint(1)
+    h_Qreorder = zeros(Cint, n)
+    # Create duplicate matrix for reordering
+    h_rowsB = copy(h_rowsA)
+    h_colsB = copy(h_colsA)
+    h_valsB = copy(h_valsA)
+
+    spH = sparse_handle()
+
+    # Create matrix descriptor
+    desca = CUSPARSE.CuMatrixDescriptor()
+    CUSPARSE.cusparseSetMatType(desca, CUSPARSE.CUSPARSE_MATRIX_TYPE_GENERAL)
+    CUSPARSE.cusparseSetMatIndexBase(desca, CUSPARSE.CUSPARSE_INDEX_BASE_ZERO)
+
+    # Reordering
+    if ordering == :AMD
+        cusolverSpXcsrsymamdHost(
+            spH,
+            n, nnzA, desca,
+            h_rowsA, h_colsA, h_Qreorder,
+        )
+    elseif ordering == :MDQ
+        cusolverSpXcsrsymmdqHost(
+            spH,
+            n, nnzA, desca,
+            h_rowsA, h_colsA, h_Qreorder,
+        )
+    elseif ordering == :METIS
+        cusolverSpXcsrmetisndHost(
+            spH,
+            n, nnzA, desca,
+            h_rowsA, h_colsA, C_NULL, h_Qreorder,
+        )
+    elseif ordering == :RCM
+        cusolverSpXcsrsymrcmHost(
+            spH,
+            n, nnzA, desca,
+            h_rowsA, h_colsA, h_Qreorder,
+        )
+    end
+
+    h_mapBfromA = zeros(Cint, nnzA)
+    @inbounds for i in 1:nnzA
+        h_mapBfromA[i] = i # identity matrix
+    end
+
+    # Compute permutation in two steps
+    size_perm = Ref{Csize_t}(0)
+    cusolverSpXcsrperm_bufferSizeHost(
+        spH,
+        m, n, nnzA, desca,
+        h_rowsB, h_colsB, h_Qreorder, h_Qreorder,
+        size_perm,
+    )
+
+    buffer_cpu = zeros(Cint, size_perm[])
+    cusolverSpXcsrpermHost(
+        spH,
+        m, n, nnzA, desca,
+        h_rowsB, h_colsB, h_Qreorder, h_Qreorder, h_mapBfromA,
+        buffer_cpu,
+    )
+
+    # Apply permutation
+    h_valsB = h_valsA[h_mapBfromA]
+
+    # LU Factorization
+    info = Ref{CUSOLVER.csrqrInfo_t}()
+    cusolverSpCreateCsrluInfoHost(info)
+
+    cusolverSpXcsrluAnalysisHost(
+        spH,
+        m, nnzA, desca,
+        h_rowsB, h_colsB, info[],
+    )
+
+    size_internal = Ref{Cint}(0)
+    size_lu = Ref{Cint}(0)
+    cusolverSpDcsrluBufferInfoHost(
+        spH,
+        n, nnzA, desca,
+        h_valsB, h_rowsB, h_colsB,
+        info[],
+        size_internal, size_lu
+    )
+
+    n_bytes = size_lu[] * sizeof(Cint)
+    buffer_lu = zeros(Cint, size_lu[])
+    pivot_threshold = 1.0
+
+    cusolverSpDcsrluFactorHost(
+        spH, n, nnzA, desca,
+        h_valsB, h_rowsB, h_colsB,
+        info[], pivot_threshold,
+        buffer_lu,
+    )
+
+    # Check singularity
+    if check
+        singularity = Ref{Cint}(0)
+        cusolverSpDcsrluZeroPivotHost(
+            spH, info[], tol, singularity,
+        )
+
+        # Check that the matrix is nonsingular
+        if singularity[] >= 0
+            SingularException(singularity[])
+        end
+    end
+
+    # Get size of L and U
+    pnnzU = Ref{Cint}(0)
+    pnnzL = Ref{Cint}(0)
+    cusolverSpXcsrluNnzHost(
+        spH,
+        pnnzL, pnnzU, info[],
+    )
+
+    nnzL = pnnzL[]
+    nnzU = pnnzU[]
+
+    # Retrieve L and U matrices
+    h_Plu = zeros(Cint, m)
+    h_Qlu = zeros(Cint, n)
+
+    h_valsL = zeros(nnzL)
+    h_rowsL = zeros(Cint, m+1)
+    h_colsL = zeros(Cint, nnzL)
+
+    h_valsU = zeros(nnzU)
+    h_rowsU = zeros(Cint, m+1)
+    h_colsU = zeros(Cint, nnzU)
+
+    # Extract
+    cusolverSpDcsrluExtractHost(
+        spH,
+        h_Plu, h_Qlu,
+        desca,
+        h_valsL, h_rowsL, h_colsL,
+        desca,
+        h_valsU, h_rowsU, h_colsU,
+        info[],
+        buffer_lu,
+    )
+
+    h_P = h_Qreorder[h_Plu .+ 1]
+    h_Q = h_Qreorder[h_Qlu .+ 1]
+
+    return RfHostLU(
+        nnzA, h_rowsA, h_colsA, h_valsA,
+        nnzL, h_rowsL, h_colsL, h_valsL,
+        nnzU, h_rowsU, h_colsU, h_valsU,
+        h_P, h_Q,
+    )
+end
+
+struct RfLU{T} <: LinearAlgebra.Factorization{T}
+    rf::RfHandle
+    nrhs::Int
+    n::Int
+    m::Int
+    nnzA::Int
+    drowsA::CuVector{Cint}
+    dcolsA::CuVector{Cint}
+    dP::CuVector{Cint}
+    dQ::CuVector{Cint}
+    dT::CuVector{T}
+end
+
+function RfLU(
+    A::CuSparseMatrixCSR{T, Ti};
+    nrhs=1, ordering=:AMD, check=true, fast_mode=true,
+    factorization_algo=CUSOLVERRF_FACTORIZATION_ALG0,
+    triangular_algo=CUSOLVERRF_TRIANGULAR_SOLVE_ALG1,
+) where {T, Ti}
+    if nrhs > 1
+        error("Currently CusolverRF supports only one right-hand side.")
+    end
+    n, m = size(A)
+    lu_host = RfHostLU(A; ordering=ordering, check=check)
+
+    # Allocations (device)
+    d_T = CUDA.zeros(Cdouble, m * nrhs)
+
+    rf = sparse_rf_handle(;
+        fast_mode=fast_mode,
+        factorization_algo=factorization_algo,
+        triangular_algo=triangular_algo,
+    )
+
+    # Assemble internal data structures
+    cusolverRfSetupHost(
+        n, lu_host.nnzA, lu_host.rowsA, lu_host.colsA, lu_host.valsA,
+        lu_host.nnzL, lu_host.rowsL, lu_host.colsL, lu_host.valsL,
+        lu_host.nnzU, lu_host.rowsU, lu_host.colsU, lu_host.valsU,
+        lu_host.P, lu_host.Q,
+        rf
+    )
+    # Analyze available parallelism
+    cusolverRfAnalyze(rf)
+    # LU factorization
+    cusolverRfRefactor(rf)
+
+    return RfLU{T}(
+        rf, nrhs, n, m, lu_host.nnzA,
+        lu_host.rowsA, lu_host.colsA, lu_host.P, lu_host.Q, d_T
+    )
+end
+
+# Update factorization inplace
+function rf_refactor!(rflu::RfLU{T}, A::CuSparseMatrixCSR{T, Ti}) where {T, Ti}
+    cusolverRfResetValues(
+        rflu.n, rflu.nnzA,
+        rflu.drowsA, rflu.dcolsA, A.nzVal, rflu.dP, rflu.dQ,
+        rflu.rf
+    )
+    cusolverRfRefactor(rflu.rf)
+    return
+end
+
+# Solve system Ax = b
+function rf_solve!(rflu::RfLU{T}, x::CuVector{T}) where T
+    n = rflu.n
+    cusolverRfSolve(rflu.rf, rflu.dP, rflu.dQ, rflu.nrhs, rflu.dT, n, x, n)
+    return
+end
+
+# Batch factorization should not mix with classical LU factorization.
+# We implement a structure apart.
+struct RfBatchLU{T} <: LinearAlgebra.Factorization{T}
+    rf::RfHandle
+    batchsize::Int
+    n::Int
+    m::Int
+    nnzA::Int
+    drowsA::CuVector{Cint}
+    dcolsA::CuVector{Cint}
+    dP::CuVector{Cint}
+    dQ::CuVector{Cint}
+    dT::CuVector{T}
+end
+
+function RfBatchLU(
+    A::CuSparseMatrixCSR{T, Ti}, batchsize::Int;
+    ordering=:AMD, check=true, fast_mode=true,
+    factorization_algo=CUSOLVERRF_FACTORIZATION_ALG0,
+    triangular_algo=CUSOLVERRF_TRIANGULAR_SOLVE_ALG1,
+) where {T, Ti}
+    n, m = size(A)
+    lu_host = RfHostLU(A; ordering=ordering, check=check)
+
+    # Allocations (device)
+    d_T = CUDA.zeros(Cdouble, m * batchsize * 2)
+
+    rf = sparse_rf_handle(;
+        fast_mode=fast_mode,
+        factorization_algo=factorization_algo,
+        triangular_algo=triangular_algo,
+    )
+
+    # Assemble internal data structures
+    h_valsA_batch = Vector{Float64}[lu_host.valsA for i in 1:batchsize]
+    ptrA_batch = pointer.(h_valsA_batch)
+    cusolverRfBatchSetupHost(
+        batchsize,
+        n, lu_host.nnzA, lu_host.rowsA, lu_host.colsA, ptrA_batch,
+        lu_host.nnzL, lu_host.rowsL, lu_host.colsL, lu_host.valsL,
+        lu_host.nnzU, lu_host.rowsU, lu_host.colsU, lu_host.valsU,
+        lu_host.P, lu_host.Q,
+        rf,
+    )
+    # Analyze available parallelism
+    cusolverRfBatchAnalyze(rf)
+    # LU factorization
+    cusolverRfBatchRefactor(rf)
+
+    return RfBatchLU{T}(
+        rf, batchsize, n, m, lu_host.nnzA,
+        lu_host.rowsA, lu_host.colsA, lu_host.P, lu_host.Q, d_T
+    )
+end
+
+# Update factorization inplace
+## Single matrix
+function rf_batch_refactor!(rflu::RfBatchLU{T}, A::CuSparseMatrixCSR{T, Ti}) where {T, Ti}
+    ptrs = [pointer(A.nzVal) for i in 1:rflu.batchsize]
+    Aptrs = CuArray(ptrs)
+    cusolverRfBatchResetValues(
+        rflu.batchsize, rflu.n, rflu.nnzA,
+        rflu.drowsA, rflu.dcolsA, Aptrs, rflu.dP, rflu.dQ,
+        rflu.rf
+    )
+    unsafe_free!(Aptrs)
+    cusolverRfBatchRefactor(rflu.rf)
+    return
+end
+## Multiple matrices
+function rf_batch_refactor!(rflu::RfBatchLU{T}, As::Vector{CuSparseMatrixCSR{T, Ti}}) where {T, Ti}
+    @assert length(As) == rflu.batchsize
+    ptrs = [pointer(A.nzVal) for A in As]
+    Aptrs = CuArray(ptrs)
+    cusolverRfBatchResetValues(
+        rflu.batchsize, rflu.n, rflu.nnzA,
+        rflu.drowsA, rflu.dcolsA, Aptrs, rflu.dP, rflu.dQ,
+        rflu.rf
+    )
+    unsafe_free!(Aptrs)
+    cusolverRfBatchRefactor(rflu.rf)
+    return
+end
+
+function rf_batch_solve!(rflu::RfBatchLU{T}, xs::Vector{CuVector{T}}) where T
+    @assert length(xs) == rflu.batchsize
+    n, nrhs = rflu.n, 1
+    Xptrs = unsafe_batch(xs)
+    cusolverRfBatchSolve(rflu.rf, rflu.dP, rflu.dQ, nrhs, rflu.dT, n, Xptrs, n)
+    unsafe_free!(Xptrs)
+    return
+end
+
+function rf_batch_solve!(rflu::RfBatchLU{T}, X::CuMatrix{T}) where T
+    @assert size(X, 2) == rflu.batchsize
+    n = rflu.n
+    nrhs = 1
+    Xptrs = unsafe_strided_batch(X)
+    # Forward and backward solve
+    cusolverRfBatchSolve(rflu.rf, rflu.dP, rflu.dQ, nrhs, rflu.dT, n, Xptrs, n)
+    unsafe_free!(Xptrs)
+    return
+end
+
+# Operators overloading
+function LinearAlgebra.ldiv!(x::CuArray{T}, rflu::RfLU{T}, b::CuArray{T}) where T
+    copyto!(x, b)
+    rf_solve!(rflu, x)
+end
+function LinearAlgebra.ldiv!(rflu::RfLU{T}, x::CuArray{T}) where T
+    rf_solve!(rflu, x)
+end
+
+LinearAlgebra.lu(A::CuSparseMatrixCSR; options...) = RfLU(A; options...)
+LinearAlgebra.lu!(rflu::RfLU, A::CuSparseMatrixCSR) = rf_refactor!(rflu, A)
+
+# Batch
+function LinearAlgebra.ldiv!(x::CuMatrix{T}, rflu::RfBatchLU{T}, b::CuMatrix{T}) where T
+    copyto!(x, b)
+    rf_batch_solve!(rflu, x)
+end
+function LinearAlgebra.ldiv!(rflu::RfBatchLU{T}, x::CuMatrix{T}) where T
+    rf_batch_solve!(rflu, x)
+end
+
+LinearAlgebra.lu!(rflu::RfBatchLU, A::CuSparseMatrixCSR) = rf_batch_refactor!(rflu, A)
+

--- a/lib/cusolver/libcusolver.jl
+++ b/lib/cusolver/libcusolver.jl
@@ -4246,12 +4246,12 @@ end
 
 @checked function cusolverDnXgesvdr(handle, params, jobu, jobv, m, n, k, p, niters, dataTypeA, A, lda, dataTypeSrand, Srand, dataTypeUrand, Urand, ldUrand, dataTypeVrand, Vrand, ldVrand, computeType, bufferOnDevice, workspaceInBytesOnDevice, bufferOnHost, workspaceInBytesOnHost, d_info)
     initialize_context()
-    ccall((:cusolverDnXgesvdr, libcusolver), cusolverStatus_t, (cusolverDnHandle_t, cusolverDnParams_t, UInt8, UInt8, Int64, Int64, Int64, Int64, Int64, cudaDataType, CuPtr{Cvoid}, Int64, cudaDataType, CuPtr{Cvoid}, cudaDataType, CuPtr{Cvoid}, Int64, cudaDataType, CuPtr{Cvoid}, Int64, cudaDataType, CuPtr{Cvoid}, Csize_t, Ptr{Cvoid}, Csize_t, CuPtr{Cint}), handle, params, jobu, jobv, m, n, k, p, niters, dataTypeA, A, lda, dataTypeSrand, Srand, dataTypeUrand, Urand, ldUrand, dataTypeVrand, Vrand, ldVrand, computeType, bufferOnDevice, workspaceInBytesOnDevice, bufferOnHost, workspaceInBytesOnHost, d_info)
+    ccall((:cusolverDnXgesvdr, libcusolver()), cusolverStatus_t, (cusolverDnHandle_t, cusolverDnParams_t, UInt8, UInt8, Int64, Int64, Int64, Int64, Int64, cudaDataType, CuPtr{Cvoid}, Int64, cudaDataType, CuPtr{Cvoid}, cudaDataType, CuPtr{Cvoid}, Int64, cudaDataType, CuPtr{Cvoid}, Int64, cudaDataType, CuPtr{Cvoid}, Csize_t, Ptr{Cvoid}, Csize_t, CuPtr{Cint}), handle, params, jobu, jobv, m, n, k, p, niters, dataTypeA, A, lda, dataTypeSrand, Srand, dataTypeUrand, Urand, ldUrand, dataTypeVrand, Vrand, ldVrand, computeType, bufferOnDevice, workspaceInBytesOnDevice, bufferOnHost, workspaceInBytesOnHost, d_info)
 end
 
 @checked function cusolverDnXgesvdr_bufferSize(handle, params, jobu, jobv, m, n, k, p, niters, dataTypeA, A, lda, dataTypeSrand, Srand, dataTypeUrand, Urand, ldUrand, dataTypeVrand, Vrand, ldVrand, computeType, workspaceInBytesOnDevice, workspaceInBytesOnHost)
     initialize_context()
-    ccall((:cusolverDnXgesvdr_bufferSize, libcusolver), cusolverStatus_t, (cusolverDnHandle_t, cusolverDnParams_t, UInt8, UInt8, Int64, Int64, Int64, Int64, Int64, cudaDataType, CuPtr{Cvoid}, Int64, cudaDataType, CuPtr{Cvoid}, cudaDataType, CuPtr{Cvoid}, Int64, cudaDataType, CuPtr{Cvoid}, Int64, cudaDataType, CuPtr{Csize_t}, Ptr{Csize_t}), handle, params, jobu, jobv, m, n, k, p, niters, dataTypeA, A, lda, dataTypeSrand, Srand, dataTypeUrand, Urand, ldUrand, dataTypeVrand, Vrand, ldVrand, computeType, workspaceInBytesOnDevice, workspaceInBytesOnHost)
+    ccall((:cusolverDnXgesvdr_bufferSize, libcusolver()), cusolverStatus_t, (cusolverDnHandle_t, cusolverDnParams_t, UInt8, UInt8, Int64, Int64, Int64, Int64, Int64, cudaDataType, CuPtr{Cvoid}, Int64, cudaDataType, CuPtr{Cvoid}, cudaDataType, CuPtr{Cvoid}, Int64, cudaDataType, CuPtr{Cvoid}, Int64, cudaDataType, CuPtr{Csize_t}, Ptr{Csize_t}), handle, params, jobu, jobv, m, n, k, p, niters, dataTypeA, A, lda, dataTypeSrand, Srand, dataTypeUrand, Urand, ldUrand, dataTypeVrand, Vrand, ldVrand, computeType, workspaceInBytesOnDevice, workspaceInBytesOnHost)
 end
 
 ## from cusolverMg.h
@@ -4439,4 +4439,691 @@ end
                     Ptr{Cint}),
                    handle, uplo, N, array_d_A, IA, JA, descrA, computeType, array_d_work,
                    lwork, h_info)
+end
+
+# Julia wrapper for header: cusolverSp_LOWLEVEL_PREVIEW.h
+# Automatically generated using Clang.jl
+
+@checked function cusolverSpCreateCsrluInfoHost(info)
+    initialize_context()
+    ccall((:cusolverSpCreateCsrluInfoHost, libcusolver()), cusolverStatus_t, (Ptr{csrluInfoHost_t},), info)
+end
+
+@checked function cusolverSpDestroyCsrluInfoHost(info)
+    initialize_context()
+    ccall((:cusolverSpDestroyCsrluInfoHost, libcusolver()), cusolverStatus_t, (csrluInfoHost_t,), info)
+end
+
+@checked function cusolverSpXcsrluAnalysisHost(handle, n, nnzA, descrA, csrRowPtrA, csrColIndA, info)
+    initialize_context()
+    ccall((:cusolverSpXcsrluAnalysisHost, libcusolver()), cusolverStatus_t, (cusolverSpHandle_t, Cint, Cint, cusparseMatDescr_t, Ptr{Cint}, Ptr{Cint}, csrluInfoHost_t), handle, n, nnzA, descrA, csrRowPtrA, csrColIndA, info)
+end
+
+@checked function cusolverSpScsrluBufferInfoHost(handle, n, nnzA, descrA, csrValA, csrRowPtrA, csrColIndA, info, internalDataInBytes, workspaceInBytes)
+    initialize_context()
+    ccall((:cusolverSpScsrluBufferInfoHost, libcusolver()), cusolverStatus_t, (cusolverSpHandle_t, Cint, Cint, cusparseMatDescr_t, Ptr{Cfloat}, Ptr{Cint}, Ptr{Cint}, csrluInfoHost_t, Ptr{Cint}, Ptr{Cint}), handle, n, nnzA, descrA, csrValA, csrRowPtrA, csrColIndA, info, internalDataInBytes, workspaceInBytes)
+end
+
+@checked function cusolverSpDcsrluBufferInfoHost(handle, n, nnzA, descrA, csrValA, csrRowPtrA, csrColIndA, info, internalDataInBytes, workspaceInBytes)
+    initialize_context()
+    ccall((:cusolverSpDcsrluBufferInfoHost, libcusolver()), cusolverStatus_t, (cusolverSpHandle_t, Cint, Cint, cusparseMatDescr_t, Ptr{Cdouble}, Ptr{Cint}, Ptr{Cint}, csrluInfoHost_t, Ptr{Cint}, Ptr{Cint}), handle, n, nnzA, descrA, csrValA, csrRowPtrA, csrColIndA, info, internalDataInBytes, workspaceInBytes)
+end
+
+@checked function cusolverSpCcsrluBufferInfoHost(handle, n, nnzA, descrA, csrValA, csrRowPtrA, csrColIndA, info, internalDataInBytes, workspaceInBytes)
+    initialize_context()
+    ccall((:cusolverSpCcsrluBufferInfoHost, libcusolver()), cusolverStatus_t, (cusolverSpHandle_t, Cint, Cint, cusparseMatDescr_t, Ptr{cuComplex}, Ptr{Cint}, Ptr{Cint}, csrluInfoHost_t, Ptr{Cint}, Ptr{Cint}), handle, n, nnzA, descrA, csrValA, csrRowPtrA, csrColIndA, info, internalDataInBytes, workspaceInBytes)
+end
+
+@checked function cusolverSpZcsrluBufferInfoHost(handle, n, nnzA, descrA, csrValA, csrRowPtrA, csrColIndA, info, internalDataInBytes, workspaceInBytes)
+    initialize_context()
+    ccall((:cusolverSpZcsrluBufferInfoHost, libcusolver()), cusolverStatus_t, (cusolverSpHandle_t, Cint, Cint, cusparseMatDescr_t, Ptr{cuDoubleComplex}, Ptr{Cint}, Ptr{Cint}, csrluInfoHost_t, Ptr{Cint}, Ptr{Cint}), handle, n, nnzA, descrA, csrValA, csrRowPtrA, csrColIndA, info, internalDataInBytes, workspaceInBytes)
+end
+
+@checked function cusolverSpScsrluFactorHost(handle, n, nnzA, descrA, csrValA, csrRowPtrA, csrColIndA, info, pivot_threshold, pBuffer)
+    initialize_context()
+    ccall((:cusolverSpScsrluFactorHost, libcusolver()), cusolverStatus_t, (cusolverSpHandle_t, Cint, Cint, cusparseMatDescr_t, Ptr{Cfloat}, Ptr{Cint}, Ptr{Cint}, csrluInfoHost_t, Cfloat, Ptr{Cvoid}), handle, n, nnzA, descrA, csrValA, csrRowPtrA, csrColIndA, info, pivot_threshold, pBuffer)
+end
+
+@checked function cusolverSpDcsrluFactorHost(handle, n, nnzA, descrA, csrValA, csrRowPtrA, csrColIndA, info, pivot_threshold, pBuffer)
+    initialize_context()
+    ccall((:cusolverSpDcsrluFactorHost, libcusolver()), cusolverStatus_t, (cusolverSpHandle_t, Cint, Cint, cusparseMatDescr_t, Ptr{Cdouble}, Ptr{Cint}, Ptr{Cint}, csrluInfoHost_t, Cdouble, Ptr{Cvoid}), handle, n, nnzA, descrA, csrValA, csrRowPtrA, csrColIndA, info, pivot_threshold, pBuffer)
+end
+
+@checked function cusolverSpCcsrluFactorHost(handle, n, nnzA, descrA, csrValA, csrRowPtrA, csrColIndA, info, pivot_threshold, pBuffer)
+    initialize_context()
+    ccall((:cusolverSpCcsrluFactorHost, libcusolver()), cusolverStatus_t, (cusolverSpHandle_t, Cint, Cint, cusparseMatDescr_t, Ptr{cuComplex}, Ptr{Cint}, Ptr{Cint}, csrluInfoHost_t, Cfloat, Ptr{Cvoid}), handle, n, nnzA, descrA, csrValA, csrRowPtrA, csrColIndA, info, pivot_threshold, pBuffer)
+end
+
+@checked function cusolverSpZcsrluFactorHost(handle, n, nnzA, descrA, csrValA, csrRowPtrA, csrColIndA, info, pivot_threshold, pBuffer)
+    initialize_context()
+    ccall((:cusolverSpZcsrluFactorHost, libcusolver()), cusolverStatus_t, (cusolverSpHandle_t, Cint, Cint, cusparseMatDescr_t, Ptr{cuDoubleComplex}, Ptr{Cint}, Ptr{Cint}, csrluInfoHost_t, Cdouble, Ptr{Cvoid}), handle, n, nnzA, descrA, csrValA, csrRowPtrA, csrColIndA, info, pivot_threshold, pBuffer)
+end
+
+@checked function cusolverSpScsrluZeroPivotHost(handle, info, tol, position)
+    initialize_context()
+    ccall((:cusolverSpScsrluZeroPivotHost, libcusolver()), cusolverStatus_t, (cusolverSpHandle_t, csrluInfoHost_t, Cfloat, Ptr{Cint}), handle, info, tol, position)
+end
+
+@checked function cusolverSpDcsrluZeroPivotHost(handle, info, tol, position)
+    initialize_context()
+    ccall((:cusolverSpDcsrluZeroPivotHost, libcusolver()), cusolverStatus_t, (cusolverSpHandle_t, csrluInfoHost_t, Cdouble, Ptr{Cint}), handle, info, tol, position)
+end
+
+@checked function cusolverSpCcsrluZeroPivotHost(handle, info, tol, position)
+    initialize_context()
+    ccall((:cusolverSpCcsrluZeroPivotHost, libcusolver()), cusolverStatus_t, (cusolverSpHandle_t, csrluInfoHost_t, Cfloat, Ptr{Cint}), handle, info, tol, position)
+end
+
+@checked function cusolverSpZcsrluZeroPivotHost(handle, info, tol, position)
+    initialize_context()
+    ccall((:cusolverSpZcsrluZeroPivotHost, libcusolver()), cusolverStatus_t, (cusolverSpHandle_t, csrluInfoHost_t, Cdouble, Ptr{Cint}), handle, info, tol, position)
+end
+
+@checked function cusolverSpScsrluSolveHost(handle, n, b, x, info, pBuffer)
+    initialize_context()
+    ccall((:cusolverSpScsrluSolveHost, libcusolver()), cusolverStatus_t, (cusolverSpHandle_t, Cint, Ptr{Cfloat}, Ptr{Cfloat}, csrluInfoHost_t, Ptr{Cvoid}), handle, n, b, x, info, pBuffer)
+end
+
+@checked function cusolverSpDcsrluSolveHost(handle, n, b, x, info, pBuffer)
+    initialize_context()
+    ccall((:cusolverSpDcsrluSolveHost, libcusolver()), cusolverStatus_t, (cusolverSpHandle_t, Cint, Ptr{Cdouble}, Ptr{Cdouble}, csrluInfoHost_t, Ptr{Cvoid}), handle, n, b, x, info, pBuffer)
+end
+
+@checked function cusolverSpCcsrluSolveHost(handle, n, b, x, info, pBuffer)
+    initialize_context()
+    ccall((:cusolverSpCcsrluSolveHost, libcusolver()), cusolverStatus_t, (cusolverSpHandle_t, Cint, Ptr{cuComplex}, Ptr{cuComplex}, csrluInfoHost_t, Ptr{Cvoid}), handle, n, b, x, info, pBuffer)
+end
+
+@checked function cusolverSpZcsrluSolveHost(handle, n, b, x, info, pBuffer)
+    initialize_context()
+    ccall((:cusolverSpZcsrluSolveHost, libcusolver()), cusolverStatus_t, (cusolverSpHandle_t, Cint, Ptr{cuDoubleComplex}, Ptr{cuDoubleComplex}, csrluInfoHost_t, Ptr{Cvoid}), handle, n, b, x, info, pBuffer)
+end
+
+@checked function cusolverSpXcsrluNnzHost(handle, nnzLRef, nnzURef, info)
+    initialize_context()
+    ccall((:cusolverSpXcsrluNnzHost, libcusolver()), cusolverStatus_t, (cusolverSpHandle_t, Ptr{Cint}, Ptr{Cint}, csrluInfoHost_t), handle, nnzLRef, nnzURef, info)
+end
+
+@checked function cusolverSpScsrluExtractHost(handle, P, Q, descrL, csrValL, csrRowPtrL, csrColIndL, descrU, csrValU, csrRowPtrU, csrColIndU, info, pBuffer)
+    initialize_context()
+    ccall((:cusolverSpScsrluExtractHost, libcusolver()), cusolverStatus_t, (cusolverSpHandle_t, Ptr{Cint}, Ptr{Cint}, cusparseMatDescr_t, Ptr{Cfloat}, Ptr{Cint}, Ptr{Cint}, cusparseMatDescr_t, Ptr{Cfloat}, Ptr{Cint}, Ptr{Cint}, csrluInfoHost_t, Ptr{Cvoid}), handle, P, Q, descrL, csrValL, csrRowPtrL, csrColIndL, descrU, csrValU, csrRowPtrU, csrColIndU, info, pBuffer)
+end
+
+@checked function cusolverSpDcsrluExtractHost(handle, P, Q, descrL, csrValL, csrRowPtrL, csrColIndL, descrU, csrValU, csrRowPtrU, csrColIndU, info, pBuffer)
+    initialize_context()
+    ccall((:cusolverSpDcsrluExtractHost, libcusolver()), cusolverStatus_t, (cusolverSpHandle_t, Ptr{Cint}, Ptr{Cint}, cusparseMatDescr_t, Ptr{Cdouble}, Ptr{Cint}, Ptr{Cint}, cusparseMatDescr_t, Ptr{Cdouble}, Ptr{Cint}, Ptr{Cint}, csrluInfoHost_t, Ptr{Cvoid}), handle, P, Q, descrL, csrValL, csrRowPtrL, csrColIndL, descrU, csrValU, csrRowPtrU, csrColIndU, info, pBuffer)
+end
+
+@checked function cusolverSpCcsrluExtractHost(handle, P, Q, descrL, csrValL, csrRowPtrL, csrColIndL, descrU, csrValU, csrRowPtrU, csrColIndU, info, pBuffer)
+    initialize_context()
+    ccall((:cusolverSpCcsrluExtractHost, libcusolver()), cusolverStatus_t, (cusolverSpHandle_t, Ptr{Cint}, Ptr{Cint}, cusparseMatDescr_t, Ptr{cuComplex}, Ptr{Cint}, Ptr{Cint}, cusparseMatDescr_t, Ptr{cuComplex}, Ptr{Cint}, Ptr{Cint}, csrluInfoHost_t, Ptr{Cvoid}), handle, P, Q, descrL, csrValL, csrRowPtrL, csrColIndL, descrU, csrValU, csrRowPtrU, csrColIndU, info, pBuffer)
+end
+
+@checked function cusolverSpZcsrluExtractHost(handle, P, Q, descrL, csrValL, csrRowPtrL, csrColIndL, descrU, csrValU, csrRowPtrU, csrColIndU, info, pBuffer)
+    initialize_context()
+    ccall((:cusolverSpZcsrluExtractHost, libcusolver()), cusolverStatus_t, (cusolverSpHandle_t, Ptr{Cint}, Ptr{Cint}, cusparseMatDescr_t, Ptr{cuDoubleComplex}, Ptr{Cint}, Ptr{Cint}, cusparseMatDescr_t, Ptr{cuDoubleComplex}, Ptr{Cint}, Ptr{Cint}, csrluInfoHost_t, Ptr{Cvoid}), handle, P, Q, descrL, csrValL, csrRowPtrL, csrColIndL, descrU, csrValU, csrRowPtrU, csrColIndU, info, pBuffer)
+end
+
+@checked function cusolverSpCreateCsrqrInfoHost(info)
+    initialize_context()
+    ccall((:cusolverSpCreateCsrqrInfoHost, libcusolver()), cusolverStatus_t, (Ptr{csrqrInfoHost_t},), info)
+end
+
+@checked function cusolverSpDestroyCsrqrInfoHost(info)
+    initialize_context()
+    ccall((:cusolverSpDestroyCsrqrInfoHost, libcusolver()), cusolverStatus_t, (csrqrInfoHost_t,), info)
+end
+
+@checked function cusolverSpXcsrqrAnalysisHost(handle, m, n, nnzA, descrA, csrRowPtrA, csrColIndA, info)
+    initialize_context()
+    ccall((:cusolverSpXcsrqrAnalysisHost, libcusolver()), cusolverStatus_t, (cusolverSpHandle_t, Cint, Cint, Cint, cusparseMatDescr_t, Ptr{Cint}, Ptr{Cint}, csrqrInfoHost_t), handle, m, n, nnzA, descrA, csrRowPtrA, csrColIndA, info)
+end
+
+@checked function cusolverSpScsrqrBufferInfoHost(handle, m, n, nnzA, descrA, csrValA, csrRowPtrA, csrColIndA, info, internalDataInBytes, workspaceInBytes)
+    initialize_context()
+    ccall((:cusolverSpScsrqrBufferInfoHost, libcusolver()), cusolverStatus_t, (cusolverSpHandle_t, Cint, Cint, Cint, cusparseMatDescr_t, Ptr{Cfloat}, Ptr{Cint}, Ptr{Cint}, csrqrInfoHost_t, Ptr{Cint}, Ptr{Cint}), handle, m, n, nnzA, descrA, csrValA, csrRowPtrA, csrColIndA, info, internalDataInBytes, workspaceInBytes)
+end
+
+@checked function cusolverSpDcsrqrBufferInfoHost(handle, m, n, nnzA, descrA, csrValA, csrRowPtrA, csrColIndA, info, internalDataInBytes, workspaceInBytes)
+    initialize_context()
+    ccall((:cusolverSpDcsrqrBufferInfoHost, libcusolver()), cusolverStatus_t, (cusolverSpHandle_t, Cint, Cint, Cint, cusparseMatDescr_t, Ptr{Cdouble}, Ptr{Cint}, Ptr{Cint}, csrqrInfoHost_t, Ptr{Cint}, Ptr{Cint}), handle, m, n, nnzA, descrA, csrValA, csrRowPtrA, csrColIndA, info, internalDataInBytes, workspaceInBytes)
+end
+
+@checked function cusolverSpCcsrqrBufferInfoHost(handle, m, n, nnzA, descrA, csrValA, csrRowPtrA, csrColIndA, info, internalDataInBytes, workspaceInBytes)
+    initialize_context()
+    ccall((:cusolverSpCcsrqrBufferInfoHost, libcusolver()), cusolverStatus_t, (cusolverSpHandle_t, Cint, Cint, Cint, cusparseMatDescr_t, Ptr{cuComplex}, Ptr{Cint}, Ptr{Cint}, csrqrInfoHost_t, Ptr{Cint}, Ptr{Cint}), handle, m, n, nnzA, descrA, csrValA, csrRowPtrA, csrColIndA, info, internalDataInBytes, workspaceInBytes)
+end
+
+@checked function cusolverSpZcsrqrBufferInfoHost(handle, m, n, nnzA, descrA, csrValA, csrRowPtrA, csrColIndA, info, internalDataInBytes, workspaceInBytes)
+    initialize_context()
+    ccall((:cusolverSpZcsrqrBufferInfoHost, libcusolver()), cusolverStatus_t, (cusolverSpHandle_t, Cint, Cint, Cint, cusparseMatDescr_t, Ptr{cuDoubleComplex}, Ptr{Cint}, Ptr{Cint}, csrqrInfoHost_t, Ptr{Cint}, Ptr{Cint}), handle, m, n, nnzA, descrA, csrValA, csrRowPtrA, csrColIndA, info, internalDataInBytes, workspaceInBytes)
+end
+
+@checked function cusolverSpScsrqrSetupHost(handle, m, n, nnzA, descrA, csrValA, csrRowPtrA, csrColIndA, mu, info)
+    initialize_context()
+    ccall((:cusolverSpScsrqrSetupHost, libcusolver()), cusolverStatus_t, (cusolverSpHandle_t, Cint, Cint, Cint, cusparseMatDescr_t, Ptr{Cfloat}, Ptr{Cint}, Ptr{Cint}, Cfloat, csrqrInfoHost_t), handle, m, n, nnzA, descrA, csrValA, csrRowPtrA, csrColIndA, mu, info)
+end
+
+@checked function cusolverSpDcsrqrSetupHost(handle, m, n, nnzA, descrA, csrValA, csrRowPtrA, csrColIndA, mu, info)
+    initialize_context()
+    ccall((:cusolverSpDcsrqrSetupHost, libcusolver()), cusolverStatus_t, (cusolverSpHandle_t, Cint, Cint, Cint, cusparseMatDescr_t, Ptr{Cdouble}, Ptr{Cint}, Ptr{Cint}, Cdouble, csrqrInfoHost_t), handle, m, n, nnzA, descrA, csrValA, csrRowPtrA, csrColIndA, mu, info)
+end
+
+@checked function cusolverSpCcsrqrSetupHost(handle, m, n, nnzA, descrA, csrValA, csrRowPtrA, csrColIndA, mu, info)
+    initialize_context()
+    ccall((:cusolverSpCcsrqrSetupHost, libcusolver()), cusolverStatus_t, (cusolverSpHandle_t, Cint, Cint, Cint, cusparseMatDescr_t, Ptr{cuComplex}, Ptr{Cint}, Ptr{Cint}, cuComplex, csrqrInfoHost_t), handle, m, n, nnzA, descrA, csrValA, csrRowPtrA, csrColIndA, mu, info)
+end
+
+@checked function cusolverSpZcsrqrSetupHost(handle, m, n, nnzA, descrA, csrValA, csrRowPtrA, csrColIndA, mu, info)
+    initialize_context()
+    ccall((:cusolverSpZcsrqrSetupHost, libcusolver()), cusolverStatus_t, (cusolverSpHandle_t, Cint, Cint, Cint, cusparseMatDescr_t, Ptr{cuDoubleComplex}, Ptr{Cint}, Ptr{Cint}, cuDoubleComplex, csrqrInfoHost_t), handle, m, n, nnzA, descrA, csrValA, csrRowPtrA, csrColIndA, mu, info)
+end
+
+@checked function cusolverSpScsrqrFactorHost(handle, m, n, nnzA, b, x, info, pBuffer)
+    initialize_context()
+    ccall((:cusolverSpScsrqrFactorHost, libcusolver()), cusolverStatus_t, (cusolverSpHandle_t, Cint, Cint, Cint, Ptr{Cfloat}, Ptr{Cfloat}, csrqrInfoHost_t, Ptr{Cvoid}), handle, m, n, nnzA, b, x, info, pBuffer)
+end
+
+@checked function cusolverSpDcsrqrFactorHost(handle, m, n, nnzA, b, x, info, pBuffer)
+    initialize_context()
+    ccall((:cusolverSpDcsrqrFactorHost, libcusolver()), cusolverStatus_t, (cusolverSpHandle_t, Cint, Cint, Cint, Ptr{Cdouble}, Ptr{Cdouble}, csrqrInfoHost_t, Ptr{Cvoid}), handle, m, n, nnzA, b, x, info, pBuffer)
+end
+
+@checked function cusolverSpCcsrqrFactorHost(handle, m, n, nnzA, b, x, info, pBuffer)
+    initialize_context()
+    ccall((:cusolverSpCcsrqrFactorHost, libcusolver()), cusolverStatus_t, (cusolverSpHandle_t, Cint, Cint, Cint, Ptr{cuComplex}, Ptr{cuComplex}, csrqrInfoHost_t, Ptr{Cvoid}), handle, m, n, nnzA, b, x, info, pBuffer)
+end
+
+@checked function cusolverSpZcsrqrFactorHost(handle, m, n, nnzA, b, x, info, pBuffer)
+    initialize_context()
+    ccall((:cusolverSpZcsrqrFactorHost, libcusolver()), cusolverStatus_t, (cusolverSpHandle_t, Cint, Cint, Cint, Ptr{cuDoubleComplex}, Ptr{cuDoubleComplex}, csrqrInfoHost_t, Ptr{Cvoid}), handle, m, n, nnzA, b, x, info, pBuffer)
+end
+
+@checked function cusolverSpScsrqrZeroPivotHost(handle, info, tol, position)
+    initialize_context()
+    ccall((:cusolverSpScsrqrZeroPivotHost, libcusolver()), cusolverStatus_t, (cusolverSpHandle_t, csrqrInfoHost_t, Cfloat, Ptr{Cint}), handle, info, tol, position)
+end
+
+@checked function cusolverSpDcsrqrZeroPivotHost(handle, info, tol, position)
+    initialize_context()
+    ccall((:cusolverSpDcsrqrZeroPivotHost, libcusolver()), cusolverStatus_t, (cusolverSpHandle_t, csrqrInfoHost_t, Cdouble, Ptr{Cint}), handle, info, tol, position)
+end
+
+@checked function cusolverSpCcsrqrZeroPivotHost(handle, info, tol, position)
+    initialize_context()
+    ccall((:cusolverSpCcsrqrZeroPivotHost, libcusolver()), cusolverStatus_t, (cusolverSpHandle_t, csrqrInfoHost_t, Cfloat, Ptr{Cint}), handle, info, tol, position)
+end
+
+@checked function cusolverSpZcsrqrZeroPivotHost(handle, info, tol, position)
+    initialize_context()
+    ccall((:cusolverSpZcsrqrZeroPivotHost, libcusolver()), cusolverStatus_t, (cusolverSpHandle_t, csrqrInfoHost_t, Cdouble, Ptr{Cint}), handle, info, tol, position)
+end
+
+@checked function cusolverSpScsrqrSolveHost(handle, m, n, b, x, info, pBuffer)
+    initialize_context()
+    ccall((:cusolverSpScsrqrSolveHost, libcusolver()), cusolverStatus_t, (cusolverSpHandle_t, Cint, Cint, Ptr{Cfloat}, Ptr{Cfloat}, csrqrInfoHost_t, Ptr{Cvoid}), handle, m, n, b, x, info, pBuffer)
+end
+
+@checked function cusolverSpDcsrqrSolveHost(handle, m, n, b, x, info, pBuffer)
+    initialize_context()
+    ccall((:cusolverSpDcsrqrSolveHost, libcusolver()), cusolverStatus_t, (cusolverSpHandle_t, Cint, Cint, Ptr{Cdouble}, Ptr{Cdouble}, csrqrInfoHost_t, Ptr{Cvoid}), handle, m, n, b, x, info, pBuffer)
+end
+
+@checked function cusolverSpCcsrqrSolveHost(handle, m, n, b, x, info, pBuffer)
+    initialize_context()
+    ccall((:cusolverSpCcsrqrSolveHost, libcusolver()), cusolverStatus_t, (cusolverSpHandle_t, Cint, Cint, Ptr{cuComplex}, Ptr{cuComplex}, csrqrInfoHost_t, Ptr{Cvoid}), handle, m, n, b, x, info, pBuffer)
+end
+
+@checked function cusolverSpZcsrqrSolveHost(handle, m, n, b, x, info, pBuffer)
+    initialize_context()
+    ccall((:cusolverSpZcsrqrSolveHost, libcusolver()), cusolverStatus_t, (cusolverSpHandle_t, Cint, Cint, Ptr{cuDoubleComplex}, Ptr{cuDoubleComplex}, csrqrInfoHost_t, Ptr{Cvoid}), handle, m, n, b, x, info, pBuffer)
+end
+
+@checked function cusolverSpXcsrqrAnalysis(handle, m, n, nnzA, descrA, csrRowPtrA, csrColIndA, info)
+    initialize_context()
+    ccall((:cusolverSpXcsrqrAnalysis, libcusolver()), cusolverStatus_t, (cusolverSpHandle_t, Cint, Cint, Cint, cusparseMatDescr_t, Ptr{Cint}, Ptr{Cint}, csrqrInfo_t), handle, m, n, nnzA, descrA, csrRowPtrA, csrColIndA, info)
+end
+
+@checked function cusolverSpScsrqrBufferInfo(handle, m, n, nnzA, descrA, csrValA, csrRowPtrA, csrColIndA, info, internalDataInBytes, workspaceInBytes)
+    initialize_context()
+    ccall((:cusolverSpScsrqrBufferInfo, libcusolver()), cusolverStatus_t, (cusolverSpHandle_t, Cint, Cint, Cint, cusparseMatDescr_t, Ptr{Cfloat}, Ptr{Cint}, Ptr{Cint}, csrqrInfo_t, Ptr{Cint}, Ptr{Cint}), handle, m, n, nnzA, descrA, csrValA, csrRowPtrA, csrColIndA, info, internalDataInBytes, workspaceInBytes)
+end
+
+@checked function cusolverSpDcsrqrBufferInfo(handle, m, n, nnzA, descrA, csrValA, csrRowPtrA, csrColIndA, info, internalDataInBytes, workspaceInBytes)
+    initialize_context()
+    ccall((:cusolverSpDcsrqrBufferInfo, libcusolver()), cusolverStatus_t, (cusolverSpHandle_t, Cint, Cint, Cint, cusparseMatDescr_t, Ptr{Cdouble}, Ptr{Cint}, Ptr{Cint}, csrqrInfo_t, Ptr{Cint}, Ptr{Cint}), handle, m, n, nnzA, descrA, csrValA, csrRowPtrA, csrColIndA, info, internalDataInBytes, workspaceInBytes)
+end
+
+@checked function cusolverSpCcsrqrBufferInfo(handle, m, n, nnzA, descrA, csrValA, csrRowPtrA, csrColIndA, info, internalDataInBytes, workspaceInBytes)
+    initialize_context()
+    ccall((:cusolverSpCcsrqrBufferInfo, libcusolver()), cusolverStatus_t, (cusolverSpHandle_t, Cint, Cint, Cint, cusparseMatDescr_t, Ptr{cuComplex}, Ptr{Cint}, Ptr{Cint}, csrqrInfo_t, Ptr{Cint}, Ptr{Cint}), handle, m, n, nnzA, descrA, csrValA, csrRowPtrA, csrColIndA, info, internalDataInBytes, workspaceInBytes)
+end
+
+@checked function cusolverSpZcsrqrBufferInfo(handle, m, n, nnzA, descrA, csrValA, csrRowPtrA, csrColIndA, info, internalDataInBytes, workspaceInBytes)
+    initialize_context()
+    ccall((:cusolverSpZcsrqrBufferInfo, libcusolver()), cusolverStatus_t, (cusolverSpHandle_t, Cint, Cint, Cint, cusparseMatDescr_t, Ptr{cuDoubleComplex}, Ptr{Cint}, Ptr{Cint}, csrqrInfo_t, Ptr{Cint}, Ptr{Cint}), handle, m, n, nnzA, descrA, csrValA, csrRowPtrA, csrColIndA, info, internalDataInBytes, workspaceInBytes)
+end
+
+@checked function cusolverSpScsrqrSetup(handle, m, n, nnzA, descrA, csrValA, csrRowPtrA, csrColIndA, mu, info)
+    initialize_context()
+    ccall((:cusolverSpScsrqrSetup, libcusolver()), cusolverStatus_t, (cusolverSpHandle_t, Cint, Cint, Cint, cusparseMatDescr_t, Ptr{Cfloat}, Ptr{Cint}, Ptr{Cint}, Cfloat, csrqrInfo_t), handle, m, n, nnzA, descrA, csrValA, csrRowPtrA, csrColIndA, mu, info)
+end
+
+@checked function cusolverSpDcsrqrSetup(handle, m, n, nnzA, descrA, csrValA, csrRowPtrA, csrColIndA, mu, info)
+    initialize_context()
+    ccall((:cusolverSpDcsrqrSetup, libcusolver()), cusolverStatus_t, (cusolverSpHandle_t, Cint, Cint, Cint, cusparseMatDescr_t, Ptr{Cdouble}, Ptr{Cint}, Ptr{Cint}, Cdouble, csrqrInfo_t), handle, m, n, nnzA, descrA, csrValA, csrRowPtrA, csrColIndA, mu, info)
+end
+
+@checked function cusolverSpCcsrqrSetup(handle, m, n, nnzA, descrA, csrValA, csrRowPtrA, csrColIndA, mu, info)
+    initialize_context()
+    ccall((:cusolverSpCcsrqrSetup, libcusolver()), cusolverStatus_t, (cusolverSpHandle_t, Cint, Cint, Cint, cusparseMatDescr_t, Ptr{cuComplex}, Ptr{Cint}, Ptr{Cint}, cuComplex, csrqrInfo_t), handle, m, n, nnzA, descrA, csrValA, csrRowPtrA, csrColIndA, mu, info)
+end
+
+@checked function cusolverSpZcsrqrSetup(handle, m, n, nnzA, descrA, csrValA, csrRowPtrA, csrColIndA, mu, info)
+    initialize_context()
+    ccall((:cusolverSpZcsrqrSetup, libcusolver()), cusolverStatus_t, (cusolverSpHandle_t, Cint, Cint, Cint, cusparseMatDescr_t, Ptr{cuDoubleComplex}, Ptr{Cint}, Ptr{Cint}, cuDoubleComplex, csrqrInfo_t), handle, m, n, nnzA, descrA, csrValA, csrRowPtrA, csrColIndA, mu, info)
+end
+
+@checked function cusolverSpScsrqrFactor(handle, m, n, nnzA, b, x, info, pBuffer)
+    initialize_context()
+    ccall((:cusolverSpScsrqrFactor, libcusolver()), cusolverStatus_t, (cusolverSpHandle_t, Cint, Cint, Cint, Ptr{Cfloat}, Ptr{Cfloat}, csrqrInfo_t, Ptr{Cvoid}), handle, m, n, nnzA, b, x, info, pBuffer)
+end
+
+@checked function cusolverSpDcsrqrFactor(handle, m, n, nnzA, b, x, info, pBuffer)
+    initialize_context()
+    ccall((:cusolverSpDcsrqrFactor, libcusolver()), cusolverStatus_t, (cusolverSpHandle_t, Cint, Cint, Cint, Ptr{Cdouble}, Ptr{Cdouble}, csrqrInfo_t, Ptr{Cvoid}), handle, m, n, nnzA, b, x, info, pBuffer)
+end
+
+@checked function cusolverSpCcsrqrFactor(handle, m, n, nnzA, b, x, info, pBuffer)
+    initialize_context()
+    ccall((:cusolverSpCcsrqrFactor, libcusolver()), cusolverStatus_t, (cusolverSpHandle_t, Cint, Cint, Cint, Ptr{cuComplex}, Ptr{cuComplex}, csrqrInfo_t, Ptr{Cvoid}), handle, m, n, nnzA, b, x, info, pBuffer)
+end
+
+@checked function cusolverSpZcsrqrFactor(handle, m, n, nnzA, b, x, info, pBuffer)
+    initialize_context()
+    ccall((:cusolverSpZcsrqrFactor, libcusolver()), cusolverStatus_t, (cusolverSpHandle_t, Cint, Cint, Cint, Ptr{cuDoubleComplex}, Ptr{cuDoubleComplex}, csrqrInfo_t, Ptr{Cvoid}), handle, m, n, nnzA, b, x, info, pBuffer)
+end
+
+@checked function cusolverSpScsrqrZeroPivot(handle, info, tol, position)
+    initialize_context()
+    ccall((:cusolverSpScsrqrZeroPivot, libcusolver()), cusolverStatus_t, (cusolverSpHandle_t, csrqrInfo_t, Cfloat, Ptr{Cint}), handle, info, tol, position)
+end
+
+@checked function cusolverSpDcsrqrZeroPivot(handle, info, tol, position)
+    initialize_context()
+    ccall((:cusolverSpDcsrqrZeroPivot, libcusolver()), cusolverStatus_t, (cusolverSpHandle_t, csrqrInfo_t, Cdouble, Ptr{Cint}), handle, info, tol, position)
+end
+
+@checked function cusolverSpCcsrqrZeroPivot(handle, info, tol, position)
+    initialize_context()
+    ccall((:cusolverSpCcsrqrZeroPivot, libcusolver()), cusolverStatus_t, (cusolverSpHandle_t, csrqrInfo_t, Cfloat, Ptr{Cint}), handle, info, tol, position)
+end
+
+@checked function cusolverSpZcsrqrZeroPivot(handle, info, tol, position)
+    initialize_context()
+    ccall((:cusolverSpZcsrqrZeroPivot, libcusolver()), cusolverStatus_t, (cusolverSpHandle_t, csrqrInfo_t, Cdouble, Ptr{Cint}), handle, info, tol, position)
+end
+
+@checked function cusolverSpScsrqrSolve(handle, m, n, b, x, info, pBuffer)
+    initialize_context()
+    ccall((:cusolverSpScsrqrSolve, libcusolver()), cusolverStatus_t, (cusolverSpHandle_t, Cint, Cint, Ptr{Cfloat}, Ptr{Cfloat}, csrqrInfo_t, Ptr{Cvoid}), handle, m, n, b, x, info, pBuffer)
+end
+
+@checked function cusolverSpDcsrqrSolve(handle, m, n, b, x, info, pBuffer)
+    initialize_context()
+    ccall((:cusolverSpDcsrqrSolve, libcusolver()), cusolverStatus_t, (cusolverSpHandle_t, Cint, Cint, Ptr{Cdouble}, Ptr{Cdouble}, csrqrInfo_t, Ptr{Cvoid}), handle, m, n, b, x, info, pBuffer)
+end
+
+@checked function cusolverSpCcsrqrSolve(handle, m, n, b, x, info, pBuffer)
+    initialize_context()
+    ccall((:cusolverSpCcsrqrSolve, libcusolver()), cusolverStatus_t, (cusolverSpHandle_t, Cint, Cint, Ptr{cuComplex}, Ptr{cuComplex}, csrqrInfo_t, Ptr{Cvoid}), handle, m, n, b, x, info, pBuffer)
+end
+
+@checked function cusolverSpZcsrqrSolve(handle, m, n, b, x, info, pBuffer)
+    initialize_context()
+    ccall((:cusolverSpZcsrqrSolve, libcusolver()), cusolverStatus_t, (cusolverSpHandle_t, Cint, Cint, Ptr{cuDoubleComplex}, Ptr{cuDoubleComplex}, csrqrInfo_t, Ptr{Cvoid}), handle, m, n, b, x, info, pBuffer)
+end
+
+@checked function cusolverSpCreateCsrcholInfoHost(info)
+    initialize_context()
+    ccall((:cusolverSpCreateCsrcholInfoHost, libcusolver()), cusolverStatus_t, (Ptr{csrcholInfoHost_t},), info)
+end
+
+@checked function cusolverSpDestroyCsrcholInfoHost(info)
+    initialize_context()
+    ccall((:cusolverSpDestroyCsrcholInfoHost, libcusolver()), cusolverStatus_t, (csrcholInfoHost_t,), info)
+end
+
+@checked function cusolverSpXcsrcholAnalysisHost(handle, n, nnzA, descrA, csrRowPtrA, csrColIndA, info)
+    initialize_context()
+    ccall((:cusolverSpXcsrcholAnalysisHost, libcusolver()), cusolverStatus_t, (cusolverSpHandle_t, Cint, Cint, cusparseMatDescr_t, Ptr{Cint}, Ptr{Cint}, csrcholInfoHost_t), handle, n, nnzA, descrA, csrRowPtrA, csrColIndA, info)
+end
+
+@checked function cusolverSpScsrcholBufferInfoHost(handle, n, nnzA, descrA, csrValA, csrRowPtrA, csrColIndA, info, internalDataInBytes, workspaceInBytes)
+    initialize_context()
+    ccall((:cusolverSpScsrcholBufferInfoHost, libcusolver()), cusolverStatus_t, (cusolverSpHandle_t, Cint, Cint, cusparseMatDescr_t, Ptr{Cfloat}, Ptr{Cint}, Ptr{Cint}, csrcholInfoHost_t, Ptr{Cint}, Ptr{Cint}), handle, n, nnzA, descrA, csrValA, csrRowPtrA, csrColIndA, info, internalDataInBytes, workspaceInBytes)
+end
+
+@checked function cusolverSpDcsrcholBufferInfoHost(handle, n, nnzA, descrA, csrValA, csrRowPtrA, csrColIndA, info, internalDataInBytes, workspaceInBytes)
+    initialize_context()
+    ccall((:cusolverSpDcsrcholBufferInfoHost, libcusolver()), cusolverStatus_t, (cusolverSpHandle_t, Cint, Cint, cusparseMatDescr_t, Ptr{Cdouble}, Ptr{Cint}, Ptr{Cint}, csrcholInfoHost_t, Ptr{Cint}, Ptr{Cint}), handle, n, nnzA, descrA, csrValA, csrRowPtrA, csrColIndA, info, internalDataInBytes, workspaceInBytes)
+end
+
+@checked function cusolverSpCcsrcholBufferInfoHost(handle, n, nnzA, descrA, csrValA, csrRowPtrA, csrColIndA, info, internalDataInBytes, workspaceInBytes)
+    initialize_context()
+    ccall((:cusolverSpCcsrcholBufferInfoHost, libcusolver()), cusolverStatus_t, (cusolverSpHandle_t, Cint, Cint, cusparseMatDescr_t, Ptr{cuComplex}, Ptr{Cint}, Ptr{Cint}, csrcholInfoHost_t, Ptr{Cint}, Ptr{Cint}), handle, n, nnzA, descrA, csrValA, csrRowPtrA, csrColIndA, info, internalDataInBytes, workspaceInBytes)
+end
+
+@checked function cusolverSpZcsrcholBufferInfoHost(handle, n, nnzA, descrA, csrValA, csrRowPtrA, csrColIndA, info, internalDataInBytes, workspaceInBytes)
+    initialize_context()
+    ccall((:cusolverSpZcsrcholBufferInfoHost, libcusolver()), cusolverStatus_t, (cusolverSpHandle_t, Cint, Cint, cusparseMatDescr_t, Ptr{cuDoubleComplex}, Ptr{Cint}, Ptr{Cint}, csrcholInfoHost_t, Ptr{Cint}, Ptr{Cint}), handle, n, nnzA, descrA, csrValA, csrRowPtrA, csrColIndA, info, internalDataInBytes, workspaceInBytes)
+end
+
+@checked function cusolverSpScsrcholFactorHost(handle, n, nnzA, descrA, csrValA, csrRowPtrA, csrColIndA, info, pBuffer)
+    initialize_context()
+    ccall((:cusolverSpScsrcholFactorHost, libcusolver()), cusolverStatus_t, (cusolverSpHandle_t, Cint, Cint, cusparseMatDescr_t, Ptr{Cfloat}, Ptr{Cint}, Ptr{Cint}, csrcholInfoHost_t, Ptr{Cvoid}), handle, n, nnzA, descrA, csrValA, csrRowPtrA, csrColIndA, info, pBuffer)
+end
+
+@checked function cusolverSpDcsrcholFactorHost(handle, n, nnzA, descrA, csrValA, csrRowPtrA, csrColIndA, info, pBuffer)
+    initialize_context()
+    ccall((:cusolverSpDcsrcholFactorHost, libcusolver()), cusolverStatus_t, (cusolverSpHandle_t, Cint, Cint, cusparseMatDescr_t, Ptr{Cdouble}, Ptr{Cint}, Ptr{Cint}, csrcholInfoHost_t, Ptr{Cvoid}), handle, n, nnzA, descrA, csrValA, csrRowPtrA, csrColIndA, info, pBuffer)
+end
+
+@checked function cusolverSpCcsrcholFactorHost(handle, n, nnzA, descrA, csrValA, csrRowPtrA, csrColIndA, info, pBuffer)
+    initialize_context()
+    ccall((:cusolverSpCcsrcholFactorHost, libcusolver()), cusolverStatus_t, (cusolverSpHandle_t, Cint, Cint, cusparseMatDescr_t, Ptr{cuComplex}, Ptr{Cint}, Ptr{Cint}, csrcholInfoHost_t, Ptr{Cvoid}), handle, n, nnzA, descrA, csrValA, csrRowPtrA, csrColIndA, info, pBuffer)
+end
+
+@checked function cusolverSpZcsrcholFactorHost(handle, n, nnzA, descrA, csrValA, csrRowPtrA, csrColIndA, info, pBuffer)
+    initialize_context()
+    ccall((:cusolverSpZcsrcholFactorHost, libcusolver()), cusolverStatus_t, (cusolverSpHandle_t, Cint, Cint, cusparseMatDescr_t, Ptr{cuDoubleComplex}, Ptr{Cint}, Ptr{Cint}, csrcholInfoHost_t, Ptr{Cvoid}), handle, n, nnzA, descrA, csrValA, csrRowPtrA, csrColIndA, info, pBuffer)
+end
+
+@checked function cusolverSpScsrcholZeroPivotHost(handle, info, tol, position)
+    initialize_context()
+    ccall((:cusolverSpScsrcholZeroPivotHost, libcusolver()), cusolverStatus_t, (cusolverSpHandle_t, csrcholInfoHost_t, Cfloat, Ptr{Cint}), handle, info, tol, position)
+end
+
+@checked function cusolverSpDcsrcholZeroPivotHost(handle, info, tol, position)
+    initialize_context()
+    ccall((:cusolverSpDcsrcholZeroPivotHost, libcusolver()), cusolverStatus_t, (cusolverSpHandle_t, csrcholInfoHost_t, Cdouble, Ptr{Cint}), handle, info, tol, position)
+end
+
+@checked function cusolverSpCcsrcholZeroPivotHost(handle, info, tol, position)
+    initialize_context()
+    ccall((:cusolverSpCcsrcholZeroPivotHost, libcusolver()), cusolverStatus_t, (cusolverSpHandle_t, csrcholInfoHost_t, Cfloat, Ptr{Cint}), handle, info, tol, position)
+end
+
+@checked function cusolverSpZcsrcholZeroPivotHost(handle, info, tol, position)
+    initialize_context()
+    ccall((:cusolverSpZcsrcholZeroPivotHost, libcusolver()), cusolverStatus_t, (cusolverSpHandle_t, csrcholInfoHost_t, Cdouble, Ptr{Cint}), handle, info, tol, position)
+end
+
+@checked function cusolverSpScsrcholSolveHost(handle, n, b, x, info, pBuffer)
+    initialize_context()
+    ccall((:cusolverSpScsrcholSolveHost, libcusolver()), cusolverStatus_t, (cusolverSpHandle_t, Cint, Ptr{Cfloat}, Ptr{Cfloat}, csrcholInfoHost_t, Ptr{Cvoid}), handle, n, b, x, info, pBuffer)
+end
+
+@checked function cusolverSpDcsrcholSolveHost(handle, n, b, x, info, pBuffer)
+    initialize_context()
+    ccall((:cusolverSpDcsrcholSolveHost, libcusolver()), cusolverStatus_t, (cusolverSpHandle_t, Cint, Ptr{Cdouble}, Ptr{Cdouble}, csrcholInfoHost_t, Ptr{Cvoid}), handle, n, b, x, info, pBuffer)
+end
+
+@checked function cusolverSpCcsrcholSolveHost(handle, n, b, x, info, pBuffer)
+    initialize_context()
+    ccall((:cusolverSpCcsrcholSolveHost, libcusolver()), cusolverStatus_t, (cusolverSpHandle_t, Cint, Ptr{cuComplex}, Ptr{cuComplex}, csrcholInfoHost_t, Ptr{Cvoid}), handle, n, b, x, info, pBuffer)
+end
+
+@checked function cusolverSpZcsrcholSolveHost(handle, n, b, x, info, pBuffer)
+    initialize_context()
+    ccall((:cusolverSpZcsrcholSolveHost, libcusolver()), cusolverStatus_t, (cusolverSpHandle_t, Cint, Ptr{cuDoubleComplex}, Ptr{cuDoubleComplex}, csrcholInfoHost_t, Ptr{Cvoid}), handle, n, b, x, info, pBuffer)
+end
+
+@checked function cusolverSpCreateCsrcholInfo(info)
+    initialize_context()
+    ccall((:cusolverSpCreateCsrcholInfo, libcusolver()), cusolverStatus_t, (Ptr{csrcholInfo_t},), info)
+end
+
+@checked function cusolverSpDestroyCsrcholInfo(info)
+    initialize_context()
+    ccall((:cusolverSpDestroyCsrcholInfo, libcusolver()), cusolverStatus_t, (csrcholInfo_t,), info)
+end
+
+@checked function cusolverSpXcsrcholAnalysis(handle, n, nnzA, descrA, csrRowPtrA, csrColIndA, info)
+    initialize_context()
+    ccall((:cusolverSpXcsrcholAnalysis, libcusolver()), cusolverStatus_t, (cusolverSpHandle_t, Cint, Cint, cusparseMatDescr_t, Ptr{Cint}, Ptr{Cint}, csrcholInfo_t), handle, n, nnzA, descrA, csrRowPtrA, csrColIndA, info)
+end
+
+@checked function cusolverSpScsrcholBufferInfo(handle, n, nnzA, descrA, csrValA, csrRowPtrA, csrColIndA, info, internalDataInBytes, workspaceInBytes)
+    initialize_context()
+    ccall((:cusolverSpScsrcholBufferInfo, libcusolver()), cusolverStatus_t, (cusolverSpHandle_t, Cint, Cint, cusparseMatDescr_t, Ptr{Cfloat}, Ptr{Cint}, Ptr{Cint}, csrcholInfo_t, Ptr{Cint}, Ptr{Cint}), handle, n, nnzA, descrA, csrValA, csrRowPtrA, csrColIndA, info, internalDataInBytes, workspaceInBytes)
+end
+
+@checked function cusolverSpDcsrcholBufferInfo(handle, n, nnzA, descrA, csrValA, csrRowPtrA, csrColIndA, info, internalDataInBytes, workspaceInBytes)
+    initialize_context()
+    ccall((:cusolverSpDcsrcholBufferInfo, libcusolver()), cusolverStatus_t, (cusolverSpHandle_t, Cint, Cint, cusparseMatDescr_t, Ptr{Cdouble}, Ptr{Cint}, Ptr{Cint}, csrcholInfo_t, Ptr{Cint}, Ptr{Cint}), handle, n, nnzA, descrA, csrValA, csrRowPtrA, csrColIndA, info, internalDataInBytes, workspaceInBytes)
+end
+
+@checked function cusolverSpCcsrcholBufferInfo(handle, n, nnzA, descrA, csrValA, csrRowPtrA, csrColIndA, info, internalDataInBytes, workspaceInBytes)
+    initialize_context()
+    ccall((:cusolverSpCcsrcholBufferInfo, libcusolver()), cusolverStatus_t, (cusolverSpHandle_t, Cint, Cint, cusparseMatDescr_t, Ptr{cuComplex}, Ptr{Cint}, Ptr{Cint}, csrcholInfo_t, Ptr{Cint}, Ptr{Cint}), handle, n, nnzA, descrA, csrValA, csrRowPtrA, csrColIndA, info, internalDataInBytes, workspaceInBytes)
+end
+
+@checked function cusolverSpZcsrcholBufferInfo(handle, n, nnzA, descrA, csrValA, csrRowPtrA, csrColIndA, info, internalDataInBytes, workspaceInBytes)
+    initialize_context()
+    ccall((:cusolverSpZcsrcholBufferInfo, libcusolver()), cusolverStatus_t, (cusolverSpHandle_t, Cint, Cint, cusparseMatDescr_t, Ptr{cuDoubleComplex}, Ptr{Cint}, Ptr{Cint}, csrcholInfo_t, Ptr{Cint}, Ptr{Cint}), handle, n, nnzA, descrA, csrValA, csrRowPtrA, csrColIndA, info, internalDataInBytes, workspaceInBytes)
+end
+
+@checked function cusolverSpScsrcholFactor(handle, n, nnzA, descrA, csrValA, csrRowPtrA, csrColIndA, info, pBuffer)
+    initialize_context()
+    ccall((:cusolverSpScsrcholFactor, libcusolver()), cusolverStatus_t, (cusolverSpHandle_t, Cint, Cint, cusparseMatDescr_t, Ptr{Cfloat}, Ptr{Cint}, Ptr{Cint}, csrcholInfo_t, Ptr{Cvoid}), handle, n, nnzA, descrA, csrValA, csrRowPtrA, csrColIndA, info, pBuffer)
+end
+
+@checked function cusolverSpDcsrcholFactor(handle, n, nnzA, descrA, csrValA, csrRowPtrA, csrColIndA, info, pBuffer)
+    initialize_context()
+    ccall((:cusolverSpDcsrcholFactor, libcusolver()), cusolverStatus_t, (cusolverSpHandle_t, Cint, Cint, cusparseMatDescr_t, Ptr{Cdouble}, Ptr{Cint}, Ptr{Cint}, csrcholInfo_t, Ptr{Cvoid}), handle, n, nnzA, descrA, csrValA, csrRowPtrA, csrColIndA, info, pBuffer)
+end
+
+@checked function cusolverSpCcsrcholFactor(handle, n, nnzA, descrA, csrValA, csrRowPtrA, csrColIndA, info, pBuffer)
+    initialize_context()
+    ccall((:cusolverSpCcsrcholFactor, libcusolver()), cusolverStatus_t, (cusolverSpHandle_t, Cint, Cint, cusparseMatDescr_t, Ptr{cuComplex}, Ptr{Cint}, Ptr{Cint}, csrcholInfo_t, Ptr{Cvoid}), handle, n, nnzA, descrA, csrValA, csrRowPtrA, csrColIndA, info, pBuffer)
+end
+
+@checked function cusolverSpZcsrcholFactor(handle, n, nnzA, descrA, csrValA, csrRowPtrA, csrColIndA, info, pBuffer)
+    initialize_context()
+    ccall((:cusolverSpZcsrcholFactor, libcusolver()), cusolverStatus_t, (cusolverSpHandle_t, Cint, Cint, cusparseMatDescr_t, Ptr{cuDoubleComplex}, Ptr{Cint}, Ptr{Cint}, csrcholInfo_t, Ptr{Cvoid}), handle, n, nnzA, descrA, csrValA, csrRowPtrA, csrColIndA, info, pBuffer)
+end
+
+@checked function cusolverSpScsrcholZeroPivot(handle, info, tol, position)
+    initialize_context()
+    ccall((:cusolverSpScsrcholZeroPivot, libcusolver()), cusolverStatus_t, (cusolverSpHandle_t, csrcholInfo_t, Cfloat, Ptr{Cint}), handle, info, tol, position)
+end
+
+@checked function cusolverSpDcsrcholZeroPivot(handle, info, tol, position)
+    initialize_context()
+    ccall((:cusolverSpDcsrcholZeroPivot, libcusolver()), cusolverStatus_t, (cusolverSpHandle_t, csrcholInfo_t, Cdouble, Ptr{Cint}), handle, info, tol, position)
+end
+
+@checked function cusolverSpCcsrcholZeroPivot(handle, info, tol, position)
+    initialize_context()
+    ccall((:cusolverSpCcsrcholZeroPivot, libcusolver()), cusolverStatus_t, (cusolverSpHandle_t, csrcholInfo_t, Cfloat, Ptr{Cint}), handle, info, tol, position)
+end
+
+@checked function cusolverSpZcsrcholZeroPivot(handle, info, tol, position)
+    initialize_context()
+    ccall((:cusolverSpZcsrcholZeroPivot, libcusolver()), cusolverStatus_t, (cusolverSpHandle_t, csrcholInfo_t, Cdouble, Ptr{Cint}), handle, info, tol, position)
+end
+
+@checked function cusolverSpScsrcholSolve(handle, n, b, x, info, pBuffer)
+    initialize_context()
+    ccall((:cusolverSpScsrcholSolve, libcusolver()), cusolverStatus_t, (cusolverSpHandle_t, Cint, Ptr{Cfloat}, Ptr{Cfloat}, csrcholInfo_t, Ptr{Cvoid}), handle, n, b, x, info, pBuffer)
+end
+
+@checked function cusolverSpDcsrcholSolve(handle, n, b, x, info, pBuffer)
+    initialize_context()
+    ccall((:cusolverSpDcsrcholSolve, libcusolver()), cusolverStatus_t, (cusolverSpHandle_t, Cint, Ptr{Cdouble}, Ptr{Cdouble}, csrcholInfo_t, Ptr{Cvoid}), handle, n, b, x, info, pBuffer)
+end
+
+@checked function cusolverSpCcsrcholSolve(handle, n, b, x, info, pBuffer)
+    initialize_context()
+    ccall((:cusolverSpCcsrcholSolve, libcusolver()), cusolverStatus_t, (cusolverSpHandle_t, Cint, Ptr{cuComplex}, Ptr{cuComplex}, csrcholInfo_t, Ptr{Cvoid}), handle, n, b, x, info, pBuffer)
+end
+
+@checked function cusolverSpZcsrcholSolve(handle, n, b, x, info, pBuffer)
+    initialize_context()
+    ccall((:cusolverSpZcsrcholSolve, libcusolver()), cusolverStatus_t, (cusolverSpHandle_t, Cint, Ptr{cuDoubleComplex}, Ptr{cuDoubleComplex}, csrcholInfo_t, Ptr{Cvoid}), handle, n, b, x, info, pBuffer)
+end
+
+@checked function cusolverSpScsrcholDiag(handle, info, diag)
+    initialize_context()
+    ccall((:cusolverSpScsrcholDiag, libcusolver()), cusolverStatus_t, (cusolverSpHandle_t, csrcholInfo_t, Ptr{Cfloat}), handle, info, diag)
+end
+
+@checked function cusolverSpDcsrcholDiag(handle, info, diag)
+    initialize_context()
+    ccall((:cusolverSpDcsrcholDiag, libcusolver()), cusolverStatus_t, (cusolverSpHandle_t, csrcholInfo_t, Ptr{Cdouble}), handle, info, diag)
+end
+
+@checked function cusolverSpCcsrcholDiag(handle, info, diag)
+    initialize_context()
+    ccall((:cusolverSpCcsrcholDiag, libcusolver()), cusolverStatus_t, (cusolverSpHandle_t, csrcholInfo_t, Ptr{Cfloat}), handle, info, diag)
+end
+
+@checked function cusolverSpZcsrcholDiag(handle, info, diag)
+    initialize_context()
+    ccall((:cusolverSpZcsrcholDiag, libcusolver()), cusolverStatus_t, (cusolverSpHandle_t, csrcholInfo_t, Ptr{Cdouble}), handle, info, diag)
+end
+
+# Julia wrapper for header: cusolverRf.h
+# Automatically generated using Clang.jl
+
+
+@checked function cusolverRfBatchResetValues(batchSize, n, nnzA, csrRowPtrA, csrColIndA, csrValA_array, P, Q, handle)
+    initialize_context()
+    ccall((:cusolverRfBatchResetValues, libcusolver()), cusolverStatus_t, (Cint, Cint, Cint, CuPtr{Cint}, CuPtr{Cint}, CuPtr{Ptr{Cdouble}}, CuPtr{Cint}, CuPtr{Cint}, cusolverRfHandle_t), batchSize, n, nnzA, csrRowPtrA, csrColIndA, csrValA_array, P, Q, handle)
+end
+
+@checked function cusolverRfCreate(handle)
+    initialize_context()
+    ccall((:cusolverRfCreate, libcusolver()), cusolverStatus_t, (Ptr{cusolverRfHandle_t},), handle)
+end
+
+@checked function cusolverRfBatchAnalyze(handle)
+    initialize_context()
+    ccall((:cusolverRfBatchAnalyze, libcusolver()), cusolverStatus_t, (cusolverRfHandle_t,), handle)
+end
+
+@checked function cusolverRfSetNumericProperties(handle, zero, boost)
+    initialize_context()
+    ccall((:cusolverRfSetNumericProperties, libcusolver()), cusolverStatus_t, (cusolverRfHandle_t, Cdouble, Cdouble), handle, zero, boost)
+end
+
+@checked function cusolverRfSetMatrixFormat(handle, format, diag)
+    initialize_context()
+    ccall((:cusolverRfSetMatrixFormat, libcusolver()), cusolverStatus_t, (cusolverRfHandle_t, cusolverRfMatrixFormat_t, cusolverRfUnitDiagonal_t), handle, format, diag)
+end
+
+@checked function cusolverRfAccessBundledFactorsDevice(handle, nnzM, Mp, Mi, Mx)
+    initialize_context()
+    ccall((:cusolverRfAccessBundledFactorsDevice, libcusolver()), cusolverStatus_t, (cusolverRfHandle_t, Ptr{Cint}, CuPtr{Ptr{Cint}}, CuPtr{Ptr{Cint}}, CuPtr{Ptr{Cdouble}}), handle, nnzM, Mp, Mi, Mx)
+end
+
+@checked function cusolverRfGetMatrixFormat(handle, format, diag)
+    initialize_context()
+    ccall((:cusolverRfGetMatrixFormat, libcusolver()), cusolverStatus_t, (cusolverRfHandle_t, Ptr{cusolverRfMatrixFormat_t}, Ptr{cusolverRfUnitDiagonal_t}), handle, format, diag)
+end
+
+@checked function cusolverRfResetValues(n, nnzA, csrRowPtrA, csrColIndA, csrValA, P, Q, handle)
+    initialize_context()
+    ccall((:cusolverRfResetValues, libcusolver()), cusolverStatus_t, (Cint, Cint, CuPtr{Cint}, CuPtr{Cint}, CuPtr{Cdouble}, CuPtr{Cint}, CuPtr{Cint}, cusolverRfHandle_t), n, nnzA, csrRowPtrA, csrColIndA, csrValA, P, Q, handle)
+end
+
+@checked function cusolverRfBatchSetupHost(batchSize, n, nnzA, h_csrRowPtrA, h_csrColIndA, h_csrValA_array, nnzL, h_csrRowPtrL, h_csrColIndL, h_csrValL, nnzU, h_csrRowPtrU, h_csrColIndU, h_csrValU, h_P, h_Q, handle)
+    initialize_context()
+    ccall((:cusolverRfBatchSetupHost, libcusolver()), cusolverStatus_t, (Cint, Cint, Cint, Ptr{Cint}, Ptr{Cint}, Ptr{Ptr{Cdouble}}, Cint, Ptr{Cint}, Ptr{Cint}, Ptr{Cdouble}, Cint, Ptr{Cint}, Ptr{Cint}, Ptr{Cdouble}, Ptr{Cint}, Ptr{Cint}, cusolverRfHandle_t), batchSize, n, nnzA, h_csrRowPtrA, h_csrColIndA, h_csrValA_array, nnzL, h_csrRowPtrL, h_csrColIndL, h_csrValL, nnzU, h_csrRowPtrU, h_csrColIndU, h_csrValU, h_P, h_Q, handle)
+end
+
+@checked function cusolverRfExtractBundledFactorsHost(handle, h_nnzM, h_Mp, h_Mi, h_Mx)
+    initialize_context()
+    ccall((:cusolverRfExtractBundledFactorsHost, libcusolver()), cusolverStatus_t, (cusolverRfHandle_t, Ptr{Cint}, Ptr{Ptr{Cint}}, Ptr{Ptr{Cint}}, Ptr{Ptr{Cdouble}}), handle, h_nnzM, h_Mp, h_Mi, h_Mx)
+end
+
+@checked function cusolverRfGetAlgs(handle, factAlg, solveAlg)
+    initialize_context()
+    ccall((:cusolverRfGetAlgs, libcusolver()), cusolverStatus_t, (cusolverRfHandle_t, Ptr{cusolverRfFactorization_t}, Ptr{cusolverRfTriangularSolve_t}), handle, factAlg, solveAlg)
+end
+
+@checked function cusolverRfAnalyze(handle)
+    initialize_context()
+    ccall((:cusolverRfAnalyze, libcusolver()), cusolverStatus_t, (cusolverRfHandle_t,), handle)
+end
+
+@checked function cusolverRfSetResetValuesFastMode(handle, fastMode)
+    initialize_context()
+    ccall((:cusolverRfSetResetValuesFastMode, libcusolver()), cusolverStatus_t, (cusolverRfHandle_t, cusolverRfResetValuesFastMode_t), handle, fastMode)
+end
+
+@checked function cusolverRfGetNumericProperties(handle, zero, boost)
+    initialize_context()
+    ccall((:cusolverRfGetNumericProperties, libcusolver()), cusolverStatus_t, (cusolverRfHandle_t, Ptr{Cdouble}, Ptr{Cdouble}), handle, zero, boost)
+end
+
+@checked function cusolverRfGetNumericBoostReport(handle, report)
+    initialize_context()
+    ccall((:cusolverRfGetNumericBoostReport, libcusolver()), cusolverStatus_t, (cusolverRfHandle_t, Ptr{cusolverRfNumericBoostReport_t}), handle, report)
+end
+
+@checked function cusolverRfSetupDevice(n, nnzA, csrRowPtrA, csrColIndA, csrValA, nnzL, csrRowPtrL, csrColIndL, csrValL, nnzU, csrRowPtrU, csrColIndU, csrValU, P, Q, handle)
+    initialize_context()
+    ccall((:cusolverRfSetupDevice, libcusolver()), cusolverStatus_t, (Cint, Cint, CuPtr{Cint}, CuPtr{Cint}, CuPtr{Cdouble}, Cint, CuPtr{Cint}, CuPtr{Cint}, CuPtr{Cdouble}, Cint, CuPtr{Cint}, CuPtr{Cint}, CuPtr{Cdouble}, CuPtr{Cint}, CuPtr{Cint}, cusolverRfHandle_t), n, nnzA, csrRowCuPtrA, csrColIndA, csrValA, nnzL, csrRowCuPtrL, csrColIndL, csrValL, nnzU, csrRowCuPtrU, csrColIndU, csrValU, P, Q, handle)
+end
+
+@checked function cusolverRfSetupHost(n, nnzA, h_csrRowPtrA, h_csrColIndA, h_csrValA, nnzL, h_csrRowPtrL, h_csrColIndL, h_csrValL, nnzU, h_csrRowPtrU, h_csrColIndU, h_csrValU, h_P, h_Q, handle)
+    initialize_context()
+    ccall((:cusolverRfSetupHost, libcusolver()), cusolverStatus_t, (Cint, Cint, Ptr{Cint}, Ptr{Cint}, Ptr{Cdouble}, Cint, Ptr{Cint}, Ptr{Cint}, Ptr{Cdouble}, Cint, Ptr{Cint}, Ptr{Cint}, Ptr{Cdouble}, Ptr{Cint}, Ptr{Cint}, cusolverRfHandle_t), n, nnzA, h_csrRowPtrA, h_csrColIndA, h_csrValA, nnzL, h_csrRowPtrL, h_csrColIndL, h_csrValL, nnzU, h_csrRowPtrU, h_csrColIndU, h_csrValU, h_P, h_Q, handle)
+end
+
+@checked function cusolverRfDestroy(handle)
+    initialize_context()
+    ccall((:cusolverRfDestroy, libcusolver()), cusolverStatus_t, (cusolverRfHandle_t,), handle)
+end
+
+@checked function cusolverRfSetAlgs(handle, factAlg, solveAlg)
+    initialize_context()
+    ccall((:cusolverRfSetAlgs, libcusolver()), cusolverStatus_t, (cusolverRfHandle_t, cusolverRfFactorization_t, cusolverRfTriangularSolve_t), handle, factAlg, solveAlg)
+end
+
+@checked function cusolverRfBatchZeroPivot(handle, position)
+    initialize_context()
+    ccall((:cusolverRfBatchZeroPivot, libcusolver()), cusolverStatus_t, (cusolverRfHandle_t, CuPtr{Cint}), handle, position)
+end
+
+@checked function cusolverRfSolve(handle, P, Q, nrhs, Temp, ldt, XF, ldxf)
+    initialize_context()
+    ccall((:cusolverRfSolve, libcusolver()), cusolverStatus_t, (cusolverRfHandle_t, CuPtr{Cint}, CuPtr{Cint}, Cint, CuPtr{Cdouble}, Cint, CuPtr{Cdouble}, Cint), handle, P, Q, nrhs, Temp, ldt, XF, ldxf)
+end
+
+@checked function cusolverRfBatchSolve(handle, P, Q, nrhs, Temp, ldt, XF_array, ldxf)
+    initialize_context()
+    ccall((:cusolverRfBatchSolve, libcusolver()), cusolverStatus_t, (cusolverRfHandle_t, CuPtr{Cint}, CuPtr{Cint}, Cint, CuPtr{Cdouble}, Cint, CuPtr{Ptr{Cdouble}}, Cint), handle, P, Q, nrhs, Temp, ldt, XF_array, ldxf)
+end
+
+@checked function cusolverRfBatchRefactor(handle)
+    initialize_context()
+    ccall((:cusolverRfBatchRefactor, libcusolver()), cusolverStatus_t, (cusolverRfHandle_t,), handle)
+end
+
+@checked function cusolverRfRefactor(handle)
+    initialize_context()
+    ccall((:cusolverRfRefactor, libcusolver()), cusolverStatus_t, (cusolverRfHandle_t,), handle)
+end
+
+@checked function cusolverRfGetResetValuesFastMode(handle, fastMode)
+    initialize_context()
+    ccall((:cusolverRfGetResetValuesFastMode, libcusolver()), cusolverStatus_t, (cusolverRfHandle_t, Ptr{cusolverRfResetValuesFastMode_t}), handle, fastMode)
+end
+
+@checked function cusolverRfExtractSplitFactorsHost(handle, h_nnzL, h_csrRowPtrL, h_csrColIndL, h_csrValL, h_nnzU, h_csrRowPtrU, h_csrColIndU, h_csrValU)
+    initialize_context()
+    ccall((:cusolverRfExtractSplitFactorsHost, libcusolver()), cusolverStatus_t, (cusolverRfHandle_t, Ptr{Cint}, Ptr{Ptr{Cint}}, Ptr{Ptr{Cint}}, Ptr{Ptr{Cdouble}}, Ptr{Cint}, Ptr{Ptr{Cint}}, Ptr{Ptr{Cint}}, Ptr{Ptr{Cdouble}}), handle, h_nnzL, h_csrRowPtrL, h_csrColIndL, h_csrValL, h_nnzU, h_csrRowPtrU, h_csrColIndU, h_csrValU)
 end

--- a/lib/cusolver/libcusolver_common.jl
+++ b/lib/cusolver/libcusolver_common.jl
@@ -127,6 +127,14 @@ const cusolverSpContext = Cvoid
 const cusolverSpHandle_t = Ptr{cusolverSpContext}
 const csrqrInfo = Cvoid
 const csrqrInfo_t = Ptr{csrqrInfo}
+const csrluInfoHost = Cvoid
+const csrluInfoHost_t = Ptr{csrluInfoHost}
+const csrqrInfoHost = Cvoid
+const csrqrInfoHost_t = Ptr{csrqrInfoHost}
+const csrcholInfoHost = Cvoid
+const csrcholInfoHost_t = Ptr{csrcholInfoHost}
+const csrcholInfo = Cvoid
+const csrcholInfo_t = Ptr{csrcholInfo}
 const cusolverMgContext = Cvoid
 const cusolverMgHandle_t = Ptr{cusolverMgContext}
 
@@ -137,3 +145,40 @@ end
 
 const cudaLibMgGrid_t = Ptr{Cvoid}
 const cudaLibMgMatrixDesc_t = Ptr{Cvoid}
+
+@cenum cusolverRfResetValuesFastMode_t::UInt32 begin
+    CUSOLVERRF_RESET_VALUES_FAST_MODE_OFF = 0
+    CUSOLVERRF_RESET_VALUES_FAST_MODE_ON = 1
+end
+
+@cenum cusolverRfMatrixFormat_t::UInt32 begin
+    CUSOLVERRF_MATRIX_FORMAT_CSR = 0
+    CUSOLVERRF_MATRIX_FORMAT_CSC = 1
+end
+
+@cenum cusolverRfUnitDiagonal_t::UInt32 begin
+    CUSOLVERRF_UNIT_DIAGONAL_STORED_L = 0
+    CUSOLVERRF_UNIT_DIAGONAL_STORED_U = 1
+    CUSOLVERRF_UNIT_DIAGONAL_ASSUMED_L = 2
+    CUSOLVERRF_UNIT_DIAGONAL_ASSUMED_U = 3
+end
+
+@cenum cusolverRfFactorization_t::UInt32 begin
+    CUSOLVERRF_FACTORIZATION_ALG0 = 0
+    CUSOLVERRF_FACTORIZATION_ALG1 = 1
+    CUSOLVERRF_FACTORIZATION_ALG2 = 2
+end
+
+@cenum cusolverRfTriangularSolve_t::UInt32 begin
+    CUSOLVERRF_TRIANGULAR_SOLVE_ALG1 = 1
+    CUSOLVERRF_TRIANGULAR_SOLVE_ALG2 = 2
+    CUSOLVERRF_TRIANGULAR_SOLVE_ALG3 = 3
+end
+
+@cenum cusolverRfNumericBoostReport_t::UInt32 begin
+    CUSOLVERRF_NUMERIC_BOOST_NOT_USED = 0
+    CUSOLVERRF_NUMERIC_BOOST_USED = 1
+end
+
+const cusolverRfCommon = Cvoid
+const cusolverRfHandle_t = Ptr{cusolverRfCommon}

--- a/res/wrap/wrap.jl
+++ b/res/wrap/wrap.jl
@@ -431,8 +431,12 @@ function main()
 
     process("cusparse", "$cuda/cusparse.h"; include_dirs=[cuda])
 
-    process("cusolver", "$cuda/cusolverDn.h", "$cuda/cusolverSp.h", "$cuda/cusolverMg.h";
-            wrapped_headers=["cusolver_common.h", "cusolverDn.h", "cusolverSp.h", "cusolverMg.h"],
+    process("cusolver", "$cuda/cusolverDn.h",
+            "$cuda/cusolverSp.h", "$cuda/cusolverSp_LOWLEVEL_PREVIEW.h",
+            "$cuda/cusolverMg.h", "$cuda/cusolverRf.h";
+            wrapped_headers=["cusolver_common.h", "cusolverDn.h",
+                             "cusolverSp.h", "cusolverSp_LOWLEVEL_PREVIEW.h",
+                             "cusolverMg.h", "cusolverRf.h"],
             include_dirs=[cuda])
 
     process("cudnn", "$cudnn/cudnn_version.h", "$cudnn/cudnn_ops_infer.h",

--- a/test/cusolver/cusolverRF.jl
+++ b/test/cusolver/cusolverRF.jl
@@ -1,0 +1,106 @@
+using LinearAlgebra, SparseArrays, Test
+using CUDA
+using CUDA.CUSOLVER
+using CUDA.CUSPARSE
+
+n = 512
+
+@testset "cusolverRF" begin
+    @testset "RfLU factorization" begin
+        A = sprand(n, n, .2)
+        A += A'
+        b = rand(n)
+        # Compute solution with UMFPACK
+        solution = A \ b
+
+        d_A = CuSparseMatrixCSR(A)
+        d_b = CuVector{Float64}(b)
+        d_x = CUDA.zeros(Float64, n)
+
+        rflu = CUSOLVER.RfLU(d_A)
+        @test isa(rflu, LinearAlgebra.Factorization)
+
+        copyto!(d_x, d_b)
+        CUSOLVER.rf_solve!(rflu, d_x)
+        res = Array(d_x)
+        @test isapprox(res, solution)
+        # Test refactoring
+        scale = 2.0
+        d_A.nzVal .*= scale
+        CUSOLVER.rf_refactor!(rflu, d_A)
+        copyto!(d_x, d_b)
+        CUSOLVER.rf_solve!(rflu, d_x)
+        res = Array(d_x)
+        @test isapprox(res, solution ./ scale)
+
+        # Test LinearAlgebra's overloading
+        d_A = CuSparseMatrixCSR(A)
+        rflu = lu(d_A)
+        ldiv!(d_x, rflu, d_b)
+        res = Array(d_x)
+        @test isapprox(res, solution)
+        d_A.nzVal .*= scale
+        lu!(rflu, d_A)
+        ldiv!(d_x, rflu, d_b)
+        res = Array(d_x)
+        @test isapprox(res, solution ./ scale)
+    end
+
+    @testset "RfBatchLU factorization" begin
+        # One matrix, multiple RHS
+        A = sprand(n, n, .2)
+        A += A'
+        nbatch = 32
+        B = rand(n, nbatch)
+        # Compute solution with UMFPACK
+        solution = A \ B
+
+        d_A = CuSparseMatrixCSR(A)
+        d_B = CuMatrix{Float64}(B)
+        d_X = CUDA.zeros(Float64, n, nbatch)
+        rflu = CUSOLVER.RfBatchLU(d_A, nbatch)
+        @test isa(rflu, LinearAlgebra.Factorization)
+
+        copyto!(d_X, d_B)
+        CUSOLVER.rf_batch_solve!(rflu, d_X)
+        res = Array(d_X)
+        @test isapprox(res, solution)
+
+        # Refactoring
+        scale = 2.0
+        d_A.nzVal .*= scale
+        CUSOLVER.rf_batch_refactor!(rflu, d_A)
+        copyto!(d_X, d_B)
+        CUSOLVER.rf_batch_solve!(rflu, d_X)
+        res = Array(d_X)
+        @test isapprox(res, solution ./ scale)
+
+        # Test LinearAlgebra's overloading
+        d_A = CuSparseMatrixCSR(A)
+        rflu = CUSOLVER.RfBatchLU(d_A, nbatch)
+        ldiv!(d_X, rflu, d_B)
+        res = Array(d_X)
+        @test isapprox(res, solution)
+        d_A.nzVal .*= scale
+        lu!(rflu, d_A)
+        ldiv!(d_X, rflu, d_B)
+        res = Array(d_X)
+        @test isapprox(res, solution ./ scale)
+
+        # Parallel refactoring
+        # Matrices should have the same sparsity pattern
+        I, J, V = findnz(A)
+        nnzA = length(V)
+        # Create a batch of matrices
+        As_batch = [sparse(I, J, randn(nnzA)) for i in 1:nbatch]
+        d_As_batch = [CuSparseMatrixCSR(Ab) for Ab in As_batch]
+        CUSOLVER.rf_batch_refactor!(rflu, d_As_batch)
+        ldiv!(d_X, rflu, d_B)
+        res = Array(d_X)
+        for i in 1:nbatch
+            solution = As_batch[i] \ B[:, i]
+            @test isapprox(res[:, i], solution)
+        end
+    end
+end
+


### PR DESCRIPTION
This PR adds a wrapper to [cusolverRF](https://docs.nvidia.com/cuda/cusolver/index.html#cuSolverRF-reference) in `lib/cusolver`: 
- cusolverRF allows to factorize a sparse matrix on the host (with a LU factorization), and then to transfer the factorization to the device. Computing the factorization of a new sparse matrix _ with the same sparsity pattern _ on the device is then very efficient
- cusolverRF is also shipped with a batch mode that allows the efficient resolution of sparse linear systems `A_i x_i = b_i` in parallel. 

This is our first attempt to contribute to CUDA.jl, so any feedback is welcome (especially about the naming/the structure of the code)! The code is designed to follow the workflow: 
```julia
n = 100
A = sprandn(n, n, .2) # matrix should be square
A += A'                               # and non-singular
b = rand(n)
d_A = CuSparseMatrixCSR(A)  # transfer matrix to the device
rflu = LinearAlgebra.lu(d_A)      # compute LU factorization with CUSOLVER and instantiate a cusolverRF's factorization
d_x = CuArray{Float64}(b)
LinearAlgebra.ldiv!(rflu, d_x)      # solve Ax = b on the GPU with cusolverRF and update d_x inplace

res = Array(d_x)   # get result back
@test res == A \ b 
```

In details, the wrapper we have developed includes: 
- a wrapper to the C functions specified in the header `cusolverSp_LOWLEVEL_PREVIEW.h` (which allows a better control on the factorization routines on the host), generated with Clang.jl
- a wrapper to the C functions specified in `cusolverRf.h`, generated also with Clang.jl
- Julia functions to compute the LU factorization of a `CuSparseMatrixCSR` on the host and to instantiate the corresponding cusolverRF's objects in memory 
- two overloadings for `LinearAlgebra.ldiv!` and `LinearAlgebra.lu!`: with this PR `lu(A)` dispatches automatically on cusolverRF's factorization when `A::CuSparseMatrixCSR`

Thanks to @amontoison for his help!