### PR TITLE
Optimize library handles

### DIFF
--- a/lib/curand/CURAND.jl
+++ b/lib/curand/CURAND.jl
@@ -27,44 +27,67 @@ const idle_curand_rngs = HandleCache{CuContext,RNG}()
 const idle_gpuarray_rngs = HandleCache{CuContext,GPUArrays.RNG}()
 
 function default_rng()
-    state = CUDA.active_state()
-    rng = get!(task_local_storage(), (:CURAND, state.context)) do
-        new_rng = pop!(idle_curand_rngs, state.context) do
+    cuda = CUDA.active_state()
+
+    # every task maintains library state per device
+    LibraryState = @NamedTuple{rng::RNG}
+    states = get!(task_local_storage(), :CURAND) do
+        Dict{CuContext,LibraryState}()
+    end::Dict{CuContext,LibraryState}
+
+    # get library state
+    @noinline function new_state(cuda)
+        new_rng = pop!(idle_curand_rngs, cuda.context) do
             RNG()
         end
 
         finalizer(current_task()) do task
-            push!(idle_curand_rngs, state.context, new_rng) do
+            push!(idle_curand_rngs, cuda.context, new_rng) do
                 # no need to do anything, as the RNG is collected by its finalizer
             end
         end
 
         Random.seed!(new_rng)
-        new_rng
-    end::RNG
+        (; rng=new_rng)
+    end
+    state = get!(states, cuda.context) do
+        new_state(cuda)
+    end
 
-    return rng
+    return state.rng
 end
 
 function GPUArrays.default_rng(::Type{<:CuArray})
-    ctx = context()
-    get!(task_local_storage(), (:GPUArraysRNG, ctx)) do
-        rng = pop!(idle_gpuarray_rngs, ctx) do
-            dev = device()
-            N = attribute(dev, DEVICE_ATTRIBUTE_MAX_THREADS_PER_BLOCK)
-            state = CuArray{NTuple{4, UInt32}}(undef, N)
-            GPUArrays.RNG(state)
+    cuda = CUDA.active_state()
+
+    # every task maintains library state per device
+    LibraryState = @NamedTuple{rng::GPUArrays.RNG}
+    states = get!(task_local_storage(), :GPUArraysRNG) do
+        Dict{CuContext,LibraryState}()
+    end::Dict{CuContext,LibraryState}
+
+    # get library state
+    @noinline function new_state(cuda)
+        new_rng = pop!(idle_gpuarray_rngs, cuda.context) do
+            N = attribute(cuda.device, DEVICE_ATTRIBUTE_MAX_THREADS_PER_BLOCK)
+            buf = CuArray{NTuple{4, UInt32}}(undef, N)
+            GPUArrays.RNG(buf)
         end
 
         finalizer(current_task()) do task
-            push!(idle_gpuarray_rngs, ctx, rng) do
+            push!(idle_gpuarray_rngs, cuda.context, new_rng) do
                 # no need to do anything, as the RNG is collected by its finalizer
             end
         end
 
-        Random.seed!(rng)
-        rng
-    end::GPUArrays.RNG
+        Random.seed!(new_rng)
+        (; rng=new_rng)
+    end
+    state = get!(states, cuda.context) do
+        new_state(cuda)
+    end
+
+    return state.rng
 end
 
 @deprecate seed!() CUDA.seed!()

--- a/lib/cusolver/CUSOLVER.jl
+++ b/lib/cusolver/CUSOLVER.jl
@@ -155,8 +155,10 @@ function devices!(devs::Vector{CuDevice})
 end
 
 devices() = get!(task_local_storage(), :CUSOLVERmg_devices) do
-    # by default, select all devices
-    sort(collect(CUDA.devices()); by=deviceid)
+    # by default, select only the first device
+    [first(CUDA.devices())]
+    # TODO: select all devices
+    #sort(collect(CUDA.devices()); by=deviceid)
 end::Vector{CuDevice}
 
 ndevices() = length(devices())


### PR DESCRIPTION
Makes them allocation-free, which among other optimizations lowers runtime to 30ns or so.

@kshyatt When changing the CUSOLVERmg code to default to using all devices, the tests started to fail, so there may be something wrong with those wrappers.