### PR TITLE
big mapreduce performance

### DIFF
--- a/test/array.jl
+++ b/test/array.jl
@@ -547,3 +547,39 @@ end
     @test Array(b) == [2, nothing, 4]
   end
 end
+
+@testset "large map reduce" begin
+  dev = device()
+
+  big_size = CUDA.big_mapreduce_threshold(dev) + 5
+  a = rand(Float32, big_size, 31)
+  c = CuArray(a)
+
+  expected = minimum(a, dims=2)
+  actual = minimum(c, dims=2)
+  @test expected == Array(actual)
+
+  expected = findmax(a, dims=2)
+  actual = findmax(c, dims=2)
+  @test expected == map(Array, actual)
+
+  expected = sum(a, dims=2)
+  actual = sum(c, dims=2)
+  @test expected == Array(actual)
+
+  a = rand(Int, big_size, 31)
+  c = CuArray(a)
+
+  expected = minimum(a, dims=2)
+  actual = minimum(c, dims=2)
+  @test expected == Array(actual)
+
+  expected = findmax(a, dims=2)
+  actual = findmax(c, dims=2)
+  @test expected == map(Array, actual)
+
+  expected = sum(a, dims=2)
+  actual = sum(c, dims=2)
+  @test expected == Array(actual)
+
+end


### PR DESCRIPTION
This is an optimization for multidimensional mapreduce when the non-reduced domain is large. (eg, `sum(CUDA.zeros(Int, 40000, 100), dims=1)`). When there is an independent reduction problem for every thread on the device, a naive loop is more efficient than `reduce_block` because not every thread is doing work at each iteration. 

Performance tested like:
```
for X in map(i->1<<i, 11:18)
for Y in map(i->1<<i, 2:2:18)
if(1024 * 32 <= X *Y <= 1024 * 1024 * 128)
      b=@benchmark begin CUDA.@sync minimum(c, dims=2) end setup=begin c=CuArray(rand(Int32, $X,$Y))end teardown=begin GC.gc(); sleep(0.01) end evals=1 samples=3 seconds=3
      println((X, Y, median(b.times)))
      end 
end 
end
```
With `minimum`, `findmax`, `sum`, and `sum(cos, ...`. The performance gain scales with problem size, but I've measured up to 10x speedup (on `sum` for size `262144, 256`). The test was performed without the current size check to allow all cases.
