### PR TITLE
fix normalize on complex number

### DIFF
--- a/lib/cublas/linalg.jl
+++ b/lib/cublas/linalg.jl
@@ -31,7 +31,14 @@ function LinearAlgebra.:(*)(transx::Transpose{<:Any,<:StridedCuVector{T}}, y::St
     return dotu(n, x, y)
 end
 
-LinearAlgebra.norm(x::DenseCuArray{<:Union{Float16, ComplexF16, CublasFloat}}) = nrm2(x)
+function LinearAlgebra.norm(x::DenseCuArray{<:Union{Float16, ComplexF16, CublasFloat}}, p::Real=2)
+    if p == 2
+        return nrm2(x)
+    else
+        return invoke(norm, Tuple{AbstractGPUArray, Real}, x, p)
+    end
+end
+
 LinearAlgebra.BLAS.asum(x::StridedCuArray{<:CublasFloat}) = asum(length(x), x)
 
 function LinearAlgebra.axpy!(alpha::Number, x::StridedCuArray{T}, y::StridedCuArray{T}) where T<:Union{Float16, ComplexF16, CublasFloat}

--- a/test/linalg.jl
+++ b/test/linalg.jl
@@ -12,3 +12,10 @@ using LinearAlgebra
     @test convert(Array, Q) == Array(convert(CuArray, Q))
     @test convert(Array{Float32}, Q) == Array(convert(CuArray{Float32}, Q))
 end
+
+@testset "normalize!" begin
+    x = rand(ComplexF32, 10)
+    dx = CuVector{ComplexF32}(x)
+    @test isreal(norm(dx, 2))
+    @test norm(normalize!(dx)) ≈ 1
+end


### PR DESCRIPTION
before this PR

```julia
julia> dx = CUDA.rand(ComplexF32, 10)

julia> using LinearAlgebra

julia> norm(dx)
2.301881f0

julia> norm(dx, 2)
2.301881070694802 + 0.0im
```

thus this causing `normalize!(dx)` to fail.

after this PR

```julia
julia> using LinearAlgebra

julia> norm(dx)
2.301881f0

julia> norm(dx, 2)
2.301881f0
```

and `normalize!(dx)` will just work