### PR TITLE
Replace PerDevice with context-keyed dictionaries.

### DIFF
--- a/lib/cublas/CUBLAS.jl
+++ b/lib/cublas/CUBLAS.jl
@@ -126,7 +126,6 @@ function xt_handle()
     cuda = CUDA.active_state()
 
     # every task maintains library state per set of devices
-    # TODO: use PerDevice here? it's a little slower, and allocates.
     LibraryState = @NamedTuple{handle::cublasXtHandle_t}
     states = get!(task_local_storage(), :CUBLASxt) do
         Dict{UInt,LibraryState}()

--- a/src/compiler/gpucompiler.jl
+++ b/src/compiler/gpucompiler.jl
@@ -1,42 +1,40 @@
 const ci_cache = GPUCompiler.CodeCache()
 
-const __device_properties_lock = ReentrantLock()
-const __device_properties = @NamedTuple{cap::VersionNumber, ptx::VersionNumber,
-                                        exitable::Bool, debuginfo::Bool, unreachable::Bool}[]
-function device_properties(dev)
-    @lock __device_properties_lock begin
-        if isempty(__device_properties)
-            resize!(__device_properties, ndevices())
+const DeviceProperties = @NamedTuple{cap::VersionNumber, ptx::VersionNumber,
+                                     exitable::Bool, debuginfo::Bool, unreachable::Bool}
+const __device_properties = LazyInitialized{Vector{DeviceProperties}}() do
+    # NOTE: this doesn't initialize any context, so we can pre-compute for all devices
+    props = Vector{DeviceProperties}(undef, ndevices())
+    for dev in devices()
+        cap = supported_capability(capability(dev))
+        ptx = v"6.3"    # we only need 6.2, but NVPTX doesn't support that
 
-            # determine compilation properties of each device
-            for dev in devices()
-                cap = supported_capability(capability(dev))
-                ptx = v"6.3"    # we only need 6.2, but NVPTX doesn't support that
-
-                # we need to take care emitting LLVM instructions like `unreachable`, which
-                # may result in thread-divergent control flow that older `ptxas` doesn't like.
-                # see e.g. JuliaGPU/CUDAnative.jl#4
-                unreachable = true
-                if cap < v"7" || toolkit_version() < v"11.3"
-                    unreachable = false
-                end
-
-                # there have been issues with emitting PTX `exit` instead of `trap` as well,
-                # see e.g. JuliaGPU/CUDA.jl#431 and NVIDIA bug #3231266 (but since switching
-                # to the toolkit's `ptxas` that specific machine/GPU now _requires_ exit...)
-                exitable = true
-                if cap < v"7"
-                    exitable = false
-                end
-
-                debuginfo = getenv("JULIA_CUDA_DEBUG_INFO", true)
-
-                __device_properties[deviceid(dev)+1] =
-                    (; cap, ptx, exitable, debuginfo, unreachable)
-            end
+        # we need to take care emitting LLVM instructions like `unreachable`, which
+        # may result in thread-divergent control flow that older `ptxas` doesn't like.
+        # see e.g. JuliaGPU/CUDAnative.jl#4
+        unreachable = true
+        if cap < v"7" || toolkit_version() < v"11.3"
+            unreachable = false
         end
-        @inbounds __device_properties[deviceid(dev)+1]
+
+        # there have been issues with emitting PTX `exit` instead of `trap` as well,
+        # see e.g. JuliaGPU/CUDA.jl#431 and NVIDIA bug #3231266 (but since switching
+        # to the toolkit's `ptxas` that specific machine/GPU now _requires_ exit...)
+        exitable = true
+        if cap < v"7"
+            exitable = false
+        end
+
+        debuginfo = getenv("JULIA_CUDA_DEBUG_INFO", true)
+
+        props[deviceid(dev)+1] =
+            (; cap, ptx, exitable, debuginfo, unreachable)
     end
+    props
+end
+function device_properties(dev)
+    props = __device_properties[]
+    @inbounds(props[deviceid(dev)+1])
 end
 
 function CUDACompilerTarget(dev::CuDevice; kwargs...)


### PR DESCRIPTION
Turns out the added complexity of maintaining two lazily-initialized arrays (both values and contexts) has more overhead than hashing the context and doing a full-blown Dict look-up, so lets just make everything do so. (for anybody reading along: the complexity here is required to support resetting a device, which invalidates all device-bound state. we've made it so that contexts created after a device reset hash differently, so we can just use that to key a dict and get a clean slate).