### PR TITLE
Support isbits union element types with CuArray.

### DIFF
--- a/src/array.jl
+++ b/src/array.jl
@@ -268,7 +268,9 @@ Base.unsafe_convert(::Type{CuPtr{T}}, x::CuArray{T}) where {T} =
 ## interop with device arrays
 
 function Base.unsafe_convert(::Type{CuDeviceArray{T,N,AS.Global}}, a::DenseCuArray{T,N}) where {T,N}
-  CuDeviceArray{T,N,AS.Global}(size(a), reinterpret(LLVMPtr{T,AS.Global}, a.baseptr), a.maxsize, a.offset)
+  CuDeviceArray{T,N,AS.Global}(size(a),
+                               reinterpret(LLVMPtr{T,AS.Global}, a.baseptr + a.offset),
+                               a.maxsize - a.offset)
 end
 
 

--- a/src/device/array.jl
+++ b/src/device/array.jl
@@ -250,11 +250,12 @@ Base.show(io::IO, mime::MIME"text/plain", a::CuDeviceArray) = show(io, a)
 end
 
 function Base.reinterpret(::Type{T}, a::CuDeviceArray{S,N,A}) where {T,S,N,A}
+  err = _reinterpret_exception(T, a)
+  err === nothing || throw(err)
+
   if sizeof(T) == sizeof(S) # fast case
     return CuDeviceArray{T,N,A}(size(a), reinterpret(LLVMPtr{T,A}, a.baseptr), a.maxsize, a.offset)
   end
-  err = _reinterpret_exception(T, a)
-  err === nothing || throw(err)
 
   isize = size(a)
   size1 = div(isize[1]*sizeof(S), sizeof(T))

--- a/src/device/intrinsics/memory_shared.jl
+++ b/src/device/intrinsics/memory_shared.jl
@@ -47,7 +47,6 @@ macro cuDynamicSharedMem(T, dims, offset=0)
     quote
         len = prod($(esc(dims)))
         ptr = emit_shmem(Val($(QuoteNode(id))), $(esc(T))) + $(esc(offset))
-        # TODO: pass offset to CuDeviceArray
         CuDeviceArray($(esc(dims)), ptr)
     end
 end

--- a/src/device/intrinsics/memory_shared.jl
+++ b/src/device/intrinsics/memory_shared.jl
@@ -47,6 +47,7 @@ macro cuDynamicSharedMem(T, dims, offset=0)
     quote
         len = prod($(esc(dims)))
         ptr = emit_shmem(Val($(QuoteNode(id))), $(esc(T))) + $(esc(offset))
+        # TODO: pass offset to CuDeviceArray
         CuDeviceArray($(esc(dims)), ptr)
     end
 end

--- a/test/array.jl
+++ b/test/array.jl
@@ -152,6 +152,19 @@ end
     @test Array(c) == reinterpret(UInt32, Int32[-2,-3])
   end
 
+  @testset "exception: non-isbits" begin
+    local err
+    @test try
+      reinterpret(Float64, CuArray([1,nothing]))
+      nothing
+    catch err′
+      err = err′
+    end isa Exception
+    @test occursin(
+      "cannot reinterpret an `Union{Nothing, Int64}` array to `Float64`, because not all types are bitstypes",
+      sprint(showerror, err))
+  end
+
   @testset "exception: 0-dim" begin
     local err
     @test try

--- a/test/device/array.jl
+++ b/test/device/array.jl
@@ -138,3 +138,108 @@ end
     da = CUDA.CuDeviceArray(1, dp)
     load_index(da)
 end
+
+
+function kernel_shmem_reinterpet_equal_size!(y)
+  a = @cuDynamicSharedMem(Float32, (blockDim().x,))
+  b = reinterpret(UInt32, a)
+  a[threadIdx().x] = threadIdx().x
+  b[threadIdx().x] += 1
+  y[threadIdx().x] = a[threadIdx().x]
+  return
+end
+
+function shmem_reinterpet_equal_size()
+  threads = 4
+  y = CUDA.zeros(threads)
+  shmem = sizeof(Float32) * threads
+  @cuda(
+    threads = threads,
+    blocks = 1,
+    shmem = shmem,
+    kernel_shmem_reinterpet_equal_size!(y)
+  )
+  return y
+end
+
+@testset "reinterpret shmem: equal size" begin
+  gpu = shmem_reinterpet_equal_size()
+  a = zeros(Float32, length(gpu))
+  b = reinterpret(UInt32, a)
+  a .= 1:length(b)
+  b .+= 1
+  @test collect(gpu) == a
+end
+
+function kernel_shmem_reinterpet_smaller_size!(y)
+  a = @cuDynamicSharedMem(UInt128, (blockDim().x,))
+  i32 = Int32(threadIdx().x)
+  p = i32 + i32 * im
+  q = i32 - i32 * im
+  b = reinterpret(typeof(p), a)
+  b[1 + 2 * (threadIdx().x - 1)] = p
+  b[2 + 2 * (threadIdx().x - 1)] = q
+  y[threadIdx().x] = a[threadIdx().x]
+  return
+end
+
+function shmem_reinterpet_smaller_size()
+  threads = 4
+  y = CUDA.zeros(UInt128, threads)
+  shmem = sizeof(UInt128) * threads
+  @cuda(
+    threads = threads,
+    blocks = 1,
+    shmem = shmem,
+    kernel_shmem_reinterpet_smaller_size!(y)
+  )
+  return y
+end
+
+@testset "reinterpret shmem: smaller size" begin
+  gpu = shmem_reinterpet_smaller_size()
+  n = length(gpu)
+  a = zeros(UInt128, n)
+  p(i) = Int32(i) + Int32(i) * im
+  q(i) = Int32(i) - Int32(i) * im
+  b = reinterpret(typeof(p(0)), a)
+  b[1:2:end] .= p.(1:n)
+  b[2:2:end] .= q.(1:n)
+  @test collect(gpu) == a
+end
+
+function kernel_shmem_reinterpet_larger_size!(y)
+  a = @cuDynamicSharedMem(Float32, (4 * blockDim().x,))
+  b = reinterpret(UInt128, a)
+  a[1 + 4 * (threadIdx().x - 1)] = threadIdx().x
+  a[2 + 4 * (threadIdx().x - 1)] = threadIdx().x * 2
+  a[3 + 4 * (threadIdx().x - 1)] = threadIdx().x * 3
+  a[4 + 4 * (threadIdx().x - 1)] = threadIdx().x * 4
+  y[threadIdx().x] = b[threadIdx().x]
+  return
+end
+
+function shmem_reinterpet_larger_size()
+  threads = 4
+  y = CUDA.zeros(UInt128, threads)
+  shmem = sizeof(UInt128) * threads
+  @cuda(
+    threads = threads,
+    blocks = 1,
+    shmem = shmem,
+    kernel_shmem_reinterpet_larger_size!(y)
+  )
+  return y
+end
+
+@testset "reinterpret shmem: larger size" begin
+  gpu = shmem_reinterpet_larger_size()
+  n = length(gpu)
+  b = zeros(UInt128, n)
+  a = reinterpret(Float32, b)
+  a[1:4:end] .= 1:n
+  a[2:4:end] .= (1:n) .* 2
+  a[3:4:end] .= (1:n) .* 3
+  a[4:4:end] .= (1:n) .* 4
+  @test collect(gpu) == b
+end


### PR DESCRIPTION
Similar to how Base supports storing unions of bitstypes inline. Works with a byte-array of selectors ~right past the last element (we don't currently reserve space for fast resizing).~ after `baseptr+maxsize`.

Still needs some work, as not all operations have been made aware of this change. Also, this peculiar case where the second `@inbounds` is required for the kernel to compile, whereas Base's codegen always elides the check:

```
julia> a = [1,nothing]
2-element Vector{Union{Nothing, Int64}}:
 1
  nothing

julia> b = CuArray(a)
2-element CuArray{Union{Nothing, Int64}, 1}:
 1
  nothing

julia> function kernel(a)
       if @inbounds(a[1]) !== nothing
       @inbounds a[1] + 1
       end
       return
       end^C

julia> @cuda kernel(b)
CUDA.HostKernel{typeof(kernel), Tuple{CuDeviceVector{Union{Nothing, Int64}, 1}}}(kernel, CuContext(0x00000000021e2750, instance 969dae16e3031c1c), CuModule(Ptr{Nothing} @0x0000000005d21690, CuContext(0x00000000021e2750, instance 969dae16e3031c1c)), CuFunction(Ptr{Nothing} @0x00000000040d9390, CuModule(Ptr{Nothing} @0x0000000005d21690, CuContext(0x00000000021e2750, instance 969dae16e3031c1c))))

julia> function kernel(a)
       if @inbounds(a[1]) !== nothing
       a[1] + 1
       end
       return
       end
kernel (generic function with 1 method)

julia> @cuda kernel(b)
ERROR: InvalidIRError: compiling kernel kernel(CuDeviceVector{Union{Nothing, Int64}, 1}) resulted in invalid LLVM IR
Reason: unsupported dynamic function invocation (call to +)
```

Fixes https://github.com/JuliaGPU/CUDA.jl/issues/103.
cc @tkf, maybe you have some comments based on your work in UnionArrays.jl