### PR TITLE
add support for half-precision gemm

### DIFF
--- a/lib/cublas/libcublas.jl
+++ b/lib/cublas/libcublas.jl
@@ -1796,6 +1796,17 @@ end
                    handle, side, uplo, trans, diag, m, n, alpha, A, lda, B, ldb, C, ldc)
 end
 
+@checked function cublasHgemmBatched(handle, transa, transb, m, n, k, alpha, Aarray, lda,
+                                     Barray, ldb, beta, Carray, ldc, batchCount)
+    initialize_api()
+    ccall((:cublasHgemmBatched, libcublas()), cublasStatus_t,
+                   (cublasHandle_t, cublasOperation_t, cublasOperation_t, Cint, Cint,
+                    Cint, RefOrCuRef{Float16}, CuPtr{Ptr{Float16}}, Cint, CuPtr{Ptr{Float16}},
+                    Cint, RefOrCuRef{Float16}, CuPtr{Ptr{Float16}}, Cint, Cint),
+                   handle, transa, transb, m, n, k, alpha, Aarray, lda, Barray, ldb, beta,
+                   Carray, ldc, batchCount)
+end
+
 @checked function cublasSgemmBatched(handle, transa, transb, m, n, k, alpha, Aarray, lda,
                                      Barray, ldb, beta, Carray, ldc, batchCount)
     initialize_api()
@@ -1883,6 +1894,19 @@ end
                    handle, transa, transb, m, n, k, alpha, A, Atype, lda, strideA, B,
                    Btype, ldb, strideB, beta, C, Ctype, ldc, strideC, batchCount,
                    computeType, algo)
+end
+
+@checked function cublasHgemmStridedBatched(handle, transa, transb, m, n, k, alpha, A, lda,
+                                            strideA, B, ldb, strideB, beta, C, ldc,
+                                            strideC, batchCount)
+    initialize_api()
+    ccall((:cublasHgemmStridedBatched, libcublas()), cublasStatus_t,
+                   (cublasHandle_t, cublasOperation_t, cublasOperation_t, Cint, Cint,
+                    Cint, RefOrCuRef{Float16}, CuPtr{Float16}, Cint, Clonglong,
+                    CuPtr{Float16}, Cint, Clonglong, RefOrCuRef{Float16}, CuPtr{Float16},
+                    Cint, Clonglong, Cint),
+                   handle, transa, transb, m, n, k, alpha, A, lda, strideA, B, ldb,
+                   strideB, beta, C, ldc, strideC, batchCount)
 end
 
 @checked function cublasSgemmStridedBatched(handle, transa, transb, m, n, k, alpha, A, lda,

--- a/lib/cublas/wrappers.jl
+++ b/lib/cublas/wrappers.jl
@@ -924,6 +924,7 @@ end
 for (fname, elty) in
         ((:cublasDgemmBatched,:Float64),
          (:cublasSgemmBatched,:Float32),
+         (:cublasHgemmBatched,:Float16),
          (:cublasZgemmBatched,:ComplexF64),
          (:cublasCgemmBatched,:ComplexF32))
     @eval begin
@@ -985,6 +986,7 @@ end
 for (fname, elty) in
         ((:cublasDgemmStridedBatched,:Float64),
          (:cublasSgemmStridedBatched,:Float32),
+         (:cublasHgemmStridedBatched,:Float16),
          (:cublasZgemmStridedBatched,:ComplexF64),
          (:cublasCgemmStridedBatched,:ComplexF32))
     @eval begin


### PR DESCRIPTION
is `Float16` the right type to use in the `ccall`?

also, what do you want to do about tests?  cublas only supports half precision for gemm, not any of the other functions (e.g. symm, trsm, hemm, etc.).  i'd have to split that big for-loop apart and duplicate the array construction.

for size(A)==(64,1,1000), size(B)==(1,64,1000), size(C)==(64,64,1000) the execution time of `CUBLAS.gemm_strided_batched!` is 3/4 as long compared to float32 on an RTX8000, and several fold *slower* on a 1080Ti.

fixes https://github.com/JuliaGPU/CUDA.jl/issues/1076