### PR TITLE
Re-introduce specialization of cufunction.

### DIFF
--- a/src/compiler/execution.jl
+++ b/src/compiler/execution.jl
@@ -278,7 +278,7 @@ The output of this function is automatically cached, i.e. you can simply call `c
 in a hot path without degrading performance. New code will be generated automatically, when
 when function changes, or when different types or keyword arguments are provided.
 """
-@timeit_ci function cufunction(f, tt=Tuple{}; name=nothing, kwargs...)
+@timeit_ci function cufunction(f::F, tt::TT=Tuple{}; name=nothing, kwargs...) where {F,TT}
     dev = device()
     cache = cufunction_cache[dev]
     source = FunctionSpec(f, tt, true, name)
@@ -287,7 +287,7 @@ when function changes, or when different types or keyword arguments are provided
     job = CompilerJob(target, source, params)
     return GPUCompiler.cached_compilation(cache, job,
                                           cufunction_compile,
-                                          cufunction_link)
+                                          cufunction_link)::HostKernel{F,tt}
 end
 
 const cufunction_cache = PerDevice{Dict{UInt, Any}}((dev)->Dict{UInt, Any}())

--- a/test/execution.jl
+++ b/test/execution.jl
@@ -41,6 +41,17 @@ end
 end
 
 
+@testset "inference" begin
+    foo() = @cuda dummy()
+    @inferred foo()
+
+    # with arguments, we call cudaconvert
+    kernel(a) = return
+    bar(a) = @cuda kernel(a)
+    @inferred bar(CuArray([1]))
+end
+
+
 @testset "reflection" begin
     CUDA.code_lowered(dummy, Tuple{})
     CUDA.code_typed(dummy, Tuple{})


### PR DESCRIPTION
The performance hit is gone with the Cmd interpolation fixes,
and we need this to minimize launch overhead.