### PR TITLE
Compile using the toolkit, not the driver.

### DIFF
--- a/Manifest.toml
+++ b/Manifest.toml
@@ -88,9 +88,9 @@ uuid = "0c68f7d7-f131-5f86-a1c3-88cf8149b2d7"
 version = "6.4.1"
 
 [[GPUCompiler]]
-deps = ["DataStructures", "ExprTools", "InteractiveUtils", "LLVM", "Libdl", "Logging", "Scratch", "Serialization", "TimerOutputs", "UUIDs"]
-git-tree-sha1 = "32ddf56e7c7b725a5cc84391d4509b8887e937ad"
-repo-rev = "8ebb0cd"
+deps = ["DataStructures", "ExprTools", "InteractiveUtils", "LLVM", "Libdl", "Logging", "TimerOutputs", "UUIDs"]
+git-tree-sha1 = "84ff0bc2a431854a519bc35a4b56272b934593d0"
+repo-rev = "02b7f5e"
 repo-url = "https://github.com/JuliaGPU/GPUCompiler.jl.git"
 uuid = "61eb1bfa-7361-4325-ad38-22787b887f55"
 version = "0.11.5"
@@ -234,12 +234,6 @@ version = "1.1.3"
 
 [[SHA]]
 uuid = "ea8e919c-243c-51af-8825-aaa63cd721ce"
-
-[[Scratch]]
-deps = ["Dates"]
-git-tree-sha1 = "ad4b278adb62d185bbcb6864dc24959ab0627bf6"
-uuid = "6c6a2e73-6563-6170-7368-637461726353"
-version = "1.0.3"
 
 [[Serialization]]
 uuid = "9e88b42a-f829-5b0c-bbe9-9e923198166b"

--- a/deps/bindeps.jl
+++ b/deps/bindeps.jl
@@ -202,7 +202,25 @@ toolkit_release() = VersionNumber(toolkit_version().major, toolkit_version().min
 
 ## binaries
 
-export nvdisasm, compute_sanitizer, has_compute_sanitizer
+export ptxas, nvlink, nvdisasm, compute_sanitizer, has_compute_sanitizer
+
+# pxtas: used for compiling PTX to SASS
+const __ptxas = Ref{String}()
+function ptxas()
+    @initialize_ref __ptxas begin
+        __ptxas[] = find_binary(toolkit(), "ptxas")
+    end
+    __ptxas[]
+end
+
+# nvlink: used for linking additional libraries
+const __nvlink = Ref{String}()
+function nvlink()
+    @initialize_ref __nvlink begin
+        __nvlink[] = find_binary(toolkit(), "nvlink")
+    end
+    __nvlink[]
+end
 
 # nvdisasm: used for reflection (decompiling SASS code)
 const __nvdisasm = Ref{String}()

--- a/src/compiler/execution.jl
+++ b/src/compiler/execution.jl
@@ -278,7 +278,7 @@ The output of this function is automatically cached, i.e. you can simply call `c
 in a hot path without degrading performance. New code will be generated automatically, when
 when function changes, or when different types or keyword arguments are provided.
 """
-@timeit_ci function cufunction(f::F, tt::Type{TT}=Tuple{}; name=nothing, kwargs...) where {F, TT}
+@timeit_ci function cufunction(f, tt=Tuple{}; name=nothing, kwargs...)
     dev = device()
     cache = cufunction_cache[dev]
     source = FunctionSpec(f, tt, true, name)
@@ -287,7 +287,7 @@ when function changes, or when different types or keyword arguments are provided
     job = CompilerJob(target, source, params)
     return GPUCompiler.cached_compilation(cache, job,
                                           cufunction_compile,
-                                          cufunction_link)::HostKernel{F,TT}
+                                          cufunction_link)
 end
 
 const cufunction_cache = PerDevice{Dict{UInt, Any}}((dev)->Dict{UInt, Any}())

--- a/src/compiler/execution.jl
+++ b/src/compiler/execution.jl
@@ -292,9 +292,9 @@ end
 
 const cufunction_cache = PerDevice{Dict{UInt, Any}}((dev)->Dict{UInt, Any}())
 
-# compile to PTX
+# compile to executable machine code
 @timeit_ci "compile" function cufunction_compile(@nospecialize(job::CompilerJob))
-    # compile
+    # lower to PTX
     method_instance, world = @timeit_ci "emit_julia" GPUCompiler.emit_julia(job)
     ir, kernel = @timeit_ci "emit_llvm" GPUCompiler.emit_llvm(job, method_instance, world)
     code = @timeit_ci "emit_asm" GPUCompiler.emit_asm(job, ir, kernel; format=LLVM.API.LLVMAssemblyFile)
@@ -304,48 +304,104 @@ const cufunction_cache = PerDevice{Dict{UInt, Any}}((dev)->Dict{UInt, Any}())
         isdeclaration(f) && !LLVM.isintrinsic(f)
     end
     intrinsic_fns = ["vprintf", "malloc", "free", "__assertfail",
-                    "__nvvm_reflect" #= TODO: should have been optimized away =#]
+                     "__nvvm_reflect" #= TODO: should have been optimized away =#]
     needs_cudadevrt = !isempty(setdiff(LLVM.name.(undefined_fs), intrinsic_fns))
 
     # find externally-initialized global variables; we'll access those using CUDA APIs.
     external_gvars = filter(isextinit, collect(globals(ir))) .|> LLVM.name
 
-    return (code, entry=LLVM.name(kernel), needs_cudadevrt, external_gvars)
+    # prepare invocations of CUDA compiler tools
+    ptxas_cmd = `$(ptxas())`
+    nvlink_cmd = `$(nvlink())`
+    ## debug flags
+    if Base.JLOptions().debug_level == 1
+        ptxas_cmd = `$ptxas_cmd --generate-line-info`
+    elseif Base.JLOptions().debug_level >= 2
+        ptxas_cmd = `$ptxas_cmd --device-debug`
+        nvlink_cmd = `$nvlink_cmd --debug`
+    end
+    ## relocatable device code
+    if needs_cudadevrt
+        ptxas_cmd = `$ptxas_cmd --compile-only`
+    end
+
+    # helper to run a binary and collect all relevant output
+    function run_and_collect(cmd)
+        stdout = Pipe()
+        proc = run(pipeline(ignorestatus(cmd); stdout, stderr=stdout), wait=false)
+        close(stdout.in)
+
+        reader = @async String(read(stdout))
+        Base.wait(proc)
+        log = strip(fetch(reader))
+
+        return proc, log
+    end
+
+    # compile to machine code
+    # NOTE: we use tempname since mktemp doesn't support suffixes, and mktempdir is slow
+    ptx_input = tempname(cleanup=false) * ".ptx"
+    ptxas_output = tempname(cleanup=false) * ".cubin"
+    nvlink_output = tempname(cleanup=false) * ".cubin"
+    image = try
+        write(ptx_input, code)
+
+        arch = "sm_$(job.target.cap.major)$(job.target.cap.minor)"
+
+        # we could use the driver's embedded JIT compiler, but that has several disadvantages:
+        # 1. fixes and improvements are slower to arrive, by using `ptxas` we only need to
+        #    upgrade the toolkit to get a newer compiler;
+        # 2. version checking is simpler, we otherwise need to use NVML to query the driver
+        #    version, which is hard to correlate to PTX JIT improvements;
+        # 3. if we want to be able to use newer (minor upgrades) of the CUDA toolkit on an
+        #    older driver, we should use the newer compiler to ensure compatibility.
+        proc, log = @timeit_ci "ptxas" run_and_collect(
+            ```$ptxas_cmd --gpu-name $arch
+                          --verbose
+                          --output-file $ptxas_output $ptx_input```)
+        if !success(proc)
+            error("Failed to compile PTX code" * (isempty(log) ? "" : "\n$log"))
+        elseif !isempty(log)
+            @debug "PTX compiler log:\n" * log
+        end
+
+        # link device libraries, if necessary
+        #
+        # this requires relocatable device code, which prevents certain optimizations and
+        # hurts performance. as such, we only do so when absolutely necessary.
+        # TODO: try LTO, `--link-time-opt --nvvmpath /opt/cuda/nvvm`.
+        #       fails with `Ignoring -lto option because no LTO objects found`
+        if needs_cudadevrt
+            proc, log = @timeit_ci "nvlink" run_and_collect(
+                ```$nvlink_cmd --arch $arch
+                               --library-path $(dirname(libcudadevrt()))
+                               --library cudadevrt
+                               --verbose --extra-warnings
+                               --output-file $nvlink_output $ptxas_output```)
+            if !success(proc)
+                error("Failed to link PTX code" * (isempty(log) ? "" : "\n$log"))
+            elseif !isempty(log)
+                @debug "PTX linker info log:\n" * log
+            end
+
+            read(nvlink_output)
+        else
+            read(ptxas_output)
+        end
+    finally
+        rm(ptx_input)
+        ispath(ptxas_output) && rm(ptxas_output)
+        ispath(nvlink_output) && rm(nvlink_output)
+    end
+
+    return (image, entry=LLVM.name(kernel), external_gvars)
 end
 
-# link to device code
+# link into an executable kernel
 @timeit_ci "link" function cufunction_link(@nospecialize(job::CompilerJob), compiled)
+    # load as an executable kernel object
     ctx = context()
-
-    # settings to JIT based on Julia's debug setting
-    jit_options = Dict{CUjit_option,Any}()
-    if Base.JLOptions().debug_level == 1
-        jit_options[JIT_GENERATE_LINE_INFO] = true
-    elseif Base.JLOptions().debug_level >= 2
-        jit_options[JIT_GENERATE_DEBUG_INFO] = true
-    end
-
-    # link the CUDA device library
-    # linking the device runtime library requires use of the CUDA linker,
-    # which in turn switches compilation to device relocatable code (-rdc) mode.
-    #
-    # even if not doing any actual calls that need -rdc (i.e., calls to the runtime
-    # library), this significantly hurts performance, so don't do it unconditionally
-    intrinsic_fns = ["vprintf", "malloc", "free", "__assertfail",
-                    "__nvvm_reflect" #= TODO: should have been optimized away =#]
-    image = if compiled.needs_cudadevrt
-        @timeit_ci "cudadevrt" begin
-        linker = CuLink(jit_options)
-        add_file!(linker, libcudadevrt(), JIT_INPUT_LIBRARY)
-        add_data!(linker, compiled.entry, compiled.code)
-        complete(linker)
-        end
-    else
-        compiled.code
-    end
-
-    # JIT into an executable kernel object
-    mod = @timeit_ci "CuModule" CuModule(image, jit_options)
+    mod = @timeit_ci "CuModule" CuModule(compiled.image)
     fun = CuFunction(mod, compiled.entry)
 
     # initialize and register the exception flag, if any

--- a/test/execution.jl
+++ b/test/execution.jl
@@ -41,17 +41,6 @@ end
 end
 
 
-@testset "inference" begin
-    foo() = @cuda dummy()
-    @inferred foo()
-
-    # with arguments, we call cudaconvert
-    kernel(a) = return
-    bar(a) = @cuda kernel(a)
-    @inferred bar(CuArray([1]))
-end
-
-
 @testset "reflection" begin
     CUDA.code_lowered(dummy, Tuple{})
     CUDA.code_typed(dummy, Tuple{})


### PR DESCRIPTION
In response to the driver's compiler bug in https://github.com/JuliaGPU/CUDA.jl/pull/891, which doesn't manifest on 11.3's `ptxas`. Should also enable https://github.com/JuliaGPU/CUDA.jl/issues/832 without having to use `libnvptxcompiler`. Might also help towards fixing https://github.com/JuliaGPU/CUDA.jl/issues/812, because if we additionally expose `libnvvm`, we can do LTO with `nvlink` (this is not exposed by the linker API).

Currently stuck on https://forums.developer.nvidia.com/t/manually-perform-separate-compilation-with-ptxas-and-nvlink/177183, I can't find how to use `nvlink` to link `libcudadevrt`.

Artifacts have not been adapted, so this only works using `JULIA_CUDA_USE_BINARYBUILDER=false. But it does pass all tests, except for the ones requiring the device runtime .