### PR TITLE
Switch contexts before performing memory operations on arrays

### DIFF
--- a/src/array.jl
+++ b/src/array.jl
@@ -225,6 +225,11 @@ Base.elsize(::Type{<:CuArray{T}}) where {T} = sizeof(T)
 Base.size(x::CuArray) = x.dims
 Base.sizeof(x::CuArray) = Base.elsize(x) * length(x)
 
+function context(A::CuArray)
+  A.storage === nothing && throw(UndefRefError())
+  return A.storage.ctx
+end
+
 function device(A::CuArray)
   A.storage === nothing && throw(UndefRefError())
   return device(A.storage.ctx)

--- a/test/array.jl
+++ b/test/array.jl
@@ -4,6 +4,7 @@ import Adapt
 @testset "constructors" begin
   xs = CuArray{Int}(undef, 2, 3)
   @test device(xs) == device()
+  @test context(xs) == context()
   @test collect(CuArray([1 2; 3 4])) == [1 2; 3 4]
   @test collect(cu[1, 2, 3]) == [1, 2, 3]
   @test collect(cu([1, 2, 3])) == [1, 2, 3]

--- a/test/array.jl
+++ b/test/array.jl
@@ -722,3 +722,22 @@ end
     end
   end
 end
+
+if length(devices()) > 1
+@testset "multigpu" begin
+  dev = device()
+  other_devs = filter(!isequal(dev), collect(devices()))
+  other_dev = first(other_devs)
+
+  @testset "issue 1176" begin
+    A = [1,2,3]
+    dA = CuArray(A)
+    synchronize()
+    B = fetch(@async begin
+        device!(other_dev)
+        Array(dA)
+    end)
+    @test A == B
+  end
+end
+end


### PR DESCRIPTION
Fixes https://github.com/JuliaGPU/CUDA.jl/issues/1175, which was caused by the REPL task still being on a different device.
Note that this just switches devices to avoid illegal memory accesses, there may still be synchronization issues (i.e. you still need to synchronize the correct stream before reading from GPU memory).

Also includes specialized copy functions for unified memory, where we don't need to switch contexts, and where we can just `memcpy` on the CPU.