### PR TITLE
Backport changes for 3.3.4

### DIFF
--- a/lib/cusolver/linalg.jl
+++ b/lib/cusolver/linalg.jl
@@ -123,3 +123,11 @@ _svdvals!(A::CuMatrix{T}, alg::SVDAlgorithm) where T =
     throw(ArgumentError("Unsupported value for `alg` keyword."))
 _svdvals!(A::CuMatrix{T}, alg::QRAlgorithm) where T = gesvd!('N', 'N', A::CuMatrix{T})[2]
 _svdvals!(A::CuMatrix{T}, alg::JacobiAlgorithm) where T = gesvdj!('N', 1, A::CuMatrix{T})[2]
+
+if VERSION >= v"1.8-"
+    function LinearAlgebra.cholesky(A::LinearAlgebra.RealHermSymComplexHerm{<:Real,<:CuMatrix},
+             ::Val{false}=Val(false); check::Bool = true)
+        C, info = LinearAlgebra._chol!(copy(parent(A)), A.uplo == 'U' ? UpperTriangular : LowerTriangular)
+        return Cholesky(C.data, A.uplo, info)
+    end
+end

--- a/src/array.jl
+++ b/src/array.jl
@@ -445,8 +445,14 @@ CuIndexStyle(i1::Colon, I...) = CuIndexStyle(I...)
 
 cuviewlength() = ()
 @inline cuviewlength(::Real, I...) = cuviewlength(I...) # skip scalar
+
+if VERSION >= v"1.8.0-DEV.120"
+@inline cuviewlength(i1::AbstractUnitRange, I...) = (Base.length(i1), cuviewlength(I...)...)
+@inline cuviewlength(i1::AbstractUnitRange, ::Base.ScalarIndex...) = (Base.length(i1),)
+else
 @inline cuviewlength(i1::AbstractUnitRange, I...) = (Base.unsafe_length(i1), cuviewlength(I...)...)
 @inline cuviewlength(i1::AbstractUnitRange, ::Base.ScalarIndex...) = (Base.unsafe_length(i1),)
+end
 
 # we don't really want an array, so don't call `adapt(Array, ...)`,
 # but just want CuArray indices to get downloaded back to the CPU.

--- a/test/device/intrinsics/math.jl
+++ b/test/device/intrinsics/math.jl
@@ -1,0 +1,86 @@
+@testset "math" begin
+    @testset "log10" begin
+        @test testf(a->log10.(a), Float32[100])
+    end
+
+    @testset "pow" begin
+        for T in (Float16, Float32, Float64, ComplexF32, ComplexF64)
+            range = (T<:Integer) ? (T(5):T(10)) : T
+            @test testf((x,y)->x.^y, rand(Float32, 1), rand(range, 1))
+            @test testf((x,y)->x.^y, rand(Float32, 1), -rand(range, 1))
+        end
+    end
+
+    @testset "isinf" begin
+      for x in (Inf32, Inf, NaN32, NaN)
+        @test testf(x->isinf.(x), [x])
+      end
+    end
+
+    @testset "isnan" begin
+      for x in (Inf32, Inf, NaN32, NaN)
+        @test testf(x->isnan.(x), [x])
+      end
+    end
+
+    for op in (exp, angle, exp2, exp10,)
+        @testset "$op" begin
+            for T in (Float16, Float32, Float64)
+                @test testf(x->op.(x), rand(T, 1))
+                @test testf(x->op.(x), -rand(T, 1))
+            end
+        end
+    end
+
+    for op in (expm1,)
+        @testset "$op" begin
+            # FIXME: add expm1(::Float16) to Base
+            for T in (Float32, Float64)
+                @test testf(x->op.(x), rand(T, 1))
+                @test testf(x->op.(x), -rand(T, 1))
+            end
+        end
+    end
+
+    for op in (exp, abs, abs2, angle, log)
+        @testset "Complex - $op" begin
+            for T in (ComplexF16, ComplexF32, ComplexF64)
+                @test testf(x->op.(x), rand(T, 1))
+                @test testf(x->op.(x), -rand(T, 1))
+            end
+
+        end
+    end
+    @testset "mod and rem" begin
+        # CUDA follows C's fmod, which behaves differently than Julia on negative numbers
+        for op in (mod, rem), T in (Float16, Float32, Float64)
+            @test testf(a->op.(a, T(2)), T[1])
+            @test testf(a->op.(a, T(2)), T[-1])
+        end
+    end
+
+    @testset "rsqrt" begin
+        # GPUCompiler.jl#173: a CUDA-only device function fails to validate
+        function kernel(a)
+            a[] = CUDA.rsqrt(a[])
+            return
+        end
+
+        # make sure this test uses an actual device function
+        @test_throws ErrorException kernel(ones(1))
+
+        for T in (Float16, Float32)
+            a = CuArray{T}([4])
+            @cuda kernel(a)
+            @test Array(a) == [0.5]
+        end
+    end
+
+    @testset "fma" begin
+        for T in (Float16, Float32, Float64)
+            @test testf((x,y,z)->fma.(x,y,z), rand(T, 1), rand(T, 1), rand(T, 1))
+            @test testf((x,y,z)->fma.(x,y,z), rand(T, 1), -rand(T, 1), -rand(T, 1))
+        end
+    end
+
+end


### PR DESCRIPTION
- Base.unsafe_length is deprecated on 1.8
- restore lost tests (#1042)
- Fix cholesky on 1.8, fix #1046
