### PR TITLE
Robustly get variables from the environment during init.

### DIFF
--- a/deps/bindeps.jl
+++ b/deps/bindeps.jl
@@ -405,12 +405,21 @@ end
 function __init_dependencies__()
     found = false
 
+    # robustly get and parse an env var
+    function getenv(var, default::T) where T
+        if haskey(ENV, var)
+            something(tryparse(T, ENV[var]), default)
+        else
+            default
+        end
+    end
+
     # CI runs in a well-defined environment, so prefer a local CUDA installation there
-    if parse(Bool, get(ENV, "CI", "false")) && !haskey(ENV, "JULIA_CUDA_USE_BINARYBUILDER")
+    if getenv("CI", false) && !haskey(ENV, "JULIA_CUDA_USE_BINARYBUILDER")
         found = use_local_cuda()
     end
 
-    if !found && parse(Bool, get(ENV, "JULIA_CUDA_USE_BINARYBUILDER", "true"))
+    if !found && getenv("JULIA_CUDA_USE_BINARYBUILDER", true)
         found = use_artifact_cuda()
     end
 


### PR DESCRIPTION
Fixes:

```
julia> CUDA.versioninfo()
┌ Error: Error during initialization of CUDA.jl
│   exception =
│    ArgumentError: invalid Bool representation: "\"false\""
```

cc @vchuravy 