### PR TITLE
lib: cusparse: fix #1075 (conversion from sparse matrix to dense matrix)

### DIFF
--- a/lib/cusparse/conversions.jl
+++ b/lib/cusparse/conversions.jl
@@ -245,7 +245,7 @@ for (cname,rname,elty) in ((:cusparseScsc2dense, :cusparseScsr2dense, :Float32),
             m,n = csc.dims
             denseA = CUDA.zeros($elty,m,n)
             if version() >= v"11.3.0" # CUSPARSE version from CUDA release notes
-                desc_csc   = CuSparseMatrixDescriptor(csc)
+                desc_csc   = create_csc_descriptor(csc)
                 desc_dense = CuDenseMatrixDescriptor(denseA)
 
                 function bufferSize()
@@ -302,7 +302,7 @@ for (elty, welty) in ((:Float16, :Float32),
             m,n = csc.dims
             denseA = CUDA.zeros($elty,m,n)
             if version() >= v"11.3.0" # CUSPARSE version from CUDA release notes
-                desc_csc   = CuSparseMatrixDescriptor(csc)
+                desc_csc   = create_csc_descriptor(csc)
                 desc_dense = CuDenseMatrixDescriptor(denseA)
 
                 function bufferSize()
@@ -326,7 +326,7 @@ for (elty, welty) in ((:Float16, :Float32),
     end
 end
 
-Base.Array{T, 2}(A::AbstractCuSparseMatrix{T}) where T = Base.Array{T, 2}(CuMatrix{T}(A))
+Base.copyto!(dest::Array{T, 2}, src::AbstractCuSparseMatrix{T}) where T = copyto!(dest, CuMatrix{T}(src))
 
 for (nname,cname,rname,elty) in ((:cusparseSnnz, :cusparseSdense2csc, :cusparseSdense2csr, :Float32),
                                  (:cusparseDnnz, :cusparseDdense2csc, :cusparseDdense2csr, :Float64),

--- a/lib/cusparse/conversions.jl
+++ b/lib/cusparse/conversions.jl
@@ -245,6 +245,7 @@ for (cname,rname,elty) in ((:cusparseScsc2dense, :cusparseScsr2dense, :Float32),
             m,n = csc.dims
             denseA = CUDA.zeros($elty,m,n)
             if version() >= v"11.3.0" # CUSPARSE version from CUDA release notes
+                # Load correct CSC description with create_csc_descriptor util
                 desc_csc   = create_csc_descriptor(csc)
                 desc_dense = CuDenseMatrixDescriptor(denseA)
 
@@ -302,6 +303,7 @@ for (elty, welty) in ((:Float16, :Float32),
             m,n = csc.dims
             denseA = CUDA.zeros($elty,m,n)
             if version() >= v"11.3.0" # CUSPARSE version from CUDA release notes
+                # Load correct CSC description with create_csc_descriptor util
                 desc_csc   = create_csc_descriptor(csc)
                 desc_dense = CuDenseMatrixDescriptor(denseA)
 

--- a/lib/cusparse/conversions.jl
+++ b/lib/cusparse/conversions.jl
@@ -326,6 +326,8 @@ for (elty, welty) in ((:Float16, :Float32),
     end
 end
 
+Base.Array{T, 2}(A::AbstractCuSparseMatrix{T}) where T = Base.Array{T, 2}(CuMatrix{T}(A))
+
 for (nname,cname,rname,elty) in ((:cusparseSnnz, :cusparseSdense2csc, :cusparseSdense2csr, :Float32),
                                  (:cusparseDnnz, :cusparseDdense2csc, :cusparseDdense2csr, :Float64),
                                  (:cusparseCnnz, :cusparseCdense2csc, :cusparseCdense2csr, :ComplexF32),

--- a/lib/cusparse/generic.jl
+++ b/lib/cusparse/generic.jl
@@ -54,9 +54,9 @@ mutable struct CuSparseMatrixDescriptor
 
     function CuSparseMatrixDescriptor(A::CuSparseMatrixCSC)
         desc_ref = Ref{cusparseSpMatDescr_t}()
-        cusparseCreateCsr(
+        cusparseCreateCsc(
             desc_ref,
-            reverse(A.dims)..., length(nonzeros(A)),
+            A.dims..., length(nonzeros(A)),
             A.colPtr, rowvals(A), nonzeros(A),
             eltype(A.colPtr), eltype(rowvals(A)), 'O', eltype(nonzeros(A))
         )

--- a/lib/cusparse/generic.jl
+++ b/lib/cusparse/generic.jl
@@ -69,6 +69,11 @@ end
 
 Base.unsafe_convert(::Type{cusparseSpMatDescr_t}, desc::CuSparseMatrixDescriptor) = desc.handle
 
+# Utility function to create a correct CSC description. Return a CuSparseMatrixDescriptor.
+# Note: By default, CuSparseMatrixDescriptor calls cusparseCreateCsr for CSC matrices,
+#       as in cuSPARSE matrix multiplication routines (mv! and mm!) do not support CSC sparse format.
+#       To create a correct CSC description with cusparseCreateCsc, we need to call
+#       explicitly create_csc_descriptor.
 function create_csc_descriptor(A::CuSparseMatrixCSC)
     desc_ref = Ref{cusparseSpMatDescr_t}()
     cusparseCreateCsc(

--- a/lib/cusparse/libcusparse.jl
+++ b/lib/cusparse/libcusparse.jl
@@ -5227,7 +5227,7 @@ end
 
 @checked function cusparseSparseToDense(handle, matA, matB, alg, buffer)
     initialize_api()
-    ccall((:cusparseSparseToDense, libcusparse()), cusparseStatus_t, (cusparseHandle_t, cusparseSpMatDescr_t, cusparseDnMatDescr_t, cusparseSparseToDenseAlg_t, Ptr{Cvoid}), handle, matA, matB, alg, buffer)
+    ccall((:cusparseSparseToDense, libcusparse()), cusparseStatus_t, (cusparseHandle_t, cusparseSpMatDescr_t, cusparseDnMatDescr_t, cusparseSparseToDenseAlg_t, CuPtr{Cvoid}), handle, matA, matB, alg, buffer)
 end
 
 @checked function cusparseCscSetPointers(spMatDescr, cscColOffsets, cscRowInd, cscValues)
@@ -5237,7 +5237,7 @@ end
 
 @checked function cusparseCreateCsc(spMatDescr, rows, cols, nnz, csrColOffsets, csrRowInd, csrValues, csrColOffsetsType, csrRowIndType, idxBase, valueType)
     initialize_api()
-    ccall((:cusparseCreateCsc, libcusparse()), cusparseStatus_t, (Ptr{cusparseSpMatDescr_t}, Int64, Int64, Int64, Ptr{Cvoid}, Ptr{Cvoid}, Ptr{Cvoid}, cusparseIndexType_t, cusparseIndexType_t, cusparseIndexBase_t, cudaDataType), spMatDescr, rows, cols, nnz, csrColOffsets, csrRowInd, csrValues, csrColOffsetsType, csrRowIndType, idxBase, valueType)
+    ccall((:cusparseCreateCsc, libcusparse()), cusparseStatus_t, (Ptr{cusparseSpMatDescr_t}, Int64, Int64, Int64, CuPtr{Cvoid}, CuPtr{Cvoid}, CuPtr{Cvoid}, cusparseIndexType_t, cusparseIndexType_t, cusparseIndexBase_t, cudaDataType), spMatDescr, rows, cols, nnz, csrColOffsets, csrRowInd, csrValues, csrColOffsetsType, csrRowIndType, idxBase, valueType)
 end
 
 @checked function cusparseDenseToSparse_bufferSize(handle, matA, matB, alg, bufferSize)

--- a/test/cusparse.jl
+++ b/test/cusparse.jl
@@ -212,6 +212,11 @@ end
             d_x = CuSparseMatrixCSC(d_x)
             h_x = collect(d_x)
             @test h_x ≈ sparse(x)
+
+            d_x_dense = CuMatrix(d_x)
+            @test h_x == collect(d_x_dense)
+            h_x_dense = Array(d_x)
+            @test h_x == h_x_dense
         end
 
         @testset "CSR(::Dense)" begin
@@ -220,6 +225,11 @@ end
             d_x = CuSparseMatrixCSR(d_x)
             h_x = collect(d_x)
             @test h_x ≈ sparse(x)
+
+            d_x_dense = CuMatrix(d_x)
+            @test h_x == collect(d_x_dense)
+            h_x_dense = Array(d_x)
+            @test h_x == h_x_dense
         end
     end
 end

--- a/test/cusparse/interfaces.jl
+++ b/test/cusparse/interfaces.jl
@@ -67,3 +67,20 @@ using LinearAlgebra, SparseArrays
         @test C ≈ collect(dC)
     end
 end
+
+@testset "Conversion" begin
+    @testset "Type $elty" for elty in [Float32, Float64, ComplexF32, ComplexF64]
+        n = 10
+        A = sprand(elty, n, n, rand())
+
+        dA_sparse_csc = CuSparseMatrixCSC(A)
+
+        # Conversion as CuMatrix
+        dA_dense_from_csc = CuMatrix(dA_sparse_csc)
+        @test collect(dA_dense_from_csc) == A
+
+        # Conversion as Matrix
+        A_dense_from_csc = Matrix(dA_sparse_csc)
+        @test A_dense_from_csc == A
+    end
+end

--- a/test/cusparse/interfaces.jl
+++ b/test/cusparse/interfaces.jl
@@ -68,19 +68,3 @@ using LinearAlgebra, SparseArrays
     end
 end
 
-@testset "Conversion" begin
-    @testset "Type $elty" for elty in [Float32, Float64, ComplexF32, ComplexF64]
-        n = 10
-        A = sprand(elty, n, n, rand())
-
-        dA_sparse_csc = CuSparseMatrixCSC(A)
-
-        # Conversion as CuMatrix
-        dA_dense_from_csc = CuMatrix(dA_sparse_csc)
-        @test collect(dA_dense_from_csc) == A
-
-        # Conversion as Matrix
-        A_dense_from_csc = Matrix(dA_sparse_csc)
-        @test A_dense_from_csc == A
-    end
-end


### PR DESCRIPTION
Fix issue #1075 
Now the following code works:
```julia
julia> CUDA.allowscalar(false)

julia> x = sprand(5,5, 0.2) |> cu
5×5 CuSparseMatrixCSC{Float32} with 8 stored entries:
 0.352324   ⋅         ⋅         ⋅        ⋅
  ⋅         ⋅         ⋅         ⋅        ⋅
  ⋅        0.781994   ⋅         ⋅        ⋅
 0.927318   ⋅         ⋅        0.58433  0.922552
 0.370246   ⋅        0.593702   ⋅       0.0792545

julia> x |> Array
5×5 Matrix{Float32}:
 0.352324  0.0       0.0       0.0      0.0
 0.0       0.0       0.0       0.0      0.0
 0.0       0.781994  0.0       0.0      0.0
 0.927318  0.0       0.0       0.58433  0.922552
 0.370246  0.0       0.593702  0.0      0.0792545

julia> x |> CuArray
5×5 CuArray{Float32, 2, CUDA.Mem.DeviceBuffer}:
 0.352324  0.0       0.0       0.0      0.0
 0.0       0.0       0.0       0.0      0.0
 0.0       0.781994  0.0       0.0      0.0
 0.927318  0.0       0.0       0.58433  0.922552
 0.370246  0.0       0.593702  0.0      0.0792545
```

