### PR TITLE
Eagerly free the CUFFT workspace when generating a new one.

### DIFF
--- a/lib/cufft/fft.jl
+++ b/lib/cufft/fft.jl
@@ -113,6 +113,7 @@ Base.size(p::CuFFTPlan) = p.sz
         # replace the workarea by one (asynchronously) allocated on the current stream
         new_workarea = similar(plan.workarea)
         cufftSetWorkArea(plan, new_workarea)
+        CUDA.unsafe_free!(plan.workarea)
         plan.workarea = plan.workarea
     end
     return


### PR DESCRIPTION
Helps a little with https://github.com/JuliaGPU/CUDA.jl/issues/926, but in the end it's other allocations too that cause the OOM.