### PR TITLE
Binary dependency changes

### DIFF
--- a/deps/bindeps.jl
+++ b/deps/bindeps.jl
@@ -239,7 +239,7 @@ end
 
 # compute-santizer: used by the test suite
 const __compute_sanitizer = Ref{Union{Nothing,String}}()
-function compute_sanitizer(throw_error::Bool=true)
+function compute_sanitizer(; throw_error::Bool=true)
     path = @initialize_ref __compute_sanitizer begin
         if toolkit_release() < v"11.0"
             nothing

--- a/deps/bindeps.jl
+++ b/deps/bindeps.jl
@@ -49,7 +49,7 @@ struct ArtifactToolkit <: AbstractToolkit
 end
 
 struct LocalToolkit <: AbstractToolkit
-    release::VersionNumber  # approximate, from `ptxas --version`
+    release::VersionNumber  # approximate, from the CUDA runtime library
     dirs::Vector{String}
 end
 
@@ -173,19 +173,14 @@ function find_local_cuda()
         __nvdisasm[] = path
     end
 
-    let path = find_cuda_binary("ptxas", dirs)
+    let path = find_cuda_library("cudart", dirs)
         if path === nothing
-            @debug "Could not find ptxas"
+            @debug "Could not find the CUDA runtime library"
             return nothing
         end
-        __ptxas[] = path
+        __libcudart[] = path
     end
-
-    release = parse_toolkit_release("ptxas", __ptxas[])
-    if release === nothing
-        @debug "Could not parse the CUDA release number from the ptxas version output"
-        return nothing
-    end
+    release = CUDA.runtime_version()
 
     @debug "Found local CUDA $(release) at $(join(dirs, ", "))"
     return LocalToolkit(release, dirs)

--- a/deps/bindeps.jl
+++ b/deps/bindeps.jl
@@ -291,8 +291,15 @@ end
 #      this is necessary (even if the dependent libraries are in the same directory)
 #      to avoid a local toolkit from messing with our artifacts (JuliaGPU/CUDA.jl#609).
 
-export libcublas, libcusparse, libcufft, libcurand, libcusolver,
+export libcudart, libcublas, libcusparse, libcufft, libcurand, libcusolver,
        libcusolvermg, has_cusolvermg, libcupti, has_cupti, libnvtx, has_nvtx
+
+const __libcudart = Ref{String}()
+function libcudart()
+    @initialize_ref __libcudart begin
+        find_library(toolkit(), "cudart")
+    end
+end
 
 const __libcublaslt = Ref{String}()
 function libcublaslt()

--- a/deps/bindeps.jl
+++ b/deps/bindeps.jl
@@ -403,6 +403,7 @@ end
 function find_library(cuda::LocalToolkit, name; optional=false)
     path = find_cuda_library(name, cuda.dirs)
     if path !== nothing
+        Libdl.dlopen(path)
         return path
     else
         optional || error("Could not find library '$name' in your local CUDA installation.")

--- a/deps/discovery.jl
+++ b/deps/discovery.jl
@@ -177,118 +177,6 @@ const cuda_releases = [v"1.0", v"1.1",
                        v"10.0", v"10.1", v"10.2",
                        v"11.0", v"11.1", v"11.2", v"11.3", v"11.4"]
 
-const cuda_library_versions = Dict(
-    v"11.0.1" => Dict(
-        # NOTE: encountered this version in a Docker container; not sure where it came from.
-        "cupti"     => "2020.1.0", # wtf
-        "nvtx"      => v"11.0.167",
-        "cublas"    => v"11.0.0", #.191
-        "cufft"     => v"10.1.3", #.191
-        "curand"    => v"10.2.0", #.191
-        "cusolver"  => v"10.4.0", #.191
-        "cusparse"  => v"11.0.0", #.191
-    ),
-    v"11.0.2" => Dict(
-        "cupti"     => "2020.1.0", # wtf
-        "nvtx"      => v"11.0.167",
-        "cublas"    => v"11.0.0", #.191
-        "cufft"     => v"10.1.3", #.191
-        "curand"    => v"10.2.0", #.191
-        "cusolver"  => v"10.4.0", #.191
-        "cusparse"  => v"11.0.0", #.191
-    ),
-    v"11.0.3" => Dict(
-        "cupti"     => "2020.1.1", # docs mention 11.0.221
-        "nvtx"      => v"11.0.167",
-        "cublas"    => v"11.2.0", #.252
-        "cufft"     => v"10.2.1", #.245
-        "curand"    => v"10.2.1", #.245
-        "cusolver"  => v"10.6.0", #.245
-        "cusparse"  => v"11.1.1", #.245
-    ),
-    v"11.1.0" => Dict(
-        "cupti"     => "2020.2.0", # docs mention 11.1.69
-        "nvtx"      => v"11.1.74",
-        "cublas"    => v"11.2.1", #.74
-        "cufft"     => v"10.3.0", #.74
-        "curand"    => v"10.2.2", #.74
-        "cusolver"  => v"11.0.0", #.74
-        "cusparse"  => v"11.2.0", #.275
-    ),
-    v"11.1.1" => Dict(
-        "cupti"     => "2020.2.1", # docs mention 11.1.105
-        "nvtx"      => v"11.1.74",
-        "cublas"    => v"11.3.0", #.106
-        "cufft"     => v"10.3.0", #.105
-        "curand"    => v"10.2.2", #.105
-        "cusolver"  => v"11.0.1", #.105
-        "cusparse"  => v"11.3.0", #.10
-    ),
-    v"11.2.0" => Dict(
-        "cupti"     => "2020.3.0", # docs mention 11.2.67
-        "nvtx"      => v"11.2.67",
-        "cublas"    => v"11.3.1", #.68
-        "cufft"     => v"10.4.0", #.72
-        "curand"    => v"10.2.3", #.68
-        "cusolver"  => v"11.0.2", #.68
-        "cusparse"  => v"11.3.1", #.68
-    ),
-    v"11.2.1" => Dict(
-        "cupti"     => "2020.3.1", # docs mention 11.2.135
-        "nvtx"      => v"11.2.67",
-        "cublas"    => v"11.4.1", #.1026
-        "cufft"     => v"10.4.0", #.135
-        "curand"    => v"10.2.3", #.135
-        "cusolver"  => v"11.1.0", #.135
-        "cusparse"  => v"11.4.0", #.135
-    ),
-    v"11.2.2" => Dict(
-        "cupti"     => "2020.3.1", # docs mention 11.2.152
-        "nvtx"      => v"11.2.152",
-        "cublas"    => v"11.4.1", #.1043
-        "cufft"     => v"10.4.1", #.152
-        "curand"    => v"10.2.3", #.152
-        "cusolver"  => v"11.1.0", #.152
-        "cusparse"  => v"11.4.1", #.1152
-    ),
-    v"11.3.0" => Dict(
-        "cupti"     => "2021.1.0", # docs mention 11.3.58
-        "nvtx"      => v"11.3.58",
-        "cublas"    => v"11.4.2", #.10064
-        "cufft"     => v"10.4.2", #.58
-        "curand"    => v"10.2.4", #.58
-        "cusolver"  => v"11.1.1", #.58
-        "cusparse"  => v"11.5.0", #.58
-    ),
-    v"11.3.1" => Dict(
-        "cupti"     => "2021.1.1", # docs mention 11.3.111
-        "nvtx"      => v"11.3.109",
-        "cublas"    => v"11.5.1", #.109
-        "cufft"     => v"10.4.2", #.109
-        "curand"    => v"10.2.4", #.109
-        "cusolver"  => v"11.1.2", #.109
-        "cusparse"  => v"11.6.0", #.109
-    ),
-    v"11.4.0" => Dict(
-        "cupti"     => "2021.2.0", # docs mention 11.4.65
-        "nvtx"      => v"11.4.43",
-        "cublas"    => v"11.5.2", #.43
-        "cufft"     => v"10.5.0", #.43
-        "curand"    => v"10.2.5", #.43
-        "cusolver"  => v"11.2.0", #.43
-        "cusparse"  => v"11.6.0", #.43
-    ),
-    v"11.4.1" => Dict(
-        "cupti"     => "2021.2.1", # docs mention 11.4.100
-        "nvtx"      => v"11.4.100",
-        "cublas"    => v"11.5.4", #.8
-        "cufft"     => v"10.5.1", #.100
-        "curand"    => v"10.2.5", #.100
-        "cusolver"  => v"11.2.0", #.100
-        "cusparse"  => v"11.6.0", #.100
-    ),
-)
-
 # return a list of versions that are supported for the given CUDA toolkit.
 # XXX: shouldn't we ignore the toolkit and just look at the driver version?
 function compatible_library_versions(library, toolkit_release)
@@ -325,8 +213,7 @@ const cuda_library_names = Dict(
 # simplified find_library/find_binary entry-points,
 # looking up name aliases and known version numbers
 # and passing the (optional) toolkit dirs as locations.
-function find_cuda_library(library::String, toolkit_dirs::Vector{String},
-                           toolkit_release::VersionNumber)
+function find_cuda_library(library::String, toolkit_dirs::Vector{String})
     # figure out the location
     locations = toolkit_dirs
     ## CUPTI is in the "extras" directory of the toolkit
@@ -348,9 +235,8 @@ function find_cuda_library(library::String, toolkit_dirs::Vector{String},
         isdir(dir) && push!(locations, dir)
     end
 
-    versions = compatible_library_versions(library, toolkit_release)
     name = get(cuda_library_names, library, library)
-    find_library(name, versions; locations)
+    find_library(name; locations)
 end
 function find_cuda_binary(name::String, toolkit_dirs::Vector{String}=String[])
     # figure out the location

--- a/deps/discovery.jl
+++ b/deps/discovery.jl
@@ -165,15 +165,7 @@ end
 
 ## CUDA-specific discovery routines
 
-const cuda_releases = [v"1.0", v"1.1",
-                       v"2.0", v"2.1", v"2.2",
-                       v"3.0", v"3.1", v"3.2",
-                       v"4.0", v"4.1", v"4.2",
-                       v"5.0", v"5.5",
-                       v"6.0", v"6.5",
-                       v"7.0", v"7.5",
-                       v"8.0",
-                       v"9.0", v"9.1", v"9.2",
+const cuda_releases = [v"9.0", v"9.1", v"9.2",
                        v"10.0", v"10.1", v"10.2",
                        v"11.0", v"11.1", v"11.2", v"11.3", v"11.4"]
 
@@ -336,21 +328,6 @@ function find_toolkit()
     dirs = valid_dirs(dirs)
     @debug "Found CUDA toolkit at $(join(dirs, ", "))"
     return dirs
-end
-
-# figure out the CUDA toolkit release (by looking at the output of a tool like `ptxas`)
-function parse_toolkit_release(tool, tool_path::String)
-    # parse the version string
-    verstr = withenv("LANG"=>"C") do
-        read(`$tool_path --version`, String)
-    end
-    m = match(r"release (?<major>\d+).(?<minor>\d+)\b", verstr)
-    if m === nothing
-        @error "Could not parse CUDA version info (\"$verstr\"); please file an issue."
-        return nothing
-    end
-
-    VersionNumber(parse(Int, m[:major]), parse(Int, m[:minor]))
 end
 
 """

--- a/lib/cudadrv/version.jl
+++ b/lib/cudadrv/version.jl
@@ -3,7 +3,7 @@
 """
     version()
 
-Returns the CUDA version as reported by the driver.
+Returns the latest version of CUDA supported by the driver.
 """
 function version()
     version_ref = Ref{Cint}()
@@ -19,3 +19,17 @@ end
 Returns the CUDA release part of the version as returned by [`version`](@ref).
 """
 release() = VersionNumber(version().major, version().minor)
+
+"""
+    runtime_version()
+
+    Returns the CUDA Runtime version.
+"""
+function runtime_version()
+    initialize_api()
+    version_ref = Ref{Cint}()
+    @ccall libcudart().cudaRuntimeGetVersion(version_ref::Ptr{Cint})::CUresult
+    major, ver = divrem(version_ref[], 1000)
+    minor, patch = divrem(ver, 10)
+    return VersionNumber(major, minor, patch)
+end

--- a/src/utilities.jl
+++ b/src/utilities.jl
@@ -33,10 +33,12 @@ end
 
 function versioninfo(io::IO=stdout)
     println(io, "CUDA toolkit $(runtime_version().major).$(runtime_version().minor), $(toolkit_origin()) installation")
-    println(io, "CUDA driver $(version().major).$(version().minor)")
     if has_nvml()
-        println(io, "NVIDIA driver $(NVML.driver_version())")
+        print(io, "NVIDIA driver $(NVML.driver_version())")
+    else
+        print(io, "Unknown NVIDIA driver")
     end
+    println(io, ", for CUDA $(version().major).$(version().minor)")
     println(io)
 
     println(io, "Libraries: ")

--- a/src/utilities.jl
+++ b/src/utilities.jl
@@ -32,8 +32,8 @@ macro sync(ex...)
 end
 
 function versioninfo(io::IO=stdout)
-    println(io, "CUDA toolkit $(toolkit_release().major).$(toolkit_release().minor), $(toolkit_origin()) installation")
-    println(io, "CUDA driver $(release().major).$(release().minor)")
+    println(io, "CUDA toolkit $(runtime_version().major).$(runtime_version().minor), $(toolkit_origin()) installation")
+    println(io, "CUDA driver $(version().major).$(version().minor)")
     if has_nvml()
         println(io, "NVIDIA driver $(NVML.driver_version())")
     end


### PR DESCRIPTION
Couple of changes:
- expose the runtime library -- some users require it, https://discourse.julialang.org/t/shared-c-dependencies-and-artifacts/68525
- use cudart for detecting the toolkit version, not ptxas
- remove the version database, users with local toolkits should provide unversioned (development) libraries
- ... except for Windows, where libraries are always versioned. brute-force the name there.