### PR TITLE
Add support for device capability-dependent code.

### DIFF
--- a/Manifest.toml
+++ b/Manifest.toml
@@ -89,7 +89,9 @@ version = "7.0.1"
 
 [[GPUCompiler]]
 deps = ["DataStructures", "ExprTools", "InteractiveUtils", "LLVM", "Libdl", "Logging", "TimerOutputs", "UUIDs"]
-git-tree-sha1 = "e8a09182a4440489e2e3dedff5ad3f6bbe555396"
+git-tree-sha1 = "adcd6c8f2c3980850340b1951b8323852c91ace2"
+repo-rev = "tb/version_bars"
+repo-url = "https://github.com/JuliaGPU/GPUCompiler.jl.git"
 uuid = "61eb1bfa-7361-4325-ad38-22787b887f55"
 version = "0.12.5"
 

--- a/src/device/intrinsics.jl
+++ b/src/device/intrinsics.jl
@@ -12,6 +12,7 @@ include("intrinsics/memory_dynamic.jl")
 include("intrinsics/atomics.jl")
 include("intrinsics/misc.jl")
 include("intrinsics/wmma.jl")
+include("intrinsics/version.jl")
 
 # functionality from libdevice
 #

--- a/src/device/intrinsics.jl
+++ b/src/device/intrinsics.jl
@@ -1,5 +1,8 @@
 # wrappers for functionality provided by the CUDA toolkit
 
+# special intrinsics for writing version-dependent code
+include("intrinsics/version.jl")
+
 # extensions to the C language
 include("intrinsics/memory_shared.jl")
 include("intrinsics/indexing.jl")
@@ -12,7 +15,6 @@ include("intrinsics/memory_dynamic.jl")
 include("intrinsics/atomics.jl")
 include("intrinsics/misc.jl")
 include("intrinsics/wmma.jl")
-include("intrinsics/version.jl")
 
 # functionality from libdevice
 #

--- a/src/device/intrinsics/version.jl
+++ b/src/device/intrinsics/version.jl
@@ -1,0 +1,66 @@
+# device intrinsics for querying the compute SimpleVersion and PTX ISA version
+
+
+## a GPU-compatible version number
+
+export SimpleVersion, @sv_str
+
+struct SimpleVersion
+    major::UInt32
+    minor::UInt32
+
+    SimpleVersion(major, minor=0) = new(major, minor)
+end
+
+function Base.tryparse(::Type{SimpleVersion}, v::AbstractString)
+    parts = split(v, ".")
+    1 <= length(parts) <= 2 || return nothing
+
+    int_parts = map(parts) do part
+        tryparse(Int, part)
+    end
+    any(isnothing, int_parts) && return nothing
+
+    SimpleVersion(int_parts...)
+end
+
+function Base.parse(::Type{SimpleVersion}, v::AbstractString)
+    ver = tryparse(SimpleVersion, v)
+    ver === nothing && throw(ArgumentError("invalid SimpleVersion string: '$v'"))
+    return ver
+end
+
+SimpleVersion(v::AbstractString) = parse(SimpleVersion, v)
+
+@inline function Base.isless(a::SimpleVersion, b::SimpleVersion)
+    (a.major < b.major) && return true
+    (a.major > b.major) && return false
+    (a.minor < b.minor) && return true
+    (a.minor > b.minor) && return false
+    return false
+end
+
+macro sv_str(str)
+    SimpleVersion(str)
+end
+
+
+## accessors for the compute SimpleVersion and PTX ISA version
+
+export compute_capability, ptx_isa_version
+
+for var in ["sm_major", "sm_minor", "ptx_major", "ptx_minor"]
+    @eval @inline $(Symbol(var))() =
+        Base.llvmcall(
+            $("""@$var = external global i32
+                 define i32 @entry() #0 {
+                     %val = load i32, i32* @$var
+                     ret i32 %val
+                 }
+                 attributes #0 = { alwaysinline }
+            """, "entry"), UInt32, Tuple{})
+end
+
+@device_function @inline compute_capability() = SimpleVersion(sm_major(), sm_minor())
+@device_function @inline ptx_isa_version() = SimpleVersion(ptx_major(), ptx_minor())
+


### PR DESCRIPTION
Builds on https://github.com/JuliaGPU/GPUCompiler.jl/pull/224.

Makes it possible to write code like:

```julia
function kernel(a)
    @inbounds a[] = if compute_capability() >= sv"6.0"
        1
    else
        2
    end
    return
end
```

```llvm
; PTX CompilerJob of kernel kernel(CuDeviceVector{Int64, 1}) for sm_75
define ptx_kernel void @_Z17julia_kernel_700613CuDeviceArrayI5Int64Li1ELi1EE({ i8 addrspace(1)*, i64, [1 x i64] } %0) local_unnamed_addr {
entry:
  %.fca.0.extract = extractvalue { i8 addrspace(1)*, i64, [1 x i64] } %0, 0
  %1 = bitcast i8 addrspace(1)* %.fca.0.extract to i64 addrspace(1)*
  store i64 1, i64 addrspace(1)* %1, align 8
  ret void
}
```

cc @jpsamaroo @vchuravy; might be interesting for you guys too. Strictly less powerful than overdubbing at the Julia level, but more lightweight (and should allow caching code, like Julia inference results, that depends on runtime properties).