### PR TITLE
Don't embed the method table in the AST.

### DIFF
--- a/src/device/utils.jl
+++ b/src/device/utils.jl
@@ -12,7 +12,7 @@ const overrides = Expr[]
 
 macro device_override(ex)
     code = quote
-        $GPUCompiler.@override($method_table, $ex)
+        $GPUCompiler.@override(CUDA.method_table, $ex)
     end
     if isdefined(Base.Experimental, Symbol("@overlay"))
         return esc(code)


### PR DESCRIPTION
This at least lets us Revise CUDA.jl again, ref https://github.com/timholy/Revise.jl/issues/646, even though we can't Revise device methods yet.