### PR TITLE
Query the CUBLAS version without requiring a handle.

### DIFF
--- a/lib/cublas/CUBLAS.jl
+++ b/lib/cublas/CUBLAS.jl
@@ -36,27 +36,27 @@ function math_mode!(handle, mode)
     flags = 0
 
     # https://github.com/facebookresearch/faiss/issues/1385
-    if version(handle) > v"11"
+    if version() > v"11"
         flags = CUBLAS_MATH_DISALLOW_REDUCED_PRECISION_REDUCTION
     end
 
     flags |= if mode == CUDA.PEDANTIC_MATH
         # prevent use of tensor cores
-        if version(handle) < v"11"
+        if version() < v"11"
             CUBLAS_DEFAULT_MATH
         else
             CUBLAS_PEDANTIC_MATH
         end
     elseif mode == CUDA.DEFAULT_MATH
         # use tensor cores, but don't reduce precision
-        if version(handle) < v"11"
+        if version() < v"11"
             CUBLAS_TENSOR_OP_MATH
         else
             CUBLAS_DEFAULT_MATH
         end
     elseif mode == CUDA.FAST_MATH
         # we'll additionally select a compute-mode with reduced precision whenever possible
-        if version(handle) < v"11"
+        if version() < v"11"
             CUBLAS_TENSOR_OP_MATH
         else
             CUBLAS_TF32_TENSOR_OP_MATH

--- a/lib/cublas/wrappers.jl
+++ b/lib/cublas/wrappers.jl
@@ -33,13 +33,9 @@ end
   value_ref[]
 end
 
-@memoize function version(handle=handle())
-  version_ref = Ref{Cint}()
-  cublasGetVersion_v2(handle, version_ref)
-  major, rem = divrem(version_ref[], 1000)
-  minor, patch = divrem(rem, 100)
-  VersionNumber(major, minor, patch)
-end
+@memoize version() = VersionNumber(cublasGetProperty(CUDA.MAJOR_VERSION),
+                                   cublasGetProperty(CUDA.MINOR_VERSION),
+                                   cublasGetProperty(CUDA.PATCH_LEVEL))
 
 @memoize function juliaStorageType(T::Type{<:Real}, ct::cublasComputeType_t)
     if ct == CUBLAS_COMPUTE_16F || ct == CUBLAS_COMPUTE_16F_PEDANTIC


### PR DESCRIPTION
This makes it possible to call versioninfo() without any available GPU memory.

Should fix the CI issues with `cyclops` (whose device 0 is currently out of memory).