### PR TITLE
Try generating code with unreachable control flow.

### DIFF
--- a/Manifest.toml
+++ b/Manifest.toml
@@ -89,8 +89,8 @@ version = "6.4.1"
 
 [[GPUCompiler]]
 deps = ["DataStructures", "ExprTools", "InteractiveUtils", "LLVM", "Libdl", "Logging", "TimerOutputs", "UUIDs"]
-git-tree-sha1 = "84ff0bc2a431854a519bc35a4b56272b934593d0"
-repo-rev = "02b7f5e"
+git-tree-sha1 = "fd742d96259a4a5a79897cfdd84d856adf4b1010"
+repo-rev = "fd3d955"
 repo-url = "https://github.com/JuliaGPU/GPUCompiler.jl.git"
 uuid = "61eb1bfa-7361-4325-ad38-22787b887f55"
 version = "0.11.5"


### PR DESCRIPTION
For now only when using CUDA 11.3's `ptxas`, since that seems to pass tests locally.

The benefit of `unreachable` is that LLVM can remove potentially GPU incompatible code. As encountered in https://github.com/JuliaGPU/CUDA.jl/issues/103, where the boundscheck on an union array resulted in a `jl_generic_apply` in code _following_ the thrown exception.