### PR TITLE
Add version not defined error

### DIFF
--- a/deps/compatibility.jl
+++ b/deps/compatibility.jl
@@ -207,7 +207,7 @@ end
     ptx_support = sort(collect(llvm_support.ptx ∩ cuda_support.ptx))
     isempty(ptx_support) && error("Your toolchain does not support any PTX ISA")
 
-    @debug("Toolchain with LLVM $(LLVM.version()), CUDA driver $(version()) and toolkit $(toolkit_version()) supports devices $(verlist(target_support)); PTX $(verlist(ptx_support))")
+    @debug("Toolchain with LLVM $(LLVM.version()), CUDA driver $(CUDA.version()) and toolkit $(toolkit_version()) supports devices $(verlist(target_support)); PTX $(verlist(ptx_support))")
 
     return (cap=target_support, ptx=ptx_support)
 end


### PR DESCRIPTION
Running the following command on a PPC system

```
JULIA_DEBUG=CUDA julia --project -e "using CUDA; CUDA.version(); CUDA.rand(1) .* CUDA.rand(1)"
```

results in
```
┌ Warning: The NVIDIA driver on this system only supports up to CUDA 11.0.0.
│ For performance reasons, it is recommended to upgrade to a driver that supports CUDA 11.2 or higher.
└ @ CUDA ~/.julia/packages/CUDA/mVgLI/src/initialization.jl:42       
┌ Debug: Trying to use artifacts...
└ @ CUDA.Deps ~/.julia/packages/CUDA/mVgLI/deps/bindeps.jl:92                  
┌ Debug: Selecting artifacts based on driver compatibility 11.0.0
└ @ CUDA.Deps ~/.julia/packages/CUDA/mVgLI/deps/bindeps.jl:104
┌ Debug: Using CUDA 11.3.1 from an artifact at /XXXXXXXX/.julia/artifacts/5eb63c9dfac027cdb3bcfb312084505a29246cd1
└ @ CUDA.Deps ~/.julia/packages/CUDA/mVgLI/deps/bindeps.jl:130                 
┌ Error: Exception while generating log record in module CUDA.Deps at /XXXXXXXXXX/.julia/packages/CUDA/mVgLI/deps/compatibility.jl:210                                                   
│   exception =                             
│    UndefVarError: version not defined
│    Stacktrace: 
│      [1] macro expansion
│        @ ./logging.jl:340 [inlined]
│      [2] macro expansion                   
│        @ ~/.julia/packages/CUDA/mVgLI/deps/compatibility.jl:210 [inlined]
│      [3] (::CUDA.Deps.var"##getter#258#22")()
...
```