### PR TITLE
dlopen CUBLAS before CUTENSOR.

### DIFF
--- a/deps/bindeps.jl
+++ b/deps/bindeps.jl
@@ -575,6 +575,9 @@ export libcutensor, has_cutensor
 const __libcutensor = Ref{Union{String,Nothing}}()
 function libcutensor(; throw_error::Bool=true)
     path = @initialize_ref __libcutensor begin
+        # CUTENSOR depends on CUBLAS and CUBLASlt to be discoverable by the linker
+        libcublas()
+
         version = Sys.iswindows() ? nothing : v"1"  # cutensor.dll is unversioned on Windows
         find_cutensor(toolkit(), version)
     end


### PR DESCRIPTION
Fixes:

```
Error in testset cutensor/reductions:
Error During Test at /home/tim/Julia/pkg/CUDA/test/cutensor/reductions.jl:15
  Got exception outside of a @test
  could not load library "/home/tim/Julia/depot/artifacts/d9a841715e3ce1f0e4b545ace8c49345c161b464/lib/libcutensor.so.1"
  libcublasLt.so.11: cannot open shared object file: No such file or directory
  Stacktrace:
    [1] dlopen(s::String, flags::UInt32; throw_error::Bool)
      @ Base.Libc.Libdl ./libdl.jl:114
    [2] dlopen (repeats 2 times)
      @ ./libdl.jl:114 [inlined]
    [3] find_cutensor(cuda::CUDA.Deps.ArtifactToolkit, version::Any)
      @ CUDA.Deps ~/Julia/pkg/CUDA/deps/bindeps.jl:596
    [4] macro expansion
      @ ~/Julia/pkg/CUDA/deps/bindeps.jl:579 [inlined]
    [5] macro expansion
      @ lock.jl:209 [inlined]
    [6] libcutensor(; throw_error::Bool)
      @ CUDA.Deps ~/Julia/pkg/CUDA/deps/bindeps.jl:19
```