### PR TITLE
Support unsigned inputs to integer intrinsics.

### DIFF
--- a/src/device/intrinsics/math.jl
+++ b/src/device/intrinsics/math.jl
@@ -133,19 +133,23 @@ Base.expm1(x::Float16) = Float16(CUDA.expm1(Float32(x)))
 
 ## integer handling (bit twiddling)
 
-@device_function brev(x::Int32) =   ccall("extern __nv_brev", llvmcall, Int32, (Int32,), x)
-@device_function brev(x::Int64) =   ccall("extern __nv_brevll", llvmcall, Int64, (Int64,), x)
+@device_function brev(x::Union{Int32, UInt32}) =   ccall("extern __nv_brev", llvmcall, UInt32, (UInt32,), x)
+@device_function brev(x::Union{Int64, UInt64}) =   ccall("extern __nv_brevll", llvmcall, UInt64, (UInt64,), x)
 
-@device_function clz(x::Int32) =   ccall("extern __nv_clz", llvmcall, Int32, (Int32,), x)
-@device_function clz(x::Int64) =   ccall("extern __nv_clzll", llvmcall, Int32, (Int64,), x)
+# TODO: range 0-32
+@device_function clz(x::Union{Int32, UInt32}) =   ccall("extern __nv_clz", llvmcall, Int32, (UInt32,), x)
+@device_function clz(x::Union{Int64, UInt64}) =   ccall("extern __nv_clzll", llvmcall, Int32, (UInt64,), x)
 
-@device_function ffs(x::Int32) = ccall("extern __nv_ffs", llvmcall, Int32, (Int32,), x)
-@device_function ffs(x::Int64) = ccall("extern __nv_ffsll", llvmcall, Int32, (Int64,), x)
+# TODO: range 0-32
+@device_function ffs(x::Union{Int32, UInt32}) = ccall("extern __nv_ffs", llvmcall, Int32, (UInt32,), x)
+@device_function ffs(x::Union{Int64, UInt64}) = ccall("extern __nv_ffsll", llvmcall, Int32, (UInt64,), x)
 
-@device_function byte_perm(x::Int32, y::Int32, z::Int32) = ccall("extern __nv_byte_perm", llvmcall, Int32, (Int32, Int32, Int32), x, y, z)
+# TODO: range 0-32
+@device_function popc(x::Union{Int32, UInt32}) = ccall("extern __nv_popc", llvmcall, Int32, (UInt32,), x)
+@device_function popc(x::Union{Int64, UInt64}) = ccall("extern __nv_popcll", llvmcall, Int32, (UInt64,), x)
 
-@device_function popc(x::Int32) = ccall("extern __nv_popc", llvmcall, Int32, (Int32,), x)
-@device_function popc(x::Int64) = ccall("extern __nv_popcll", llvmcall, Int32, (Int64,), x)
+@device_function byte_perm(x::Union{Int32, UInt32}, y::Union{Int32, UInt32}, z::Union{Int32, UInt32}) =
+    ccall("extern __nv_byte_perm", llvmcall, Int32, (UInt32, UInt32, UInt32), x, y, z)
 
 
 ## floating-point handling

--- a/src/device/intrinsics/math.jl
+++ b/src/device/intrinsics/math.jl
@@ -5,6 +5,11 @@ using Base: FastMath
 using SpecialFunctions
 
 
+## helpers
+
+within(lower, upper) = (val) -> lower <= val <= upper
+
+
 ## trigonometric
 
 @device_override Base.cos(x::Float64) = ccall("extern __nv_cos", llvmcall, Cdouble, (Cdouble,), x)
@@ -136,17 +141,27 @@ Base.expm1(x::Float16) = Float16(CUDA.expm1(Float32(x)))
 @device_function brev(x::Union{Int32, UInt32}) =   ccall("extern __nv_brev", llvmcall, UInt32, (UInt32,), x)
 @device_function brev(x::Union{Int64, UInt64}) =   ccall("extern __nv_brevll", llvmcall, UInt64, (UInt64,), x)
 
-# TODO: range 0-32
-@device_function clz(x::Union{Int32, UInt32}) =   ccall("extern __nv_clz", llvmcall, Int32, (UInt32,), x)
-@device_function clz(x::Union{Int64, UInt64}) =   ccall("extern __nv_clzll", llvmcall, Int32, (UInt64,), x)
 
-# TODO: range 0-32
-@device_function ffs(x::Union{Int32, UInt32}) = ccall("extern __nv_ffs", llvmcall, Int32, (UInt32,), x)
-@device_function ffs(x::Union{Int64, UInt64}) = ccall("extern __nv_ffsll", llvmcall, Int32, (UInt64,), x)
+@device_function clz(x::Union{Int32, UInt32}) =
+    assume(within(UInt32(0), UInt32(32)),
+           ccall("extern __nv_clz", llvmcall, Int32, (UInt32,), x))
+@device_function clz(x::Union{Int64, UInt64}) =
+    assume(within(UInt64(0), UInt64(64)),
+           ccall("extern __nv_clzll", llvmcall, Int32, (UInt64,), x))
 
-# TODO: range 0-32
-@device_function popc(x::Union{Int32, UInt32}) = ccall("extern __nv_popc", llvmcall, Int32, (UInt32,), x)
-@device_function popc(x::Union{Int64, UInt64}) = ccall("extern __nv_popcll", llvmcall, Int32, (UInt64,), x)
+@device_function ffs(x::Union{Int32, UInt32}) =
+    assume(within(UInt32(0), UInt32(32)),
+           ccall("extern __nv_ffs", llvmcall, Int32, (UInt32,), x))
+@device_function ffs(x::Union{Int64, UInt64}) =
+    assume(within(UInt64(0), UInt64(64)),
+           ccall("extern __nv_ffsll", llvmcall, Int32, (UInt64,), x))
+
+@device_function popc(x::Union{Int32, UInt32}) =
+    assume(within(UInt32(0), UInt32(32)),
+           ccall("extern __nv_popc", llvmcall, Int32, (UInt32,), x))
+@device_function popc(x::Union{Int64, UInt64}) =
+    assume(within(UInt64(0), UInt64(64)),
+           ccall("extern __nv_popcll", llvmcall, Int32, (UInt64,), x))
 
 @device_function byte_perm(x::Union{Int32, UInt32}, y::Union{Int32, UInt32}, z::Union{Int32, UInt32}) =
     ccall("extern __nv_byte_perm", llvmcall, Int32, (UInt32, UInt32, UInt32), x, y, z)

--- a/src/device/llvm.jl
+++ b/src/device/llvm.jl
@@ -13,3 +13,9 @@
 
         attributes #0 = { alwaysinline }""", "entry"),
     Nothing, Tuple{Bool}, cond)
+
+# do-block syntax
+@inline function assume(f::F, val...) where {F}
+    assume(f(val...))
+    return val
+end


### PR DESCRIPTION
This is also a bugfix, as `activemask()` can return `typemax(UInt32)` which currently results in an InexactError.
Ideally, we'd attach range metadata to the outputs to avoid checks upon conversions to Int, but there's no convenient syntax for that and I don't feel like rewriting these as LLVM.jl-based functions right now.