### PR TITLE
Consistently use chars instead of raw enums in CUSPARSE/CUSOLVER functions.

### DIFF
--- a/lib/cusolver/sparse.jl
+++ b/lib/cusolver/sparse.jl
@@ -1,10 +1,7 @@
 
 using SparseArrays
 
-using ..CUSPARSE: CuSparseMatrixCSR, CuSparseMatrixCSC,
-                  CUSPARSE_MATRIX_TYPE_GENERAL, CUSPARSE_FILL_MODE_LOWER,
-                  CUSPARSE_FILL_MODE_UPPER, CUSPARSE_DIAG_TYPE_NON_UNIT,
-                  CUSPARSE_DIAG_TYPE_UNIT, CuMatrixDescriptor
+using ..CUSPARSE: CuSparseMatrixCSR, CuSparseMatrixCSC, CuMatrixDescriptor
 
 function cusolverSpCreate()
   handle_ref = Ref{cusolverSpHandle_t}()
@@ -49,7 +46,7 @@ for (fname, elty, relty) in ((:cusolverSpScsrlsvluHost, :Float32, :Float32),
 
             Mat     = similar(A)
             transpose!(Mat, A)
-            desca = CuMatrixDescriptor(CUSPARSE_MATRIX_TYPE_GENERAL, CUSPARSE_FILL_MODE_LOWER, CUSPARSE_DIAG_TYPE_NON_UNIT, inda)
+            desca = CuMatrixDescriptor('G', 'L', 'N', inda)
             singularity = Ref{Cint}(1)
             $fname(sparse_handle(), n, length(A.nzval), desca, Mat.nzval,
                    convert(Vector{Cint},Mat.colptr), convert(Vector{Cint},Mat.rowval), b,
@@ -87,7 +84,7 @@ for (fname, elty, relty) in ((:cusolverSpScsrlsvqr, :Float32, :Float32),
                 throw(DimensionMismatch("length of x, $(length(x)), must match the length of b, $(length(b))"))
             end
 
-            desca = CuMatrixDescriptor(CUSPARSE_MATRIX_TYPE_GENERAL, CUSPARSE_FILL_MODE_LOWER, CUSPARSE_DIAG_TYPE_NON_UNIT, inda)
+            desca = CuMatrixDescriptor('G', 'L', 'N', inda)
             singularity = Ref{Cint}(1)
             $fname(sparse_handle(), n, A.nnz, desca, A.nzVal, A.rowPtr, A.colVal, b, tol, reorder, x, singularity)
 
@@ -123,7 +120,7 @@ for (fname, elty, relty) in ((:cusolverSpScsrlsvchol, :Float32, :Float32),
                 throw(DimensionMismatch("length of x, $(length(x)), must match the length of b, $(length(b))"))
             end
 
-            desca = CuMatrixDescriptor(CUSPARSE_MATRIX_TYPE_GENERAL, CUSPARSE_FILL_MODE_LOWER, CUSPARSE_DIAG_TYPE_NON_UNIT, inda)
+            desca = CuMatrixDescriptor('G', 'L', 'N', inda)
             singularity = zeros(Cint,1)
             $fname(sparse_handle(), n, A.nnz, desca, A.nzVal, A.rowPtr, A.colVal, b, tol, reorder, x, singularity)
 
@@ -158,7 +155,7 @@ for (fname, elty, relty) in ((:cusolverSpScsrlsqvqrHost, :Float32, :Float32),
                 throw(DimensionMismatch("length of x, $(length(x)), must match the length of b, $(length(b))"))
             end
 
-            desca  = CuMatrixDescriptor(CUSPARSE_MATRIX_TYPE_GENERAL, CUSPARSE_FILL_MODE_LOWER, CUSPARSE_DIAG_TYPE_NON_UNIT, inda)
+            desca  = CuMatrixDescriptor('G', 'L', 'N', inda)
             p        = zeros(Cint,n)
             min_norm = zeros($relty,1)
             rankA    = zeros(Cint,1)
@@ -193,7 +190,7 @@ for (fname, elty, relty) in ((:cusolverSpScsreigvsi, :Float32, :Float32),
                 throw(DimensionMismatch("second dimension of A, $(size(A,2)), must match the length of x_0, $(length(x_0))"))
             end
 
-            desca = CuMatrixDescriptor(CUSPARSE_MATRIX_TYPE_GENERAL, CUSPARSE_FILL_MODE_LOWER, CUSPARSE_DIAG_TYPE_NON_UNIT, inda)
+            desca = CuMatrixDescriptor('G', 'L', 'N', inda)
             x       = copy(x_0)
             μ       = CUDA.zeros($elty,1)
             $fname(sparse_handle(), n, A.nnz, desca, A.nzVal, A.rowPtr, A.colVal,
@@ -219,7 +216,7 @@ for (fname, elty, relty) in ((:cusolverSpScsreigsHost, :ComplexF32, :Float32),
                 throw(DimensionMismatch("A must be square!"))
             end
 
-            desca = CuMatrixDescriptor(CUSPARSE_MATRIX_TYPE_GENERAL, CUSPARSE_FILL_MODE_LOWER, CUSPARSE_DIAG_TYPE_NON_UNIT, inda)
+            desca = CuMatrixDescriptor('G', 'L', 'N', inda)
             numeigs = Ref{Cint}(0)
             Mat     = similar(A)
             transpose!(Mat, A)

--- a/lib/cusparse/conversions.jl
+++ b/lib/cusparse/conversions.jl
@@ -180,8 +180,8 @@ for (fname,elty) in ((:cusparseScsr2bsr, :Float32),
             mb = div((m + blockDim - 1),blockDim)
             nb = div((n + blockDim - 1),blockDim)
             bsrRowPtr = CUDA.zeros(Cint,mb + 1)
-            cudesca = CuMatrixDescriptor(CUSPARSE_MATRIX_TYPE_GENERAL, CUSPARSE_FILL_MODE_LOWER, CUSPARSE_DIAG_TYPE_NON_UNIT, inda)
-            cudescc = CuMatrixDescriptor(CUSPARSE_MATRIX_TYPE_GENERAL, CUSPARSE_FILL_MODE_LOWER, CUSPARSE_DIAG_TYPE_NON_UNIT, indc)
+            cudesca = CuMatrixDescriptor('G', 'L', 'N', inda)
+            cudescc = CuMatrixDescriptor('G', 'L', 'N', indc)
             cusparseXcsr2bsrNnz(handle(), dir, m, n, cudesca, csr.rowPtr,
                                 csr.colVal, blockDim, cudescc, bsrRowPtr, nnz_ref)
             bsrNzVal = CUDA.zeros($elty, nnz_ref[] * blockDim * blockDim )
@@ -206,8 +206,8 @@ for (fname,elty) in ((:cusparseSbsr2csr, :Float32),
             mb = div(m,bsr.blockDim)
             nb = div(n,bsr.blockDim)
             nnzVal = nnz(bsr) * bsr.blockDim * bsr.blockDim
-            cudesca = CuMatrixDescriptor(CUSPARSE_MATRIX_TYPE_GENERAL, CUSPARSE_FILL_MODE_LOWER, CUSPARSE_DIAG_TYPE_NON_UNIT, inda)
-            cudescc = CuMatrixDescriptor(CUSPARSE_MATRIX_TYPE_GENERAL, CUSPARSE_FILL_MODE_LOWER, CUSPARSE_DIAG_TYPE_NON_UNIT, indc)
+            cudesca = CuMatrixDescriptor('G', 'L', 'N', inda)
+            cudescc = CuMatrixDescriptor('G', 'L', 'N', indc)
             csrRowPtr = CUDA.zeros(Cint, m + 1)
             csrColInd = CUDA.zeros(Cint, nnzVal)
             csrNzVal  = CUDA.zeros($elty, nnzVal)
@@ -264,7 +264,7 @@ for (cname,rname,elty) in ((:cusparseScsc2dense, :cusparseScsr2dense, :Float32),
                 end
                 return denseA
             else
-                cudesc = CuMatrixDescriptor(CUSPARSE_MATRIX_TYPE_GENERAL, CUSPARSE_FILL_MODE_LOWER, CUSPARSE_DIAG_TYPE_NON_UNIT, ind)
+                cudesc = CuMatrixDescriptor('G', 'L', 'N', ind)
                 lda = max(1,stride(denseA,2))
                 $rname(handle(), m, n, cudesc, nonzeros(csr),
                        csr.rowPtr, csr.colVal, denseA, lda)
@@ -291,7 +291,7 @@ for (cname,rname,elty) in ((:cusparseScsc2dense, :cusparseScsr2dense, :Float32),
                 return denseA
             else
                 lda = max(1,stride(denseA,2))
-                cudesc = CuMatrixDescriptor(CUSPARSE_MATRIX_TYPE_GENERAL, CUSPARSE_FILL_MODE_LOWER, CUSPARSE_DIAG_TYPE_NON_UNIT, ind)
+                cudesc = CuMatrixDescriptor('G', 'L', 'N', ind)
                 $cname(handle(), m, n, cudesc, nonzeros(csc),
                        rowvals(csc), csc.colPtr, denseA, lda)
                 return denseA
@@ -366,9 +366,9 @@ for (nname,cname,rname,elty) in ((:cusparseSnnz, :cusparseSdense2csc, :cusparseS
         function CuSparseMatrixCSR(A::CuMatrix{$elty}; ind::SparseChar='O')
             m,n = size(A)
             lda = max(1, stride(A,2))
-            cudesc = CuMatrixDescriptor(CUSPARSE_MATRIX_TYPE_GENERAL,
-                                        CUSPARSE_FILL_MODE_LOWER,
-                                        CUSPARSE_DIAG_TYPE_NON_UNIT, ind)
+            cudesc = CuMatrixDescriptor('G',
+                                        'L',
+                                        'N', ind)
             nnzRowCol = CUDA.zeros(Cint, m)
             nnzTotal = Ref{Cint}(1)
             $nname(handle(),
@@ -386,9 +386,9 @@ for (nname,cname,rname,elty) in ((:cusparseSnnz, :cusparseSdense2csc, :cusparseS
         function CuSparseMatrixCSC(A::CuMatrix{$elty}; ind::SparseChar='O')
             m,n = size(A)
             lda = max(1, stride(A,2))
-            cudesc = CuMatrixDescriptor(CUSPARSE_MATRIX_TYPE_GENERAL,
-                                        CUSPARSE_FILL_MODE_LOWER,
-                                        CUSPARSE_DIAG_TYPE_NON_UNIT, ind)
+            cudesc = CuMatrixDescriptor('G',
+                                        'L',
+                                        'N', ind)
             nnzRowCol = CUDA.zeros(Cint, n)
             nnzTotal = Ref{Cint}(1)
             $nname(handle(),

--- a/lib/cusparse/extra.jl
+++ b/lib/cusparse/extra.jl
@@ -15,9 +15,9 @@ for (bname,gname,elty) in ((:cusparseScsrgeam2_bufferSizeExt, :cusparseScsrgeam2
         function geam(alpha::Number, A::CuSparseMatrixCSR{$elty}, beta::Number, B::CuSparseMatrixCSR{$elty}, index::SparseChar)
             m, n = size(A)
             @assert (m, n) == size(B)
-            descrA = CuMatrixDescriptor(CUSPARSE_MATRIX_TYPE_GENERAL, CUSPARSE_FILL_MODE_LOWER, CUSPARSE_DIAG_TYPE_NON_UNIT, index)
-            descrB = CuMatrixDescriptor(CUSPARSE_MATRIX_TYPE_GENERAL, CUSPARSE_FILL_MODE_LOWER, CUSPARSE_DIAG_TYPE_NON_UNIT, index)
-            descrC = CuMatrixDescriptor(CUSPARSE_MATRIX_TYPE_GENERAL, CUSPARSE_FILL_MODE_LOWER, CUSPARSE_DIAG_TYPE_NON_UNIT, index)
+            descrA = CuMatrixDescriptor('G', 'L', 'N', index)
+            descrB = CuMatrixDescriptor('G', 'L', 'N', index)
+            descrC = CuMatrixDescriptor('G', 'L', 'N', index)
 
             cusparseSetPointerMode(handle(), CUSPARSE_POINTER_MODE_HOST)
             rowPtrC = CuArray{Int32,1}(undef, m+1)
@@ -31,7 +31,7 @@ for (bname,gname,elty) in ((:cusparseScsrgeam2_bufferSizeExt, :cusparseScsrgeam2
                     out)
                 return out[]
             end
-            
+
             C = with_workspace(bufferSize) do buffer
                 function get_nnzC(buffer)
                     nnzTotalDevHostPtr = Ref{Cint}(1)
@@ -42,7 +42,7 @@ for (bname,gname,elty) in ((:cusparseScsrgeam2_bufferSizeExt, :cusparseScsrgeam2
                         buffer)
                     return nnzTotalDevHostPtr[]
                 end
-            
+
                 nnzC = get_nnzC(buffer)
                 colValC = CuArray{Int32,1}(undef, Int(nnzC))
                 nzValC = CuArray{$elty,1}(undef, Int(nnzC))

--- a/lib/cusparse/helpers.jl
+++ b/lib/cusparse/helpers.jl
@@ -17,14 +17,14 @@ end
 
 Base.unsafe_convert(::Type{cusparseMatDescr_t}, desc::CuMatrixDescriptor) = desc.handle
 
-function CuMatrixDescriptor(MatrixType, FillMode, DiagType, IndexBase)
+function CuMatrixDescriptor(MatrixType::Char, FillMode::Char, DiagType::Char, IndexBase::Char)
     desc = CuMatrixDescriptor()
-    if MatrixType != CUSPARSE_MATRIX_TYPE_GENERAL
+    if MatrixType != 'G'
         cusparseSetMatType(desc, MatrixType)
     end
     cusparseSetMatFillMode(desc, FillMode)
     cusparseSetMatDiagType(desc, DiagType)
-    if IndexBase != CUSPARSE_INDEX_BASE_ZERO
+    if IndexBase != 'Z'
         cusparseSetMatIndexBase(desc, IndexBase)
     end
     return desc

--- a/lib/cusparse/level2.jl
+++ b/lib/cusparse/level2.jl
@@ -24,7 +24,7 @@ for (fname,elty) in ((:cusparseSbsrmv, :Float32),
                      beta::Number,
                      Y::CuVector{$elty},
                      index::SparseChar)
-            desc = CuMatrixDescriptor(CUSPARSE_MATRIX_TYPE_GENERAL, CUSPARSE_FILL_MODE_LOWER, CUSPARSE_DIAG_TYPE_NON_UNIT, index)
+            desc = CuMatrixDescriptor('G', 'L', 'N', index)
             m,n = A.dims
             mb = div(m,A.blockDim)
             nb = div(n,A.blockDim)
@@ -65,7 +65,7 @@ for (bname,aname,sname,elty) in ((:cusparseSbsrsv2_bufferSize, :cusparseSbsrsv2_
                       A::CuSparseMatrixBSR{$elty},
                       X::CuVector{$elty},
                       index::SparseChar)
-            desc = CuMatrixDescriptor(CUSPARSE_MATRIX_TYPE_GENERAL, uplo, diag, index)
+            desc = CuMatrixDescriptor('G', uplo, diag, index)
             m,n = A.dims
             if m != n
                 throw(DimensionMismatch("A must be square, but has dimensions ($m,$n)!"))
@@ -118,7 +118,7 @@ for (bname,aname,sname,elty) in ((:cusparseScsrsv2_bufferSize, :cusparseScsrsv2_
                       A::CuSparseMatrixCSR{$elty},
                       X::CuVector{$elty},
                       index::SparseChar)
-            desc = CuMatrixDescriptor(CUSPARSE_MATRIX_TYPE_GENERAL, uplo, diag, index)
+            desc = CuMatrixDescriptor('G', uplo, diag, index)
             m,n = A.dims
             if m != n
                 throw(DimensionMismatch("A must be square, but has dimensions ($m,$n)!"))
@@ -178,7 +178,7 @@ for (bname,aname,sname,elty) in ((:cusparseScsrsv2_bufferSize, :cusparseScsrsv2_
             if uplo == 'U'
                 cuplo = 'L'
             end
-            desc = CuMatrixDescriptor(CUSPARSE_MATRIX_TYPE_GENERAL, cuplo, diag, index)
+            desc = CuMatrixDescriptor('G', cuplo, diag, index)
             n,m = A.dims
             if m != n
                 throw(DimensionMismatch("A must be square, but has dimensions ($m,$n)!"))

--- a/lib/cusparse/level3.jl
+++ b/lib/cusparse/level3.jl
@@ -26,7 +26,7 @@ for (fname,elty) in ((:cusparseSbsrmm, :Float32),
                      beta::Number,
                      C::StridedCuMatrix{$elty},
                      index::SparseChar)
-            desc = CuMatrixDescriptor(CUSPARSE_MATRIX_TYPE_GENERAL, CUSPARSE_FILL_MODE_LOWER, CUSPARSE_DIAG_TYPE_NON_UNIT, index)
+            desc = CuMatrixDescriptor('G', 'L', 'N', index)
             m,k = A.dims
             mb = div(m,A.blockDim)
             kb = div(k,A.blockDim)
@@ -69,7 +69,7 @@ for (fname,elty) in ((:cusparseScsrmm2, :Float32),
             elseif transb == 'T' && transa != 'N'
                 throw(ArgumentError("When using B^T, A can be neither transposed nor adjointed"))
             end
-            desc = CuMatrixDescriptor(CUSPARSE_MATRIX_TYPE_GENERAL, CUSPARSE_FILL_MODE_LOWER, CUSPARSE_DIAG_TYPE_NON_UNIT, index)
+            desc = CuMatrixDescriptor('G', 'L', 'N', index)
             m,k = A.dims
             n = size(C)[2]
             if transa == 'N' && transb == 'N'
@@ -105,7 +105,7 @@ for (fname,elty) in ((:cusparseScsrmm2, :Float32),
             if transa == 'N'
                 ctransa = 'T'
             end
-            desc = CuMatrixDescriptor(CUSPARSE_MATRIX_TYPE_GENERAL, CUSPARSE_FILL_MODE_LOWER, CUSPARSE_DIAG_TYPE_NON_UNIT, index)
+            desc = CuMatrixDescriptor('G', 'L', 'N', index)
             k,m = A.dims
             n = size(C)[2]
             if ctransa == 'N' && transb == 'N'
@@ -151,7 +151,7 @@ for (bname,aname,sname,elty) in ((:cusparseSbsrsm2_bufferSize, :cusparseSbsrsm2_
                       A::CuSparseMatrixBSR{$elty},
                       X::StridedCuMatrix{$elty},
                       index::SparseChar)
-            desc = CuMatrixDescriptor(CUSPARSE_MATRIX_TYPE_GENERAL, uplo, diag, index)
+            desc = CuMatrixDescriptor('G', uplo, diag, index)
             m,n = A.dims
             if m != n
                  throw(DimensionMismatch("A must be square, but has dimensions ($m,$n)!"))
@@ -211,7 +211,7 @@ for (bname,aname,sname,elty) in ((:cusparseScsrsm2_bufferSizeExt, :cusparseScsrs
                       A::CuSparseMatrixCSR{$elty},
                       X::StridedCuMatrix{$elty},
                       index::SparseChar)
-            desc = CuMatrixDescriptor(CUSPARSE_MATRIX_TYPE_GENERAL, uplo, diag, index)
+            desc = CuMatrixDescriptor('G', uplo, diag, index)
             m,n = A.dims
             if m != n
                 throw(DimensionMismatch("A must be square, but has dimensions ($m,$n)!"))
@@ -279,7 +279,7 @@ for (bname,aname,sname,elty) in ((:cusparseScsrsm2_bufferSizeExt, :cusparseScsrs
             if uplo == 'U'
                 cuplo = 'L'
             end
-            desc = CuMatrixDescriptor(CUSPARSE_MATRIX_TYPE_GENERAL, cuplo, diag, index)
+            desc = CuMatrixDescriptor('G', cuplo, diag, index)
             n,m = A.dims
             if m != n
                 throw(DimensionMismatch("A must be square, but has dimensions ($n,$m)!"))

--- a/lib/cusparse/preconditioners.jl
+++ b/lib/cusparse/preconditioners.jl
@@ -16,7 +16,7 @@ for (bname,aname,sname,elty) in ((:cusparseScsric02_bufferSize, :cusparseScsric0
     @eval begin
         function ic02!(A::CuSparseMatrixCSR{$elty},
                        index::SparseChar)
-            desc = CuMatrixDescriptor(CUSPARSE_MATRIX_TYPE_GENERAL, CUSPARSE_FILL_MODE_LOWER, CUSPARSE_DIAG_TYPE_NON_UNIT, index)
+            desc = CuMatrixDescriptor('G', 'L', 'N', index)
             m,n = A.dims
             if m != n
                 throw(DimensionMismatch("A must be square, but has dimensions ($m,$n)!"))
@@ -57,7 +57,7 @@ for (bname,aname,sname,elty) in ((:cusparseScsric02_bufferSize, :cusparseScsric0
     @eval begin
         function ic02!(A::CuSparseMatrixCSC{$elty},
                        index::SparseChar)
-            desc = CuMatrixDescriptor(CUSPARSE_MATRIX_TYPE_GENERAL, CUSPARSE_FILL_MODE_LOWER, CUSPARSE_DIAG_TYPE_NON_UNIT, index)
+            desc = CuMatrixDescriptor('G', 'L', 'N', index)
             m,n = A.dims
             if m != n
                 throw(DimensionMismatch("A must be square, but has dimensions ($m,$n)!"))
@@ -104,7 +104,7 @@ for (bname,aname,sname,elty) in ((:cusparseScsrilu02_bufferSize, :cusparseScsril
     @eval begin
         function ilu02!(A::CuSparseMatrixCSR{$elty},
                         index::SparseChar)
-            desc = CuMatrixDescriptor(CUSPARSE_MATRIX_TYPE_GENERAL, CUSPARSE_FILL_MODE_LOWER, CUSPARSE_DIAG_TYPE_NON_UNIT, index)
+            desc = CuMatrixDescriptor('G', 'L', 'N', index)
             m,n = A.dims
             if m != n
                 throw(DimensionMismatch("A must be square, but has dimensions ($m,$n)!"))
@@ -146,7 +146,7 @@ for (bname,aname,sname,elty) in ((:cusparseScsrilu02_bufferSize, :cusparseScsril
     @eval begin
         function ilu02!(A::CuSparseMatrixCSC{$elty},
                         index::SparseChar)
-            desc = CuMatrixDescriptor(CUSPARSE_MATRIX_TYPE_GENERAL, CUSPARSE_FILL_MODE_LOWER, CUSPARSE_DIAG_TYPE_NON_UNIT, index)
+            desc = CuMatrixDescriptor('G', 'L', 'N', index)
             m,n = A.dims
             if m != n
                 throw(DimensionMismatch("A must be square, but has dimensions ($m,$n)!"))
@@ -188,7 +188,7 @@ for (bname,aname,sname,elty) in ((:cusparseSbsric02_bufferSize, :cusparseSbsric0
     @eval begin
         function ic02!(A::CuSparseMatrixBSR{$elty},
                        index::SparseChar)
-            desc = CuMatrixDescriptor(CUSPARSE_MATRIX_TYPE_GENERAL, CUSPARSE_FILL_MODE_UPPER, CUSPARSE_DIAG_TYPE_NON_UNIT, index)
+            desc = CuMatrixDescriptor('G', 'U', 'N', index)
             m,n = A.dims
             if m != n
                 throw(DimensionMismatch("A must be square, but has dimensions ($m,$n)!"))
@@ -231,7 +231,7 @@ for (bname,aname,sname,elty) in ((:cusparseSbsrilu02_bufferSize, :cusparseSbsril
     @eval begin
         function ilu02!(A::CuSparseMatrixBSR{$elty},
                         index::SparseChar)
-            desc = CuMatrixDescriptor(CUSPARSE_MATRIX_TYPE_GENERAL, CUSPARSE_FILL_MODE_UPPER, CUSPARSE_DIAG_TYPE_NON_UNIT, index)
+            desc = CuMatrixDescriptor('G', 'U', 'N', index)
             m,n = A.dims
             if m != n
                 throw(DimensionMismatch("A must be square, but has dimensions ($m,$n)!"))


### PR DESCRIPTION
Otherwise the `CuMatrixDescriptor` constructor would need to handle both.