### PR TITLE
Make handle cache thread-safe.

### DIFF
--- a/lib/utils/APIUtils.jl
+++ b/lib/utils/APIUtils.jl
@@ -10,8 +10,8 @@ using Libdl
 # helpers that facilitate working with CUDA APIs
 include("call.jl")
 include("enum.jl")
-include("cache.jl")
 include("threading.jl")
+include("cache.jl")
 include("memoization.jl")
 
 end


### PR DESCRIPTION
Fixes https://github.com/JuliaGPU/CUDA.jl/issues/1072, hopefully without introducing deadlocks. I first tried doing `GC.disable_finalizers` in the non-finalizer cache accesses, but that doesn't actually seem to prevent finalizers from running.