### PR TITLE
Native device synchronization

### DIFF
--- a/lib/cudadrv/context.jl
+++ b/lib/cudadrv/context.jl
@@ -311,15 +311,23 @@ function CuDevice(ctx::CuContext)
 end
 
 """
-    device_synchronize()
+    synchronize(ctx::Context)
 
-Block for the current device's tasks to complete. This is a heavyweight operation, typically
-you only need to call [`synchronize`](@ref) which only synchronizes the stream associated
-with the current task.
+Synchronize the current context, waiting for all outstanding operations to complete.
+
+!!! warning
+
+    This is an operation that blocks in the driver, and should be avoided if possible.
+    Instead, use [`device_synchronize()`](@ref) to perform synchronization in Julia.
 """
-function device_synchronize()
-    cuCtxSynchronize()
-    check_exceptions()
+function synchronize(ctx::CuContext)
+    push!(CuContext, ctx)
+    try
+        cuCtxSynchronize()
+        check_exceptions()
+    finally
+        pop!(CuContext)
+    end
 end
 
 

--- a/lib/cudadrv/stream.jl
+++ b/lib/cudadrv/stream.jl
@@ -2,7 +2,7 @@
 
 export
     CuStream, CuDefaultStream, CuStreamLegacy, CuStreamPerThread,
-    priority, priority_range, synchronize
+    priority, priority_range, synchronize, device_synchronize
 
 
 mutable struct CuStream
@@ -142,6 +142,15 @@ function synchronize(stream::CuStream=stream(); blocking::Bool=true)
     @label(exit)
     check_exceptions()
 end
+
+"""
+    device_synchronize()
+
+Block for the current device's tasks to complete. This is a heavyweight operation, typically
+you only need to call [`synchronize`](@ref) which only synchronizes the stream associated
+with the current task.
+"""
+device_synchronize() = synchronize(CuStreamLegacy())
 
 """
     priority_range()

--- a/src/initialization.jl
+++ b/src/initialization.jl
@@ -65,7 +65,7 @@ end
                 try
                     $(ex)
                 finally
-                    $task_local_state() !== nothing && $synchronize()
+                    $task_local_state() !== nothing && $device_synchronize()
                 end
             end
         )

--- a/test/cudadrv.jl
+++ b/test/cudadrv.jl
@@ -3,6 +3,8 @@
 ctx = CuCurrentContext()
 dev = CuCurrentDevice()
 
+synchronize(ctx)
+
 let ctx2 = CuContext(dev)
     @test ctx2 == CuCurrentContext()    # ctor implicitly pushes
     activate(ctx)

--- a/test/setup.jl
+++ b/test/setup.jl
@@ -132,7 +132,7 @@ macro grab_output(ex)
                     ret = $(esc(ex))
 
                     # NOTE: CUDA requires a 'proper' sync to flush its printf buffer
-                    device_synchronize()
+                    synchronize(context())
                 end
             end
             ret, read(fname, String)


### PR DESCRIPTION
Turns out we can use legacy stream semantics to perform our own device synchronization. And with that, we can solve (most of) https://github.com/JuliaGPU/CUDA.jl/issues/875 without throwing concurrent execution out of the window.