### PR TITLE
Fix two-step mapreduce with wrapped output.

### DIFF
--- a/src/mapreduce.jl
+++ b/src/mapreduce.jl
@@ -225,7 +225,10 @@ function GPUArrays.mapreducedim!(f::F, op::OP, R::AnyCuArray{T},
                 copyto!(partial, (i-1)*sz+1, R, 1, sz)
             end
         end
-        kernel(f, op, init, Rreduce, Rother, Val(shuffle), partial, A; threads, blocks, shmem)
+        # NOTE: we can't use the previously-compiled kernel, since the type of `partial`
+        #       might not match the original output container (e.g. if that was a view).
+        @cuda(threads=threads, blocks=blocks, shmem=shmem,
+              partial_mapreduce_grid(f, op, init, Rreduce, Rother, Val(shuffle), partial, A))
 
         GPUArrays.mapreducedim!(identity, op, R′, partial; init=init)
     end

--- a/test/array.jl
+++ b/test/array.jl
@@ -584,3 +584,8 @@ end
   b .= 3
   @test Array(y) == [2]
 end
+
+@testset "issue 919" begin
+  # two-step mapreduce with wrapped CuArray as output
+  @test vec(Array(sum!(view(CUDA.zeros(1,1,1), 1, :, :), CUDA.ones(1,4096)))) == [4096f0]
+end


### PR DESCRIPTION
Fixes https://github.com/JuliaGPU/CUDA.jl/issues/919