### PR TITLE
Re-initialize the random seed every time.

### DIFF
--- a/src/compiler/execution.jl
+++ b/src/compiler/execution.jl
@@ -354,13 +354,6 @@ end
         filter!(!isequal("exception_flag"), compiled.external_gvars)
     end
 
-    # initialize random seeds, if used
-    if "global_random_seed" in compiled.external_gvars
-        random_state = missing
-        initialize_random_seeds!(mod)
-        filter!(!isequal("global_random_seed"), compiled.external_gvars)
-    end
-
     return HostKernel{typeof(job.source.f),job.source.tt}(job.source.f, ctx, mod, fun)
 end
 


### PR DESCRIPTION
Turns out we can't rely on the shared memory persisting across launches,
so we need to initialize the key at every launch. That also implies we
need a fresh seed for every launch, because otherwise two subsequent
launches would generate the same numbers. To avoid having to upload a
seed before every launch, use the `clock` register as a source of
randomness to initialize the key with.

Should fix the sporadic failures seed on CI.