### PR TITLE
Perform actual synchronization API calls when we need the memory

### DIFF
--- a/lib/cudadrv/module.jl
+++ b/lib/cudadrv/module.jl
@@ -39,6 +39,9 @@ mutable struct CuModule
         #      release threshold, we have it actually free up that memory, but that requires
         #      synchronizing all streams to make sure pending frees are actually executed.
         device_synchronize()
+        #
+        # XXX: our custom legacy stream sync doesn't release memory (NVIDIA bug #3383169)
+        cuCtxSynchronize()
 
         # FIXME: maybe all CUDA API calls need to run under retry_reclaim?
         #        that would require a redesign of the memory pool,

--- a/src/pool.jl
+++ b/src/pool.jl
@@ -381,11 +381,6 @@ end
 
 ## utilities
 
-used_memory(ctx=context()) = @lock allocated_lock begin
-    mapreduce(sizeof∘first, +, values(allocated(ctx)); init=0)
-end
-
-
 """
     @allocated
 
@@ -508,8 +503,8 @@ function memory_status(io::IO=stdout)
   if stream_ordered(state.device)
     pool = memory_pool(state.device)
     if version() >= v"11.3"
-      pool_reserved_bytes = attribute(UInt64, pool, MEMPOOL_ATTR_RESERVED_MEM_CURRENT)
-      pool_used_bytes = attribute(UInt64, pool, MEMPOOL_ATTR_USED_MEM_CURRENT)
+      pool_reserved_bytes = cached_memory()
+      pool_used_bytes = used_memory()
       @printf(io, "Memory pool usage: %s (%s reserved)",
                   Base.format_bytes(pool_used_bytes),
                   Base.format_bytes(pool_reserved_bytes))
@@ -522,9 +517,34 @@ function memory_status(io::IO=stdout)
 end
 
 """
+    used_memory()
+
+Returns the amount of memory from the CUDA memory pool that is currently in use by the
+application.
+
+!!! warning
+
+    This function is only available on CUDA driver 11.3 and later.
+"""
+function used_memory()
+  state = active_state()
+  if version() >= v"11.3" && stream_ordered(state.device)
+    # we can only query the memory pool's reserved memory on CUDA 11.3 and later
+    pool = memory_pool(state.device)
+    Int(attribute(UInt64, pool, MEMPOOL_ATTR_USED_MEM_CURRENT))
+  else
+    0
+  end
+end
+
+"""
     cached_memory()
 
-Returns the cached amount of memory (in bytes) being held on by the CUDA allocator.
+Returns the amount of backing memory currently allocated for the CUDA memory pool.
+
+!!! warning
+
+    This function is only available on CUDA driver 11.3 and later.
 """
 function cached_memory()
   state = active_state()

--- a/src/pool.jl
+++ b/src/pool.jl
@@ -230,6 +230,11 @@ end
                 gctime += Base.@elapsed GC.gc(true)
             elseif phase == 4
                 device_synchronize()
+
+                # NVIDIA bug #3383169: or non-blocking sync doesn't trigger memory release.
+                # also, synchronizing the legacy stream (as device_synchronize() does)
+                # doesn't seem equivalent to actually synchronizing the device.
+                cuCtxSynchronize()
             end
 
             buf = actual_alloc(sz; async=true, stream=something(stream, state.stream))

--- a/test/pool.jl
+++ b/test/pool.jl
@@ -33,4 +33,6 @@ end
 
 @testset "memory_status" begin
     CUDA.memory_status(devnull)
+    CUDA.used_memory()
+    CUDA.cached_memory()
 end


### PR DESCRIPTION
Apparently our non-blocking synchronization doesn't trigger memory release. In addition, synchronizing the legacy stream (as introduced in https://github.com/JuliaGPU/CUDA.jl/pull/1147) doesn't release memory either, which explains the OOM segfault as seen in https://github.com/JuliaGPU/CUDA.jl/pull/1155.