### PR TITLE
Try using exit instead of trap everywhere again.

### DIFF
--- a/src/compiler/gpucompiler.jl
+++ b/src/compiler/gpucompiler.jl
@@ -21,13 +21,7 @@ function device_properties(dev)
                     unreachable = false
                 end
 
-                # there have been issues with emitting PTX `exit` instead of `trap` as well,
-                # see e.g. JuliaGPU/CUDA.jl#431 and NVIDIA bug #3231266 (but since switching
-                # to the toolkit's `ptxas` that specific machine/GPU now _requires_ exit...)
                 exitable = true
-                if cap < v"7"
-                    exitable = false
-                end
 
                 debuginfo = getenv("JULIA_CUDA_DEBUG_INFO", true)
 


### PR DESCRIPTION
Same as https://github.com/JuliaGPU/CUDA.jl/pull/947 again. Turns out https://github.com/JuliaGPU/CUDA.jl/pull/947#issuecomment-853783625 was a red herring, and was actually caused by https://github.com/JuliaGPU/CUDA.jl/issues/955.