### PR TITLE
Move refcounting to an array storage type

### DIFF
--- a/test/array.jl
+++ b/test/array.jl
@@ -34,10 +34,10 @@ import Adapt
       @test eltype(a) == eltype(b)
       @test ndims(a) == ndims(b)
       @test a.storage.buffer == b.storage.buffer
+      @test a.storage.ctx == b.storage.ctx
       @test a.maxsize == b.maxsize
       @test a.offset == b.offset
       @test a.dims == b.dims
-      @test a.ctx == b.ctx
     end
 
     test_eq(Base.unsafe_wrap(CuArray, ptr, 2),              CuArray{Int,1}(data.storage, (2,)))

--- a/test/iterator.jl
+++ b/test/iterator.jl
@@ -11,7 +11,7 @@ cubatches = CuIterator(batch for batch in batches) # ensure generators are accep
 previous_cubatch = missing
 for (batch, cubatch) in zip(batches, cubatches)
     global previous_cubatch
-    @test ismissing(previous_cubatch) || all(x -> x.state == CUDA.ARRAY_FREED, previous_cubatch)
+    @test ismissing(previous_cubatch) || all(x -> x.storage.refcount[] == 0, previous_cubatch)
     @test batch == Array.(cubatch)
     @test all(x -> x isa CuArray, cubatch)
     previous_cubatch = cubatch

--- a/test/iterator.jl
+++ b/test/iterator.jl
@@ -11,7 +11,7 @@ cubatches = CuIterator(batch for batch in batches) # ensure generators are accep
 previous_cubatch = missing
 for (batch, cubatch) in zip(batches, cubatches)
     global previous_cubatch
-    @test ismissing(previous_cubatch) || all(x -> x.storage.refcount[] == 0, previous_cubatch)
+    @test ismissing(previous_cubatch) || all(x -> x.storage === nothing, previous_cubatch)
     @test batch == Array.(cubatch)
     @test all(x -> x isa CuArray, cubatch)
     previous_cubatch = cubatch

--- a/test/pointer.jl
+++ b/test/pointer.jl
@@ -41,7 +41,7 @@ ccall(:clock, Nothing, (Ptr{Int},), a)
 @test_throws Exception ccall(:clock, Nothing, (CuPtr{Int},), a)
 ccall(:clock, Nothing, (PtrOrCuPtr{Int},), a)
 
-b = CuArray{eltype(a), ndims(a)}(CU_NULL, size(a))
+b = CuArray{eltype(a), ndims(a)}(CUDA.ArrayStorage(Mem.DeviceBuffer(CU_NULL, 0), 0), size(a))
 ccall(:clock, Nothing, (CuPtr{Int},), b)
 @test_throws Exception ccall(:clock, Nothing, (Ptr{Int},), b)
 ccall(:clock, Nothing, (PtrOrCuPtr{Int},), b)

--- a/test/pointer.jl
+++ b/test/pointer.jl
@@ -41,7 +41,7 @@ ccall(:clock, Nothing, (Ptr{Int},), a)
 @test_throws Exception ccall(:clock, Nothing, (CuPtr{Int},), a)
 ccall(:clock, Nothing, (PtrOrCuPtr{Int},), a)
 
-b = CuArray{eltype(a), ndims(a)}(CUDA.ArrayStorage(Mem.DeviceBuffer(CU_NULL, 0), 0), size(a))
+b = CuArray{eltype(a), ndims(a)}(CUDA.ArrayStorage(Mem.DeviceBuffer(CU_NULL, 0), context(), 0), size(a))
 ccall(:clock, Nothing, (CuPtr{Int},), b)
 @test_throws Exception ccall(:clock, Nothing, (Ptr{Int},), b)
 ccall(:clock, Nothing, (PtrOrCuPtr{Int},), b)

--- a/test/pool.jl
+++ b/test/pool.jl
@@ -17,7 +17,8 @@ end
     @test isa(ret, CuArray{Int32})
     @test occursin("1 GPU allocation: 4 bytes", out)
 
-    ret, out = @grab_output CUDA.@time Base.unsafe_wrap(CuArray, CuPtr{Int32}(12345678), (2, 3))
+    x = CuArray{Int32}(undef, 6)
+    ret, out = @grab_output CUDA.@time Base.unsafe_wrap(CuArray, pointer(x), (2, 3))
     @test isa(ret, CuArray{Int32})
     @test !occursin("GPU allocation", out)
 end


### PR DESCRIPTION
Simplifies the allocator: Instead of refcounting using a global dict, we now keep track using an atomic struct field. This avoids having to take a lock in the allocation path, improving performance.

Before:

```
julia> @benchmark CuArray{Int}(undef, 1024)
BenchmarkTools.Trial: 
  memory estimate:  208 bytes
  allocs estimate:  7
  --------------
  minimum time:     852.206 ns (0.00% GC)
  median time:      987.778 ns (0.00% GC)
  mean time:        1.979 μs (5.39% GC)
  maximum time:     3.789 ms (9.53% GC)
  --------------
  samples:          10000
  evals/sample:     63
```

After:
```
julia> @benchmark CuArray{Int}(undef, 1024)
BenchmarkTools.Trial: 
  memory estimate:  128 bytes
  allocs estimate:  4
  --------------
  minimum time:     574.550 ns (0.00% GC)
  median time:      656.050 ns (0.00% GC)
  mean time:        1.604 μs (4.02% GC)
  maximum time:     1.825 ms (6.15% GC)
  --------------
  samples:          10000
  evals/sample:     180
```