### PR TITLE
Detect common integer exponentiations and handle them directly.

### DIFF
--- a/src/device/intrinsics/math.jl
+++ b/src/device/intrinsics/math.jl
@@ -220,8 +220,22 @@ within(lower, upper) = (val) -> lower <= val <= upper
 @device_override FastMath.pow_fast(x::Float32, y::Float32) = ccall("extern __nv_fast_powf", llvmcall, Cfloat, (Cfloat, Cfloat), x, y)
 @device_override Base.:(^)(x::Float64, y::Int32) = ccall("extern __nv_powi", llvmcall, Cdouble, (Cdouble, Int32), x, y)
 @device_override Base.:(^)(x::Float32, y::Int32) = ccall("extern __nv_powif", llvmcall, Cfloat, (Cfloat, Int32), x, y)
-@device_override Base.:(^)(x::Float64, y::Int64) = x ^ Float64(y)
-@device_override Base.:(^)(x::Float32, y::Int64) = x ^ Float32(y)
+@device_override @inline function Base.:(^)(x::Float32, y::Int64)
+    y == -1 && return inv(x)
+    y == 0 && return one(x)
+    y == 1 && return x
+    y == 2 && return x*x
+    y == 3 && return x*x*x
+    x ^ Float32(y)
+end
+@device_override @inline function Base.:(^)(x::Float64, y::Int64)
+    y == -1 && return inv(x)
+    y == 0 && return one(x)
+    y == 1 && return x
+    y == 2 && return x*x
+    y == 3 && return x*x*x
+    x ^ Float64(y)
+end
 
 ## rounding and selection
 


### PR DESCRIPTION
Fixes https://github.com/JuliaGPU/CUDA.jl/issues/1031, ref https://github.com/CliMA/Oceananigans.jl/issues/1832#issuecomment-875793587:

```julia
julia> f(x) = x^2
f (generic function with 1 method)

julia> CUDA.code_llvm(f, Tuple{Float64})
;  @ REPL[3]:1 within `f'
define double @julia_f_1422(double %0) {
top:
; ┌ @ intfuncs.jl:312 within `literal_pow'
; │┌ @ float.jl:332 within `*'
    %1 = fmul double %0, %0
; └└
  ret double %1
}
```
```julia
julia> const factor = 2
2

julia> g(x) = x^factor
g (generic function with 1 method)

julia> CUDA.code_llvm(g, Tuple{Float64})
;  @ REPL[4]:1 within `g'
define double @julia_g_3022(double %0) {
top:
; ┌ @ math.jl:918 within `^'
; │┌ @ float.jl:332 within `*'
    %1 = fmul double %0, %0
; └└
  ret double %1
}
```

cc @glwagner