### PR TITLE
Highlighting the removal of the memory management environment variables

### DIFF
--- a/docs/src/usage/memory.md
+++ b/docs/src/usage/memory.md
@@ -170,7 +170,7 @@ Stacktrace:
  [8] (::REPL.var"#26#27"{REPL.REPLBackend})() at ./task.jl:358
 ```
 
-### Environment variables
+### Environment variables (only available in versions prior to 3.4)
 
 Several environment variables affect the behavior of the memory allocator:
 


### PR DESCRIPTION
I was caught by surprise when the warning about the removal of the `JULIA_CUDA_MEMORY_LIMIT` appeared:
```
┌ Warning: Support for GPU memory limits (JULIA_CUDA_MEMORY_LIMIT) has been removed.
└ @ CUDA ~/.julia/packages/CUDA/zx5iI/src/initialization.jl:54
```
I think this should be reflected in the docs to prevent confusion. Additionally I did not find any discussion on why this environment variable was removed. Is it because nowadays the usage of CUDA.jl with threads is working well and running multiple processes with CUDA.jl is not advised anymore?