### PR TITLE
Preserve Int32 hardware indices

### DIFF
--- a/Manifest.toml
+++ b/Manifest.toml
@@ -104,7 +104,9 @@ version = "1.3.0"
 
 [[LLVM]]
 deps = ["CEnum", "LLVMExtra_jll", "Libdl", "Printf", "Unicode"]
-git-tree-sha1 = "36d95ecdfbc3240d728f68d73064d5b097fbf2ef"
+git-tree-sha1 = "42618bdbc1a61d41f55cd0f24458259220d1bcf9"
+repo-rev = "9155a8c"
+repo-url = "https://github.com/maleadt/LLVM.jl.git"
 uuid = "929cbde3-209d-540e-8aea-75f648917ca0"
 version = "4.5.2"
 

--- a/examples/pairwise.jl
+++ b/examples/pairwise.jl
@@ -47,8 +47,8 @@ end
 # pairwise distance calculation kernel
 function pairwise_dist_kernel(lat::CuDeviceVector{Float32}, lon::CuDeviceVector{Float32},
                               rowresult::CuDeviceMatrix{Float32}, n)
-    i = (blockIdx().x-1) * blockDim().x + threadIdx().x
-    j = (blockIdx().y-1) * blockDim().y + threadIdx().y
+    i = (blockIdx().x-0x1) * blockDim().x + threadIdx().x
+    j = (blockIdx().y-0x1) * blockDim().y + threadIdx().y
 
     if i <= n && j <= n
         # store to shared memory

--- a/examples/peakflops.jl
+++ b/examples/peakflops.jl
@@ -4,7 +4,7 @@ using Test
 
 "Dummy kernel doing 100 FMAs."
 function kernel_100fma(a, b, c, out)
-    i = (blockIdx().x-1) * blockDim().x + threadIdx().x
+    i = (blockIdx().x-0x1) * blockDim().x + threadIdx().x
     @inbounds if i <= length(out)
         a_val = a[i]
         b_val = b[i]

--- a/examples/vadd.jl
+++ b/examples/vadd.jl
@@ -3,7 +3,7 @@ using Test
 using CUDA
 
 function vadd(a, b, c)
-    i = (blockIdx().x-1) * blockDim().x + threadIdx().x
+    i = (blockIdx().x-0x1) * blockDim().x + threadIdx().x
     c[i] = a[i] + b[i]
     return
 end

--- a/perf/byval.jl
+++ b/perf/byval.jl
@@ -6,7 +6,7 @@ const threads = 256
 
 # simple add matrixes kernel
 function kernel_add_mat(n, x1, x2, y)
-    i = (blockIdx().x-1) * blockDim().x + threadIdx().x
+    i = (blockIdx().x-0x1) * blockDim().x + threadIdx().x
     if i <= n
         @inbounds y[i] = x1[i] + x2[i]
     end
@@ -20,7 +20,7 @@ end
 # add arrays of matrixes kernel
 function kernel_add_mat_z_slices(n, vararg...)
     x1, x2, y = get_inputs3(blockIdx().y, vararg...)
-    i = (blockIdx().x-1) * blockDim().x + threadIdx().x
+    i = (blockIdx().x-0x1) * blockDim().x + threadIdx().x
     if i <= n
         @inbounds y[i] = x1[i] + x2[i]
     end

--- a/perf/kernel.jl
+++ b/perf/kernel.jl
@@ -14,21 +14,21 @@ end
 src = CUDA.rand(Float32, 512, 1000)
 dest = similar(src)
 function indexing_kernel(dest, src)
-    i = (blockIdx().x-1) * blockDim().x + threadIdx().x
+    i = (blockIdx().x-0x1) * blockDim().x + threadIdx().x
     @inbounds dest[i] = src[i]
     return
 end
 group["indexing"] = @async_benchmarkable @cuda threads=size(src,1) blocks=size(src,2) $indexing_kernel($dest, $src)
 
 function checked_indexing_kernel(dest, src)
-    i = (blockIdx().x-1) * blockDim().x + threadIdx().x
+    i = (blockIdx().x-0x1) * blockDim().x + threadIdx().x
     dest[i] = src[i]
     return
 end
 group["indexing_checked"] = @async_benchmarkable @cuda threads=size(src,1) blocks=size(src,2) $checked_indexing_kernel($dest, $src)
 
 function rand_kernel(dest::AbstractArray{T}) where {T}
-    i = (blockIdx().x-1) * blockDim().x + threadIdx().x
+    i = (blockIdx().x-0x1) * blockDim().x + threadIdx().x
     dest[i] = rand(T)
     return
 end

--- a/src/accumulate.jl
+++ b/src/accumulate.jl
@@ -22,9 +22,9 @@ function partial_scan(op::Function, output::AbstractArray{T}, input::AbstractArr
     temp = CuDynamicSharedArray(T, (2*threads,))
 
     # iterate the main dimension using threads and the first block dimension
-    i = (blockIdx().x-1) * blockDim().x + threadIdx().x
+    i = (blockIdx().x-0x1) * blockDim().x + threadIdx().x
     # iterate the other dimensions using the remaining block dimensions
-    j = (blockIdx().z-1) * gridDim().y + blockIdx().y
+    j = (blockIdx().z-0x1) * gridDim().y + blockIdx().y
 
     if j > length(Rother)
         return
@@ -105,9 +105,9 @@ function aggregate_partial_scan(op::Function, output::AbstractArray,
     block = blockIdx().x
 
     # iterate the main dimension using threads and the first block dimension
-    i = (blockIdx().x-1) * blockDim().x + threadIdx().x
+    i = (blockIdx().x-0x1) * blockDim().x + threadIdx().x
     # iterate the other dimensions using the remaining block dimensions
-    j = (blockIdx().z-1) * gridDim().y + blockIdx().y
+    j = (blockIdx().z-0x1) * gridDim().y + blockIdx().y
 
     @inbounds if block > 1 && i <= length(Rdim) && j <= length(Rother)
         I = Rother[j]

--- a/src/device/array.jl
+++ b/src/device/array.jl
@@ -68,7 +68,7 @@ Base.pointer(x::CuDeviceArray{T,<:Any,A}) where {T,A} = Base.unsafe_convert(LLVM
 end
 
 typetagdata(a::CuDeviceArray{<:Any,<:Any,A}, i=1) where {A} =
-  reinterpret(LLVMPtr{UInt8,A}, a.ptr + a.maxsize) + i - 1
+  reinterpret(LLVMPtr{UInt8,A}, a.ptr + a.maxsize) + i - one(i)
 
 
 ## conversions
@@ -105,7 +105,7 @@ function union_types(T::Union)
     return typs
 end
 
-@inline function arrayref(A::CuDeviceArray{T}, index::Int) where {T}
+@inline function arrayref(A::CuDeviceArray{T}, index::Integer) where {T}
     @boundscheck checkbounds(A, index)
     if isbitstype(T)
         arrayref_bits(A, index)
@@ -114,12 +114,12 @@ end
     end
 end
 
-@inline function arrayref_bits(A::CuDeviceArray{T}, index::Int) where {T}
+@inline function arrayref_bits(A::CuDeviceArray{T}, index::Integer) where {T}
     align = alignment(A)
     unsafe_load(pointer(A), index, Val(align))
 end
 
-@inline @generated function arrayref_union(A::CuDeviceArray{T,AS}, index::Int) where {T,AS}
+@inline @generated function arrayref_union(A::CuDeviceArray{T,AS}, index::Integer) where {T,AS}
     typs = union_types(T)
 
     # generate code that conditionally loads a value based on the selector value.
@@ -147,7 +147,7 @@ end
     end
 end
 
-@inline function arrayset(A::CuDeviceArray{T}, x::T, index::Int) where {T}
+@inline function arrayset(A::CuDeviceArray{T}, x::T, index::Integer) where {T}
     @boundscheck checkbounds(A, index)
     if isbitstype(T)
         arrayset_bits(A, x, index)
@@ -157,12 +157,12 @@ end
     return A
 end
 
-@inline function arrayset_bits(A::CuDeviceArray{T}, x::T, index::Int) where {T}
+@inline function arrayset_bits(A::CuDeviceArray{T}, x::T, index::Integer) where {T}
     align = alignment(A)
     unsafe_store!(pointer(A), x, index, Val(align))
 end
 
-@inline @generated function arrayset_union(A::CuDeviceArray{T,AS}, x::T, index::Int) where {T,AS}
+@inline @generated function arrayset_union(A::CuDeviceArray{T,AS}, x::T, index::Integer) where {T,AS}
     typs = union_types(T)
     sel = findfirst(isequal(x), typs)
 
@@ -178,7 +178,7 @@ end
     end
 end
 
-@inline function const_arrayref(A::CuDeviceArray{T}, index::Int) where {T}
+@inline function const_arrayref(A::CuDeviceArray{T}, index::Integer) where {T}
     @boundscheck checkbounds(A, index)
     align = alignment(A)
     unsafe_cached_load(pointer(A), index, Val(align))
@@ -187,9 +187,9 @@ end
 
 ## indexing
 
-Base.@propagate_inbounds Base.getindex(A::CuDeviceArray{T}, i1::Int) where {T} =
+Base.@propagate_inbounds Base.getindex(A::CuDeviceArray{T}, i1::Integer) where {T} =
     arrayref(A, i1)
-Base.@propagate_inbounds Base.setindex!(A::CuDeviceArray{T}, x, i1::Int) where {T} =
+Base.@propagate_inbounds Base.setindex!(A::CuDeviceArray{T}, x, i1::Integer) where {T} =
     arrayset(A, convert(T,x)::T, i1)
 
 Base.IndexStyle(::Type{<:CuDeviceArray}) = Base.IndexLinear()
@@ -216,10 +216,10 @@ Base.Experimental.Const(A::CuDeviceArray) = Const(A)
 Base.IndexStyle(::Type{<:Const}) = IndexLinear()
 Base.size(C::Const) = size(C.a)
 Base.axes(C::Const) = axes(C.a)
-Base.@propagate_inbounds Base.getindex(A::Const, i1::Int) = const_arrayref(A.a, i1)
+Base.@propagate_inbounds Base.getindex(A::Const, i1::Integer) = const_arrayref(A.a, i1)
 
 # deprecated
-Base.@propagate_inbounds ldg(A::CuDeviceArray, i1::Integer) = const_arrayref(A, Int(i1))
+Base.@propagate_inbounds ldg(A::CuDeviceArray, i1::Integer) = const_arrayref(A, i1)
 
 
 ## other

--- a/src/device/array.jl
+++ b/src/device/array.jl
@@ -79,56 +79,6 @@ Base.unsafe_convert(::Type{LLVMPtr{T,A}}, x::CuDeviceArray{T,<:Any,A}) where {T,
 
 ## indexing intrinsics
 
-# preserve the specific integer type when indexing device arrays,
-# to avoid extending 32-bit hardware indices to 64-bit.
-Base.to_index(::CuDeviceArray, i::Integer) = i
-
-if VERSION <= v"1.8-"
-    # NOTE: before JuliaLang/julia#42289, `to_index` was required to return an Int index.
-    #       work around that restriction by adding additional methods for ::Integer.
-    for IT in (Int, Integer)    # also (::Int,::CuDevicArray) methods to avoid ambiguities
-        @eval begin
-            # getindex
-            @inline function Base._getindex(::IndexLinear, A::CuDeviceArray,
-                                            I::Vararg{$IT,M}) where M
-                @boundscheck checkbounds(A, I...)
-                @inbounds r = getindex(A, Base._to_linear_index(A, I...))
-                r
-            end
-            @inline function Base._getindex(::IndexCartesian, A::CuDeviceArray,
-                                            I::Vararg{$IT,M}) where M
-                @boundscheck checkbounds(A, I...)
-                @inbounds r = getindex(A, Base._to_subscript_indices(A, I...)...)
-                r
-            end
-            Base.@propagate_inbounds Base._getindex(::IndexCartesian, A::CuDeviceArray{T,N},
-                                                    I::Vararg{$IT, N}) where {T,N} =
-                getindex(A, I...)
-
-            # setindex
-            @inline function Base._setindex!(::IndexLinear, A::CuDeviceArray, v,
-                                            I::Vararg{$IT,M}) where M
-                @boundscheck checkbounds(A, I...)
-                @inbounds r = setindex!(A, v, Base._to_linear_index(A, I...))
-                r
-            end
-            Base.@propagate_inbounds Base._setindex!(::IndexCartesian, A::CuDeviceArray{T,N},
-                                                     v, I::Vararg{$IT, N}) where {T,N} =
-                setindex!(A, v, I...)
-            @inline function Base._setindex!(::IndexCartesian, A::CuDeviceArray, v,
-                                            I::Vararg{$IT,M}) where M
-                @boundscheck checkbounds(A, I...)
-                @inbounds r = setindex!(A, v, Base._to_subscript_indices(A, I...)...)
-                r
-            end
-
-            # helpers
-            Base._to_subscript_indices(A::CuDeviceArray{T,N},
-                                       I::Vararg{$IT,N}) where {T,N} = I
-        end
-    end
-end
-
 # TODO: arrays as allocated by the CUDA APIs are 256-byte aligned. we should keep track of
 #       this information, because it enables optimizations like Load Store Vectorization
 #       (cfr. shared memory and its wider-than-datatype alignment)
@@ -237,12 +187,25 @@ end
 
 ## indexing
 
+Base.IndexStyle(::Type{<:CuDeviceArray}) = Base.IndexLinear()
+
 Base.@propagate_inbounds Base.getindex(A::CuDeviceArray{T}, i1::Integer) where {T} =
     arrayref(A, i1)
 Base.@propagate_inbounds Base.setindex!(A::CuDeviceArray{T}, x, i1::Integer) where {T} =
     arrayset(A, convert(T,x)::T, i1)
 
-Base.IndexStyle(::Type{<:CuDeviceArray}) = Base.IndexLinear()
+# preserve the specific integer type when indexing device arrays,
+# to avoid extending 32-bit hardware indices to 64-bit.
+Base.to_index(::CuDeviceArray, i::Integer) = i
+
+# Base doesn't like Integer indices, so we need our own ND get and setindex! routines.
+# See also: https://github.com/JuliaLang/julia/pull/42289
+Base.@propagate_inbounds Base.getindex(A::CuDeviceArray,
+                                       I::Union{Integer, CartesianIndex}...) =
+    A[Base._to_linear_index(A, to_indices(A, I)...)]
+Base.@propagate_inbounds Base.setindex!(A::CuDeviceArray, x,
+                                        I::Union{Integer, CartesianIndex}...) =
+    A[Base._to_linear_index(A, to_indices(A, I)...)] = x
 
 
 ## const indexing

--- a/src/device/intrinsics/indexing.jl
+++ b/src/device/intrinsics/indexing.jl
@@ -43,22 +43,22 @@ for dim in (:x, :y, :z)
     # Thread index
     fn = Symbol("threadIdx_$dim")
     intr = Symbol("tid.$dim")
-    @eval @inline $fn() = Int(_index($(Val(intr)), $(Val(0:max_block_size[dim]-1)))) + 1
+    @eval @inline $fn() = _index($(Val(intr)), $(Val(0:max_block_size[dim]-1))) + 0x1
 
     # Block size (#threads per block)
     fn = Symbol("blockDim_$dim")
     intr = Symbol("ntid.$dim")
-    @eval @inline $fn() = Int(_index($(Val(intr)), $(Val(1:max_block_size[dim]))))
+    @eval @inline $fn() = _index($(Val(intr)), $(Val(1:max_block_size[dim])))
 
     # Block index
     fn = Symbol("blockIdx_$dim")
     intr = Symbol("ctaid.$dim")
-    @eval @inline $fn() = Int(_index($(Val(intr)), $(Val(0:max_grid_size[dim]-1)))) + 1
+    @eval @inline $fn() = _index($(Val(intr)), $(Val(0:max_grid_size[dim]-1))) + 0x1
 
     # Grid size (#blocks per grid)
     fn = Symbol("gridDim_$dim")
     intr = Symbol("nctaid.$dim")
-    @eval @inline $fn() = Int(_index($(Val(intr)), $(Val(1:max_grid_size[dim]))))
+    @eval @inline $fn() = _index($(Val(intr)), $(Val(1:max_grid_size[dim])))
 end
 
 @device_functions begin
@@ -68,42 +68,42 @@ end
 
 Returns the dimensions of the grid.
 """
-@inline gridDim() =   (x=gridDim_x(),   y=gridDim_y(),   z=gridDim_z())
+@inline gridDim() =   CuDim3(gridDim_x(),   gridDim_y(),   gridDim_z())
 
 """
     blockIdx()::CuDim3
 
 Returns the block index within the grid.
 """
-@inline blockIdx() =  (x=blockIdx_x(),  y=blockIdx_y(),  z=blockIdx_z())
+@inline blockIdx() =  CuDim3(blockIdx_x(),  blockIdx_y(),  blockIdx_z())
 
 """
     blockDim()::CuDim3
 
 Returns the dimensions of the block.
 """
-@inline blockDim() =  (x=blockDim_x(),  y=blockDim_y(),  z=blockDim_z())
+@inline blockDim() =  CuDim3(blockDim_x(),  blockDim_y(),  blockDim_z())
 
 """
     threadIdx()::CuDim3
 
 Returns the thread index within the block.
 """
-@inline threadIdx() = (x=threadIdx_x(), y=threadIdx_y(), z=threadIdx_z())
+@inline threadIdx() = CuDim3(threadIdx_x(), threadIdx_y(), threadIdx_z())
 
 """
     warpsize()::UInt32
 
 Returns the warp size (in threads).
 """
-@inline warpsize() = Int(ccall("llvm.nvvm.read.ptx.sreg.warpsize", llvmcall, UInt32, ()))
+@inline warpsize() = ccall("llvm.nvvm.read.ptx.sreg.warpsize", llvmcall, UInt32, ())
 
 """
     laneid()::UInt32
 
 Returns the thread's lane within the warp.
 """
-@inline laneid() = Int(ccall("llvm.nvvm.read.ptx.sreg.laneid", llvmcall, UInt32, ()))+UInt32(1)
+@inline laneid() = ccall("llvm.nvvm.read.ptx.sreg.laneid", llvmcall, UInt32, ()) + 0x1
 
 """
     active_mask()

--- a/src/device/pointer.jl
+++ b/src/device/pointer.jl
@@ -33,8 +33,9 @@ for T in LDGTypes
     typ = Symbol(class, width)
 
     intr = "llvm.nvvm.ldg.global.$class.$typ.p1$typ"
-    @eval @inline function pointerref_ldg(base_ptr::LLVMPtr{$T,AS.Global}, i::Int, ::Val{align}) where align
-        offset = i-1 # in elements
+    @eval @inline function pointerref_ldg(base_ptr::LLVMPtr{$T,AS.Global}, i::Integer,
+                                          ::Val{align}) where align
+        offset = i-one(i) # in elements
         ptr = base_ptr + offset*sizeof($T)
         @typed_ccall($intr, llvmcall, $T, (LLVMPtr{$T,AS.Global}, Int32), ptr, align)
     end
@@ -45,7 +46,7 @@ end
 export unsafe_cached_load
 
 unsafe_cached_load(p::LLVMPtr{<:Union{LDGTypes...},AS.Global}, i::Integer=1, align::Val=Val(1)) =
-    pointerref_ldg(p, Int(i), align)
+    pointerref_ldg(p, i, align)
 # NOTE: fall back to normal unsafe_load for unsupported types. we could be smarter here,
 #       e.g. destruct/load/reconstruct, but that's too complicated for what it's worth.
 unsafe_cached_load(p::LLVMPtr, i::Integer=1, align::Val=Val(1)) =

--- a/src/device/random.jl
+++ b/src/device/random.jl
@@ -62,9 +62,9 @@ end
 @inline Philox2x32() = Philox2x32{7}()
 
 @inline function Base.getproperty(rng::Philox2x32, field::Symbol)
-    threadId = threadIdx().x + (threadIdx().y - 1) * blockDim().x +
-                               (threadIdx().z - 1) * blockDim().x * blockDim().y
-    warpId = (threadId - 1) >> 5 + 1  # fld1
+    threadId = threadIdx().x + (threadIdx().y - 0x1) * blockDim().x +
+                               (threadIdx().z - 0x1) * blockDim().x * blockDim().y
+    warpId = (threadId - 0x1) >> 0x5 + 0x1  # fld1
 
     if field === :seed
         @inbounds global_random_seed()[1]
@@ -73,17 +73,17 @@ end
     elseif field === :ctr1
         @inbounds global_random_counters()[warpId]
     elseif field === :ctr2
-        blockId = blockIdx().x + (blockIdx().y - 1) * gridDim().x +
-                                 (blockIdx().z - 1) * gridDim().x * gridDim().y
-        globalId = threadId + (blockId - 1) * (blockDim().x * blockDim().y * blockDim().z)
+        blockId = blockIdx().x + (blockIdx().y - 0x1) * gridDim().x +
+                                 (blockIdx().z - 0x1) * gridDim().x * gridDim().y
+        globalId = threadId + (blockId - 0x1) * (blockDim().x * blockDim().y * blockDim().z)
         globalId%UInt32
     end::UInt32
 end
 
 @inline function Base.setproperty!(rng::Philox2x32, field::Symbol, x)
-    threadId = threadIdx().x + (threadIdx().y - 1) * blockDim().x +
-                               (threadIdx().z - 1) * blockDim().x * blockDim().y
-    warpId = (threadId - 1) >> 5 + 1  # fld1
+    threadId = threadIdx().x + (threadIdx().y - 0x1) * blockDim().x +
+                               (threadIdx().z - 0x1) * blockDim().x * blockDim().y
+    warpId = (threadId - 0x1) >> 0x5 + 0x1  # fld1
 
     if field === :key
         @inbounds global_random_keys()[warpId] = x
@@ -140,7 +140,7 @@ function Random.rand(rng::Philox2x32{R},::Type{UInt64}) where {R}
     # NOTE: this performs the same update on every thread in the warp, but each warp writes
     #       to a unique location so the duplicate writes are innocuous
     # XXX: what if this overflows? we can't increment ctr2. bump the key?
-    rng.ctr1 += UInt32(1)
+    rng.ctr1 += 0x1
 
     # NOTE: it's too expensive to keep both numbers around in case the user only wanted one,
     #       so just make our 2x32 generator return 64-bit numbers by default.

--- a/src/indexing.jl
+++ b/src/indexing.jl
@@ -23,7 +23,7 @@ function Base.getindex(xs::AnyCuArray{T}, bools::AnyCuArray{Bool}) where {T}
 
   if n > 0
     function kernel(ys::CuDeviceArray{T}, xs::CuDeviceArray{T}, bools, indices)
-        i = threadIdx().x + (blockIdx().x - 1) * blockDim().x
+        i = threadIdx().x + (blockIdx().x - 0x1) * blockDim().x
 
         @inbounds if i <= length(xs) && bools[i]
             b = indices[i]   # new position
@@ -57,7 +57,7 @@ function Base.findall(bools::AnyCuArray{Bool})
 
     if n > 0
         function kernel(ys::CuDeviceArray, bools, indices)
-            i = threadIdx().x + (blockIdx().x - 1) * blockDim().x
+            i = threadIdx().x + (blockIdx().x - 0x1) * blockDim().x
 
             @inbounds if i <= length(bools) && bools[i]
                 i′ = CartesianIndices(bools)[i]

--- a/src/mapreduce.jl
+++ b/src/mapreduce.jl
@@ -7,7 +7,7 @@
 # Reduce a value across a warp
 @inline function reduce_warp(op, val)
     assume(warpsize() == 32)
-    offset = UInt32(1)
+    offset = 0x00000001
     while offset < warpsize()
         val = op(val, shfl_down_sync(0xffffffff, val, offset))
         offset <<= 1
@@ -141,7 +141,7 @@ reductions.
 """
 function big_mapreduce_kernel(f, op, neutral, Rreduce, Rother, R, As)
 	val = op(neutral, neutral)
-	grid_idx = threadIdx().x + (blockIdx().x - 1) * blockDim().x
+	grid_idx = threadIdx().x + (blockIdx().x - 0x1) * blockDim().x
 	if grid_idx > length(Rother)
 		return
 	end

--- a/src/random.jl
+++ b/src/random.jl
@@ -41,8 +41,8 @@ function Random.rand!(rng::RNG, A::AnyCuArray)
 
         # grid-stride loop
         threadId = threadIdx().x
-        window = (blockDim().x - 1) * gridDim().x
-        offset = (blockIdx().x - 1) * blockDim().x
+        window = (blockDim().x - 0x1) * gridDim().x
+        offset = (blockIdx().x - 0x1) * blockDim().x
         while offset < length(A)
             i = threadId + offset
             if i <= length(A)
@@ -78,8 +78,8 @@ function Random.randn!(rng::RNG, A::AnyCuArray{<:T}) where {T<:Union{AbstractFlo
 
         # grid-stride loop
         threadId = threadIdx().x
-        window = (blockDim().x - 1) * gridDim().x
-        offset = (blockIdx().x - 1) * blockDim().x
+        window = (blockDim().x - 0x1) * gridDim().x
+        offset = (blockIdx().x - 0x1) * blockDim().x
         while offset < length(A)
             i = threadId + offset
             j = threadId + offset + window

--- a/src/reverse.jl
+++ b/src/reverse.jl
@@ -13,7 +13,7 @@ function _reverse(input::AnyCuArray{T, N}, output::AnyCuArray{T, N};
     numelemsincurrdim = shape[dims]
 
     function kernel(input::AbstractArray{T, N}, output::AbstractArray{T, N}) where {T, N}
-        offset_in = blockDim().x * (blockIdx().x - 1)
+        offset_in = blockDim().x * (blockIdx().x - 0x1)
 
         index_in = offset_in + threadIdx().x
 
@@ -47,7 +47,7 @@ function _reverse(data::AnyCuArray{T, N}; dims::Integer=1) where {T, N}
     numelemsincurrdim = shape[dims]
 
     function kernel(data::AbstractArray{T, N}) where {T, N}
-        offset_in = blockDim().x * (blockIdx().x - 1)
+        offset_in = blockDim().x * (blockIdx().x - 0x1)
 
         index_in = offset_in + threadIdx().x
 

--- a/src/sorting.jl
+++ b/src/sorting.jl
@@ -70,8 +70,8 @@ Uses block y index to decide which values to operate on.
 """
 @inline function batch_partition(values, pivot, swap, sums, lo, hi, parity, lt::F1, by::F2) where {F1,F2}
     sync_threads()
-    blockIdx_yz = (blockIdx().z - 1) * gridDim().y + blockIdx().y
-    idx0 = lo + (blockIdx_yz - 1) * blockDim().x + threadIdx().x
+    blockIdx_yz = (blockIdx().z - 0x1) * gridDim().y + blockIdx().y
+    idx0 = lo + (blockIdx_yz - 0x1) * blockDim().x + threadIdx().x
     val = idx0 <= hi ? values[idx0] : one(eltype(values))
     comparison = flex_lt(pivot, val, parity, lt, by)
 
@@ -232,7 +232,7 @@ function bitonic_median(vals :: AbstractArray{T}, swap, lo, L, stride, lt::F1, b
         j = k ÷ 2
 
         while j > 0
-            i = threadIdx().x - 1
+            i = threadIdx().x - 0x1
             l = xor(i, j)
             to_swap = (i & k) == 0 && bitonic_lt(l, i) || (i & k) != 0 && bitonic_lt(i, l)
             to_swap = to_swap == (i < l)
@@ -267,7 +267,7 @@ elements spaced by `stride`. Good for sampling pivot values as well as short sor
         sync_threads()
         for level in 0:L
             # get left/right neighbor depending on even/odd level
-            buddy = threadIdx().x - 1 + 2 * (1 & (threadIdx().x % 2 != level % 2))
+            buddy = threadIdx().x - 0x1 + 0x2 * (0x00000001 & (threadIdx().x % 0x2 != level % 0x2))
             buddy_val = if 1 <= buddy <= L && threadIdx().x <= L
                  swap[buddy]
             else

--- a/test/device/array.jl
+++ b/test/device/array.jl
@@ -48,7 +48,7 @@ end
     len = prod(dims)
 
     function kernel(input::CuDeviceArray{Float32}, output::CuDeviceArray{Float32})
-        i = (blockIdx().x-1) * blockDim().x + threadIdx().x
+        i = (blockIdx().x-0x1) * blockDim().x + threadIdx().x
 
         if i <= length(input)
             output[i] = Float64(input[i])   # force conversion upon setindex!
@@ -105,7 +105,7 @@ end
 
 @testset "views" begin
     function kernel(array)
-        i = (blockIdx().x-1) * blockDim().x + threadIdx().x
+        i = (blockIdx().x-0x1) * blockDim().x + threadIdx().x
 
         _sub = view(array, 2:length(array)-1)
         if i <= length(_sub)
@@ -177,8 +177,8 @@ function kernel_shmem_reinterpet_smaller_size!(y)
   p = i32 + i32 * im
   q = i32 - i32 * im
   b = reinterpret(typeof(p), a)
-  b[1 + 2 * (threadIdx().x - 1)] = p
-  b[2 + 2 * (threadIdx().x - 1)] = q
+  b[1 + 2 * (threadIdx().x - 0x1)] = p
+  b[2 + 2 * (threadIdx().x - 0x1)] = q
   y[threadIdx().x] = a[threadIdx().x]
   return
 end
@@ -211,10 +211,10 @@ end
 function kernel_shmem_reinterpet_larger_size!(y)
   a = CuDynamicSharedArray(Float32, (4 * blockDim().x,))
   b = reinterpret(UInt128, a)
-  a[1 + 4 * (threadIdx().x - 1)] = threadIdx().x
-  a[2 + 4 * (threadIdx().x - 1)] = threadIdx().x * 2
-  a[3 + 4 * (threadIdx().x - 1)] = threadIdx().x * 3
-  a[4 + 4 * (threadIdx().x - 1)] = threadIdx().x * 4
+  a[1 + 4 * (threadIdx().x - 0x1)] = threadIdx().x
+  a[2 + 4 * (threadIdx().x - 0x1)] = threadIdx().x * 2
+  a[3 + 4 * (threadIdx().x - 0x1)] = threadIdx().x * 3
+  a[4 + 4 * (threadIdx().x - 0x1)] = threadIdx().x * 4
   y[threadIdx().x] = b[threadIdx().x]
   return
 end

--- a/test/device/intrinsics.jl
+++ b/test/device/intrinsics.jl
@@ -121,7 +121,7 @@ end
 
 @testset "llvm ir barrier int" begin
     function kernel_barrier_count(an_array_of_1)
-        i = (blockIdx().x-1) * blockDim().x + threadIdx().x
+        i = (blockIdx().x-0x1) * blockDim().x + threadIdx().x
         if sync_threads_count(an_array_of_1[i]) == 3
             an_array_of_1[i] += Int32(1)
         end
@@ -136,7 +136,7 @@ end
     @test b_out == b_in .+ 1
 
     function kernel_barrier_and(an_array_of_1)
-        i = (blockIdx().x-1) * blockDim().x + threadIdx().x
+        i = (blockIdx().x-0x1) * blockDim().x + threadIdx().x
         if sync_threads_and(an_array_of_1[i]) > 0
             an_array_of_1[i] += Int32(1)
         end
@@ -151,7 +151,7 @@ end
     @test a_out == a_in .+ 1
 
     function kernel_barrier_or(an_array_of_1)
-        i = (blockIdx().x-1) * blockDim().x + threadIdx().x
+        i = (blockIdx().x-0x1) * blockDim().x + threadIdx().x
         if sync_threads_or(an_array_of_1[i]) > 0
             an_array_of_1[i] += Int32(1)
         end
@@ -168,7 +168,7 @@ end
 
 @testset "llvm ir barrier bool" begin
     function kernel_barrier_count(an_array_of_1)
-        i = (blockIdx().x-1) * blockDim().x + threadIdx().x
+        i = (blockIdx().x-0x1) * blockDim().x + threadIdx().x
         if sync_threads_count(an_array_of_1[i] > 0) == 3
             an_array_of_1[i] += Int32(1)
         end
@@ -183,7 +183,7 @@ end
     @test b_out == b_in .+ 1
 
     function kernel_barrier_and(an_array_of_1)
-        i = (blockIdx().x-1) * blockDim().x + threadIdx().x
+        i = (blockIdx().x-0x1) * blockDim().x + threadIdx().x
         if sync_threads_and(an_array_of_1[i] > 0)
             an_array_of_1[i] += Int32(1)
         end
@@ -198,7 +198,7 @@ end
     @test a_out == a_in .+ 1
 
     function kernel_barrier_or(an_array_of_1)
-        i = (blockIdx().x-1) * blockDim().x + threadIdx().x
+        i = (blockIdx().x-0x1) * blockDim().x + threadIdx().x
         if sync_threads_or(an_array_of_1[i] > 0)
             an_array_of_1[i] += Int32(1)
         end

--- a/test/execution.jl
+++ b/test/execution.jl
@@ -174,7 +174,7 @@ len = prod(dims)
 
 @testset "manually allocated" begin
     function kernel(input, output)
-        i = (blockIdx().x-1) * blockDim().x + threadIdx().x
+        i = (blockIdx().x-0x1) * blockDim().x + threadIdx().x
 
         val = input[i]
         output[i] = val
@@ -195,7 +195,7 @@ end
 
 @testset "scalar through single-value array" begin
     function kernel(a, x)
-        i = (blockIdx().x-1) * blockDim().x + threadIdx().x
+        i = (blockIdx().x-0x1) * blockDim().x + threadIdx().x
         max = gridDim().x * blockDim().x
         if i == max
             _val = a[i]
@@ -218,7 +218,7 @@ end
 @testset "scalar through single-value array, using device function" begin
     @noinline child(a, i) = a[i]
     function parent(a, x)
-        i = (blockIdx().x-1) * blockDim().x + threadIdx().x
+        i = (blockIdx().x-0x1) * blockDim().x + threadIdx().x
         max = gridDim().x * blockDim().x
         if i == max
             _val = child(a, i)
@@ -273,7 +273,7 @@ end
     @eval struct ExecGhost end
 
     function kernel(ghost, a, b, c)
-        i = (blockIdx().x-1) * blockDim().x + threadIdx().x
+        i = (blockIdx().x-0x1) * blockDim().x + threadIdx().x
         c[i] = a[i] + b[i]
         return
     end
@@ -284,7 +284,7 @@ end
     # bug: ghost type function parameters confused aggregate type rewriting
 
     function kernel(ghost, out, aggregate)
-        i = (blockIdx().x-1) * blockDim().x + threadIdx().x
+        i = (blockIdx().x-0x1) * blockDim().x + threadIdx().x
         out[i] = aggregate[1]
         return
     end
@@ -686,7 +686,7 @@ end
         end
 
         # Perform parallel reduction
-        local_index = threadIdx().x - 1
+        local_index = threadIdx().x - 0x1
         @inbounds tmp_local[local_index + 1] = acc
         sync_threads()
 
@@ -738,7 +738,7 @@ end
         end
 
         # Perform parallel reduction
-        local_index = threadIdx().x - 1
+        local_index = threadIdx().x - 0x1
         @inbounds tmp_local[local_index + 1] = acc
         sync_threads()
 
@@ -795,7 +795,7 @@ end
         offset = blockDim().x ÷ 2
         while offset > 0
             @inbounds if threadIdx().x <= offset
-                other = tmp_local[(threadIdx().x - 1) + offset + 1]
+                other = tmp_local[(threadIdx().x - 0x1) + offset + 1]
                 mine = tmp_local[threadIdx().x]
                 tmp_local[threadIdx().x] = op(mine, other)
             end
@@ -1030,7 +1030,7 @@ if capability(device()) >= v"6.0" && attribute(device(), CUDA.DEVICE_ATTRIBUTE_C
 
 @testset "cooperative groups" begin
     function kernel_vadd(a, b, c)
-        i = (blockIdx().x-1) * blockDim().x + threadIdx().x
+        i = (blockIdx().x-0x1) * blockDim().x + threadIdx().x
         grid_handle = this_grid()
         c[i] = a[i] + b[i]
         sync_grid(grid_handle)


### PR DESCRIPTION
Closes https://github.com/JuliaLang/julia/pull/42289, depends on https://github.com/maleadt/LLVM.jl/pull/268. This PR tries to preserve 32-bit hardware indices as long as possible, resulting in better generated code quality:

Demo of improved generated code quality:

```julia
function vadd(a, b, c)
    i = (blockIdx().x-0x1) * blockDim().x + threadIdx().x
    @inbounds c[i] = a[i] + b[i]
    return
end
```

Before (extending the hardware indices to 64-bit and then applying the 1-based offset):

```llvm
%3 = call i32 @llvm.nvvm.read.ptx.sreg.ctaid.x()
%4 = zext i32 %3 to i64
%5 = call i32 @llvm.nvvm.read.ptx.sreg.ntid.x()
%6 = zext i32 %5 to i64
%7 = mul nuw nsw i64 %6, %4
%8 = call i32 @llvm.nvvm.read.ptx.sreg.tid.x()
%narrow = add nuw nsw i32 %8, 1
%9 = zext i32 %narrow to i64
%10 = add nuw nsw i64 %7, %9
%11 = add nsw i64 %10, -1
%12 = bitcast i8 addrspace(1)* %.fca.0.extract9 to float addrspace(1)*
%13 = getelementptr inbounds float, float addrspace(1)* %12, i64 %11
%14 = load float, float addrspace(1)* %13, align 4
%15 = bitcast i8 addrspace(1)* %.fca.0.extract1 to float addrspace(1)*
%16 = getelementptr inbounds float, float addrspace(1)* %15, i64 %11
%17 = load float, float addrspace(1)* %16, align 4
%18 = fadd float %14, %17
%19 = bitcast i8 addrspace(1)* %.fca.0.extract to float addrspace(1)*
%20 = getelementptr inbounds float, float addrspace(1)* %19, i64 %11
store float %18, float addrspace(1)* %20, align 4
```

```
mov.u32         %r1, %ctaid.x;
mov.u32         %r2, %ntid.x;
mul.wide.u32    %rd4, %r2, %r1;
mov.u32         %r3, %tid.x;
cvt.u64.u32     %rd5, %r3;
add.s64         %rd6, %rd4, %rd5;
shl.b64         %rd7, %rd6, 2;
add.s64         %rd8, %rd7, -4;
add.s64         %rd9, %rd1, %rd8;
ld.global.f32   %f1, [%rd9+4];
add.s64         %rd10, %rd2, %rd8;
ld.global.f32   %f2, [%rd10+4];
add.f32         %f3, %f1, %f2;
add.s64         %rd11, %rd3, %rd8;
st.global.f32   [%rd11+4], %f3;
```

After (preserving 32-bit indices and also doing the 1-based offsetting in 32-bits):

```llvm
%3 = call i32 @llvm.nvvm.read.ptx.sreg.ctaid.x()
%4 = call i32 @llvm.nvvm.read.ptx.sreg.ntid.x()
%5 = mul i32 %4, %3
%6 = call i32 @llvm.nvvm.read.ptx.sreg.tid.x()
%7 = add i32 %5, %6
%8 = zext i32 %7 to i64
%9 = bitcast i8 addrspace(1)* %.fca.0.extract9 to float addrspace(1)*
%10 = getelementptr inbounds float, float addrspace(1)* %9, i64 %8
%11 = load float, float addrspace(1)* %10, align 4
%12 = bitcast i8 addrspace(1)* %.fca.0.extract1 to float addrspace(1)*
%13 = getelementptr inbounds float, float addrspace(1)* %12, i64 %8
%14 = load float, float addrspace(1)* %13, align 4
%15 = fadd float %11, %14
%16 = bitcast i8 addrspace(1)* %.fca.0.extract to float addrspace(1)*
%17 = getelementptr inbounds float, float addrspace(1)* %16, i64 %8
store float %15, float addrspace(1)* %17, align 4
```

```
mov.u32         %r1, %ctaid.x;
mov.u32         %r2, %ntid.x;
mov.u32         %r3, %tid.x;
mad.lo.s32      %r4, %r2, %r1, %r3;
mul.wide.u32    %rd4, %r4, 4;
add.s64         %rd5, %rd1, %rd4;
ld.global.f32   %f1, [%rd5];
add.s64         %rd6, %rd2, %rd4;
ld.global.f32   %f2, [%rd6];
add.f32         %f3, %f1, %f2;
add.s64         %rd7, %rd3, %rd4;
st.global.f32   [%rd7], %f3;
```

Notice the `mad` we can now use.

Of course, realistic applications will still be quickly extending to 64-bits (because of Julia's integer literals), but at least we now have the option to micro-optimize code to preserve 32-bit indices. This especially matters when wanting to lower register pressure; the above goes from 4 + 12 32-bit resp. 64-bit registers, to 5 + 8 of them, a significant reduction!