### PR TITLE
Introduce a HandleCache type.

### DIFF
--- a/lib/cudnn/CUDNN.jl
+++ b/lib/cudnn/CUDNN.jl
@@ -4,7 +4,7 @@ using ..APIUtils
 
 using ..CUDA
 using ..CUDA: CUstream, libraryPropertyType
-using ..CUDA: libcudnn, @retry_reclaim, isdebug
+using ..CUDA: libcudnn, @retry_reclaim, isdebug, @context!
 
 using CEnum
 
@@ -52,26 +52,20 @@ function math_mode(mode=CUDA.math_mode())
 end
 
 # cache for created, but unused handles
-const handle_cache_lock = ReentrantLock()
-const idle_handles = DefaultDict{CuContext,Vector{cudnnHandle_t}}(()->cudnnHandle_t[])
+const idle_handles = HandleCache{CuContext,cudnnHandle_t}()
 
 function handle()
     state = CUDA.active_state()
     handle, stream = get!(task_local_storage(), (:CUDNN, state.context)) do
-        new_handle = @lock handle_cache_lock begin
-            if isempty(idle_handles[state.context])
-                cudnnCreate()
-            else
-                pop!(idle_handles[state.context])
-            end
+        new_handle = pop!(idle_handles, state.context) do
+            cudnnCreate()
         end
 
         finalizer(current_task()) do task
-            @spinlock handle_cache_lock begin
-                push!(idle_handles[state.context], new_handle)
+            push!(idle_handles, state.context, new_handle) do
+                @context! skip_destroyed=true state.context cudnnDestroy(new_handle)
             end
         end
-        # TODO: cudnnDestroy to preserve memory, or at exit?
 
         cudnnSetStream(new_handle, state.stream)
 

--- a/lib/utils/APIUtils.jl
+++ b/lib/utils/APIUtils.jl
@@ -7,6 +7,7 @@ using Libdl
 # helpers that facilitate working with CUDA APIs
 include("call.jl")
 include("enum.jl")
+include("cache.jl")
 include("threading.jl")
 
 end

--- a/lib/utils/cache.jl
+++ b/lib/utils/cache.jl
@@ -1,0 +1,63 @@
+# a cache for library handles
+
+export HandleCache
+
+struct HandleCache{K,V}
+    active_handles::Set{Pair{K,V}}      # for debugging, and to prevent handle finalization
+    idle_handles::Dict{K,Vector{V}}
+    lock::ReentrantLock
+
+    max_entries::Int
+
+    function HandleCache{K,V}(max_entries::Int=32) where {K,V}
+        return new{K,V}(Set{Pair{K,V}}(), Dict{K,Vector{V}}(), ReentrantLock(), max_entries)
+    end
+end
+
+# remove a handle from the cache, or create a new one
+function Base.pop!(f::Function, cache::HandleCache{K,V}, key) where {K,V}
+    function check_cache(f::Function=()->nothing)
+        lock(cache.lock) do
+            handle = if !haskey(cache.idle_handles, key) || isempty(cache.idle_handles[key])
+                f()
+            else
+                pop!(cache.idle_handles[key])
+            end
+
+            if handle !== nothing
+                push!(cache.active_handles, key=>handle)
+            end
+
+            return handle
+        end
+    end
+
+    handle = check_cache()
+
+    if handle === nothing
+        # if we didn't find anything, perform a quick GC collection to free up old handles.
+        GC.gc(false)
+
+        handle = check_cache(f)
+    end
+
+    return handle::V
+end
+
+# put a handle in the cache, or destroy it if it doesn't fit
+function Base.push!(f::Function, cache::HandleCache{K,V}, key::K, handle::V) where {K,V}
+    # cache accesses should be protected by lock(), which inhibits finalizers.
+    # XXX: regular lock so that can be called from non-finalizers?
+    @assert !islocked(cache.lock)
+    delete!(cache.active_handles, key=>handle)
+
+    if haskey(cache.idle_handles, key)
+        if length(cache.idle_handles[key]) > cache.max_entries
+            f()
+        else
+            push!(cache.idle_handles[key], handle)
+        end
+    else
+        cache.idle_handles[key] = [handle]
+    end
+end


### PR DESCRIPTION
- deduplicates the ad-hoc caching logic
- limits the amount of cached handles to lower memory usage
- interfaces with the GC to increase the chance of cache hits