### PR TITLE
lib: cusparse: fix #962

### DIFF
--- a/lib/cusparse/interfaces.jl
+++ b/lib/cusparse/interfaces.jl
@@ -10,6 +10,11 @@ end
 
 function mm_wrapper(transa::SparseChar, transb::SparseChar, alpha::Number,
                     A::CuSparseMatrix{T}, B::CuMatrix{T}, beta::Number, C::CuMatrix{T}) where {T}
+    size(A, 2) == size(B, 1) || throw(DimensionMismatch())
+    size(A, 1) == size(C, 1) || throw(DimensionMismatch())
+    size(B, 2) == size(C, 2) || throw(DimensionMismatch())
+    isempty(B) && return CUDA.zeros(eltype(B), size(A, 1), 0)
+
     if version() <= v"10.3.1"
         # Generic mm! doesn't support transposed B on CUDA10
         return mm2!(transa, transb, alpha, A, B, beta, C, 'O')

--- a/test/cusparse/interfaces.jl
+++ b/test/cusparse/interfaces.jl
@@ -17,6 +17,9 @@ using LinearAlgebra, SparseArrays
         db = CuArray(b)
         dc = CuArray(c)
 
+        # test with empty inputs
+        @test Array(dA * CUDA.zeros(elty, n, 0)) == zeros(elty, n, 0)
+
         mul!(c, f(A), b, alpha, beta)
         mul!(dc, f(dA), db, alpha, beta)
         @test c ≈ collect(dc)


### PR DESCRIPTION
`CUSPARSE.CuSparseMatrixCSC(sprand(10, 10, 0.1))*CuArray(zeros(10, 0))`
returns `DivideError: integer division error`.

This is because here the dimensions of the multipilicand is 0, and
consequently the `C` passed to the `mm!` function (originating from
`mul!`) is not defined, and while it is expected to be defined when
passed as an argument to `CuDenseMatrixDescriptor`. This same `C` value
however, is defined anytime the dimensions of the multipilicand isn't 0,
i.e., when `size(B)[2] != 0`.

So, in such cases, return the expected CuArray value instead, in
symmetry with how regular SparseMatrices behave.

Signed-off-by: Anant Thazhemadam <anant.thazhemadam@gmail.com>