### PR TITLE
Work around offset calculation bug in cuMemcpy3DAsync.

### DIFF
--- a/src/pointer.jl
+++ b/src/pointer.jl
@@ -173,6 +173,20 @@ Base.cconvert(::Type{<:CuArrayPtr}, x) = x
 Base.unsafe_convert(::Type{P}, x::CuArrayPtr) where {P<:CuArrayPtr} = convert(P, x)
 
 
+## limited pointer arithmetic & comparison
+
+Base.isequal(x::CuArrayPtr, y::CuArrayPtr) = (x === y)
+Base.isless(x::CuArrayPtr{T}, y::CuArrayPtr{T}) where {T} = x < y
+
+Base.:(==)(x::CuArrayPtr, y::CuArrayPtr) = UInt(x) == UInt(y)
+Base.:(<)(x::CuArrayPtr,  y::CuArrayPtr) = UInt(x) < UInt(y)
+Base.:(-)(x::CuArrayPtr,  y::CuArrayPtr) = UInt(x) - UInt(y)
+
+Base.:(+)(x::CuArrayPtr, y::Integer) = oftype(x, Base.add_ptr(UInt(x), (y % UInt) % UInt))
+Base.:(-)(x::CuArrayPtr, y::Integer) = oftype(x, Base.sub_ptr(UInt(x), (y % UInt) % UInt))
+Base.:(+)(x::Integer, y::CuArrayPtr) = y + x
+
+
 
 #
 # CUDA reference objects


### PR DESCRIPTION
I heard back from NVIDIA, this is indeed a bug in `cuMemcpy3DAsync` and can be worked around by doing the pointer offset calculation manually. Fixes https://github.com/JuliaGPU/CUDA.jl/issues/863.

cc @omlins, this means you can use CUDA.jl 3.0 without having to fall back to the `none` memory pool.