### PR TITLE
Implement forward compatibility

### DIFF
--- a/Artifacts.toml
+++ b/Artifacts.toml
@@ -323,14 +323,36 @@ os = "windows"
 [[CUDA_compat]]
 arch = "x86_64"
 cuda = "11.4"
-git-tree-sha1 = "e58c179459a075faff014459109c6b16640d682e"
+git-tree-sha1 = "d9b5623143a996f924e7a5eee9d06354cb650d73"
 lazy = true
 libc = "glibc"
 os = "linux"
 
     [[CUDA_compat.download]]
-    sha256 = "21fff413216ac5455b064af5c3471109b43954227de4086d160b6e66e9086736"
-    url = "https://github.com/JuliaBinaryWrappers/CUDA_compat_jll.jl/releases/download/CUDA_compat-v0.0.1+0/CUDA_compat.v0.0.1.x86_64-linux-gnu-cuda+11.4.tar.gz"
+    sha256 = "5896f52335e2fe476e9a6aba95f03bd6823a2daf588de9b77fbde9bd705565b5"
+    url = "https://github.com/JuliaBinaryWrappers/CUDA_compat_jll.jl/releases/download/CUDA_compat-v0.0.1+1/CUDA_compat.v0.0.1.x86_64-linux-gnu-cuda+11.4.tar.gz"
+[[CUDA_compat]]
+arch = "powerpc64le"
+cuda = "11.4"
+git-tree-sha1 = "5ca98503d53babfc52c443f89ad987440658abd9"
+lazy = true
+libc = "glibc"
+os = "linux"
+
+    [[CUDA_compat.download]]
+    sha256 = "39abaeb9dc0373fa90a19c7913b78aaa12a02a4a131fe030c588c03f89b3cc62"
+    url = "https://github.com/JuliaBinaryWrappers/CUDA_compat_jll.jl/releases/download/CUDA_compat-v0.0.1+1/CUDA_compat.v0.0.1.powerpc64le-linux-gnu-cuda+11.4.tar.gz"
+[[CUDA_compat]]
+arch = "aarch64"
+cuda = "11.4"
+git-tree-sha1 = "c1df0667b90f795bfd9889c0cd5fbbf79db89ab5"
+lazy = true
+libc = "glibc"
+os = "linux"
+
+    [[CUDA_compat.download]]
+    sha256 = "575fe55e77d98aa711925d7fa85133eef5dfbcf551adef8734ec47bb674c0e1a"
+    url = "https://github.com/JuliaBinaryWrappers/CUDA_compat_jll.jl/releases/download/CUDA_compat-v0.0.1+1/CUDA_compat.v0.0.1.aarch64-linux-gnu-cuda+11.4.tar.gz"
 
 
 # CUDNN

--- a/Artifacts.toml
+++ b/Artifacts.toml
@@ -318,6 +318,21 @@ os = "windows"
     url = "https://github.com/JuliaBinaryWrappers/CUDA_loader_jll.jl/releases/download/CUDA_loader-v0.2.0+2/CUDA_loader.v0.2.0.x86_64-w64-mingw32-cuda+11.4.tar.gz"
 
 
+# CUDA forward compatibility package
+
+[[CUDA_compat]]
+arch = "x86_64"
+cuda = "11.4"
+git-tree-sha1 = "e58c179459a075faff014459109c6b16640d682e"
+lazy = true
+libc = "glibc"
+os = "linux"
+
+    [[CUDA_compat.download]]
+    sha256 = "21fff413216ac5455b064af5c3471109b43954227de4086d160b6e66e9086736"
+    url = "https://github.com/JuliaBinaryWrappers/CUDA_compat_jll.jl/releases/download/CUDA_compat-v0.0.1+0/CUDA_compat.v0.0.1.x86_64-linux-gnu-cuda+11.4.tar.gz"
+
+
 # CUDNN
 
 ## v8.0 (old-style artifacts)

--- a/lib/cublas/CUBLAS.jl
+++ b/lib/cublas/CUBLAS.jl
@@ -4,7 +4,7 @@ using ..APIUtils
 
 using ..CUDA
 using ..CUDA: CUstream, cuComplex, cuDoubleComplex, libraryPropertyType, cudaDataType
-using ..CUDA: libcublas, unsafe_free!, @retry_reclaim, isdebug, @sync, @context!
+using ..CUDA: libcublas, unsafe_free!, @retry_reclaim, isdebug, @sync, @context!, initialize_context
 
 using GPUArrays
 

--- a/lib/cublas/error.jl
+++ b/lib/cublas/error.jl
@@ -51,10 +51,6 @@ end
     end
 end
 
-function initialize_api()
-    CUDA.prepare_cuda_state()
-end
-
 macro check(ex, errs...)
     check = :(isequal(err, CUBLAS_STATUS_ALLOC_FAILED))
     for err in errs

--- a/lib/cublas/libcublas.jl
+++ b/lib/cublas/libcublas.jl
@@ -2,14 +2,14 @@
 # Automatically generated using Clang.jl
 
 @checked function cublasCreate_v2(handle)
-    initialize_api()
+    initialize_context()
     ccall((:cublasCreate_v2, libcublas()), cublasStatus_t,
                    (Ref{cublasHandle_t},),
                    handle)
 end
 
 @checked function cublasDestroy_v2(handle)
-    initialize_api()
+    initialize_context()
     ccall((:cublasDestroy_v2, libcublas()), cublasStatus_t,
                    (cublasHandle_t,),
                    handle)
@@ -32,63 +32,63 @@ function cublasGetCudartVersion()
 end
 
 @checked function cublasSetStream_v2(handle, streamId)
-    initialize_api()
+    initialize_context()
     ccall((:cublasSetStream_v2, libcublas()), cublasStatus_t,
                    (cublasHandle_t, CUstream),
                    handle, streamId)
 end
 
 @checked function cublasGetStream_v2(handle, streamId)
-    initialize_api()
+    initialize_context()
     ccall((:cublasGetStream_v2, libcublas()), cublasStatus_t,
                    (cublasHandle_t, Ref{CUstream}),
                    handle, streamId)
 end
 
 @checked function cublasGetPointerMode_v2(handle, mode)
-    initialize_api()
+    initialize_context()
     ccall((:cublasGetPointerMode_v2, libcublas()), cublasStatus_t,
                    (cublasHandle_t, Ref{cublasPointerMode_t}),
                    handle, mode)
 end
 
 @checked function cublasSetPointerMode_v2(handle, mode)
-    initialize_api()
+    initialize_context()
     ccall((:cublasSetPointerMode_v2, libcublas()), cublasStatus_t,
                    (cublasHandle_t, cublasPointerMode_t),
                    handle, mode)
 end
 
 @checked function cublasGetAtomicsMode(handle, mode)
-    initialize_api()
+    initialize_context()
     ccall((:cublasGetAtomicsMode, libcublas()), cublasStatus_t,
                    (cublasHandle_t, Ref{cublasAtomicsMode_t}),
                    handle, mode)
 end
 
 @checked function cublasSetAtomicsMode(handle, mode)
-    initialize_api()
+    initialize_context()
     ccall((:cublasSetAtomicsMode, libcublas()), cublasStatus_t,
                    (cublasHandle_t, cublasAtomicsMode_t),
                    handle, mode)
 end
 
 @checked function cublasGetMathMode(handle, mode)
-    initialize_api()
+    initialize_context()
     ccall((:cublasGetMathMode, libcublas()), cublasStatus_t,
                    (cublasHandle_t, Ref{UInt32}),
                    handle, mode)
 end
 
 @checked function cublasSetMathMode(handle, mode)
-    initialize_api()
+    initialize_context()
     ccall((:cublasSetMathMode, libcublas()), cublasStatus_t,
                    (cublasHandle_t, UInt32),
                    handle, mode)
 end
 
 @checked function cublasLoggerConfigure(logIsOn, logToStdOut, logToStdErr, logFileName)
-    initialize_api()
+    initialize_context()
     ccall((:cublasLoggerConfigure, libcublas()), cublasStatus_t,
                    (Cint, Cint, Cint, Cstring),
                    logIsOn, logToStdOut, logToStdErr, logFileName)
@@ -107,70 +107,70 @@ end
 end
 
 @checked function cublasSetVector(n, elemSize, x, incx, devicePtr, incy)
-    initialize_api()
+    initialize_context()
     ccall((:cublasSetVector, libcublas()), cublasStatus_t,
                    (Cint, Cint, Ptr{Cvoid}, Cint, CuPtr{Cvoid}, Cint),
                    n, elemSize, x, incx, devicePtr, incy)
 end
 
 @checked function cublasGetVector(n, elemSize, x, incx, y, incy)
-    initialize_api()
+    initialize_context()
     ccall((:cublasGetVector, libcublas()), cublasStatus_t,
                    (Cint, Cint, CuPtr{Cvoid}, Cint, Ptr{Cvoid}, Cint),
                    n, elemSize, x, incx, y, incy)
 end
 
 @checked function cublasSetMatrix(rows, cols, elemSize, A, lda, B, ldb)
-    initialize_api()
+    initialize_context()
     ccall((:cublasSetMatrix, libcublas()), cublasStatus_t,
                    (Cint, Cint, Cint, Ptr{Cvoid}, Cint, CuPtr{Cvoid}, Cint),
                    rows, cols, elemSize, A, lda, B, ldb)
 end
 
 @checked function cublasGetMatrix(rows, cols, elemSize, A, lda, B, ldb)
-    initialize_api()
+    initialize_context()
     ccall((:cublasGetMatrix, libcublas()), cublasStatus_t,
                    (Cint, Cint, Cint, CuPtr{Cvoid}, Cint, Ptr{Cvoid}, Cint),
                    rows, cols, elemSize, A, lda, B, ldb)
 end
 
 @checked function cublasSetVectorAsync(n, elemSize, hostPtr, incx, devicePtr, incy, stream)
-    initialize_api()
+    initialize_context()
     ccall((:cublasSetVectorAsync, libcublas()), cublasStatus_t,
                    (Cint, Cint, Ptr{Cvoid}, Cint, CuPtr{Cvoid}, Cint, CUstream),
                    n, elemSize, hostPtr, incx, devicePtr, incy, stream)
 end
 
 @checked function cublasGetVectorAsync(n, elemSize, devicePtr, incx, hostPtr, incy, stream)
-    initialize_api()
+    initialize_context()
     ccall((:cublasGetVectorAsync, libcublas()), cublasStatus_t,
                    (Cint, Cint, CuPtr{Cvoid}, Cint, Ptr{Cvoid}, Cint, CUstream),
                    n, elemSize, devicePtr, incx, hostPtr, incy, stream)
 end
 
 @checked function cublasSetMatrixAsync(rows, cols, elemSize, A, lda, B, ldb, stream)
-    initialize_api()
+    initialize_context()
     ccall((:cublasSetMatrixAsync, libcublas()), cublasStatus_t,
                    (Cint, Cint, Cint, Ptr{Cvoid}, Cint, CuPtr{Cvoid}, Cint, CUstream),
                    rows, cols, elemSize, A, lda, B, ldb, stream)
 end
 
 @checked function cublasGetMatrixAsync(rows, cols, elemSize, A, lda, B, ldb, stream)
-    initialize_api()
+    initialize_context()
     ccall((:cublasGetMatrixAsync, libcublas()), cublasStatus_t,
                    (Cint, Cint, Cint, CuPtr{Cvoid}, Cint, Ptr{Cvoid}, Cint, CUstream),
                    rows, cols, elemSize, A, lda, B, ldb, stream)
 end
 
 function cublasXerbla(srName, info)
-    initialize_api()
+    initialize_context()
     ccall((:cublasXerbla, libcublas()), Cvoid,
                    (Cstring, Cint),
                    srName, info)
 end
 
 @checked function cublasNrm2Ex(handle, n, x, xType, incx, result, resultType, executionType)
-    initialize_api()
+    initialize_context()
     ccall((:cublasNrm2Ex, libcublas()), cublasStatus_t,
                    (cublasHandle_t, Cint, CuPtr{Cvoid}, cudaDataType, Cint,
                     PtrOrCuPtr{Cvoid}, cudaDataType, cudaDataType),
@@ -178,28 +178,28 @@ end
 end
 
 @checked function cublasSnrm2_v2(handle, n, x, incx, result)
-    initialize_api()
+    initialize_context()
     ccall((:cublasSnrm2_v2, libcublas()), cublasStatus_t,
                    (cublasHandle_t, Cint, CuPtr{Cfloat}, Cint, RefOrCuRef{Cfloat}),
                    handle, n, x, incx, result)
 end
 
 @checked function cublasDnrm2_v2(handle, n, x, incx, result)
-    initialize_api()
+    initialize_context()
     ccall((:cublasDnrm2_v2, libcublas()), cublasStatus_t,
                    (cublasHandle_t, Cint, CuPtr{Cdouble}, Cint, RefOrCuRef{Cdouble}),
                    handle, n, x, incx, result)
 end
 
 @checked function cublasScnrm2_v2(handle, n, x, incx, result)
-    initialize_api()
+    initialize_context()
     ccall((:cublasScnrm2_v2, libcublas()), cublasStatus_t,
                    (cublasHandle_t, Cint, CuPtr{cuComplex}, Cint, RefOrCuRef{Cfloat}),
                    handle, n, x, incx, result)
 end
 
 @checked function cublasDznrm2_v2(handle, n, x, incx, result)
-    initialize_api()
+    initialize_context()
     ccall((:cublasDznrm2_v2, libcublas()), cublasStatus_t,
                    (cublasHandle_t, Cint, CuPtr{cuDoubleComplex}, Cint,
                     RefOrCuRef{Cdouble}),
@@ -208,7 +208,7 @@ end
 
 @checked function cublasDotEx(handle, n, x, xType, incx, y, yType, incy, result,
                               resultType, executionType)
-    initialize_api()
+    initialize_context()
     ccall((:cublasDotEx, libcublas()), cublasStatus_t,
                    (cublasHandle_t, Cint, CuPtr{Cvoid}, cudaDataType, Cint, CuPtr{Cvoid},
                     cudaDataType, Cint, PtrOrCuPtr{Cvoid}, cudaDataType, cudaDataType),
@@ -218,7 +218,7 @@ end
 
 @checked function cublasDotcEx(handle, n, x, xType, incx, y, yType, incy, result,
                                resultType, executionType)
-    initialize_api()
+    initialize_context()
     ccall((:cublasDotcEx, libcublas()), cublasStatus_t,
                    (cublasHandle_t, Cint, CuPtr{Cvoid}, cudaDataType, Cint, CuPtr{Cvoid},
                     cudaDataType, Cint, PtrOrCuPtr{Cvoid}, cudaDataType, cudaDataType),
@@ -227,7 +227,7 @@ end
 end
 
 @checked function cublasSdot_v2(handle, n, x, incx, y, incy, result)
-    initialize_api()
+    initialize_context()
     ccall((:cublasSdot_v2, libcublas()), cublasStatus_t,
                    (cublasHandle_t, Cint, CuPtr{Cfloat}, Cint, CuPtr{Cfloat}, Cint,
                     RefOrCuRef{Cfloat}),
@@ -235,7 +235,7 @@ end
 end
 
 @checked function cublasDdot_v2(handle, n, x, incx, y, incy, result)
-    initialize_api()
+    initialize_context()
     ccall((:cublasDdot_v2, libcublas()), cublasStatus_t,
                    (cublasHandle_t, Cint, CuPtr{Cdouble}, Cint, CuPtr{Cdouble}, Cint,
                     RefOrCuRef{Cdouble}),
@@ -243,7 +243,7 @@ end
 end
 
 @checked function cublasCdotu_v2(handle, n, x, incx, y, incy, result)
-    initialize_api()
+    initialize_context()
     ccall((:cublasCdotu_v2, libcublas()), cublasStatus_t,
                    (cublasHandle_t, Cint, CuPtr{cuComplex}, Cint, CuPtr{cuComplex}, Cint,
                     RefOrCuRef{cuComplex}),
@@ -251,7 +251,7 @@ end
 end
 
 @checked function cublasCdotc_v2(handle, n, x, incx, y, incy, result)
-    initialize_api()
+    initialize_context()
     ccall((:cublasCdotc_v2, libcublas()), cublasStatus_t,
                    (cublasHandle_t, Cint, CuPtr{cuComplex}, Cint, CuPtr{cuComplex}, Cint,
                     RefOrCuRef{cuComplex}),
@@ -259,7 +259,7 @@ end
 end
 
 @checked function cublasZdotu_v2(handle, n, x, incx, y, incy, result)
-    initialize_api()
+    initialize_context()
     ccall((:cublasZdotu_v2, libcublas()), cublasStatus_t,
                    (cublasHandle_t, Cint, CuPtr{cuDoubleComplex}, Cint,
                     CuPtr{cuDoubleComplex}, Cint, RefOrCuRef{cuDoubleComplex}),
@@ -267,7 +267,7 @@ end
 end
 
 @checked function cublasZdotc_v2(handle, n, x, incx, y, incy, result)
-    initialize_api()
+    initialize_context()
     ccall((:cublasZdotc_v2, libcublas()), cublasStatus_t,
                    (cublasHandle_t, Cint, CuPtr{cuDoubleComplex}, Cint,
                     CuPtr{cuDoubleComplex}, Cint, RefOrCuRef{cuDoubleComplex}),
@@ -275,7 +275,7 @@ end
 end
 
 @checked function cublasScalEx(handle, n, alpha, alphaType, x, xType, incx, executionType)
-    initialize_api()
+    initialize_context()
     ccall((:cublasScalEx, libcublas()), cublasStatus_t,
                    (cublasHandle_t, Cint, PtrOrCuPtr{Cvoid}, cudaDataType, CuPtr{Cvoid},
                     cudaDataType, Cint, cudaDataType),
@@ -283,35 +283,35 @@ end
 end
 
 @checked function cublasSscal_v2(handle, n, alpha, x, incx)
-    initialize_api()
+    initialize_context()
     ccall((:cublasSscal_v2, libcublas()), cublasStatus_t,
                    (cublasHandle_t, Cint, RefOrCuRef{Cfloat}, CuPtr{Cfloat}, Cint),
                    handle, n, alpha, x, incx)
 end
 
 @checked function cublasDscal_v2(handle, n, alpha, x, incx)
-    initialize_api()
+    initialize_context()
     ccall((:cublasDscal_v2, libcublas()), cublasStatus_t,
                    (cublasHandle_t, Cint, RefOrCuRef{Cdouble}, CuPtr{Cdouble}, Cint),
                    handle, n, alpha, x, incx)
 end
 
 @checked function cublasCscal_v2(handle, n, alpha, x, incx)
-    initialize_api()
+    initialize_context()
     ccall((:cublasCscal_v2, libcublas()), cublasStatus_t,
                    (cublasHandle_t, Cint, RefOrCuRef{cuComplex}, CuPtr{cuComplex}, Cint),
                    handle, n, alpha, x, incx)
 end
 
 @checked function cublasCsscal_v2(handle, n, alpha, x, incx)
-    initialize_api()
+    initialize_context()
     ccall((:cublasCsscal_v2, libcublas()), cublasStatus_t,
                    (cublasHandle_t, Cint, RefOrCuRef{Cfloat}, CuPtr{cuComplex}, Cint),
                    handle, n, alpha, x, incx)
 end
 
 @checked function cublasZscal_v2(handle, n, alpha, x, incx)
-    initialize_api()
+    initialize_context()
     ccall((:cublasZscal_v2, libcublas()), cublasStatus_t,
                    (cublasHandle_t, Cint, RefOrCuRef{cuDoubleComplex},
                     CuPtr{cuDoubleComplex}, Cint),
@@ -319,7 +319,7 @@ end
 end
 
 @checked function cublasZdscal_v2(handle, n, alpha, x, incx)
-    initialize_api()
+    initialize_context()
     ccall((:cublasZdscal_v2, libcublas()), cublasStatus_t,
                    (cublasHandle_t, Cint, RefOrCuRef{Cdouble}, CuPtr{cuDoubleComplex},
                     Cint),
@@ -328,7 +328,7 @@ end
 
 @checked function cublasAxpyEx(handle, n, alpha, alphaType, x, xType, incx, y, yType, incy,
                                executiontype)
-    initialize_api()
+    initialize_context()
     ccall((:cublasAxpyEx, libcublas()), cublasStatus_t,
                    (cublasHandle_t, Cint, PtrOrCuPtr{Cvoid}, cudaDataType, CuPtr{Cvoid},
                     cudaDataType, Cint, CuPtr{Cvoid}, cudaDataType, Cint, cudaDataType),
@@ -337,7 +337,7 @@ end
 end
 
 @checked function cublasSaxpy_v2(handle, n, alpha, x, incx, y, incy)
-    initialize_api()
+    initialize_context()
     ccall((:cublasSaxpy_v2, libcublas()), cublasStatus_t,
                    (cublasHandle_t, Cint, RefOrCuRef{Cfloat}, CuPtr{Cfloat}, Cint,
                     CuPtr{Cfloat}, Cint),
@@ -345,7 +345,7 @@ end
 end
 
 @checked function cublasDaxpy_v2(handle, n, alpha, x, incx, y, incy)
-    initialize_api()
+    initialize_context()
     ccall((:cublasDaxpy_v2, libcublas()), cublasStatus_t,
                    (cublasHandle_t, Cint, RefOrCuRef{Cdouble}, CuPtr{Cdouble}, Cint,
                     CuPtr{Cdouble}, Cint),
@@ -353,7 +353,7 @@ end
 end
 
 @checked function cublasCaxpy_v2(handle, n, alpha, x, incx, y, incy)
-    initialize_api()
+    initialize_context()
     ccall((:cublasCaxpy_v2, libcublas()), cublasStatus_t,
                    (cublasHandle_t, Cint, RefOrCuRef{cuComplex}, CuPtr{cuComplex}, Cint,
                     CuPtr{cuComplex}, Cint),
@@ -361,7 +361,7 @@ end
 end
 
 @checked function cublasZaxpy_v2(handle, n, alpha, x, incx, y, incy)
-    initialize_api()
+    initialize_context()
     ccall((:cublasZaxpy_v2, libcublas()), cublasStatus_t,
                    (cublasHandle_t, Cint, RefOrCuRef{cuDoubleComplex},
                     CuPtr{cuDoubleComplex}, Cint, CuPtr{cuDoubleComplex}, Cint),
@@ -369,7 +369,7 @@ end
 end
 
 @checked function cublasCopyEx(handle, n, x, xType, incx, y, yType, incy)
-    initialize_api()
+    initialize_context()
     ccall((:cublasCopyEx, libcublas()), cublasStatus_t,
                    (cublasHandle_t, Cint, CuPtr{Cvoid}, cudaDataType, Cint, CuPtr{Cvoid},
                     cudaDataType, Cint),
@@ -377,28 +377,28 @@ end
 end
 
 @checked function cublasScopy_v2(handle, n, x, incx, y, incy)
-    initialize_api()
+    initialize_context()
     ccall((:cublasScopy_v2, libcublas()), cublasStatus_t,
                    (cublasHandle_t, Cint, CuPtr{Cfloat}, Cint, CuPtr{Cfloat}, Cint),
                    handle, n, x, incx, y, incy)
 end
 
 @checked function cublasDcopy_v2(handle, n, x, incx, y, incy)
-    initialize_api()
+    initialize_context()
     ccall((:cublasDcopy_v2, libcublas()), cublasStatus_t,
                    (cublasHandle_t, Cint, CuPtr{Cdouble}, Cint, CuPtr{Cdouble}, Cint),
                    handle, n, x, incx, y, incy)
 end
 
 @checked function cublasCcopy_v2(handle, n, x, incx, y, incy)
-    initialize_api()
+    initialize_context()
     ccall((:cublasCcopy_v2, libcublas()), cublasStatus_t,
                    (cublasHandle_t, Cint, CuPtr{cuComplex}, Cint, CuPtr{cuComplex}, Cint),
                    handle, n, x, incx, y, incy)
 end
 
 @checked function cublasZcopy_v2(handle, n, x, incx, y, incy)
-    initialize_api()
+    initialize_context()
     ccall((:cublasZcopy_v2, libcublas()), cublasStatus_t,
                    (cublasHandle_t, Cint, CuPtr{cuDoubleComplex}, Cint,
                     CuPtr{cuDoubleComplex}, Cint),
@@ -406,28 +406,28 @@ end
 end
 
 @checked function cublasSswap_v2(handle, n, x, incx, y, incy)
-    initialize_api()
+    initialize_context()
     ccall((:cublasSswap_v2, libcublas()), cublasStatus_t,
                    (cublasHandle_t, Cint, CuPtr{Cfloat}, Cint, CuPtr{Cfloat}, Cint),
                    handle, n, x, incx, y, incy)
 end
 
 @checked function cublasDswap_v2(handle, n, x, incx, y, incy)
-    initialize_api()
+    initialize_context()
     ccall((:cublasDswap_v2, libcublas()), cublasStatus_t,
                    (cublasHandle_t, Cint, CuPtr{Cdouble}, Cint, CuPtr{Cdouble}, Cint),
                    handle, n, x, incx, y, incy)
 end
 
 @checked function cublasCswap_v2(handle, n, x, incx, y, incy)
-    initialize_api()
+    initialize_context()
     ccall((:cublasCswap_v2, libcublas()), cublasStatus_t,
                    (cublasHandle_t, Cint, CuPtr{cuComplex}, Cint, CuPtr{cuComplex}, Cint),
                    handle, n, x, incx, y, incy)
 end
 
 @checked function cublasZswap_v2(handle, n, x, incx, y, incy)
-    initialize_api()
+    initialize_context()
     ccall((:cublasZswap_v2, libcublas()), cublasStatus_t,
                    (cublasHandle_t, Cint, CuPtr{cuDoubleComplex}, Cint,
                     CuPtr{cuDoubleComplex}, Cint),
@@ -435,7 +435,7 @@ end
 end
 
 @checked function cublasSwapEx(handle, n, x, xType, incx, y, yType, incy)
-    initialize_api()
+    initialize_context()
     ccall((:cublasSwapEx, libcublas()), cublasStatus_t,
                    (cublasHandle_t, Cint, CuPtr{Cvoid}, cudaDataType, Cint, CuPtr{Cvoid},
                     cudaDataType, Cint),
@@ -443,35 +443,35 @@ end
 end
 
 @checked function cublasIsamax_v2(handle, n, x, incx, result)
-    initialize_api()
+    initialize_context()
     ccall((:cublasIsamax_v2, libcublas()), cublasStatus_t,
                    (cublasHandle_t, Cint, CuPtr{Cfloat}, Cint, RefOrCuRef{Cint}),
                    handle, n, x, incx, result)
 end
 
 @checked function cublasIdamax_v2(handle, n, x, incx, result)
-    initialize_api()
+    initialize_context()
     ccall((:cublasIdamax_v2, libcublas()), cublasStatus_t,
                    (cublasHandle_t, Cint, CuPtr{Cdouble}, Cint, RefOrCuRef{Cint}),
                    handle, n, x, incx, result)
 end
 
 @checked function cublasIcamax_v2(handle, n, x, incx, result)
-    initialize_api()
+    initialize_context()
     ccall((:cublasIcamax_v2, libcublas()), cublasStatus_t,
                    (cublasHandle_t, Cint, CuPtr{cuComplex}, Cint, RefOrCuRef{Cint}),
                    handle, n, x, incx, result)
 end
 
 @checked function cublasIzamax_v2(handle, n, x, incx, result)
-    initialize_api()
+    initialize_context()
     ccall((:cublasIzamax_v2, libcublas()), cublasStatus_t,
                    (cublasHandle_t, Cint, CuPtr{cuDoubleComplex}, Cint, RefOrCuRef{Cint}),
                    handle, n, x, incx, result)
 end
 
 @checked function cublasIamaxEx(handle, n, x, xType, incx, result)
-    initialize_api()
+    initialize_context()
     ccall((:cublasIamaxEx, libcublas()), cublasStatus_t,
                    (cublasHandle_t, Cint, CuPtr{Cvoid}, cudaDataType, Cint,
                     RefOrCuRef{Cint}),
@@ -479,35 +479,35 @@ end
 end
 
 @checked function cublasIsamin_v2(handle, n, x, incx, result)
-    initialize_api()
+    initialize_context()
     ccall((:cublasIsamin_v2, libcublas()), cublasStatus_t,
                    (cublasHandle_t, Cint, CuPtr{Cfloat}, Cint, RefOrCuRef{Cint}),
                    handle, n, x, incx, result)
 end
 
 @checked function cublasIdamin_v2(handle, n, x, incx, result)
-    initialize_api()
+    initialize_context()
     ccall((:cublasIdamin_v2, libcublas()), cublasStatus_t,
                    (cublasHandle_t, Cint, CuPtr{Cdouble}, Cint, RefOrCuRef{Cint}),
                    handle, n, x, incx, result)
 end
 
 @checked function cublasIcamin_v2(handle, n, x, incx, result)
-    initialize_api()
+    initialize_context()
     ccall((:cublasIcamin_v2, libcublas()), cublasStatus_t,
                    (cublasHandle_t, Cint, CuPtr{cuComplex}, Cint, RefOrCuRef{Cint}),
                    handle, n, x, incx, result)
 end
 
 @checked function cublasIzamin_v2(handle, n, x, incx, result)
-    initialize_api()
+    initialize_context()
     ccall((:cublasIzamin_v2, libcublas()), cublasStatus_t,
                    (cublasHandle_t, Cint, CuPtr{cuDoubleComplex}, Cint, RefOrCuRef{Cint}),
                    handle, n, x, incx, result)
 end
 
 @checked function cublasIaminEx(handle, n, x, xType, incx, result)
-    initialize_api()
+    initialize_context()
     ccall((:cublasIaminEx, libcublas()), cublasStatus_t,
                    (cublasHandle_t, Cint, CuPtr{Cvoid}, cudaDataType, Cint,
                     RefOrCuRef{Cint}),
@@ -515,7 +515,7 @@ end
 end
 
 @checked function cublasAsumEx(handle, n, x, xType, incx, result, resultType, executiontype)
-    initialize_api()
+    initialize_context()
     ccall((:cublasAsumEx, libcublas()), cublasStatus_t,
                    (cublasHandle_t, Cint, CuPtr{Cvoid}, cudaDataType, Cint,
                     PtrOrCuPtr{Cvoid}, cudaDataType, cudaDataType),
@@ -523,28 +523,28 @@ end
 end
 
 @checked function cublasSasum_v2(handle, n, x, incx, result)
-    initialize_api()
+    initialize_context()
     ccall((:cublasSasum_v2, libcublas()), cublasStatus_t,
                    (cublasHandle_t, Cint, CuPtr{Cfloat}, Cint, RefOrCuRef{Cfloat}),
                    handle, n, x, incx, result)
 end
 
 @checked function cublasDasum_v2(handle, n, x, incx, result)
-    initialize_api()
+    initialize_context()
     ccall((:cublasDasum_v2, libcublas()), cublasStatus_t,
                    (cublasHandle_t, Cint, CuPtr{Cdouble}, Cint, RefOrCuRef{Cdouble}),
                    handle, n, x, incx, result)
 end
 
 @checked function cublasScasum_v2(handle, n, x, incx, result)
-    initialize_api()
+    initialize_context()
     ccall((:cublasScasum_v2, libcublas()), cublasStatus_t,
                    (cublasHandle_t, Cint, CuPtr{cuComplex}, Cint, RefOrCuRef{Cfloat}),
                    handle, n, x, incx, result)
 end
 
 @checked function cublasDzasum_v2(handle, n, x, incx, result)
-    initialize_api()
+    initialize_context()
     ccall((:cublasDzasum_v2, libcublas()), cublasStatus_t,
                    (cublasHandle_t, Cint, CuPtr{cuDoubleComplex}, Cint,
                     RefOrCuRef{Cdouble}),
@@ -552,7 +552,7 @@ end
 end
 
 @checked function cublasSrot_v2(handle, n, x, incx, y, incy, c, s)
-    initialize_api()
+    initialize_context()
     ccall((:cublasSrot_v2, libcublas()), cublasStatus_t,
                    (cublasHandle_t, Cint, CuPtr{Cfloat}, Cint, CuPtr{Cfloat}, Cint,
                     RefOrCuRef{Cfloat}, RefOrCuRef{Cfloat}),
@@ -560,7 +560,7 @@ end
 end
 
 @checked function cublasDrot_v2(handle, n, x, incx, y, incy, c, s)
-    initialize_api()
+    initialize_context()
     ccall((:cublasDrot_v2, libcublas()), cublasStatus_t,
                    (cublasHandle_t, Cint, CuPtr{Cdouble}, Cint, CuPtr{Cdouble}, Cint,
                     RefOrCuRef{Cdouble}, RefOrCuRef{Cdouble}),
@@ -568,7 +568,7 @@ end
 end
 
 @checked function cublasCrot_v2(handle, n, x, incx, y, incy, c, s)
-    initialize_api()
+    initialize_context()
     ccall((:cublasCrot_v2, libcublas()), cublasStatus_t,
                    (cublasHandle_t, Cint, CuPtr{cuComplex}, Cint, CuPtr{cuComplex}, Cint,
                     RefOrCuRef{Cfloat}, RefOrCuRef{cuComplex}),
@@ -576,7 +576,7 @@ end
 end
 
 @checked function cublasCsrot_v2(handle, n, x, incx, y, incy, c, s)
-    initialize_api()
+    initialize_context()
     ccall((:cublasCsrot_v2, libcublas()), cublasStatus_t,
                    (cublasHandle_t, Cint, CuPtr{cuComplex}, Cint, CuPtr{cuComplex}, Cint,
                     RefOrCuRef{Cfloat}, RefOrCuRef{Cfloat}),
@@ -584,7 +584,7 @@ end
 end
 
 @checked function cublasZrot_v2(handle, n, x, incx, y, incy, c, s)
-    initialize_api()
+    initialize_context()
     ccall((:cublasZrot_v2, libcublas()), cublasStatus_t,
                    (cublasHandle_t, Cint, CuPtr{cuDoubleComplex}, Cint,
                     CuPtr{cuDoubleComplex}, Cint, RefOrCuRef{Cdouble},
@@ -593,7 +593,7 @@ end
 end
 
 @checked function cublasZdrot_v2(handle, n, x, incx, y, incy, c, s)
-    initialize_api()
+    initialize_context()
     ccall((:cublasZdrot_v2, libcublas()), cublasStatus_t,
                    (cublasHandle_t, Cint, CuPtr{cuDoubleComplex}, Cint,
                     CuPtr{cuDoubleComplex}, Cint, RefOrCuRef{Cdouble}, RefOrCuRef{Cdouble}),
@@ -602,7 +602,7 @@ end
 
 @checked function cublasRotEx(handle, n, x, xType, incx, y, yType, incy, c, s, csType,
                               executiontype)
-    initialize_api()
+    initialize_context()
     ccall((:cublasRotEx, libcublas()), cublasStatus_t,
                    (cublasHandle_t, Cint, CuPtr{Cvoid}, cudaDataType, Cint, CuPtr{Cvoid},
                     cudaDataType, Cint, PtrOrCuPtr{Cvoid}, PtrOrCuPtr{Cvoid}, cudaDataType,
@@ -611,7 +611,7 @@ end
 end
 
 @checked function cublasSrotg_v2(handle, a, b, c, s)
-    initialize_api()
+    initialize_context()
     ccall((:cublasSrotg_v2, libcublas()), cublasStatus_t,
                    (cublasHandle_t, RefOrCuRef{Cfloat}, RefOrCuRef{Cfloat},
                     RefOrCuRef{Cfloat}, RefOrCuRef{Cfloat}),
@@ -619,7 +619,7 @@ end
 end
 
 @checked function cublasDrotg_v2(handle, a, b, c, s)
-    initialize_api()
+    initialize_context()
     ccall((:cublasDrotg_v2, libcublas()), cublasStatus_t,
                    (cublasHandle_t, RefOrCuRef{Cdouble}, RefOrCuRef{Cdouble},
                     PtrOrCuPtr{Cdouble}, PtrOrCuPtr{Cdouble}),
@@ -627,7 +627,7 @@ end
 end
 
 @checked function cublasCrotg_v2(handle, a, b, c, s)
-    initialize_api()
+    initialize_context()
     ccall((:cublasCrotg_v2, libcublas()), cublasStatus_t,
                    (cublasHandle_t, RefOrCuRef{cuComplex}, RefOrCuRef{cuComplex},
                     RefOrCuRef{Cfloat}, RefOrCuRef{cuComplex}),
@@ -635,7 +635,7 @@ end
 end
 
 @checked function cublasZrotg_v2(handle, a, b, c, s)
-    initialize_api()
+    initialize_context()
     ccall((:cublasZrotg_v2, libcublas()), cublasStatus_t,
                    (cublasHandle_t, RefOrCuRef{cuDoubleComplex},
                     RefOrCuRef{cuDoubleComplex}, RefOrCuRef{Cdouble},
@@ -644,7 +644,7 @@ end
 end
 
 @checked function cublasRotgEx(handle, a, b, abType, c, s, csType, executiontype)
-    initialize_api()
+    initialize_context()
     ccall((:cublasRotgEx, libcublas()), cublasStatus_t,
                    (cublasHandle_t, Ptr{Cvoid}, Ptr{Cvoid}, cudaDataType,
                     PtrOrCuPtr{Cvoid}, PtrOrCuPtr{Cvoid}, cudaDataType, cudaDataType),
@@ -652,7 +652,7 @@ end
 end
 
 @checked function cublasSrotm_v2(handle, n, x, incx, y, incy, param)
-    initialize_api()
+    initialize_context()
     ccall((:cublasSrotm_v2, libcublas()), cublasStatus_t,
                    (cublasHandle_t, Cint, CuPtr{Cfloat}, Cint, CuPtr{Cfloat}, Cint,
                     PtrOrCuPtr{Cfloat}),
@@ -660,7 +660,7 @@ end
 end
 
 @checked function cublasDrotm_v2(handle, n, x, incx, y, incy, param)
-    initialize_api()
+    initialize_context()
     ccall((:cublasDrotm_v2, libcublas()), cublasStatus_t,
                    (cublasHandle_t, Cint, CuPtr{Cdouble}, Cint, CuPtr{Cdouble}, Cint,
                     PtrOrCuPtr{Cdouble}),
@@ -669,7 +669,7 @@ end
 
 @checked function cublasRotmEx(handle, n, x, xType, incx, y, yType, incy, param, paramType,
                                executiontype)
-    initialize_api()
+    initialize_context()
     ccall((:cublasRotmEx, libcublas()), cublasStatus_t,
                    (cublasHandle_t, Cint, CuPtr{Cvoid}, cudaDataType, Cint, CuPtr{Cvoid},
                     cudaDataType, Cint, PtrOrCuPtr{Cvoid}, cudaDataType, cudaDataType),
@@ -678,7 +678,7 @@ end
 end
 
 @checked function cublasSrotmg_v2(handle, d1, d2, x1, y1, param)
-    initialize_api()
+    initialize_context()
     ccall((:cublasSrotmg_v2, libcublas()), cublasStatus_t,
                    (cublasHandle_t, RefOrCuRef{Cfloat}, RefOrCuRef{Cfloat},
                     RefOrCuRef{Cfloat}, RefOrCuRef{Cfloat}, PtrOrCuPtr{Cfloat}),
@@ -686,7 +686,7 @@ end
 end
 
 @checked function cublasDrotmg_v2(handle, d1, d2, x1, y1, param)
-    initialize_api()
+    initialize_context()
     ccall((:cublasDrotmg_v2, libcublas()), cublasStatus_t,
                    (cublasHandle_t, RefOrCuRef{Cdouble}, RefOrCuRef{Cdouble},
                     RefOrCuRef{Cdouble}, RefOrCuRef{Cdouble}, PtrOrCuPtr{Cdouble}),
@@ -695,7 +695,7 @@ end
 
 @checked function cublasRotmgEx(handle, d1, d1Type, d2, d2Type, x1, x1Type, y1, y1Type,
                                 param, paramType, executiontype)
-    initialize_api()
+    initialize_context()
     ccall((:cublasRotmgEx, libcublas()), cublasStatus_t,
                    (cublasHandle_t, PtrOrCuPtr{Cvoid}, cudaDataType, PtrOrCuPtr{Cvoid},
                     cudaDataType, PtrOrCuPtr{Cvoid}, cudaDataType, PtrOrCuPtr{Cvoid},
@@ -705,7 +705,7 @@ end
 end
 
 @checked function cublasSgemv_v2(handle, trans, m, n, alpha, A, lda, x, incx, beta, y, incy)
-    initialize_api()
+    initialize_context()
     ccall((:cublasSgemv_v2, libcublas()), cublasStatus_t,
                    (cublasHandle_t, cublasOperation_t, Cint, Cint, RefOrCuRef{Cfloat},
                     CuPtr{Cfloat}, Cint, CuPtr{Cfloat}, Cint, RefOrCuRef{Cfloat},
@@ -714,7 +714,7 @@ end
 end
 
 @checked function cublasDgemv_v2(handle, trans, m, n, alpha, A, lda, x, incx, beta, y, incy)
-    initialize_api()
+    initialize_context()
     ccall((:cublasDgemv_v2, libcublas()), cublasStatus_t,
                    (cublasHandle_t, cublasOperation_t, Cint, Cint, RefOrCuRef{Cdouble},
                     CuPtr{Cdouble}, Cint, CuPtr{Cdouble}, Cint, RefOrCuRef{Cdouble},
@@ -723,7 +723,7 @@ end
 end
 
 @checked function cublasCgemv_v2(handle, trans, m, n, alpha, A, lda, x, incx, beta, y, incy)
-    initialize_api()
+    initialize_context()
     ccall((:cublasCgemv_v2, libcublas()), cublasStatus_t,
                    (cublasHandle_t, cublasOperation_t, Cint, Cint, RefOrCuRef{cuComplex},
                     CuPtr{cuComplex}, Cint, CuPtr{cuComplex}, Cint, RefOrCuRef{cuComplex},
@@ -732,7 +732,7 @@ end
 end
 
 @checked function cublasZgemv_v2(handle, trans, m, n, alpha, A, lda, x, incx, beta, y, incy)
-    initialize_api()
+    initialize_context()
     ccall((:cublasZgemv_v2, libcublas()), cublasStatus_t,
                    (cublasHandle_t, cublasOperation_t, Cint, Cint,
                     RefOrCuRef{cuDoubleComplex}, CuPtr{cuDoubleComplex}, Cint,
@@ -743,7 +743,7 @@ end
 
 @checked function cublasSgbmv_v2(handle, trans, m, n, kl, ku, alpha, A, lda, x, incx, beta,
                                  y, incy)
-    initialize_api()
+    initialize_context()
     ccall((:cublasSgbmv_v2, libcublas()), cublasStatus_t,
                    (cublasHandle_t, cublasOperation_t, Cint, Cint, Cint, Cint,
                     RefOrCuRef{Cfloat}, CuPtr{Cfloat}, Cint, CuPtr{Cfloat}, Cint,
@@ -753,7 +753,7 @@ end
 
 @checked function cublasDgbmv_v2(handle, trans, m, n, kl, ku, alpha, A, lda, x, incx, beta,
                                  y, incy)
-    initialize_api()
+    initialize_context()
     ccall((:cublasDgbmv_v2, libcublas()), cublasStatus_t,
                    (cublasHandle_t, cublasOperation_t, Cint, Cint, Cint, Cint,
                     RefOrCuRef{Cdouble}, CuPtr{Cdouble}, Cint, CuPtr{Cdouble}, Cint,
@@ -763,7 +763,7 @@ end
 
 @checked function cublasCgbmv_v2(handle, trans, m, n, kl, ku, alpha, A, lda, x, incx, beta,
                                  y, incy)
-    initialize_api()
+    initialize_context()
     ccall((:cublasCgbmv_v2, libcublas()), cublasStatus_t,
                    (cublasHandle_t, cublasOperation_t, Cint, Cint, Cint, Cint,
                     RefOrCuRef{cuComplex}, CuPtr{cuComplex}, Cint, CuPtr{cuComplex}, Cint,
@@ -773,7 +773,7 @@ end
 
 @checked function cublasZgbmv_v2(handle, trans, m, n, kl, ku, alpha, A, lda, x, incx, beta,
                                  y, incy)
-    initialize_api()
+    initialize_context()
     ccall((:cublasZgbmv_v2, libcublas()), cublasStatus_t,
                    (cublasHandle_t, cublasOperation_t, Cint, Cint, Cint, Cint,
                     RefOrCuRef{cuDoubleComplex}, CuPtr{cuDoubleComplex}, Cint,
@@ -783,7 +783,7 @@ end
 end
 
 @checked function cublasStrmv_v2(handle, uplo, trans, diag, n, A, lda, x, incx)
-    initialize_api()
+    initialize_context()
     ccall((:cublasStrmv_v2, libcublas()), cublasStatus_t,
                    (cublasHandle_t, cublasFillMode_t, cublasOperation_t, cublasDiagType_t,
                     Cint, CuPtr{Cfloat}, Cint, CuPtr{Cfloat}, Cint),
@@ -791,7 +791,7 @@ end
 end
 
 @checked function cublasDtrmv_v2(handle, uplo, trans, diag, n, A, lda, x, incx)
-    initialize_api()
+    initialize_context()
     ccall((:cublasDtrmv_v2, libcublas()), cublasStatus_t,
                    (cublasHandle_t, cublasFillMode_t, cublasOperation_t, cublasDiagType_t,
                     Cint, CuPtr{Cdouble}, Cint, CuPtr{Cdouble}, Cint),
@@ -799,7 +799,7 @@ end
 end
 
 @checked function cublasCtrmv_v2(handle, uplo, trans, diag, n, A, lda, x, incx)
-    initialize_api()
+    initialize_context()
     ccall((:cublasCtrmv_v2, libcublas()), cublasStatus_t,
                    (cublasHandle_t, cublasFillMode_t, cublasOperation_t, cublasDiagType_t,
                     Cint, CuPtr{cuComplex}, Cint, CuPtr{cuComplex}, Cint),
@@ -807,7 +807,7 @@ end
 end
 
 @checked function cublasZtrmv_v2(handle, uplo, trans, diag, n, A, lda, x, incx)
-    initialize_api()
+    initialize_context()
     ccall((:cublasZtrmv_v2, libcublas()), cublasStatus_t,
                    (cublasHandle_t, cublasFillMode_t, cublasOperation_t, cublasDiagType_t,
                     Cint, CuPtr{cuDoubleComplex}, Cint, CuPtr{cuDoubleComplex}, Cint),
@@ -815,7 +815,7 @@ end
 end
 
 @checked function cublasStbmv_v2(handle, uplo, trans, diag, n, k, A, lda, x, incx)
-    initialize_api()
+    initialize_context()
     ccall((:cublasStbmv_v2, libcublas()), cublasStatus_t,
                    (cublasHandle_t, cublasFillMode_t, cublasOperation_t, cublasDiagType_t,
                     Cint, Cint, CuPtr{Cfloat}, Cint, CuPtr{Cfloat}, Cint),
@@ -823,7 +823,7 @@ end
 end
 
 @checked function cublasDtbmv_v2(handle, uplo, trans, diag, n, k, A, lda, x, incx)
-    initialize_api()
+    initialize_context()
     ccall((:cublasDtbmv_v2, libcublas()), cublasStatus_t,
                    (cublasHandle_t, cublasFillMode_t, cublasOperation_t, cublasDiagType_t,
                     Cint, Cint, CuPtr{Cdouble}, Cint, CuPtr{Cdouble}, Cint),
@@ -831,7 +831,7 @@ end
 end
 
 @checked function cublasCtbmv_v2(handle, uplo, trans, diag, n, k, A, lda, x, incx)
-    initialize_api()
+    initialize_context()
     ccall((:cublasCtbmv_v2, libcublas()), cublasStatus_t,
                    (cublasHandle_t, cublasFillMode_t, cublasOperation_t, cublasDiagType_t,
                     Cint, Cint, CuPtr{cuComplex}, Cint, CuPtr{cuComplex}, Cint),
@@ -839,7 +839,7 @@ end
 end
 
 @checked function cublasZtbmv_v2(handle, uplo, trans, diag, n, k, A, lda, x, incx)
-    initialize_api()
+    initialize_context()
     ccall((:cublasZtbmv_v2, libcublas()), cublasStatus_t,
                    (cublasHandle_t, cublasFillMode_t, cublasOperation_t, cublasDiagType_t,
                     Cint, Cint, CuPtr{cuDoubleComplex}, Cint, CuPtr{cuDoubleComplex}, Cint),
@@ -847,7 +847,7 @@ end
 end
 
 @checked function cublasStpmv_v2(handle, uplo, trans, diag, n, AP, x, incx)
-    initialize_api()
+    initialize_context()
     ccall((:cublasStpmv_v2, libcublas()), cublasStatus_t,
                    (cublasHandle_t, cublasFillMode_t, cublasOperation_t, cublasDiagType_t,
                     Cint, CuPtr{Cfloat}, CuPtr{Cfloat}, Cint),
@@ -855,7 +855,7 @@ end
 end
 
 @checked function cublasDtpmv_v2(handle, uplo, trans, diag, n, AP, x, incx)
-    initialize_api()
+    initialize_context()
     ccall((:cublasDtpmv_v2, libcublas()), cublasStatus_t,
                    (cublasHandle_t, cublasFillMode_t, cublasOperation_t, cublasDiagType_t,
                     Cint, CuPtr{Cdouble}, CuPtr{Cdouble}, Cint),
@@ -863,7 +863,7 @@ end
 end
 
 @checked function cublasCtpmv_v2(handle, uplo, trans, diag, n, AP, x, incx)
-    initialize_api()
+    initialize_context()
     ccall((:cublasCtpmv_v2, libcublas()), cublasStatus_t,
                    (cublasHandle_t, cublasFillMode_t, cublasOperation_t, cublasDiagType_t,
                     Cint, CuPtr{cuComplex}, CuPtr{cuComplex}, Cint),
@@ -871,7 +871,7 @@ end
 end
 
 @checked function cublasZtpmv_v2(handle, uplo, trans, diag, n, AP, x, incx)
-    initialize_api()
+    initialize_context()
     ccall((:cublasZtpmv_v2, libcublas()), cublasStatus_t,
                    (cublasHandle_t, cublasFillMode_t, cublasOperation_t, cublasDiagType_t,
                     Cint, CuPtr{cuDoubleComplex}, CuPtr{cuDoubleComplex}, Cint),
@@ -879,7 +879,7 @@ end
 end
 
 @checked function cublasStrsv_v2(handle, uplo, trans, diag, n, A, lda, x, incx)
-    initialize_api()
+    initialize_context()
     ccall((:cublasStrsv_v2, libcublas()), cublasStatus_t,
                    (cublasHandle_t, cublasFillMode_t, cublasOperation_t, cublasDiagType_t,
                     Cint, CuPtr{Cfloat}, Cint, CuPtr{Cfloat}, Cint),
@@ -887,7 +887,7 @@ end
 end
 
 @checked function cublasDtrsv_v2(handle, uplo, trans, diag, n, A, lda, x, incx)
-    initialize_api()
+    initialize_context()
     ccall((:cublasDtrsv_v2, libcublas()), cublasStatus_t,
                    (cublasHandle_t, cublasFillMode_t, cublasOperation_t, cublasDiagType_t,
                     Cint, CuPtr{Cdouble}, Cint, CuPtr{Cdouble}, Cint),
@@ -895,7 +895,7 @@ end
 end
 
 @checked function cublasCtrsv_v2(handle, uplo, trans, diag, n, A, lda, x, incx)
-    initialize_api()
+    initialize_context()
     ccall((:cublasCtrsv_v2, libcublas()), cublasStatus_t,
                    (cublasHandle_t, cublasFillMode_t, cublasOperation_t, cublasDiagType_t,
                     Cint, CuPtr{cuComplex}, Cint, CuPtr{cuComplex}, Cint),
@@ -903,7 +903,7 @@ end
 end
 
 @checked function cublasZtrsv_v2(handle, uplo, trans, diag, n, A, lda, x, incx)
-    initialize_api()
+    initialize_context()
     ccall((:cublasZtrsv_v2, libcublas()), cublasStatus_t,
                    (cublasHandle_t, cublasFillMode_t, cublasOperation_t, cublasDiagType_t,
                     Cint, CuPtr{cuDoubleComplex}, Cint, CuPtr{cuDoubleComplex}, Cint),
@@ -911,7 +911,7 @@ end
 end
 
 @checked function cublasStpsv_v2(handle, uplo, trans, diag, n, AP, x, incx)
-    initialize_api()
+    initialize_context()
     ccall((:cublasStpsv_v2, libcublas()), cublasStatus_t,
                    (cublasHandle_t, cublasFillMode_t, cublasOperation_t, cublasDiagType_t,
                     Cint, CuPtr{Cfloat}, CuPtr{Cfloat}, Cint),
@@ -919,7 +919,7 @@ end
 end
 
 @checked function cublasDtpsv_v2(handle, uplo, trans, diag, n, AP, x, incx)
-    initialize_api()
+    initialize_context()
     ccall((:cublasDtpsv_v2, libcublas()), cublasStatus_t,
                    (cublasHandle_t, cublasFillMode_t, cublasOperation_t, cublasDiagType_t,
                     Cint, CuPtr{Cdouble}, CuPtr{Cdouble}, Cint),
@@ -927,7 +927,7 @@ end
 end
 
 @checked function cublasCtpsv_v2(handle, uplo, trans, diag, n, AP, x, incx)
-    initialize_api()
+    initialize_context()
     ccall((:cublasCtpsv_v2, libcublas()), cublasStatus_t,
                    (cublasHandle_t, cublasFillMode_t, cublasOperation_t, cublasDiagType_t,
                     Cint, CuPtr{cuComplex}, CuPtr{cuComplex}, Cint),
@@ -935,7 +935,7 @@ end
 end
 
 @checked function cublasZtpsv_v2(handle, uplo, trans, diag, n, AP, x, incx)
-    initialize_api()
+    initialize_context()
     ccall((:cublasZtpsv_v2, libcublas()), cublasStatus_t,
                    (cublasHandle_t, cublasFillMode_t, cublasOperation_t, cublasDiagType_t,
                     Cint, CuPtr{cuDoubleComplex}, CuPtr{cuDoubleComplex}, Cint),
@@ -943,7 +943,7 @@ end
 end
 
 @checked function cublasStbsv_v2(handle, uplo, trans, diag, n, k, A, lda, x, incx)
-    initialize_api()
+    initialize_context()
     ccall((:cublasStbsv_v2, libcublas()), cublasStatus_t,
                    (cublasHandle_t, cublasFillMode_t, cublasOperation_t, cublasDiagType_t,
                     Cint, Cint, CuPtr{Cfloat}, Cint, CuPtr{Cfloat}, Cint),
@@ -951,7 +951,7 @@ end
 end
 
 @checked function cublasDtbsv_v2(handle, uplo, trans, diag, n, k, A, lda, x, incx)
-    initialize_api()
+    initialize_context()
     ccall((:cublasDtbsv_v2, libcublas()), cublasStatus_t,
                    (cublasHandle_t, cublasFillMode_t, cublasOperation_t, cublasDiagType_t,
                     Cint, Cint, CuPtr{Cdouble}, Cint, CuPtr{Cdouble}, Cint),
@@ -959,7 +959,7 @@ end
 end
 
 @checked function cublasCtbsv_v2(handle, uplo, trans, diag, n, k, A, lda, x, incx)
-    initialize_api()
+    initialize_context()
     ccall((:cublasCtbsv_v2, libcublas()), cublasStatus_t,
                    (cublasHandle_t, cublasFillMode_t, cublasOperation_t, cublasDiagType_t,
                     Cint, Cint, CuPtr{cuComplex}, Cint, CuPtr{cuComplex}, Cint),
@@ -967,7 +967,7 @@ end
 end
 
 @checked function cublasZtbsv_v2(handle, uplo, trans, diag, n, k, A, lda, x, incx)
-    initialize_api()
+    initialize_context()
     ccall((:cublasZtbsv_v2, libcublas()), cublasStatus_t,
                    (cublasHandle_t, cublasFillMode_t, cublasOperation_t, cublasDiagType_t,
                     Cint, Cint, CuPtr{cuDoubleComplex}, Cint, CuPtr{cuDoubleComplex}, Cint),
@@ -975,7 +975,7 @@ end
 end
 
 @checked function cublasSsymv_v2(handle, uplo, n, alpha, A, lda, x, incx, beta, y, incy)
-    initialize_api()
+    initialize_context()
     ccall((:cublasSsymv_v2, libcublas()), cublasStatus_t,
                    (cublasHandle_t, cublasFillMode_t, Cint, RefOrCuRef{Cfloat},
                     CuPtr{Cfloat}, Cint, CuPtr{Cfloat}, Cint, RefOrCuRef{Cfloat},
@@ -984,7 +984,7 @@ end
 end
 
 @checked function cublasDsymv_v2(handle, uplo, n, alpha, A, lda, x, incx, beta, y, incy)
-    initialize_api()
+    initialize_context()
     ccall((:cublasDsymv_v2, libcublas()), cublasStatus_t,
                    (cublasHandle_t, cublasFillMode_t, Cint, RefOrCuRef{Cdouble},
                     CuPtr{Cdouble}, Cint, CuPtr{Cdouble}, Cint, RefOrCuRef{Cdouble},
@@ -993,7 +993,7 @@ end
 end
 
 @checked function cublasCsymv_v2(handle, uplo, n, alpha, A, lda, x, incx, beta, y, incy)
-    initialize_api()
+    initialize_context()
     ccall((:cublasCsymv_v2, libcublas()), cublasStatus_t,
                    (cublasHandle_t, cublasFillMode_t, Cint, RefOrCuRef{cuComplex},
                     CuPtr{cuComplex}, Cint, CuPtr{cuComplex}, Cint, RefOrCuRef{cuComplex},
@@ -1002,7 +1002,7 @@ end
 end
 
 @checked function cublasZsymv_v2(handle, uplo, n, alpha, A, lda, x, incx, beta, y, incy)
-    initialize_api()
+    initialize_context()
     ccall((:cublasZsymv_v2, libcublas()), cublasStatus_t,
                    (cublasHandle_t, cublasFillMode_t, Cint, RefOrCuRef{cuDoubleComplex},
                     CuPtr{cuDoubleComplex}, Cint, CuPtr{cuDoubleComplex}, Cint,
@@ -1011,7 +1011,7 @@ end
 end
 
 @checked function cublasChemv_v2(handle, uplo, n, alpha, A, lda, x, incx, beta, y, incy)
-    initialize_api()
+    initialize_context()
     ccall((:cublasChemv_v2, libcublas()), cublasStatus_t,
                    (cublasHandle_t, cublasFillMode_t, Cint, RefOrCuRef{cuComplex},
                     CuPtr{cuComplex}, Cint, CuPtr{cuComplex}, Cint, RefOrCuRef{cuComplex},
@@ -1020,7 +1020,7 @@ end
 end
 
 @checked function cublasZhemv_v2(handle, uplo, n, alpha, A, lda, x, incx, beta, y, incy)
-    initialize_api()
+    initialize_context()
     ccall((:cublasZhemv_v2, libcublas()), cublasStatus_t,
                    (cublasHandle_t, cublasFillMode_t, Cint, RefOrCuRef{cuDoubleComplex},
                     CuPtr{cuDoubleComplex}, Cint, CuPtr{cuDoubleComplex}, Cint,
@@ -1029,7 +1029,7 @@ end
 end
 
 @checked function cublasSsbmv_v2(handle, uplo, n, k, alpha, A, lda, x, incx, beta, y, incy)
-    initialize_api()
+    initialize_context()
     ccall((:cublasSsbmv_v2, libcublas()), cublasStatus_t,
                    (cublasHandle_t, cublasFillMode_t, Cint, Cint, RefOrCuRef{Cfloat},
                     CuPtr{Cfloat}, Cint, CuPtr{Cfloat}, Cint, RefOrCuRef{Cfloat},
@@ -1038,7 +1038,7 @@ end
 end
 
 @checked function cublasDsbmv_v2(handle, uplo, n, k, alpha, A, lda, x, incx, beta, y, incy)
-    initialize_api()
+    initialize_context()
     ccall((:cublasDsbmv_v2, libcublas()), cublasStatus_t,
                    (cublasHandle_t, cublasFillMode_t, Cint, Cint, RefOrCuRef{Cdouble},
                     CuPtr{Cdouble}, Cint, CuPtr{Cdouble}, Cint, RefOrCuRef{Cdouble},
@@ -1047,7 +1047,7 @@ end
 end
 
 @checked function cublasChbmv_v2(handle, uplo, n, k, alpha, A, lda, x, incx, beta, y, incy)
-    initialize_api()
+    initialize_context()
     ccall((:cublasChbmv_v2, libcublas()), cublasStatus_t,
                    (cublasHandle_t, cublasFillMode_t, Cint, Cint, RefOrCuRef{cuComplex},
                     CuPtr{cuComplex}, Cint, CuPtr{cuComplex}, Cint, RefOrCuRef{cuComplex},
@@ -1056,7 +1056,7 @@ end
 end
 
 @checked function cublasZhbmv_v2(handle, uplo, n, k, alpha, A, lda, x, incx, beta, y, incy)
-    initialize_api()
+    initialize_context()
     ccall((:cublasZhbmv_v2, libcublas()), cublasStatus_t,
                    (cublasHandle_t, cublasFillMode_t, Cint, Cint,
                     RefOrCuRef{cuDoubleComplex}, CuPtr{cuDoubleComplex}, Cint,
@@ -1066,7 +1066,7 @@ end
 end
 
 @checked function cublasSspmv_v2(handle, uplo, n, alpha, AP, x, incx, beta, y, incy)
-    initialize_api()
+    initialize_context()
     ccall((:cublasSspmv_v2, libcublas()), cublasStatus_t,
                    (cublasHandle_t, cublasFillMode_t, Cint, RefOrCuRef{Cfloat},
                     CuPtr{Cfloat}, CuPtr{Cfloat}, Cint, RefOrCuRef{Cfloat}, CuPtr{Cfloat},
@@ -1075,7 +1075,7 @@ end
 end
 
 @checked function cublasDspmv_v2(handle, uplo, n, alpha, AP, x, incx, beta, y, incy)
-    initialize_api()
+    initialize_context()
     ccall((:cublasDspmv_v2, libcublas()), cublasStatus_t,
                    (cublasHandle_t, cublasFillMode_t, Cint, RefOrCuRef{Cdouble},
                     CuPtr{Cdouble}, CuPtr{Cdouble}, Cint, RefOrCuRef{Cdouble},
@@ -1084,7 +1084,7 @@ end
 end
 
 @checked function cublasChpmv_v2(handle, uplo, n, alpha, AP, x, incx, beta, y, incy)
-    initialize_api()
+    initialize_context()
     ccall((:cublasChpmv_v2, libcublas()), cublasStatus_t,
                    (cublasHandle_t, cublasFillMode_t, Cint, RefOrCuRef{cuComplex},
                     CuPtr{cuComplex}, CuPtr{cuComplex}, Cint, RefOrCuRef{cuComplex},
@@ -1093,7 +1093,7 @@ end
 end
 
 @checked function cublasZhpmv_v2(handle, uplo, n, alpha, AP, x, incx, beta, y, incy)
-    initialize_api()
+    initialize_context()
     ccall((:cublasZhpmv_v2, libcublas()), cublasStatus_t,
                    (cublasHandle_t, cublasFillMode_t, Cint, RefOrCuRef{cuDoubleComplex},
                     CuPtr{cuDoubleComplex}, CuPtr{cuDoubleComplex}, Cint,
@@ -1102,7 +1102,7 @@ end
 end
 
 @checked function cublasSger_v2(handle, m, n, alpha, x, incx, y, incy, A, lda)
-    initialize_api()
+    initialize_context()
     ccall((:cublasSger_v2, libcublas()), cublasStatus_t,
                    (cublasHandle_t, Cint, Cint, RefOrCuRef{Cfloat}, CuPtr{Cfloat}, Cint,
                     CuPtr{Cfloat}, Cint, CuPtr{Cfloat}, Cint),
@@ -1110,7 +1110,7 @@ end
 end
 
 @checked function cublasDger_v2(handle, m, n, alpha, x, incx, y, incy, A, lda)
-    initialize_api()
+    initialize_context()
     ccall((:cublasDger_v2, libcublas()), cublasStatus_t,
                    (cublasHandle_t, Cint, Cint, RefOrCuRef{Cdouble}, CuPtr{Cdouble}, Cint,
                     CuPtr{Cdouble}, Cint, CuPtr{Cdouble}, Cint),
@@ -1118,7 +1118,7 @@ end
 end
 
 @checked function cublasCgeru_v2(handle, m, n, alpha, x, incx, y, incy, A, lda)
-    initialize_api()
+    initialize_context()
     ccall((:cublasCgeru_v2, libcublas()), cublasStatus_t,
                    (cublasHandle_t, Cint, Cint, RefOrCuRef{cuComplex}, CuPtr{cuComplex},
                     Cint, CuPtr{cuComplex}, Cint, CuPtr{cuComplex}, Cint),
@@ -1126,7 +1126,7 @@ end
 end
 
 @checked function cublasCgerc_v2(handle, m, n, alpha, x, incx, y, incy, A, lda)
-    initialize_api()
+    initialize_context()
     ccall((:cublasCgerc_v2, libcublas()), cublasStatus_t,
                    (cublasHandle_t, Cint, Cint, RefOrCuRef{cuComplex}, CuPtr{cuComplex},
                     Cint, CuPtr{cuComplex}, Cint, CuPtr{cuComplex}, Cint),
@@ -1134,7 +1134,7 @@ end
 end
 
 @checked function cublasZgeru_v2(handle, m, n, alpha, x, incx, y, incy, A, lda)
-    initialize_api()
+    initialize_context()
     ccall((:cublasZgeru_v2, libcublas()), cublasStatus_t,
                    (cublasHandle_t, Cint, Cint, RefOrCuRef{cuDoubleComplex},
                     CuPtr{cuDoubleComplex}, Cint, CuPtr{cuDoubleComplex}, Cint,
@@ -1143,7 +1143,7 @@ end
 end
 
 @checked function cublasZgerc_v2(handle, m, n, alpha, x, incx, y, incy, A, lda)
-    initialize_api()
+    initialize_context()
     ccall((:cublasZgerc_v2, libcublas()), cublasStatus_t,
                    (cublasHandle_t, Cint, Cint, RefOrCuRef{cuDoubleComplex},
                     CuPtr{cuDoubleComplex}, Cint, CuPtr{cuDoubleComplex}, Cint,
@@ -1152,7 +1152,7 @@ end
 end
 
 @checked function cublasSsyr_v2(handle, uplo, n, alpha, x, incx, A, lda)
-    initialize_api()
+    initialize_context()
     ccall((:cublasSsyr_v2, libcublas()), cublasStatus_t,
                    (cublasHandle_t, cublasFillMode_t, Cint, RefOrCuRef{Cfloat},
                     CuPtr{Cfloat}, Cint, CuPtr{Cfloat}, Cint),
@@ -1160,7 +1160,7 @@ end
 end
 
 @checked function cublasDsyr_v2(handle, uplo, n, alpha, x, incx, A, lda)
-    initialize_api()
+    initialize_context()
     ccall((:cublasDsyr_v2, libcublas()), cublasStatus_t,
                    (cublasHandle_t, cublasFillMode_t, Cint, RefOrCuRef{Cdouble},
                     CuPtr{Cdouble}, Cint, CuPtr{Cdouble}, Cint),
@@ -1168,7 +1168,7 @@ end
 end
 
 @checked function cublasCsyr_v2(handle, uplo, n, alpha, x, incx, A, lda)
-    initialize_api()
+    initialize_context()
     ccall((:cublasCsyr_v2, libcublas()), cublasStatus_t,
                    (cublasHandle_t, cublasFillMode_t, Cint, RefOrCuRef{cuComplex},
                     CuPtr{cuComplex}, Cint, CuPtr{cuComplex}, Cint),
@@ -1176,7 +1176,7 @@ end
 end
 
 @checked function cublasZsyr_v2(handle, uplo, n, alpha, x, incx, A, lda)
-    initialize_api()
+    initialize_context()
     ccall((:cublasZsyr_v2, libcublas()), cublasStatus_t,
                    (cublasHandle_t, cublasFillMode_t, Cint, RefOrCuRef{cuDoubleComplex},
                     CuPtr{cuDoubleComplex}, Cint, CuPtr{cuDoubleComplex}, Cint),
@@ -1184,7 +1184,7 @@ end
 end
 
 @checked function cublasCher_v2(handle, uplo, n, alpha, x, incx, A, lda)
-    initialize_api()
+    initialize_context()
     ccall((:cublasCher_v2, libcublas()), cublasStatus_t,
                    (cublasHandle_t, cublasFillMode_t, Cint, RefOrCuRef{Cfloat},
                     CuPtr{cuComplex}, Cint, CuPtr{cuComplex}, Cint),
@@ -1192,7 +1192,7 @@ end
 end
 
 @checked function cublasZher_v2(handle, uplo, n, alpha, x, incx, A, lda)
-    initialize_api()
+    initialize_context()
     ccall((:cublasZher_v2, libcublas()), cublasStatus_t,
                    (cublasHandle_t, cublasFillMode_t, Cint, RefOrCuRef{Cdouble},
                     CuPtr{cuDoubleComplex}, Cint, CuPtr{cuDoubleComplex}, Cint),
@@ -1200,7 +1200,7 @@ end
 end
 
 @checked function cublasSspr_v2(handle, uplo, n, alpha, x, incx, AP)
-    initialize_api()
+    initialize_context()
     ccall((:cublasSspr_v2, libcublas()), cublasStatus_t,
                    (cublasHandle_t, cublasFillMode_t, Cint, RefOrCuRef{Cfloat},
                     CuPtr{Cfloat}, Cint, CuPtr{Cfloat}),
@@ -1208,7 +1208,7 @@ end
 end
 
 @checked function cublasDspr_v2(handle, uplo, n, alpha, x, incx, AP)
-    initialize_api()
+    initialize_context()
     ccall((:cublasDspr_v2, libcublas()), cublasStatus_t,
                    (cublasHandle_t, cublasFillMode_t, Cint, RefOrCuRef{Cdouble},
                     CuPtr{Cdouble}, Cint, CuPtr{Cdouble}),
@@ -1216,7 +1216,7 @@ end
 end
 
 @checked function cublasChpr_v2(handle, uplo, n, alpha, x, incx, AP)
-    initialize_api()
+    initialize_context()
     ccall((:cublasChpr_v2, libcublas()), cublasStatus_t,
                    (cublasHandle_t, cublasFillMode_t, Cint, RefOrCuRef{Cfloat},
                     CuPtr{cuComplex}, Cint, CuPtr{cuComplex}),
@@ -1224,7 +1224,7 @@ end
 end
 
 @checked function cublasZhpr_v2(handle, uplo, n, alpha, x, incx, AP)
-    initialize_api()
+    initialize_context()
     ccall((:cublasZhpr_v2, libcublas()), cublasStatus_t,
                    (cublasHandle_t, cublasFillMode_t, Cint, RefOrCuRef{Cdouble},
                     CuPtr{cuDoubleComplex}, Cint, CuPtr{cuDoubleComplex}),
@@ -1232,7 +1232,7 @@ end
 end
 
 @checked function cublasSsyr2_v2(handle, uplo, n, alpha, x, incx, y, incy, A, lda)
-    initialize_api()
+    initialize_context()
     ccall((:cublasSsyr2_v2, libcublas()), cublasStatus_t,
                    (cublasHandle_t, cublasFillMode_t, Cint, RefOrCuRef{Cfloat},
                     CuPtr{Cfloat}, Cint, CuPtr{Cfloat}, Cint, CuPtr{Cfloat}, Cint),
@@ -1240,7 +1240,7 @@ end
 end
 
 @checked function cublasDsyr2_v2(handle, uplo, n, alpha, x, incx, y, incy, A, lda)
-    initialize_api()
+    initialize_context()
     ccall((:cublasDsyr2_v2, libcublas()), cublasStatus_t,
                    (cublasHandle_t, cublasFillMode_t, Cint, RefOrCuRef{Cdouble},
                     CuPtr{Cdouble}, Cint, CuPtr{Cdouble}, Cint, CuPtr{Cdouble}, Cint),
@@ -1248,7 +1248,7 @@ end
 end
 
 @checked function cublasCsyr2_v2(handle, uplo, n, alpha, x, incx, y, incy, A, lda)
-    initialize_api()
+    initialize_context()
     ccall((:cublasCsyr2_v2, libcublas()), cublasStatus_t,
                    (cublasHandle_t, cublasFillMode_t, Cint, RefOrCuRef{cuComplex},
                     CuPtr{cuComplex}, Cint, CuPtr{cuComplex}, Cint, CuPtr{cuComplex}, Cint),
@@ -1256,7 +1256,7 @@ end
 end
 
 @checked function cublasZsyr2_v2(handle, uplo, n, alpha, x, incx, y, incy, A, lda)
-    initialize_api()
+    initialize_context()
     ccall((:cublasZsyr2_v2, libcublas()), cublasStatus_t,
                    (cublasHandle_t, cublasFillMode_t, Cint, RefOrCuRef{cuDoubleComplex},
                     CuPtr{cuDoubleComplex}, Cint, CuPtr{cuDoubleComplex}, Cint,
@@ -1265,7 +1265,7 @@ end
 end
 
 @checked function cublasCher2_v2(handle, uplo, n, alpha, x, incx, y, incy, A, lda)
-    initialize_api()
+    initialize_context()
     ccall((:cublasCher2_v2, libcublas()), cublasStatus_t,
                    (cublasHandle_t, cublasFillMode_t, Cint, RefOrCuRef{cuComplex},
                     CuPtr{cuComplex}, Cint, CuPtr{cuComplex}, Cint, CuPtr{cuComplex}, Cint),
@@ -1273,7 +1273,7 @@ end
 end
 
 @checked function cublasZher2_v2(handle, uplo, n, alpha, x, incx, y, incy, A, lda)
-    initialize_api()
+    initialize_context()
     ccall((:cublasZher2_v2, libcublas()), cublasStatus_t,
                    (cublasHandle_t, cublasFillMode_t, Cint, RefOrCuRef{cuDoubleComplex},
                     CuPtr{cuDoubleComplex}, Cint, CuPtr{cuDoubleComplex}, Cint,
@@ -1282,7 +1282,7 @@ end
 end
 
 @checked function cublasSspr2_v2(handle, uplo, n, alpha, x, incx, y, incy, AP)
-    initialize_api()
+    initialize_context()
     ccall((:cublasSspr2_v2, libcublas()), cublasStatus_t,
                    (cublasHandle_t, cublasFillMode_t, Cint, RefOrCuRef{Cfloat},
                     CuPtr{Cfloat}, Cint, CuPtr{Cfloat}, Cint, CuPtr{Cfloat}),
@@ -1290,7 +1290,7 @@ end
 end
 
 @checked function cublasDspr2_v2(handle, uplo, n, alpha, x, incx, y, incy, AP)
-    initialize_api()
+    initialize_context()
     ccall((:cublasDspr2_v2, libcublas()), cublasStatus_t,
                    (cublasHandle_t, cublasFillMode_t, Cint, RefOrCuRef{Cdouble},
                     CuPtr{Cdouble}, Cint, CuPtr{Cdouble}, Cint, CuPtr{Cdouble}),
@@ -1298,7 +1298,7 @@ end
 end
 
 @checked function cublasChpr2_v2(handle, uplo, n, alpha, x, incx, y, incy, AP)
-    initialize_api()
+    initialize_context()
     ccall((:cublasChpr2_v2, libcublas()), cublasStatus_t,
                    (cublasHandle_t, cublasFillMode_t, Cint, RefOrCuRef{cuComplex},
                     CuPtr{cuComplex}, Cint, CuPtr{cuComplex}, Cint, CuPtr{cuComplex}),
@@ -1306,7 +1306,7 @@ end
 end
 
 @checked function cublasZhpr2_v2(handle, uplo, n, alpha, x, incx, y, incy, AP)
-    initialize_api()
+    initialize_context()
     ccall((:cublasZhpr2_v2, libcublas()), cublasStatus_t,
                    (cublasHandle_t, cublasFillMode_t, Cint, RefOrCuRef{cuDoubleComplex},
                     CuPtr{cuDoubleComplex}, Cint, CuPtr{cuDoubleComplex}, Cint,
@@ -1316,7 +1316,7 @@ end
 
 @checked function cublasSgemm_v2(handle, transa, transb, m, n, k, alpha, A, lda, B, ldb,
                                  beta, C, ldc)
-    initialize_api()
+    initialize_context()
     ccall((:cublasSgemm_v2, libcublas()), cublasStatus_t,
                    (cublasHandle_t, cublasOperation_t, cublasOperation_t, Cint, Cint,
                     Cint, RefOrCuRef{Cfloat}, CuPtr{Cfloat}, Cint, CuPtr{Cfloat}, Cint,
@@ -1326,7 +1326,7 @@ end
 
 @checked function cublasDgemm_v2(handle, transa, transb, m, n, k, alpha, A, lda, B, ldb,
                                  beta, C, ldc)
-    initialize_api()
+    initialize_context()
     ccall((:cublasDgemm_v2, libcublas()), cublasStatus_t,
                    (cublasHandle_t, cublasOperation_t, cublasOperation_t, Cint, Cint,
                     Cint, RefOrCuRef{Cdouble}, CuPtr{Cdouble}, Cint, CuPtr{Cdouble}, Cint,
@@ -1336,7 +1336,7 @@ end
 
 @checked function cublasCgemm_v2(handle, transa, transb, m, n, k, alpha, A, lda, B, ldb,
                                  beta, C, ldc)
-    initialize_api()
+    initialize_context()
     ccall((:cublasCgemm_v2, libcublas()), cublasStatus_t,
                    (cublasHandle_t, cublasOperation_t, cublasOperation_t, Cint, Cint,
                     Cint, RefOrCuRef{cuComplex}, CuPtr{cuComplex}, Cint, CuPtr{cuComplex},
@@ -1346,7 +1346,7 @@ end
 
 @checked function cublasCgemm3m(handle, transa, transb, m, n, k, alpha, A, lda, B, ldb,
                                 beta, C, ldc)
-    initialize_api()
+    initialize_context()
     ccall((:cublasCgemm3m, libcublas()), cublasStatus_t,
                    (cublasHandle_t, cublasOperation_t, cublasOperation_t, Cint, Cint,
                     Cint, RefOrCuRef{cuComplex}, CuPtr{cuComplex}, Cint, CuPtr{cuComplex},
@@ -1356,7 +1356,7 @@ end
 
 @checked function cublasCgemm3mEx(handle, transa, transb, m, n, k, alpha, A, Atype, lda, B,
                                   Btype, ldb, beta, C, Ctype, ldc)
-    initialize_api()
+    initialize_context()
     ccall((:cublasCgemm3mEx, libcublas()), cublasStatus_t,
                    (cublasHandle_t, cublasOperation_t, cublasOperation_t, Cint, Cint,
                     Cint, RefOrCuRef{cuComplex}, CuPtr{Cvoid}, cudaDataType, Cint,
@@ -1368,7 +1368,7 @@ end
 
 @checked function cublasZgemm_v2(handle, transa, transb, m, n, k, alpha, A, lda, B, ldb,
                                  beta, C, ldc)
-    initialize_api()
+    initialize_context()
     ccall((:cublasZgemm_v2, libcublas()), cublasStatus_t,
                    (cublasHandle_t, cublasOperation_t, cublasOperation_t, Cint, Cint,
                     Cint, RefOrCuRef{cuDoubleComplex}, CuPtr{cuDoubleComplex}, Cint,
@@ -1379,7 +1379,7 @@ end
 
 @checked function cublasZgemm3m(handle, transa, transb, m, n, k, alpha, A, lda, B, ldb,
                                 beta, C, ldc)
-    initialize_api()
+    initialize_context()
     ccall((:cublasZgemm3m, libcublas()), cublasStatus_t,
                    (cublasHandle_t, cublasOperation_t, cublasOperation_t, Cint, Cint,
                     Cint, RefOrCuRef{cuDoubleComplex}, CuPtr{cuDoubleComplex}, Cint,
@@ -1390,7 +1390,7 @@ end
 
 @checked function cublasSgemmEx(handle, transa, transb, m, n, k, alpha, A, Atype, lda, B,
                                 Btype, ldb, beta, C, Ctype, ldc)
-    initialize_api()
+    initialize_context()
     ccall((:cublasSgemmEx, libcublas()), cublasStatus_t,
                    (cublasHandle_t, cublasOperation_t, cublasOperation_t, Cint, Cint,
                     Cint, RefOrCuRef{Cfloat}, CuPtr{Cvoid}, cudaDataType, Cint,
@@ -1402,7 +1402,7 @@ end
 
 @checked function cublasGemmEx(handle, transa, transb, m, n, k, alpha, A, Atype, lda, B,
                                Btype, ldb, beta, C, Ctype, ldc, computeType, algo)
-    initialize_api()
+    initialize_context()
     ccall((:cublasGemmEx, libcublas()), cublasStatus_t,
                    (cublasHandle_t, cublasOperation_t, cublasOperation_t, Cint, Cint,
                     Cint, PtrOrCuPtr{Cvoid}, CuPtr{Cvoid}, cudaDataType, Cint,
@@ -1414,7 +1414,7 @@ end
 
 @checked function cublasCgemmEx(handle, transa, transb, m, n, k, alpha, A, Atype, lda, B,
                                 Btype, ldb, beta, C, Ctype, ldc)
-    initialize_api()
+    initialize_context()
     ccall((:cublasCgemmEx, libcublas()), cublasStatus_t,
                    (cublasHandle_t, cublasOperation_t, cublasOperation_t, Cint, Cint,
                     Cint, RefOrCuRef{cuComplex}, CuPtr{Cvoid}, cudaDataType, Cint,
@@ -1426,7 +1426,7 @@ end
 
 @checked function cublasUint8gemmBias(handle, transa, transb, transc, m, n, k, A, A_bias,
                                       lda, B, B_bias, ldb, C, C_bias, ldc, C_mult, C_shift)
-    initialize_api()
+    initialize_context()
     ccall((:cublasUint8gemmBias, libcublas()), cublasStatus_t,
                    (cublasHandle_t, cublasOperation_t, cublasOperation_t,
                     cublasOperation_t, Cint, Cint, Cint, CuPtr{Cuchar}, Cint, Cint,
@@ -1436,7 +1436,7 @@ end
 end
 
 @checked function cublasSsyrk_v2(handle, uplo, trans, n, k, alpha, A, lda, beta, C, ldc)
-    initialize_api()
+    initialize_context()
     ccall((:cublasSsyrk_v2, libcublas()), cublasStatus_t,
                    (cublasHandle_t, cublasFillMode_t, cublasOperation_t, Cint, Cint,
                     RefOrCuRef{Cfloat}, CuPtr{Cfloat}, Cint, RefOrCuRef{Cfloat},
@@ -1445,7 +1445,7 @@ end
 end
 
 @checked function cublasDsyrk_v2(handle, uplo, trans, n, k, alpha, A, lda, beta, C, ldc)
-    initialize_api()
+    initialize_context()
     ccall((:cublasDsyrk_v2, libcublas()), cublasStatus_t,
                    (cublasHandle_t, cublasFillMode_t, cublasOperation_t, Cint, Cint,
                     RefOrCuRef{Cdouble}, CuPtr{Cdouble}, Cint, RefOrCuRef{Cdouble},
@@ -1454,7 +1454,7 @@ end
 end
 
 @checked function cublasCsyrk_v2(handle, uplo, trans, n, k, alpha, A, lda, beta, C, ldc)
-    initialize_api()
+    initialize_context()
     ccall((:cublasCsyrk_v2, libcublas()), cublasStatus_t,
                    (cublasHandle_t, cublasFillMode_t, cublasOperation_t, Cint, Cint,
                     RefOrCuRef{cuComplex}, CuPtr{cuComplex}, Cint, RefOrCuRef{cuComplex},
@@ -1463,7 +1463,7 @@ end
 end
 
 @checked function cublasZsyrk_v2(handle, uplo, trans, n, k, alpha, A, lda, beta, C, ldc)
-    initialize_api()
+    initialize_context()
     ccall((:cublasZsyrk_v2, libcublas()), cublasStatus_t,
                    (cublasHandle_t, cublasFillMode_t, cublasOperation_t, Cint, Cint,
                     RefOrCuRef{cuDoubleComplex}, CuPtr{cuDoubleComplex}, Cint,
@@ -1473,7 +1473,7 @@ end
 
 @checked function cublasCsyrkEx(handle, uplo, trans, n, k, alpha, A, Atype, lda, beta, C,
                                 Ctype, ldc)
-    initialize_api()
+    initialize_context()
     ccall((:cublasCsyrkEx, libcublas()), cublasStatus_t,
                    (cublasHandle_t, cublasFillMode_t, cublasOperation_t, Cint, Cint,
                     RefOrCuRef{cuComplex}, CuPtr{Cvoid}, cudaDataType, Cint,
@@ -1483,7 +1483,7 @@ end
 
 @checked function cublasCsyrk3mEx(handle, uplo, trans, n, k, alpha, A, Atype, lda, beta, C,
                                   Ctype, ldc)
-    initialize_api()
+    initialize_context()
     ccall((:cublasCsyrk3mEx, libcublas()), cublasStatus_t,
                    (cublasHandle_t, cublasFillMode_t, cublasOperation_t, Cint, Cint,
                     RefOrCuRef{cuComplex}, CuPtr{Cvoid}, cudaDataType, Cint,
@@ -1492,7 +1492,7 @@ end
 end
 
 @checked function cublasCherk_v2(handle, uplo, trans, n, k, alpha, A, lda, beta, C, ldc)
-    initialize_api()
+    initialize_context()
     ccall((:cublasCherk_v2, libcublas()), cublasStatus_t,
                    (cublasHandle_t, cublasFillMode_t, cublasOperation_t, Cint, Cint,
                     RefOrCuRef{Cfloat}, CuPtr{cuComplex}, Cint, RefOrCuRef{Cfloat},
@@ -1501,7 +1501,7 @@ end
 end
 
 @checked function cublasZherk_v2(handle, uplo, trans, n, k, alpha, A, lda, beta, C, ldc)
-    initialize_api()
+    initialize_context()
     ccall((:cublasZherk_v2, libcublas()), cublasStatus_t,
                    (cublasHandle_t, cublasFillMode_t, cublasOperation_t, Cint, Cint,
                     RefOrCuRef{Cdouble}, CuPtr{cuDoubleComplex}, Cint, RefOrCuRef{Cdouble},
@@ -1511,7 +1511,7 @@ end
 
 @checked function cublasCherkEx(handle, uplo, trans, n, k, alpha, A, Atype, lda, beta, C,
                                 Ctype, ldc)
-    initialize_api()
+    initialize_context()
     ccall((:cublasCherkEx, libcublas()), cublasStatus_t,
                    (cublasHandle_t, cublasFillMode_t, cublasOperation_t, Cint, Cint,
                     RefOrCuRef{Cfloat}, CuPtr{Cvoid}, cudaDataType, Cint,
@@ -1521,7 +1521,7 @@ end
 
 @checked function cublasCherk3mEx(handle, uplo, trans, n, k, alpha, A, Atype, lda, beta, C,
                                   Ctype, ldc)
-    initialize_api()
+    initialize_context()
     ccall((:cublasCherk3mEx, libcublas()), cublasStatus_t,
                    (cublasHandle_t, cublasFillMode_t, cublasOperation_t, Cint, Cint,
                     RefOrCuRef{Cfloat}, CuPtr{Cvoid}, cudaDataType, Cint,
@@ -1531,7 +1531,7 @@ end
 
 @checked function cublasSsyr2k_v2(handle, uplo, trans, n, k, alpha, A, lda, B, ldb, beta,
                                   C, ldc)
-    initialize_api()
+    initialize_context()
     ccall((:cublasSsyr2k_v2, libcublas()), cublasStatus_t,
                    (cublasHandle_t, cublasFillMode_t, cublasOperation_t, Cint, Cint,
                     RefOrCuRef{Cfloat}, CuPtr{Cfloat}, Cint, CuPtr{Cfloat}, Cint,
@@ -1541,7 +1541,7 @@ end
 
 @checked function cublasDsyr2k_v2(handle, uplo, trans, n, k, alpha, A, lda, B, ldb, beta,
                                   C, ldc)
-    initialize_api()
+    initialize_context()
     ccall((:cublasDsyr2k_v2, libcublas()), cublasStatus_t,
                    (cublasHandle_t, cublasFillMode_t, cublasOperation_t, Cint, Cint,
                     RefOrCuRef{Cdouble}, CuPtr{Cdouble}, Cint, CuPtr{Cdouble}, Cint,
@@ -1551,7 +1551,7 @@ end
 
 @checked function cublasCsyr2k_v2(handle, uplo, trans, n, k, alpha, A, lda, B, ldb, beta,
                                   C, ldc)
-    initialize_api()
+    initialize_context()
     ccall((:cublasCsyr2k_v2, libcublas()), cublasStatus_t,
                    (cublasHandle_t, cublasFillMode_t, cublasOperation_t, Cint, Cint,
                     RefOrCuRef{cuComplex}, CuPtr{cuComplex}, Cint, CuPtr{cuComplex}, Cint,
@@ -1561,7 +1561,7 @@ end
 
 @checked function cublasZsyr2k_v2(handle, uplo, trans, n, k, alpha, A, lda, B, ldb, beta,
                                   C, ldc)
-    initialize_api()
+    initialize_context()
     ccall((:cublasZsyr2k_v2, libcublas()), cublasStatus_t,
                    (cublasHandle_t, cublasFillMode_t, cublasOperation_t, Cint, Cint,
                     RefOrCuRef{cuDoubleComplex}, CuPtr{cuDoubleComplex}, Cint,
@@ -1572,7 +1572,7 @@ end
 
 @checked function cublasCher2k_v2(handle, uplo, trans, n, k, alpha, A, lda, B, ldb, beta,
                                   C, ldc)
-    initialize_api()
+    initialize_context()
     ccall((:cublasCher2k_v2, libcublas()), cublasStatus_t,
                    (cublasHandle_t, cublasFillMode_t, cublasOperation_t, Cint, Cint,
                     RefOrCuRef{cuComplex}, CuPtr{cuComplex}, Cint, CuPtr{cuComplex}, Cint,
@@ -1582,7 +1582,7 @@ end
 
 @checked function cublasZher2k_v2(handle, uplo, trans, n, k, alpha, A, lda, B, ldb, beta,
                                   C, ldc)
-    initialize_api()
+    initialize_context()
     ccall((:cublasZher2k_v2, libcublas()), cublasStatus_t,
                    (cublasHandle_t, cublasFillMode_t, cublasOperation_t, Cint, Cint,
                     RefOrCuRef{cuDoubleComplex}, CuPtr{cuDoubleComplex}, Cint,
@@ -1593,7 +1593,7 @@ end
 
 @checked function cublasSsyrkx(handle, uplo, trans, n, k, alpha, A, lda, B, ldb, beta, C,
                                ldc)
-    initialize_api()
+    initialize_context()
     ccall((:cublasSsyrkx, libcublas()), cublasStatus_t,
                    (cublasHandle_t, cublasFillMode_t, cublasOperation_t, Cint, Cint,
                     RefOrCuRef{Cfloat}, CuPtr{Cfloat}, Cint, CuPtr{Cfloat}, Cint,
@@ -1603,7 +1603,7 @@ end
 
 @checked function cublasDsyrkx(handle, uplo, trans, n, k, alpha, A, lda, B, ldb, beta, C,
                                ldc)
-    initialize_api()
+    initialize_context()
     ccall((:cublasDsyrkx, libcublas()), cublasStatus_t,
                    (cublasHandle_t, cublasFillMode_t, cublasOperation_t, Cint, Cint,
                     RefOrCuRef{Cdouble}, CuPtr{Cdouble}, Cint, CuPtr{Cdouble}, Cint,
@@ -1613,7 +1613,7 @@ end
 
 @checked function cublasCsyrkx(handle, uplo, trans, n, k, alpha, A, lda, B, ldb, beta, C,
                                ldc)
-    initialize_api()
+    initialize_context()
     ccall((:cublasCsyrkx, libcublas()), cublasStatus_t,
                    (cublasHandle_t, cublasFillMode_t, cublasOperation_t, Cint, Cint,
                     RefOrCuRef{cuComplex}, CuPtr{cuComplex}, Cint, CuPtr{cuComplex}, Cint,
@@ -1623,7 +1623,7 @@ end
 
 @checked function cublasZsyrkx(handle, uplo, trans, n, k, alpha, A, lda, B, ldb, beta, C,
                                ldc)
-    initialize_api()
+    initialize_context()
     ccall((:cublasZsyrkx, libcublas()), cublasStatus_t,
                    (cublasHandle_t, cublasFillMode_t, cublasOperation_t, Cint, Cint,
                     RefOrCuRef{cuDoubleComplex}, CuPtr{cuDoubleComplex}, Cint,
@@ -1634,7 +1634,7 @@ end
 
 @checked function cublasCherkx(handle, uplo, trans, n, k, alpha, A, lda, B, ldb, beta, C,
                                ldc)
-    initialize_api()
+    initialize_context()
     ccall((:cublasCherkx, libcublas()), cublasStatus_t,
                    (cublasHandle_t, cublasFillMode_t, cublasOperation_t, Cint, Cint,
                     RefOrCuRef{cuComplex}, CuPtr{cuComplex}, Cint, CuPtr{cuComplex}, Cint,
@@ -1644,7 +1644,7 @@ end
 
 @checked function cublasZherkx(handle, uplo, trans, n, k, alpha, A, lda, B, ldb, beta, C,
                                ldc)
-    initialize_api()
+    initialize_context()
     ccall((:cublasZherkx, libcublas()), cublasStatus_t,
                    (cublasHandle_t, cublasFillMode_t, cublasOperation_t, Cint, Cint,
                     RefOrCuRef{cuDoubleComplex}, CuPtr{cuDoubleComplex}, Cint,
@@ -1655,7 +1655,7 @@ end
 
 @checked function cublasSsymm_v2(handle, side, uplo, m, n, alpha, A, lda, B, ldb, beta, C,
                                  ldc)
-    initialize_api()
+    initialize_context()
     ccall((:cublasSsymm_v2, libcublas()), cublasStatus_t,
                    (cublasHandle_t, cublasSideMode_t, cublasFillMode_t, Cint, Cint,
                     RefOrCuRef{Cfloat}, CuPtr{Cfloat}, Cint, CuPtr{Cfloat}, Cint,
@@ -1665,7 +1665,7 @@ end
 
 @checked function cublasDsymm_v2(handle, side, uplo, m, n, alpha, A, lda, B, ldb, beta, C,
                                  ldc)
-    initialize_api()
+    initialize_context()
     ccall((:cublasDsymm_v2, libcublas()), cublasStatus_t,
                    (cublasHandle_t, cublasSideMode_t, cublasFillMode_t, Cint, Cint,
                     RefOrCuRef{Cdouble}, CuPtr{Cdouble}, Cint, CuPtr{Cdouble}, Cint,
@@ -1675,7 +1675,7 @@ end
 
 @checked function cublasCsymm_v2(handle, side, uplo, m, n, alpha, A, lda, B, ldb, beta, C,
                                  ldc)
-    initialize_api()
+    initialize_context()
     ccall((:cublasCsymm_v2, libcublas()), cublasStatus_t,
                    (cublasHandle_t, cublasSideMode_t, cublasFillMode_t, Cint, Cint,
                     RefOrCuRef{cuComplex}, CuPtr{cuComplex}, Cint, CuPtr{cuComplex}, Cint,
@@ -1685,7 +1685,7 @@ end
 
 @checked function cublasZsymm_v2(handle, side, uplo, m, n, alpha, A, lda, B, ldb, beta, C,
                                  ldc)
-    initialize_api()
+    initialize_context()
     ccall((:cublasZsymm_v2, libcublas()), cublasStatus_t,
                    (cublasHandle_t, cublasSideMode_t, cublasFillMode_t, Cint, Cint,
                     RefOrCuRef{cuDoubleComplex}, CuPtr{cuDoubleComplex}, Cint,
@@ -1696,7 +1696,7 @@ end
 
 @checked function cublasChemm_v2(handle, side, uplo, m, n, alpha, A, lda, B, ldb, beta, C,
                                  ldc)
-    initialize_api()
+    initialize_context()
     ccall((:cublasChemm_v2, libcublas()), cublasStatus_t,
                    (cublasHandle_t, cublasSideMode_t, cublasFillMode_t, Cint, Cint,
                     RefOrCuRef{cuComplex}, CuPtr{cuComplex}, Cint, CuPtr{cuComplex}, Cint,
@@ -1706,7 +1706,7 @@ end
 
 @checked function cublasZhemm_v2(handle, side, uplo, m, n, alpha, A, lda, B, ldb, beta, C,
                                  ldc)
-    initialize_api()
+    initialize_context()
     ccall((:cublasZhemm_v2, libcublas()), cublasStatus_t,
                    (cublasHandle_t, cublasSideMode_t, cublasFillMode_t, Cint, Cint,
                     RefOrCuRef{cuDoubleComplex}, CuPtr{cuDoubleComplex}, Cint,
@@ -1717,7 +1717,7 @@ end
 
 @checked function cublasStrsm_v2(handle, side, uplo, trans, diag, m, n, alpha, A, lda, B,
                                  ldb)
-    initialize_api()
+    initialize_context()
     ccall((:cublasStrsm_v2, libcublas()), cublasStatus_t,
                    (cublasHandle_t, cublasSideMode_t, cublasFillMode_t, cublasOperation_t,
                     cublasDiagType_t, Cint, Cint, RefOrCuRef{Cfloat}, CuPtr{Cfloat}, Cint,
@@ -1727,7 +1727,7 @@ end
 
 @checked function cublasDtrsm_v2(handle, side, uplo, trans, diag, m, n, alpha, A, lda, B,
                                  ldb)
-    initialize_api()
+    initialize_context()
     ccall((:cublasDtrsm_v2, libcublas()), cublasStatus_t,
                    (cublasHandle_t, cublasSideMode_t, cublasFillMode_t, cublasOperation_t,
                     cublasDiagType_t, Cint, Cint, RefOrCuRef{Cdouble}, CuPtr{Cdouble},
@@ -1737,7 +1737,7 @@ end
 
 @checked function cublasCtrsm_v2(handle, side, uplo, trans, diag, m, n, alpha, A, lda, B,
                                  ldb)
-    initialize_api()
+    initialize_context()
     ccall((:cublasCtrsm_v2, libcublas()), cublasStatus_t,
                    (cublasHandle_t, cublasSideMode_t, cublasFillMode_t, cublasOperation_t,
                     cublasDiagType_t, Cint, Cint, RefOrCuRef{cuComplex}, CuPtr{cuComplex},
@@ -1747,7 +1747,7 @@ end
 
 @checked function cublasZtrsm_v2(handle, side, uplo, trans, diag, m, n, alpha, A, lda, B,
                                  ldb)
-    initialize_api()
+    initialize_context()
     ccall((:cublasZtrsm_v2, libcublas()), cublasStatus_t,
                    (cublasHandle_t, cublasSideMode_t, cublasFillMode_t, cublasOperation_t,
                     cublasDiagType_t, Cint, Cint, RefOrCuRef{cuDoubleComplex},
@@ -1757,7 +1757,7 @@ end
 
 @checked function cublasStrmm_v2(handle, side, uplo, trans, diag, m, n, alpha, A, lda, B,
                                  ldb, C, ldc)
-    initialize_api()
+    initialize_context()
     ccall((:cublasStrmm_v2, libcublas()), cublasStatus_t,
                    (cublasHandle_t, cublasSideMode_t, cublasFillMode_t, cublasOperation_t,
                     cublasDiagType_t, Cint, Cint, RefOrCuRef{Cfloat}, CuPtr{Cfloat}, Cint,
@@ -1767,7 +1767,7 @@ end
 
 @checked function cublasDtrmm_v2(handle, side, uplo, trans, diag, m, n, alpha, A, lda, B,
                                  ldb, C, ldc)
-    initialize_api()
+    initialize_context()
     ccall((:cublasDtrmm_v2, libcublas()), cublasStatus_t,
                    (cublasHandle_t, cublasSideMode_t, cublasFillMode_t, cublasOperation_t,
                     cublasDiagType_t, Cint, Cint, RefOrCuRef{Cdouble}, CuPtr{Cdouble},
@@ -1777,7 +1777,7 @@ end
 
 @checked function cublasCtrmm_v2(handle, side, uplo, trans, diag, m, n, alpha, A, lda, B,
                                  ldb, C, ldc)
-    initialize_api()
+    initialize_context()
     ccall((:cublasCtrmm_v2, libcublas()), cublasStatus_t,
                    (cublasHandle_t, cublasSideMode_t, cublasFillMode_t, cublasOperation_t,
                     cublasDiagType_t, Cint, Cint, RefOrCuRef{cuComplex}, CuPtr{cuComplex},
@@ -1787,7 +1787,7 @@ end
 
 @checked function cublasZtrmm_v2(handle, side, uplo, trans, diag, m, n, alpha, A, lda, B,
                                  ldb, C, ldc)
-    initialize_api()
+    initialize_context()
     ccall((:cublasZtrmm_v2, libcublas()), cublasStatus_t,
                    (cublasHandle_t, cublasSideMode_t, cublasFillMode_t, cublasOperation_t,
                     cublasDiagType_t, Cint, Cint, RefOrCuRef{cuDoubleComplex},
@@ -1798,7 +1798,7 @@ end
 
 @checked function cublasHgemmBatched(handle, transa, transb, m, n, k, alpha, Aarray, lda,
                                      Barray, ldb, beta, Carray, ldc, batchCount)
-    initialize_api()
+    initialize_context()
     ccall((:cublasHgemmBatched, libcublas()), cublasStatus_t,
                    (cublasHandle_t, cublasOperation_t, cublasOperation_t, Cint, Cint,
                     Cint, RefOrCuRef{Float16}, CuPtr{Ptr{Float16}}, Cint, CuPtr{Ptr{Float16}},
@@ -1809,7 +1809,7 @@ end
 
 @checked function cublasSgemmBatched(handle, transa, transb, m, n, k, alpha, Aarray, lda,
                                      Barray, ldb, beta, Carray, ldc, batchCount)
-    initialize_api()
+    initialize_context()
     ccall((:cublasSgemmBatched, libcublas()), cublasStatus_t,
                    (cublasHandle_t, cublasOperation_t, cublasOperation_t, Cint, Cint,
                     Cint, RefOrCuRef{Cfloat}, CuPtr{Ptr{Cfloat}}, Cint, CuPtr{Ptr{Cfloat}},
@@ -1820,7 +1820,7 @@ end
 
 @checked function cublasDgemmBatched(handle, transa, transb, m, n, k, alpha, Aarray, lda,
                                      Barray, ldb, beta, Carray, ldc, batchCount)
-    initialize_api()
+    initialize_context()
     ccall((:cublasDgemmBatched, libcublas()), cublasStatus_t,
                    (cublasHandle_t, cublasOperation_t, cublasOperation_t, Cint, Cint,
                     Cint, RefOrCuRef{Cdouble}, CuPtr{Ptr{Cdouble}}, Cint,
@@ -1832,7 +1832,7 @@ end
 
 @checked function cublasCgemmBatched(handle, transa, transb, m, n, k, alpha, Aarray, lda,
                                      Barray, ldb, beta, Carray, ldc, batchCount)
-    initialize_api()
+    initialize_context()
     ccall((:cublasCgemmBatched, libcublas()), cublasStatus_t,
                    (cublasHandle_t, cublasOperation_t, cublasOperation_t, Cint, Cint,
                     Cint, RefOrCuRef{cuComplex}, CuPtr{Ptr{cuComplex}}, Cint,
@@ -1844,7 +1844,7 @@ end
 
 @checked function cublasCgemm3mBatched(handle, transa, transb, m, n, k, alpha, Aarray, lda,
                                        Barray, ldb, beta, Carray, ldc, batchCount)
-    initialize_api()
+    initialize_context()
     ccall((:cublasCgemm3mBatched, libcublas()), cublasStatus_t,
                    (cublasHandle_t, cublasOperation_t, cublasOperation_t, Cint, Cint,
                     Cint, RefOrCuRef{cuComplex}, CuPtr{Ptr{cuComplex}}, Cint,
@@ -1856,7 +1856,7 @@ end
 
 @checked function cublasZgemmBatched(handle, transa, transb, m, n, k, alpha, Aarray, lda,
                                      Barray, ldb, beta, Carray, ldc, batchCount)
-    initialize_api()
+    initialize_context()
     ccall((:cublasZgemmBatched, libcublas()), cublasStatus_t,
                    (cublasHandle_t, cublasOperation_t, cublasOperation_t, Cint, Cint,
                     Cint, RefOrCuRef{cuDoubleComplex}, CuPtr{Ptr{cuDoubleComplex}}, Cint,
@@ -1869,7 +1869,7 @@ end
 @checked function cublasGemmBatchedEx(handle, transa, transb, m, n, k, alpha, Aarray,
                                       Atype, lda, Barray, Btype, ldb, beta, Carray, Ctype,
                                       ldc, batchCount, computeType, algo)
-    initialize_api()
+    initialize_context()
     ccall((:cublasGemmBatchedEx, libcublas()), cublasStatus_t,
                    (cublasHandle_t, cublasOperation_t, cublasOperation_t, Cint, Cint,
                     Cint, PtrOrCuPtr{Cvoid}, CuPtr{Ptr{Cvoid}}, cudaDataType, Cint,
@@ -1884,7 +1884,7 @@ end
                                              Atype, lda, strideA, B, Btype, ldb, strideB,
                                              beta, C, Ctype, ldc, strideC, batchCount,
                                              computeType, algo)
-    initialize_api()
+    initialize_context()
     ccall((:cublasGemmStridedBatchedEx, libcublas()), cublasStatus_t,
                    (cublasHandle_t, cublasOperation_t, cublasOperation_t, Cint, Cint,
                     Cint, PtrOrCuPtr{Cvoid}, CuPtr{Cvoid}, cudaDataType, Cint, Clonglong,
@@ -1899,7 +1899,7 @@ end
 @checked function cublasHgemmStridedBatched(handle, transa, transb, m, n, k, alpha, A, lda,
                                             strideA, B, ldb, strideB, beta, C, ldc,
                                             strideC, batchCount)
-    initialize_api()
+    initialize_context()
     ccall((:cublasHgemmStridedBatched, libcublas()), cublasStatus_t,
                    (cublasHandle_t, cublasOperation_t, cublasOperation_t, Cint, Cint,
                     Cint, RefOrCuRef{Float16}, CuPtr{Float16}, Cint, Clonglong,
@@ -1912,7 +1912,7 @@ end
 @checked function cublasSgemmStridedBatched(handle, transa, transb, m, n, k, alpha, A, lda,
                                             strideA, B, ldb, strideB, beta, C, ldc,
                                             strideC, batchCount)
-    initialize_api()
+    initialize_context()
     ccall((:cublasSgemmStridedBatched, libcublas()), cublasStatus_t,
                    (cublasHandle_t, cublasOperation_t, cublasOperation_t, Cint, Cint,
                     Cint, RefOrCuRef{Cfloat}, CuPtr{Cfloat}, Cint, Clonglong,
@@ -1925,7 +1925,7 @@ end
 @checked function cublasDgemmStridedBatched(handle, transa, transb, m, n, k, alpha, A, lda,
                                             strideA, B, ldb, strideB, beta, C, ldc,
                                             strideC, batchCount)
-    initialize_api()
+    initialize_context()
     ccall((:cublasDgemmStridedBatched, libcublas()), cublasStatus_t,
                    (cublasHandle_t, cublasOperation_t, cublasOperation_t, Cint, Cint,
                     Cint, RefOrCuRef{Cdouble}, CuPtr{Cdouble}, Cint, Clonglong,
@@ -1938,7 +1938,7 @@ end
 @checked function cublasCgemmStridedBatched(handle, transa, transb, m, n, k, alpha, A, lda,
                                             strideA, B, ldb, strideB, beta, C, ldc,
                                             strideC, batchCount)
-    initialize_api()
+    initialize_context()
     ccall((:cublasCgemmStridedBatched, libcublas()), cublasStatus_t,
                    (cublasHandle_t, cublasOperation_t, cublasOperation_t, Cint, Cint,
                     Cint, RefOrCuRef{cuComplex}, CuPtr{cuComplex}, Cint, Clonglong,
@@ -1951,7 +1951,7 @@ end
 @checked function cublasCgemm3mStridedBatched(handle, transa, transb, m, n, k, alpha, A,
                                               lda, strideA, B, ldb, strideB, beta, C, ldc,
                                               strideC, batchCount)
-    initialize_api()
+    initialize_context()
     ccall((:cublasCgemm3mStridedBatched, libcublas()), cublasStatus_t,
                    (cublasHandle_t, cublasOperation_t, cublasOperation_t, Cint, Cint,
                     Cint, RefOrCuRef{cuComplex}, CuPtr{cuComplex}, Cint, Clonglong,
@@ -1964,7 +1964,7 @@ end
 @checked function cublasZgemmStridedBatched(handle, transa, transb, m, n, k, alpha, A, lda,
                                             strideA, B, ldb, strideB, beta, C, ldc,
                                             strideC, batchCount)
-    initialize_api()
+    initialize_context()
     ccall((:cublasZgemmStridedBatched, libcublas()), cublasStatus_t,
                    (cublasHandle_t, cublasOperation_t, cublasOperation_t, Cint, Cint,
                     Cint, RefOrCuRef{cuDoubleComplex}, CuPtr{cuDoubleComplex}, Cint,
@@ -1977,7 +1977,7 @@ end
 
 @checked function cublasSgeam(handle, transa, transb, m, n, alpha, A, lda, beta, B, ldb, C,
                               ldc)
-    initialize_api()
+    initialize_context()
     ccall((:cublasSgeam, libcublas()), cublasStatus_t,
                    (cublasHandle_t, cublasOperation_t, cublasOperation_t, Cint, Cint,
                     RefOrCuRef{Cfloat}, CuPtr{Cfloat}, Cint, RefOrCuRef{Cfloat},
@@ -1987,7 +1987,7 @@ end
 
 @checked function cublasDgeam(handle, transa, transb, m, n, alpha, A, lda, beta, B, ldb, C,
                               ldc)
-    initialize_api()
+    initialize_context()
     ccall((:cublasDgeam, libcublas()), cublasStatus_t,
                    (cublasHandle_t, cublasOperation_t, cublasOperation_t, Cint, Cint,
                     RefOrCuRef{Cdouble}, CuPtr{Cdouble}, Cint, RefOrCuRef{Cdouble},
@@ -1997,7 +1997,7 @@ end
 
 @checked function cublasCgeam(handle, transa, transb, m, n, alpha, A, lda, beta, B, ldb, C,
                               ldc)
-    initialize_api()
+    initialize_context()
     ccall((:cublasCgeam, libcublas()), cublasStatus_t,
                    (cublasHandle_t, cublasOperation_t, cublasOperation_t, Cint, Cint,
                     RefOrCuRef{cuComplex}, CuPtr{cuComplex}, Cint, RefOrCuRef{cuComplex},
@@ -2007,7 +2007,7 @@ end
 
 @checked function cublasZgeam(handle, transa, transb, m, n, alpha, A, lda, beta, B, ldb, C,
                               ldc)
-    initialize_api()
+    initialize_context()
     ccall((:cublasZgeam, libcublas()), cublasStatus_t,
                    (cublasHandle_t, cublasOperation_t, cublasOperation_t, Cint, Cint,
                     RefOrCuRef{cuDoubleComplex}, CuPtr{cuDoubleComplex}, Cint,
@@ -2017,7 +2017,7 @@ end
 end
 
 @checked function cublasSgetrfBatched(handle, n, A, lda, P, info, batchSize)
-    initialize_api()
+    initialize_context()
     ccall((:cublasSgetrfBatched, libcublas()), cublasStatus_t,
                    (cublasHandle_t, Cint, CuPtr{Ptr{Cfloat}}, Cint, CuPtr{Cint},
                     CuPtr{Cint}, Cint),
@@ -2025,7 +2025,7 @@ end
 end
 
 @checked function cublasDgetrfBatched(handle, n, A, lda, P, info, batchSize)
-    initialize_api()
+    initialize_context()
     ccall((:cublasDgetrfBatched, libcublas()), cublasStatus_t,
                    (cublasHandle_t, Cint, CuPtr{Ptr{Cdouble}}, Cint, CuPtr{Cint},
                     CuPtr{Cint}, Cint),
@@ -2033,7 +2033,7 @@ end
 end
 
 @checked function cublasCgetrfBatched(handle, n, A, lda, P, info, batchSize)
-    initialize_api()
+    initialize_context()
     ccall((:cublasCgetrfBatched, libcublas()), cublasStatus_t,
                    (cublasHandle_t, Cint, CuPtr{Ptr{cuComplex}}, Cint, CuPtr{Cint},
                     CuPtr{Cint}, Cint),
@@ -2041,7 +2041,7 @@ end
 end
 
 @checked function cublasZgetrfBatched(handle, n, A, lda, P, info, batchSize)
-    initialize_api()
+    initialize_context()
     ccall((:cublasZgetrfBatched, libcublas()), cublasStatus_t,
                    (cublasHandle_t, Cint, CuPtr{Ptr{cuDoubleComplex}}, Cint, CuPtr{Cint},
                     CuPtr{Cint}, Cint),
@@ -2049,7 +2049,7 @@ end
 end
 
 @checked function cublasSgetriBatched(handle, n, A, lda, P, C, ldc, info, batchSize)
-    initialize_api()
+    initialize_context()
     ccall((:cublasSgetriBatched, libcublas()), cublasStatus_t,
                    (cublasHandle_t, Cint, CuPtr{Ptr{Cfloat}}, Cint, CuPtr{Cint},
                     CuPtr{Ptr{Cfloat}}, Cint, CuPtr{Cint}, Cint),
@@ -2057,7 +2057,7 @@ end
 end
 
 @checked function cublasDgetriBatched(handle, n, A, lda, P, C, ldc, info, batchSize)
-    initialize_api()
+    initialize_context()
     ccall((:cublasDgetriBatched, libcublas()), cublasStatus_t,
                    (cublasHandle_t, Cint, CuPtr{Ptr{Cdouble}}, Cint, CuPtr{Cint},
                     CuPtr{Ptr{Cdouble}}, Cint, CuPtr{Cint}, Cint),
@@ -2065,7 +2065,7 @@ end
 end
 
 @checked function cublasCgetriBatched(handle, n, A, lda, P, C, ldc, info, batchSize)
-    initialize_api()
+    initialize_context()
     ccall((:cublasCgetriBatched, libcublas()), cublasStatus_t,
                    (cublasHandle_t, Cint, CuPtr{Ptr{cuComplex}}, Cint, CuPtr{Cint},
                     CuPtr{Ptr{cuComplex}}, Cint, CuPtr{Cint}, Cint),
@@ -2073,7 +2073,7 @@ end
 end
 
 @checked function cublasZgetriBatched(handle, n, A, lda, P, C, ldc, info, batchSize)
-    initialize_api()
+    initialize_context()
     ccall((:cublasZgetriBatched, libcublas()), cublasStatus_t,
                    (cublasHandle_t, Cint, CuPtr{Ptr{cuDoubleComplex}}, Cint, CuPtr{Cint},
                     CuPtr{Ptr{cuDoubleComplex}}, Cint, CuPtr{Cint}, Cint),
@@ -2082,7 +2082,7 @@ end
 
 @checked function cublasSgetrsBatched(handle, trans, n, nrhs, Aarray, lda, devIpiv, Barray,
                                       ldb, info, batchSize)
-    initialize_api()
+    initialize_context()
     ccall((:cublasSgetrsBatched, libcublas()), cublasStatus_t,
                    (cublasHandle_t, cublasOperation_t, Cint, Cint, CuPtr{Ptr{Cfloat}},
                     Cint, CuPtr{Cint}, CuPtr{Ptr{Cfloat}}, Cint, Ptr{Cint}, Cint),
@@ -2092,7 +2092,7 @@ end
 
 @checked function cublasDgetrsBatched(handle, trans, n, nrhs, Aarray, lda, devIpiv, Barray,
                                       ldb, info, batchSize)
-    initialize_api()
+    initialize_context()
     ccall((:cublasDgetrsBatched, libcublas()), cublasStatus_t,
                    (cublasHandle_t, cublasOperation_t, Cint, Cint, CuPtr{Ptr{Cdouble}},
                     Cint, CuPtr{Cint}, CuPtr{Ptr{Cdouble}}, Cint, Ptr{Cint}, Cint),
@@ -2102,7 +2102,7 @@ end
 
 @checked function cublasCgetrsBatched(handle, trans, n, nrhs, Aarray, lda, devIpiv, Barray,
                                       ldb, info, batchSize)
-    initialize_api()
+    initialize_context()
     ccall((:cublasCgetrsBatched, libcublas()), cublasStatus_t,
                    (cublasHandle_t, cublasOperation_t, Cint, Cint, CuPtr{Ptr{cuComplex}},
                     Cint, CuPtr{Cint}, CuPtr{Ptr{cuComplex}}, Cint, Ptr{Cint}, Cint),
@@ -2112,7 +2112,7 @@ end
 
 @checked function cublasZgetrsBatched(handle, trans, n, nrhs, Aarray, lda, devIpiv, Barray,
                                       ldb, info, batchSize)
-    initialize_api()
+    initialize_context()
     ccall((:cublasZgetrsBatched, libcublas()), cublasStatus_t,
                    (cublasHandle_t, cublasOperation_t, Cint, Cint,
                     CuPtr{Ptr{cuDoubleComplex}}, Cint, CuPtr{Cint},
@@ -2123,7 +2123,7 @@ end
 
 @checked function cublasStrsmBatched(handle, side, uplo, trans, diag, m, n, alpha, A, lda,
                                      B, ldb, batchCount)
-    initialize_api()
+    initialize_context()
     ccall((:cublasStrsmBatched, libcublas()), cublasStatus_t,
                    (cublasHandle_t, cublasSideMode_t, cublasFillMode_t, cublasOperation_t,
                     cublasDiagType_t, Cint, Cint, RefOrCuRef{Cfloat}, CuPtr{Ptr{Cfloat}},
@@ -2134,7 +2134,7 @@ end
 
 @checked function cublasDtrsmBatched(handle, side, uplo, trans, diag, m, n, alpha, A, lda,
                                      B, ldb, batchCount)
-    initialize_api()
+    initialize_context()
     ccall((:cublasDtrsmBatched, libcublas()), cublasStatus_t,
                    (cublasHandle_t, cublasSideMode_t, cublasFillMode_t, cublasOperation_t,
                     cublasDiagType_t, Cint, Cint, RefOrCuRef{Cdouble}, CuPtr{Ptr{Cdouble}},
@@ -2145,7 +2145,7 @@ end
 
 @checked function cublasCtrsmBatched(handle, side, uplo, trans, diag, m, n, alpha, A, lda,
                                      B, ldb, batchCount)
-    initialize_api()
+    initialize_context()
     ccall((:cublasCtrsmBatched, libcublas()), cublasStatus_t,
                    (cublasHandle_t, cublasSideMode_t, cublasFillMode_t, cublasOperation_t,
                     cublasDiagType_t, Cint, Cint, RefOrCuRef{cuComplex},
@@ -2156,7 +2156,7 @@ end
 
 @checked function cublasZtrsmBatched(handle, side, uplo, trans, diag, m, n, alpha, A, lda,
                                      B, ldb, batchCount)
-    initialize_api()
+    initialize_context()
     ccall((:cublasZtrsmBatched, libcublas()), cublasStatus_t,
                    (cublasHandle_t, cublasSideMode_t, cublasFillMode_t, cublasOperation_t,
                     cublasDiagType_t, Cint, Cint, RefOrCuRef{cuDoubleComplex},
@@ -2167,7 +2167,7 @@ end
 end
 
 @checked function cublasSmatinvBatched(handle, n, A, lda, Ainv, lda_inv, info, batchSize)
-    initialize_api()
+    initialize_context()
     ccall((:cublasSmatinvBatched, libcublas()), cublasStatus_t,
                    (cublasHandle_t, Cint, CuPtr{Ptr{Cfloat}}, Cint, CuPtr{Ptr{Cfloat}},
                     Cint, CuPtr{Cint}, Cint),
@@ -2175,7 +2175,7 @@ end
 end
 
 @checked function cublasDmatinvBatched(handle, n, A, lda, Ainv, lda_inv, info, batchSize)
-    initialize_api()
+    initialize_context()
     ccall((:cublasDmatinvBatched, libcublas()), cublasStatus_t,
                    (cublasHandle_t, Cint, CuPtr{Ptr{Cdouble}}, Cint, CuPtr{Ptr{Cdouble}},
                     Cint, CuPtr{Cint}, Cint),
@@ -2183,7 +2183,7 @@ end
 end
 
 @checked function cublasCmatinvBatched(handle, n, A, lda, Ainv, lda_inv, info, batchSize)
-    initialize_api()
+    initialize_context()
     ccall((:cublasCmatinvBatched, libcublas()), cublasStatus_t,
                    (cublasHandle_t, Cint, CuPtr{Ptr{cuComplex}}, Cint,
                     CuPtr{Ptr{cuComplex}}, Cint, CuPtr{Cint}, Cint),
@@ -2191,7 +2191,7 @@ end
 end
 
 @checked function cublasZmatinvBatched(handle, n, A, lda, Ainv, lda_inv, info, batchSize)
-    initialize_api()
+    initialize_context()
     ccall((:cublasZmatinvBatched, libcublas()), cublasStatus_t,
                    (cublasHandle_t, Cint, CuPtr{Ptr{cuDoubleComplex}}, Cint,
                     CuPtr{Ptr{cuDoubleComplex}}, Cint, CuPtr{Cint}, Cint),
@@ -2199,7 +2199,7 @@ end
 end
 
 @checked function cublasSgeqrfBatched(handle, m, n, Aarray, lda, TauArray, info, batchSize)
-    initialize_api()
+    initialize_context()
     ccall((:cublasSgeqrfBatched, libcublas()), cublasStatus_t,
                    (cublasHandle_t, Cint, Cint, CuPtr{Ptr{Cfloat}}, Cint,
                     CuPtr{Ptr{Cfloat}}, Ptr{Cint}, Cint),
@@ -2207,7 +2207,7 @@ end
 end
 
 @checked function cublasDgeqrfBatched(handle, m, n, Aarray, lda, TauArray, info, batchSize)
-    initialize_api()
+    initialize_context()
     ccall((:cublasDgeqrfBatched, libcublas()), cublasStatus_t,
                    (cublasHandle_t, Cint, Cint, CuPtr{Ptr{Cdouble}}, Cint,
                     CuPtr{Ptr{Cdouble}}, Ptr{Cint}, Cint),
@@ -2215,7 +2215,7 @@ end
 end
 
 @checked function cublasCgeqrfBatched(handle, m, n, Aarray, lda, TauArray, info, batchSize)
-    initialize_api()
+    initialize_context()
     ccall((:cublasCgeqrfBatched, libcublas()), cublasStatus_t,
                    (cublasHandle_t, Cint, Cint, CuPtr{Ptr{cuComplex}}, Cint,
                     CuPtr{Ptr{cuComplex}}, Ptr{Cint}, Cint),
@@ -2223,7 +2223,7 @@ end
 end
 
 @checked function cublasZgeqrfBatched(handle, m, n, Aarray, lda, TauArray, info, batchSize)
-    initialize_api()
+    initialize_context()
     ccall((:cublasZgeqrfBatched, libcublas()), cublasStatus_t,
                    (cublasHandle_t, Cint, Cint, CuPtr{Ptr{cuDoubleComplex}}, Cint,
                     CuPtr{Ptr{cuDoubleComplex}}, Ptr{Cint}, Cint),
@@ -2232,7 +2232,7 @@ end
 
 @checked function cublasSgelsBatched(handle, trans, m, n, nrhs, Aarray, lda, Carray, ldc,
                                      info, devInfoArray, batchSize)
-    initialize_api()
+    initialize_context()
     ccall((:cublasSgelsBatched, libcublas()), cublasStatus_t,
                    (cublasHandle_t, cublasOperation_t, Cint, Cint, Cint,
                     CuPtr{Ptr{Cfloat}}, Cint, CuPtr{Ptr{Cfloat}}, Cint, Ptr{Cint},
@@ -2243,7 +2243,7 @@ end
 
 @checked function cublasDgelsBatched(handle, trans, m, n, nrhs, Aarray, lda, Carray, ldc,
                                      info, devInfoArray, batchSize)
-    initialize_api()
+    initialize_context()
     ccall((:cublasDgelsBatched, libcublas()), cublasStatus_t,
                    (cublasHandle_t, cublasOperation_t, Cint, Cint, Cint,
                     CuPtr{Ptr{Cdouble}}, Cint, CuPtr{Ptr{Cdouble}}, Cint, Ptr{Cint},
@@ -2254,7 +2254,7 @@ end
 
 @checked function cublasCgelsBatched(handle, trans, m, n, nrhs, Aarray, lda, Carray, ldc,
                                      info, devInfoArray, batchSize)
-    initialize_api()
+    initialize_context()
     ccall((:cublasCgelsBatched, libcublas()), cublasStatus_t,
                    (cublasHandle_t, cublasOperation_t, Cint, Cint, Cint,
                     CuPtr{Ptr{cuComplex}}, Cint, CuPtr{Ptr{cuComplex}}, Cint, Ptr{Cint},
@@ -2265,7 +2265,7 @@ end
 
 @checked function cublasZgelsBatched(handle, trans, m, n, nrhs, Aarray, lda, Carray, ldc,
                                      info, devInfoArray, batchSize)
-    initialize_api()
+    initialize_context()
     ccall((:cublasZgelsBatched, libcublas()), cublasStatus_t,
                    (cublasHandle_t, cublasOperation_t, Cint, Cint, Cint,
                     CuPtr{Ptr{cuDoubleComplex}}, Cint, CuPtr{Ptr{cuDoubleComplex}}, Cint,
@@ -2275,7 +2275,7 @@ end
 end
 
 @checked function cublasSdgmm(handle, mode, m, n, A, lda, x, incx, C, ldc)
-    initialize_api()
+    initialize_context()
     ccall((:cublasSdgmm, libcublas()), cublasStatus_t,
                    (cublasHandle_t, cublasSideMode_t, Cint, Cint, CuPtr{Cfloat}, Cint,
                     CuPtr{Cfloat}, Cint, CuPtr{Cfloat}, Cint),
@@ -2283,7 +2283,7 @@ end
 end
 
 @checked function cublasDdgmm(handle, mode, m, n, A, lda, x, incx, C, ldc)
-    initialize_api()
+    initialize_context()
     ccall((:cublasDdgmm, libcublas()), cublasStatus_t,
                    (cublasHandle_t, cublasSideMode_t, Cint, Cint, CuPtr{Cdouble}, Cint,
                     CuPtr{Cdouble}, Cint, CuPtr{Cdouble}, Cint),
@@ -2291,7 +2291,7 @@ end
 end
 
 @checked function cublasCdgmm(handle, mode, m, n, A, lda, x, incx, C, ldc)
-    initialize_api()
+    initialize_context()
     ccall((:cublasCdgmm, libcublas()), cublasStatus_t,
                    (cublasHandle_t, cublasSideMode_t, Cint, Cint, CuPtr{cuComplex}, Cint,
                     CuPtr{cuComplex}, Cint, CuPtr{cuComplex}, Cint),
@@ -2299,7 +2299,7 @@ end
 end
 
 @checked function cublasZdgmm(handle, mode, m, n, A, lda, x, incx, C, ldc)
-    initialize_api()
+    initialize_context()
     ccall((:cublasZdgmm, libcublas()), cublasStatus_t,
                    (cublasHandle_t, cublasSideMode_t, Cint, Cint, CuPtr{cuDoubleComplex},
                     Cint, CuPtr{cuDoubleComplex}, Cint, CuPtr{cuDoubleComplex}, Cint),
@@ -2307,7 +2307,7 @@ end
 end
 
 @checked function cublasStpttr(handle, uplo, n, AP, A, lda)
-    initialize_api()
+    initialize_context()
     ccall((:cublasStpttr, libcublas()), cublasStatus_t,
                    (cublasHandle_t, cublasFillMode_t, Cint, CuPtr{Cfloat}, CuPtr{Cfloat},
                     Cint),
@@ -2315,7 +2315,7 @@ end
 end
 
 @checked function cublasDtpttr(handle, uplo, n, AP, A, lda)
-    initialize_api()
+    initialize_context()
     ccall((:cublasDtpttr, libcublas()), cublasStatus_t,
                    (cublasHandle_t, cublasFillMode_t, Cint, CuPtr{Cdouble},
                     CuPtr{Cdouble}, Cint),
@@ -2323,7 +2323,7 @@ end
 end
 
 @checked function cublasCtpttr(handle, uplo, n, AP, A, lda)
-    initialize_api()
+    initialize_context()
     ccall((:cublasCtpttr, libcublas()), cublasStatus_t,
                    (cublasHandle_t, cublasFillMode_t, Cint, CuPtr{cuComplex},
                     CuPtr{cuComplex}, Cint),
@@ -2331,7 +2331,7 @@ end
 end
 
 @checked function cublasZtpttr(handle, uplo, n, AP, A, lda)
-    initialize_api()
+    initialize_context()
     ccall((:cublasZtpttr, libcublas()), cublasStatus_t,
                    (cublasHandle_t, cublasFillMode_t, Cint, CuPtr{cuDoubleComplex},
                     CuPtr{cuDoubleComplex}, Cint),
@@ -2339,7 +2339,7 @@ end
 end
 
 @checked function cublasStrttp(handle, uplo, n, A, lda, AP)
-    initialize_api()
+    initialize_context()
     ccall((:cublasStrttp, libcublas()), cublasStatus_t,
                    (cublasHandle_t, cublasFillMode_t, Cint, CuPtr{Cfloat}, Cint,
                     CuPtr{Cfloat}),
@@ -2347,7 +2347,7 @@ end
 end
 
 @checked function cublasDtrttp(handle, uplo, n, A, lda, AP)
-    initialize_api()
+    initialize_context()
     ccall((:cublasDtrttp, libcublas()), cublasStatus_t,
                    (cublasHandle_t, cublasFillMode_t, Cint, CuPtr{Cdouble}, Cint,
                     CuPtr{Cdouble}),
@@ -2355,7 +2355,7 @@ end
 end
 
 @checked function cublasCtrttp(handle, uplo, n, A, lda, AP)
-    initialize_api()
+    initialize_context()
     ccall((:cublasCtrttp, libcublas()), cublasStatus_t,
                    (cublasHandle_t, cublasFillMode_t, Cint, CuPtr{cuComplex}, Cint,
                     CuPtr{cuComplex}),
@@ -2363,7 +2363,7 @@ end
 end
 
 @checked function cublasZtrttp(handle, uplo, n, A, lda, AP)
-    initialize_api()
+    initialize_context()
     ccall((:cublasZtrttp, libcublas()), cublasStatus_t,
                    (cublasHandle_t, cublasFillMode_t, Cint, CuPtr{cuDoubleComplex}, Cint,
                     CuPtr{cuDoubleComplex}),
@@ -2373,77 +2373,77 @@ end
 # Automatically generated using Clang.jl
 
 @checked function cublasXtCreate(handle)
-    initialize_api()
+    initialize_context()
     ccall((:cublasXtCreate, libcublas()), cublasStatus_t,
                    (Ptr{cublasXtHandle_t},),
                    handle)
 end
 
 @checked function cublasXtDestroy(handle)
-    initialize_api()
+    initialize_context()
     ccall((:cublasXtDestroy, libcublas()), cublasStatus_t,
                    (cublasXtHandle_t,),
                    handle)
 end
 
 @checked function cublasXtGetNumBoards(nbDevices, deviceId, nbBoards)
-    initialize_api()
+    initialize_context()
     ccall((:cublasXtGetNumBoards, libcublas()), cublasStatus_t,
                    (Cint, Ptr{Cint}, Ptr{Cint}),
                    nbDevices, deviceId, nbBoards)
 end
 
 @checked function cublasXtMaxBoards(nbGpuBoards)
-    initialize_api()
+    initialize_context()
     ccall((:cublasXtMaxBoards, libcublas()), cublasStatus_t,
                    (Ptr{Cint},),
                    nbGpuBoards)
 end
 
 @checked function cublasXtDeviceSelect(handle, nbDevices, deviceId)
-    initialize_api()
+    initialize_context()
     ccall((:cublasXtDeviceSelect, libcublas()), cublasStatus_t,
                    (cublasXtHandle_t, Cint, Ptr{Cint}),
                    handle, nbDevices, deviceId)
 end
 
 @checked function cublasXtSetBlockDim(handle, blockDim)
-    initialize_api()
+    initialize_context()
     ccall((:cublasXtSetBlockDim, libcublas()), cublasStatus_t,
                    (cublasXtHandle_t, Cint),
                    handle, blockDim)
 end
 
 @checked function cublasXtGetBlockDim(handle, blockDim)
-    initialize_api()
+    initialize_context()
     ccall((:cublasXtGetBlockDim, libcublas()), cublasStatus_t,
                    (cublasXtHandle_t, Ptr{Cint}),
                    handle, blockDim)
 end
 
 @checked function cublasXtGetPinningMemMode(handle, mode)
-    initialize_api()
+    initialize_context()
     ccall((:cublasXtGetPinningMemMode, libcublas()), cublasStatus_t,
                    (cublasXtHandle_t, Ptr{cublasXtPinnedMemMode_t}),
                    handle, mode)
 end
 
 @checked function cublasXtSetPinningMemMode(handle, mode)
-    initialize_api()
+    initialize_context()
     ccall((:cublasXtSetPinningMemMode, libcublas()), cublasStatus_t,
                    (cublasXtHandle_t, cublasXtPinnedMemMode_t),
                    handle, mode)
 end
 
 @checked function cublasXtSetCpuRoutine(handle, blasOp, type, blasFunctor)
-    initialize_api()
+    initialize_context()
     ccall((:cublasXtSetCpuRoutine, libcublas()), cublasStatus_t,
                    (cublasXtHandle_t, cublasXtBlasOp_t, cublasXtOpType_t, Ptr{Cvoid}),
                    handle, blasOp, type, blasFunctor)
 end
 
 @checked function cublasXtSetCpuRatio(handle, blasOp, type, ratio)
-    initialize_api()
+    initialize_context()
     ccall((:cublasXtSetCpuRatio, libcublas()), cublasStatus_t,
                    (cublasXtHandle_t, cublasXtBlasOp_t, cublasXtOpType_t, Cfloat),
                    handle, blasOp, type, ratio)
@@ -2451,7 +2451,7 @@ end
 
 @checked function cublasXtSgemm(handle, transa, transb, m, n, k, alpha, A, lda, B, ldb,
                                 beta, C, ldc)
-    initialize_api()
+    initialize_context()
     ccall((:cublasXtSgemm, libcublas()), cublasStatus_t,
                    (cublasXtHandle_t, cublasOperation_t, cublasOperation_t, Csize_t,
                     Csize_t, Csize_t, RefOrCuRef{Cfloat}, PtrOrCuPtr{Cfloat}, Csize_t,
@@ -2462,7 +2462,7 @@ end
 
 @checked function cublasXtDgemm(handle, transa, transb, m, n, k, alpha, A, lda, B, ldb,
                                 beta, C, ldc)
-    initialize_api()
+    initialize_context()
     ccall((:cublasXtDgemm, libcublas()), cublasStatus_t,
                    (cublasXtHandle_t, cublasOperation_t, cublasOperation_t, Csize_t,
                     Csize_t, Csize_t, RefOrCuRef{Cdouble}, PtrOrCuPtr{Cdouble}, Csize_t,
@@ -2473,7 +2473,7 @@ end
 
 @checked function cublasXtCgemm(handle, transa, transb, m, n, k, alpha, A, lda, B, ldb,
                                 beta, C, ldc)
-    initialize_api()
+    initialize_context()
     ccall((:cublasXtCgemm, libcublas()), cublasStatus_t,
                    (cublasXtHandle_t, cublasOperation_t, cublasOperation_t, Csize_t,
                     Csize_t, Csize_t, RefOrCuRef{cuComplex}, PtrOrCuPtr{cuComplex},
@@ -2484,7 +2484,7 @@ end
 
 @checked function cublasXtZgemm(handle, transa, transb, m, n, k, alpha, A, lda, B, ldb,
                                 beta, C, ldc)
-    initialize_api()
+    initialize_context()
     ccall((:cublasXtZgemm, libcublas()), cublasStatus_t,
                    (cublasXtHandle_t, cublasOperation_t, cublasOperation_t, Csize_t,
                     Csize_t, Csize_t, RefOrCuRef{cuDoubleComplex},
@@ -2495,7 +2495,7 @@ end
 end
 
 @checked function cublasXtSsyrk(handle, uplo, trans, n, k, alpha, A, lda, beta, C, ldc)
-    initialize_api()
+    initialize_context()
     ccall((:cublasXtSsyrk, libcublas()), cublasStatus_t,
                    (cublasXtHandle_t, cublasFillMode_t, cublasOperation_t, Csize_t,
                     Csize_t, RefOrCuRef{Cfloat}, PtrOrCuPtr{Cfloat}, Csize_t,
@@ -2504,7 +2504,7 @@ end
 end
 
 @checked function cublasXtDsyrk(handle, uplo, trans, n, k, alpha, A, lda, beta, C, ldc)
-    initialize_api()
+    initialize_context()
     ccall((:cublasXtDsyrk, libcublas()), cublasStatus_t,
                    (cublasXtHandle_t, cublasFillMode_t, cublasOperation_t, Csize_t,
                     Csize_t, RefOrCuRef{Cdouble}, PtrOrCuPtr{Cdouble}, Csize_t,
@@ -2513,7 +2513,7 @@ end
 end
 
 @checked function cublasXtCsyrk(handle, uplo, trans, n, k, alpha, A, lda, beta, C, ldc)
-    initialize_api()
+    initialize_context()
     ccall((:cublasXtCsyrk, libcublas()), cublasStatus_t,
                    (cublasXtHandle_t, cublasFillMode_t, cublasOperation_t, Csize_t,
                     Csize_t, RefOrCuRef{cuComplex}, PtrOrCuPtr{cuComplex}, Csize_t,
@@ -2522,7 +2522,7 @@ end
 end
 
 @checked function cublasXtZsyrk(handle, uplo, trans, n, k, alpha, A, lda, beta, C, ldc)
-    initialize_api()
+    initialize_context()
     ccall((:cublasXtZsyrk, libcublas()), cublasStatus_t,
                    (cublasXtHandle_t, cublasFillMode_t, cublasOperation_t, Csize_t,
                     Csize_t, RefOrCuRef{cuDoubleComplex}, PtrOrCuPtr{cuDoubleComplex},
@@ -2532,7 +2532,7 @@ end
 end
 
 @checked function cublasXtCherk(handle, uplo, trans, n, k, alpha, A, lda, beta, C, ldc)
-    initialize_api()
+    initialize_context()
     ccall((:cublasXtCherk, libcublas()), cublasStatus_t,
                    (cublasXtHandle_t, cublasFillMode_t, cublasOperation_t, Csize_t,
                     Csize_t, RefOrCuRef{Cfloat}, PtrOrCuPtr{cuComplex}, Csize_t,
@@ -2541,7 +2541,7 @@ end
 end
 
 @checked function cublasXtZherk(handle, uplo, trans, n, k, alpha, A, lda, beta, C, ldc)
-    initialize_api()
+    initialize_context()
     ccall((:cublasXtZherk, libcublas()), cublasStatus_t,
                    (cublasXtHandle_t, cublasFillMode_t, cublasOperation_t, Csize_t,
                     Csize_t, RefOrCuRef{Cdouble}, PtrOrCuPtr{cuDoubleComplex}, Csize_t,
@@ -2551,7 +2551,7 @@ end
 
 @checked function cublasXtSsyr2k(handle, uplo, trans, n, k, alpha, A, lda, B, ldb, beta, C,
                                  ldc)
-    initialize_api()
+    initialize_context()
     ccall((:cublasXtSsyr2k, libcublas()), cublasStatus_t,
                    (cublasXtHandle_t, cublasFillMode_t, cublasOperation_t, Csize_t,
                     Csize_t, RefOrCuRef{Cfloat}, PtrOrCuPtr{Cfloat}, Csize_t,
@@ -2562,7 +2562,7 @@ end
 
 @checked function cublasXtDsyr2k(handle, uplo, trans, n, k, alpha, A, lda, B, ldb, beta, C,
                                  ldc)
-    initialize_api()
+    initialize_context()
     ccall((:cublasXtDsyr2k, libcublas()), cublasStatus_t,
                    (cublasXtHandle_t, cublasFillMode_t, cublasOperation_t, Csize_t,
                     Csize_t, RefOrCuRef{Cdouble}, PtrOrCuPtr{Cdouble}, Csize_t,
@@ -2573,7 +2573,7 @@ end
 
 @checked function cublasXtCsyr2k(handle, uplo, trans, n, k, alpha, A, lda, B, ldb, beta, C,
                                  ldc)
-    initialize_api()
+    initialize_context()
     ccall((:cublasXtCsyr2k, libcublas()), cublasStatus_t,
                    (cublasXtHandle_t, cublasFillMode_t, cublasOperation_t, Csize_t,
                     Csize_t, RefOrCuRef{cuComplex}, PtrOrCuPtr{cuComplex}, Csize_t,
@@ -2584,7 +2584,7 @@ end
 
 @checked function cublasXtZsyr2k(handle, uplo, trans, n, k, alpha, A, lda, B, ldb, beta, C,
                                  ldc)
-    initialize_api()
+    initialize_context()
     ccall((:cublasXtZsyr2k, libcublas()), cublasStatus_t,
                    (cublasXtHandle_t, cublasFillMode_t, cublasOperation_t, Csize_t,
                     Csize_t, RefOrCuRef{cuDoubleComplex}, PtrOrCuPtr{cuDoubleComplex},
@@ -2595,7 +2595,7 @@ end
 
 @checked function cublasXtCherkx(handle, uplo, trans, n, k, alpha, A, lda, B, ldb, beta, C,
                                  ldc)
-    initialize_api()
+    initialize_context()
     ccall((:cublasXtCherkx, libcublas()), cublasStatus_t,
                    (cublasXtHandle_t, cublasFillMode_t, cublasOperation_t, Csize_t,
                     Csize_t, RefOrCuRef{cuComplex}, PtrOrCuPtr{cuComplex}, Csize_t,
@@ -2606,7 +2606,7 @@ end
 
 @checked function cublasXtZherkx(handle, uplo, trans, n, k, alpha, A, lda, B, ldb, beta, C,
                                  ldc)
-    initialize_api()
+    initialize_context()
     ccall((:cublasXtZherkx, libcublas()), cublasStatus_t,
                    (cublasXtHandle_t, cublasFillMode_t, cublasOperation_t, Csize_t,
                     Csize_t, RefOrCuRef{cuDoubleComplex}, PtrOrCuPtr{cuDoubleComplex},
@@ -2616,7 +2616,7 @@ end
 end
 
 @checked function cublasXtStrsm(handle, side, uplo, trans, diag, m, n, alpha, A, lda, B, ldb)
-    initialize_api()
+    initialize_context()
     ccall((:cublasXtStrsm, libcublas()), cublasStatus_t,
                    (cublasXtHandle_t, cublasSideMode_t, cublasFillMode_t,
                     cublasOperation_t, cublasDiagType_t, Csize_t, Csize_t,
@@ -2626,7 +2626,7 @@ end
 end
 
 @checked function cublasXtDtrsm(handle, side, uplo, trans, diag, m, n, alpha, A, lda, B, ldb)
-    initialize_api()
+    initialize_context()
     ccall((:cublasXtDtrsm, libcublas()), cublasStatus_t,
                    (cublasXtHandle_t, cublasSideMode_t, cublasFillMode_t,
                     cublasOperation_t, cublasDiagType_t, Csize_t, Csize_t,
@@ -2636,7 +2636,7 @@ end
 end
 
 @checked function cublasXtCtrsm(handle, side, uplo, trans, diag, m, n, alpha, A, lda, B, ldb)
-    initialize_api()
+    initialize_context()
     ccall((:cublasXtCtrsm, libcublas()), cublasStatus_t,
                    (cublasXtHandle_t, cublasSideMode_t, cublasFillMode_t,
                     cublasOperation_t, cublasDiagType_t, Csize_t, Csize_t,
@@ -2646,7 +2646,7 @@ end
 end
 
 @checked function cublasXtZtrsm(handle, side, uplo, trans, diag, m, n, alpha, A, lda, B, ldb)
-    initialize_api()
+    initialize_context()
     ccall((:cublasXtZtrsm, libcublas()), cublasStatus_t,
                    (cublasXtHandle_t, cublasSideMode_t, cublasFillMode_t,
                     cublasOperation_t, cublasDiagType_t, Csize_t, Csize_t,
@@ -2657,7 +2657,7 @@ end
 
 @checked function cublasXtSsymm(handle, side, uplo, m, n, alpha, A, lda, B, ldb, beta, C,
                                 ldc)
-    initialize_api()
+    initialize_context()
     ccall((:cublasXtSsymm, libcublas()), cublasStatus_t,
                    (cublasXtHandle_t, cublasSideMode_t, cublasFillMode_t, Csize_t,
                     Csize_t, RefOrCuRef{Cfloat}, PtrOrCuPtr{Cfloat}, Csize_t,
@@ -2668,7 +2668,7 @@ end
 
 @checked function cublasXtDsymm(handle, side, uplo, m, n, alpha, A, lda, B, ldb, beta, C,
                                 ldc)
-    initialize_api()
+    initialize_context()
     ccall((:cublasXtDsymm, libcublas()), cublasStatus_t,
                    (cublasXtHandle_t, cublasSideMode_t, cublasFillMode_t, Csize_t,
                     Csize_t, RefOrCuRef{Cdouble}, PtrOrCuPtr{Cdouble}, Csize_t,
@@ -2679,7 +2679,7 @@ end
 
 @checked function cublasXtCsymm(handle, side, uplo, m, n, alpha, A, lda, B, ldb, beta, C,
                                 ldc)
-    initialize_api()
+    initialize_context()
     ccall((:cublasXtCsymm, libcublas()), cublasStatus_t,
                    (cublasXtHandle_t, cublasSideMode_t, cublasFillMode_t, Csize_t,
                     Csize_t, RefOrCuRef{cuComplex}, PtrOrCuPtr{cuComplex}, Csize_t,
@@ -2690,7 +2690,7 @@ end
 
 @checked function cublasXtZsymm(handle, side, uplo, m, n, alpha, A, lda, B, ldb, beta, C,
                                 ldc)
-    initialize_api()
+    initialize_context()
     ccall((:cublasXtZsymm, libcublas()), cublasStatus_t,
                    (cublasXtHandle_t, cublasSideMode_t, cublasFillMode_t, Csize_t,
                     Csize_t, RefOrCuRef{cuDoubleComplex}, PtrOrCuPtr{cuDoubleComplex},
@@ -2701,7 +2701,7 @@ end
 
 @checked function cublasXtChemm(handle, side, uplo, m, n, alpha, A, lda, B, ldb, beta, C,
                                 ldc)
-    initialize_api()
+    initialize_context()
     ccall((:cublasXtChemm, libcublas()), cublasStatus_t,
                    (cublasXtHandle_t, cublasSideMode_t, cublasFillMode_t, Csize_t,
                     Csize_t, RefOrCuRef{cuComplex}, PtrOrCuPtr{cuComplex}, Csize_t,
@@ -2712,7 +2712,7 @@ end
 
 @checked function cublasXtZhemm(handle, side, uplo, m, n, alpha, A, lda, B, ldb, beta, C,
                                 ldc)
-    initialize_api()
+    initialize_context()
     ccall((:cublasXtZhemm, libcublas()), cublasStatus_t,
                    (cublasXtHandle_t, cublasSideMode_t, cublasFillMode_t, Csize_t,
                     Csize_t, RefOrCuRef{cuDoubleComplex}, PtrOrCuPtr{cuDoubleComplex},
@@ -2723,7 +2723,7 @@ end
 
 @checked function cublasXtSsyrkx(handle, uplo, trans, n, k, alpha, A, lda, B, ldb, beta, C,
                                  ldc)
-    initialize_api()
+    initialize_context()
     ccall((:cublasXtSsyrkx, libcublas()), cublasStatus_t,
                    (cublasXtHandle_t, cublasFillMode_t, cublasOperation_t, Csize_t,
                     Csize_t, RefOrCuRef{Cfloat}, PtrOrCuPtr{Cfloat}, Csize_t,
@@ -2734,7 +2734,7 @@ end
 
 @checked function cublasXtDsyrkx(handle, uplo, trans, n, k, alpha, A, lda, B, ldb, beta, C,
                                  ldc)
-    initialize_api()
+    initialize_context()
     ccall((:cublasXtDsyrkx, libcublas()), cublasStatus_t,
                    (cublasXtHandle_t, cublasFillMode_t, cublasOperation_t, Csize_t,
                     Csize_t, RefOrCuRef{Cdouble}, PtrOrCuPtr{Cdouble}, Csize_t,
@@ -2745,7 +2745,7 @@ end
 
 @checked function cublasXtCsyrkx(handle, uplo, trans, n, k, alpha, A, lda, B, ldb, beta, C,
                                  ldc)
-    initialize_api()
+    initialize_context()
     ccall((:cublasXtCsyrkx, libcublas()), cublasStatus_t,
                    (cublasXtHandle_t, cublasFillMode_t, cublasOperation_t, Csize_t,
                     Csize_t, RefOrCuRef{cuComplex}, PtrOrCuPtr{cuComplex}, Csize_t,
@@ -2756,7 +2756,7 @@ end
 
 @checked function cublasXtZsyrkx(handle, uplo, trans, n, k, alpha, A, lda, B, ldb, beta, C,
                                  ldc)
-    initialize_api()
+    initialize_context()
     ccall((:cublasXtZsyrkx, libcublas()), cublasStatus_t,
                    (cublasXtHandle_t, cublasFillMode_t, cublasOperation_t, Csize_t,
                     Csize_t, RefOrCuRef{cuDoubleComplex}, PtrOrCuPtr{cuDoubleComplex},
@@ -2767,7 +2767,7 @@ end
 
 @checked function cublasXtCher2k(handle, uplo, trans, n, k, alpha, A, lda, B, ldb, beta, C,
                                  ldc)
-    initialize_api()
+    initialize_context()
     ccall((:cublasXtCher2k, libcublas()), cublasStatus_t,
                    (cublasXtHandle_t, cublasFillMode_t, cublasOperation_t, Csize_t,
                     Csize_t, RefOrCuRef{cuComplex}, PtrOrCuPtr{cuComplex}, Csize_t,
@@ -2778,7 +2778,7 @@ end
 
 @checked function cublasXtZher2k(handle, uplo, trans, n, k, alpha, A, lda, B, ldb, beta, C,
                                  ldc)
-    initialize_api()
+    initialize_context()
     ccall((:cublasXtZher2k, libcublas()), cublasStatus_t,
                    (cublasXtHandle_t, cublasFillMode_t, cublasOperation_t, Csize_t,
                     Csize_t, RefOrCuRef{cuDoubleComplex}, PtrOrCuPtr{cuDoubleComplex},
@@ -2788,7 +2788,7 @@ end
 end
 
 @checked function cublasXtSspmm(handle, side, uplo, m, n, alpha, AP, B, ldb, beta, C, ldc)
-    initialize_api()
+    initialize_context()
     ccall((:cublasXtSspmm, libcublas()), cublasStatus_t,
                    (cublasXtHandle_t, cublasSideMode_t, cublasFillMode_t, Csize_t,
                     Csize_t, Ref{Cfloat}, Ptr{Cfloat}, PtrOrCuPtr{Cfloat}, Csize_t,
@@ -2797,7 +2797,7 @@ end
 end
 
 @checked function cublasXtDspmm(handle, side, uplo, m, n, alpha, AP, B, ldb, beta, C, ldc)
-    initialize_api()
+    initialize_context()
     ccall((:cublasXtDspmm, libcublas()), cublasStatus_t,
                    (cublasXtHandle_t, cublasSideMode_t, cublasFillMode_t, Csize_t,
                     Csize_t, Ref{Cdouble}, Ptr{Cdouble}, PtrOrCuPtr{Cdouble}, Csize_t,
@@ -2806,7 +2806,7 @@ end
 end
 
 @checked function cublasXtCspmm(handle, side, uplo, m, n, alpha, AP, B, ldb, beta, C, ldc)
-    initialize_api()
+    initialize_context()
     ccall((:cublasXtCspmm, libcublas()), cublasStatus_t,
                    (cublasXtHandle_t, cublasSideMode_t, cublasFillMode_t, Csize_t,
                     Csize_t, Ref{cuComplex}, Ptr{cuComplex}, PtrOrCuPtr{cuComplex},
@@ -2815,7 +2815,7 @@ end
 end
 
 @checked function cublasXtZspmm(handle, side, uplo, m, n, alpha, AP, B, ldb, beta, C, ldc)
-    initialize_api()
+    initialize_context()
     ccall((:cublasXtZspmm, libcublas()), cublasStatus_t,
                    (cublasXtHandle_t, cublasSideMode_t, cublasFillMode_t, Csize_t,
                     Csize_t, Ref{cuDoubleComplex}, Ptr{cuDoubleComplex},
@@ -2826,7 +2826,7 @@ end
 
 @checked function cublasXtStrmm(handle, side, uplo, trans, diag, m, n, alpha, A, lda, B,
                                 ldb, C, ldc)
-    initialize_api()
+    initialize_context()
     ccall((:cublasXtStrmm, libcublas()), cublasStatus_t,
                    (cublasXtHandle_t, cublasSideMode_t, cublasFillMode_t,
                     cublasOperation_t, cublasDiagType_t, Csize_t, Csize_t,
@@ -2837,7 +2837,7 @@ end
 
 @checked function cublasXtDtrmm(handle, side, uplo, trans, diag, m, n, alpha, A, lda, B,
                                 ldb, C, ldc)
-    initialize_api()
+    initialize_context()
     ccall((:cublasXtDtrmm, libcublas()), cublasStatus_t,
                    (cublasXtHandle_t, cublasSideMode_t, cublasFillMode_t,
                     cublasOperation_t, cublasDiagType_t, Csize_t, Csize_t,
@@ -2848,7 +2848,7 @@ end
 
 @checked function cublasXtCtrmm(handle, side, uplo, trans, diag, m, n, alpha, A, lda, B,
                                 ldb, C, ldc)
-    initialize_api()
+    initialize_context()
     ccall((:cublasXtCtrmm, libcublas()), cublasStatus_t,
                    (cublasXtHandle_t, cublasSideMode_t, cublasFillMode_t,
                     cublasOperation_t, cublasDiagType_t, Csize_t, Csize_t,
@@ -2859,7 +2859,7 @@ end
 
 @checked function cublasXtZtrmm(handle, side, uplo, trans, diag, m, n, alpha, A, lda, B,
                                 ldb, C, ldc)
-    initialize_api()
+    initialize_context()
     ccall((:cublasXtZtrmm, libcublas()), cublasStatus_t,
                    (cublasXtHandle_t, cublasSideMode_t, cublasFillMode_t,
                     cublasOperation_t, cublasDiagType_t, Csize_t, Csize_t,
@@ -2872,6 +2872,6 @@ end
 ## added in CUDA 11 Update 1
 
 @checked function cublasSetWorkspace_v2(handle, workspace, workspaceSizeInBytes)
-    initialize_api()
+    initialize_context()
     ccall((:cublasSetWorkspace_v2, libcublas()), cublasStatus_t, (cublasHandle_t, CuPtr{Cvoid}, Csize_t), handle, workspace, workspaceSizeInBytes)
 end

--- a/lib/cublas/libcublas_deprecated.jl
+++ b/lib/cublas/libcublas_deprecated.jl
@@ -2,7 +2,7 @@
 
 @checked function cublasHgemm(handle, transa, transb, m, n, k, alpha, A, lda, B, ldb,
                               beta, C, ldc)
-    initialize_api()
+    initialize_context()
     ccall((:cublasDgemm_v2, libcublas()), cublasStatus_t,
                    (cublasHandle_t, cublasOperation_t, cublasOperation_t, Cint, Cint,
                     Cint, RefOrCuRef{Float16}, CuPtr{Float16}, Cint, CuPtr{Float16}, Cint,

--- a/lib/cudadrv/CUDAdrv.jl
+++ b/lib/cudadrv/CUDAdrv.jl
@@ -57,7 +57,7 @@ function libcuda()
                 Libdl.dlclose(library_handle)
             end
         end
-        system_version = get_version(system_driver)
+        _system_version[] = get_version(system_driver)
         _libcuda[] = system_driver
         # XXX: apparently cuDriverGetVersion can be used before cuInit,
         #      despite the docs stating "any function [...] will return
@@ -74,7 +74,7 @@ function libcuda()
             end
             return
         end
-        if system_version < v"11.4"
+        if _system_version[] < v"11.4"
             platform = Base.BinaryPlatforms.HostPlatform()
             platform.tags["cuda"] = "11.4"
 

--- a/lib/cudadrv/CUDAdrv.jl
+++ b/lib/cudadrv/CUDAdrv.jl
@@ -19,6 +19,8 @@ function libcuda()
                          Typically, that involves an entry in '/etc/ld.so.conf', or setting LD_LIBRARY_PATH.""")
             end
         end
+
+        cuInit(0)
     end
 
     # memoized because otherwise each ccall would perform discovery again

--- a/lib/cudadrv/CUDAdrv.jl
+++ b/lib/cudadrv/CUDAdrv.jl
@@ -6,26 +6,7 @@ using Printf
 
 import Libdl
 
-const _libcuda = Ref{String}()
-function libcuda()
-    if !isassigned(_libcuda)
-        if Sys.iswindows()
-            _libcuda[] = "nvcuda"
-        else
-            _libcuda[] = Libdl.find_library(["libcuda.so.1", "libcuda.so"])
-            if isempty(_libcuda[])
-                error("""Could not find the CUDA driver library 'libcuda.so'. Please make sure you have installed the NVIDIA driver for your GPU.
-                         If you're sure it's installed, look for `libcuda.so` in your system and make sure it's discoverable by the dynamic linker.
-                         Typically, that involves an entry in '/etc/ld.so.conf', or setting LD_LIBRARY_PATH.""")
-            end
-        end
-
-        cuInit(0)
-    end
-
-    # memoized because otherwise each ccall would perform discovery again
-    _libcuda[]
-end
+using LazyArtifacts
 
 
 # low-level wrappers
@@ -37,6 +18,99 @@ include("libcuda_common.jl")
 include("error.jl")
 include("libcuda.jl")
 include("libcuda_deprecated.jl")
+
+const _libcuda = Ref{String}()
+function libcuda()
+    if !isassigned(_libcuda)
+        # find the local system library
+        system_driver = if Sys.iswindows()
+            Libdl.find_library("nvcuda")
+        else
+            Libdl.find_library(["libcuda.so.1", "libcuda.so"])
+        end
+        if name == ""
+            if Sys.iswindows()
+                error("""Could not find the CUDA driver library. Please make sure you have installed the NVIDIA driver for your GPU.
+                         If you're sure it's installed, look for `libcuda.so` in your system and make sure it's discoverable by the linker.
+                         Typically, that involves an entry in '/etc/ld.so.conf', or setting LD_LIBRARY_PATH.""")
+            else
+                error("""Could not find the CUDA driver library. Please make sure you have installed the NVIDIA driver for your GPU.
+                         If you're sure it's installed, look for `nvcuda.dll` in your system and make sure it's discoverable by the linker.
+                         Typically, that involves adding an entry to PATH.""")
+            end
+        end
+
+        # NOTE: we can't re-use the function wrappers from libcuda.so,
+        #       as those use libcuda() whose value is cached by ccall.
+
+        # query the system driver version
+        function get_version(driver)
+            library_handle = Libdl.dlopen(driver)
+            try
+                function_handle = Libdl.dlsym(library_handle, "cuDriverGetVersion")
+                version_ref = Ref{Cint}()
+                @check ccall(function_handle, CUresult, (Ptr{Cint},), version_ref)
+                major, ver = divrem(version_ref[], 1000)
+                minor, patch = divrem(ver, 10)
+                return VersionNumber(major, minor, patch)
+            finally
+                Libdl.dlclose(library_handle)
+            end
+        end
+        system_version = get_version(system_driver)
+        _libcuda[] = system_driver
+        # XXX: apparently cuDriverGetVersion can be used before cuInit,
+        #      despite the docs stating "any function [...] will return
+        #      CUDA_ERROR_NOT_INITIALIZED"; is this a recent change?
+
+        # if we're using an older driver; consider using forward compatibility
+        function do_init(driver)
+            library_handle = Libdl.dlopen(driver)
+            try
+                function_handle = Libdl.dlsym(library_handle, "cuInit")
+                @check ccall(function_handle, CUresult, (UInt32,), 0)
+            finally
+                Libdl.dlclose(library_handle)
+            end
+            return
+        end
+        if system_version < v"11.4"
+            platform = Base.BinaryPlatforms.HostPlatform()
+            platform.tags["cuda"] = "11.4"
+
+            artifact = try
+                @artifact_str("CUDA_compat", platform)
+            catch ex
+                @debug "Could not download forward compatibility package" exception=(ex,catch_backtrace())
+                nothing
+            end
+
+            if artifact !== nothing
+                # TODO: do we need to dlopen the JIT compiler library for it to
+                #       be discoverable? doesn't that clash with a system one
+                #       if compat cuInit fails? or should we load it _after_
+                #       the compat driver initialization succeeds?
+                #compat_compiler = joinpath(artifact, "lib", "libnvidia-ptxjitcompiler.so")
+                #Libdl.dlopen(compat_compiler)
+
+                compat_driver = joinpath(artifact, "lib", "libcuda.so")
+                try
+                    # just calling cuDriverGetVersion doesn't trigger errors,
+                    # so perform driver intialization here
+                    do_init(compat_driver)
+                    _libcuda[] = compat_driver
+                catch ex
+                    @debug "Could not use forward compatibility package" exception=(ex,catch_backtrace())
+                end
+            end
+        end
+
+        cuInit(0)
+    end
+
+    # memoized because otherwise each ccall would perform discovery again
+    _libcuda[]
+end
 
 # high-level wrappers
 include("types.jl")

--- a/lib/cudadrv/error.jl
+++ b/lib/cudadrv/error.jl
@@ -76,20 +76,6 @@ Base.show(io::IO, ::MIME"text/plain", err::CuError) = print(io, "CuError($(err.c
 
 ## API call wrapper
 
-const __initialized_driver = LazyInitialized{Bool}()
-@inline function initialize_api()
-    get!(__initialized_driver; hook=__init_driver__) do
-        if haskey(ENV, "_") && basename(ENV["_"]) == "rr"
-            @error("Running under rr, which is incompatible with CUDA")
-            return false
-        end
-        cuInit(0)
-
-        return true
-    end
-    return
-end
-
 @inline function initialize_context()
     prepare_cuda_state()
     return

--- a/lib/cudadrv/libcuda.jl
+++ b/lib/cudadrv/libcuda.jl
@@ -2,14 +2,12 @@
 # Automatically generated using Clang.jl
 
 @checked function cuGetErrorString(error, pStr)
-    initialize_api()
     ccall((:cuGetErrorString, libcuda()), CUresult,
                    (CUresult, Ptr{Cstring}),
                    error, pStr)
 end
 
 @checked function cuGetErrorName(error, pStr)
-    initialize_api()
     ccall((:cuGetErrorName, libcuda()), CUresult,
                    (CUresult, Ptr{Cstring}),
                    error, pStr)
@@ -22,56 +20,48 @@ end
 end
 
 @checked function cuDriverGetVersion(driverVersion)
-    initialize_api()
     ccall((:cuDriverGetVersion, libcuda()), CUresult,
                    (Ptr{Cint},),
                    driverVersion)
 end
 
 @checked function cuDeviceGet(device, ordinal)
-    initialize_api()
     ccall((:cuDeviceGet, libcuda()), CUresult,
                    (Ptr{CUdevice}, Cint),
                    device, ordinal)
 end
 
 @checked function cuDeviceGetCount(count)
-    initialize_api()
     ccall((:cuDeviceGetCount, libcuda()), CUresult,
                    (Ptr{Cint},),
                    count)
 end
 
 @checked function cuDeviceGetName(name, len, dev)
-    initialize_api()
     ccall((:cuDeviceGetName, libcuda()), CUresult,
                    (Cstring, Cint, CUdevice),
                    name, len, dev)
 end
 
 @checked function cuDeviceGetUuid(uuid, dev)
-    initialize_api()
     ccall((:cuDeviceGetUuid, libcuda()), CUresult,
                    (Ptr{CUuuid}, CUdevice),
                    uuid, dev)
 end
 
 @checked function cuDeviceTotalMem_v2(bytes, dev)
-    initialize_api()
     ccall((:cuDeviceTotalMem_v2, libcuda()), CUresult,
                    (Ptr{Csize_t}, CUdevice),
                    bytes, dev)
 end
 
 @checked function cuDeviceGetAttribute(pi, attrib, dev)
-    initialize_api()
     ccall((:cuDeviceGetAttribute, libcuda()), CUresult,
                    (Ptr{Cint}, CUdevice_attribute, CUdevice),
                    pi, attrib, dev)
 end
 
 @checked function cuDeviceGetNvSciSyncAttributes(nvSciSyncAttrList, dev, flags)
-    initialize_api()
     initialize_context()
     ccall((:cuDeviceGetNvSciSyncAttributes, libcuda()), CUresult,
                    (Ptr{Cvoid}, CUdevice, Cint),
@@ -79,105 +69,90 @@ end
 end
 
 @checked function cuDeviceGetProperties(prop, dev)
-    initialize_api()
     ccall((:cuDeviceGetProperties, libcuda()), CUresult,
                    (Ptr{CUdevprop}, CUdevice),
                    prop, dev)
 end
 
 @checked function cuDeviceComputeCapability(major, minor, dev)
-    initialize_api()
     ccall((:cuDeviceComputeCapability, libcuda()), CUresult,
                    (Ptr{Cint}, Ptr{Cint}, CUdevice),
                    major, minor, dev)
 end
 
 @checked function cuDevicePrimaryCtxRetain(pctx, dev)
-    initialize_api()
     ccall((:cuDevicePrimaryCtxRetain, libcuda()), CUresult,
                    (Ptr{CUcontext}, CUdevice),
                    pctx, dev)
 end
 
 @checked function cuDevicePrimaryCtxRelease_v2(dev)
-    initialize_api()
     ccall((:cuDevicePrimaryCtxRelease_v2, libcuda()), CUresult,
                    (CUdevice,),
                    dev)
 end
 
 @checked function cuDevicePrimaryCtxSetFlags_v2(dev, flags)
-    initialize_api()
     ccall((:cuDevicePrimaryCtxSetFlags_v2, libcuda()), CUresult,
                    (CUdevice, UInt32),
                    dev, flags)
 end
 
 @checked function cuDevicePrimaryCtxGetState(dev, flags, active)
-    initialize_api()
     ccall((:cuDevicePrimaryCtxGetState, libcuda()), CUresult,
                    (CUdevice, Ptr{UInt32}, Ptr{Cint}),
                    dev, flags, active)
 end
 
 @checked function cuDevicePrimaryCtxReset_v2(dev)
-    initialize_api()
     ccall((:cuDevicePrimaryCtxReset_v2, libcuda()), CUresult,
                    (CUdevice,),
                    dev)
 end
 
 @checked function cuCtxCreate_v2(pctx, flags, dev)
-    initialize_api()
     ccall((:cuCtxCreate_v2, libcuda()), CUresult,
                    (Ptr{CUcontext}, UInt32, CUdevice),
                    pctx, flags, dev)
 end
 
 @checked function cuCtxDestroy_v2(ctx)
-    initialize_api()
     ccall((:cuCtxDestroy_v2, libcuda()), CUresult,
                    (CUcontext,),
                    ctx)
 end
 
 @checked function cuCtxPushCurrent_v2(ctx)
-    initialize_api()
     ccall((:cuCtxPushCurrent_v2, libcuda()), CUresult,
                    (CUcontext,),
                    ctx)
 end
 
 @checked function cuCtxPopCurrent_v2(pctx)
-    initialize_api()
     ccall((:cuCtxPopCurrent_v2, libcuda()), CUresult,
                    (Ptr{CUcontext},),
                    pctx)
 end
 
 @checked function cuCtxSetCurrent(ctx)
-    initialize_api()
     ccall((:cuCtxSetCurrent, libcuda()), CUresult,
                    (CUcontext,),
                    ctx)
 end
 
 @checked function cuCtxGetCurrent(pctx)
-    initialize_api()
     ccall((:cuCtxGetCurrent, libcuda()), CUresult,
                    (Ptr{CUcontext},),
                    pctx)
 end
 
 @checked function cuCtxGetDevice(device)
-    initialize_api()
     ccall((:cuCtxGetDevice, libcuda()), CUresult,
                    (Ptr{CUdevice},),
                    device)
 end
 
 @checked function cuCtxGetFlags(flags)
-    initialize_api()
     initialize_context()
     ccall((:cuCtxGetFlags, libcuda()), CUresult,
                    (Ptr{UInt32},),
@@ -185,13 +160,11 @@ end
 end
 
 @checked function cuCtxSynchronize()
-    initialize_api()
     initialize_context()
     ccall((:cuCtxSynchronize, libcuda()), CUresult, ())
 end
 
 @checked function cuCtxSetLimit(limit, value)
-    initialize_api()
     initialize_context()
     ccall((:cuCtxSetLimit, libcuda()), CUresult,
                    (CUlimit, Csize_t),
@@ -199,7 +172,6 @@ end
 end
 
 @checked function cuCtxGetLimit(pvalue, limit)
-    initialize_api()
     initialize_context()
     ccall((:cuCtxGetLimit, libcuda()), CUresult,
                    (Ptr{Csize_t}, CUlimit),
@@ -207,7 +179,6 @@ end
 end
 
 @checked function cuCtxGetCacheConfig(pconfig)
-    initialize_api()
     initialize_context()
     ccall((:cuCtxGetCacheConfig, libcuda()), CUresult,
                    (Ptr{CUfunc_cache},),
@@ -215,7 +186,6 @@ end
 end
 
 @checked function cuCtxSetCacheConfig(config)
-    initialize_api()
     initialize_context()
     ccall((:cuCtxSetCacheConfig, libcuda()), CUresult,
                    (CUfunc_cache,),
@@ -223,7 +193,6 @@ end
 end
 
 @checked function cuCtxGetSharedMemConfig(pConfig)
-    initialize_api()
     initialize_context()
     ccall((:cuCtxGetSharedMemConfig, libcuda()), CUresult,
                    (Ptr{CUsharedconfig},),
@@ -231,7 +200,6 @@ end
 end
 
 @checked function cuCtxSetSharedMemConfig(config)
-    initialize_api()
     initialize_context()
     ccall((:cuCtxSetSharedMemConfig, libcuda()), CUresult,
                    (CUsharedconfig,),
@@ -239,7 +207,6 @@ end
 end
 
 @checked function cuCtxGetApiVersion(ctx, version)
-    initialize_api()
     initialize_context()
     ccall((:cuCtxGetApiVersion, libcuda()), CUresult,
                    (CUcontext, Ptr{UInt32}),
@@ -247,7 +214,6 @@ end
 end
 
 @checked function cuCtxGetStreamPriorityRange(leastPriority, greatestPriority)
-    initialize_api()
     initialize_context()
     ccall((:cuCtxGetStreamPriorityRange, libcuda()), CUresult,
                    (Ptr{Cint}, Ptr{Cint}),
@@ -255,13 +221,11 @@ end
 end
 
 @checked function cuCtxResetPersistingL2Cache()
-    initialize_api()
     initialize_context()
     ccall((:cuCtxResetPersistingL2Cache, libcuda()), CUresult, ())
 end
 
 @checked function cuCtxAttach(pctx, flags)
-    initialize_api()
     initialize_context()
     ccall((:cuCtxAttach, libcuda()), CUresult,
                    (Ptr{CUcontext}, UInt32),
@@ -269,7 +233,6 @@ end
 end
 
 @checked function cuCtxDetach(ctx)
-    initialize_api()
     initialize_context()
     ccall((:cuCtxDetach, libcuda()), CUresult,
                    (CUcontext,),
@@ -277,7 +240,6 @@ end
 end
 
 @checked function cuModuleLoad(_module, fname)
-    initialize_api()
     initialize_context()
     ccall((:cuModuleLoad, libcuda()), CUresult,
                    (Ptr{CUmodule}, Cstring),
@@ -285,7 +247,6 @@ end
 end
 
 @checked function cuModuleLoadData(_module, image)
-    initialize_api()
     initialize_context()
     ccall((:cuModuleLoadData, libcuda()), CUresult,
                    (Ptr{CUmodule}, Ptr{Cvoid}),
@@ -293,7 +254,6 @@ end
 end
 
 @checked function cuModuleLoadDataEx(_module, image, numOptions, options, optionValues)
-    initialize_api()
     initialize_context()
     ccall((:cuModuleLoadDataEx, libcuda()), CUresult,
                    (Ptr{CUmodule}, Ptr{Cvoid}, UInt32, Ptr{CUjit_option}, Ptr{Ptr{Cvoid}}),
@@ -301,7 +261,6 @@ end
 end
 
 @checked function cuModuleLoadFatBinary(_module, fatCubin)
-    initialize_api()
     initialize_context()
     ccall((:cuModuleLoadFatBinary, libcuda()), CUresult,
                    (Ptr{CUmodule}, Ptr{Cvoid}),
@@ -309,7 +268,6 @@ end
 end
 
 @checked function cuModuleUnload(hmod)
-    initialize_api()
     initialize_context()
     ccall((:cuModuleUnload, libcuda()), CUresult,
                    (CUmodule,),
@@ -317,7 +275,6 @@ end
 end
 
 @checked function cuModuleGetFunction(hfunc, hmod, name)
-    initialize_api()
     initialize_context()
     ccall((:cuModuleGetFunction, libcuda()), CUresult,
                    (Ptr{CUfunction}, CUmodule, Cstring),
@@ -325,7 +282,6 @@ end
 end
 
 @checked function cuModuleGetGlobal_v2(dptr, bytes, hmod, name)
-    initialize_api()
     initialize_context()
     ccall((:cuModuleGetGlobal_v2, libcuda()), CUresult,
                    (Ptr{CUdeviceptr}, Ptr{Csize_t}, CUmodule, Cstring),
@@ -333,7 +289,6 @@ end
 end
 
 @checked function cuModuleGetTexRef(pTexRef, hmod, name)
-    initialize_api()
     initialize_context()
     ccall((:cuModuleGetTexRef, libcuda()), CUresult,
                    (Ptr{CUtexref}, CUmodule, Cstring),
@@ -341,7 +296,6 @@ end
 end
 
 @checked function cuModuleGetSurfRef(pSurfRef, hmod, name)
-    initialize_api()
     initialize_context()
     ccall((:cuModuleGetSurfRef, libcuda()), CUresult,
                    (Ptr{CUsurfref}, CUmodule, Cstring),
@@ -349,7 +303,6 @@ end
 end
 
 @checked function cuLinkCreate_v2(numOptions, options, optionValues, stateOut)
-    initialize_api()
     initialize_context()
     ccall((:cuLinkCreate_v2, libcuda()), CUresult,
                    (UInt32, Ptr{CUjit_option}, Ptr{Ptr{Cvoid}}, Ptr{CUlinkState}),
@@ -358,7 +311,6 @@ end
 
 @checked function cuLinkAddData_v2(state, type, data, size, name, numOptions, options,
                                    optionValues)
-    initialize_api()
     initialize_context()
     ccall((:cuLinkAddData_v2, libcuda()), CUresult,
                    (CUlinkState, CUjitInputType, Ptr{Cvoid}, Csize_t, Cstring, UInt32,
@@ -367,7 +319,6 @@ end
 end
 
 @checked function cuLinkAddFile_v2(state, type, path, numOptions, options, optionValues)
-    initialize_api()
     initialize_context()
     ccall((:cuLinkAddFile_v2, libcuda()), CUresult,
                    (CUlinkState, CUjitInputType, Cstring, UInt32, Ptr{CUjit_option},
@@ -376,7 +327,6 @@ end
 end
 
 @checked function cuLinkComplete(state, cubinOut, sizeOut)
-    initialize_api()
     initialize_context()
     ccall((:cuLinkComplete, libcuda()), CUresult,
                    (CUlinkState, Ptr{Ptr{Cvoid}}, Ptr{Csize_t}),
@@ -384,7 +334,6 @@ end
 end
 
 @checked function cuLinkDestroy(state)
-    initialize_api()
     initialize_context()
     ccall((:cuLinkDestroy, libcuda()), CUresult,
                    (CUlinkState,),
@@ -392,7 +341,6 @@ end
 end
 
 @checked function cuMemGetInfo_v2(free, total)
-    initialize_api()
     initialize_context()
     ccall((:cuMemGetInfo_v2, libcuda()), CUresult,
                    (Ptr{Csize_t}, Ptr{Csize_t}),
@@ -400,7 +348,6 @@ end
 end
 
 @checked function cuMemAlloc_v2(dptr, bytesize)
-    initialize_api()
     initialize_context()
     ccall((:cuMemAlloc_v2, libcuda()), CUresult,
                    (Ptr{CUdeviceptr}, Csize_t),
@@ -408,7 +355,6 @@ end
 end
 
 @checked function cuMemAllocPitch_v2(dptr, pPitch, WidthInBytes, Height, ElementSizeBytes)
-    initialize_api()
     initialize_context()
     ccall((:cuMemAllocPitch_v2, libcuda()), CUresult,
                    (Ptr{CUdeviceptr}, Ptr{Csize_t}, Csize_t, Csize_t, UInt32),
@@ -416,7 +362,6 @@ end
 end
 
 @checked function cuMemFree_v2(dptr)
-    initialize_api()
     initialize_context()
     ccall((:cuMemFree_v2, libcuda()), CUresult,
                    (CUdeviceptr,),
@@ -424,7 +369,6 @@ end
 end
 
 @checked function cuMemGetAddressRange_v2(pbase, psize, dptr)
-    initialize_api()
     initialize_context()
     ccall((:cuMemGetAddressRange_v2, libcuda()), CUresult,
                    (Ptr{CUdeviceptr}, Ptr{Csize_t}, CUdeviceptr),
@@ -432,7 +376,6 @@ end
 end
 
 @checked function cuMemAllocHost_v2(pp, bytesize)
-    initialize_api()
     initialize_context()
     ccall((:cuMemAllocHost_v2, libcuda()), CUresult,
                    (Ptr{Ptr{Cvoid}}, Csize_t),
@@ -440,7 +383,6 @@ end
 end
 
 @checked function cuMemFreeHost(p)
-    initialize_api()
     initialize_context()
     ccall((:cuMemFreeHost, libcuda()), CUresult,
                    (Ptr{Cvoid},),
@@ -448,7 +390,6 @@ end
 end
 
 @checked function cuMemHostAlloc(pp, bytesize, Flags)
-    initialize_api()
     initialize_context()
     ccall((:cuMemHostAlloc, libcuda()), CUresult,
                    (Ptr{Ptr{Cvoid}}, Csize_t, UInt32),
@@ -456,7 +397,6 @@ end
 end
 
 @checked function cuMemHostGetDevicePointer_v2(pdptr, p, Flags)
-    initialize_api()
     initialize_context()
     ccall((:cuMemHostGetDevicePointer_v2, libcuda()), CUresult,
                    (Ptr{CUdeviceptr}, Ptr{Cvoid}, UInt32),
@@ -464,7 +404,6 @@ end
 end
 
 @checked function cuMemHostGetFlags(pFlags, p)
-    initialize_api()
     initialize_context()
     ccall((:cuMemHostGetFlags, libcuda()), CUresult,
                    (Ptr{UInt32}, Ptr{Cvoid}),
@@ -472,7 +411,6 @@ end
 end
 
 @checked function cuMemAllocManaged(dptr, bytesize, flags)
-    initialize_api()
     initialize_context()
     ccall((:cuMemAllocManaged, libcuda()), CUresult,
                    (Ptr{CUdeviceptr}, Csize_t, UInt32),
@@ -480,7 +418,6 @@ end
 end
 
 @checked function cuDeviceGetByPCIBusId(dev, pciBusId)
-    initialize_api()
     initialize_context()
     ccall((:cuDeviceGetByPCIBusId, libcuda()), CUresult,
                    (Ptr{CUdevice}, Cstring),
@@ -488,7 +425,6 @@ end
 end
 
 @checked function cuDeviceGetPCIBusId(pciBusId, len, dev)
-    initialize_api()
     initialize_context()
     ccall((:cuDeviceGetPCIBusId, libcuda()), CUresult,
                    (Cstring, Cint, CUdevice),
@@ -496,7 +432,6 @@ end
 end
 
 @checked function cuIpcGetEventHandle(pHandle, event)
-    initialize_api()
     initialize_context()
     ccall((:cuIpcGetEventHandle, libcuda()), CUresult,
                    (Ptr{CUipcEventHandle}, CUevent),
@@ -504,7 +439,6 @@ end
 end
 
 @checked function cuIpcOpenEventHandle(phEvent, handle)
-    initialize_api()
     initialize_context()
     ccall((:cuIpcOpenEventHandle, libcuda()), CUresult,
                    (Ptr{CUevent}, CUipcEventHandle),
@@ -512,7 +446,6 @@ end
 end
 
 @checked function cuIpcGetMemHandle(pHandle, dptr)
-    initialize_api()
     initialize_context()
     ccall((:cuIpcGetMemHandle, libcuda()), CUresult,
                    (Ptr{CUipcMemHandle}, CUdeviceptr),
@@ -520,7 +453,6 @@ end
 end
 
 @checked function cuIpcCloseMemHandle(dptr)
-    initialize_api()
     initialize_context()
     ccall((:cuIpcCloseMemHandle, libcuda()), CUresult,
                    (CUdeviceptr,),
@@ -528,7 +460,6 @@ end
 end
 
 @checked function cuMemHostRegister_v2(p, bytesize, Flags)
-    initialize_api()
     initialize_context()
     ccall((:cuMemHostRegister_v2, libcuda()), CUresult,
                    (Ptr{Cvoid}, Csize_t, UInt32),
@@ -536,7 +467,6 @@ end
 end
 
 @checked function cuMemHostUnregister(p)
-    initialize_api()
     initialize_context()
     ccall((:cuMemHostUnregister, libcuda()), CUresult,
                    (Ptr{Cvoid},),
@@ -544,7 +474,6 @@ end
 end
 
 @checked function cuMemcpy(dst, src, ByteCount)
-    initialize_api()
     initialize_context()
     ccall((:cuMemcpy, libcuda()), CUresult,
                    (CUdeviceptr, CUdeviceptr, Csize_t),
@@ -552,7 +481,6 @@ end
 end
 
 @checked function cuMemcpyPeer(dstDevice, dstContext, srcDevice, srcContext, ByteCount)
-    initialize_api()
     initialize_context()
     ccall((:cuMemcpyPeer, libcuda()), CUresult,
                    (CUdeviceptr, CUcontext, CUdeviceptr, CUcontext, Csize_t),
@@ -560,7 +488,6 @@ end
 end
 
 @checked function cuMemcpyHtoD_v2(dstDevice, srcHost, ByteCount)
-    initialize_api()
     initialize_context()
     ccall((:cuMemcpyHtoD_v2, libcuda()), CUresult,
                    (CUdeviceptr, Ptr{Cvoid}, Csize_t),
@@ -568,7 +495,6 @@ end
 end
 
 @checked function cuMemcpyDtoH_v2(dstHost, srcDevice, ByteCount)
-    initialize_api()
     initialize_context()
     ccall((:cuMemcpyDtoH_v2, libcuda()), CUresult,
                    (Ptr{Cvoid}, CUdeviceptr, Csize_t),
@@ -576,7 +502,6 @@ end
 end
 
 @checked function cuMemcpyDtoD_v2(dstDevice, srcDevice, ByteCount)
-    initialize_api()
     initialize_context()
     ccall((:cuMemcpyDtoD_v2, libcuda()), CUresult,
                    (CUdeviceptr, CUdeviceptr, Csize_t),
@@ -584,7 +509,6 @@ end
 end
 
 @checked function cuMemcpyDtoA_v2(dstArray, dstOffset, srcDevice, ByteCount)
-    initialize_api()
     initialize_context()
     ccall((:cuMemcpyDtoA_v2, libcuda()), CUresult,
                    (CUarray, Csize_t, CUdeviceptr, Csize_t),
@@ -592,7 +516,6 @@ end
 end
 
 @checked function cuMemcpyAtoD_v2(dstDevice, srcArray, srcOffset, ByteCount)
-    initialize_api()
     initialize_context()
     ccall((:cuMemcpyAtoD_v2, libcuda()), CUresult,
                    (CUdeviceptr, CUarray, Csize_t, Csize_t),
@@ -600,7 +523,6 @@ end
 end
 
 @checked function cuMemcpyHtoA_v2(dstArray, dstOffset, srcHost, ByteCount)
-    initialize_api()
     initialize_context()
     ccall((:cuMemcpyHtoA_v2, libcuda()), CUresult,
                    (CUarray, Csize_t, Ptr{Cvoid}, Csize_t),
@@ -608,7 +530,6 @@ end
 end
 
 @checked function cuMemcpyAtoH_v2(dstHost, srcArray, srcOffset, ByteCount)
-    initialize_api()
     initialize_context()
     ccall((:cuMemcpyAtoH_v2, libcuda()), CUresult,
                    (Ptr{Cvoid}, CUarray, Csize_t, Csize_t),
@@ -616,7 +537,6 @@ end
 end
 
 @checked function cuMemcpyAtoA_v2(dstArray, dstOffset, srcArray, srcOffset, ByteCount)
-    initialize_api()
     initialize_context()
     ccall((:cuMemcpyAtoA_v2, libcuda()), CUresult,
                    (CUarray, Csize_t, CUarray, Csize_t, Csize_t),
@@ -624,7 +544,6 @@ end
 end
 
 @checked function cuMemcpy2D_v2(pCopy)
-    initialize_api()
     initialize_context()
     ccall((:cuMemcpy2D_v2, libcuda()), CUresult,
                    (Ptr{CUDA_MEMCPY2D},),
@@ -632,7 +551,6 @@ end
 end
 
 @checked function cuMemcpy2DUnaligned_v2(pCopy)
-    initialize_api()
     initialize_context()
     ccall((:cuMemcpy2DUnaligned_v2, libcuda()), CUresult,
                    (Ptr{CUDA_MEMCPY2D},),
@@ -640,7 +558,6 @@ end
 end
 
 @checked function cuMemcpy3D_v2(pCopy)
-    initialize_api()
     initialize_context()
     ccall((:cuMemcpy3D_v2, libcuda()), CUresult,
                    (Ptr{CUDA_MEMCPY3D},),
@@ -648,7 +565,6 @@ end
 end
 
 @checked function cuMemcpy3DPeer(pCopy)
-    initialize_api()
     initialize_context()
     ccall((:cuMemcpy3DPeer, libcuda()), CUresult,
                    (Ptr{CUDA_MEMCPY3D_PEER},),
@@ -656,7 +572,6 @@ end
 end
 
 @checked function cuMemcpyAsync(dst, src, ByteCount, hStream)
-    initialize_api()
     initialize_context()
     ccall((:cuMemcpyAsync, libcuda()), CUresult,
                    (CUdeviceptr, CUdeviceptr, Csize_t, CUstream),
@@ -665,7 +580,6 @@ end
 
 @checked function cuMemcpyPeerAsync(dstDevice, dstContext, srcDevice, srcContext,
                                     ByteCount, hStream)
-    initialize_api()
     initialize_context()
     ccall((:cuMemcpyPeerAsync, libcuda()), CUresult,
                    (CUdeviceptr, CUcontext, CUdeviceptr, CUcontext, Csize_t, CUstream),
@@ -673,7 +587,6 @@ end
 end
 
 @checked function cuMemcpyHtoDAsync_v2(dstDevice, srcHost, ByteCount, hStream)
-    initialize_api()
     initialize_context()
     ccall((:cuMemcpyHtoDAsync_v2, libcuda()), CUresult,
                    (CUdeviceptr, Ptr{Cvoid}, Csize_t, CUstream),
@@ -681,7 +594,6 @@ end
 end
 
 @checked function cuMemcpyDtoHAsync_v2(dstHost, srcDevice, ByteCount, hStream)
-    initialize_api()
     initialize_context()
     ccall((:cuMemcpyDtoHAsync_v2, libcuda()), CUresult,
                    (Ptr{Cvoid}, CUdeviceptr, Csize_t, CUstream),
@@ -689,7 +601,6 @@ end
 end
 
 @checked function cuMemcpyDtoDAsync_v2(dstDevice, srcDevice, ByteCount, hStream)
-    initialize_api()
     initialize_context()
     ccall((:cuMemcpyDtoDAsync_v2, libcuda()), CUresult,
                    (CUdeviceptr, CUdeviceptr, Csize_t, CUstream),
@@ -697,7 +608,6 @@ end
 end
 
 @checked function cuMemcpyHtoAAsync_v2(dstArray, dstOffset, srcHost, ByteCount, hStream)
-    initialize_api()
     initialize_context()
     ccall((:cuMemcpyHtoAAsync_v2, libcuda()), CUresult,
                    (CUarray, Csize_t, Ptr{Cvoid}, Csize_t, CUstream),
@@ -705,7 +615,6 @@ end
 end
 
 @checked function cuMemcpyAtoHAsync_v2(dstHost, srcArray, srcOffset, ByteCount, hStream)
-    initialize_api()
     initialize_context()
     ccall((:cuMemcpyAtoHAsync_v2, libcuda()), CUresult,
                    (Ptr{Cvoid}, CUarray, Csize_t, Csize_t, CUstream),
@@ -713,7 +622,6 @@ end
 end
 
 @checked function cuMemcpy2DAsync_v2(pCopy, hStream)
-    initialize_api()
     initialize_context()
     ccall((:cuMemcpy2DAsync_v2, libcuda()), CUresult,
                    (Ptr{CUDA_MEMCPY2D}, CUstream),
@@ -721,7 +629,6 @@ end
 end
 
 @checked function cuMemcpy3DAsync_v2(pCopy, hStream)
-    initialize_api()
     initialize_context()
     ccall((:cuMemcpy3DAsync_v2, libcuda()), CUresult,
                    (Ptr{CUDA_MEMCPY3D}, CUstream),
@@ -729,7 +636,6 @@ end
 end
 
 @checked function cuMemcpy3DPeerAsync(pCopy, hStream)
-    initialize_api()
     initialize_context()
     ccall((:cuMemcpy3DPeerAsync, libcuda()), CUresult,
                    (Ptr{CUDA_MEMCPY3D_PEER}, CUstream),
@@ -737,7 +643,6 @@ end
 end
 
 @checked function cuMemsetD8_v2(dstDevice, uc, N)
-    initialize_api()
     initialize_context()
     ccall((:cuMemsetD8_v2, libcuda()), CUresult,
                    (CUdeviceptr, Cuchar, Csize_t),
@@ -745,7 +650,6 @@ end
 end
 
 @checked function cuMemsetD16_v2(dstDevice, us, N)
-    initialize_api()
     initialize_context()
     ccall((:cuMemsetD16_v2, libcuda()), CUresult,
                    (CUdeviceptr, UInt16, Csize_t),
@@ -753,7 +657,6 @@ end
 end
 
 @checked function cuMemsetD32_v2(dstDevice, ui, N)
-    initialize_api()
     initialize_context()
     ccall((:cuMemsetD32_v2, libcuda()), CUresult,
                    (CUdeviceptr, UInt32, Csize_t),
@@ -761,7 +664,6 @@ end
 end
 
 @checked function cuMemsetD2D8_v2(dstDevice, dstPitch, uc, Width, Height)
-    initialize_api()
     initialize_context()
     ccall((:cuMemsetD2D8_v2, libcuda()), CUresult,
                    (CUdeviceptr, Csize_t, Cuchar, Csize_t, Csize_t),
@@ -769,7 +671,6 @@ end
 end
 
 @checked function cuMemsetD2D16_v2(dstDevice, dstPitch, us, Width, Height)
-    initialize_api()
     initialize_context()
     ccall((:cuMemsetD2D16_v2, libcuda()), CUresult,
                    (CUdeviceptr, Csize_t, UInt16, Csize_t, Csize_t),
@@ -777,7 +678,6 @@ end
 end
 
 @checked function cuMemsetD2D32_v2(dstDevice, dstPitch, ui, Width, Height)
-    initialize_api()
     initialize_context()
     ccall((:cuMemsetD2D32_v2, libcuda()), CUresult,
                    (CUdeviceptr, Csize_t, UInt32, Csize_t, Csize_t),
@@ -785,7 +685,6 @@ end
 end
 
 @checked function cuMemsetD8Async(dstDevice, uc, N, hStream)
-    initialize_api()
     initialize_context()
     ccall((:cuMemsetD8Async, libcuda()), CUresult,
                    (CUdeviceptr, Cuchar, Csize_t, CUstream),
@@ -793,7 +692,6 @@ end
 end
 
 @checked function cuMemsetD16Async(dstDevice, us, N, hStream)
-    initialize_api()
     initialize_context()
     ccall((:cuMemsetD16Async, libcuda()), CUresult,
                    (CUdeviceptr, UInt16, Csize_t, CUstream),
@@ -801,7 +699,6 @@ end
 end
 
 @checked function cuMemsetD32Async(dstDevice, ui, N, hStream)
-    initialize_api()
     initialize_context()
     ccall((:cuMemsetD32Async, libcuda()), CUresult,
                    (CUdeviceptr, UInt32, Csize_t, CUstream),
@@ -809,7 +706,6 @@ end
 end
 
 @checked function cuMemsetD2D8Async(dstDevice, dstPitch, uc, Width, Height, hStream)
-    initialize_api()
     initialize_context()
     ccall((:cuMemsetD2D8Async, libcuda()), CUresult,
                    (CUdeviceptr, Csize_t, Cuchar, Csize_t, Csize_t, CUstream),
@@ -817,7 +713,6 @@ end
 end
 
 @checked function cuMemsetD2D16Async(dstDevice, dstPitch, us, Width, Height, hStream)
-    initialize_api()
     initialize_context()
     ccall((:cuMemsetD2D16Async, libcuda()), CUresult,
                    (CUdeviceptr, Csize_t, UInt16, Csize_t, Csize_t, CUstream),
@@ -825,7 +720,6 @@ end
 end
 
 @checked function cuMemsetD2D32Async(dstDevice, dstPitch, ui, Width, Height, hStream)
-    initialize_api()
     initialize_context()
     ccall((:cuMemsetD2D32Async, libcuda()), CUresult,
                    (CUdeviceptr, Csize_t, UInt32, Csize_t, Csize_t, CUstream),
@@ -833,7 +727,6 @@ end
 end
 
 @checked function cuArrayCreate_v2(pHandle, pAllocateArray)
-    initialize_api()
     initialize_context()
     ccall((:cuArrayCreate_v2, libcuda()), CUresult,
                    (Ptr{CUarray}, Ptr{CUDA_ARRAY_DESCRIPTOR}),
@@ -841,7 +734,6 @@ end
 end
 
 @checked function cuArrayGetDescriptor_v2(pArrayDescriptor, hArray)
-    initialize_api()
     initialize_context()
     ccall((:cuArrayGetDescriptor_v2, libcuda()), CUresult,
                    (Ptr{CUDA_ARRAY_DESCRIPTOR}, CUarray),
@@ -849,7 +741,6 @@ end
 end
 
 @checked function cuArrayDestroy(hArray)
-    initialize_api()
     initialize_context()
     ccall((:cuArrayDestroy, libcuda()), CUresult,
                    (CUarray,),
@@ -857,7 +748,6 @@ end
 end
 
 @checked function cuArray3DCreate_v2(pHandle, pAllocateArray)
-    initialize_api()
     initialize_context()
     ccall((:cuArray3DCreate_v2, libcuda()), CUresult,
                    (Ptr{CUarray}, Ptr{CUDA_ARRAY3D_DESCRIPTOR}),
@@ -865,7 +755,6 @@ end
 end
 
 @checked function cuArray3DGetDescriptor_v2(pArrayDescriptor, hArray)
-    initialize_api()
     initialize_context()
     ccall((:cuArray3DGetDescriptor_v2, libcuda()), CUresult,
                    (Ptr{CUDA_ARRAY3D_DESCRIPTOR}, CUarray),
@@ -873,7 +762,6 @@ end
 end
 
 @checked function cuMipmappedArrayCreate(pHandle, pMipmappedArrayDesc, numMipmapLevels)
-    initialize_api()
     initialize_context()
     ccall((:cuMipmappedArrayCreate, libcuda()), CUresult,
                    (Ptr{CUmipmappedArray}, Ptr{CUDA_ARRAY3D_DESCRIPTOR}, UInt32),
@@ -881,7 +769,6 @@ end
 end
 
 @checked function cuMipmappedArrayGetLevel(pLevelArray, hMipmappedArray, level)
-    initialize_api()
     initialize_context()
     ccall((:cuMipmappedArrayGetLevel, libcuda()), CUresult,
                    (Ptr{CUarray}, CUmipmappedArray, UInt32),
@@ -889,7 +776,6 @@ end
 end
 
 @checked function cuMipmappedArrayDestroy(hMipmappedArray)
-    initialize_api()
     initialize_context()
     ccall((:cuMipmappedArrayDestroy, libcuda()), CUresult,
                    (CUmipmappedArray,),
@@ -897,7 +783,6 @@ end
 end
 
 @checked function cuMemAddressReserve(ptr, size, alignment, addr, flags)
-    initialize_api()
     initialize_context()
     ccall((:cuMemAddressReserve, libcuda()), CUresult,
                    (Ptr{CUdeviceptr}, Csize_t, Csize_t, CUdeviceptr, Culonglong),
@@ -905,7 +790,6 @@ end
 end
 
 @checked function cuMemAddressFree(ptr, size)
-    initialize_api()
     initialize_context()
     ccall((:cuMemAddressFree, libcuda()), CUresult,
                    (CUdeviceptr, Csize_t),
@@ -913,7 +797,6 @@ end
 end
 
 @checked function cuMemCreate(handle, size, prop, flags)
-    initialize_api()
     initialize_context()
     ccall((:cuMemCreate, libcuda()), CUresult,
                    (Ptr{CUmemGenericAllocationHandle}, Csize_t, Ptr{CUmemAllocationProp},
@@ -922,7 +805,6 @@ end
 end
 
 @checked function cuMemRelease(handle)
-    initialize_api()
     initialize_context()
     ccall((:cuMemRelease, libcuda()), CUresult,
                    (CUmemGenericAllocationHandle,),
@@ -930,7 +812,6 @@ end
 end
 
 @checked function cuMemMap(ptr, size, offset, handle, flags)
-    initialize_api()
     initialize_context()
     ccall((:cuMemMap, libcuda()), CUresult,
                    (CUdeviceptr, Csize_t, Csize_t, CUmemGenericAllocationHandle,
@@ -939,7 +820,6 @@ end
 end
 
 @checked function cuMemUnmap(ptr, size)
-    initialize_api()
     initialize_context()
     ccall((:cuMemUnmap, libcuda()), CUresult,
                    (CUdeviceptr, Csize_t),
@@ -947,7 +827,6 @@ end
 end
 
 @checked function cuMemSetAccess(ptr, size, desc, count)
-    initialize_api()
     initialize_context()
     ccall((:cuMemSetAccess, libcuda()), CUresult,
                    (CUdeviceptr, Csize_t, Ptr{CUmemAccessDesc}, Csize_t),
@@ -955,7 +834,6 @@ end
 end
 
 @checked function cuMemGetAccess(flags, location, ptr)
-    initialize_api()
     initialize_context()
     ccall((:cuMemGetAccess, libcuda()), CUresult,
                    (Ptr{Culonglong}, Ptr{CUmemLocation}, CUdeviceptr),
@@ -963,7 +841,6 @@ end
 end
 
 @checked function cuMemExportToShareableHandle(shareableHandle, handle, handleType, flags)
-    initialize_api()
     initialize_context()
     ccall((:cuMemExportToShareableHandle, libcuda()), CUresult,
                    (Ptr{Cvoid}, CUmemGenericAllocationHandle, CUmemAllocationHandleType,
@@ -972,7 +849,6 @@ end
 end
 
 @checked function cuMemImportFromShareableHandle(handle, osHandle, shHandleType)
-    initialize_api()
     initialize_context()
     ccall((:cuMemImportFromShareableHandle, libcuda()), CUresult,
                    (Ptr{CUmemGenericAllocationHandle}, Ptr{Cvoid},
@@ -981,7 +857,6 @@ end
 end
 
 @checked function cuMemGetAllocationGranularity(granularity, prop, option)
-    initialize_api()
     initialize_context()
     ccall((:cuMemGetAllocationGranularity, libcuda()), CUresult,
                    (Ptr{Csize_t}, Ptr{CUmemAllocationProp},
@@ -990,7 +865,6 @@ end
 end
 
 @checked function cuMemGetAllocationPropertiesFromHandle(prop, handle)
-    initialize_api()
     initialize_context()
     ccall((:cuMemGetAllocationPropertiesFromHandle, libcuda()), CUresult,
                    (Ptr{CUmemAllocationProp}, CUmemGenericAllocationHandle),
@@ -998,7 +872,6 @@ end
 end
 
 @checked function cuMemRetainAllocationHandle(handle, addr)
-    initialize_api()
     initialize_context()
     ccall((:cuMemRetainAllocationHandle, libcuda()), CUresult,
                    (Ptr{CUmemGenericAllocationHandle}, Ptr{Cvoid}),
@@ -1006,7 +879,6 @@ end
 end
 
 @checked function cuPointerGetAttribute(data, attribute, ptr)
-    initialize_api()
     initialize_context()
     ccall((:cuPointerGetAttribute, libcuda()), CUresult,
                    (Ptr{Cvoid}, CUpointer_attribute, CUdeviceptr),
@@ -1014,7 +886,6 @@ end
 end
 
 @checked function cuMemPrefetchAsync(devPtr, count, dstDevice, hStream)
-    initialize_api()
     initialize_context()
     ccall((:cuMemPrefetchAsync, libcuda()), CUresult,
                    (CUdeviceptr, Csize_t, CUdevice, CUstream),
@@ -1022,7 +893,6 @@ end
 end
 
 @checked function cuMemAdvise(devPtr, count, advice, device)
-    initialize_api()
     initialize_context()
     ccall((:cuMemAdvise, libcuda()), CUresult,
                    (CUdeviceptr, Csize_t, CUmem_advise, CUdevice),
@@ -1030,7 +900,6 @@ end
 end
 
 @checked function cuMemRangeGetAttribute(data, dataSize, attribute, devPtr, count)
-    initialize_api()
     initialize_context()
     ccall((:cuMemRangeGetAttribute, libcuda()), CUresult,
                    (Ptr{Cvoid}, Csize_t, CUmem_range_attribute, CUdeviceptr, Csize_t),
@@ -1039,7 +908,6 @@ end
 
 @checked function cuMemRangeGetAttributes(data, dataSizes, attributes, numAttributes,
                                           devPtr, count)
-    initialize_api()
     initialize_context()
     ccall((:cuMemRangeGetAttributes, libcuda()), CUresult,
                    (Ptr{Ptr{Cvoid}}, Ptr{Csize_t}, Ptr{CUmem_range_attribute}, Csize_t,
@@ -1048,7 +916,6 @@ end
 end
 
 @checked function cuPointerSetAttribute(value, attribute, ptr)
-    initialize_api()
     initialize_context()
     ccall((:cuPointerSetAttribute, libcuda()), CUresult,
                    (Ptr{Cvoid}, CUpointer_attribute, CUdeviceptr),
@@ -1056,7 +923,6 @@ end
 end
 
 @checked function cuPointerGetAttributes(numAttributes, attributes, data, ptr)
-    initialize_api()
     initialize_context()
     ccall((:cuPointerGetAttributes, libcuda()), CUresult,
                    (UInt32, Ptr{CUpointer_attribute}, Ptr{Ptr{Cvoid}}, CUdeviceptr),
@@ -1064,7 +930,6 @@ end
 end
 
 @checked function cuStreamCreate(phStream, Flags)
-    initialize_api()
     initialize_context()
     ccall((:cuStreamCreate, libcuda()), CUresult,
                    (Ptr{CUstream}, UInt32),
@@ -1072,7 +937,6 @@ end
 end
 
 @checked function cuStreamCreateWithPriority(phStream, flags, priority)
-    initialize_api()
     initialize_context()
     ccall((:cuStreamCreateWithPriority, libcuda()), CUresult,
                    (Ptr{CUstream}, UInt32, Cint),
@@ -1080,7 +944,6 @@ end
 end
 
 @checked function cuStreamGetPriority(hStream, priority)
-    initialize_api()
     initialize_context()
     ccall((:cuStreamGetPriority, libcuda()), CUresult,
                    (CUstream, Ptr{Cint}),
@@ -1088,7 +951,6 @@ end
 end
 
 @checked function cuStreamGetFlags(hStream, flags)
-    initialize_api()
     initialize_context()
     ccall((:cuStreamGetFlags, libcuda()), CUresult,
                    (CUstream, Ptr{UInt32}),
@@ -1096,7 +958,6 @@ end
 end
 
 @checked function cuStreamGetCtx(hStream, pctx)
-    initialize_api()
     initialize_context()
     ccall((:cuStreamGetCtx, libcuda()), CUresult,
                    (CUstream, Ptr{CUcontext}),
@@ -1104,7 +965,6 @@ end
 end
 
 @checked function cuStreamWaitEvent(hStream, hEvent, Flags)
-    initialize_api()
     initialize_context()
     ccall((:cuStreamWaitEvent, libcuda()), CUresult,
                    (CUstream, CUevent, UInt32),
@@ -1112,7 +972,6 @@ end
 end
 
 @checked function cuStreamAddCallback(hStream, callback, userData, flags)
-    initialize_api()
     initialize_context()
     ccall((:cuStreamAddCallback, libcuda()), CUresult,
                    (CUstream, CUstreamCallback, Ptr{Cvoid}, UInt32),
@@ -1120,7 +979,6 @@ end
 end
 
 @checked function cuStreamBeginCapture_v2(hStream, mode)
-    initialize_api()
     initialize_context()
     ccall((:cuStreamBeginCapture_v2, libcuda()), CUresult,
                    (CUstream, CUstreamCaptureMode),
@@ -1128,7 +986,6 @@ end
 end
 
 @checked function cuThreadExchangeStreamCaptureMode(mode)
-    initialize_api()
     initialize_context()
     ccall((:cuThreadExchangeStreamCaptureMode, libcuda()), CUresult,
                    (Ptr{CUstreamCaptureMode},),
@@ -1136,7 +993,6 @@ end
 end
 
 @checked function cuStreamEndCapture(hStream, phGraph)
-    initialize_api()
     initialize_context()
     ccall((:cuStreamEndCapture, libcuda()), CUresult,
                    (CUstream, Ptr{CUgraph}),
@@ -1144,7 +1000,6 @@ end
 end
 
 @checked function cuStreamIsCapturing(hStream, captureStatus)
-    initialize_api()
     initialize_context()
     ccall((:cuStreamIsCapturing, libcuda()), CUresult,
                    (CUstream, Ptr{CUstreamCaptureStatus}),
@@ -1152,7 +1007,6 @@ end
 end
 
 @checked function cuStreamGetCaptureInfo(hStream, captureStatus, id)
-    initialize_api()
     initialize_context()
     ccall((:cuStreamGetCaptureInfo, libcuda()), CUresult,
                    (CUstream, Ptr{CUstreamCaptureStatus}, Ptr{cuuint64_t}),
@@ -1160,7 +1014,6 @@ end
 end
 
 @checked function cuStreamAttachMemAsync(hStream, dptr, length, flags)
-    initialize_api()
     initialize_context()
     ccall((:cuStreamAttachMemAsync, libcuda()), CUresult,
                    (CUstream, CUdeviceptr, Csize_t, UInt32),
@@ -1168,7 +1021,6 @@ end
 end
 
 @checked function cuStreamQuery(hStream)
-    initialize_api()
     initialize_context()
     ccall((:cuStreamQuery, libcuda()), CUresult,
                    (CUstream,),
@@ -1176,7 +1028,6 @@ end
 end
 
 @checked function cuStreamSynchronize(hStream)
-    initialize_api()
     initialize_context()
     ccall((:cuStreamSynchronize, libcuda()), CUresult,
                    (CUstream,),
@@ -1184,7 +1035,6 @@ end
 end
 
 @checked function cuStreamDestroy_v2(hStream)
-    initialize_api()
     initialize_context()
     ccall((:cuStreamDestroy_v2, libcuda()), CUresult,
                    (CUstream,),
@@ -1192,7 +1042,6 @@ end
 end
 
 @checked function cuStreamCopyAttributes(dst, src)
-    initialize_api()
     initialize_context()
     ccall((:cuStreamCopyAttributes, libcuda()), CUresult,
                    (CUstream, CUstream),
@@ -1200,7 +1049,6 @@ end
 end
 
 @checked function cuStreamGetAttribute(hStream, attr, value_out)
-    initialize_api()
     initialize_context()
     ccall((:cuStreamGetAttribute, libcuda()), CUresult,
                    (CUstream, CUstreamAttrID, Ptr{CUstreamAttrValue}),
@@ -1208,7 +1056,6 @@ end
 end
 
 @checked function cuStreamSetAttribute(hStream, attr, value)
-    initialize_api()
     initialize_context()
     ccall((:cuStreamSetAttribute, libcuda()), CUresult,
                    (CUstream, CUstreamAttrID, Ptr{CUstreamAttrValue}),
@@ -1216,7 +1063,6 @@ end
 end
 
 @checked function cuEventCreate(phEvent, Flags)
-    initialize_api()
     initialize_context()
     ccall((:cuEventCreate, libcuda()), CUresult,
                    (Ptr{CUevent}, UInt32),
@@ -1224,7 +1070,6 @@ end
 end
 
 @checked function cuEventRecord(hEvent, hStream)
-    initialize_api()
     initialize_context()
     ccall((:cuEventRecord, libcuda()), CUresult,
                    (CUevent, CUstream),
@@ -1232,7 +1077,6 @@ end
 end
 
 @checked function cuEventQuery(hEvent)
-    initialize_api()
     initialize_context()
     ccall((:cuEventQuery, libcuda()), CUresult,
                    (CUevent,),
@@ -1240,7 +1084,6 @@ end
 end
 
 @checked function cuEventSynchronize(hEvent)
-    initialize_api()
     initialize_context()
     ccall((:cuEventSynchronize, libcuda()), CUresult,
                    (CUevent,),
@@ -1248,7 +1091,6 @@ end
 end
 
 @checked function cuEventDestroy_v2(hEvent)
-    initialize_api()
     initialize_context()
     ccall((:cuEventDestroy_v2, libcuda()), CUresult,
                    (CUevent,),
@@ -1256,7 +1098,6 @@ end
 end
 
 @checked function cuEventElapsedTime(pMilliseconds, hStart, hEnd)
-    initialize_api()
     initialize_context()
     ccall((:cuEventElapsedTime, libcuda()), CUresult,
                    (Ptr{Cfloat}, CUevent, CUevent),
@@ -1264,7 +1105,6 @@ end
 end
 
 @checked function cuImportExternalMemory(extMem_out, memHandleDesc)
-    initialize_api()
     initialize_context()
     ccall((:cuImportExternalMemory, libcuda()), CUresult,
                    (Ptr{CUexternalMemory}, Ptr{CUDA_EXTERNAL_MEMORY_HANDLE_DESC}),
@@ -1272,7 +1112,6 @@ end
 end
 
 @checked function cuExternalMemoryGetMappedBuffer(devPtr, extMem, bufferDesc)
-    initialize_api()
     initialize_context()
     ccall((:cuExternalMemoryGetMappedBuffer, libcuda()), CUresult,
                    (Ptr{CUdeviceptr}, CUexternalMemory,
@@ -1281,7 +1120,6 @@ end
 end
 
 @checked function cuExternalMemoryGetMappedMipmappedArray(mipmap, extMem, mipmapDesc)
-    initialize_api()
     initialize_context()
     ccall((:cuExternalMemoryGetMappedMipmappedArray, libcuda()), CUresult,
                    (Ptr{CUmipmappedArray}, CUexternalMemory,
@@ -1290,7 +1128,6 @@ end
 end
 
 @checked function cuDestroyExternalMemory(extMem)
-    initialize_api()
     initialize_context()
     ccall((:cuDestroyExternalMemory, libcuda()), CUresult,
                    (CUexternalMemory,),
@@ -1298,7 +1135,6 @@ end
 end
 
 @checked function cuImportExternalSemaphore(extSem_out, semHandleDesc)
-    initialize_api()
     initialize_context()
     ccall((:cuImportExternalSemaphore, libcuda()), CUresult,
                    (Ptr{CUexternalSemaphore}, Ptr{CUDA_EXTERNAL_SEMAPHORE_HANDLE_DESC}),
@@ -1307,7 +1143,6 @@ end
 
 @checked function cuSignalExternalSemaphoresAsync(extSemArray, paramsArray, numExtSems,
                                                   stream)
-    initialize_api()
     initialize_context()
     ccall((:cuSignalExternalSemaphoresAsync, libcuda()), CUresult,
                    (Ptr{CUexternalSemaphore}, Ptr{CUDA_EXTERNAL_SEMAPHORE_SIGNAL_PARAMS},
@@ -1316,7 +1151,6 @@ end
 end
 
 @checked function cuWaitExternalSemaphoresAsync(extSemArray, paramsArray, numExtSems, stream)
-    initialize_api()
     initialize_context()
     ccall((:cuWaitExternalSemaphoresAsync, libcuda()), CUresult,
                    (Ptr{CUexternalSemaphore}, Ptr{CUDA_EXTERNAL_SEMAPHORE_WAIT_PARAMS},
@@ -1325,7 +1159,6 @@ end
 end
 
 @checked function cuDestroyExternalSemaphore(extSem)
-    initialize_api()
     initialize_context()
     ccall((:cuDestroyExternalSemaphore, libcuda()), CUresult,
                    (CUexternalSemaphore,),
@@ -1333,7 +1166,6 @@ end
 end
 
 @checked function cuStreamWaitValue32(stream, addr, value, flags)
-    initialize_api()
     initialize_context()
     ccall((:cuStreamWaitValue32, libcuda()), CUresult,
                    (CUstream, CUdeviceptr, cuuint32_t, UInt32),
@@ -1341,7 +1173,6 @@ end
 end
 
 @checked function cuStreamWaitValue64(stream, addr, value, flags)
-    initialize_api()
     initialize_context()
     ccall((:cuStreamWaitValue64, libcuda()), CUresult,
                    (CUstream, CUdeviceptr, cuuint64_t, UInt32),
@@ -1349,7 +1180,6 @@ end
 end
 
 @checked function cuStreamWriteValue32(stream, addr, value, flags)
-    initialize_api()
     initialize_context()
     ccall((:cuStreamWriteValue32, libcuda()), CUresult,
                    (CUstream, CUdeviceptr, cuuint32_t, UInt32),
@@ -1357,7 +1187,6 @@ end
 end
 
 @checked function cuStreamWriteValue64(stream, addr, value, flags)
-    initialize_api()
     initialize_context()
     ccall((:cuStreamWriteValue64, libcuda()), CUresult,
                    (CUstream, CUdeviceptr, cuuint64_t, UInt32),
@@ -1365,7 +1194,6 @@ end
 end
 
 @checked function cuFuncGetAttribute(pi, attrib, hfunc)
-    initialize_api()
     initialize_context()
     ccall((:cuFuncGetAttribute, libcuda()), CUresult,
                    (Ptr{Cint}, CUfunction_attribute, CUfunction),
@@ -1373,7 +1201,6 @@ end
 end
 
 @checked function cuFuncSetAttribute(hfunc, attrib, value)
-    initialize_api()
     initialize_context()
     ccall((:cuFuncSetAttribute, libcuda()), CUresult,
                    (CUfunction, CUfunction_attribute, Cint),
@@ -1381,7 +1208,6 @@ end
 end
 
 @checked function cuFuncSetCacheConfig(hfunc, config)
-    initialize_api()
     initialize_context()
     ccall((:cuFuncSetCacheConfig, libcuda()), CUresult,
                    (CUfunction, CUfunc_cache),
@@ -1389,7 +1215,6 @@ end
 end
 
 @checked function cuFuncSetSharedMemConfig(hfunc, config)
-    initialize_api()
     initialize_context()
     ccall((:cuFuncSetSharedMemConfig, libcuda()), CUresult,
                    (CUfunction, CUsharedconfig),
@@ -1398,7 +1223,6 @@ end
 
 @checked function cuLaunchKernel(f, gridDimX, gridDimY, gridDimZ, blockDimX, blockDimY,
                                  blockDimZ, sharedMemBytes, hStream, kernelParams, extra)
-    initialize_api()
     initialize_context()
     ccall((:cuLaunchKernel, libcuda()), CUresult,
                    (CUfunction, UInt32, UInt32, UInt32, UInt32, UInt32, UInt32, UInt32,
@@ -1410,7 +1234,6 @@ end
 @checked function cuLaunchCooperativeKernel(f, gridDimX, gridDimY, gridDimZ, blockDimX,
                                             blockDimY, blockDimZ, sharedMemBytes, hStream,
                                             kernelParams)
-    initialize_api()
     initialize_context()
     ccall((:cuLaunchCooperativeKernel, libcuda()), CUresult,
                    (CUfunction, UInt32, UInt32, UInt32, UInt32, UInt32, UInt32, UInt32,
@@ -1420,7 +1243,6 @@ end
 end
 
 @checked function cuLaunchCooperativeKernelMultiDevice(launchParamsList, numDevices, flags)
-    initialize_api()
     initialize_context()
     ccall((:cuLaunchCooperativeKernelMultiDevice, libcuda()), CUresult,
                    (Ptr{CUDA_LAUNCH_PARAMS}, UInt32, UInt32),
@@ -1428,7 +1250,6 @@ end
 end
 
 @checked function cuLaunchHostFunc(hStream, fn, userData)
-    initialize_api()
     initialize_context()
     ccall((:cuLaunchHostFunc, libcuda()), CUresult,
                    (CUstream, CUhostFn, Ptr{Cvoid}),
@@ -1436,7 +1257,6 @@ end
 end
 
 @checked function cuFuncSetBlockShape(hfunc, x, y, z)
-    initialize_api()
     initialize_context()
     ccall((:cuFuncSetBlockShape, libcuda()), CUresult,
                    (CUfunction, Cint, Cint, Cint),
@@ -1444,7 +1264,6 @@ end
 end
 
 @checked function cuFuncSetSharedSize(hfunc, bytes)
-    initialize_api()
     initialize_context()
     ccall((:cuFuncSetSharedSize, libcuda()), CUresult,
                    (CUfunction, UInt32),
@@ -1452,7 +1271,6 @@ end
 end
 
 @checked function cuParamSetSize(hfunc, numbytes)
-    initialize_api()
     initialize_context()
     ccall((:cuParamSetSize, libcuda()), CUresult,
                    (CUfunction, UInt32),
@@ -1460,7 +1278,6 @@ end
 end
 
 @checked function cuParamSeti(hfunc, offset, value)
-    initialize_api()
     initialize_context()
     ccall((:cuParamSeti, libcuda()), CUresult,
                    (CUfunction, Cint, UInt32),
@@ -1468,7 +1285,6 @@ end
 end
 
 @checked function cuParamSetf(hfunc, offset, value)
-    initialize_api()
     initialize_context()
     ccall((:cuParamSetf, libcuda()), CUresult,
                    (CUfunction, Cint, Cfloat),
@@ -1476,7 +1292,6 @@ end
 end
 
 @checked function cuParamSetv(hfunc, offset, ptr, numbytes)
-    initialize_api()
     initialize_context()
     ccall((:cuParamSetv, libcuda()), CUresult,
                    (CUfunction, Cint, Ptr{Cvoid}, UInt32),
@@ -1484,7 +1299,6 @@ end
 end
 
 @checked function cuLaunch(f)
-    initialize_api()
     initialize_context()
     ccall((:cuLaunch, libcuda()), CUresult,
                    (CUfunction,),
@@ -1492,7 +1306,6 @@ end
 end
 
 @checked function cuLaunchGrid(f, grid_width, grid_height)
-    initialize_api()
     initialize_context()
     ccall((:cuLaunchGrid, libcuda()), CUresult,
                    (CUfunction, Cint, Cint),
@@ -1500,7 +1313,6 @@ end
 end
 
 @checked function cuLaunchGridAsync(f, grid_width, grid_height, hStream)
-    initialize_api()
     initialize_context()
     ccall((:cuLaunchGridAsync, libcuda()), CUresult,
                    (CUfunction, Cint, Cint, CUstream),
@@ -1508,7 +1320,6 @@ end
 end
 
 @checked function cuParamSetTexRef(hfunc, texunit, hTexRef)
-    initialize_api()
     initialize_context()
     ccall((:cuParamSetTexRef, libcuda()), CUresult,
                    (CUfunction, Cint, CUtexref),
@@ -1516,7 +1327,6 @@ end
 end
 
 @checked function cuGraphCreate(phGraph, flags)
-    initialize_api()
     initialize_context()
     ccall((:cuGraphCreate, libcuda()), CUresult,
                    (Ptr{CUgraph}, UInt32),
@@ -1525,7 +1335,6 @@ end
 
 @checked function cuGraphAddKernelNode(phGraphNode, hGraph, dependencies, numDependencies,
                                        nodeParams)
-    initialize_api()
     initialize_context()
     ccall((:cuGraphAddKernelNode, libcuda()), CUresult,
                    (Ptr{CUgraphNode}, CUgraph, Ptr{CUgraphNode}, Csize_t,
@@ -1534,7 +1343,6 @@ end
 end
 
 @checked function cuGraphKernelNodeGetParams(hNode, nodeParams)
-    initialize_api()
     initialize_context()
     ccall((:cuGraphKernelNodeGetParams, libcuda()), CUresult,
                    (CUgraphNode, Ptr{CUDA_KERNEL_NODE_PARAMS}),
@@ -1542,7 +1350,6 @@ end
 end
 
 @checked function cuGraphKernelNodeSetParams(hNode, nodeParams)
-    initialize_api()
     initialize_context()
     ccall((:cuGraphKernelNodeSetParams, libcuda()), CUresult,
                    (CUgraphNode, Ptr{CUDA_KERNEL_NODE_PARAMS}),
@@ -1551,7 +1358,6 @@ end
 
 @checked function cuGraphAddMemcpyNode(phGraphNode, hGraph, dependencies, numDependencies,
                                        copyParams, ctx)
-    initialize_api()
     initialize_context()
     ccall((:cuGraphAddMemcpyNode, libcuda()), CUresult,
                    (Ptr{CUgraphNode}, CUgraph, Ptr{CUgraphNode}, Csize_t,
@@ -1560,7 +1366,6 @@ end
 end
 
 @checked function cuGraphMemcpyNodeGetParams(hNode, nodeParams)
-    initialize_api()
     initialize_context()
     ccall((:cuGraphMemcpyNodeGetParams, libcuda()), CUresult,
                    (CUgraphNode, Ptr{CUDA_MEMCPY3D}),
@@ -1568,7 +1373,6 @@ end
 end
 
 @checked function cuGraphMemcpyNodeSetParams(hNode, nodeParams)
-    initialize_api()
     initialize_context()
     ccall((:cuGraphMemcpyNodeSetParams, libcuda()), CUresult,
                    (CUgraphNode, Ptr{CUDA_MEMCPY3D}),
@@ -1577,7 +1381,6 @@ end
 
 @checked function cuGraphAddMemsetNode(phGraphNode, hGraph, dependencies, numDependencies,
                                        memsetParams, ctx)
-    initialize_api()
     initialize_context()
     ccall((:cuGraphAddMemsetNode, libcuda()), CUresult,
                    (Ptr{CUgraphNode}, CUgraph, Ptr{CUgraphNode}, Csize_t,
@@ -1586,7 +1389,6 @@ end
 end
 
 @checked function cuGraphMemsetNodeGetParams(hNode, nodeParams)
-    initialize_api()
     initialize_context()
     ccall((:cuGraphMemsetNodeGetParams, libcuda()), CUresult,
                    (CUgraphNode, Ptr{CUDA_MEMSET_NODE_PARAMS}),
@@ -1594,7 +1396,6 @@ end
 end
 
 @checked function cuGraphMemsetNodeSetParams(hNode, nodeParams)
-    initialize_api()
     initialize_context()
     ccall((:cuGraphMemsetNodeSetParams, libcuda()), CUresult,
                    (CUgraphNode, Ptr{CUDA_MEMSET_NODE_PARAMS}),
@@ -1603,7 +1404,6 @@ end
 
 @checked function cuGraphAddHostNode(phGraphNode, hGraph, dependencies, numDependencies,
                                      nodeParams)
-    initialize_api()
     initialize_context()
     ccall((:cuGraphAddHostNode, libcuda()), CUresult,
                    (Ptr{CUgraphNode}, CUgraph, Ptr{CUgraphNode}, Csize_t,
@@ -1612,7 +1412,6 @@ end
 end
 
 @checked function cuGraphHostNodeGetParams(hNode, nodeParams)
-    initialize_api()
     initialize_context()
     ccall((:cuGraphHostNodeGetParams, libcuda()), CUresult,
                    (CUgraphNode, Ptr{CUDA_HOST_NODE_PARAMS}),
@@ -1620,7 +1419,6 @@ end
 end
 
 @checked function cuGraphHostNodeSetParams(hNode, nodeParams)
-    initialize_api()
     initialize_context()
     ccall((:cuGraphHostNodeSetParams, libcuda()), CUresult,
                    (CUgraphNode, Ptr{CUDA_HOST_NODE_PARAMS}),
@@ -1629,7 +1427,6 @@ end
 
 @checked function cuGraphAddChildGraphNode(phGraphNode, hGraph, dependencies,
                                            numDependencies, childGraph)
-    initialize_api()
     initialize_context()
     ccall((:cuGraphAddChildGraphNode, libcuda()), CUresult,
                    (Ptr{CUgraphNode}, CUgraph, Ptr{CUgraphNode}, Csize_t, CUgraph),
@@ -1637,7 +1434,6 @@ end
 end
 
 @checked function cuGraphChildGraphNodeGetGraph(hNode, phGraph)
-    initialize_api()
     initialize_context()
     ccall((:cuGraphChildGraphNodeGetGraph, libcuda()), CUresult,
                    (CUgraphNode, Ptr{CUgraph}),
@@ -1645,7 +1441,6 @@ end
 end
 
 @checked function cuGraphAddEmptyNode(phGraphNode, hGraph, dependencies, numDependencies)
-    initialize_api()
     initialize_context()
     ccall((:cuGraphAddEmptyNode, libcuda()), CUresult,
                    (Ptr{CUgraphNode}, CUgraph, Ptr{CUgraphNode}, Csize_t),
@@ -1653,7 +1448,6 @@ end
 end
 
 @checked function cuGraphClone(phGraphClone, originalGraph)
-    initialize_api()
     initialize_context()
     ccall((:cuGraphClone, libcuda()), CUresult,
                    (Ptr{CUgraph}, CUgraph),
@@ -1661,7 +1455,6 @@ end
 end
 
 @checked function cuGraphNodeFindInClone(phNode, hOriginalNode, hClonedGraph)
-    initialize_api()
     initialize_context()
     ccall((:cuGraphNodeFindInClone, libcuda()), CUresult,
                    (Ptr{CUgraphNode}, CUgraphNode, CUgraph),
@@ -1669,7 +1462,6 @@ end
 end
 
 @checked function cuGraphNodeGetType(hNode, type)
-    initialize_api()
     initialize_context()
     ccall((:cuGraphNodeGetType, libcuda()), CUresult,
                    (CUgraphNode, Ptr{CUgraphNodeType}),
@@ -1677,7 +1469,6 @@ end
 end
 
 @checked function cuGraphGetNodes(hGraph, nodes, numNodes)
-    initialize_api()
     initialize_context()
     ccall((:cuGraphGetNodes, libcuda()), CUresult,
                    (CUgraph, Ptr{CUgraphNode}, Ptr{Csize_t}),
@@ -1685,7 +1476,6 @@ end
 end
 
 @checked function cuGraphGetRootNodes(hGraph, rootNodes, numRootNodes)
-    initialize_api()
     initialize_context()
     ccall((:cuGraphGetRootNodes, libcuda()), CUresult,
                    (CUgraph, Ptr{CUgraphNode}, Ptr{Csize_t}),
@@ -1693,7 +1483,6 @@ end
 end
 
 @checked function cuGraphGetEdges(hGraph, from, to, numEdges)
-    initialize_api()
     initialize_context()
     ccall((:cuGraphGetEdges, libcuda()), CUresult,
                    (CUgraph, Ptr{CUgraphNode}, Ptr{CUgraphNode}, Ptr{Csize_t}),
@@ -1701,7 +1490,6 @@ end
 end
 
 @checked function cuGraphNodeGetDependencies(hNode, dependencies, numDependencies)
-    initialize_api()
     initialize_context()
     ccall((:cuGraphNodeGetDependencies, libcuda()), CUresult,
                    (CUgraphNode, Ptr{CUgraphNode}, Ptr{Csize_t}),
@@ -1709,7 +1497,6 @@ end
 end
 
 @checked function cuGraphNodeGetDependentNodes(hNode, dependentNodes, numDependentNodes)
-    initialize_api()
     initialize_context()
     ccall((:cuGraphNodeGetDependentNodes, libcuda()), CUresult,
                    (CUgraphNode, Ptr{CUgraphNode}, Ptr{Csize_t}),
@@ -1717,7 +1504,6 @@ end
 end
 
 @checked function cuGraphAddDependencies(hGraph, from, to, numDependencies)
-    initialize_api()
     initialize_context()
     ccall((:cuGraphAddDependencies, libcuda()), CUresult,
                    (CUgraph, Ptr{CUgraphNode}, Ptr{CUgraphNode}, Csize_t),
@@ -1725,7 +1511,6 @@ end
 end
 
 @checked function cuGraphRemoveDependencies(hGraph, from, to, numDependencies)
-    initialize_api()
     initialize_context()
     ccall((:cuGraphRemoveDependencies, libcuda()), CUresult,
                    (CUgraph, Ptr{CUgraphNode}, Ptr{CUgraphNode}, Csize_t),
@@ -1733,7 +1518,6 @@ end
 end
 
 @checked function cuGraphDestroyNode(hNode)
-    initialize_api()
     initialize_context()
     ccall((:cuGraphDestroyNode, libcuda()), CUresult,
                    (CUgraphNode,),
@@ -1742,7 +1526,6 @@ end
 
 @checked function cuGraphInstantiate_v2(phGraphExec, hGraph, phErrorNode, logBuffer,
                                         bufferSize)
-    initialize_api()
     initialize_context()
     ccall((:cuGraphInstantiate_v2, libcuda()), CUresult,
                    (Ptr{CUgraphExec}, CUgraph, Ptr{CUgraphNode}, Cstring, Csize_t),
@@ -1750,7 +1533,6 @@ end
 end
 
 @checked function cuGraphExecKernelNodeSetParams(hGraphExec, hNode, nodeParams)
-    initialize_api()
     initialize_context()
     ccall((:cuGraphExecKernelNodeSetParams, libcuda()), CUresult,
                    (CUgraphExec, CUgraphNode, Ptr{CUDA_KERNEL_NODE_PARAMS}),
@@ -1758,7 +1540,6 @@ end
 end
 
 @checked function cuGraphExecMemcpyNodeSetParams(hGraphExec, hNode, copyParams, ctx)
-    initialize_api()
     initialize_context()
     ccall((:cuGraphExecMemcpyNodeSetParams, libcuda()), CUresult,
                    (CUgraphExec, CUgraphNode, Ptr{CUDA_MEMCPY3D}, CUcontext),
@@ -1766,7 +1547,6 @@ end
 end
 
 @checked function cuGraphExecMemsetNodeSetParams(hGraphExec, hNode, memsetParams, ctx)
-    initialize_api()
     initialize_context()
     ccall((:cuGraphExecMemsetNodeSetParams, libcuda()), CUresult,
                    (CUgraphExec, CUgraphNode, Ptr{CUDA_MEMSET_NODE_PARAMS}, CUcontext),
@@ -1774,7 +1554,6 @@ end
 end
 
 @checked function cuGraphExecHostNodeSetParams(hGraphExec, hNode, nodeParams)
-    initialize_api()
     initialize_context()
     ccall((:cuGraphExecHostNodeSetParams, libcuda()), CUresult,
                    (CUgraphExec, CUgraphNode, Ptr{CUDA_HOST_NODE_PARAMS}),
@@ -1782,7 +1561,6 @@ end
 end
 
 @checked function cuGraphLaunch(hGraphExec, hStream)
-    initialize_api()
     initialize_context()
     ccall((:cuGraphLaunch, libcuda()), CUresult,
                    (CUgraphExec, CUstream),
@@ -1790,7 +1568,6 @@ end
 end
 
 @checked function cuGraphExecDestroy(hGraphExec)
-    initialize_api()
     initialize_context()
     ccall((:cuGraphExecDestroy, libcuda()), CUresult,
                    (CUgraphExec,),
@@ -1798,7 +1575,6 @@ end
 end
 
 @checked function cuGraphDestroy(hGraph)
-    initialize_api()
     initialize_context()
     ccall((:cuGraphDestroy, libcuda()), CUresult,
                    (CUgraph,),
@@ -1806,7 +1582,6 @@ end
 end
 
 @checked function cuGraphExecUpdate(hGraphExec, hGraph, hErrorNode_out, updateResult_out)
-    initialize_api()
     initialize_context()
     ccall((:cuGraphExecUpdate, libcuda()), CUresult,
                    (CUgraphExec, CUgraph, Ptr{CUgraphNode}, Ptr{CUgraphExecUpdateResult}),
@@ -1814,7 +1589,6 @@ end
 end
 
 @checked function cuGraphKernelNodeCopyAttributes(dst, src)
-    initialize_api()
     initialize_context()
     ccall((:cuGraphKernelNodeCopyAttributes, libcuda()), CUresult,
                    (CUgraphNode, CUgraphNode),
@@ -1822,7 +1596,6 @@ end
 end
 
 @checked function cuGraphKernelNodeGetAttribute(hNode, attr, value_out)
-    initialize_api()
     initialize_context()
     ccall((:cuGraphKernelNodeGetAttribute, libcuda()), CUresult,
                    (CUgraphNode, CUkernelNodeAttrID, Ptr{CUkernelNodeAttrValue}),
@@ -1830,7 +1603,6 @@ end
 end
 
 @checked function cuGraphKernelNodeSetAttribute(hNode, attr, value)
-    initialize_api()
     initialize_context()
     ccall((:cuGraphKernelNodeSetAttribute, libcuda()), CUresult,
                    (CUgraphNode, CUkernelNodeAttrID, Ptr{CUkernelNodeAttrValue}),
@@ -1839,7 +1611,6 @@ end
 
 @checked function cuOccupancyMaxActiveBlocksPerMultiprocessor(numBlocks, func, blockSize,
                                                               dynamicSMemSize)
-    initialize_api()
     initialize_context()
     ccall((:cuOccupancyMaxActiveBlocksPerMultiprocessor, libcuda()), CUresult,
                    (Ptr{Cint}, CUfunction, Cint, Csize_t),
@@ -1850,7 +1621,6 @@ end
                                                                        blockSize,
                                                                        dynamicSMemSize,
                                                                        flags)
-    initialize_api()
     initialize_context()
     ccall((:cuOccupancyMaxActiveBlocksPerMultiprocessorWithFlags, libcuda()), CUresult,
                    (Ptr{Cint}, CUfunction, Cint, Csize_t, UInt32),
@@ -1860,7 +1630,6 @@ end
 @checked function cuOccupancyMaxPotentialBlockSize(minGridSize, blockSize, func,
                                                    blockSizeToDynamicSMemSize,
                                                    dynamicSMemSize, blockSizeLimit)
-    initialize_api()
     initialize_context()
     ccall((:cuOccupancyMaxPotentialBlockSize, libcuda()), CUresult,
                    (Ptr{Cint}, Ptr{Cint}, CUfunction, CUoccupancyB2DSize, Csize_t, Cint),
@@ -1872,7 +1641,6 @@ end
                                                             blockSizeToDynamicSMemSize,
                                                             dynamicSMemSize,
                                                             blockSizeLimit, flags)
-    initialize_api()
     initialize_context()
     ccall((:cuOccupancyMaxPotentialBlockSizeWithFlags, libcuda()), CUresult,
                    (Ptr{Cint}, Ptr{Cint}, CUfunction, CUoccupancyB2DSize, Csize_t, Cint,
@@ -1883,7 +1651,6 @@ end
 
 @checked function cuOccupancyAvailableDynamicSMemPerBlock(dynamicSmemSize, func, numBlocks,
                                                           blockSize)
-    initialize_api()
     initialize_context()
     ccall((:cuOccupancyAvailableDynamicSMemPerBlock, libcuda()), CUresult,
                    (Ptr{Csize_t}, CUfunction, Cint, Cint),
@@ -1891,7 +1658,6 @@ end
 end
 
 @checked function cuTexRefSetArray(hTexRef, hArray, Flags)
-    initialize_api()
     initialize_context()
     ccall((:cuTexRefSetArray, libcuda()), CUresult,
                    (CUtexref, CUarray, UInt32),
@@ -1899,7 +1665,6 @@ end
 end
 
 @checked function cuTexRefSetMipmappedArray(hTexRef, hMipmappedArray, Flags)
-    initialize_api()
     initialize_context()
     ccall((:cuTexRefSetMipmappedArray, libcuda()), CUresult,
                    (CUtexref, CUmipmappedArray, UInt32),
@@ -1907,7 +1672,6 @@ end
 end
 
 @checked function cuTexRefSetAddress_v2(ByteOffset, hTexRef, dptr, bytes)
-    initialize_api()
     initialize_context()
     ccall((:cuTexRefSetAddress_v2, libcuda()), CUresult,
                    (Ptr{Csize_t}, CUtexref, CUdeviceptr, Csize_t),
@@ -1915,7 +1679,6 @@ end
 end
 
 @checked function cuTexRefSetAddress2D_v3(hTexRef, desc, dptr, Pitch)
-    initialize_api()
     initialize_context()
     ccall((:cuTexRefSetAddress2D_v3, libcuda()), CUresult,
                    (CUtexref, Ptr{CUDA_ARRAY_DESCRIPTOR}, CUdeviceptr, Csize_t),
@@ -1923,7 +1686,6 @@ end
 end
 
 @checked function cuTexRefSetFormat(hTexRef, fmt, NumPackedComponents)
-    initialize_api()
     initialize_context()
     ccall((:cuTexRefSetFormat, libcuda()), CUresult,
                    (CUtexref, CUarray_format, Cint),
@@ -1931,7 +1693,6 @@ end
 end
 
 @checked function cuTexRefSetAddressMode(hTexRef, dim, am)
-    initialize_api()
     initialize_context()
     ccall((:cuTexRefSetAddressMode, libcuda()), CUresult,
                    (CUtexref, Cint, CUaddress_mode),
@@ -1939,7 +1700,6 @@ end
 end
 
 @checked function cuTexRefSetFilterMode(hTexRef, fm)
-    initialize_api()
     initialize_context()
     ccall((:cuTexRefSetFilterMode, libcuda()), CUresult,
                    (CUtexref, CUfilter_mode),
@@ -1947,7 +1707,6 @@ end
 end
 
 @checked function cuTexRefSetMipmapFilterMode(hTexRef, fm)
-    initialize_api()
     initialize_context()
     ccall((:cuTexRefSetMipmapFilterMode, libcuda()), CUresult,
                    (CUtexref, CUfilter_mode),
@@ -1955,7 +1714,6 @@ end
 end
 
 @checked function cuTexRefSetMipmapLevelBias(hTexRef, bias)
-    initialize_api()
     initialize_context()
     ccall((:cuTexRefSetMipmapLevelBias, libcuda()), CUresult,
                    (CUtexref, Cfloat),
@@ -1964,7 +1722,6 @@ end
 
 @checked function cuTexRefSetMipmapLevelClamp(hTexRef, minMipmapLevelClamp,
                                               maxMipmapLevelClamp)
-    initialize_api()
     initialize_context()
     ccall((:cuTexRefSetMipmapLevelClamp, libcuda()), CUresult,
                    (CUtexref, Cfloat, Cfloat),
@@ -1972,7 +1729,6 @@ end
 end
 
 @checked function cuTexRefSetMaxAnisotropy(hTexRef, maxAniso)
-    initialize_api()
     initialize_context()
     ccall((:cuTexRefSetMaxAnisotropy, libcuda()), CUresult,
                    (CUtexref, UInt32),
@@ -1980,7 +1736,6 @@ end
 end
 
 @checked function cuTexRefSetBorderColor(hTexRef, pBorderColor)
-    initialize_api()
     initialize_context()
     ccall((:cuTexRefSetBorderColor, libcuda()), CUresult,
                    (CUtexref, Ptr{Cfloat}),
@@ -1988,7 +1743,6 @@ end
 end
 
 @checked function cuTexRefSetFlags(hTexRef, Flags)
-    initialize_api()
     initialize_context()
     ccall((:cuTexRefSetFlags, libcuda()), CUresult,
                    (CUtexref, UInt32),
@@ -1996,7 +1750,6 @@ end
 end
 
 @checked function cuTexRefGetAddress_v2(pdptr, hTexRef)
-    initialize_api()
     initialize_context()
     ccall((:cuTexRefGetAddress_v2, libcuda()), CUresult,
                    (Ptr{CUdeviceptr}, CUtexref),
@@ -2004,7 +1757,6 @@ end
 end
 
 @checked function cuTexRefGetArray(phArray, hTexRef)
-    initialize_api()
     initialize_context()
     ccall((:cuTexRefGetArray, libcuda()), CUresult,
                    (Ptr{CUarray}, CUtexref),
@@ -2012,7 +1764,6 @@ end
 end
 
 @checked function cuTexRefGetMipmappedArray(phMipmappedArray, hTexRef)
-    initialize_api()
     initialize_context()
     ccall((:cuTexRefGetMipmappedArray, libcuda()), CUresult,
                    (Ptr{CUmipmappedArray}, CUtexref),
@@ -2020,7 +1771,6 @@ end
 end
 
 @checked function cuTexRefGetAddressMode(pam, hTexRef, dim)
-    initialize_api()
     initialize_context()
     ccall((:cuTexRefGetAddressMode, libcuda()), CUresult,
                    (Ptr{CUaddress_mode}, CUtexref, Cint),
@@ -2028,7 +1778,6 @@ end
 end
 
 @checked function cuTexRefGetFilterMode(pfm, hTexRef)
-    initialize_api()
     initialize_context()
     ccall((:cuTexRefGetFilterMode, libcuda()), CUresult,
                    (Ptr{CUfilter_mode}, CUtexref),
@@ -2036,7 +1785,6 @@ end
 end
 
 @checked function cuTexRefGetFormat(pFormat, pNumChannels, hTexRef)
-    initialize_api()
     initialize_context()
     ccall((:cuTexRefGetFormat, libcuda()), CUresult,
                    (Ptr{CUarray_format}, Ptr{Cint}, CUtexref),
@@ -2044,7 +1792,6 @@ end
 end
 
 @checked function cuTexRefGetMipmapFilterMode(pfm, hTexRef)
-    initialize_api()
     initialize_context()
     ccall((:cuTexRefGetMipmapFilterMode, libcuda()), CUresult,
                    (Ptr{CUfilter_mode}, CUtexref),
@@ -2052,7 +1799,6 @@ end
 end
 
 @checked function cuTexRefGetMipmapLevelBias(pbias, hTexRef)
-    initialize_api()
     initialize_context()
     ccall((:cuTexRefGetMipmapLevelBias, libcuda()), CUresult,
                    (Ptr{Cfloat}, CUtexref),
@@ -2061,7 +1807,6 @@ end
 
 @checked function cuTexRefGetMipmapLevelClamp(pminMipmapLevelClamp, pmaxMipmapLevelClamp,
                                               hTexRef)
-    initialize_api()
     initialize_context()
     ccall((:cuTexRefGetMipmapLevelClamp, libcuda()), CUresult,
                    (Ptr{Cfloat}, Ptr{Cfloat}, CUtexref),
@@ -2069,7 +1814,6 @@ end
 end
 
 @checked function cuTexRefGetMaxAnisotropy(pmaxAniso, hTexRef)
-    initialize_api()
     initialize_context()
     ccall((:cuTexRefGetMaxAnisotropy, libcuda()), CUresult,
                    (Ptr{Cint}, CUtexref),
@@ -2077,7 +1821,6 @@ end
 end
 
 @checked function cuTexRefGetBorderColor(pBorderColor, hTexRef)
-    initialize_api()
     initialize_context()
     ccall((:cuTexRefGetBorderColor, libcuda()), CUresult,
                    (Ptr{Cfloat}, CUtexref),
@@ -2085,7 +1828,6 @@ end
 end
 
 @checked function cuTexRefGetFlags(pFlags, hTexRef)
-    initialize_api()
     initialize_context()
     ccall((:cuTexRefGetFlags, libcuda()), CUresult,
                    (Ptr{UInt32}, CUtexref),
@@ -2093,7 +1835,6 @@ end
 end
 
 @checked function cuTexRefCreate(pTexRef)
-    initialize_api()
     initialize_context()
     ccall((:cuTexRefCreate, libcuda()), CUresult,
                    (Ptr{CUtexref},),
@@ -2101,7 +1842,6 @@ end
 end
 
 @checked function cuTexRefDestroy(hTexRef)
-    initialize_api()
     initialize_context()
     ccall((:cuTexRefDestroy, libcuda()), CUresult,
                    (CUtexref,),
@@ -2109,7 +1849,6 @@ end
 end
 
 @checked function cuSurfRefSetArray(hSurfRef, hArray, Flags)
-    initialize_api()
     initialize_context()
     ccall((:cuSurfRefSetArray, libcuda()), CUresult,
                    (CUsurfref, CUarray, UInt32),
@@ -2117,7 +1856,6 @@ end
 end
 
 @checked function cuSurfRefGetArray(phArray, hSurfRef)
-    initialize_api()
     initialize_context()
     ccall((:cuSurfRefGetArray, libcuda()), CUresult,
                    (Ptr{CUarray}, CUsurfref),
@@ -2125,7 +1863,6 @@ end
 end
 
 @checked function cuTexObjectCreate(pTexObject, pResDesc, pTexDesc, pResViewDesc)
-    initialize_api()
     initialize_context()
     ccall((:cuTexObjectCreate, libcuda()), CUresult,
                    (Ptr{CUtexObject}, Ptr{CUDA_RESOURCE_DESC}, Ptr{CUDA_TEXTURE_DESC},
@@ -2134,7 +1871,6 @@ end
 end
 
 @checked function cuTexObjectDestroy(texObject)
-    initialize_api()
     initialize_context()
     ccall((:cuTexObjectDestroy, libcuda()), CUresult,
                    (CUtexObject,),
@@ -2142,7 +1878,6 @@ end
 end
 
 @checked function cuTexObjectGetResourceDesc(pResDesc, texObject)
-    initialize_api()
     initialize_context()
     ccall((:cuTexObjectGetResourceDesc, libcuda()), CUresult,
                    (Ptr{CUDA_RESOURCE_DESC}, CUtexObject),
@@ -2150,7 +1885,6 @@ end
 end
 
 @checked function cuTexObjectGetTextureDesc(pTexDesc, texObject)
-    initialize_api()
     initialize_context()
     ccall((:cuTexObjectGetTextureDesc, libcuda()), CUresult,
                    (Ptr{CUDA_TEXTURE_DESC}, CUtexObject),
@@ -2158,7 +1892,6 @@ end
 end
 
 @checked function cuTexObjectGetResourceViewDesc(pResViewDesc, texObject)
-    initialize_api()
     initialize_context()
     ccall((:cuTexObjectGetResourceViewDesc, libcuda()), CUresult,
                    (Ptr{CUDA_RESOURCE_VIEW_DESC}, CUtexObject),
@@ -2166,7 +1899,6 @@ end
 end
 
 @checked function cuSurfObjectCreate(pSurfObject, pResDesc)
-    initialize_api()
     initialize_context()
     ccall((:cuSurfObjectCreate, libcuda()), CUresult,
                    (Ptr{CUsurfObject}, Ptr{CUDA_RESOURCE_DESC}),
@@ -2174,7 +1906,6 @@ end
 end
 
 @checked function cuSurfObjectDestroy(surfObject)
-    initialize_api()
     initialize_context()
     ccall((:cuSurfObjectDestroy, libcuda()), CUresult,
                    (CUsurfObject,),
@@ -2182,7 +1913,6 @@ end
 end
 
 @checked function cuSurfObjectGetResourceDesc(pResDesc, surfObject)
-    initialize_api()
     initialize_context()
     ccall((:cuSurfObjectGetResourceDesc, libcuda()), CUresult,
                    (Ptr{CUDA_RESOURCE_DESC}, CUsurfObject),
@@ -2190,7 +1920,6 @@ end
 end
 
 @checked function cuDeviceCanAccessPeer(canAccessPeer, dev, peerDev)
-    initialize_api()
     initialize_context()
     ccall((:cuDeviceCanAccessPeer, libcuda()), CUresult,
                    (Ptr{Cint}, CUdevice, CUdevice),
@@ -2198,7 +1927,6 @@ end
 end
 
 @checked function cuCtxEnablePeerAccess(peerContext, Flags)
-    initialize_api()
     initialize_context()
     ccall((:cuCtxEnablePeerAccess, libcuda()), CUresult,
                    (CUcontext, UInt32),
@@ -2206,7 +1934,6 @@ end
 end
 
 @checked function cuCtxDisablePeerAccess(peerContext)
-    initialize_api()
     initialize_context()
     ccall((:cuCtxDisablePeerAccess, libcuda()), CUresult,
                    (CUcontext,),
@@ -2214,7 +1941,6 @@ end
 end
 
 @checked function cuDeviceGetP2PAttribute(value, attrib, srcDevice, dstDevice)
-    initialize_api()
     initialize_context()
     ccall((:cuDeviceGetP2PAttribute, libcuda()), CUresult,
                    (Ptr{Cint}, CUdevice_P2PAttribute, CUdevice, CUdevice),
@@ -2222,7 +1948,6 @@ end
 end
 
 @checked function cuGraphicsUnregisterResource(resource)
-    initialize_api()
     initialize_context()
     ccall((:cuGraphicsUnregisterResource, libcuda()), CUresult,
                    (CUgraphicsResource,),
@@ -2230,7 +1955,6 @@ end
 end
 
 @checked function cuGraphicsSubResourceGetMappedArray(pArray, resource, arrayIndex, mipLevel)
-    initialize_api()
     initialize_context()
     ccall((:cuGraphicsSubResourceGetMappedArray, libcuda()), CUresult,
                    (Ptr{CUarray}, CUgraphicsResource, UInt32, UInt32),
@@ -2238,7 +1962,6 @@ end
 end
 
 @checked function cuGraphicsResourceGetMappedMipmappedArray(pMipmappedArray, resource)
-    initialize_api()
     initialize_context()
     ccall((:cuGraphicsResourceGetMappedMipmappedArray, libcuda()), CUresult,
                    (Ptr{CUmipmappedArray}, CUgraphicsResource),
@@ -2246,7 +1969,6 @@ end
 end
 
 @checked function cuGraphicsResourceGetMappedPointer_v2(pDevPtr, pSize, resource)
-    initialize_api()
     initialize_context()
     ccall((:cuGraphicsResourceGetMappedPointer_v2, libcuda()), CUresult,
                    (Ptr{CUdeviceptr}, Ptr{Csize_t}, CUgraphicsResource),
@@ -2254,7 +1976,6 @@ end
 end
 
 @checked function cuGraphicsResourceSetMapFlags_v2(resource, flags)
-    initialize_api()
     initialize_context()
     ccall((:cuGraphicsResourceSetMapFlags_v2, libcuda()), CUresult,
                    (CUgraphicsResource, UInt32),
@@ -2262,7 +1983,6 @@ end
 end
 
 @checked function cuGraphicsMapResources(count, resources, hStream)
-    initialize_api()
     initialize_context()
     ccall((:cuGraphicsMapResources, libcuda()), CUresult,
                    (UInt32, Ptr{CUgraphicsResource}, CUstream),
@@ -2270,7 +1990,6 @@ end
 end
 
 @checked function cuGraphicsUnmapResources(count, resources, hStream)
-    initialize_api()
     initialize_context()
     ccall((:cuGraphicsUnmapResources, libcuda()), CUresult,
                    (UInt32, Ptr{CUgraphicsResource}, CUstream),
@@ -2278,7 +1997,6 @@ end
 end
 
 @checked function cuGetExportTable(ppExportTable, pExportTableId)
-    initialize_api()
     initialize_context()
     ccall((:cuGetExportTable, libcuda()), CUresult,
                    (Ptr{Ptr{Cvoid}}, Ptr{CUuuid}),
@@ -2286,7 +2004,6 @@ end
 end
 
 @checked function cuFuncGetModule(hmod, hfunc)
-    initialize_api()
     initialize_context()
     ccall((:cuFuncGetModule, libcuda()), CUresult,
                    (Ptr{CUmodule}, CUfunction),
@@ -2296,7 +2013,6 @@ end
 # Automatically generated using Clang.jl
 
 @checked function cuProfilerInitialize(configFile, outputFile, outputMode)
-    initialize_api()
     initialize_context()
     ccall((:cuProfilerInitialize, libcuda()), CUresult,
                    (Cstring, Cstring, CUoutput_mode),
@@ -2304,85 +2020,71 @@ end
 end
 
 @checked function cuProfilerStart()
-    initialize_api()
     initialize_context()
     ccall((:cuProfilerStart, libcuda()), CUresult, ())
 end
 
 @checked function cuProfilerStop()
-    initialize_api()
     initialize_context()
     ccall((:cuProfilerStop, libcuda()), CUresult, ())
 end
 
 @checked function cuGLUnmapBufferObject(buffer)
-    initialize_api()
     initialize_context()
     ccall((:cuGLUnmapBufferObject, libcuda()), CUresult, (GLuint,), buffer)
 end
 
 @checked function cuGLMapBufferObject_v2(dptr, size, buffer)
-    initialize_api()
     initialize_context()
     ccall((:cuGLMapBufferObject_v2, libcuda()), CUresult, (Ptr{CUdeviceptr}, Ptr{Csize_t}, GLuint), dptr, size, buffer)
 end
 
 @checked function cuGraphicsGLRegisterImage(pCudaResource, image, target, Flags)
-    initialize_api()
     initialize_context()
     ccall((:cuGraphicsGLRegisterImage, libcuda()), CUresult, (Ptr{CUgraphicsResource}, GLuint, GLenum, UInt32), pCudaResource, image, target, Flags)
 end
 
 @checked function cuGLInit()
-    initialize_api()
     initialize_context()
     ccall((:cuGLInit, libcuda()), CUresult, ())
 end
 
 @checked function cuGLCtxCreate_v2(pCtx, Flags, device)
-    initialize_api()
     initialize_context()
     ccall((:cuGLCtxCreate_v2, libcuda()), CUresult, (Ptr{CUcontext}, UInt32, CUdevice), pCtx, Flags, device)
 end
 
 @checked function cuGLUnmapBufferObjectAsync(buffer, hStream)
-    initialize_api()
     initialize_context()
     ccall((:cuGLUnmapBufferObjectAsync, libcuda()), CUresult, (GLuint, CUstream), buffer, hStream)
 end
 
 @checked function cuGLSetBufferObjectMapFlags(buffer, Flags)
-    initialize_api()
     initialize_context()
     ccall((:cuGLSetBufferObjectMapFlags, libcuda()), CUresult, (GLuint, UInt32), buffer, Flags)
 end
 
 @checked function cuGLUnregisterBufferObject(buffer)
-    initialize_api()
     initialize_context()
     ccall((:cuGLUnregisterBufferObject, libcuda()), CUresult, (GLuint,), buffer)
 end
 
 @checked function cuGraphicsGLRegisterBuffer(pCudaResource, buffer, Flags)
-    initialize_api()
     initialize_context()
     ccall((:cuGraphicsGLRegisterBuffer, libcuda()), CUresult, (Ptr{CUgraphicsResource}, GLuint, UInt32), pCudaResource, buffer, Flags)
 end
 
 @checked function cuGLRegisterBufferObject(buffer)
-    initialize_api()
     initialize_context()
     ccall((:cuGLRegisterBufferObject, libcuda()), CUresult, (GLuint,), buffer)
 end
 
 @checked function cuGLMapBufferObjectAsync_v2(dptr, size, buffer, hStream)
-    initialize_api()
     initialize_context()
     ccall((:cuGLMapBufferObjectAsync_v2, libcuda()), CUresult, (Ptr{CUdeviceptr}, Ptr{Csize_t}, GLuint, CUstream), dptr, size, buffer, hStream)
 end
 
 @checked function cuGLGetDevices_v2(pCudaDeviceCount, pCudaDevices, cudaDeviceCount, deviceList)
-    initialize_api()
     initialize_context()
     ccall((:cuGLGetDevices_v2, libcuda()), CUresult, (Ptr{UInt32}, Ptr{CUdevice}, UInt32, CUGLDeviceList), pCudaDeviceCount, pCudaDevices, cudaDeviceCount, deviceList)
 end
@@ -2390,55 +2092,46 @@ end
 ## Added in CUDA 11.1
 
 @checked function cuGraphAddEventRecordNode(phGraphNode, hGraph, dependencies, numDependencies, event)
-    initialize_api()
     initialize_context()
     ccall((:cuGraphAddEventRecordNode, libcuda()), CUresult, (Ptr{CUgraphNode}, CUgraph, Ptr{CUgraphNode}, Csize_t, CUevent), phGraphNode, hGraph, dependencies, numDependencies, event)
 end
 
 @checked function cuDeviceGetTexture1DLinearMaxWidth(maxWidthInElements, format, numChannels, dev)
-    initialize_api()
     initialize_context()
     ccall((:cuDeviceGetTexture1DLinearMaxWidth, libcuda()), CUresult, (Ptr{Csize_t}, CUarray_format, UInt32, CUdevice), maxWidthInElements, format, numChannels, dev)
 end
 
 @checked function cuArrayGetSparseProperties(sparseProperties, array)
-    initialize_api()
     initialize_context()
     ccall((:cuArrayGetSparseProperties, libcuda()), CUresult, (Ptr{CUDA_ARRAY_SPARSE_PROPERTIES}, CUarray), sparseProperties, array)
 end
 
 @checked function cuGraphEventRecordNodeSetEvent(hNode, event)
-    initialize_api()
     initialize_context()
     ccall((:cuGraphEventRecordNodeSetEvent, libcuda()), CUresult, (CUgraphNode, CUevent), hNode, event)
 end
 
 @checked function cuMemMapArrayAsync(mapInfoList, count, hStream)
-    initialize_api()
     initialize_context()
     ccall((:cuMemMapArrayAsync, libcuda()), CUresult, (Ptr{CUarrayMapInfo}, UInt32, CUstream), mapInfoList, count, hStream)
 end
 
 @checked function cuGraphExecEventRecordNodeSetEvent(hGraphExec, hNode, event)
-    initialize_api()
     initialize_context()
     ccall((:cuGraphExecEventRecordNodeSetEvent, libcuda()), CUresult, (CUgraphExec, CUgraphNode, CUevent), hGraphExec, hNode, event)
 end
 
 @checked function cuGraphEventWaitNodeGetEvent(hNode, event_out)
-    initialize_api()
     initialize_context()
     ccall((:cuGraphEventWaitNodeGetEvent, libcuda()), CUresult, (CUgraphNode, Ptr{CUevent}), hNode, event_out)
 end
 
 @checked function cuMipmappedArrayGetSparseProperties(sparseProperties, mipmap)
-    initialize_api()
     initialize_context()
     ccall((:cuMipmappedArrayGetSparseProperties, libcuda()), CUresult, (Ptr{CUDA_ARRAY_SPARSE_PROPERTIES}, CUmipmappedArray), sparseProperties, mipmap)
 end
 
 @checked function cuEventRecordWithFlags(hEvent, hStream, flags)
-    initialize_api()
     initialize_context()
     ccall((:cuEventRecordWithFlags, libcuda()), CUresult, (CUevent, CUstream, UInt32), hEvent, hStream, flags)
 end
@@ -2448,43 +2141,36 @@ end
 end
 
 @checked function cuGraphExecEventWaitNodeSetEvent(hGraphExec, hNode, event)
-    initialize_api()
     initialize_context()
     ccall((:cuGraphExecEventWaitNodeSetEvent, libcuda()), CUresult, (CUgraphExec, CUgraphNode, CUevent), hGraphExec, hNode, event)
 end
 
 @checked function cuGraphUpload(hGraphExec, hStream)
-    initialize_api()
     initialize_context()
     ccall((:cuGraphUpload, libcuda()), CUresult, (CUgraphExec, CUstream), hGraphExec, hStream)
 end
 
 @checked function cuIpcOpenMemHandle_v2(pdptr, handle, Flags)
-    initialize_api()
     initialize_context()
     ccall((:cuIpcOpenMemHandle_v2, libcuda()), CUresult, (Ptr{CUdeviceptr}, CUipcMemHandle, UInt32), pdptr, handle, Flags)
 end
 
 @checked function cuGraphAddEventWaitNode(phGraphNode, hGraph, dependencies, numDependencies, event)
-    initialize_api()
     initialize_context()
     ccall((:cuGraphAddEventWaitNode, libcuda()), CUresult, (Ptr{CUgraphNode}, CUgraph, Ptr{CUgraphNode}, Csize_t, CUevent), phGraphNode, hGraph, dependencies, numDependencies, event)
 end
 
 @checked function cuGraphEventWaitNodeSetEvent(hNode, event)
-    initialize_api()
     initialize_context()
     ccall((:cuGraphEventWaitNodeSetEvent, libcuda()), CUresult, (CUgraphNode, CUevent), hNode, event)
 end
 
 @checked function cuGraphEventRecordNodeGetEvent(hNode, event_out)
-    initialize_api()
     initialize_context()
     ccall((:cuGraphEventRecordNodeGetEvent, libcuda()), CUresult, (CUgraphNode, Ptr{CUevent}), hNode, event_out)
 end
 
 @checked function cuGraphExecChildGraphNodeSetParams(hGraphExec, hNode, childGraph)
-    initialize_api()
     initialize_context()
     ccall((:cuGraphExecChildGraphNodeSetParams, libcuda()), CUresult, (CUgraphExec, CUgraphNode, CUgraph), hGraphExec, hNode, childGraph)
 end
@@ -2492,157 +2178,131 @@ end
 ## Added in CUDA 11.2
 
 @checked function cuGraphExecExternalSemaphoresSignalNodeSetParams(hGraphExec, hNode, nodeParams)
-    initialize_api()
     initialize_context()
     ccall((:cuGraphExecExternalSemaphoresSignalNodeSetParams, libcuda()), CUresult, (CUgraphExec, CUgraphNode, Ptr{CUDA_EXT_SEM_SIGNAL_NODE_PARAMS}), hGraphExec, hNode, nodeParams)
 end
 
 @checked function cuDeviceSetMemPool(dev, pool)
-    initialize_api()
     initialize_context()
     ccall((:cuDeviceSetMemPool, libcuda()), CUresult, (CUdevice, CUmemoryPool), dev, pool)
 end
 
 @checked function cuGraphExternalSemaphoresWaitNodeSetParams(hNode, nodeParams)
-    initialize_api()
     initialize_context()
     ccall((:cuGraphExternalSemaphoresWaitNodeSetParams, libcuda()), CUresult, (CUgraphNode, Ptr{CUDA_EXT_SEM_WAIT_NODE_PARAMS}), hNode, nodeParams)
 end
 
 @checked function cuMemPoolDestroy(pool)
-    initialize_api()
     initialize_context()
     ccall((:cuMemPoolDestroy, libcuda()), CUresult, (CUmemoryPool,), pool)
 end
 
 @checked function cuGraphAddExternalSemaphoresSignalNode(phGraphNode, hGraph, dependencies, numDependencies, nodeParams)
-    initialize_api()
     initialize_context()
     ccall((:cuGraphAddExternalSemaphoresSignalNode, libcuda()), CUresult, (Ptr{CUgraphNode}, CUgraph, Ptr{CUgraphNode}, Csize_t, Ptr{CUDA_EXT_SEM_SIGNAL_NODE_PARAMS}), phGraphNode, hGraph, dependencies, numDependencies, nodeParams)
 end
 
 @checked function cuGraphExternalSemaphoresSignalNodeGetParams(hNode, params_out)
-    initialize_api()
     initialize_context()
     ccall((:cuGraphExternalSemaphoresSignalNodeGetParams, libcuda()), CUresult, (CUgraphNode, Ptr{CUDA_EXT_SEM_SIGNAL_NODE_PARAMS}), hNode, params_out)
 end
 
 @checked function cuMemPoolExportPointer(shareData_out, ptr)
-    initialize_api()
     initialize_context()
     ccall((:cuMemPoolExportPointer, libcuda()), CUresult, (Ptr{CUmemPoolPtrExportData}, CUdeviceptr), shareData_out, ptr)
 end
 
 @checked function cuGraphExecExternalSemaphoresWaitNodeSetParams(hGraphExec, hNode, nodeParams)
-    initialize_api()
     initialize_context()
     ccall((:cuGraphExecExternalSemaphoresWaitNodeSetParams, libcuda()), CUresult, (CUgraphExec, CUgraphNode, Ptr{CUDA_EXT_SEM_WAIT_NODE_PARAMS}), hGraphExec, hNode, nodeParams)
 end
 
 @checked function cuMemFreeAsync(dptr, hStream)
-    initialize_api()
     initialize_context()
     ccall((:cuMemFreeAsync, libcuda()), CUresult, (CUdeviceptr, CUstream), dptr, hStream)
 end
 
 @checked function cuMemPoolImportPointer(ptr_out, pool, shareData)
-    initialize_api()
     initialize_context()
     ccall((:cuMemPoolImportPointer, libcuda()), CUresult, (Ptr{CUdeviceptr}, CUmemoryPool, Ptr{CUmemPoolPtrExportData}), ptr_out, pool, shareData)
 end
 
 @checked function cuMemPoolImportFromShareableHandle(pool_out, handle, handleType, flags)
-    initialize_api()
     initialize_context()
     ccall((:cuMemPoolImportFromShareableHandle, libcuda()), CUresult, (Ptr{CUmemoryPool}, Ptr{Cvoid}, CUmemAllocationHandleType, Culonglong), pool_out, handle, handleType, flags)
 end
 
 @checked function cuArrayGetPlane(pPlaneArray, hArray, planeIdx)
-    initialize_api()
     initialize_context()
     ccall((:cuArrayGetPlane, libcuda()), CUresult, (Ptr{CUarray}, CUarray, UInt32), pPlaneArray, hArray, planeIdx)
 end
 
 @checked function cuMemPoolSetAttribute(pool, attr, value)
-    initialize_api()
     initialize_context()
     ccall((:cuMemPoolSetAttribute, libcuda()), CUresult, (CUmemoryPool, CUmemPool_attribute, Ptr{Cvoid}), pool, attr, value)
 end
 
 @checked function cuMemPoolSetAccess(pool, map, count)
-    initialize_api()
     initialize_context()
     ccall((:cuMemPoolSetAccess, libcuda()), CUresult, (CUmemoryPool, Ptr{CUmemAccessDesc}, Csize_t), pool, map, count)
 end
 
 @checked function cuGraphAddExternalSemaphoresWaitNode(phGraphNode, hGraph, dependencies, numDependencies, nodeParams)
-    initialize_api()
     initialize_context()
     ccall((:cuGraphAddExternalSemaphoresWaitNode, libcuda()), CUresult, (Ptr{CUgraphNode}, CUgraph, Ptr{CUgraphNode}, Csize_t, Ptr{CUDA_EXT_SEM_WAIT_NODE_PARAMS}), phGraphNode, hGraph, dependencies, numDependencies, nodeParams)
 end
 
 @checked function cuMemPoolCreate(pool, poolProps)
-    initialize_api()
     initialize_context()
     ccall((:cuMemPoolCreate, libcuda()), CUresult, (Ptr{CUmemoryPool}, Ptr{CUmemPoolProps}), pool, poolProps)
 end
 
 @checked function cuMemPoolGetAttribute(pool, attr, value)
-    initialize_api()
     initialize_context()
     ccall((:cuMemPoolGetAttribute, libcuda()), CUresult, (CUmemoryPool, CUmemPool_attribute, Ptr{Cvoid}), pool, attr, value)
 end
 
 @checked function cuMemAllocAsync(dptr, bytesize, hStream)
-    initialize_api()
     initialize_context()
     ccall((:cuMemAllocAsync, libcuda()), CUresult, (Ptr{CUdeviceptr}, Csize_t, CUstream), dptr, bytesize, hStream)
 end
 
 @checked function cuMemPoolTrimTo(pool, minBytesToKeep)
-    initialize_api()
     initialize_context()
     ccall((:cuMemPoolTrimTo, libcuda()), CUresult, (CUmemoryPool, Csize_t), pool, minBytesToKeep)
 end
 
 @checked function cuDeviceGetMemPool(pool, dev)
-    initialize_api()
     initialize_context()
     ccall((:cuDeviceGetMemPool, libcuda()), CUresult, (Ptr{CUmemoryPool}, CUdevice), pool, dev)
 end
 
 @checked function cuGraphExternalSemaphoresWaitNodeGetParams(hNode, params_out)
-    initialize_api()
     initialize_context()
     ccall((:cuGraphExternalSemaphoresWaitNodeGetParams, libcuda()), CUresult, (CUgraphNode, Ptr{CUDA_EXT_SEM_WAIT_NODE_PARAMS}), hNode, params_out)
 end
 
 @checked function cuMemAllocFromPoolAsync(dptr, bytesize, pool, hStream)
-    initialize_api()
     initialize_context()
     ccall((:cuMemAllocFromPoolAsync, libcuda()), CUresult, (Ptr{CUdeviceptr}, Csize_t, CUmemoryPool, CUstream), dptr, bytesize, pool, hStream)
 end
 
 @checked function cuMemPoolExportToShareableHandle(handle_out, pool, handleType, flags)
-    initialize_api()
     initialize_context()
     ccall((:cuMemPoolExportToShareableHandle, libcuda()), CUresult, (Ptr{Cvoid}, CUmemoryPool, CUmemAllocationHandleType, Culonglong), handle_out, pool, handleType, flags)
 end
 
 @checked function cuMemPoolGetAccess(flags, memPool, location)
-    initialize_api()
     initialize_context()
     ccall((:cuMemPoolGetAccess, libcuda()), CUresult, (Ptr{CUmemAccess_flags}, CUmemoryPool, Ptr{CUmemLocation}), flags, memPool, location)
 end
 
 @checked function cuDeviceGetDefaultMemPool(pool_out, dev)
-    initialize_api()
     initialize_context()
     ccall((:cuDeviceGetDefaultMemPool, libcuda()), CUresult, (Ptr{CUmemoryPool}, CUdevice), pool_out, dev)
 end
 
 @checked function cuGraphExternalSemaphoresSignalNodeSetParams(hNode, nodeParams)
-    initialize_api()
     initialize_context()
     ccall((:cuGraphExternalSemaphoresSignalNodeSetParams, libcuda()), CUresult, (CUgraphNode, Ptr{CUDA_EXT_SEM_SIGNAL_NODE_PARAMS}), hNode, nodeParams)
 end

--- a/lib/cudadrv/libcuda_deprecated.jl
+++ b/lib/cudadrv/libcuda_deprecated.jl
@@ -20,7 +20,6 @@ end
 
 @checked function cuGraphInstantiate(phGraphExec, hGraph, phErrorNode, logBuffer,
                                         bufferSize)
-    initialize_api()
     ccall((:cuGraphInstantiate, libcuda()), CUresult,
                    (Ptr{CUgraphExec}, CUgraph, Ptr{CUgraphNode}, Cstring, Csize_t),
                    phGraphExec, hGraph, phErrorNode, logBuffer, bufferSize)
@@ -29,7 +28,6 @@ end
 ## superseded in CUDA 11.1
 
 @checked function cuIpcOpenMemHandle(pdptr, handle, Flags)
-    initialize_api()
     ccall((:cuIpcOpenMemHandle, libcuda()), CUresult,
                    (Ptr{CUdeviceptr}, CUipcMemHandle, UInt32),
                    pdptr, handle, Flags)

--- a/lib/cudadrv/version.jl
+++ b/lib/cudadrv/version.jl
@@ -26,7 +26,6 @@ release() = VersionNumber(version().major, version().minor)
     Returns the CUDA Runtime version.
 """
 function runtime_version()
-    initialize_api()
     version_ref = Ref{Cint}()
     @ccall libcudart().cudaRuntimeGetVersion(version_ref::Ptr{Cint})::CUresult
     major, ver = divrem(version_ref[], 1000)

--- a/lib/cudadrv/version.jl
+++ b/lib/cudadrv/version.jl
@@ -1,9 +1,23 @@
 # Version management
 
+# NVML.driver_version() wrongly reports the forward compatible version,
+# so we record the system libcuda version when we initialize the library.
+const _system_version = Ref{VersionNumber}()
+
+"""
+    system_version()
+
+Returns the latest version of CUDA supported by the system driver.
+"""
+function system_version()
+    libcuda()   # initializes _system_version
+    _system_version[]
+end
+
 """
     version()
 
-Returns the latest version of CUDA supported by the driver.
+Returns the latest version of CUDA supported by the loaded driver.
 """
 function version()
     version_ref = Ref{Cint}()

--- a/lib/cudnn/CUDNN.jl
+++ b/lib/cudnn/CUDNN.jl
@@ -11,7 +11,7 @@ using ..APIUtils
 
 using ..CUDA
 using ..CUDA: CUstream, libraryPropertyType
-using ..CUDA: libcudnn, @retry_reclaim, isdebug, @context!
+using ..CUDA: libcudnn, @retry_reclaim, isdebug, @context!, initialize_context
 
 using CEnum: @cenum
 

--- a/lib/cudnn/error.jl
+++ b/lib/cudnn/error.jl
@@ -23,10 +23,6 @@ name(err::CUDNNError) = unsafe_string(cudnnGetErrorString(err))
     end
 end
 
-function initialize_api()
-    CUDA.prepare_cuda_state()
-end
-
 macro check(ex, errs...)
     check = :(isequal(err, CUDNN_STATUS_ALLOC_FAILED))
     for err in errs

--- a/lib/cudnn/libcudnn.jl
+++ b/lib/cudnn/libcudnn.jl
@@ -16,7 +16,7 @@ function cudnnGetErrorString(status)
 end
 
 @checked function cudnnQueryRuntimeError(handle, rstatus, mode, tag)
-    initialize_api()
+    initialize_context()
     ccall((:cudnnQueryRuntimeError, libcudnn()), cudnnStatus_t,
                    (cudnnHandle_t, Ptr{cudnnStatus_t}, cudnnErrQueryMode_t,
                     Ptr{cudnnRuntimeTag_t}),
@@ -30,42 +30,42 @@ end
 end
 
 @checked function cudnnCreate(handle)
-    initialize_api()
+    initialize_context()
     ccall((:cudnnCreate, libcudnn()), cudnnStatus_t,
                    (Ptr{cudnnHandle_t},),
                    handle)
 end
 
 @checked function cudnnDestroy(handle)
-    initialize_api()
+    initialize_context()
     ccall((:cudnnDestroy, libcudnn()), cudnnStatus_t,
                    (cudnnHandle_t,),
                    handle)
 end
 
 @checked function cudnnSetStream(handle, streamId)
-    initialize_api()
+    initialize_context()
     ccall((:cudnnSetStream, libcudnn()), cudnnStatus_t,
                    (cudnnHandle_t, CUstream),
                    handle, streamId)
 end
 
 @checked function cudnnGetStream(handle, streamId)
-    initialize_api()
+    initialize_context()
     ccall((:cudnnGetStream, libcudnn()), cudnnStatus_t,
                    (cudnnHandle_t, Ptr{CUstream}),
                    handle, streamId)
 end
 
 @checked function cudnnCreateTensorDescriptor(tensorDesc)
-    initialize_api()
+    initialize_context()
     ccall((:cudnnCreateTensorDescriptor, libcudnn()), cudnnStatus_t,
                    (Ptr{cudnnTensorDescriptor_t},),
                    tensorDesc)
 end
 
 @checked function cudnnSetTensor4dDescriptor(tensorDesc, format, dataType, n, c, h, w)
-    initialize_api()
+    initialize_context()
     ccall((:cudnnSetTensor4dDescriptor, libcudnn()), cudnnStatus_t,
                    (cudnnTensorDescriptor_t, cudnnTensorFormat_t, cudnnDataType_t, Cint,
                     Cint, Cint, Cint),
@@ -74,7 +74,7 @@ end
 
 @checked function cudnnSetTensor4dDescriptorEx(tensorDesc, dataType, n, c, h, w, nStride,
                                                cStride, hStride, wStride)
-    initialize_api()
+    initialize_context()
     ccall((:cudnnSetTensor4dDescriptorEx, libcudnn()), cudnnStatus_t,
                    (cudnnTensorDescriptor_t, cudnnDataType_t, Cint, Cint, Cint, Cint,
                     Cint, Cint, Cint, Cint),
@@ -83,7 +83,7 @@ end
 
 @checked function cudnnGetTensor4dDescriptor(tensorDesc, dataType, n, c, h, w, nStride,
                                              cStride, hStride, wStride)
-    initialize_api()
+    initialize_context()
     ccall((:cudnnGetTensor4dDescriptor, libcudnn()), cudnnStatus_t,
                    (cudnnTensorDescriptor_t, Ptr{cudnnDataType_t}, Ptr{Cint}, Ptr{Cint},
                     Ptr{Cint}, Ptr{Cint}, Ptr{Cint}, Ptr{Cint}, Ptr{Cint}, Ptr{Cint}),
@@ -91,14 +91,14 @@ end
 end
 
 @checked function cudnnSetTensorNdDescriptor(tensorDesc, dataType, nbDims, dimA, strideA)
-    initialize_api()
+    initialize_context()
     ccall((:cudnnSetTensorNdDescriptor, libcudnn()), cudnnStatus_t,
                    (cudnnTensorDescriptor_t, cudnnDataType_t, Cint, Ptr{Cint}, Ptr{Cint}),
                    tensorDesc, dataType, nbDims, dimA, strideA)
 end
 
 @checked function cudnnSetTensorNdDescriptorEx(tensorDesc, format, dataType, nbDims, dimA)
-    initialize_api()
+    initialize_context()
     ccall((:cudnnSetTensorNdDescriptorEx, libcudnn()), cudnnStatus_t,
                    (cudnnTensorDescriptor_t, cudnnTensorFormat_t, cudnnDataType_t, Cint,
                     Ptr{Cint}),
@@ -107,7 +107,7 @@ end
 
 @checked function cudnnGetTensorNdDescriptor(tensorDesc, nbDimsRequested, dataType, nbDims,
                                              dimA, strideA)
-    initialize_api()
+    initialize_context()
     ccall((:cudnnGetTensorNdDescriptor, libcudnn()), cudnnStatus_t,
                    (cudnnTensorDescriptor_t, Cint, Ptr{cudnnDataType_t}, Ptr{Cint},
                     Ptr{Cint}, Ptr{Cint}),
@@ -115,21 +115,21 @@ end
 end
 
 @checked function cudnnGetTensorSizeInBytes(tensorDesc, size)
-    initialize_api()
+    initialize_context()
     ccall((:cudnnGetTensorSizeInBytes, libcudnn()), cudnnStatus_t,
                    (cudnnTensorDescriptor_t, Ptr{Csize_t}),
                    tensorDesc, size)
 end
 
 @checked function cudnnDestroyTensorDescriptor(tensorDesc)
-    initialize_api()
+    initialize_context()
     ccall((:cudnnDestroyTensorDescriptor, libcudnn()), cudnnStatus_t,
                    (cudnnTensorDescriptor_t,),
                    tensorDesc)
 end
 
 @checked function cudnnInitTransformDest(transformDesc, srcDesc, destDesc, destSizeInBytes)
-    initialize_api()
+    initialize_context()
     ccall((:cudnnInitTransformDest, libcudnn()), cudnnStatus_t,
                    (cudnnTensorTransformDescriptor_t, cudnnTensorDescriptor_t,
                     cudnnTensorDescriptor_t, Ptr{Csize_t}),
@@ -137,7 +137,7 @@ end
 end
 
 @checked function cudnnCreateTensorTransformDescriptor(transformDesc)
-    initialize_api()
+    initialize_context()
     ccall((:cudnnCreateTensorTransformDescriptor, libcudnn()), cudnnStatus_t,
                    (Ptr{cudnnTensorTransformDescriptor_t},),
                    transformDesc)
@@ -145,7 +145,7 @@ end
 
 @checked function cudnnSetTensorTransformDescriptor(transformDesc, nbDims, destFormat,
                                                     padBeforeA, padAfterA, foldA, direction)
-    initialize_api()
+    initialize_context()
     ccall((:cudnnSetTensorTransformDescriptor, libcudnn()), cudnnStatus_t,
                    (cudnnTensorTransformDescriptor_t, UInt32, cudnnTensorFormat_t,
                     Ptr{Int32}, Ptr{Int32}, Ptr{UInt32}, cudnnFoldingDirection_t),
@@ -156,7 +156,7 @@ end
 @checked function cudnnGetTensorTransformDescriptor(transformDesc, nbDimsRequested,
                                                     destFormat, padBeforeA, padAfterA,
                                                     foldA, direction)
-    initialize_api()
+    initialize_context()
     ccall((:cudnnGetTensorTransformDescriptor, libcudnn()), cudnnStatus_t,
                    (cudnnTensorTransformDescriptor_t, UInt32, Ptr{cudnnTensorFormat_t},
                     Ptr{Int32}, Ptr{Int32}, Ptr{UInt32}, Ptr{cudnnFoldingDirection_t}),
@@ -165,14 +165,14 @@ end
 end
 
 @checked function cudnnDestroyTensorTransformDescriptor(transformDesc)
-    initialize_api()
+    initialize_context()
     ccall((:cudnnDestroyTensorTransformDescriptor, libcudnn()), cudnnStatus_t,
                    (cudnnTensorTransformDescriptor_t,),
                    transformDesc)
 end
 
 @checked function cudnnTransformTensor(handle, alpha, xDesc, x, beta, yDesc, y)
-    initialize_api()
+    initialize_context()
     ccall((:cudnnTransformTensor, libcudnn()), cudnnStatus_t,
                    (cudnnHandle_t, Ptr{Cvoid}, cudnnTensorDescriptor_t, Ptr{Cvoid},
                     Ptr{Cvoid}, cudnnTensorDescriptor_t, Ptr{Cvoid}),
@@ -181,7 +181,7 @@ end
 
 @checked function cudnnTransformTensorEx(handle, transDesc, alpha, srcDesc, srcData, beta,
                                          destDesc, destData)
-    initialize_api()
+    initialize_context()
     ccall((:cudnnTransformTensorEx, libcudnn()), cudnnStatus_t,
                    (cudnnHandle_t, cudnnTensorTransformDescriptor_t, Ptr{Cvoid},
                     cudnnTensorDescriptor_t, Ptr{Cvoid}, Ptr{Cvoid},
@@ -199,7 +199,7 @@ end
                                                             diffPadTransDesc,
                                                             gradFoldTransDesc,
                                                             gradUnfoldTransDesc)
-    initialize_api()
+    initialize_context()
     ccall((:cudnnGetFoldedConvBackwardDataDescriptors, libcudnn()), cudnnStatus_t,
                    (cudnnHandle_t, cudnnFilterDescriptor_t, cudnnTensorDescriptor_t,
                     cudnnConvolutionDescriptor_t, cudnnTensorDescriptor_t,
@@ -214,7 +214,7 @@ end
 end
 
 @checked function cudnnAddTensor(handle, alpha, aDesc, A, beta, cDesc, C)
-    initialize_api()
+    initialize_context()
     ccall((:cudnnAddTensor, libcudnn()), cudnnStatus_t,
                    (cudnnHandle_t, Ptr{Cvoid}, cudnnTensorDescriptor_t, CuPtr{Cvoid},
                     Ptr{Cvoid}, cudnnTensorDescriptor_t, CuPtr{Cvoid}),
@@ -222,7 +222,7 @@ end
 end
 
 @checked function cudnnCreateOpTensorDescriptor(opTensorDesc)
-    initialize_api()
+    initialize_context()
     ccall((:cudnnCreateOpTensorDescriptor, libcudnn()), cudnnStatus_t,
                    (Ptr{cudnnOpTensorDescriptor_t},),
                    opTensorDesc)
@@ -230,7 +230,7 @@ end
 
 @checked function cudnnSetOpTensorDescriptor(opTensorDesc, opTensorOp, opTensorCompType,
                                              opTensorNanOpt)
-    initialize_api()
+    initialize_context()
     ccall((:cudnnSetOpTensorDescriptor, libcudnn()), cudnnStatus_t,
                    (cudnnOpTensorDescriptor_t, cudnnOpTensorOp_t, cudnnDataType_t,
                     cudnnNanPropagation_t),
@@ -239,7 +239,7 @@ end
 
 @checked function cudnnGetOpTensorDescriptor(opTensorDesc, opTensorOp, opTensorCompType,
                                              opTensorNanOpt)
-    initialize_api()
+    initialize_context()
     ccall((:cudnnGetOpTensorDescriptor, libcudnn()), cudnnStatus_t,
                    (cudnnOpTensorDescriptor_t, Ptr{cudnnOpTensorOp_t},
                     Ptr{cudnnDataType_t}, Ptr{cudnnNanPropagation_t}),
@@ -247,7 +247,7 @@ end
 end
 
 @checked function cudnnDestroyOpTensorDescriptor(opTensorDesc)
-    initialize_api()
+    initialize_context()
     ccall((:cudnnDestroyOpTensorDescriptor, libcudnn()), cudnnStatus_t,
                    (cudnnOpTensorDescriptor_t,),
                    opTensorDesc)
@@ -255,7 +255,7 @@ end
 
 @checked function cudnnOpTensor(handle, opTensorDesc, alpha1, aDesc, A, alpha2, bDesc, B,
                                 beta, cDesc, C)
-    initialize_api()
+    initialize_context()
     ccall((:cudnnOpTensor, libcudnn()), cudnnStatus_t,
                    (cudnnHandle_t, cudnnOpTensorDescriptor_t, Ptr{Cvoid},
                     cudnnTensorDescriptor_t, CuPtr{Cvoid}, Ptr{Cvoid},
@@ -266,7 +266,7 @@ end
 end
 
 @checked function cudnnCreateReduceTensorDescriptor(reduceTensorDesc)
-    initialize_api()
+    initialize_context()
     ccall((:cudnnCreateReduceTensorDescriptor, libcudnn()), cudnnStatus_t,
                    (Ptr{cudnnReduceTensorDescriptor_t},),
                    reduceTensorDesc)
@@ -276,7 +276,7 @@ end
                                                  reduceTensorCompType, reduceTensorNanOpt,
                                                  reduceTensorIndices,
                                                  reduceTensorIndicesType)
-    initialize_api()
+    initialize_context()
     ccall((:cudnnSetReduceTensorDescriptor, libcudnn()), cudnnStatus_t,
                    (cudnnReduceTensorDescriptor_t, cudnnReduceTensorOp_t, cudnnDataType_t,
                     cudnnNanPropagation_t, cudnnReduceTensorIndices_t, cudnnIndicesType_t),
@@ -288,7 +288,7 @@ end
                                                  reduceTensorCompType, reduceTensorNanOpt,
                                                  reduceTensorIndices,
                                                  reduceTensorIndicesType)
-    initialize_api()
+    initialize_context()
     ccall((:cudnnGetReduceTensorDescriptor, libcudnn()), cudnnStatus_t,
                    (cudnnReduceTensorDescriptor_t, Ptr{cudnnReduceTensorOp_t},
                     Ptr{cudnnDataType_t}, Ptr{cudnnNanPropagation_t},
@@ -298,7 +298,7 @@ end
 end
 
 @checked function cudnnDestroyReduceTensorDescriptor(reduceTensorDesc)
-    initialize_api()
+    initialize_context()
     ccall((:cudnnDestroyReduceTensorDescriptor, libcudnn()), cudnnStatus_t,
                    (cudnnReduceTensorDescriptor_t,),
                    reduceTensorDesc)
@@ -306,7 +306,7 @@ end
 
 @checked function cudnnGetReductionIndicesSize(handle, reduceTensorDesc, aDesc, cDesc,
                                                sizeInBytes)
-    initialize_api()
+    initialize_context()
     ccall((:cudnnGetReductionIndicesSize, libcudnn()), cudnnStatus_t,
                    (cudnnHandle_t, cudnnReduceTensorDescriptor_t, cudnnTensorDescriptor_t,
                     cudnnTensorDescriptor_t, Ptr{Csize_t}),
@@ -315,7 +315,7 @@ end
 
 @checked function cudnnGetReductionWorkspaceSize(handle, reduceTensorDesc, aDesc, cDesc,
                                                  sizeInBytes)
-    initialize_api()
+    initialize_context()
     ccall((:cudnnGetReductionWorkspaceSize, libcudnn()), cudnnStatus_t,
                    (cudnnHandle_t, cudnnReduceTensorDescriptor_t, cudnnTensorDescriptor_t,
                     cudnnTensorDescriptor_t, Ref{Csize_t}),
@@ -325,7 +325,7 @@ end
 @checked function cudnnReduceTensor(handle, reduceTensorDesc, indices, indicesSizeInBytes,
                                     workspace, workspaceSizeInBytes, alpha, aDesc, A, beta,
                                     cDesc, C)
-    initialize_api()
+    initialize_context()
     ccall((:cudnnReduceTensor, libcudnn()), cudnnStatus_t,
                    (cudnnHandle_t, cudnnReduceTensorDescriptor_t, Ptr{Cvoid}, Csize_t,
                     CuPtr{Cvoid}, Csize_t, Ptr{Cvoid}, cudnnTensorDescriptor_t,
@@ -335,28 +335,28 @@ end
 end
 
 @checked function cudnnSetTensor(handle, yDesc, y, valuePtr)
-    initialize_api()
+    initialize_context()
     ccall((:cudnnSetTensor, libcudnn()), cudnnStatus_t,
                    (cudnnHandle_t, cudnnTensorDescriptor_t, CuPtr{Cvoid}, Ptr{Cvoid}),
                    handle, yDesc, y, valuePtr)
 end
 
 @checked function cudnnScaleTensor(handle, yDesc, y, alpha)
-    initialize_api()
+    initialize_context()
     ccall((:cudnnScaleTensor, libcudnn()), cudnnStatus_t,
                    (cudnnHandle_t, cudnnTensorDescriptor_t, CuPtr{Cvoid}, Ptr{Cvoid}),
                    handle, yDesc, y, alpha)
 end
 
 @checked function cudnnCreateFilterDescriptor(filterDesc)
-    initialize_api()
+    initialize_context()
     ccall((:cudnnCreateFilterDescriptor, libcudnn()), cudnnStatus_t,
                    (Ptr{cudnnFilterDescriptor_t},),
                    filterDesc)
 end
 
 @checked function cudnnSetFilter4dDescriptor(filterDesc, dataType, format, k, c, h, w)
-    initialize_api()
+    initialize_context()
     ccall((:cudnnSetFilter4dDescriptor, libcudnn()), cudnnStatus_t,
                    (cudnnFilterDescriptor_t, cudnnDataType_t, cudnnTensorFormat_t, Cint,
                     Cint, Cint, Cint),
@@ -364,7 +364,7 @@ end
 end
 
 @checked function cudnnGetFilter4dDescriptor(filterDesc, dataType, format, k, c, h, w)
-    initialize_api()
+    initialize_context()
     ccall((:cudnnGetFilter4dDescriptor, libcudnn()), cudnnStatus_t,
                    (cudnnFilterDescriptor_t, Ptr{cudnnDataType_t},
                     Ptr{cudnnTensorFormat_t}, Ptr{Cint}, Ptr{Cint}, Ptr{Cint}, Ptr{Cint}),
@@ -373,7 +373,7 @@ end
 
 @checked function cudnnSetFilterNdDescriptor(filterDesc, dataType, format, nbDims,
                                              filterDimA)
-    initialize_api()
+    initialize_context()
     ccall((:cudnnSetFilterNdDescriptor, libcudnn()), cudnnStatus_t,
                    (cudnnFilterDescriptor_t, cudnnDataType_t, cudnnTensorFormat_t, Cint,
                     Ptr{Cint}),
@@ -382,7 +382,7 @@ end
 
 @checked function cudnnGetFilterNdDescriptor(filterDesc, nbDimsRequested, dataType, format,
                                              nbDims, filterDimA)
-    initialize_api()
+    initialize_context()
     ccall((:cudnnGetFilterNdDescriptor, libcudnn()), cudnnStatus_t,
                    (cudnnFilterDescriptor_t, Cint, Ptr{cudnnDataType_t},
                     Ptr{cudnnTensorFormat_t}, Ptr{Cint}, Ptr{Cint}),
@@ -390,7 +390,7 @@ end
 end
 
 @checked function cudnnGetFilterSizeInBytes(filterDesc, size)
-    initialize_api()
+    initialize_context()
     ccall((:cudnnGetFilterSizeInBytes, libcudnn()), cudnnStatus_t,
                    (cudnnFilterDescriptor_t, Ptr{Csize_t}),
                    filterDesc, size)
@@ -398,7 +398,7 @@ end
 
 @checked function cudnnTransformFilter(handle, transDesc, alpha, srcDesc, srcData, beta,
                                        destDesc, destData)
-    initialize_api()
+    initialize_context()
     ccall((:cudnnTransformFilter, libcudnn()), cudnnStatus_t,
                    (cudnnHandle_t, cudnnTensorTransformDescriptor_t, Ptr{Cvoid},
                     cudnnFilterDescriptor_t, CuPtr{Cvoid}, Ptr{Cvoid},
@@ -407,7 +407,7 @@ end
 end
 
 @checked function cudnnDestroyFilterDescriptor(filterDesc)
-    initialize_api()
+    initialize_context()
     ccall((:cudnnDestroyFilterDescriptor, libcudnn()), cudnnStatus_t,
                    (cudnnFilterDescriptor_t,),
                    filterDesc)
@@ -416,7 +416,7 @@ end
 @checked function cudnnReorderFilterAndBias(handle, filterDesc, reorderType, filterData,
                                             reorderedFilterData, reorderBias, biasData,
                                             reorderedBiasData)
-    initialize_api()
+    initialize_context()
     ccall((:cudnnReorderFilterAndBias, libcudnn()), cudnnStatus_t,
                    (cudnnHandle_t, cudnnFilterDescriptor_t, cudnnReorderType_t,
                     CuPtr{Cvoid}, CuPtr{Cvoid}, Cint, CuPtr{Cvoid}, CuPtr{Cvoid}),
@@ -425,49 +425,49 @@ end
 end
 
 @checked function cudnnCreateConvolutionDescriptor(convDesc)
-    initialize_api()
+    initialize_context()
     ccall((:cudnnCreateConvolutionDescriptor, libcudnn()), cudnnStatus_t,
                    (Ptr{cudnnConvolutionDescriptor_t},),
                    convDesc)
 end
 
 @checked function cudnnSetConvolutionMathType(convDesc, mathType)
-    initialize_api()
+    initialize_context()
     ccall((:cudnnSetConvolutionMathType, libcudnn()), cudnnStatus_t,
                    (cudnnConvolutionDescriptor_t, cudnnMathType_t),
                    convDesc, mathType)
 end
 
 @checked function cudnnGetConvolutionMathType(convDesc, mathType)
-    initialize_api()
+    initialize_context()
     ccall((:cudnnGetConvolutionMathType, libcudnn()), cudnnStatus_t,
                    (cudnnConvolutionDescriptor_t, Ptr{cudnnMathType_t}),
                    convDesc, mathType)
 end
 
 @checked function cudnnSetConvolutionGroupCount(convDesc, groupCount)
-    initialize_api()
+    initialize_context()
     ccall((:cudnnSetConvolutionGroupCount, libcudnn()), cudnnStatus_t,
                    (cudnnConvolutionDescriptor_t, Cint),
                    convDesc, groupCount)
 end
 
 @checked function cudnnGetConvolutionGroupCount(convDesc, groupCount)
-    initialize_api()
+    initialize_context()
     ccall((:cudnnGetConvolutionGroupCount, libcudnn()), cudnnStatus_t,
                    (cudnnConvolutionDescriptor_t, Ptr{Cint}),
                    convDesc, groupCount)
 end
 
 @checked function cudnnSetConvolutionReorderType(convDesc, reorderType)
-    initialize_api()
+    initialize_context()
     ccall((:cudnnSetConvolutionReorderType, libcudnn()), cudnnStatus_t,
                    (cudnnConvolutionDescriptor_t, cudnnReorderType_t),
                    convDesc, reorderType)
 end
 
 @checked function cudnnGetConvolutionReorderType(convDesc, reorderType)
-    initialize_api()
+    initialize_context()
     ccall((:cudnnGetConvolutionReorderType, libcudnn()), cudnnStatus_t,
                    (cudnnConvolutionDescriptor_t, Ptr{cudnnReorderType_t}),
                    convDesc, reorderType)
@@ -475,7 +475,7 @@ end
 
 @checked function cudnnSetConvolution2dDescriptor(convDesc, pad_h, pad_w, u, v, dilation_h,
                                                   dilation_w, mode, computeType)
-    initialize_api()
+    initialize_context()
     ccall((:cudnnSetConvolution2dDescriptor, libcudnn()), cudnnStatus_t,
                    (cudnnConvolutionDescriptor_t, Cint, Cint, Cint, Cint, Cint, Cint,
                     cudnnConvolutionMode_t, cudnnDataType_t),
@@ -484,7 +484,7 @@ end
 
 @checked function cudnnGetConvolution2dDescriptor(convDesc, pad_h, pad_w, u, v, dilation_h,
                                                   dilation_w, mode, computeType)
-    initialize_api()
+    initialize_context()
     ccall((:cudnnGetConvolution2dDescriptor, libcudnn()), cudnnStatus_t,
                    (cudnnConvolutionDescriptor_t, Ptr{Cint}, Ptr{Cint}, Ptr{Cint},
                     Ptr{Cint}, Ptr{Cint}, Ptr{Cint}, Ptr{cudnnConvolutionMode_t},
@@ -494,7 +494,7 @@ end
 
 @checked function cudnnGetConvolution2dForwardOutputDim(convDesc, inputTensorDesc,
                                                         filterDesc, n, c, h, w)
-    initialize_api()
+    initialize_context()
     ccall((:cudnnGetConvolution2dForwardOutputDim, libcudnn()), cudnnStatus_t,
                    (cudnnConvolutionDescriptor_t, cudnnTensorDescriptor_t,
                     cudnnFilterDescriptor_t, Ptr{Cint}, Ptr{Cint}, Ptr{Cint}, Ptr{Cint}),
@@ -504,7 +504,7 @@ end
 @checked function cudnnSetConvolutionNdDescriptor(convDesc, arrayLength, padA,
                                                   filterStrideA, dilationA, mode,
                                                   computeType)
-    initialize_api()
+    initialize_context()
     ccall((:cudnnSetConvolutionNdDescriptor, libcudnn()), cudnnStatus_t,
                    (cudnnConvolutionDescriptor_t, Cint, Ptr{Cint}, Ptr{Cint}, Ptr{Cint},
                     cudnnConvolutionMode_t, cudnnDataType_t),
@@ -515,7 +515,7 @@ end
 @checked function cudnnGetConvolutionNdDescriptor(convDesc, arrayLengthRequested,
                                                   arrayLength, padA, strideA, dilationA,
                                                   mode, computeType)
-    initialize_api()
+    initialize_context()
     ccall((:cudnnGetConvolutionNdDescriptor, libcudnn()), cudnnStatus_t,
                    (cudnnConvolutionDescriptor_t, Cint, Ptr{Cint}, Ptr{Cint}, Ptr{Cint},
                     Ptr{Cint}, Ptr{cudnnConvolutionMode_t}, Ptr{cudnnDataType_t}),
@@ -525,7 +525,7 @@ end
 
 @checked function cudnnGetConvolutionNdForwardOutputDim(convDesc, inputTensorDesc,
                                                         filterDesc, nbDims, tensorOuputDimA)
-    initialize_api()
+    initialize_context()
     ccall((:cudnnGetConvolutionNdForwardOutputDim, libcudnn()), cudnnStatus_t,
                    (cudnnConvolutionDescriptor_t, cudnnTensorDescriptor_t,
                     cudnnFilterDescriptor_t, Cint, Ptr{Cint}),
@@ -533,14 +533,14 @@ end
 end
 
 @checked function cudnnDestroyConvolutionDescriptor(convDesc)
-    initialize_api()
+    initialize_context()
     ccall((:cudnnDestroyConvolutionDescriptor, libcudnn()), cudnnStatus_t,
                    (cudnnConvolutionDescriptor_t,),
                    convDesc)
 end
 
 @checked function cudnnGetConvolutionForwardAlgorithmMaxCount(handle, count)
-    initialize_api()
+    initialize_context()
     ccall((:cudnnGetConvolutionForwardAlgorithmMaxCount, libcudnn()), cudnnStatus_t,
                    (cudnnHandle_t, Ptr{Cint}),
                    handle, count)
@@ -549,7 +549,7 @@ end
 @checked function cudnnFindConvolutionForwardAlgorithm(handle, xDesc, wDesc, convDesc,
                                                        yDesc, requestedAlgoCount,
                                                        returnedAlgoCount, perfResults)
-    initialize_api()
+    initialize_context()
     ccall((:cudnnFindConvolutionForwardAlgorithm, libcudnn()), cudnnStatus_t,
                    (cudnnHandle_t, cudnnTensorDescriptor_t, cudnnFilterDescriptor_t,
                     cudnnConvolutionDescriptor_t, cudnnTensorDescriptor_t, Cint, Ptr{Cint},
@@ -563,7 +563,7 @@ end
                                                          requestedAlgoCount,
                                                          returnedAlgoCount, perfResults,
                                                          workSpace, workSpaceSizeInBytes)
-    initialize_api()
+    initialize_context()
     ccall((:cudnnFindConvolutionForwardAlgorithmEx, libcudnn()), cudnnStatus_t,
                    (cudnnHandle_t, cudnnTensorDescriptor_t, CuPtr{Cvoid},
                     cudnnFilterDescriptor_t, CuPtr{Cvoid}, cudnnConvolutionDescriptor_t,
@@ -577,7 +577,7 @@ end
                                                          convDesc, destDesc,
                                                          requestedAlgoCount,
                                                          returnedAlgoCount, perfResults)
-    initialize_api()
+    initialize_context()
     ccall((:cudnnGetConvolutionForwardAlgorithm_v7, libcudnn()), cudnnStatus_t,
                    (cudnnHandle_t, cudnnTensorDescriptor_t, cudnnFilterDescriptor_t,
                     cudnnConvolutionDescriptor_t, cudnnTensorDescriptor_t, Cint, Ptr{Cint},
@@ -588,7 +588,7 @@ end
 
 @checked function cudnnGetConvolutionForwardWorkspaceSize(handle, xDesc, wDesc, convDesc,
                                                           yDesc, algo, sizeInBytes)
-    initialize_api()
+    initialize_context()
     ccall((:cudnnGetConvolutionForwardWorkspaceSize, libcudnn()), cudnnStatus_t,
                    (cudnnHandle_t, cudnnTensorDescriptor_t, cudnnFilterDescriptor_t,
                     cudnnConvolutionDescriptor_t, cudnnTensorDescriptor_t,
@@ -599,7 +599,7 @@ end
 @checked function cudnnConvolutionForward(handle, alpha, xDesc, x, wDesc, w, convDesc,
                                           algo, workSpace, workSpaceSizeInBytes, beta,
                                           yDesc, y)
-    initialize_api()
+    initialize_context()
     ccall((:cudnnConvolutionForward, libcudnn()), cudnnStatus_t,
                    (cudnnHandle_t, Ptr{Cvoid}, cudnnTensorDescriptor_t, CuPtr{Cvoid},
                     cudnnFilterDescriptor_t, CuPtr{Cvoid}, cudnnConvolutionDescriptor_t,
@@ -614,7 +614,7 @@ end
                                                         workSpaceSizeInBytes, alpha2,
                                                         zDesc, z, biasDesc, bias,
                                                         activationDesc, yDesc, y)
-    initialize_api()
+    initialize_context()
     ccall((:cudnnConvolutionBiasActivationForward, libcudnn()), cudnnStatus_t,
                    (cudnnHandle_t, Ptr{Cvoid}, cudnnTensorDescriptor_t, CuPtr{Cvoid},
                     cudnnFilterDescriptor_t, CuPtr{Cvoid}, cudnnConvolutionDescriptor_t,
@@ -628,7 +628,7 @@ end
 end
 
 @checked function cudnnConvolutionBackwardBias(handle, alpha, dyDesc, dy, beta, dbDesc, db)
-    initialize_api()
+    initialize_context()
     ccall((:cudnnConvolutionBackwardBias, libcudnn()), cudnnStatus_t,
                    (cudnnHandle_t, Ptr{Cvoid}, cudnnTensorDescriptor_t, CuPtr{Cvoid},
                     Ptr{Cvoid}, cudnnTensorDescriptor_t, CuPtr{Cvoid}),
@@ -636,7 +636,7 @@ end
 end
 
 @checked function cudnnGetConvolutionBackwardFilterAlgorithmMaxCount(handle, count)
-    initialize_api()
+    initialize_context()
     ccall((:cudnnGetConvolutionBackwardFilterAlgorithmMaxCount, libcudnn()), cudnnStatus_t,
                    (cudnnHandle_t, Ptr{Cint}),
                    handle, count)
@@ -646,7 +646,7 @@ end
                                                               convDesc, dwDesc,
                                                               requestedAlgoCount,
                                                               returnedAlgoCount, perfResults)
-    initialize_api()
+    initialize_context()
     ccall((:cudnnFindConvolutionBackwardFilterAlgorithm, libcudnn()), cudnnStatus_t,
                    (cudnnHandle_t, cudnnTensorDescriptor_t, cudnnTensorDescriptor_t,
                     cudnnConvolutionDescriptor_t, cudnnFilterDescriptor_t, Cint, Ptr{Cint},
@@ -661,7 +661,7 @@ end
                                                                 returnedAlgoCount,
                                                                 perfResults, workSpace,
                                                                 workSpaceSizeInBytes)
-    initialize_api()
+    initialize_context()
     ccall((:cudnnFindConvolutionBackwardFilterAlgorithmEx, libcudnn()), cudnnStatus_t,
                    (cudnnHandle_t, cudnnTensorDescriptor_t, CuPtr{Cvoid},
                     cudnnTensorDescriptor_t, CuPtr{Cvoid}, cudnnConvolutionDescriptor_t,
@@ -676,7 +676,7 @@ end
                                                                 requestedAlgoCount,
                                                                 returnedAlgoCount,
                                                                 perfResults)
-    initialize_api()
+    initialize_context()
     ccall((:cudnnGetConvolutionBackwardFilterAlgorithm_v7, libcudnn()), cudnnStatus_t,
                    (cudnnHandle_t, cudnnTensorDescriptor_t, cudnnTensorDescriptor_t,
                     cudnnConvolutionDescriptor_t, cudnnFilterDescriptor_t, Cint, Ptr{Cint},
@@ -688,7 +688,7 @@ end
 @checked function cudnnGetConvolutionBackwardFilterWorkspaceSize(handle, xDesc, dyDesc,
                                                                  convDesc, gradDesc, algo,
                                                                  sizeInBytes)
-    initialize_api()
+    initialize_context()
     ccall((:cudnnGetConvolutionBackwardFilterWorkspaceSize, libcudnn()), cudnnStatus_t,
                    (cudnnHandle_t, cudnnTensorDescriptor_t, cudnnTensorDescriptor_t,
                     cudnnConvolutionDescriptor_t, cudnnFilterDescriptor_t,
@@ -699,7 +699,7 @@ end
 @checked function cudnnConvolutionBackwardFilter(handle, alpha, xDesc, x, dyDesc, dy,
                                                  convDesc, algo, workSpace,
                                                  workSpaceSizeInBytes, beta, dwDesc, dw)
-    initialize_api()
+    initialize_context()
     ccall((:cudnnConvolutionBackwardFilter, libcudnn()), cudnnStatus_t,
                    (cudnnHandle_t, Ptr{Cvoid}, cudnnTensorDescriptor_t, CuPtr{Cvoid},
                     cudnnTensorDescriptor_t, CuPtr{Cvoid}, cudnnConvolutionDescriptor_t,
@@ -710,7 +710,7 @@ end
 end
 
 @checked function cudnnGetConvolutionBackwardDataAlgorithmMaxCount(handle, count)
-    initialize_api()
+    initialize_context()
     ccall((:cudnnGetConvolutionBackwardDataAlgorithmMaxCount, libcudnn()), cudnnStatus_t,
                    (cudnnHandle_t, Ptr{Cint}),
                    handle, count)
@@ -720,7 +720,7 @@ end
                                                             convDesc, dxDesc,
                                                             requestedAlgoCount,
                                                             returnedAlgoCount, perfResults)
-    initialize_api()
+    initialize_context()
     ccall((:cudnnFindConvolutionBackwardDataAlgorithm, libcudnn()), cudnnStatus_t,
                    (cudnnHandle_t, cudnnFilterDescriptor_t, cudnnTensorDescriptor_t,
                     cudnnConvolutionDescriptor_t, cudnnTensorDescriptor_t, Cint, Ptr{Cint},
@@ -735,7 +735,7 @@ end
                                                               returnedAlgoCount,
                                                               perfResults, workSpace,
                                                               workSpaceSizeInBytes)
-    initialize_api()
+    initialize_context()
     ccall((:cudnnFindConvolutionBackwardDataAlgorithmEx, libcudnn()), cudnnStatus_t,
                    (cudnnHandle_t, cudnnFilterDescriptor_t, CuPtr{Cvoid},
                     cudnnTensorDescriptor_t, CuPtr{Cvoid}, cudnnConvolutionDescriptor_t,
@@ -749,7 +749,7 @@ end
                                                               convDesc, gradDesc,
                                                               requestedAlgoCount,
                                                               returnedAlgoCount, perfResults)
-    initialize_api()
+    initialize_context()
     ccall((:cudnnGetConvolutionBackwardDataAlgorithm_v7, libcudnn()), cudnnStatus_t,
                    (cudnnHandle_t, cudnnFilterDescriptor_t, cudnnTensorDescriptor_t,
                     cudnnConvolutionDescriptor_t, cudnnTensorDescriptor_t, Cint, Ptr{Cint},
@@ -761,7 +761,7 @@ end
 @checked function cudnnGetConvolutionBackwardDataWorkspaceSize(handle, wDesc, dyDesc,
                                                                convDesc, dxDesc, algo,
                                                                sizeInBytes)
-    initialize_api()
+    initialize_context()
     ccall((:cudnnGetConvolutionBackwardDataWorkspaceSize, libcudnn()), cudnnStatus_t,
                    (cudnnHandle_t, cudnnFilterDescriptor_t, cudnnTensorDescriptor_t,
                     cudnnConvolutionDescriptor_t, cudnnTensorDescriptor_t,
@@ -772,7 +772,7 @@ end
 @checked function cudnnConvolutionBackwardData(handle, alpha, wDesc, w, dyDesc, dy,
                                                convDesc, algo, workSpace,
                                                workSpaceSizeInBytes, beta, dxDesc, dx)
-    initialize_api()
+    initialize_context()
     ccall((:cudnnConvolutionBackwardData, libcudnn()), cudnnStatus_t,
                    (cudnnHandle_t, Ptr{Cvoid}, cudnnFilterDescriptor_t, CuPtr{Cvoid},
                     cudnnTensorDescriptor_t, CuPtr{Cvoid}, cudnnConvolutionDescriptor_t,
@@ -783,7 +783,7 @@ end
 end
 
 @checked function cudnnIm2Col(handle, xDesc, x, wDesc, convDesc, colBuffer)
-    initialize_api()
+    initialize_context()
     ccall((:cudnnIm2Col, libcudnn()), cudnnStatus_t,
                    (cudnnHandle_t, cudnnTensorDescriptor_t, CuPtr{Cvoid},
                     cudnnFilterDescriptor_t, cudnnConvolutionDescriptor_t, CuPtr{Cvoid}),
@@ -791,7 +791,7 @@ end
 end
 
 @checked function cudnnSoftmaxForward(handle, algo, mode, alpha, xDesc, x, beta, yDesc, y)
-    initialize_api()
+    initialize_context()
     ccall((:cudnnSoftmaxForward, libcudnn()), cudnnStatus_t,
                    (cudnnHandle_t, cudnnSoftmaxAlgorithm_t, cudnnSoftmaxMode_t,
                     Ptr{Cvoid}, cudnnTensorDescriptor_t, CuPtr{Cvoid}, Ptr{Cvoid},
@@ -801,7 +801,7 @@ end
 
 @checked function cudnnSoftmaxBackward(handle, algo, mode, alpha, yDesc, y, dyDesc, dy,
                                        beta, dxDesc, dx)
-    initialize_api()
+    initialize_context()
     ccall((:cudnnSoftmaxBackward, libcudnn()), cudnnStatus_t,
                    (cudnnHandle_t, cudnnSoftmaxAlgorithm_t, cudnnSoftmaxMode_t,
                     Ptr{Cvoid}, cudnnTensorDescriptor_t, CuPtr{Cvoid},
@@ -811,7 +811,7 @@ end
 end
 
 @checked function cudnnCreatePoolingDescriptor(poolingDesc)
-    initialize_api()
+    initialize_context()
     ccall((:cudnnCreatePoolingDescriptor, libcudnn()), cudnnStatus_t,
                    (Ptr{cudnnPoolingDescriptor_t},),
                    poolingDesc)
@@ -821,7 +821,7 @@ end
                                               windowHeight, windowWidth, verticalPadding,
                                               horizontalPadding, verticalStride,
                                               horizontalStride)
-    initialize_api()
+    initialize_context()
     ccall((:cudnnSetPooling2dDescriptor, libcudnn()), cudnnStatus_t,
                    (cudnnPoolingDescriptor_t, cudnnPoolingMode_t, cudnnNanPropagation_t,
                     Cint, Cint, Cint, Cint, Cint, Cint),
@@ -833,7 +833,7 @@ end
                                               windowHeight, windowWidth, verticalPadding,
                                               horizontalPadding, verticalStride,
                                               horizontalStride)
-    initialize_api()
+    initialize_context()
     ccall((:cudnnGetPooling2dDescriptor, libcudnn()), cudnnStatus_t,
                    (cudnnPoolingDescriptor_t, Ptr{cudnnPoolingMode_t},
                     Ptr{cudnnNanPropagation_t}, Ptr{Cint}, Ptr{Cint}, Ptr{Cint}, Ptr{Cint},
@@ -844,7 +844,7 @@ end
 
 @checked function cudnnSetPoolingNdDescriptor(poolingDesc, mode, maxpoolingNanOpt, nbDims,
                                               windowDimA, paddingA, strideA)
-    initialize_api()
+    initialize_context()
     ccall((:cudnnSetPoolingNdDescriptor, libcudnn()), cudnnStatus_t,
                    (cudnnPoolingDescriptor_t, cudnnPoolingMode_t, cudnnNanPropagation_t,
                     Cint, Ptr{Cint}, Ptr{Cint}, Ptr{Cint}),
@@ -855,7 +855,7 @@ end
 @checked function cudnnGetPoolingNdDescriptor(poolingDesc, nbDimsRequested, mode,
                                               maxpoolingNanOpt, nbDims, windowDimA,
                                               paddingA, strideA)
-    initialize_api()
+    initialize_context()
     ccall((:cudnnGetPoolingNdDescriptor, libcudnn()), cudnnStatus_t,
                    (cudnnPoolingDescriptor_t, Cint, Ptr{cudnnPoolingMode_t},
                     Ptr{cudnnNanPropagation_t}, Ptr{Cint}, Ptr{Cint}, Ptr{Cint}, Ptr{Cint}),
@@ -865,14 +865,14 @@ end
 
 @checked function cudnnGetPoolingNdForwardOutputDim(poolingDesc, inputTensorDesc, nbDims,
                                                     outputTensorDimA)
-    initialize_api()
+    initialize_context()
     ccall((:cudnnGetPoolingNdForwardOutputDim, libcudnn()), cudnnStatus_t,
                    (cudnnPoolingDescriptor_t, cudnnTensorDescriptor_t, Cint, Ptr{Cint}),
                    poolingDesc, inputTensorDesc, nbDims, outputTensorDimA)
 end
 
 @checked function cudnnGetPooling2dForwardOutputDim(poolingDesc, inputTensorDesc, n, c, h, w)
-    initialize_api()
+    initialize_context()
     ccall((:cudnnGetPooling2dForwardOutputDim, libcudnn()), cudnnStatus_t,
                    (cudnnPoolingDescriptor_t, cudnnTensorDescriptor_t, Ptr{Cint},
                     Ptr{Cint}, Ptr{Cint}, Ptr{Cint}),
@@ -880,14 +880,14 @@ end
 end
 
 @checked function cudnnDestroyPoolingDescriptor(poolingDesc)
-    initialize_api()
+    initialize_context()
     ccall((:cudnnDestroyPoolingDescriptor, libcudnn()), cudnnStatus_t,
                    (cudnnPoolingDescriptor_t,),
                    poolingDesc)
 end
 
 @checked function cudnnPoolingForward(handle, poolingDesc, alpha, xDesc, x, beta, yDesc, y)
-    initialize_api()
+    initialize_context()
     ccall((:cudnnPoolingForward, libcudnn()), cudnnStatus_t,
                    (cudnnHandle_t, cudnnPoolingDescriptor_t, Ptr{Cvoid},
                     cudnnTensorDescriptor_t, CuPtr{Cvoid}, Ptr{Cvoid},
@@ -897,7 +897,7 @@ end
 
 @checked function cudnnPoolingBackward(handle, poolingDesc, alpha, yDesc, y, dyDesc, dy,
                                        xDesc, x, beta, dxDesc, dx)
-    initialize_api()
+    initialize_context()
     ccall((:cudnnPoolingBackward, libcudnn()), cudnnStatus_t,
                    (cudnnHandle_t, cudnnPoolingDescriptor_t, Ptr{Cvoid},
                     cudnnTensorDescriptor_t, CuPtr{Cvoid}, cudnnTensorDescriptor_t,
@@ -908,14 +908,14 @@ end
 end
 
 @checked function cudnnCreateActivationDescriptor(activationDesc)
-    initialize_api()
+    initialize_context()
     ccall((:cudnnCreateActivationDescriptor, libcudnn()), cudnnStatus_t,
                    (Ptr{cudnnActivationDescriptor_t},),
                    activationDesc)
 end
 
 @checked function cudnnSetActivationDescriptor(activationDesc, mode, reluNanOpt, coef)
-    initialize_api()
+    initialize_context()
     ccall((:cudnnSetActivationDescriptor, libcudnn()), cudnnStatus_t,
                    (cudnnActivationDescriptor_t, cudnnActivationMode_t,
                     cudnnNanPropagation_t, Cdouble),
@@ -923,7 +923,7 @@ end
 end
 
 @checked function cudnnGetActivationDescriptor(activationDesc, mode, reluNanOpt, coef)
-    initialize_api()
+    initialize_context()
     ccall((:cudnnGetActivationDescriptor, libcudnn()), cudnnStatus_t,
                    (cudnnActivationDescriptor_t, Ptr{cudnnActivationMode_t},
                     Ptr{cudnnNanPropagation_t}, Ptr{Cdouble}),
@@ -931,7 +931,7 @@ end
 end
 
 @checked function cudnnDestroyActivationDescriptor(activationDesc)
-    initialize_api()
+    initialize_context()
     ccall((:cudnnDestroyActivationDescriptor, libcudnn()), cudnnStatus_t,
                    (cudnnActivationDescriptor_t,),
                    activationDesc)
@@ -939,7 +939,7 @@ end
 
 @checked function cudnnActivationForward(handle, activationDesc, alpha, xDesc, x, beta,
                                          yDesc, y)
-    initialize_api()
+    initialize_context()
     ccall((:cudnnActivationForward, libcudnn()), cudnnStatus_t,
                    (cudnnHandle_t, cudnnActivationDescriptor_t, Ptr{Cvoid},
                     cudnnTensorDescriptor_t, CuPtr{Cvoid}, Ptr{Cvoid},
@@ -949,7 +949,7 @@ end
 
 @checked function cudnnActivationBackward(handle, activationDesc, alpha, yDesc, y, dyDesc,
                                           dy, xDesc, x, beta, dxDesc, dx)
-    initialize_api()
+    initialize_context()
     ccall((:cudnnActivationBackward, libcudnn()), cudnnStatus_t,
                    (cudnnHandle_t, cudnnActivationDescriptor_t, Ptr{Cvoid},
                     cudnnTensorDescriptor_t, CuPtr{Cvoid}, cudnnTensorDescriptor_t,
@@ -960,21 +960,21 @@ end
 end
 
 @checked function cudnnCreateLRNDescriptor(normDesc)
-    initialize_api()
+    initialize_context()
     ccall((:cudnnCreateLRNDescriptor, libcudnn()), cudnnStatus_t,
                    (Ptr{cudnnLRNDescriptor_t},),
                    normDesc)
 end
 
 @checked function cudnnSetLRNDescriptor(normDesc, lrnN, lrnAlpha, lrnBeta, lrnK)
-    initialize_api()
+    initialize_context()
     ccall((:cudnnSetLRNDescriptor, libcudnn()), cudnnStatus_t,
                    (cudnnLRNDescriptor_t, UInt32, Cdouble, Cdouble, Cdouble),
                    normDesc, lrnN, lrnAlpha, lrnBeta, lrnK)
 end
 
 @checked function cudnnGetLRNDescriptor(normDesc, lrnN, lrnAlpha, lrnBeta, lrnK)
-    initialize_api()
+    initialize_context()
     ccall((:cudnnGetLRNDescriptor, libcudnn()), cudnnStatus_t,
                    (cudnnLRNDescriptor_t, Ptr{UInt32}, Ptr{Cdouble}, Ptr{Cdouble},
                     Ptr{Cdouble}),
@@ -982,7 +982,7 @@ end
 end
 
 @checked function cudnnDestroyLRNDescriptor(lrnDesc)
-    initialize_api()
+    initialize_context()
     ccall((:cudnnDestroyLRNDescriptor, libcudnn()), cudnnStatus_t,
                    (cudnnLRNDescriptor_t,),
                    lrnDesc)
@@ -990,7 +990,7 @@ end
 
 @checked function cudnnLRNCrossChannelForward(handle, normDesc, lrnMode, alpha, xDesc, x,
                                               beta, yDesc, y)
-    initialize_api()
+    initialize_context()
     ccall((:cudnnLRNCrossChannelForward, libcudnn()), cudnnStatus_t,
                    (cudnnHandle_t, cudnnLRNDescriptor_t, cudnnLRNMode_t, Ptr{Cvoid},
                     cudnnTensorDescriptor_t, CuPtr{Cvoid}, Ptr{Cvoid},
@@ -1000,7 +1000,7 @@ end
 
 @checked function cudnnLRNCrossChannelBackward(handle, normDesc, lrnMode, alpha, yDesc, y,
                                                dyDesc, dy, xDesc, x, beta, dxDesc, dx)
-    initialize_api()
+    initialize_context()
     ccall((:cudnnLRNCrossChannelBackward, libcudnn()), cudnnStatus_t,
                    (cudnnHandle_t, cudnnLRNDescriptor_t, cudnnLRNMode_t, Ptr{Cvoid},
                     cudnnTensorDescriptor_t, CuPtr{Cvoid}, cudnnTensorDescriptor_t,
@@ -1012,7 +1012,7 @@ end
 
 @checked function cudnnDivisiveNormalizationForward(handle, normDesc, mode, alpha, xDesc,
                                                     x, means, temp, temp2, beta, yDesc, y)
-    initialize_api()
+    initialize_context()
     ccall((:cudnnDivisiveNormalizationForward, libcudnn()), cudnnStatus_t,
                    (cudnnHandle_t, cudnnLRNDescriptor_t, cudnnDivNormMode_t, Ptr{Cvoid},
                     cudnnTensorDescriptor_t, CuPtr{Cvoid}, CuPtr{Cvoid}, CuPtr{Cvoid},
@@ -1024,7 +1024,7 @@ end
 @checked function cudnnDivisiveNormalizationBackward(handle, normDesc, mode, alpha, xDesc,
                                                      x, means, dy, temp, temp2, beta,
                                                      dXdMeansDesc, dx, dMeans)
-    initialize_api()
+    initialize_context()
     ccall((:cudnnDivisiveNormalizationBackward, libcudnn()), cudnnStatus_t,
                    (cudnnHandle_t, cudnnLRNDescriptor_t, cudnnDivNormMode_t, Ptr{Cvoid},
                     cudnnTensorDescriptor_t, CuPtr{Cvoid}, CuPtr{Cvoid}, CuPtr{Cvoid},
@@ -1035,7 +1035,7 @@ end
 end
 
 @checked function cudnnDeriveBNTensorDescriptor(derivedBnDesc, xDesc, mode)
-    initialize_api()
+    initialize_context()
     ccall((:cudnnDeriveBNTensorDescriptor, libcudnn()), cudnnStatus_t,
                    (cudnnTensorDescriptor_t, cudnnTensorDescriptor_t, cudnnBatchNormMode_t),
                    derivedBnDesc, xDesc, mode)
@@ -1047,7 +1047,7 @@ end
                                                                            bnScaleBiasMeanVarDesc,
                                                                            activationDesc,
                                                                            sizeInBytes)
-    initialize_api()
+    initialize_context()
     ccall((:cudnnGetBatchNormalizationForwardTrainingExWorkspaceSize, libcudnn()), cudnnStatus_t,
                    (cudnnHandle_t, cudnnBatchNormMode_t, cudnnBatchNormOps_t,
                     cudnnTensorDescriptor_t, cudnnTensorDescriptor_t,
@@ -1063,7 +1063,7 @@ end
                                                                     dBnScaleBiasDesc,
                                                                     activationDesc,
                                                                     sizeInBytes)
-    initialize_api()
+    initialize_context()
     ccall((:cudnnGetBatchNormalizationBackwardExWorkspaceSize, libcudnn()), cudnnStatus_t,
                    (cudnnHandle_t, cudnnBatchNormMode_t, cudnnBatchNormOps_t,
                     cudnnTensorDescriptor_t, cudnnTensorDescriptor_t,
@@ -1077,7 +1077,7 @@ end
 @checked function cudnnGetBatchNormalizationTrainingExReserveSpaceSize(handle, mode, bnOps,
                                                                        activationDesc,
                                                                        xDesc, sizeInBytes)
-    initialize_api()
+    initialize_context()
     ccall((:cudnnGetBatchNormalizationTrainingExReserveSpaceSize, libcudnn()), cudnnStatus_t,
                    (cudnnHandle_t, cudnnBatchNormMode_t, cudnnBatchNormOps_t,
                     cudnnActivationDescriptor_t, cudnnTensorDescriptor_t, Ref{Csize_t}),
@@ -1092,7 +1092,7 @@ end
                                                          resultRunningVariance, epsilon,
                                                          resultSaveMean,
                                                          resultSaveInvVariance)
-    initialize_api()
+    initialize_context()
     ccall((:cudnnBatchNormalizationForwardTraining, libcudnn()), cudnnStatus_t,
                    (cudnnHandle_t, cudnnBatchNormMode_t, Ptr{Cvoid}, Ptr{Cvoid},
                     cudnnTensorDescriptor_t, CuPtr{Cvoid}, cudnnTensorDescriptor_t,
@@ -1117,7 +1117,7 @@ end
                                                            workSpaceSizeInBytes,
                                                            reserveSpace,
                                                            reserveSpaceSizeInBytes)
-    initialize_api()
+    initialize_context()
     ccall((:cudnnBatchNormalizationForwardTrainingEx, libcudnn()), cudnnStatus_t,
                    (cudnnHandle_t, cudnnBatchNormMode_t, cudnnBatchNormOps_t, Ptr{Cvoid},
                     Ptr{Cvoid}, cudnnTensorDescriptor_t, CuPtr{Cvoid},
@@ -1138,7 +1138,7 @@ end
                                                           bnScaleBiasMeanVarDesc, bnScale,
                                                           bnBias, estimatedMean,
                                                           estimatedVariance, epsilon)
-    initialize_api()
+    initialize_context()
     ccall((:cudnnBatchNormalizationForwardInference, libcudnn()), cudnnStatus_t,
                    (cudnnHandle_t, cudnnBatchNormMode_t, Ptr{Cvoid}, Ptr{Cvoid},
                     cudnnTensorDescriptor_t, CuPtr{Cvoid}, cudnnTensorDescriptor_t,
@@ -1154,7 +1154,7 @@ end
                                                   dxDesc, dx, dBnScaleBiasDesc, bnScale,
                                                   dBnScaleResult, dBnBiasResult, epsilon,
                                                   savedMean, savedInvVariance)
-    initialize_api()
+    initialize_context()
     ccall((:cudnnBatchNormalizationBackward, libcudnn()), cudnnStatus_t,
                    (cudnnHandle_t, cudnnBatchNormMode_t, Ptr{Cvoid}, Ptr{Cvoid},
                     Ptr{Cvoid}, Ptr{Cvoid}, cudnnTensorDescriptor_t, CuPtr{Cvoid},
@@ -1177,7 +1177,7 @@ end
                                                     savedInvVariance, activationDesc,
                                                     workSpace, workSpaceSizeInBytes,
                                                     reserveSpace, reserveSpaceSizeInBytes)
-    initialize_api()
+    initialize_context()
     ccall((:cudnnBatchNormalizationBackwardEx, libcudnn()), cudnnStatus_t,
                    (cudnnHandle_t, cudnnBatchNormMode_t, cudnnBatchNormOps_t, Ptr{Cvoid},
                     Ptr{Cvoid}, Ptr{Cvoid}, Ptr{Cvoid}, cudnnTensorDescriptor_t,
@@ -1197,7 +1197,7 @@ end
 end
 
 @checked function cudnnCreateSpatialTransformerDescriptor(stDesc)
-    initialize_api()
+    initialize_context()
     ccall((:cudnnCreateSpatialTransformerDescriptor, libcudnn()), cudnnStatus_t,
                    (Ptr{cudnnSpatialTransformerDescriptor_t},),
                    stDesc)
@@ -1205,7 +1205,7 @@ end
 
 @checked function cudnnSetSpatialTransformerNdDescriptor(stDesc, samplerType, dataType,
                                                          nbDims, dimA)
-    initialize_api()
+    initialize_context()
     ccall((:cudnnSetSpatialTransformerNdDescriptor, libcudnn()), cudnnStatus_t,
                    (cudnnSpatialTransformerDescriptor_t, cudnnSamplerType_t,
                     cudnnDataType_t, Cint, Ptr{Cint}),
@@ -1213,14 +1213,14 @@ end
 end
 
 @checked function cudnnDestroySpatialTransformerDescriptor(stDesc)
-    initialize_api()
+    initialize_context()
     ccall((:cudnnDestroySpatialTransformerDescriptor, libcudnn()), cudnnStatus_t,
                    (cudnnSpatialTransformerDescriptor_t,),
                    stDesc)
 end
 
 @checked function cudnnSpatialTfGridGeneratorForward(handle, stDesc, theta, grid)
-    initialize_api()
+    initialize_context()
     ccall((:cudnnSpatialTfGridGeneratorForward, libcudnn()), cudnnStatus_t,
                    (cudnnHandle_t, cudnnSpatialTransformerDescriptor_t, CuPtr{Cvoid},
                     CuPtr{Cvoid}),
@@ -1228,7 +1228,7 @@ end
 end
 
 @checked function cudnnSpatialTfGridGeneratorBackward(handle, stDesc, dgrid, dtheta)
-    initialize_api()
+    initialize_context()
     ccall((:cudnnSpatialTfGridGeneratorBackward, libcudnn()), cudnnStatus_t,
                    (cudnnHandle_t, cudnnSpatialTransformerDescriptor_t, CuPtr{Cvoid},
                     CuPtr{Cvoid}),
@@ -1237,7 +1237,7 @@ end
 
 @checked function cudnnSpatialTfSamplerForward(handle, stDesc, alpha, xDesc, x, grid, beta,
                                                yDesc, y)
-    initialize_api()
+    initialize_context()
     ccall((:cudnnSpatialTfSamplerForward, libcudnn()), cudnnStatus_t,
                    (cudnnHandle_t, cudnnSpatialTransformerDescriptor_t, Ptr{Cvoid},
                     cudnnTensorDescriptor_t, CuPtr{Cvoid}, CuPtr{Cvoid}, Ptr{Cvoid},
@@ -1248,7 +1248,7 @@ end
 @checked function cudnnSpatialTfSamplerBackward(handle, stDesc, alpha, xDesc, x, beta,
                                                 dxDesc, dx, alphaDgrid, dyDesc, dy, grid,
                                                 betaDgrid, dgrid)
-    initialize_api()
+    initialize_context()
     ccall((:cudnnSpatialTfSamplerBackward, libcudnn()), cudnnStatus_t,
                    (cudnnHandle_t, cudnnSpatialTransformerDescriptor_t, Ptr{Cvoid},
                     cudnnTensorDescriptor_t, CuPtr{Cvoid}, Ptr{Cvoid},
@@ -1260,28 +1260,28 @@ end
 end
 
 @checked function cudnnCreateDropoutDescriptor(dropoutDesc)
-    initialize_api()
+    initialize_context()
     ccall((:cudnnCreateDropoutDescriptor, libcudnn()), cudnnStatus_t,
                    (Ptr{cudnnDropoutDescriptor_t},),
                    dropoutDesc)
 end
 
 @checked function cudnnDestroyDropoutDescriptor(dropoutDesc)
-    initialize_api()
+    initialize_context()
     ccall((:cudnnDestroyDropoutDescriptor, libcudnn()), cudnnStatus_t,
                    (cudnnDropoutDescriptor_t,),
                    dropoutDesc)
 end
 
 @checked function cudnnDropoutGetStatesSize(handle, sizeInBytes)
-    initialize_api()
+    initialize_context()
     ccall((:cudnnDropoutGetStatesSize, libcudnn()), cudnnStatus_t,
                    (cudnnHandle_t, Ptr{Csize_t}),
                    handle, sizeInBytes)
 end
 
 @checked function cudnnDropoutGetReserveSpaceSize(xdesc, sizeInBytes)
-    initialize_api()
+    initialize_context()
     ccall((:cudnnDropoutGetReserveSpaceSize, libcudnn()), cudnnStatus_t,
                    (cudnnTensorDescriptor_t, Ref{Csize_t}),
                    xdesc, sizeInBytes)
@@ -1289,7 +1289,7 @@ end
 
 @checked function cudnnSetDropoutDescriptor(dropoutDesc, handle, dropout, states,
                                             stateSizeInBytes, seed)
-    initialize_api()
+    initialize_context()
     ccall((:cudnnSetDropoutDescriptor, libcudnn()), cudnnStatus_t,
                    (cudnnDropoutDescriptor_t, cudnnHandle_t, Cfloat, CuPtr{Cvoid},
                     Csize_t, Culonglong),
@@ -1298,7 +1298,7 @@ end
 
 @checked function cudnnRestoreDropoutDescriptor(dropoutDesc, handle, dropout, states,
                                                 stateSizeInBytes, seed)
-    initialize_api()
+    initialize_context()
     ccall((:cudnnRestoreDropoutDescriptor, libcudnn()), cudnnStatus_t,
                    (cudnnDropoutDescriptor_t, cudnnHandle_t, Cfloat, CuPtr{Cvoid},
                     Csize_t, Culonglong),
@@ -1306,7 +1306,7 @@ end
 end
 
 @checked function cudnnGetDropoutDescriptor(dropoutDesc, handle, dropout, states, seed)
-    initialize_api()
+    initialize_context()
     ccall((:cudnnGetDropoutDescriptor, libcudnn()), cudnnStatus_t,
                    (cudnnDropoutDescriptor_t, cudnnHandle_t, Ptr{Cfloat},
                     Ptr{CuPtr{Cvoid}}, Ptr{Culonglong}),
@@ -1315,7 +1315,7 @@ end
 
 @checked function cudnnDropoutForward(handle, dropoutDesc, xdesc, x, ydesc, y,
                                       reserveSpace, reserveSpaceSizeInBytes)
-    initialize_api()
+    initialize_context()
     ccall((:cudnnDropoutForward, libcudnn()), cudnnStatus_t,
                    (cudnnHandle_t, cudnnDropoutDescriptor_t, cudnnTensorDescriptor_t,
                     CuPtr{Cvoid}, cudnnTensorDescriptor_t, CuPtr{Cvoid}, CuPtr{Cvoid},
@@ -1326,7 +1326,7 @@ end
 
 @checked function cudnnDropoutBackward(handle, dropoutDesc, dydesc, dy, dxdesc, dx,
                                        reserveSpace, reserveSpaceSizeInBytes)
-    initialize_api()
+    initialize_context()
     ccall((:cudnnDropoutBackward, libcudnn()), cudnnStatus_t,
                    (cudnnHandle_t, cudnnDropoutDescriptor_t, cudnnTensorDescriptor_t,
                     CuPtr{Cvoid}, cudnnTensorDescriptor_t, CuPtr{Cvoid}, CuPtr{Cvoid},
@@ -1336,49 +1336,49 @@ end
 end
 
 @checked function cudnnCreateRNNDescriptor(rnnDesc)
-    initialize_api()
+    initialize_context()
     ccall((:cudnnCreateRNNDescriptor, libcudnn()), cudnnStatus_t,
                    (Ptr{cudnnRNNDescriptor_t},),
                    rnnDesc)
 end
 
 @checked function cudnnDestroyRNNDescriptor(rnnDesc)
-    initialize_api()
+    initialize_context()
     ccall((:cudnnDestroyRNNDescriptor, libcudnn()), cudnnStatus_t,
                    (cudnnRNNDescriptor_t,),
                    rnnDesc)
 end
 
 @checked function cudnnSetRNNMatrixMathType(rnnDesc, mType)
-    initialize_api()
+    initialize_context()
     ccall((:cudnnSetRNNMatrixMathType, libcudnn()), cudnnStatus_t,
                    (cudnnRNNDescriptor_t, cudnnMathType_t),
                    rnnDesc, mType)
 end
 
 @checked function cudnnGetRNNMatrixMathType(rnnDesc, mType)
-    initialize_api()
+    initialize_context()
     ccall((:cudnnGetRNNMatrixMathType, libcudnn()), cudnnStatus_t,
                    (cudnnRNNDescriptor_t, Ptr{cudnnMathType_t}),
                    rnnDesc, mType)
 end
 
 @checked function cudnnSetRNNBiasMode(rnnDesc, biasMode)
-    initialize_api()
+    initialize_context()
     ccall((:cudnnSetRNNBiasMode, libcudnn()), cudnnStatus_t,
                    (cudnnRNNDescriptor_t, cudnnRNNBiasMode_t),
                    rnnDesc, biasMode)
 end
 
 @checked function cudnnGetRNNBiasMode(rnnDesc, biasMode)
-    initialize_api()
+    initialize_context()
     ccall((:cudnnGetRNNBiasMode, libcudnn()), cudnnStatus_t,
                    (cudnnRNNDescriptor_t, Ptr{cudnnRNNBiasMode_t}),
                    rnnDesc, biasMode)
 end
 
 @checked function cudnnRNNSetClip(handle, rnnDesc, clipMode, clipNanOpt, lclip, rclip)
-    initialize_api()
+    initialize_context()
     ccall((:cudnnRNNSetClip, libcudnn()), cudnnStatus_t,
                    (cudnnHandle_t, cudnnRNNDescriptor_t, cudnnRNNClipMode_t,
                     cudnnNanPropagation_t, Cdouble, Cdouble),
@@ -1386,7 +1386,7 @@ end
 end
 
 @checked function cudnnRNNGetClip(handle, rnnDesc, clipMode, clipNanOpt, lclip, rclip)
-    initialize_api()
+    initialize_context()
     ccall((:cudnnRNNGetClip, libcudnn()), cudnnStatus_t,
                    (cudnnHandle_t, cudnnRNNDescriptor_t, Ptr{cudnnRNNClipMode_t},
                     Ptr{cudnnNanPropagation_t}, Ptr{Cdouble}, Ptr{Cdouble}),
@@ -1394,21 +1394,21 @@ end
 end
 
 @checked function cudnnSetRNNProjectionLayers(handle, rnnDesc, recProjSize, outProjSize)
-    initialize_api()
+    initialize_context()
     ccall((:cudnnSetRNNProjectionLayers, libcudnn()), cudnnStatus_t,
                    (cudnnHandle_t, cudnnRNNDescriptor_t, Cint, Cint),
                    handle, rnnDesc, recProjSize, outProjSize)
 end
 
 @checked function cudnnGetRNNProjectionLayers(handle, rnnDesc, recProjSize, outProjSize)
-    initialize_api()
+    initialize_context()
     ccall((:cudnnGetRNNProjectionLayers, libcudnn()), cudnnStatus_t,
                    (cudnnHandle_t, cudnnRNNDescriptor_t, Ptr{Cint}, Ptr{Cint}),
                    handle, rnnDesc, recProjSize, outProjSize)
 end
 
 @checked function cudnnCreatePersistentRNNPlan(rnnDesc, minibatch, dataType, plan)
-    initialize_api()
+    initialize_context()
     ccall((:cudnnCreatePersistentRNNPlan, libcudnn()), cudnnStatus_t,
                    (cudnnRNNDescriptor_t, Cint, cudnnDataType_t,
                     Ptr{cudnnPersistentRNNPlan_t}),
@@ -1416,21 +1416,21 @@ end
 end
 
 @checked function cudnnDestroyPersistentRNNPlan(plan)
-    initialize_api()
+    initialize_context()
     ccall((:cudnnDestroyPersistentRNNPlan, libcudnn()), cudnnStatus_t,
                    (cudnnPersistentRNNPlan_t,),
                    plan)
 end
 
 @checked function cudnnSetPersistentRNNPlan(rnnDesc, plan)
-    initialize_api()
+    initialize_context()
     ccall((:cudnnSetPersistentRNNPlan, libcudnn()), cudnnStatus_t,
                    (cudnnRNNDescriptor_t, cudnnPersistentRNNPlan_t),
                    rnnDesc, plan)
 end
 
 @checked function cudnnGetRNNWorkspaceSize(handle, rnnDesc, seqLength, xDesc, sizeInBytes)
-    initialize_api()
+    initialize_context()
     ccall((:cudnnGetRNNWorkspaceSize, libcudnn()), cudnnStatus_t,
                    (cudnnHandle_t, cudnnRNNDescriptor_t, Cint,
                     Ptr{cudnnTensorDescriptor_t}, Ref{Csize_t}),
@@ -1439,7 +1439,7 @@ end
 
 @checked function cudnnGetRNNTrainingReserveSize(handle, rnnDesc, seqLength, xDesc,
                                                  sizeInBytes)
-    initialize_api()
+    initialize_context()
     ccall((:cudnnGetRNNTrainingReserveSize, libcudnn()), cudnnStatus_t,
                    (cudnnHandle_t, cudnnRNNDescriptor_t, Cint,
                     Ptr{cudnnTensorDescriptor_t}, Ref{Csize_t}),
@@ -1447,7 +1447,7 @@ end
 end
 
 @checked function cudnnGetRNNParamsSize(handle, rnnDesc, xDesc, sizeInBytes, dataType)
-    initialize_api()
+    initialize_context()
     ccall((:cudnnGetRNNParamsSize, libcudnn()), cudnnStatus_t,
                    (cudnnHandle_t, cudnnRNNDescriptor_t, cudnnTensorDescriptor_t,
                     Ref{Csize_t}, cudnnDataType_t),
@@ -1457,7 +1457,7 @@ end
 @checked function cudnnGetRNNLinLayerMatrixParams(handle, rnnDesc, pseudoLayer, xDesc,
                                                   wDesc, w, linLayerID, linLayerMatDesc,
                                                   linLayerMat)
-    initialize_api()
+    initialize_context()
     ccall((:cudnnGetRNNLinLayerMatrixParams, libcudnn()), cudnnStatus_t,
                    (cudnnHandle_t, cudnnRNNDescriptor_t, Cint, cudnnTensorDescriptor_t,
                     cudnnFilterDescriptor_t, CuPtr{Cvoid}, Cint, cudnnFilterDescriptor_t,
@@ -1469,7 +1469,7 @@ end
 @checked function cudnnGetRNNLinLayerBiasParams(handle, rnnDesc, pseudoLayer, xDesc, wDesc,
                                                 w, linLayerID, linLayerBiasDesc,
                                                 linLayerBias)
-    initialize_api()
+    initialize_context()
     ccall((:cudnnGetRNNLinLayerBiasParams, libcudnn()), cudnnStatus_t,
                    (cudnnHandle_t, cudnnRNNDescriptor_t, Cint, cudnnTensorDescriptor_t,
                     cudnnFilterDescriptor_t, CuPtr{Cvoid}, Cint, cudnnFilterDescriptor_t,
@@ -1481,7 +1481,7 @@ end
 @checked function cudnnRNNForwardInference(handle, rnnDesc, seqLength, xDesc, x, hxDesc,
                                            hx, cxDesc, cx, wDesc, w, yDesc, y, hyDesc, hy,
                                            cyDesc, cy, workspace, workSpaceSizeInBytes)
-    initialize_api()
+    initialize_context()
     ccall((:cudnnRNNForwardInference, libcudnn()), cudnnStatus_t,
                    (cudnnHandle_t, cudnnRNNDescriptor_t, Cint,
                     Ptr{cudnnTensorDescriptor_t}, CuPtr{Cvoid}, cudnnTensorDescriptor_t,
@@ -1497,7 +1497,7 @@ end
                                           cxDesc, cx, wDesc, w, yDesc, y, hyDesc, hy,
                                           cyDesc, cy, workspace, workSpaceSizeInBytes,
                                           reserveSpace, reserveSpaceSizeInBytes)
-    initialize_api()
+    initialize_context()
     ccall((:cudnnRNNForwardTraining, libcudnn()), cudnnStatus_t,
                    (cudnnHandle_t, cudnnRNNDescriptor_t, Cint,
                     Ptr{cudnnTensorDescriptor_t}, CuPtr{Cvoid}, cudnnTensorDescriptor_t,
@@ -1516,7 +1516,7 @@ end
                                        cxDesc, cx, dxDesc, dx, dhxDesc, dhx, dcxDesc, dcx,
                                        workspace, workSpaceSizeInBytes, reserveSpace,
                                        reserveSpaceSizeInBytes)
-    initialize_api()
+    initialize_context()
     ccall((:cudnnRNNBackwardData, libcudnn()), cudnnStatus_t,
                    (cudnnHandle_t, cudnnRNNDescriptor_t, Cint,
                     Ptr{cudnnTensorDescriptor_t}, CuPtr{Cvoid},
@@ -1536,7 +1536,7 @@ end
 @checked function cudnnRNNBackwardWeights(handle, rnnDesc, seqLength, xDesc, x, hxDesc, hx,
                                           yDesc, y, workspace, workSpaceSizeInBytes,
                                           dwDesc, dw, reserveSpace, reserveSpaceSizeInBytes)
-    initialize_api()
+    initialize_context()
     ccall((:cudnnRNNBackwardWeights, libcudnn()), cudnnStatus_t,
                    (cudnnHandle_t, cudnnRNNDescriptor_t, Cint,
                     Ptr{cudnnTensorDescriptor_t}, CuPtr{Cvoid}, cudnnTensorDescriptor_t,
@@ -1547,28 +1547,28 @@ end
 end
 
 @checked function cudnnSetRNNPaddingMode(rnnDesc, paddingMode)
-    initialize_api()
+    initialize_context()
     ccall((:cudnnSetRNNPaddingMode, libcudnn()), cudnnStatus_t,
                    (cudnnRNNDescriptor_t, cudnnRNNPaddingMode_t),
                    rnnDesc, paddingMode)
 end
 
 @checked function cudnnGetRNNPaddingMode(rnnDesc, paddingMode)
-    initialize_api()
+    initialize_context()
     ccall((:cudnnGetRNNPaddingMode, libcudnn()), cudnnStatus_t,
                    (cudnnRNNDescriptor_t, Ptr{cudnnRNNPaddingMode_t}),
                    rnnDesc, paddingMode)
 end
 
 @checked function cudnnCreateRNNDataDescriptor(rnnDataDesc)
-    initialize_api()
+    initialize_context()
     ccall((:cudnnCreateRNNDataDescriptor, libcudnn()), cudnnStatus_t,
                    (Ptr{cudnnRNNDataDescriptor_t},),
                    rnnDataDesc)
 end
 
 @checked function cudnnDestroyRNNDataDescriptor(rnnDataDesc)
-    initialize_api()
+    initialize_context()
     ccall((:cudnnDestroyRNNDataDescriptor, libcudnn()), cudnnStatus_t,
                    (cudnnRNNDataDescriptor_t,),
                    rnnDataDesc)
@@ -1577,7 +1577,7 @@ end
 @checked function cudnnSetRNNDataDescriptor(rnnDataDesc, dataType, layout, maxSeqLength,
                                             batchSize, vectorSize, seqLengthArray,
                                             paddingFill)
-    initialize_api()
+    initialize_context()
     ccall((:cudnnSetRNNDataDescriptor, libcudnn()), cudnnStatus_t,
                    (cudnnRNNDataDescriptor_t, cudnnDataType_t, cudnnRNNDataLayout_t, Cint,
                     Cint, Cint, Ptr{Cint}, Ptr{Cvoid}),
@@ -1588,7 +1588,7 @@ end
 @checked function cudnnGetRNNDataDescriptor(rnnDataDesc, dataType, layout, maxSeqLength,
                                             batchSize, vectorSize, arrayLengthRequested,
                                             seqLengthArray, paddingFill)
-    initialize_api()
+    initialize_context()
     ccall((:cudnnGetRNNDataDescriptor, libcudnn()), cudnnStatus_t,
                    (cudnnRNNDataDescriptor_t, Ptr{cudnnDataType_t},
                     Ptr{cudnnRNNDataLayout_t}, Ptr{Cint}, Ptr{Cint}, Ptr{Cint}, Cint,
@@ -1602,7 +1602,7 @@ end
                                             kDesc, keys, cDesc, cAttn, iDesc, iAttn, qDesc,
                                             queries, workSpace, workSpaceSizeInBytes,
                                             reserveSpace, reserveSpaceSizeInBytes)
-    initialize_api()
+    initialize_context()
     ccall((:cudnnRNNForwardTrainingEx, libcudnn()), cudnnStatus_t,
                    (cudnnHandle_t, cudnnRNNDescriptor_t, cudnnRNNDataDescriptor_t,
                     CuPtr{Cvoid}, cudnnTensorDescriptor_t, CuPtr{Cvoid},
@@ -1623,7 +1623,7 @@ end
                                              cx, wDesc, w, yDesc, y, hyDesc, hy, cyDesc,
                                              cy, kDesc, keys, cDesc, cAttn, iDesc, iAttn,
                                              qDesc, queries, workSpace, workSpaceSizeInBytes)
-    initialize_api()
+    initialize_context()
     ccall((:cudnnRNNForwardInferenceEx, libcudnn()), cudnnStatus_t,
                    (cudnnHandle_t, cudnnRNNDescriptor_t, cudnnRNNDataDescriptor_t,
                     CuPtr{Cvoid}, cudnnTensorDescriptor_t, CuPtr{Cvoid},
@@ -1645,7 +1645,7 @@ end
                                          dcxDesc, dcx, dkDesc, dkeys, workSpace,
                                          workSpaceSizeInBytes, reserveSpace,
                                          reserveSpaceSizeInBytes)
-    initialize_api()
+    initialize_context()
     ccall((:cudnnRNNBackwardDataEx, libcudnn()), cudnnStatus_t,
                    (cudnnHandle_t, cudnnRNNDescriptor_t, cudnnRNNDataDescriptor_t,
                     CuPtr{Cvoid}, cudnnRNNDataDescriptor_t, CuPtr{Cvoid},
@@ -1666,7 +1666,7 @@ end
 @checked function cudnnRNNBackwardWeightsEx(handle, rnnDesc, xDesc, x, hxDesc, hx, yDesc,
                                             y, workSpace, workSpaceSizeInBytes, dwDesc, dw,
                                             reserveSpace, reserveSpaceSizeInBytes)
-    initialize_api()
+    initialize_context()
     ccall((:cudnnRNNBackwardWeightsEx, libcudnn()), cudnnStatus_t,
                    (cudnnHandle_t, cudnnRNNDescriptor_t, cudnnRNNDataDescriptor_t,
                     CuPtr{Cvoid}, cudnnTensorDescriptor_t, CuPtr{Cvoid},
@@ -1677,14 +1677,14 @@ end
 end
 
 @checked function cudnnSetRNNAlgorithmDescriptor(handle, rnnDesc, algoDesc)
-    initialize_api()
+    initialize_context()
     ccall((:cudnnSetRNNAlgorithmDescriptor, libcudnn()), cudnnStatus_t,
                    (cudnnHandle_t, cudnnRNNDescriptor_t, cudnnAlgorithmDescriptor_t),
                    handle, rnnDesc, algoDesc)
 end
 
 @checked function cudnnGetRNNForwardInferenceAlgorithmMaxCount(handle, rnnDesc, count)
-    initialize_api()
+    initialize_context()
     ccall((:cudnnGetRNNForwardInferenceAlgorithmMaxCount, libcudnn()), cudnnStatus_t,
                    (cudnnHandle_t, cudnnRNNDescriptor_t, Ptr{Cint}),
                    handle, rnnDesc, count)
@@ -1697,7 +1697,7 @@ end
                                                           requestedAlgoCount,
                                                           returnedAlgoCount, perfResults,
                                                           workspace, workSpaceSizeInBytes)
-    initialize_api()
+    initialize_context()
     ccall((:cudnnFindRNNForwardInferenceAlgorithmEx, libcudnn()), cudnnStatus_t,
                    (cudnnHandle_t, cudnnRNNDescriptor_t, Cint,
                     Ptr{cudnnTensorDescriptor_t}, CuPtr{Cvoid}, cudnnTensorDescriptor_t,
@@ -1712,7 +1712,7 @@ end
 end
 
 @checked function cudnnGetRNNForwardTrainingAlgorithmMaxCount(handle, rnnDesc, count)
-    initialize_api()
+    initialize_context()
     ccall((:cudnnGetRNNForwardTrainingAlgorithmMaxCount, libcudnn()), cudnnStatus_t,
                    (cudnnHandle_t, cudnnRNNDescriptor_t, Ptr{Cint}),
                    handle, rnnDesc, count)
@@ -1727,7 +1727,7 @@ end
                                                          workspace, workSpaceSizeInBytes,
                                                          reserveSpace,
                                                          reserveSpaceSizeInBytes)
-    initialize_api()
+    initialize_context()
     ccall((:cudnnFindRNNForwardTrainingAlgorithmEx, libcudnn()), cudnnStatus_t,
                    (cudnnHandle_t, cudnnRNNDescriptor_t, Cint,
                     Ptr{cudnnTensorDescriptor_t}, CuPtr{Cvoid}, cudnnTensorDescriptor_t,
@@ -1744,7 +1744,7 @@ end
 end
 
 @checked function cudnnGetRNNBackwardDataAlgorithmMaxCount(handle, rnnDesc, count)
-    initialize_api()
+    initialize_context()
     ccall((:cudnnGetRNNBackwardDataAlgorithmMaxCount, libcudnn()), cudnnStatus_t,
                    (cudnnHandle_t, cudnnRNNDescriptor_t, Ptr{Cint}),
                    handle, rnnDesc, count)
@@ -1759,7 +1759,7 @@ end
                                                       returnedAlgoCount, perfResults,
                                                       workspace, workSpaceSizeInBytes,
                                                       reserveSpace, reserveSpaceSizeInBytes)
-    initialize_api()
+    initialize_context()
     ccall((:cudnnFindRNNBackwardDataAlgorithmEx, libcudnn()), cudnnStatus_t,
                    (cudnnHandle_t, cudnnRNNDescriptor_t, Cint,
                     Ptr{cudnnTensorDescriptor_t}, CuPtr{Cvoid},
@@ -1779,7 +1779,7 @@ end
 end
 
 @checked function cudnnGetRNNBackwardWeightsAlgorithmMaxCount(handle, rnnDesc, count)
-    initialize_api()
+    initialize_context()
     ccall((:cudnnGetRNNBackwardWeightsAlgorithmMaxCount, libcudnn()), cudnnStatus_t,
                    (cudnnHandle_t, cudnnRNNDescriptor_t, Ptr{Cint}),
                    handle, rnnDesc, count)
@@ -1792,7 +1792,7 @@ end
                                                          workspace, workSpaceSizeInBytes,
                                                          dwDesc, dw, reserveSpace,
                                                          reserveSpaceSizeInBytes)
-    initialize_api()
+    initialize_context()
     ccall((:cudnnFindRNNBackwardWeightsAlgorithmEx, libcudnn()), cudnnStatus_t,
                    (cudnnHandle_t, cudnnRNNDescriptor_t, Cint,
                     Ptr{cudnnTensorDescriptor_t}, CuPtr{Cvoid}, cudnnTensorDescriptor_t,
@@ -1806,14 +1806,14 @@ end
 end
 
 @checked function cudnnCreateSeqDataDescriptor(seqDataDesc)
-    initialize_api()
+    initialize_context()
     ccall((:cudnnCreateSeqDataDescriptor, libcudnn()), cudnnStatus_t,
                    (Ptr{cudnnSeqDataDescriptor_t},),
                    seqDataDesc)
 end
 
 @checked function cudnnDestroySeqDataDescriptor(seqDataDesc)
-    initialize_api()
+    initialize_context()
     ccall((:cudnnDestroySeqDataDescriptor, libcudnn()), cudnnStatus_t,
                    (cudnnSeqDataDescriptor_t,),
                    seqDataDesc)
@@ -1821,7 +1821,7 @@ end
 
 @checked function cudnnSetSeqDataDescriptor(seqDataDesc, dataType, nbDims, dimA, axes,
                                             seqLengthArraySize, seqLengthArray, paddingFill)
-    initialize_api()
+    initialize_context()
     ccall((:cudnnSetSeqDataDescriptor, libcudnn()), cudnnStatus_t,
                    (cudnnSeqDataDescriptor_t, cudnnDataType_t, Cint, Ptr{Cint},
                     Ptr{cudnnSeqDataAxis_t}, Csize_t, Ptr{Cint}, Ptr{Cvoid}),
@@ -1833,7 +1833,7 @@ end
                                             dimA, axes, seqLengthArraySize,
                                             seqLengthSizeRequested, seqLengthArray,
                                             paddingFill)
-    initialize_api()
+    initialize_context()
     ccall((:cudnnGetSeqDataDescriptor, libcudnn()), cudnnStatus_t,
                    (cudnnSeqDataDescriptor_t, Ptr{cudnnDataType_t}, Ptr{Cint}, Cint,
                     Ptr{Cint}, Ptr{cudnnSeqDataAxis_t}, Ptr{Csize_t}, Csize_t, Ptr{Cint},
@@ -1843,14 +1843,14 @@ end
 end
 
 @checked function cudnnCreateAttnDescriptor(attnDesc)
-    initialize_api()
+    initialize_context()
     ccall((:cudnnCreateAttnDescriptor, libcudnn()), cudnnStatus_t,
                    (Ptr{cudnnAttnDescriptor_t},),
                    attnDesc)
 end
 
 @checked function cudnnDestroyAttnDescriptor(attnDesc)
-    initialize_api()
+    initialize_context()
     ccall((:cudnnDestroyAttnDescriptor, libcudnn()), cudnnStatus_t,
                    (cudnnAttnDescriptor_t,),
                    attnDesc)
@@ -1861,7 +1861,7 @@ end
                                          postDropoutDesc, qSize, kSize, vSize, qProjSize,
                                          kProjSize, vProjSize, oProjSize, qoMaxSeqLength,
                                          kvMaxSeqLength, maxBatchSize, maxBeamSize)
-    initialize_api()
+    initialize_context()
     ccall((:cudnnSetAttnDescriptor, libcudnn()), cudnnStatus_t,
                    (cudnnAttnDescriptor_t, UInt32, Cint, Cdouble, cudnnDataType_t,
                     cudnnDataType_t, cudnnMathType_t, cudnnDropoutDescriptor_t,
@@ -1878,7 +1878,7 @@ end
                                          postDropoutDesc, qSize, kSize, vSize, qProjSize,
                                          kProjSize, vProjSize, oProjSize, qoMaxSeqLength,
                                          kvMaxSeqLength, maxBatchSize, maxBeamSize)
-    initialize_api()
+    initialize_context()
     ccall((:cudnnGetAttnDescriptor, libcudnn()), cudnnStatus_t,
                    (cudnnAttnDescriptor_t, Ptr{UInt32}, Ptr{Cint}, Ptr{Cdouble},
                     Ptr{cudnnDataType_t}, Ptr{cudnnDataType_t}, Ptr{cudnnMathType_t},
@@ -1893,7 +1893,7 @@ end
 
 @checked function cudnnGetMultiHeadAttnBuffers(handle, attnDesc, weightSizeInBytes,
                                                workSpaceSizeInBytes, reserveSpaceSizeInBytes)
-    initialize_api()
+    initialize_context()
     ccall((:cudnnGetMultiHeadAttnBuffers, libcudnn()), cudnnStatus_t,
                    (cudnnHandle_t, cudnnAttnDescriptor_t, Ptr{Csize_t}, Ptr{Csize_t},
                     Ptr{Csize_t}),
@@ -1903,7 +1903,7 @@ end
 
 @checked function cudnnGetMultiHeadAttnWeights(handle, attnDesc, wKind, weightSizeInBytes,
                                                weights, wDesc, wAddr)
-    initialize_api()
+    initialize_context()
     ccall((:cudnnGetMultiHeadAttnWeights, libcudnn()), cudnnStatus_t,
                    (cudnnHandle_t, cudnnAttnDescriptor_t, cudnnMultiHeadAttnWeightKind_t,
                     Csize_t, CuPtr{Cvoid}, cudnnTensorDescriptor_t, CuPtr{Ptr{Cvoid}}),
@@ -1916,7 +1916,7 @@ end
                                             oDesc, out, weightSizeInBytes, weights,
                                             workSpaceSizeInBytes, workSpace,
                                             reserveSpaceSizeInBytes, reserveSpace)
-    initialize_api()
+    initialize_context()
     ccall((:cudnnMultiHeadAttnForward, libcudnn()), cudnnStatus_t,
                    (cudnnHandle_t, cudnnAttnDescriptor_t, Cint, Ptr{Cint}, Ptr{Cint},
                     CuPtr{Cint}, CuPtr{Cint}, cudnnSeqDataDescriptor_t, CuPtr{Cvoid},
@@ -1937,7 +1937,7 @@ end
                                                  values, weightSizeInBytes, weights,
                                                  workSpaceSizeInBytes, workSpace,
                                                  reserveSpaceSizeInBytes, reserveSpace)
-    initialize_api()
+    initialize_context()
     ccall((:cudnnMultiHeadAttnBackwardData, libcudnn()), cudnnStatus_t,
                    (cudnnHandle_t, cudnnAttnDescriptor_t, Ptr{Cint}, Ptr{Cint},
                     CuPtr{Cint}, CuPtr{Cint}, cudnnSeqDataDescriptor_t, CuPtr{Cvoid},
@@ -1957,7 +1957,7 @@ end
                                                     weights, dweights,
                                                     workSpaceSizeInBytes, workSpace,
                                                     reserveSpaceSizeInBytes, reserveSpace)
-    initialize_api()
+    initialize_context()
     ccall((:cudnnMultiHeadAttnBackwardWeights, libcudnn()), cudnnStatus_t,
                    (cudnnHandle_t, cudnnAttnDescriptor_t, cudnnWgradMode_t,
                     cudnnSeqDataDescriptor_t, CuPtr{Cvoid}, cudnnSeqDataDescriptor_t,
@@ -1970,21 +1970,21 @@ end
 end
 
 @checked function cudnnCreateCTCLossDescriptor(ctcLossDesc)
-    initialize_api()
+    initialize_context()
     ccall((:cudnnCreateCTCLossDescriptor, libcudnn()), cudnnStatus_t,
                    (Ptr{cudnnCTCLossDescriptor_t},),
                    ctcLossDesc)
 end
 
 @checked function cudnnSetCTCLossDescriptor(ctcLossDesc, compType)
-    initialize_api()
+    initialize_context()
     ccall((:cudnnSetCTCLossDescriptor, libcudnn()), cudnnStatus_t,
                    (cudnnCTCLossDescriptor_t, cudnnDataType_t),
                    ctcLossDesc, compType)
 end
 
 @checked function cudnnSetCTCLossDescriptorEx(ctcLossDesc, compType, normMode, gradMode)
-    initialize_api()
+    initialize_context()
     ccall((:cudnnSetCTCLossDescriptorEx, libcudnn()), cudnnStatus_t,
                    (cudnnCTCLossDescriptor_t, cudnnDataType_t,
                     cudnnLossNormalizationMode_t, cudnnNanPropagation_t),
@@ -1992,14 +1992,14 @@ end
 end
 
 @checked function cudnnGetCTCLossDescriptor(ctcLossDesc, compType)
-    initialize_api()
+    initialize_context()
     ccall((:cudnnGetCTCLossDescriptor, libcudnn()), cudnnStatus_t,
                    (cudnnCTCLossDescriptor_t, Ptr{cudnnDataType_t}),
                    ctcLossDesc, compType)
 end
 
 @checked function cudnnGetCTCLossDescriptorEx(ctcLossDesc, compType, normMode, gradMode)
-    initialize_api()
+    initialize_context()
     ccall((:cudnnGetCTCLossDescriptorEx, libcudnn()), cudnnStatus_t,
                    (cudnnCTCLossDescriptor_t, Ptr{cudnnDataType_t},
                     Ptr{cudnnLossNormalizationMode_t}, Ptr{cudnnNanPropagation_t}),
@@ -2007,7 +2007,7 @@ end
 end
 
 @checked function cudnnDestroyCTCLossDescriptor(ctcLossDesc)
-    initialize_api()
+    initialize_context()
     ccall((:cudnnDestroyCTCLossDescriptor, libcudnn()), cudnnStatus_t,
                    (cudnnCTCLossDescriptor_t,),
                    ctcLossDesc)
@@ -2016,7 +2016,7 @@ end
 @checked function cudnnCTCLoss(handle, probsDesc, probs, labels, labelLengths,
                                inputLengths, costs, gradientsDesc, gradients, algo,
                                ctcLossDesc, workspace, workSpaceSizeInBytes)
-    initialize_api()
+    initialize_context()
     ccall((:cudnnCTCLoss, libcudnn()), cudnnStatus_t,
                    (cudnnHandle_t, cudnnTensorDescriptor_t, CuPtr{Cvoid}, Ptr{Cint},
                     Ptr{Cint}, Ptr{Cint}, CuPtr{Cvoid}, cudnnTensorDescriptor_t,
@@ -2030,7 +2030,7 @@ end
 @checked function cudnnGetCTCLossWorkspaceSize(handle, probsDesc, gradientsDesc, labels,
                                                labelLengths, inputLengths, algo,
                                                ctcLossDesc, sizeInBytes)
-    initialize_api()
+    initialize_context()
     ccall((:cudnnGetCTCLossWorkspaceSize, libcudnn()), cudnnStatus_t,
                    (cudnnHandle_t, cudnnTensorDescriptor_t, cudnnTensorDescriptor_t,
                     Ptr{Cint}, Ptr{Cint}, Ptr{Cint}, cudnnCTCLossAlgo_t,
@@ -2040,49 +2040,49 @@ end
 end
 
 @checked function cudnnCreateAlgorithmDescriptor(algoDesc)
-    initialize_api()
+    initialize_context()
     ccall((:cudnnCreateAlgorithmDescriptor, libcudnn()), cudnnStatus_t,
                    (Ptr{cudnnAlgorithmDescriptor_t},),
                    algoDesc)
 end
 
 @checked function cudnnSetAlgorithmDescriptor(algoDesc, algorithm)
-    initialize_api()
+    initialize_context()
     ccall((:cudnnSetAlgorithmDescriptor, libcudnn()), cudnnStatus_t,
                    (cudnnAlgorithmDescriptor_t, cudnnAlgorithm_t),
                    algoDesc, algorithm)
 end
 
 @checked function cudnnGetAlgorithmDescriptor(algoDesc, algorithm)
-    initialize_api()
+    initialize_context()
     ccall((:cudnnGetAlgorithmDescriptor, libcudnn()), cudnnStatus_t,
                    (cudnnAlgorithmDescriptor_t, Ptr{cudnnAlgorithm_t}),
                    algoDesc, algorithm)
 end
 
 @checked function cudnnCopyAlgorithmDescriptor(src, dest)
-    initialize_api()
+    initialize_context()
     ccall((:cudnnCopyAlgorithmDescriptor, libcudnn()), cudnnStatus_t,
                    (cudnnAlgorithmDescriptor_t, cudnnAlgorithmDescriptor_t),
                    src, dest)
 end
 
 @checked function cudnnDestroyAlgorithmDescriptor(algoDesc)
-    initialize_api()
+    initialize_context()
     ccall((:cudnnDestroyAlgorithmDescriptor, libcudnn()), cudnnStatus_t,
                    (cudnnAlgorithmDescriptor_t,),
                    algoDesc)
 end
 
 @checked function cudnnCreateAlgorithmPerformance(algoPerf, numberToCreate)
-    initialize_api()
+    initialize_context()
     ccall((:cudnnCreateAlgorithmPerformance, libcudnn()), cudnnStatus_t,
                    (Ptr{cudnnAlgorithmPerformance_t}, Cint),
                    algoPerf, numberToCreate)
 end
 
 @checked function cudnnSetAlgorithmPerformance(algoPerf, algoDesc, status, time, memory)
-    initialize_api()
+    initialize_context()
     ccall((:cudnnSetAlgorithmPerformance, libcudnn()), cudnnStatus_t,
                    (cudnnAlgorithmPerformance_t, cudnnAlgorithmDescriptor_t,
                     cudnnStatus_t, Cfloat, Csize_t),
@@ -2090,7 +2090,7 @@ end
 end
 
 @checked function cudnnGetAlgorithmPerformance(algoPerf, algoDesc, status, time, memory)
-    initialize_api()
+    initialize_context()
     ccall((:cudnnGetAlgorithmPerformance, libcudnn()), cudnnStatus_t,
                    (cudnnAlgorithmPerformance_t, Ptr{cudnnAlgorithmDescriptor_t},
                     Ptr{cudnnStatus_t}, Ptr{Cfloat}, Ptr{Csize_t}),
@@ -2098,28 +2098,28 @@ end
 end
 
 @checked function cudnnDestroyAlgorithmPerformance(algoPerf, numberToDestroy)
-    initialize_api()
+    initialize_context()
     ccall((:cudnnDestroyAlgorithmPerformance, libcudnn()), cudnnStatus_t,
                    (Ptr{cudnnAlgorithmPerformance_t}, Cint),
                    algoPerf, numberToDestroy)
 end
 
 @checked function cudnnGetAlgorithmSpaceSize(handle, algoDesc, algoSpaceSizeInBytes)
-    initialize_api()
+    initialize_context()
     ccall((:cudnnGetAlgorithmSpaceSize, libcudnn()), cudnnStatus_t,
                    (cudnnHandle_t, cudnnAlgorithmDescriptor_t, Ptr{Csize_t}),
                    handle, algoDesc, algoSpaceSizeInBytes)
 end
 
 @checked function cudnnSaveAlgorithm(handle, algoDesc, algoSpace, algoSpaceSizeInBytes)
-    initialize_api()
+    initialize_context()
     ccall((:cudnnSaveAlgorithm, libcudnn()), cudnnStatus_t,
                    (cudnnHandle_t, cudnnAlgorithmDescriptor_t, Ptr{Cvoid}, Csize_t),
                    handle, algoDesc, algoSpace, algoSpaceSizeInBytes)
 end
 
 @checked function cudnnRestoreAlgorithm(handle, algoSpace, algoSpaceSizeInBytes, algoDesc)
-    initialize_api()
+    initialize_context()
     ccall((:cudnnRestoreAlgorithm, libcudnn()), cudnnStatus_t,
                    (cudnnHandle_t, Ptr{Cvoid}, Csize_t, cudnnAlgorithmDescriptor_t),
                    handle, algoSpace, algoSpaceSizeInBytes, algoDesc)
@@ -2138,21 +2138,21 @@ end
 end
 
 @checked function cudnnCreateFusedOpsConstParamPack(constPack, ops)
-    initialize_api()
+    initialize_context()
     ccall((:cudnnCreateFusedOpsConstParamPack, libcudnn()), cudnnStatus_t,
                    (Ptr{cudnnFusedOpsConstParamPack_t}, cudnnFusedOps_t),
                    constPack, ops)
 end
 
 @checked function cudnnDestroyFusedOpsConstParamPack(constPack)
-    initialize_api()
+    initialize_context()
     ccall((:cudnnDestroyFusedOpsConstParamPack, libcudnn()), cudnnStatus_t,
                    (cudnnFusedOpsConstParamPack_t,),
                    constPack)
 end
 
 @checked function cudnnSetFusedOpsConstParamPackAttribute(constPack, paramLabel, param)
-    initialize_api()
+    initialize_context()
     ccall((:cudnnSetFusedOpsConstParamPackAttribute, libcudnn()), cudnnStatus_t,
                    (cudnnFusedOpsConstParamPack_t, cudnnFusedOpsConstParamLabel_t,
                     Ptr{Cvoid}),
@@ -2161,7 +2161,7 @@ end
 
 @checked function cudnnGetFusedOpsConstParamPackAttribute(constPack, paramLabel, param,
                                                           isNULL)
-    initialize_api()
+    initialize_context()
     ccall((:cudnnGetFusedOpsConstParamPackAttribute, libcudnn()), cudnnStatus_t,
                    (cudnnFusedOpsConstParamPack_t, cudnnFusedOpsConstParamLabel_t,
                     Ptr{Cvoid}, Ptr{Cint}),
@@ -2169,21 +2169,21 @@ end
 end
 
 @checked function cudnnCreateFusedOpsVariantParamPack(varPack, ops)
-    initialize_api()
+    initialize_context()
     ccall((:cudnnCreateFusedOpsVariantParamPack, libcudnn()), cudnnStatus_t,
                    (Ptr{cudnnFusedOpsVariantParamPack_t}, cudnnFusedOps_t),
                    varPack, ops)
 end
 
 @checked function cudnnDestroyFusedOpsVariantParamPack(varPack)
-    initialize_api()
+    initialize_context()
     ccall((:cudnnDestroyFusedOpsVariantParamPack, libcudnn()), cudnnStatus_t,
                    (cudnnFusedOpsVariantParamPack_t,),
                    varPack)
 end
 
 @checked function cudnnSetFusedOpsVariantParamPackAttribute(varPack, paramLabel, ptr)
-    initialize_api()
+    initialize_context()
     ccall((:cudnnSetFusedOpsVariantParamPackAttribute, libcudnn()), cudnnStatus_t,
                    (cudnnFusedOpsVariantParamPack_t, cudnnFusedOpsVariantParamLabel_t,
                     PtrOrCuPtr{Cvoid}),
@@ -2191,7 +2191,7 @@ end
 end
 
 @checked function cudnnGetFusedOpsVariantParamPackAttribute(varPack, paramLabel, ptr)
-    initialize_api()
+    initialize_context()
     ccall((:cudnnGetFusedOpsVariantParamPackAttribute, libcudnn()), cudnnStatus_t,
                    (cudnnFusedOpsVariantParamPack_t, cudnnFusedOpsVariantParamLabel_t,
                     PtrOrCuPtr{Cvoid}),
@@ -2199,21 +2199,21 @@ end
 end
 
 @checked function cudnnCreateFusedOpsPlan(plan, ops)
-    initialize_api()
+    initialize_context()
     ccall((:cudnnCreateFusedOpsPlan, libcudnn()), cudnnStatus_t,
                    (Ptr{cudnnFusedOpsPlan_t}, cudnnFusedOps_t),
                    plan, ops)
 end
 
 @checked function cudnnDestroyFusedOpsPlan(plan)
-    initialize_api()
+    initialize_context()
     ccall((:cudnnDestroyFusedOpsPlan, libcudnn()), cudnnStatus_t,
                    (cudnnFusedOpsPlan_t,),
                    plan)
 end
 
 @checked function cudnnMakeFusedOpsPlan(handle, plan, constPack, workspaceSizeInBytes)
-    initialize_api()
+    initialize_context()
     ccall((:cudnnMakeFusedOpsPlan, libcudnn()), cudnnStatus_t,
                    (cudnnHandle_t, cudnnFusedOpsPlan_t, cudnnFusedOpsConstParamPack_t,
                     Ptr{Csize_t}),
@@ -2221,7 +2221,7 @@ end
 end
 
 @checked function cudnnFusedOpsExecute(handle, plan, varPack)
-    initialize_api()
+    initialize_context()
     ccall((:cudnnFusedOpsExecute, libcudnn()), cudnnStatus_t,
                    (cudnnHandle_t, cudnnFusedOpsPlan_t, cudnnFusedOpsVariantParamPack_t),
                    handle, plan, varPack)
@@ -2230,7 +2230,7 @@ end
 @checked function cudnnSetRNNDescriptor_v6(handle, rnnDesc, hiddenSize, numLayers,
                                            dropoutDesc, inputMode, direction, mode, algo,
                                            mathPrec)
-    initialize_api()
+    initialize_context()
     ccall((:cudnnSetRNNDescriptor_v6, libcudnn()), cudnnStatus_t,
                    (cudnnHandle_t, cudnnRNNDescriptor_t, Cint, Cint,
                     cudnnDropoutDescriptor_t, cudnnRNNInputMode_t, cudnnDirectionMode_t,
@@ -2243,159 +2243,159 @@ end
 ## added in CUDNN 8.0
 
 @checked function cudnnDeriveNormTensorDescriptor(derivedNormScaleBiasDesc, derivedNormMeanVarDesc, xDesc, mode, groupCnt)
-    initialize_api()
+    initialize_context()
     ccall((:cudnnDeriveNormTensorDescriptor, libcudnn()), cudnnStatus_t, (cudnnTensorDescriptor_t, cudnnTensorDescriptor_t, cudnnTensorDescriptor_t, cudnnNormMode_t, Cint), derivedNormScaleBiasDesc, derivedNormMeanVarDesc, xDesc, mode, groupCnt)
 end
 
 @checked function cudnnAdvTrainVersionCheck()
-    initialize_api()
+    initialize_context()
     ccall((:cudnnAdvTrainVersionCheck, libcudnn()), cudnnStatus_t, ())
 end
 
 @checked function cudnnOpsTrainVersionCheck()
-    initialize_api()
+    initialize_context()
     ccall((:cudnnOpsTrainVersionCheck, libcudnn()), cudnnStatus_t, ())
 end
 
 @checked function cudnnGetRNNWeightSpaceSize(handle, rnnDesc, weightSpaceSize)
-    initialize_api()
+    initialize_context()
     ccall((:cudnnGetRNNWeightSpaceSize, libcudnn()), cudnnStatus_t, (cudnnHandle_t, cudnnRNNDescriptor_t, Ref{Csize_t}), handle, rnnDesc, weightSpaceSize)
 end
 
 @checked function cudnnGetRNNDescriptor_v6(handle, rnnDesc, hiddenSize, numLayers, dropoutDesc, inputMode, direction, cellMode, algo, mathPrec)
-    initialize_api()
+    initialize_context()
     ccall((:cudnnGetRNNDescriptor_v6, libcudnn()), cudnnStatus_t, (cudnnHandle_t, cudnnRNNDescriptor_t, Ref{Cint}, Ref{Cint}, Ref{cudnnDropoutDescriptor_t}, Ref{cudnnRNNInputMode_t}, Ref{cudnnDirectionMode_t}, Ref{cudnnRNNMode_t}, Ref{cudnnRNNAlgo_t}, Ref{cudnnDataType_t}), handle, rnnDesc, hiddenSize, numLayers, dropoutDesc, inputMode, direction, cellMode, algo, mathPrec)
 end
 
 @checked function cudnnGetCTCLossDescriptor_v8(ctcLossDesc, compType, normMode, gradMode, maxLabelLength)
-    initialize_api()
+    initialize_context()
     ccall((:cudnnGetCTCLossDescriptor_v8, libcudnn()), cudnnStatus_t, (cudnnCTCLossDescriptor_t, Ref{cudnnDataType_t}, Ref{cudnnLossNormalizationMode_t}, Ref{cudnnNanPropagation_t}, Ref{Cint}), ctcLossDesc, compType, normMode, gradMode, maxLabelLength)
 end
 
 @checked function cudnnSetRNNDescriptor_v8(rnnDesc, algo, cellMode, biasMode, dirMode, inputMode, dataType, mathPrec, mathType, inputSize, hiddenSize, projSize, numLayers, dropoutDesc, auxFlags)
-    initialize_api()
+    initialize_context()
     ccall((:cudnnSetRNNDescriptor_v8, libcudnn()), cudnnStatus_t, (cudnnRNNDescriptor_t, cudnnRNNAlgo_t, cudnnRNNMode_t, cudnnRNNBiasMode_t, cudnnDirectionMode_t, cudnnRNNInputMode_t, cudnnDataType_t, cudnnDataType_t, cudnnMathType_t, Int32, Int32, Int32, Int32, cudnnDropoutDescriptor_t, UInt32), rnnDesc, algo, cellMode, biasMode, dirMode, inputMode, dataType, mathPrec, mathType, inputSize, hiddenSize, projSize, numLayers, dropoutDesc, auxFlags)
 end
 
 @checked function cudnnGetRNNTempSpaceSizes(handle, rnnDesc, fMode, xDesc, workSpaceSize, reserveSpaceSize)
-    initialize_api()
+    initialize_context()
     ccall((:cudnnGetRNNTempSpaceSizes, libcudnn()), cudnnStatus_t, (cudnnHandle_t, cudnnRNNDescriptor_t, cudnnForwardMode_t, cudnnRNNDataDescriptor_t, Ref{Csize_t}, Ref{Csize_t}), handle, rnnDesc, fMode, xDesc, workSpaceSize, reserveSpaceSize)
 end
 
 @checked function cudnnCTCLoss_v8(handle, algo, ctcLossDesc, probsDesc, probs, labels, labelLengths, inputLengths, costs, gradientsDesc, gradients, workSpaceSizeInBytes, workspace)
-    initialize_api()
+    initialize_context()
     ccall((:cudnnCTCLoss_v8, libcudnn()), cudnnStatus_t, (cudnnHandle_t, cudnnCTCLossAlgo_t, cudnnCTCLossDescriptor_t, cudnnTensorDescriptor_t, Ptr{Cvoid}, CuPtr{Cint}, CuPtr{Cint}, CuPtr{Cint}, Ptr{Cvoid}, cudnnTensorDescriptor_t, Ptr{Cvoid}, Csize_t, CuPtr{Cvoid}), handle, algo, ctcLossDesc, probsDesc, probs, labels, labelLengths, inputLengths, costs, gradientsDesc, gradients, workSpaceSizeInBytes, workspace)
 end
 
 @checked function cudnnAdvInferVersionCheck()
-    initialize_api()
+    initialize_context()
     ccall((:cudnnAdvInferVersionCheck, libcudnn()), cudnnStatus_t, ())
 end
 
 @checked function cudnnSetCTCLossDescriptor_v8(ctcLossDesc, compType, normMode, gradMode, maxLabelLength)
-    initialize_api()
+    initialize_context()
     ccall((:cudnnSetCTCLossDescriptor_v8, libcudnn()), cudnnStatus_t, (cudnnCTCLossDescriptor_t, cudnnDataType_t, cudnnLossNormalizationMode_t, cudnnNanPropagation_t, Cint), ctcLossDesc, compType, normMode, gradMode, maxLabelLength)
 end
 
 @checked function cudnnGetNormalizationTrainingReserveSpaceSize(handle, mode, normOps, algo, activationDesc, xDesc, sizeInBytes, groupCnt)
-    initialize_api()
+    initialize_context()
     ccall((:cudnnGetNormalizationTrainingReserveSpaceSize, libcudnn()), cudnnStatus_t, (cudnnHandle_t, cudnnNormMode_t, cudnnNormOps_t, cudnnNormAlgo_t, cudnnActivationDescriptor_t, cudnnTensorDescriptor_t, Ref{Csize_t}, Cint), handle, mode, normOps, algo, activationDesc, xDesc, sizeInBytes, groupCnt)
 end
 
 @checked function cudnnGetRNNWeightParams(handle, rnnDesc, pseudoLayer, weightSpaceSize, weightSpace, linLayerID, mDesc, mAddr, bDesc, bAddr)
-    initialize_api()
+    initialize_context()
     ccall((:cudnnGetRNNWeightParams, libcudnn()), cudnnStatus_t, (cudnnHandle_t, cudnnRNNDescriptor_t, Int32, Csize_t, CuPtr{Cvoid}, Int32, cudnnTensorDescriptor_t, Ptr{CuPtr{Cvoid}}, cudnnTensorDescriptor_t, Ptr{CuPtr{Cvoid}}), handle, rnnDesc, pseudoLayer, weightSpaceSize, weightSpace, linLayerID, mDesc, mAddr, bDesc, bAddr)
 end
 
 @checked function cudnnGetNormalizationForwardTrainingWorkspaceSize(handle, mode, normOps, algo, xDesc, zDesc, yDesc, normScaleBiasDesc, activationDesc, normMeanVarDesc, sizeInBytes, groupCnt)
-    initialize_api()
+    initialize_context()
     ccall((:cudnnGetNormalizationForwardTrainingWorkspaceSize, libcudnn()), cudnnStatus_t, (cudnnHandle_t, cudnnNormMode_t, cudnnNormOps_t, cudnnNormAlgo_t, cudnnTensorDescriptor_t, cudnnTensorDescriptor_t, cudnnTensorDescriptor_t, cudnnTensorDescriptor_t, cudnnActivationDescriptor_t, cudnnTensorDescriptor_t, Ref{Csize_t}, Cint), handle, mode, normOps, algo, xDesc, zDesc, yDesc, normScaleBiasDesc, activationDesc, normMeanVarDesc, sizeInBytes, groupCnt)
 end
 
 @checked function cudnnRNNBackwardWeights_v8(handle, rnnDesc, addGrad, devSeqLengths, xDesc, x, hDesc, hx, yDesc, y, weightSpaceSize, dweightSpace, workSpaceSize, workSpace, reserveSpaceSize, reserveSpace)
-    initialize_api()
+    initialize_context()
     ccall((:cudnnRNNBackwardWeights_v8, libcudnn()), cudnnStatus_t, (cudnnHandle_t, cudnnRNNDescriptor_t, cudnnWgradMode_t, CuPtr{Int32}, cudnnRNNDataDescriptor_t, CuPtr{Cvoid}, cudnnTensorDescriptor_t, CuPtr{Cvoid}, cudnnRNNDataDescriptor_t, CuPtr{Cvoid}, Csize_t, CuPtr{Cvoid}, Csize_t, CuPtr{Cvoid}, Csize_t, CuPtr{Cvoid}), handle, rnnDesc, addGrad, devSeqLengths, xDesc, x, hDesc, hx, yDesc, y, weightSpaceSize, dweightSpace, workSpaceSize, workSpace, reserveSpaceSize, reserveSpace)
 end
 
 @checked function cudnnCnnInferVersionCheck()
-    initialize_api()
+    initialize_context()
     ccall((:cudnnCnnInferVersionCheck, libcudnn()), cudnnStatus_t, ())
 end
 
 @checked function cudnnCnnTrainVersionCheck()
-    initialize_api()
+    initialize_context()
     ccall((:cudnnCnnTrainVersionCheck, libcudnn()), cudnnStatus_t, ())
 end
 
 @checked function cudnnRNNGetClip_v8(rnnDesc, clipMode, clipNanOpt, lclip, rclip)
-    initialize_api()
+    initialize_context()
     ccall((:cudnnRNNGetClip_v8, libcudnn()), cudnnStatus_t, (cudnnRNNDescriptor_t, Ref{cudnnRNNClipMode_t}, Ref{cudnnNanPropagation_t}, Ref{Cdouble}, Ref{Cdouble}), rnnDesc, clipMode, clipNanOpt, lclip, rclip)
 end
 
 @checked function cudnnGetRNNDescriptor_v8(rnnDesc, algo, cellMode, biasMode, dirMode, inputMode, dataType, mathPrec, mathType, inputSize, hiddenSize, projSize, numLayers, dropoutDesc, auxFlags)
-    initialize_api()
+    initialize_context()
     ccall((:cudnnGetRNNDescriptor_v8, libcudnn()), cudnnStatus_t, (cudnnRNNDescriptor_t, Ref{cudnnRNNAlgo_t}, Ref{cudnnRNNMode_t}, Ref{cudnnRNNBiasMode_t}, Ref{cudnnDirectionMode_t}, Ref{cudnnRNNInputMode_t}, Ref{cudnnDataType_t}, Ref{cudnnDataType_t}, Ref{cudnnMathType_t}, Ref{Int32}, Ref{Int32}, Ref{Int32}, Ref{Int32}, Ref{cudnnDropoutDescriptor_t}, Ref{UInt32}), rnnDesc, algo, cellMode, biasMode, dirMode, inputMode, dataType, mathPrec, mathType, inputSize, hiddenSize, projSize, numLayers, dropoutDesc, auxFlags)
 end
 
 @checked function cudnnGetNormalizationBackwardWorkspaceSize(handle, mode, normOps, algo, xDesc, yDesc, dyDesc, dzDesc, dxDesc, dNormScaleBiasDesc, activationDesc, normMeanVarDesc, sizeInBytes, groupCnt)
-    initialize_api()
+    initialize_context()
     ccall((:cudnnGetNormalizationBackwardWorkspaceSize, libcudnn()), cudnnStatus_t, (cudnnHandle_t, cudnnNormMode_t, cudnnNormOps_t, cudnnNormAlgo_t, cudnnTensorDescriptor_t, cudnnTensorDescriptor_t, cudnnTensorDescriptor_t, cudnnTensorDescriptor_t, cudnnTensorDescriptor_t, cudnnTensorDescriptor_t, cudnnActivationDescriptor_t, cudnnTensorDescriptor_t, Ref{Csize_t}, Cint), handle, mode, normOps, algo, xDesc, yDesc, dyDesc, dzDesc, dxDesc, dNormScaleBiasDesc, activationDesc, normMeanVarDesc, sizeInBytes, groupCnt)
 end
 
 @checked function cudnnNormalizationForwardInference(handle, mode, normOps, algo, alpha, beta, xDesc, x, normScaleBiasDesc, normScale, normBias, normMeanVarDesc, estimatedMean, estimatedVariance, zDesc, z, activationDesc, yDesc, y, epsilon, groupCnt)
-    initialize_api()
+    initialize_context()
     ccall((:cudnnNormalizationForwardInference, libcudnn()), cudnnStatus_t, (cudnnHandle_t, cudnnNormMode_t, cudnnNormOps_t, cudnnNormAlgo_t, Ptr{Cvoid}, Ptr{Cvoid}, cudnnTensorDescriptor_t, CuPtr{Cvoid}, cudnnTensorDescriptor_t, CuPtr{Cvoid}, CuPtr{Cvoid}, cudnnTensorDescriptor_t, CuPtr{Cvoid}, CuPtr{Cvoid}, cudnnTensorDescriptor_t, CuPtr{Cvoid}, cudnnActivationDescriptor_t, cudnnTensorDescriptor_t, CuPtr{Cvoid}, Cdouble, Cint), handle, mode, normOps, algo, alpha, beta, xDesc, x, normScaleBiasDesc, normScale, normBias, normMeanVarDesc, estimatedMean, estimatedVariance, zDesc, z, activationDesc, yDesc, y, epsilon, groupCnt)
 end
 
 @checked function cudnnOpsInferVersionCheck()
-    initialize_api()
+    initialize_context()
     ccall((:cudnnOpsInferVersionCheck, libcudnn()), cudnnStatus_t, ())
 end
 
 @checked function cudnnNormalizationForwardTraining(handle, mode, normOps, algo, alpha, beta, xDesc, xData, normScaleBiasDesc, normScale, normBias, exponentialAverageFactor, normMeanVarDesc, resultRunningMean, resultRunningVariance, epsilon, resultSaveMean, resultSaveInvVariance, activationDesc, zDesc, zData, yDesc, yData, workspace, workSpaceSizeInBytes, reserveSpace, reserveSpaceSizeInBytes, groupCnt)
-    initialize_api()
+    initialize_context()
     ccall((:cudnnNormalizationForwardTraining, libcudnn()), cudnnStatus_t, (cudnnHandle_t, cudnnNormMode_t, cudnnNormOps_t, cudnnNormAlgo_t, Ptr{Cvoid}, Ptr{Cvoid}, cudnnTensorDescriptor_t, CuPtr{Cvoid}, cudnnTensorDescriptor_t, CuPtr{Cvoid}, CuPtr{Cvoid}, Cdouble, cudnnTensorDescriptor_t, CuPtr{Cvoid}, CuPtr{Cvoid}, Cdouble, CuPtr{Cvoid}, CuPtr{Cvoid}, cudnnActivationDescriptor_t, cudnnTensorDescriptor_t, CuPtr{Cvoid}, cudnnTensorDescriptor_t, CuPtr{Cvoid}, CuPtr{Cvoid}, Csize_t, CuPtr{Cvoid}, Csize_t, Cint), handle, mode, normOps, algo, alpha, beta, xDesc, xData, normScaleBiasDesc, normScale, normBias, exponentialAverageFactor, normMeanVarDesc, resultRunningMean, resultRunningVariance, epsilon, resultSaveMean, resultSaveInvVariance, activationDesc, zDesc, zData, yDesc, yData, workspace, workSpaceSizeInBytes, reserveSpace, reserveSpaceSizeInBytes, groupCnt)
 end
 
 @checked function cudnnGetCTCLossWorkspaceSize_v8(handle, algo, ctcLossDesc, probsDesc, gradientsDesc, sizeInBytes)
-    initialize_api()
+    initialize_context()
     ccall((:cudnnGetCTCLossWorkspaceSize_v8, libcudnn()), cudnnStatus_t, (cudnnHandle_t, cudnnCTCLossAlgo_t, cudnnCTCLossDescriptor_t, cudnnTensorDescriptor_t, cudnnTensorDescriptor_t, Ptr{Csize_t}), handle, algo, ctcLossDesc, probsDesc, gradientsDesc, sizeInBytes)
 end
 
 @checked function cudnnRNNSetClip_v8(rnnDesc, clipMode, clipNanOpt, lclip, rclip)
-    initialize_api()
+    initialize_context()
     ccall((:cudnnRNNSetClip_v8, libcudnn()), cudnnStatus_t, (cudnnRNNDescriptor_t, cudnnRNNClipMode_t, cudnnNanPropagation_t, Cdouble, Cdouble), rnnDesc, clipMode, clipNanOpt, lclip, rclip)
 end
 
 @checked function cudnnRNNForward(handle, rnnDesc, fwdMode, devSeqLengths, xDesc, x, yDesc, y, hDesc, hx, hy, cDesc, cx, cy, weightSpaceSize, weightSpace, workSpaceSize, workSpace, reserveSpaceSize, reserveSpace)
-    initialize_api()
+    initialize_context()
     ccall((:cudnnRNNForward, libcudnn()), cudnnStatus_t, (cudnnHandle_t, cudnnRNNDescriptor_t, cudnnForwardMode_t, CuPtr{Int32}, cudnnRNNDataDescriptor_t, CuPtr{Cvoid}, cudnnRNNDataDescriptor_t, CuPtr{Cvoid}, cudnnTensorDescriptor_t, CuPtr{Cvoid}, CuPtr{Cvoid}, cudnnTensorDescriptor_t, CuPtr{Cvoid}, CuPtr{Cvoid}, Csize_t, CuPtr{Cvoid}, Csize_t, CuPtr{Cvoid}, Csize_t, CuPtr{Cvoid}), handle, rnnDesc, fwdMode, devSeqLengths, xDesc, x, yDesc, y, hDesc, hx, hy, cDesc, cx, cy, weightSpaceSize, weightSpace, workSpaceSize, workSpace, reserveSpaceSize, reserveSpace)
 end
 
 @checked function cudnnBuildRNNDynamic(handle, rnnDesc, miniBatch)
-    initialize_api()
+    initialize_context()
     ccall((:cudnnBuildRNNDynamic, libcudnn()), cudnnStatus_t, (cudnnHandle_t, cudnnRNNDescriptor_t, Cint), handle, rnnDesc, miniBatch)
 end
 
 @checked function cudnnRNNBackwardData_v8(handle, rnnDesc, devSeqLengths, yDesc, y, dy, xDesc, dx, hDesc, hx, dhy, dhx, cDesc, cx, dcy, dcx, weightSpaceSize, weightSpace, workSpaceSize, workSpace, reserveSpaceSize, reserveSpace)
-    initialize_api()
+    initialize_context()
     ccall((:cudnnRNNBackwardData_v8, libcudnn()), cudnnStatus_t, (cudnnHandle_t, cudnnRNNDescriptor_t, CuPtr{Int32}, cudnnRNNDataDescriptor_t, CuPtr{Cvoid}, CuPtr{Cvoid}, cudnnRNNDataDescriptor_t, CuPtr{Cvoid}, cudnnTensorDescriptor_t, CuPtr{Cvoid}, CuPtr{Cvoid}, CuPtr{Cvoid}, cudnnTensorDescriptor_t, CuPtr{Cvoid}, CuPtr{Cvoid}, CuPtr{Cvoid}, Csize_t, CuPtr{Cvoid}, Csize_t, CuPtr{Cvoid}, Csize_t, CuPtr{Cvoid}), handle, rnnDesc, devSeqLengths, yDesc, y, dy, xDesc, dx, hDesc, hx, dhy, dhx, cDesc, cx, dcy, dcx, weightSpaceSize, weightSpace, workSpaceSize, workSpace, reserveSpaceSize, reserveSpace)
 end
 
 @checked function cudnnNormalizationBackward(handle, mode, normOps, algo, alphaDataDiff, betaDataDiff, alphaParamDiff, betaParamDiff, xDesc, xData, yDesc, yData, dyDesc, dyData, dzDesc, dzData, dxDesc, dxData, dNormScaleBiasDesc, normScaleData, normBiasData, dNormScaleData, dNormBiasData, epsilon, normMeanVarDesc, savedMean, savedInvVariance, activationDesc, workSpace, workSpaceSizeInBytes, reserveSpace, reserveSpaceSizeInBytes, groupCnt)
-    initialize_api()
+    initialize_context()
     ccall((:cudnnNormalizationBackward, libcudnn()), cudnnStatus_t, (cudnnHandle_t, cudnnNormMode_t, cudnnNormOps_t, cudnnNormAlgo_t, Ptr{Cvoid}, Ptr{Cvoid}, Ptr{Cvoid}, Ptr{Cvoid}, cudnnTensorDescriptor_t, CuPtr{Cvoid}, cudnnTensorDescriptor_t, CuPtr{Cvoid}, cudnnTensorDescriptor_t, CuPtr{Cvoid}, cudnnTensorDescriptor_t, CuPtr{Cvoid}, cudnnTensorDescriptor_t, CuPtr{Cvoid}, cudnnTensorDescriptor_t, CuPtr{Cvoid}, CuPtr{Cvoid}, CuPtr{Cvoid}, CuPtr{Cvoid}, Cdouble, cudnnTensorDescriptor_t, CuPtr{Cvoid}, CuPtr{Cvoid}, cudnnActivationDescriptor_t, CuPtr{Cvoid}, Csize_t, CuPtr{Cvoid}, Csize_t, Cint), handle, mode, normOps, algo, alphaDataDiff, betaDataDiff, alphaParamDiff, betaParamDiff, xDesc, xData, yDesc, yData, dyDesc, dyData, dzDesc, dzData, dxDesc, dxData, dNormScaleBiasDesc, normScaleData, normBiasData, dNormScaleData, dNormBiasData, epsilon, normMeanVarDesc, savedMean, savedInvVariance, activationDesc, workSpace, workSpaceSizeInBytes, reserveSpace, reserveSpaceSizeInBytes, groupCnt)
 end
 
 ## Added in CUDNN 8.2
 
 @checked function cudnnSetActivationDescriptorSwishBeta(activationDesc, swish_beta)
-    initialize_api()
+    initialize_context()
     ccall((:cudnnSetActivationDescriptorSwishBeta, libcudnn), cudnnStatus_t, (cudnnActivationDescriptor_t, Cdouble), activationDesc, swish_beta)
 end
 
 @checked function cudnnGetActivationDescriptorSwishBeta(activationDesc, swish_beta)
-    initialize_api()
+    initialize_context()
     ccall((:cudnnGetActivationDescriptorSwishBeta, libcudnn), cudnnStatus_t, (cudnnActivationDescriptor_t, Ptr{Cdouble}), activationDesc, swish_beta)
 end
 

--- a/lib/cudnn/libcudnn_deprecated.jl
+++ b/lib/cudnn/libcudnn_deprecated.jl
@@ -23,7 +23,7 @@ end
 @checked function cudnnGetConvolutionBackwardDataAlgorithm(handle, wDesc, dyDesc, convDesc,
                                                            dxDesc, preference,
                                                            memoryLimitInBytes, algo)
-    initialize_api()
+    initialize_context()
     ccall((:cudnnGetConvolutionBackwardDataAlgorithm, libcudnn()), cudnnStatus_t,
                    (cudnnHandle_t, cudnnFilterDescriptor_t, cudnnTensorDescriptor_t,
                     cudnnConvolutionDescriptor_t, cudnnTensorDescriptor_t,
@@ -36,7 +36,7 @@ end
 @checked function cudnnSetRNNDescriptor(handle, rnnDesc, hiddenSize, numLayers,
                                         dropoutDesc, inputMode, direction, mode, algo,
                                         mathPrec)
-    initialize_api()
+    initialize_context()
     ccall((:cudnnSetRNNDescriptor, libcudnn()), cudnnStatus_t,
                    (cudnnHandle_t, cudnnRNNDescriptor_t, Cint, Cint,
                     cudnnDropoutDescriptor_t, cudnnRNNInputMode_t, cudnnDirectionMode_t,
@@ -48,7 +48,7 @@ end
 @checked function cudnnGetRNNDescriptor(handle, rnnDesc, hiddenSize, numLayers,
                                         dropoutDesc, inputMode, direction, mode, algo,
                                         mathPrec)
-    initialize_api()
+    initialize_context()
     ccall((:cudnnGetRNNDescriptor, libcudnn()), cudnnStatus_t,
                    (cudnnHandle_t, cudnnRNNDescriptor_t, Ptr{Cint}, Ptr{Cint},
                     Ptr{cudnnDropoutDescriptor_t}, Ptr{cudnnRNNInputMode_t},
@@ -60,7 +60,7 @@ end
 
 @checked function cudnnSetRNNDescriptor_v5(rnnDesc, hiddenSize, numLayers, dropoutDesc,
                                            inputMode, direction, mode, mathPrec)
-    initialize_api()
+    initialize_context()
     ccall((:cudnnSetRNNDescriptor_v5, libcudnn()), cudnnStatus_t,
                    (cudnnRNNDescriptor_t, Cint, Cint, cudnnDropoutDescriptor_t,
                     cudnnRNNInputMode_t, cudnnDirectionMode_t, cudnnRNNMode_t,
@@ -72,7 +72,7 @@ end
 @checked function cudnnGetConvolutionForwardAlgorithm(handle, xDesc, wDesc, convDesc,
                                                       yDesc, preference,
                                                       memoryLimitInBytes, algo)
-    initialize_api()
+    initialize_context()
     ccall((:cudnnGetConvolutionForwardAlgorithm, libcudnn()), cudnnStatus_t,
                    (cudnnHandle_t, cudnnTensorDescriptor_t, cudnnFilterDescriptor_t,
                     cudnnConvolutionDescriptor_t, cudnnTensorDescriptor_t,
@@ -85,7 +85,7 @@ end
 @checked function cudnnGetConvolutionBackwardFilterAlgorithm(handle, xDesc, dyDesc,
                                                              convDesc, dwDesc, preference,
                                                              memoryLimitInBytes, algo)
-    initialize_api()
+    initialize_context()
     ccall((:cudnnGetConvolutionBackwardFilterAlgorithm, libcudnn()), cudnnStatus_t,
                    (cudnnHandle_t, cudnnTensorDescriptor_t, cudnnTensorDescriptor_t,
                     cudnnConvolutionDescriptor_t, cudnnFilterDescriptor_t,

--- a/lib/cufft/CUFFT.jl
+++ b/lib/cufft/CUFFT.jl
@@ -4,7 +4,7 @@ using ..APIUtils
 
 using ..CUDA
 using ..CUDA: CUstream, cuComplex, cuDoubleComplex, libraryPropertyType
-using ..CUDA: libcufft, unsafe_free!, @retry_reclaim, @context!
+using ..CUDA: libcufft, unsafe_free!, @retry_reclaim, @context!, initialize_context
 
 using CEnum: @cenum
 

--- a/lib/cufft/error.jl
+++ b/lib/cufft/error.jl
@@ -65,10 +65,6 @@ end
     end
 end
 
-function initialize_api()
-    CUDA.prepare_cuda_state()
-end
-
 macro check(ex, errs...)
     check = :(isequal(err, CUFFT_ALLOC_FAILED))
     for err in errs

--- a/lib/cufft/libcufft.jl
+++ b/lib/cufft/libcufft.jl
@@ -2,21 +2,21 @@
 # Automatically generated using Clang.jl
 
 @checked function cufftPlan1d(plan, nx, type, batch)
-    initialize_api()
+    initialize_context()
     ccall((:cufftPlan1d, libcufft()), cufftResult,
                    (Ptr{cufftHandle}, Cint, cufftType, Cint),
                    plan, nx, type, batch)
 end
 
 @checked function cufftPlan2d(plan, nx, ny, type)
-    initialize_api()
+    initialize_context()
     ccall((:cufftPlan2d, libcufft()), cufftResult,
                    (Ptr{cufftHandle}, Cint, Cint, cufftType),
                    plan, nx, ny, type)
 end
 
 @checked function cufftPlan3d(plan, nx, ny, nz, type)
-    initialize_api()
+    initialize_context()
     ccall((:cufftPlan3d, libcufft()), cufftResult,
                    (Ptr{cufftHandle}, Cint, Cint, Cint, cufftType),
                    plan, nx, ny, nz, type)
@@ -24,7 +24,7 @@ end
 
 @checked function cufftPlanMany(plan, rank, n, inembed, istride, idist, onembed, ostride,
                                 odist, type, batch)
-    initialize_api()
+    initialize_context()
     ccall((:cufftPlanMany, libcufft()), cufftResult,
                    (Ptr{cufftHandle}, Cint, Ptr{Cint}, Ptr{Cint}, Cint, Cint, Ptr{Cint},
                     Cint, Cint, cufftType, Cint),
@@ -33,21 +33,21 @@ end
 end
 
 @checked function cufftMakePlan1d(plan, nx, type, batch, workSize)
-    initialize_api()
+    initialize_context()
     ccall((:cufftMakePlan1d, libcufft()), cufftResult,
                    (cufftHandle, Cint, cufftType, Cint, Ptr{Csize_t}),
                    plan, nx, type, batch, workSize)
 end
 
 @checked function cufftMakePlan2d(plan, nx, ny, type, workSize)
-    initialize_api()
+    initialize_context()
     ccall((:cufftMakePlan2d, libcufft()), cufftResult,
                    (cufftHandle, Cint, Cint, cufftType, Ptr{Csize_t}),
                    plan, nx, ny, type, workSize)
 end
 
 @checked function cufftMakePlan3d(plan, nx, ny, nz, type, workSize)
-    initialize_api()
+    initialize_context()
     ccall((:cufftMakePlan3d, libcufft()), cufftResult,
                    (cufftHandle, Cint, Cint, Cint, cufftType, Ptr{Csize_t}),
                    plan, nx, ny, nz, type, workSize)
@@ -55,7 +55,7 @@ end
 
 @checked function cufftMakePlanMany(plan, rank, n, inembed, istride, idist, onembed,
                                     ostride, odist, type, batch, workSize)
-    initialize_api()
+    initialize_context()
     ccall((:cufftMakePlanMany, libcufft()), cufftResult,
                    (cufftHandle, Cint, Ptr{Cint}, Ptr{Cint}, Cint, Cint, Ptr{Cint}, Cint,
                     Cint, cufftType, Cint, Ptr{Csize_t}),
@@ -65,7 +65,7 @@ end
 
 @checked function cufftMakePlanMany64(plan, rank, n, inembed, istride, idist, onembed,
                                       ostride, odist, type, batch, workSize)
-    initialize_api()
+    initialize_context()
     ccall((:cufftMakePlanMany64, libcufft()), cufftResult,
                    (cufftHandle, Cint, Ptr{Clonglong}, Ptr{Clonglong}, Clonglong,
                     Clonglong, Ptr{Clonglong}, Clonglong, Clonglong, cufftType, Clonglong,
@@ -76,7 +76,7 @@ end
 
 @checked function cufftGetSizeMany64(plan, rank, n, inembed, istride, idist, onembed,
                                      ostride, odist, type, batch, workSize)
-    initialize_api()
+    initialize_context()
     ccall((:cufftGetSizeMany64, libcufft()), cufftResult,
                    (cufftHandle, Cint, Ptr{Clonglong}, Ptr{Clonglong}, Clonglong,
                     Clonglong, Ptr{Clonglong}, Clonglong, Clonglong, cufftType, Clonglong,
@@ -86,21 +86,21 @@ end
 end
 
 @checked function cufftEstimate1d(nx, type, batch, workSize)
-    initialize_api()
+    initialize_context()
     ccall((:cufftEstimate1d, libcufft()), cufftResult,
                    (Cint, cufftType, Cint, Ptr{Csize_t}),
                    nx, type, batch, workSize)
 end
 
 @checked function cufftEstimate2d(nx, ny, type, workSize)
-    initialize_api()
+    initialize_context()
     ccall((:cufftEstimate2d, libcufft()), cufftResult,
                    (Cint, Cint, cufftType, Ptr{Csize_t}),
                    nx, ny, type, workSize)
 end
 
 @checked function cufftEstimate3d(nx, ny, nz, type, workSize)
-    initialize_api()
+    initialize_context()
     ccall((:cufftEstimate3d, libcufft()), cufftResult,
                    (Cint, Cint, Cint, cufftType, Ptr{Csize_t}),
                    nx, ny, nz, type, workSize)
@@ -108,7 +108,7 @@ end
 
 @checked function cufftEstimateMany(rank, n, inembed, istride, idist, onembed, ostride,
                                     odist, type, batch, workSize)
-    initialize_api()
+    initialize_context()
     ccall((:cufftEstimateMany, libcufft()), cufftResult,
                    (Cint, Ptr{Cint}, Ptr{Cint}, Cint, Cint, Ptr{Cint}, Cint, Cint,
                     cufftType, Cint, Ptr{Csize_t}),
@@ -117,28 +117,28 @@ end
 end
 
 @checked function cufftCreate(handle)
-    initialize_api()
+    initialize_context()
     ccall((:cufftCreate, libcufft()), cufftResult,
                    (Ptr{cufftHandle},),
                    handle)
 end
 
 @checked function cufftGetSize1d(handle, nx, type, batch, workSize)
-    initialize_api()
+    initialize_context()
     ccall((:cufftGetSize1d, libcufft()), cufftResult,
                    (cufftHandle, Cint, cufftType, Cint, Ptr{Csize_t}),
                    handle, nx, type, batch, workSize)
 end
 
 @checked function cufftGetSize2d(handle, nx, ny, type, workSize)
-    initialize_api()
+    initialize_context()
     ccall((:cufftGetSize2d, libcufft()), cufftResult,
                    (cufftHandle, Cint, Cint, cufftType, Ptr{Csize_t}),
                    handle, nx, ny, type, workSize)
 end
 
 @checked function cufftGetSize3d(handle, nx, ny, nz, type, workSize)
-    initialize_api()
+    initialize_context()
     ccall((:cufftGetSize3d, libcufft()), cufftResult,
                    (cufftHandle, Cint, Cint, Cint, cufftType, Ptr{Csize_t}),
                    handle, nx, ny, nz, type, workSize)
@@ -146,7 +146,7 @@ end
 
 @checked function cufftGetSizeMany(handle, rank, n, inembed, istride, idist, onembed,
                                    ostride, odist, type, batch, workArea)
-    initialize_api()
+    initialize_context()
     ccall((:cufftGetSizeMany, libcufft()), cufftResult,
                    (cufftHandle, Cint, Ptr{Cint}, Ptr{Cint}, Cint, Cint, Ptr{Cint}, Cint,
                     Cint, cufftType, Cint, Ptr{Csize_t}),
@@ -155,49 +155,49 @@ end
 end
 
 @checked function cufftGetSize(handle, workSize)
-    initialize_api()
+    initialize_context()
     ccall((:cufftGetSize, libcufft()), cufftResult,
                    (cufftHandle, Ptr{Csize_t}),
                    handle, workSize)
 end
 
 @checked function cufftSetWorkArea(plan, workArea)
-    initialize_api()
+    initialize_context()
     ccall((:cufftSetWorkArea, libcufft()), cufftResult,
                    (cufftHandle, CuPtr{Cvoid}),
                    plan, workArea)
 end
 
 @checked function cufftSetAutoAllocation(plan, autoAllocate)
-    initialize_api()
+    initialize_context()
     ccall((:cufftSetAutoAllocation, libcufft()), cufftResult,
                    (cufftHandle, Cint),
                    plan, autoAllocate)
 end
 
 @checked function cufftExecC2C(plan, idata, odata, direction)
-    initialize_api()
+    initialize_context()
     ccall((:cufftExecC2C, libcufft()), cufftResult,
                    (cufftHandle, CuPtr{cufftComplex}, CuPtr{cufftComplex}, Cint),
                    plan, idata, odata, direction)
 end
 
 @checked function cufftExecR2C(plan, idata, odata)
-    initialize_api()
+    initialize_context()
     ccall((:cufftExecR2C, libcufft()), cufftResult,
                    (cufftHandle, CuPtr{cufftReal}, CuPtr{cufftComplex}),
                    plan, idata, odata)
 end
 
 @checked function cufftExecC2R(plan, idata, odata)
-    initialize_api()
+    initialize_context()
     ccall((:cufftExecC2R, libcufft()), cufftResult,
                    (cufftHandle, CuPtr{cufftComplex}, CuPtr{cufftReal}),
                    plan, idata, odata)
 end
 
 @checked function cufftExecZ2Z(plan, idata, odata, direction)
-    initialize_api()
+    initialize_context()
     ccall((:cufftExecZ2Z, libcufft()), cufftResult,
                    (cufftHandle, CuPtr{cufftDoubleComplex}, CuPtr{cufftDoubleComplex},
                     Cint),
@@ -205,28 +205,28 @@ end
 end
 
 @checked function cufftExecD2Z(plan, idata, odata)
-    initialize_api()
+    initialize_context()
     ccall((:cufftExecD2Z, libcufft()), cufftResult,
                    (cufftHandle, CuPtr{cufftDoubleReal}, CuPtr{cufftDoubleComplex}),
                    plan, idata, odata)
 end
 
 @checked function cufftExecZ2D(plan, idata, odata)
-    initialize_api()
+    initialize_context()
     ccall((:cufftExecZ2D, libcufft()), cufftResult,
                    (cufftHandle, CuPtr{cufftDoubleComplex}, CuPtr{cufftDoubleReal}),
                    plan, idata, odata)
 end
 
 @checked function cufftSetStream(plan, stream)
-    initialize_api()
+    initialize_context()
     ccall((:cufftSetStream, libcufft()), cufftResult,
                    (cufftHandle, CUstream),
                    plan, stream)
 end
 
 @checked function cufftDestroy(plan)
-    initialize_api()
+    initialize_context()
     ccall((:cufftDestroy, libcufft()), cufftResult,
                    (cufftHandle,),
                    plan)

--- a/lib/cupti/CUPTI.jl
+++ b/lib/cupti/CUPTI.jl
@@ -3,7 +3,7 @@ module CUPTI
 using ..APIUtils
 
 using ..CUDA
-using ..CUDA: libcupti, @retry_reclaim
+using ..CUDA: libcupti, @retry_reclaim, initialize_context
 using ..CUDA: CUuuid, CUcontext, CUstream, CUdevice, CUdevice_attribute,
               CUgraph, CUgraphNode, CUgraphNodeType, CUgraphExec, CUaccessPolicyWindow
 

--- a/lib/cupti/error.jl
+++ b/lib/cupti/error.jl
@@ -117,10 +117,6 @@ end
     end
 end
 
-function initialize_api()
-    CUDA.prepare_cuda_state()
-end
-
 macro check(ex, errs...)
     check = :(isequal(err, CUPTI_ERROR_OUT_OF_MEMORY))
     for err in errs

--- a/lib/cupti/libcupti.jl
+++ b/lib/cupti/libcupti.jl
@@ -14,28 +14,28 @@ end
 end
 
 @checked function cuptiSupportedDomains(domainCount, domainTable)
-    initialize_api()
+    initialize_context()
     ccall((:cuptiSupportedDomains, libcupti()), CUptiResult,
                    (Ptr{Csize_t}, Ptr{CUpti_DomainTable}),
                    domainCount, domainTable)
 end
 
 @checked function cuptiSubscribe(subscriber, callback, userdata)
-    initialize_api()
+    initialize_context()
     ccall((:cuptiSubscribe, libcupti()), CUptiResult,
                    (Ptr{CUpti_SubscriberHandle}, CUpti_CallbackFunc, Ptr{Cvoid}),
                    subscriber, callback, userdata)
 end
 
 @checked function cuptiUnsubscribe(subscriber)
-    initialize_api()
+    initialize_context()
     ccall((:cuptiUnsubscribe, libcupti()), CUptiResult,
                    (CUpti_SubscriberHandle,),
                    subscriber)
 end
 
 @checked function cuptiGetCallbackState(enable, subscriber, domain, cbid)
-    initialize_api()
+    initialize_context()
     ccall((:cuptiGetCallbackState, libcupti()), CUptiResult,
                    (Ptr{UInt32}, CUpti_SubscriberHandle, CUpti_CallbackDomain,
                     CUpti_CallbackId),
@@ -43,63 +43,63 @@ end
 end
 
 @checked function cuptiEnableCallback(enable, subscriber, domain, cbid)
-    initialize_api()
+    initialize_context()
     ccall((:cuptiEnableCallback, libcupti()), CUptiResult,
                    (UInt32, CUpti_SubscriberHandle, CUpti_CallbackDomain, CUpti_CallbackId),
                    enable, subscriber, domain, cbid)
 end
 
 @checked function cuptiEnableDomain(enable, subscriber, domain)
-    initialize_api()
+    initialize_context()
     ccall((:cuptiEnableDomain, libcupti()), CUptiResult,
                    (UInt32, CUpti_SubscriberHandle, CUpti_CallbackDomain),
                    enable, subscriber, domain)
 end
 
 @checked function cuptiEnableAllDomains(enable, subscriber)
-    initialize_api()
+    initialize_context()
     ccall((:cuptiEnableAllDomains, libcupti()), CUptiResult,
                    (UInt32, CUpti_SubscriberHandle),
                    enable, subscriber)
 end
 
 @checked function cuptiGetCallbackName(domain, cbid, name)
-    initialize_api()
+    initialize_context()
     ccall((:cuptiGetCallbackName, libcupti()), CUptiResult,
                    (CUpti_CallbackDomain, UInt32, Ptr{Cstring}),
                    domain, cbid, name)
 end
 
 @checked function cuptiSetEventCollectionMode(context, mode)
-    initialize_api()
+    initialize_context()
     ccall((:cuptiSetEventCollectionMode, libcupti()), CUptiResult,
                    (CUcontext, CUpti_EventCollectionMode),
                    context, mode)
 end
 
 @checked function cuptiDeviceGetAttribute(device, attrib, valueSize, value)
-    initialize_api()
+    initialize_context()
     ccall((:cuptiDeviceGetAttribute, libcupti()), CUptiResult,
                    (CUdevice, CUpti_DeviceAttribute, Ptr{Csize_t}, Ptr{Cvoid}),
                    device, attrib, valueSize, value)
 end
 
 @checked function cuptiDeviceGetTimestamp(context, timestamp)
-    initialize_api()
+    initialize_context()
     ccall((:cuptiDeviceGetTimestamp, libcupti()), CUptiResult,
                    (CUcontext, Ptr{UInt64}),
                    context, timestamp)
 end
 
 @checked function cuptiDeviceGetNumEventDomains(device, numDomains)
-    initialize_api()
+    initialize_context()
     ccall((:cuptiDeviceGetNumEventDomains, libcupti()), CUptiResult,
                    (CUdevice, Ptr{UInt32}),
                    device, numDomains)
 end
 
 @checked function cuptiDeviceEnumEventDomains(device, arraySizeBytes, domainArray)
-    initialize_api()
+    initialize_context()
     ccall((:cuptiDeviceEnumEventDomains, libcupti()), CUptiResult,
                    (CUdevice, Ptr{Csize_t}, Ptr{CUpti_EventDomainID}),
                    device, arraySizeBytes, domainArray)
@@ -107,7 +107,7 @@ end
 
 @checked function cuptiDeviceGetEventDomainAttribute(device, eventDomain, attrib,
                                                      valueSize, value)
-    initialize_api()
+    initialize_context()
     ccall((:cuptiDeviceGetEventDomainAttribute, libcupti()), CUptiResult,
                    (CUdevice, CUpti_EventDomainID, CUpti_EventDomainAttribute,
                     Ptr{Csize_t}, Ptr{Cvoid}),
@@ -115,21 +115,21 @@ end
 end
 
 @checked function cuptiGetNumEventDomains(numDomains)
-    initialize_api()
+    initialize_context()
     ccall((:cuptiGetNumEventDomains, libcupti()), CUptiResult,
                    (Ptr{UInt32},),
                    numDomains)
 end
 
 @checked function cuptiEnumEventDomains(arraySizeBytes, domainArray)
-    initialize_api()
+    initialize_context()
     ccall((:cuptiEnumEventDomains, libcupti()), CUptiResult,
                    (Ptr{Csize_t}, Ptr{CUpti_EventDomainID}),
                    arraySizeBytes, domainArray)
 end
 
 @checked function cuptiEventDomainGetAttribute(eventDomain, attrib, valueSize, value)
-    initialize_api()
+    initialize_context()
     ccall((:cuptiEventDomainGetAttribute, libcupti()), CUptiResult,
                    (CUpti_EventDomainID, CUpti_EventDomainAttribute, Ptr{Csize_t},
                     Ptr{Cvoid}),
@@ -137,98 +137,98 @@ end
 end
 
 @checked function cuptiEventDomainGetNumEvents(eventDomain, numEvents)
-    initialize_api()
+    initialize_context()
     ccall((:cuptiEventDomainGetNumEvents, libcupti()), CUptiResult,
                    (CUpti_EventDomainID, Ptr{UInt32}),
                    eventDomain, numEvents)
 end
 
 @checked function cuptiEventDomainEnumEvents(eventDomain, arraySizeBytes, eventArray)
-    initialize_api()
+    initialize_context()
     ccall((:cuptiEventDomainEnumEvents, libcupti()), CUptiResult,
                    (CUpti_EventDomainID, Ptr{Csize_t}, Ptr{CUpti_EventID}),
                    eventDomain, arraySizeBytes, eventArray)
 end
 
 @checked function cuptiEventGetAttribute(event, attrib, valueSize, value)
-    initialize_api()
+    initialize_context()
     ccall((:cuptiEventGetAttribute, libcupti()), CUptiResult,
                    (CUpti_EventID, CUpti_EventAttribute, Ptr{Csize_t}, Ptr{Cvoid}),
                    event, attrib, valueSize, value)
 end
 
 @checked function cuptiEventGetIdFromName(device, eventName, event)
-    initialize_api()
+    initialize_context()
     ccall((:cuptiEventGetIdFromName, libcupti()), CUptiResult,
                    (CUdevice, Cstring, Ptr{CUpti_EventID}),
                    device, eventName, event)
 end
 
 @checked function cuptiEventGroupCreate(context, eventGroup, flags)
-    initialize_api()
+    initialize_context()
     ccall((:cuptiEventGroupCreate, libcupti()), CUptiResult,
                    (CUcontext, Ptr{CUpti_EventGroup}, UInt32),
                    context, eventGroup, flags)
 end
 
 @checked function cuptiEventGroupDestroy(eventGroup)
-    initialize_api()
+    initialize_context()
     ccall((:cuptiEventGroupDestroy, libcupti()), CUptiResult,
                    (CUpti_EventGroup,),
                    eventGroup)
 end
 
 @checked function cuptiEventGroupGetAttribute(eventGroup, attrib, valueSize, value)
-    initialize_api()
+    initialize_context()
     ccall((:cuptiEventGroupGetAttribute, libcupti()), CUptiResult,
                    (CUpti_EventGroup, CUpti_EventGroupAttribute, Ptr{Csize_t}, Ptr{Cvoid}),
                    eventGroup, attrib, valueSize, value)
 end
 
 @checked function cuptiEventGroupSetAttribute(eventGroup, attrib, valueSize, value)
-    initialize_api()
+    initialize_context()
     ccall((:cuptiEventGroupSetAttribute, libcupti()), CUptiResult,
                    (CUpti_EventGroup, CUpti_EventGroupAttribute, Csize_t, Ptr{Cvoid}),
                    eventGroup, attrib, valueSize, value)
 end
 
 @checked function cuptiEventGroupAddEvent(eventGroup, event)
-    initialize_api()
+    initialize_context()
     ccall((:cuptiEventGroupAddEvent, libcupti()), CUptiResult,
                    (CUpti_EventGroup, CUpti_EventID),
                    eventGroup, event)
 end
 
 @checked function cuptiEventGroupRemoveEvent(eventGroup, event)
-    initialize_api()
+    initialize_context()
     ccall((:cuptiEventGroupRemoveEvent, libcupti()), CUptiResult,
                    (CUpti_EventGroup, CUpti_EventID),
                    eventGroup, event)
 end
 
 @checked function cuptiEventGroupRemoveAllEvents(eventGroup)
-    initialize_api()
+    initialize_context()
     ccall((:cuptiEventGroupRemoveAllEvents, libcupti()), CUptiResult,
                    (CUpti_EventGroup,),
                    eventGroup)
 end
 
 @checked function cuptiEventGroupResetAllEvents(eventGroup)
-    initialize_api()
+    initialize_context()
     ccall((:cuptiEventGroupResetAllEvents, libcupti()), CUptiResult,
                    (CUpti_EventGroup,),
                    eventGroup)
 end
 
 @checked function cuptiEventGroupEnable(eventGroup)
-    initialize_api()
+    initialize_context()
     ccall((:cuptiEventGroupEnable, libcupti()), CUptiResult,
                    (CUpti_EventGroup,),
                    eventGroup)
 end
 
 @checked function cuptiEventGroupDisable(eventGroup)
-    initialize_api()
+    initialize_context()
     ccall((:cuptiEventGroupDisable, libcupti()), CUptiResult,
                    (CUpti_EventGroup,),
                    eventGroup)
@@ -236,7 +236,7 @@ end
 
 @checked function cuptiEventGroupReadEvent(eventGroup, flags, event,
                                            eventValueBufferSizeBytes, eventValueBuffer)
-    initialize_api()
+    initialize_context()
     ccall((:cuptiEventGroupReadEvent, libcupti()), CUptiResult,
                    (CUpti_EventGroup, CUpti_ReadEventFlags, CUpti_EventID, Ptr{Csize_t},
                     Ptr{UInt64}),
@@ -247,7 +247,7 @@ end
                                                eventValueBufferSizeBytes, eventValueBuffer,
                                                eventIdArraySizeBytes, eventIdArray,
                                                numEventIdsRead)
-    initialize_api()
+    initialize_context()
     ccall((:cuptiEventGroupReadAllEvents, libcupti()), CUptiResult,
                    (CUpti_EventGroup, CUpti_ReadEventFlags, Ptr{Csize_t}, Ptr{UInt64},
                     Ptr{Csize_t}, Ptr{CUpti_EventID}, Ptr{Csize_t}),
@@ -257,126 +257,126 @@ end
 
 @checked function cuptiEventGroupSetsCreate(context, eventIdArraySizeBytes, eventIdArray,
                                             eventGroupPasses)
-    initialize_api()
+    initialize_context()
     ccall((:cuptiEventGroupSetsCreate, libcupti()), CUptiResult,
                    (CUcontext, Csize_t, Ptr{CUpti_EventID}, Ptr{Ptr{CUpti_EventGroupSets}}),
                    context, eventIdArraySizeBytes, eventIdArray, eventGroupPasses)
 end
 
 @checked function cuptiEventGroupSetsDestroy(eventGroupSets)
-    initialize_api()
+    initialize_context()
     ccall((:cuptiEventGroupSetsDestroy, libcupti()), CUptiResult,
                    (Ptr{CUpti_EventGroupSets},),
                    eventGroupSets)
 end
 
 @checked function cuptiEventGroupSetEnable(eventGroupSet)
-    initialize_api()
+    initialize_context()
     ccall((:cuptiEventGroupSetEnable, libcupti()), CUptiResult,
                    (Ptr{CUpti_EventGroupSet},),
                    eventGroupSet)
 end
 
 @checked function cuptiEventGroupSetDisable(eventGroupSet)
-    initialize_api()
+    initialize_context()
     ccall((:cuptiEventGroupSetDisable, libcupti()), CUptiResult,
                    (Ptr{CUpti_EventGroupSet},),
                    eventGroupSet)
 end
 
 @checked function cuptiEnableKernelReplayMode(context)
-    initialize_api()
+    initialize_context()
     ccall((:cuptiEnableKernelReplayMode, libcupti()), CUptiResult,
                    (CUcontext,),
                    context)
 end
 
 @checked function cuptiDisableKernelReplayMode(context)
-    initialize_api()
+    initialize_context()
     ccall((:cuptiDisableKernelReplayMode, libcupti()), CUptiResult,
                    (CUcontext,),
                    context)
 end
 
 @checked function cuptiKernelReplaySubscribeUpdate(updateFunc, customData)
-    initialize_api()
+    initialize_context()
     ccall((:cuptiKernelReplaySubscribeUpdate, libcupti()), CUptiResult,
                    (CUpti_KernelReplayUpdateFunc, Ptr{Cvoid}),
                    updateFunc, customData)
 end
 
 @checked function cuptiGetNumMetrics(numMetrics)
-    initialize_api()
+    initialize_context()
     ccall((:cuptiGetNumMetrics, libcupti()), CUptiResult,
                    (Ptr{UInt32},),
                    numMetrics)
 end
 
 @checked function cuptiEnumMetrics(arraySizeBytes, metricArray)
-    initialize_api()
+    initialize_context()
     ccall((:cuptiEnumMetrics, libcupti()), CUptiResult,
                    (Ptr{Csize_t}, Ptr{CUpti_MetricID}),
                    arraySizeBytes, metricArray)
 end
 
 @checked function cuptiDeviceGetNumMetrics(device, numMetrics)
-    initialize_api()
+    initialize_context()
     ccall((:cuptiDeviceGetNumMetrics, libcupti()), CUptiResult,
                    (CUdevice, Ptr{UInt32}),
                    device, numMetrics)
 end
 
 @checked function cuptiDeviceEnumMetrics(device, arraySizeBytes, metricArray)
-    initialize_api()
+    initialize_context()
     ccall((:cuptiDeviceEnumMetrics, libcupti()), CUptiResult,
                    (CUdevice, Ptr{Csize_t}, Ptr{CUpti_MetricID}),
                    device, arraySizeBytes, metricArray)
 end
 
 @checked function cuptiMetricGetAttribute(metric, attrib, valueSize, value)
-    initialize_api()
+    initialize_context()
     ccall((:cuptiMetricGetAttribute, libcupti()), CUptiResult,
                    (CUpti_MetricID, CUpti_MetricAttribute, Ptr{Csize_t}, Ptr{Cvoid}),
                    metric, attrib, valueSize, value)
 end
 
 @checked function cuptiMetricGetIdFromName(device, metricName, metric)
-    initialize_api()
+    initialize_context()
     ccall((:cuptiMetricGetIdFromName, libcupti()), CUptiResult,
                    (CUdevice, Cstring, Ptr{CUpti_MetricID}),
                    device, metricName, metric)
 end
 
 @checked function cuptiMetricGetNumEvents(metric, numEvents)
-    initialize_api()
+    initialize_context()
     ccall((:cuptiMetricGetNumEvents, libcupti()), CUptiResult,
                    (CUpti_MetricID, Ptr{UInt32}),
                    metric, numEvents)
 end
 
 @checked function cuptiMetricEnumEvents(metric, eventIdArraySizeBytes, eventIdArray)
-    initialize_api()
+    initialize_context()
     ccall((:cuptiMetricEnumEvents, libcupti()), CUptiResult,
                    (CUpti_MetricID, Ptr{Csize_t}, Ptr{CUpti_EventID}),
                    metric, eventIdArraySizeBytes, eventIdArray)
 end
 
 @checked function cuptiMetricGetNumProperties(metric, numProp)
-    initialize_api()
+    initialize_context()
     ccall((:cuptiMetricGetNumProperties, libcupti()), CUptiResult,
                    (CUpti_MetricID, Ptr{UInt32}),
                    metric, numProp)
 end
 
 @checked function cuptiMetricEnumProperties(metric, propIdArraySizeBytes, propIdArray)
-    initialize_api()
+    initialize_context()
     ccall((:cuptiMetricEnumProperties, libcupti()), CUptiResult,
                    (CUpti_MetricID, Ptr{Csize_t}, Ptr{CUpti_MetricPropertyID}),
                    metric, propIdArraySizeBytes, propIdArray)
 end
 
 @checked function cuptiMetricGetRequiredEventGroupSets(context, metric, eventGroupSets)
-    initialize_api()
+    initialize_context()
     ccall((:cuptiMetricGetRequiredEventGroupSets, libcupti()), CUptiResult,
                    (CUcontext, CUpti_MetricID, Ptr{Ptr{CUpti_EventGroupSets}}),
                    context, metric, eventGroupSets)
@@ -384,7 +384,7 @@ end
 
 @checked function cuptiMetricCreateEventGroupSets(context, metricIdArraySizeBytes,
                                                   metricIdArray, eventGroupPasses)
-    initialize_api()
+    initialize_context()
     ccall((:cuptiMetricCreateEventGroupSets, libcupti()), CUptiResult,
                    (CUcontext, Csize_t, Ptr{CUpti_MetricID},
                     Ptr{Ptr{CUpti_EventGroupSets}}),
@@ -394,7 +394,7 @@ end
 @checked function cuptiMetricGetValue(device, metric, eventIdArraySizeBytes, eventIdArray,
                                       eventValueArraySizeBytes, eventValueArray,
                                       timeDuration, metricValue)
-    initialize_api()
+    initialize_context()
     ccall((:cuptiMetricGetValue, libcupti()), CUptiResult,
                    (CUdevice, CUpti_MetricID, Csize_t, Ptr{CUpti_EventID}, Csize_t,
                     Ptr{UInt64}, UInt64, Ptr{CUpti_MetricValue}),
@@ -406,7 +406,7 @@ end
                                        eventValueArraySizeBytes, eventValueArray,
                                        propIdArraySizeBytes, propIdArray,
                                        propValueArraySizeBytes, propValueArray, metricValue)
-    initialize_api()
+    initialize_context()
     ccall((:cuptiMetricGetValue2, libcupti()), CUptiResult,
                    (CUpti_MetricID, Csize_t, Ptr{CUpti_EventID}, Csize_t, Ptr{UInt64},
                     Csize_t, Ptr{CUpti_MetricPropertyID}, Csize_t, Ptr{UInt64},
@@ -417,206 +417,206 @@ end
 end
 
 @checked function cuptiGetTimestamp(timestamp)
-    initialize_api()
+    initialize_context()
     ccall((:cuptiGetTimestamp, libcupti()), CUptiResult,
                    (Ptr{UInt64},),
                    timestamp)
 end
 
 @checked function cuptiGetContextId(context, contextId)
-    initialize_api()
+    initialize_context()
     ccall((:cuptiGetContextId, libcupti()), CUptiResult,
                    (CUcontext, Ptr{UInt32}),
                    context, contextId)
 end
 
 @checked function cuptiGetStreamId(context, stream, streamId)
-    initialize_api()
+    initialize_context()
     ccall((:cuptiGetStreamId, libcupti()), CUptiResult,
                    (CUcontext, CUstream, Ptr{UInt32}),
                    context, stream, streamId)
 end
 
 @checked function cuptiGetStreamIdEx(context, stream, perThreadStream, streamId)
-    initialize_api()
+    initialize_context()
     ccall((:cuptiGetStreamIdEx, libcupti()), CUptiResult,
                    (CUcontext, CUstream, UInt8, Ptr{UInt32}),
                    context, stream, perThreadStream, streamId)
 end
 
 @checked function cuptiGetDeviceId(context, deviceId)
-    initialize_api()
+    initialize_context()
     ccall((:cuptiGetDeviceId, libcupti()), CUptiResult,
                    (CUcontext, Ptr{UInt32}),
                    context, deviceId)
 end
 
 @checked function cuptiGetGraphNodeId(node, nodeId)
-    initialize_api()
+    initialize_context()
     ccall((:cuptiGetGraphNodeId, libcupti()), CUptiResult,
                    (CUgraphNode, Ptr{UInt64}),
                    node, nodeId)
 end
 
 @checked function cuptiActivityEnable(kind)
-    initialize_api()
+    initialize_context()
     ccall((:cuptiActivityEnable, libcupti()), CUptiResult,
                    (CUpti_ActivityKind,),
                    kind)
 end
 
 @checked function cuptiActivityDisable(kind)
-    initialize_api()
+    initialize_context()
     ccall((:cuptiActivityDisable, libcupti()), CUptiResult,
                    (CUpti_ActivityKind,),
                    kind)
 end
 
 @checked function cuptiActivityEnableContext(context, kind)
-    initialize_api()
+    initialize_context()
     ccall((:cuptiActivityEnableContext, libcupti()), CUptiResult,
                    (CUcontext, CUpti_ActivityKind),
                    context, kind)
 end
 
 @checked function cuptiActivityDisableContext(context, kind)
-    initialize_api()
+    initialize_context()
     ccall((:cuptiActivityDisableContext, libcupti()), CUptiResult,
                    (CUcontext, CUpti_ActivityKind),
                    context, kind)
 end
 
 @checked function cuptiActivityGetNumDroppedRecords(context, streamId, dropped)
-    initialize_api()
+    initialize_context()
     ccall((:cuptiActivityGetNumDroppedRecords, libcupti()), CUptiResult,
                    (CUcontext, UInt32, Ptr{Csize_t}),
                    context, streamId, dropped)
 end
 
 @checked function cuptiActivityGetNextRecord(buffer, validBufferSizeBytes, record)
-    initialize_api()
+    initialize_context()
     ccall((:cuptiActivityGetNextRecord, libcupti()), CUptiResult,
                    (Ptr{UInt8}, Csize_t, Ptr{Ptr{CUpti_Activity}}),
                    buffer, validBufferSizeBytes, record)
 end
 
 @checked function cuptiActivityRegisterCallbacks(funcBufferRequested, funcBufferCompleted)
-    initialize_api()
+    initialize_context()
     ccall((:cuptiActivityRegisterCallbacks, libcupti()), CUptiResult,
                    (CUpti_BuffersCallbackRequestFunc, CUpti_BuffersCallbackCompleteFunc),
                    funcBufferRequested, funcBufferCompleted)
 end
 
 @checked function cuptiActivityFlush(context, streamId, flag)
-    initialize_api()
+    initialize_context()
     ccall((:cuptiActivityFlush, libcupti()), CUptiResult,
                    (CUcontext, UInt32, UInt32),
                    context, streamId, flag)
 end
 
 @checked function cuptiActivityFlushAll(flag)
-    initialize_api()
+    initialize_context()
     ccall((:cuptiActivityFlushAll, libcupti()), CUptiResult,
                    (UInt32,),
                    flag)
 end
 
 @checked function cuptiActivityGetAttribute(attr, valueSize, value)
-    initialize_api()
+    initialize_context()
     ccall((:cuptiActivityGetAttribute, libcupti()), CUptiResult,
                    (CUpti_ActivityAttribute, Ptr{Csize_t}, Ptr{Cvoid}),
                    attr, valueSize, value)
 end
 
 @checked function cuptiActivitySetAttribute(attr, valueSize, value)
-    initialize_api()
+    initialize_context()
     ccall((:cuptiActivitySetAttribute, libcupti()), CUptiResult,
                    (CUpti_ActivityAttribute, Ptr{Csize_t}, Ptr{Cvoid}),
                    attr, valueSize, value)
 end
 
 @checked function cuptiActivityConfigureUnifiedMemoryCounter(config, count)
-    initialize_api()
+    initialize_context()
     ccall((:cuptiActivityConfigureUnifiedMemoryCounter, libcupti()), CUptiResult,
                    (Ptr{CUpti_ActivityUnifiedMemoryCounterConfig}, UInt32),
                    config, count)
 end
 
 @checked function cuptiGetAutoBoostState(context, state)
-    initialize_api()
+    initialize_context()
     ccall((:cuptiGetAutoBoostState, libcupti()), CUptiResult,
                    (CUcontext, Ptr{CUpti_ActivityAutoBoostState}),
                    context, state)
 end
 
 @checked function cuptiActivityConfigurePCSampling(ctx, config)
-    initialize_api()
+    initialize_context()
     ccall((:cuptiActivityConfigurePCSampling, libcupti()), CUptiResult,
                    (CUcontext, Ptr{CUpti_ActivityPCSamplingConfig}),
                    ctx, config)
 end
 
 @checked function cuptiGetLastError()
-    initialize_api()
+    initialize_context()
     ccall((:cuptiGetLastError, libcupti()), CUptiResult, ())
 end
 
 @checked function cuptiSetThreadIdType(type)
-    initialize_api()
+    initialize_context()
     ccall((:cuptiSetThreadIdType, libcupti()), CUptiResult,
                    (CUpti_ActivityThreadIdType,),
                    type)
 end
 
 @checked function cuptiGetThreadIdType(type)
-    initialize_api()
+    initialize_context()
     ccall((:cuptiGetThreadIdType, libcupti()), CUptiResult,
                    (Ptr{CUpti_ActivityThreadIdType},),
                    type)
 end
 
 @checked function cuptiComputeCapabilitySupported(major, minor, support)
-    initialize_api()
+    initialize_context()
     ccall((:cuptiComputeCapabilitySupported, libcupti()), CUptiResult,
                    (Cint, Cint, Ptr{Cint}),
                    major, minor, support)
 end
 
 @checked function cuptiDeviceSupported(dev, support)
-    initialize_api()
+    initialize_context()
     ccall((:cuptiDeviceSupported, libcupti()), CUptiResult,
                    (CUdevice, Ptr{Cint}),
                    dev, support)
 end
 
 @checked function cuptiDeviceVirtualizationMode(dev, mode)
-    initialize_api()
+    initialize_context()
     ccall((:cuptiDeviceVirtualizationMode, libcupti()), CUptiResult,
                    (CUdevice, Ptr{CUpti_DeviceVirtualizationMode}),
                    dev, mode)
 end
 
 @checked function cuptiFinalize()
-    initialize_api()
+    initialize_context()
     ccall((:cuptiFinalize, libcupti()), CUptiResult, ())
 end
 
 @checked function cuptiActivityPushExternalCorrelationId(kind, id)
-    initialize_api()
+    initialize_context()
     ccall((:cuptiActivityPushExternalCorrelationId, libcupti()), CUptiResult,
                    (CUpti_ExternalCorrelationKind, UInt64),
                    kind, id)
 end
 
 @checked function cuptiActivityPopExternalCorrelationId(kind, lastId)
-    initialize_api()
+    initialize_context()
     ccall((:cuptiActivityPopExternalCorrelationId, libcupti()), CUptiResult,
                    (CUpti_ExternalCorrelationKind, Ptr{UInt64}),
                    kind, lastId)
 end
 
 @checked function cuptiActivityEnableLatencyTimestamps(enable)
-    initialize_api()
+    initialize_context()
     ccall((:cuptiActivityEnableLatencyTimestamps, libcupti()), CUptiResult,
                    (UInt8,),
                    enable)
@@ -625,35 +625,35 @@ end
 # Automatically generated using Clang.jl
 
 @checked function cuptiProfilerInitialize(pParams)
-    initialize_api()
+    initialize_context()
     ccall((:cuptiProfilerInitialize, libcupti()), CUptiResult,
                    (Ptr{CUpti_Profiler_Initialize_Params},),
                    pParams)
 end
 
 @checked function cuptiProfilerDeInitialize(pParams)
-    initialize_api()
+    initialize_context()
     ccall((:cuptiProfilerDeInitialize, libcupti()), CUptiResult,
                    (Ptr{CUpti_Profiler_DeInitialize_Params},),
                    pParams)
 end
 
 @checked function cuptiProfilerCounterDataImageCalculateSize(pParams)
-    initialize_api()
+    initialize_context()
     ccall((:cuptiProfilerCounterDataImageCalculateSize, libcupti()), CUptiResult,
                    (Ptr{CUpti_Profiler_CounterDataImage_CalculateSize_Params},),
                    pParams)
 end
 
 @checked function cuptiProfilerCounterDataImageInitialize(pParams)
-    initialize_api()
+    initialize_context()
     ccall((:cuptiProfilerCounterDataImageInitialize, libcupti()), CUptiResult,
                    (Ptr{CUpti_Profiler_CounterDataImage_Initialize_Params},),
                    pParams)
 end
 
 @checked function cuptiProfilerCounterDataImageCalculateScratchBufferSize(pParams)
-    initialize_api()
+    initialize_context()
     ccall((:cuptiProfilerCounterDataImageCalculateScratchBufferSize, libcupti()), CUptiResult,
                    (Ptr{CUpti_Profiler_CounterDataImage_CalculateScratchBufferSize_Params},
                     ),
@@ -661,98 +661,98 @@ end
 end
 
 @checked function cuptiProfilerCounterDataImageInitializeScratchBuffer(pParams)
-    initialize_api()
+    initialize_context()
     ccall((:cuptiProfilerCounterDataImageInitializeScratchBuffer, libcupti()), CUptiResult,
                    (Ptr{CUpti_Profiler_CounterDataImage_InitializeScratchBuffer_Params},),
                    pParams)
 end
 
 @checked function cuptiProfilerBeginSession(pParams)
-    initialize_api()
+    initialize_context()
     ccall((:cuptiProfilerBeginSession, libcupti()), CUptiResult,
                    (Ptr{CUpti_Profiler_BeginSession_Params},),
                    pParams)
 end
 
 @checked function cuptiProfilerEndSession(pParams)
-    initialize_api()
+    initialize_context()
     ccall((:cuptiProfilerEndSession, libcupti()), CUptiResult,
                    (Ptr{CUpti_Profiler_EndSession_Params},),
                    pParams)
 end
 
 @checked function cuptiProfilerSetConfig(pParams)
-    initialize_api()
+    initialize_context()
     ccall((:cuptiProfilerSetConfig, libcupti()), CUptiResult,
                    (Ptr{CUpti_Profiler_SetConfig_Params},),
                    pParams)
 end
 
 @checked function cuptiProfilerUnsetConfig(pParams)
-    initialize_api()
+    initialize_context()
     ccall((:cuptiProfilerUnsetConfig, libcupti()), CUptiResult,
                    (Ptr{CUpti_Profiler_UnsetConfig_Params},),
                    pParams)
 end
 
 @checked function cuptiProfilerBeginPass(pParams)
-    initialize_api()
+    initialize_context()
     ccall((:cuptiProfilerBeginPass, libcupti()), CUptiResult,
                    (Ptr{CUpti_Profiler_BeginPass_Params},),
                    pParams)
 end
 
 @checked function cuptiProfilerEndPass(pParams)
-    initialize_api()
+    initialize_context()
     ccall((:cuptiProfilerEndPass, libcupti()), CUptiResult,
                    (Ptr{CUpti_Profiler_EndPass_Params},),
                    pParams)
 end
 
 @checked function cuptiProfilerEnableProfiling(pParams)
-    initialize_api()
+    initialize_context()
     ccall((:cuptiProfilerEnableProfiling, libcupti()), CUptiResult,
                    (Ptr{CUpti_Profiler_EnableProfiling_Params},),
                    pParams)
 end
 
 @checked function cuptiProfilerDisableProfiling(pParams)
-    initialize_api()
+    initialize_context()
     ccall((:cuptiProfilerDisableProfiling, libcupti()), CUptiResult,
                    (Ptr{CUpti_Profiler_DisableProfiling_Params},),
                    pParams)
 end
 
 @checked function cuptiProfilerIsPassCollected(pParams)
-    initialize_api()
+    initialize_context()
     ccall((:cuptiProfilerIsPassCollected, libcupti()), CUptiResult,
                    (Ptr{CUpti_Profiler_IsPassCollected_Params},),
                    pParams)
 end
 
 @checked function cuptiProfilerFlushCounterData(pParams)
-    initialize_api()
+    initialize_context()
     ccall((:cuptiProfilerFlushCounterData, libcupti()), CUptiResult,
                    (Ptr{CUpti_Profiler_FlushCounterData_Params},),
                    pParams)
 end
 
 @checked function cuptiProfilerPushRange(pParams)
-    initialize_api()
+    initialize_context()
     ccall((:cuptiProfilerPushRange, libcupti()), CUptiResult,
                    (Ptr{CUpti_Profiler_PushRange_Params},),
                    pParams)
 end
 
 @checked function cuptiProfilerPopRange(pParams)
-    initialize_api()
+    initialize_context()
     ccall((:cuptiProfilerPopRange, libcupti()), CUptiResult,
                    (Ptr{CUpti_Profiler_PopRange_Params},),
                    pParams)
 end
 
 @checked function cuptiProfilerGetCounterAvailability(pParams)
-    initialize_api()
+    initialize_context()
     ccall((:cuptiProfilerGetCounterAvailability, libcupti()), CUptiResult,
                    (Ptr{CUpti_Profiler_GetCounterAvailability_Params},),
                    pParams)
@@ -761,19 +761,19 @@ end
 ## Added in CUDA 11.1
 
 @checked function cuptiGetGraphId(graph, pId)
-    initialize_api()
+    initialize_context()
     ccall((:cuptiGetGraphId, libcupti()), CUptiResult, (CUgraph, Ptr{UInt32}), graph, pId)
 end
 
 @checked function cuptiActivityFlushPeriod(time)
-    initialize_api()
+    initialize_context()
     ccall((:cuptiActivityFlushPeriod, libcupti()), CUptiResult, (UInt32,), time)
 end
 
 ## Added in CUDA 11.2
 
 @checked function cuptiActivityEnableLaunchAttributes(enable)
-    initialize_api()
+    initialize_context()
     ccall((:cuptiActivityEnableLaunchAttributes, libcupti()), CUptiResult, (UInt8,), enable)
 end
 

--- a/lib/curand/CURAND.jl
+++ b/lib/curand/CURAND.jl
@@ -4,7 +4,7 @@ using ..APIUtils
 
 using ..CUDA
 using ..CUDA: CUstream, libraryPropertyType, DEVICE_ATTRIBUTE_MAX_THREADS_PER_BLOCK
-using ..CUDA: libcurand, @retry_reclaim
+using ..CUDA: libcurand, @retry_reclaim, initialize_context
 
 using CEnum: @cenum
 

--- a/lib/curand/error.jl
+++ b/lib/curand/error.jl
@@ -57,10 +57,6 @@ end
     end
 end
 
-function initialize_api()
-    CUDA.prepare_cuda_state()
-end
-
 macro check(ex, errs...)
     check = :(isequal(err, CURAND_STATUS_ALLOCATION_FAILED))
     for err in errs

--- a/lib/curand/libcurand.jl
+++ b/lib/curand/libcurand.jl
@@ -2,21 +2,21 @@
 # Automatically generated using Clang.jl
 
 @checked function curandCreateGenerator(generator, rng_type)
-    initialize_api()
+    initialize_context()
     ccall((:curandCreateGenerator, libcurand()), curandStatus_t,
                    (Ptr{curandGenerator_t}, curandRngType_t),
                    generator, rng_type)
 end
 
 @checked function curandCreateGeneratorHost(generator, rng_type)
-    initialize_api()
+    initialize_context()
     ccall((:curandCreateGeneratorHost, libcurand()), curandStatus_t,
                    (Ptr{curandGenerator_t}, curandRngType_t),
                    generator, rng_type)
 end
 
 @checked function curandDestroyGenerator(generator)
-    initialize_api()
+    initialize_context()
     ccall((:curandDestroyGenerator, libcurand()), curandStatus_t,
                    (curandGenerator_t,),
                    generator)
@@ -35,133 +35,133 @@ end
 end
 
 @checked function curandSetStream(generator, stream)
-    initialize_api()
+    initialize_context()
     ccall((:curandSetStream, libcurand()), curandStatus_t,
                    (curandGenerator_t, CUstream),
                    generator, stream)
 end
 
 @checked function curandSetPseudoRandomGeneratorSeed(generator, seed)
-    initialize_api()
+    initialize_context()
     ccall((:curandSetPseudoRandomGeneratorSeed, libcurand()), curandStatus_t,
                    (curandGenerator_t, Culonglong),
                    generator, seed)
 end
 
 @checked function curandSetGeneratorOffset(generator, offset)
-    initialize_api()
+    initialize_context()
     ccall((:curandSetGeneratorOffset, libcurand()), curandStatus_t,
                    (curandGenerator_t, Culonglong),
                    generator, offset)
 end
 
 @checked function curandSetGeneratorOrdering(generator, order)
-    initialize_api()
+    initialize_context()
     ccall((:curandSetGeneratorOrdering, libcurand()), curandStatus_t,
                    (curandGenerator_t, curandOrdering_t),
                    generator, order)
 end
 
 @checked function curandSetQuasiRandomGeneratorDimensions(generator, num_dimensions)
-    initialize_api()
+    initialize_context()
     ccall((:curandSetQuasiRandomGeneratorDimensions, libcurand()), curandStatus_t,
                    (curandGenerator_t, UInt32),
                    generator, num_dimensions)
 end
 
 @checked function curandGenerate(generator, outputPtr, num)
-    initialize_api()
+    initialize_context()
     ccall((:curandGenerate, libcurand()), curandStatus_t,
                    (curandGenerator_t, CuPtr{UInt32}, Csize_t),
                    generator, outputPtr, num)
 end
 
 @checked function curandGenerateLongLong(generator, outputPtr, num)
-    initialize_api()
+    initialize_context()
     ccall((:curandGenerateLongLong, libcurand()), curandStatus_t,
                    (curandGenerator_t, CuPtr{Culonglong}, Csize_t),
                    generator, outputPtr, num)
 end
 
 @checked function curandGenerateUniform(generator, outputPtr, num)
-    initialize_api()
+    initialize_context()
     ccall((:curandGenerateUniform, libcurand()), curandStatus_t,
                    (curandGenerator_t, CuPtr{Cfloat}, Csize_t),
                    generator, outputPtr, num)
 end
 
 @checked function curandGenerateUniformDouble(generator, outputPtr, num)
-    initialize_api()
+    initialize_context()
     ccall((:curandGenerateUniformDouble, libcurand()), curandStatus_t,
                    (curandGenerator_t, CuPtr{Cdouble}, Csize_t),
                    generator, outputPtr, num)
 end
 
 @checked function curandGenerateNormal(generator, outputPtr, n, mean, stddev)
-    initialize_api()
+    initialize_context()
     ccall((:curandGenerateNormal, libcurand()), curandStatus_t,
                    (curandGenerator_t, CuPtr{Cfloat}, Csize_t, Cfloat, Cfloat),
                    generator, outputPtr, n, mean, stddev)
 end
 
 @checked function curandGenerateNormalDouble(generator, outputPtr, n, mean, stddev)
-    initialize_api()
+    initialize_context()
     ccall((:curandGenerateNormalDouble, libcurand()), curandStatus_t,
                    (curandGenerator_t, CuPtr{Cdouble}, Csize_t, Cdouble, Cdouble),
                    generator, outputPtr, n, mean, stddev)
 end
 
 @checked function curandGenerateLogNormal(generator, outputPtr, n, mean, stddev)
-    initialize_api()
+    initialize_context()
     ccall((:curandGenerateLogNormal, libcurand()), curandStatus_t,
                    (curandGenerator_t, CuPtr{Cfloat}, Csize_t, Cfloat, Cfloat),
                    generator, outputPtr, n, mean, stddev)
 end
 
 @checked function curandGenerateLogNormalDouble(generator, outputPtr, n, mean, stddev)
-    initialize_api()
+    initialize_context()
     ccall((:curandGenerateLogNormalDouble, libcurand()), curandStatus_t,
                    (curandGenerator_t, CuPtr{Cdouble}, Csize_t, Cdouble, Cdouble),
                    generator, outputPtr, n, mean, stddev)
 end
 
 @checked function curandCreatePoissonDistribution(lambda, discrete_distribution)
-    initialize_api()
+    initialize_context()
     ccall((:curandCreatePoissonDistribution, libcurand()), curandStatus_t,
                    (Cdouble, Ptr{curandDiscreteDistribution_t}),
                    lambda, discrete_distribution)
 end
 
 @checked function curandDestroyDistribution(discrete_distribution)
-    initialize_api()
+    initialize_context()
     ccall((:curandDestroyDistribution, libcurand()), curandStatus_t,
                    (curandDiscreteDistribution_t,),
                    discrete_distribution)
 end
 
 @checked function curandGeneratePoisson(generator, outputPtr, n, lambda)
-    initialize_api()
+    initialize_context()
     ccall((:curandGeneratePoisson, libcurand()), curandStatus_t,
                    (curandGenerator_t, CuPtr{UInt32}, Csize_t, Cdouble),
                    generator, outputPtr, n, lambda)
 end
 
 @checked function curandGeneratePoissonMethod(generator, outputPtr, n, lambda, method)
-    initialize_api()
+    initialize_context()
     ccall((:curandGeneratePoissonMethod, libcurand()), curandStatus_t,
                    (curandGenerator_t, CuPtr{UInt32}, Csize_t, Cdouble, curandMethod_t),
                    generator, outputPtr, n, lambda, method)
 end
 
 @checked function curandGenerateBinomial(generator, outputPtr, num, n, p)
-    initialize_api()
+    initialize_context()
     ccall((:curandGenerateBinomial, libcurand()), curandStatus_t,
                    (curandGenerator_t, CuPtr{UInt32}, Csize_t, UInt32, Cdouble),
                    generator, outputPtr, num, n, p)
 end
 
 @checked function curandGenerateBinomialMethod(generator, outputPtr, num, n, p, method)
-    initialize_api()
+    initialize_context()
     ccall((:curandGenerateBinomialMethod, libcurand()), curandStatus_t,
                    (curandGenerator_t, CuPtr{UInt32}, Csize_t, UInt32, Cdouble,
                     curandMethod_t),
@@ -169,35 +169,35 @@ end
 end
 
 @checked function curandGenerateSeeds(generator)
-    initialize_api()
+    initialize_context()
     ccall((:curandGenerateSeeds, libcurand()), curandStatus_t,
                    (curandGenerator_t,),
                    generator)
 end
 
 @checked function curandGetDirectionVectors32(vectors, set)
-    initialize_api()
+    initialize_context()
     ccall((:curandGetDirectionVectors32, libcurand()), curandStatus_t,
                    (Ptr{Ptr{curandDirectionVectors32_t}}, curandDirectionVectorSet_t),
                    vectors, set)
 end
 
 @checked function curandGetScrambleConstants32(constants)
-    initialize_api()
+    initialize_context()
     ccall((:curandGetScrambleConstants32, libcurand()), curandStatus_t,
                    (Ptr{Ptr{UInt32}},),
                    constants)
 end
 
 @checked function curandGetDirectionVectors64(vectors, set)
-    initialize_api()
+    initialize_context()
     ccall((:curandGetDirectionVectors64, libcurand()), curandStatus_t,
                    (Ptr{Ptr{curandDirectionVectors64_t}}, curandDirectionVectorSet_t),
                    vectors, set)
 end
 
 @checked function curandGetScrambleConstants64(constants)
-    initialize_api()
+    initialize_context()
     ccall((:curandGetScrambleConstants64, libcurand()), curandStatus_t,
                    (Ptr{Ptr{Culonglong}},),
                    constants)

--- a/lib/cusolver/CUSOLVER.jl
+++ b/lib/cusolver/CUSOLVER.jl
@@ -4,7 +4,7 @@ using ..APIUtils
 
 using ..CUDA
 using ..CUDA: CUstream, cuComplex, cuDoubleComplex, libraryPropertyType, cudaDataType
-using ..CUDA: libcusolver, libcusolvermg, @allowscalar, assertscalar, unsafe_free!, @retry_reclaim, @context!
+using ..CUDA: libcusolver, libcusolvermg, @allowscalar, assertscalar, unsafe_free!, @retry_reclaim, @context!, initialize_context
 
 using ..CUBLAS: cublasFillMode_t, cublasOperation_t, cublasSideMode_t, cublasDiagType_t
 using ..CUSPARSE: cusparseMatDescr_t

--- a/lib/cusolver/error.jl
+++ b/lib/cusolver/error.jl
@@ -47,10 +47,6 @@ end
     end
 end
 
-function initialize_api()
-    CUDA.prepare_cuda_state()
-end
-
 macro check(ex, errs...)
     check = :(isequal(err, CUSOLVER_STATUS_ALLOC_FAILED))
     for err in errs

--- a/lib/cusolver/libcusolver.jl
+++ b/lib/cusolver/libcusolver.jl
@@ -14,56 +14,56 @@ end
 end
 
 @checked function cusolverDnCreate(handle)
-    initialize_api()
+    initialize_context()
     ccall((:cusolverDnCreate, libcusolver()), cusolverStatus_t,
                    (Ptr{cusolverDnHandle_t},),
                    handle)
 end
 
 @checked function cusolverDnDestroy(handle)
-    initialize_api()
+    initialize_context()
     ccall((:cusolverDnDestroy, libcusolver()), cusolverStatus_t,
                    (cusolverDnHandle_t,),
                    handle)
 end
 
 @checked function cusolverDnSetStream(handle, streamId)
-    initialize_api()
+    initialize_context()
     ccall((:cusolverDnSetStream, libcusolver()), cusolverStatus_t,
                    (cusolverDnHandle_t, CUstream),
                    handle, streamId)
 end
 
 @checked function cusolverDnGetStream(handle, streamId)
-    initialize_api()
+    initialize_context()
     ccall((:cusolverDnGetStream, libcusolver()), cusolverStatus_t,
                    (cusolverDnHandle_t, Ptr{CUstream}),
                    handle, streamId)
 end
 
 @checked function cusolverDnIRSParamsCreate(params_ptr)
-    initialize_api()
+    initialize_context()
     ccall((:cusolverDnIRSParamsCreate, libcusolver()), cusolverStatus_t,
                    (Ptr{cusolverDnIRSParams_t},),
                    params_ptr)
 end
 
 @checked function cusolverDnIRSParamsDestroy(params)
-    initialize_api()
+    initialize_context()
     ccall((:cusolverDnIRSParamsDestroy, libcusolver()), cusolverStatus_t,
                    (cusolverDnIRSParams_t,),
                    params)
 end
 
 @checked function cusolverDnIRSParamsSetRefinementSolver(params, refinement_solver)
-    initialize_api()
+    initialize_context()
     ccall((:cusolverDnIRSParamsSetRefinementSolver, libcusolver()), cusolverStatus_t,
                    (cusolverDnIRSParams_t, cusolverIRSRefinement_t),
                    params, refinement_solver)
 end
 
 @checked function cusolverDnIRSParamsSetSolverMainPrecision(params, solver_main_precision)
-    initialize_api()
+    initialize_context()
     ccall((:cusolverDnIRSParamsSetSolverMainPrecision, libcusolver()), cusolverStatus_t,
                    (cusolverDnIRSParams_t, cusolverPrecType_t),
                    params, solver_main_precision)
@@ -71,7 +71,7 @@ end
 
 @checked function cusolverDnIRSParamsSetSolverLowestPrecision(params,
                                                               solver_lowest_precision)
-    initialize_api()
+    initialize_context()
     ccall((:cusolverDnIRSParamsSetSolverLowestPrecision, libcusolver()), cusolverStatus_t,
                    (cusolverDnIRSParams_t, cusolverPrecType_t),
                    params, solver_lowest_precision)
@@ -79,105 +79,105 @@ end
 
 @checked function cusolverDnIRSParamsSetSolverPrecisions(params, solver_main_precision,
                                                          solver_lowest_precision)
-    initialize_api()
+    initialize_context()
     ccall((:cusolverDnIRSParamsSetSolverPrecisions, libcusolver()), cusolverStatus_t,
                    (cusolverDnIRSParams_t, cusolverPrecType_t, cusolverPrecType_t),
                    params, solver_main_precision, solver_lowest_precision)
 end
 
 @checked function cusolverDnIRSParamsSetTol(params, val)
-    initialize_api()
+    initialize_context()
     ccall((:cusolverDnIRSParamsSetTol, libcusolver()), cusolverStatus_t,
                    (cusolverDnIRSParams_t, Cdouble),
                    params, val)
 end
 
 @checked function cusolverDnIRSParamsSetTolInner(params, val)
-    initialize_api()
+    initialize_context()
     ccall((:cusolverDnIRSParamsSetTolInner, libcusolver()), cusolverStatus_t,
                    (cusolverDnIRSParams_t, Cdouble),
                    params, val)
 end
 
 @checked function cusolverDnIRSParamsSetMaxIters(params, maxiters)
-    initialize_api()
+    initialize_context()
     ccall((:cusolverDnIRSParamsSetMaxIters, libcusolver()), cusolverStatus_t,
                    (cusolverDnIRSParams_t, cusolver_int_t),
                    params, maxiters)
 end
 
 @checked function cusolverDnIRSParamsSetMaxItersInner(params, maxiters_inner)
-    initialize_api()
+    initialize_context()
     ccall((:cusolverDnIRSParamsSetMaxItersInner, libcusolver()), cusolverStatus_t,
                    (cusolverDnIRSParams_t, cusolver_int_t),
                    params, maxiters_inner)
 end
 
 @checked function cusolverDnIRSParamsGetMaxIters(params, maxiters)
-    initialize_api()
+    initialize_context()
     ccall((:cusolverDnIRSParamsGetMaxIters, libcusolver()), cusolverStatus_t,
                    (cusolverDnIRSParams_t, Ptr{cusolver_int_t}),
                    params, maxiters)
 end
 
 @checked function cusolverDnIRSParamsEnableFallback(params)
-    initialize_api()
+    initialize_context()
     ccall((:cusolverDnIRSParamsEnableFallback, libcusolver()), cusolverStatus_t,
                    (cusolverDnIRSParams_t,),
                    params)
 end
 
 @checked function cusolverDnIRSParamsDisableFallback(params)
-    initialize_api()
+    initialize_context()
     ccall((:cusolverDnIRSParamsDisableFallback, libcusolver()), cusolverStatus_t,
                    (cusolverDnIRSParams_t,),
                    params)
 end
 
 @checked function cusolverDnIRSInfosDestroy(infos)
-    initialize_api()
+    initialize_context()
     ccall((:cusolverDnIRSInfosDestroy, libcusolver()), cusolverStatus_t,
                    (cusolverDnIRSInfos_t,),
                    infos)
 end
 
 @checked function cusolverDnIRSInfosCreate(infos_ptr)
-    initialize_api()
+    initialize_context()
     ccall((:cusolverDnIRSInfosCreate, libcusolver()), cusolverStatus_t,
                    (Ptr{cusolverDnIRSInfos_t},),
                    infos_ptr)
 end
 
 @checked function cusolverDnIRSInfosGetNiters(infos, niters)
-    initialize_api()
+    initialize_context()
     ccall((:cusolverDnIRSInfosGetNiters, libcusolver()), cusolverStatus_t,
                    (cusolverDnIRSInfos_t, Ptr{cusolver_int_t}),
                    infos, niters)
 end
 
 @checked function cusolverDnIRSInfosGetOuterNiters(infos, outer_niters)
-    initialize_api()
+    initialize_context()
     ccall((:cusolverDnIRSInfosGetOuterNiters, libcusolver()), cusolverStatus_t,
                    (cusolverDnIRSInfos_t, Ptr{cusolver_int_t}),
                    infos, outer_niters)
 end
 
 @checked function cusolverDnIRSInfosRequestResidual(infos)
-    initialize_api()
+    initialize_context()
     ccall((:cusolverDnIRSInfosRequestResidual, libcusolver()), cusolverStatus_t,
                    (cusolverDnIRSInfos_t,),
                    infos)
 end
 
 @checked function cusolverDnIRSInfosGetResidualHistory(infos, residual_history)
-    initialize_api()
+    initialize_context()
     ccall((:cusolverDnIRSInfosGetResidualHistory, libcusolver()), cusolverStatus_t,
                    (cusolverDnIRSInfos_t, Ptr{Ptr{Cvoid}}),
                    infos, residual_history)
 end
 
 @checked function cusolverDnIRSInfosGetMaxIters(infos, maxiters)
-    initialize_api()
+    initialize_context()
     ccall((:cusolverDnIRSInfosGetMaxIters, libcusolver()), cusolverStatus_t,
                    (cusolverDnIRSInfos_t, Ptr{cusolver_int_t}),
                    infos, maxiters)
@@ -185,7 +185,7 @@ end
 
 @checked function cusolverDnZZgesv(handle, n, nrhs, dA, ldda, dipiv, dB, lddb, dX, lddx,
                                    dWorkspace, lwork_bytes, iter, d_info)
-    initialize_api()
+    initialize_context()
     ccall((:cusolverDnZZgesv, libcusolver()), cusolverStatus_t,
                    (cusolverDnHandle_t, cusolver_int_t, cusolver_int_t,
                     CuPtr{cuDoubleComplex}, cusolver_int_t, CuPtr{cusolver_int_t},
@@ -198,7 +198,7 @@ end
 
 @checked function cusolverDnZCgesv(handle, n, nrhs, dA, ldda, dipiv, dB, lddb, dX, lddx,
                                    dWorkspace, lwork_bytes, iter, d_info)
-    initialize_api()
+    initialize_context()
     ccall((:cusolverDnZCgesv, libcusolver()), cusolverStatus_t,
                    (cusolverDnHandle_t, cusolver_int_t, cusolver_int_t,
                     CuPtr{cuDoubleComplex}, cusolver_int_t, CuPtr{cusolver_int_t},
@@ -211,7 +211,7 @@ end
 
 @checked function cusolverDnZKgesv(handle, n, nrhs, dA, ldda, dipiv, dB, lddb, dX, lddx,
                                    dWorkspace, lwork_bytes, iter, d_info)
-    initialize_api()
+    initialize_context()
     ccall((:cusolverDnZKgesv, libcusolver()), cusolverStatus_t,
                    (cusolverDnHandle_t, cusolver_int_t, cusolver_int_t,
                     CuPtr{cuDoubleComplex}, cusolver_int_t, CuPtr{cusolver_int_t},
@@ -224,7 +224,7 @@ end
 
 @checked function cusolverDnZEgesv(handle, n, nrhs, dA, ldda, dipiv, dB, lddb, dX, lddx,
                                    dWorkspace, lwork_bytes, iter, d_info)
-    initialize_api()
+    initialize_context()
     ccall((:cusolverDnZEgesv, libcusolver()), cusolverStatus_t,
                    (cusolverDnHandle_t, cusolver_int_t, cusolver_int_t,
                     CuPtr{cuDoubleComplex}, cusolver_int_t, CuPtr{cusolver_int_t},
@@ -237,7 +237,7 @@ end
 
 @checked function cusolverDnZYgesv(handle, n, nrhs, dA, ldda, dipiv, dB, lddb, dX, lddx,
                                    dWorkspace, lwork_bytes, iter, d_info)
-    initialize_api()
+    initialize_context()
     ccall((:cusolverDnZYgesv, libcusolver()), cusolverStatus_t,
                    (cusolverDnHandle_t, cusolver_int_t, cusolver_int_t,
                     CuPtr{cuDoubleComplex}, cusolver_int_t, CuPtr{cusolver_int_t},
@@ -250,7 +250,7 @@ end
 
 @checked function cusolverDnCCgesv(handle, n, nrhs, dA, ldda, dipiv, dB, lddb, dX, lddx,
                                    dWorkspace, lwork_bytes, iter, d_info)
-    initialize_api()
+    initialize_context()
     ccall((:cusolverDnCCgesv, libcusolver()), cusolverStatus_t,
                    (cusolverDnHandle_t, cusolver_int_t, cusolver_int_t, CuPtr{cuComplex},
                     cusolver_int_t, CuPtr{cusolver_int_t}, CuPtr{cuComplex},
@@ -262,7 +262,7 @@ end
 
 @checked function cusolverDnCEgesv(handle, n, nrhs, dA, ldda, dipiv, dB, lddb, dX, lddx,
                                    dWorkspace, lwork_bytes, iter, d_info)
-    initialize_api()
+    initialize_context()
     ccall((:cusolverDnCEgesv, libcusolver()), cusolverStatus_t,
                    (cusolverDnHandle_t, cusolver_int_t, cusolver_int_t, CuPtr{cuComplex},
                     cusolver_int_t, CuPtr{cusolver_int_t}, CuPtr{cuComplex},
@@ -274,7 +274,7 @@ end
 
 @checked function cusolverDnCKgesv(handle, n, nrhs, dA, ldda, dipiv, dB, lddb, dX, lddx,
                                    dWorkspace, lwork_bytes, iter, d_info)
-    initialize_api()
+    initialize_context()
     ccall((:cusolverDnCKgesv, libcusolver()), cusolverStatus_t,
                    (cusolverDnHandle_t, cusolver_int_t, cusolver_int_t, CuPtr{cuComplex},
                     cusolver_int_t, CuPtr{cusolver_int_t}, CuPtr{cuComplex},
@@ -286,7 +286,7 @@ end
 
 @checked function cusolverDnCYgesv(handle, n, nrhs, dA, ldda, dipiv, dB, lddb, dX, lddx,
                                    dWorkspace, lwork_bytes, iter, d_info)
-    initialize_api()
+    initialize_context()
     ccall((:cusolverDnCYgesv, libcusolver()), cusolverStatus_t,
                    (cusolverDnHandle_t, cusolver_int_t, cusolver_int_t, CuPtr{cuComplex},
                     cusolver_int_t, CuPtr{cusolver_int_t}, CuPtr{cuComplex},
@@ -298,7 +298,7 @@ end
 
 @checked function cusolverDnDDgesv(handle, n, nrhs, dA, ldda, dipiv, dB, lddb, dX, lddx,
                                    dWorkspace, lwork_bytes, iter, d_info)
-    initialize_api()
+    initialize_context()
     ccall((:cusolverDnDDgesv, libcusolver()), cusolverStatus_t,
                    (cusolverDnHandle_t, cusolver_int_t, cusolver_int_t, CuPtr{Cdouble},
                     cusolver_int_t, CuPtr{cusolver_int_t}, CuPtr{Cdouble}, cusolver_int_t,
@@ -310,7 +310,7 @@ end
 
 @checked function cusolverDnDSgesv(handle, n, nrhs, dA, ldda, dipiv, dB, lddb, dX, lddx,
                                    dWorkspace, lwork_bytes, iter, d_info)
-    initialize_api()
+    initialize_context()
     ccall((:cusolverDnDSgesv, libcusolver()), cusolverStatus_t,
                    (cusolverDnHandle_t, cusolver_int_t, cusolver_int_t, CuPtr{Cdouble},
                     cusolver_int_t, CuPtr{cusolver_int_t}, CuPtr{Cdouble}, cusolver_int_t,
@@ -322,7 +322,7 @@ end
 
 @checked function cusolverDnDHgesv(handle, n, nrhs, dA, ldda, dipiv, dB, lddb, dX, lddx,
                                    dWorkspace, lwork_bytes, iter, d_info)
-    initialize_api()
+    initialize_context()
     ccall((:cusolverDnDHgesv, libcusolver()), cusolverStatus_t,
                    (cusolverDnHandle_t, cusolver_int_t, cusolver_int_t, CuPtr{Cdouble},
                     cusolver_int_t, CuPtr{cusolver_int_t}, CuPtr{Cdouble}, cusolver_int_t,
@@ -334,7 +334,7 @@ end
 
 @checked function cusolverDnDBgesv(handle, n, nrhs, dA, ldda, dipiv, dB, lddb, dX, lddx,
                                    dWorkspace, lwork_bytes, iter, d_info)
-    initialize_api()
+    initialize_context()
     ccall((:cusolverDnDBgesv, libcusolver()), cusolverStatus_t,
                    (cusolverDnHandle_t, cusolver_int_t, cusolver_int_t, CuPtr{Cdouble},
                     cusolver_int_t, CuPtr{cusolver_int_t}, CuPtr{Cdouble}, cusolver_int_t,
@@ -346,7 +346,7 @@ end
 
 @checked function cusolverDnDXgesv(handle, n, nrhs, dA, ldda, dipiv, dB, lddb, dX, lddx,
                                    dWorkspace, lwork_bytes, iter, d_info)
-    initialize_api()
+    initialize_context()
     ccall((:cusolverDnDXgesv, libcusolver()), cusolverStatus_t,
                    (cusolverDnHandle_t, cusolver_int_t, cusolver_int_t, CuPtr{Cdouble},
                     cusolver_int_t, CuPtr{cusolver_int_t}, CuPtr{Cdouble}, cusolver_int_t,
@@ -358,7 +358,7 @@ end
 
 @checked function cusolverDnSSgesv(handle, n, nrhs, dA, ldda, dipiv, dB, lddb, dX, lddx,
                                    dWorkspace, lwork_bytes, iter, d_info)
-    initialize_api()
+    initialize_context()
     ccall((:cusolverDnSSgesv, libcusolver()), cusolverStatus_t,
                    (cusolverDnHandle_t, cusolver_int_t, cusolver_int_t, CuPtr{Cfloat},
                     cusolver_int_t, CuPtr{cusolver_int_t}, CuPtr{Cfloat}, cusolver_int_t,
@@ -370,7 +370,7 @@ end
 
 @checked function cusolverDnSHgesv(handle, n, nrhs, dA, ldda, dipiv, dB, lddb, dX, lddx,
                                    dWorkspace, lwork_bytes, iter, d_info)
-    initialize_api()
+    initialize_context()
     ccall((:cusolverDnSHgesv, libcusolver()), cusolverStatus_t,
                    (cusolverDnHandle_t, cusolver_int_t, cusolver_int_t, CuPtr{Cfloat},
                     cusolver_int_t, CuPtr{cusolver_int_t}, CuPtr{Cfloat}, cusolver_int_t,
@@ -382,7 +382,7 @@ end
 
 @checked function cusolverDnSBgesv(handle, n, nrhs, dA, ldda, dipiv, dB, lddb, dX, lddx,
                                    dWorkspace, lwork_bytes, iter, d_info)
-    initialize_api()
+    initialize_context()
     ccall((:cusolverDnSBgesv, libcusolver()), cusolverStatus_t,
                    (cusolverDnHandle_t, cusolver_int_t, cusolver_int_t, CuPtr{Cfloat},
                     cusolver_int_t, CuPtr{cusolver_int_t}, CuPtr{Cfloat}, cusolver_int_t,
@@ -394,7 +394,7 @@ end
 
 @checked function cusolverDnSXgesv(handle, n, nrhs, dA, ldda, dipiv, dB, lddb, dX, lddx,
                                    dWorkspace, lwork_bytes, iter, d_info)
-    initialize_api()
+    initialize_context()
     ccall((:cusolverDnSXgesv, libcusolver()), cusolverStatus_t,
                    (cusolverDnHandle_t, cusolver_int_t, cusolver_int_t, CuPtr{Cfloat},
                     cusolver_int_t, CuPtr{cusolver_int_t}, CuPtr{Cfloat}, cusolver_int_t,
@@ -406,7 +406,7 @@ end
 
 @checked function cusolverDnZZgesv_bufferSize(handle, n, nrhs, dA, ldda, dipiv, dB, lddb,
                                               dX, lddx, dWorkspace, lwork_bytes)
-    initialize_api()
+    initialize_context()
     ccall((:cusolverDnZZgesv_bufferSize, libcusolver()), cusolverStatus_t,
                    (cusolverDnHandle_t, cusolver_int_t, cusolver_int_t,
                     CuPtr{cuDoubleComplex}, cusolver_int_t, CuPtr{cusolver_int_t},
@@ -418,7 +418,7 @@ end
 
 @checked function cusolverDnZCgesv_bufferSize(handle, n, nrhs, dA, ldda, dipiv, dB, lddb,
                                               dX, lddx, dWorkspace, lwork_bytes)
-    initialize_api()
+    initialize_context()
     ccall((:cusolverDnZCgesv_bufferSize, libcusolver()), cusolverStatus_t,
                    (cusolverDnHandle_t, cusolver_int_t, cusolver_int_t,
                     CuPtr{cuDoubleComplex}, cusolver_int_t, CuPtr{cusolver_int_t},
@@ -430,7 +430,7 @@ end
 
 @checked function cusolverDnZKgesv_bufferSize(handle, n, nrhs, dA, ldda, dipiv, dB, lddb,
                                               dX, lddx, dWorkspace, lwork_bytes)
-    initialize_api()
+    initialize_context()
     ccall((:cusolverDnZKgesv_bufferSize, libcusolver()), cusolverStatus_t,
                    (cusolverDnHandle_t, cusolver_int_t, cusolver_int_t,
                     CuPtr{cuDoubleComplex}, cusolver_int_t, CuPtr{cusolver_int_t},
@@ -442,7 +442,7 @@ end
 
 @checked function cusolverDnZEgesv_bufferSize(handle, n, nrhs, dA, ldda, dipiv, dB, lddb,
                                               dX, lddx, dWorkspace, lwork_bytes)
-    initialize_api()
+    initialize_context()
     ccall((:cusolverDnZEgesv_bufferSize, libcusolver()), cusolverStatus_t,
                    (cusolverDnHandle_t, cusolver_int_t, cusolver_int_t,
                     CuPtr{cuDoubleComplex}, cusolver_int_t, CuPtr{cusolver_int_t},
@@ -454,7 +454,7 @@ end
 
 @checked function cusolverDnZYgesv_bufferSize(handle, n, nrhs, dA, ldda, dipiv, dB, lddb,
                                               dX, lddx, dWorkspace, lwork_bytes)
-    initialize_api()
+    initialize_context()
     ccall((:cusolverDnZYgesv_bufferSize, libcusolver()), cusolverStatus_t,
                    (cusolverDnHandle_t, cusolver_int_t, cusolver_int_t,
                     CuPtr{cuDoubleComplex}, cusolver_int_t, CuPtr{cusolver_int_t},
@@ -466,7 +466,7 @@ end
 
 @checked function cusolverDnCCgesv_bufferSize(handle, n, nrhs, dA, ldda, dipiv, dB, lddb,
                                               dX, lddx, dWorkspace, lwork_bytes)
-    initialize_api()
+    initialize_context()
     ccall((:cusolverDnCCgesv_bufferSize, libcusolver()), cusolverStatus_t,
                    (cusolverDnHandle_t, cusolver_int_t, cusolver_int_t, CuPtr{cuComplex},
                     cusolver_int_t, CuPtr{cusolver_int_t}, CuPtr{cuComplex},
@@ -478,7 +478,7 @@ end
 
 @checked function cusolverDnCKgesv_bufferSize(handle, n, nrhs, dA, ldda, dipiv, dB, lddb,
                                               dX, lddx, dWorkspace, lwork_bytes)
-    initialize_api()
+    initialize_context()
     ccall((:cusolverDnCKgesv_bufferSize, libcusolver()), cusolverStatus_t,
                    (cusolverDnHandle_t, cusolver_int_t, cusolver_int_t, CuPtr{cuComplex},
                     cusolver_int_t, CuPtr{cusolver_int_t}, CuPtr{cuComplex},
@@ -490,7 +490,7 @@ end
 
 @checked function cusolverDnCEgesv_bufferSize(handle, n, nrhs, dA, ldda, dipiv, dB, lddb,
                                               dX, lddx, dWorkspace, lwork_bytes)
-    initialize_api()
+    initialize_context()
     ccall((:cusolverDnCEgesv_bufferSize, libcusolver()), cusolverStatus_t,
                    (cusolverDnHandle_t, cusolver_int_t, cusolver_int_t, CuPtr{cuComplex},
                     cusolver_int_t, CuPtr{cusolver_int_t}, CuPtr{cuComplex},
@@ -502,7 +502,7 @@ end
 
 @checked function cusolverDnCYgesv_bufferSize(handle, n, nrhs, dA, ldda, dipiv, dB, lddb,
                                               dX, lddx, dWorkspace, lwork_bytes)
-    initialize_api()
+    initialize_context()
     ccall((:cusolverDnCYgesv_bufferSize, libcusolver()), cusolverStatus_t,
                    (cusolverDnHandle_t, cusolver_int_t, cusolver_int_t, CuPtr{cuComplex},
                     cusolver_int_t, CuPtr{cusolver_int_t}, CuPtr{cuComplex},
@@ -514,7 +514,7 @@ end
 
 @checked function cusolverDnDDgesv_bufferSize(handle, n, nrhs, dA, ldda, dipiv, dB, lddb,
                                               dX, lddx, dWorkspace, lwork_bytes)
-    initialize_api()
+    initialize_context()
     ccall((:cusolverDnDDgesv_bufferSize, libcusolver()), cusolverStatus_t,
                    (cusolverDnHandle_t, cusolver_int_t, cusolver_int_t, CuPtr{Cdouble},
                     cusolver_int_t, CuPtr{cusolver_int_t}, CuPtr{Cdouble}, cusolver_int_t,
@@ -525,7 +525,7 @@ end
 
 @checked function cusolverDnDSgesv_bufferSize(handle, n, nrhs, dA, ldda, dipiv, dB, lddb,
                                               dX, lddx, dWorkspace, lwork_bytes)
-    initialize_api()
+    initialize_context()
     ccall((:cusolverDnDSgesv_bufferSize, libcusolver()), cusolverStatus_t,
                    (cusolverDnHandle_t, cusolver_int_t, cusolver_int_t, CuPtr{Cdouble},
                     cusolver_int_t, CuPtr{cusolver_int_t}, CuPtr{Cdouble}, cusolver_int_t,
@@ -536,7 +536,7 @@ end
 
 @checked function cusolverDnDHgesv_bufferSize(handle, n, nrhs, dA, ldda, dipiv, dB, lddb,
                                               dX, lddx, dWorkspace, lwork_bytes)
-    initialize_api()
+    initialize_context()
     ccall((:cusolverDnDHgesv_bufferSize, libcusolver()), cusolverStatus_t,
                    (cusolverDnHandle_t, cusolver_int_t, cusolver_int_t, CuPtr{Cdouble},
                     cusolver_int_t, CuPtr{cusolver_int_t}, CuPtr{Cdouble}, cusolver_int_t,
@@ -547,7 +547,7 @@ end
 
 @checked function cusolverDnDBgesv_bufferSize(handle, n, nrhs, dA, ldda, dipiv, dB, lddb,
                                               dX, lddx, dWorkspace, lwork_bytes)
-    initialize_api()
+    initialize_context()
     ccall((:cusolverDnDBgesv_bufferSize, libcusolver()), cusolverStatus_t,
                    (cusolverDnHandle_t, cusolver_int_t, cusolver_int_t, CuPtr{Cdouble},
                     cusolver_int_t, CuPtr{cusolver_int_t}, CuPtr{Cdouble}, cusolver_int_t,
@@ -558,7 +558,7 @@ end
 
 @checked function cusolverDnDXgesv_bufferSize(handle, n, nrhs, dA, ldda, dipiv, dB, lddb,
                                               dX, lddx, dWorkspace, lwork_bytes)
-    initialize_api()
+    initialize_context()
     ccall((:cusolverDnDXgesv_bufferSize, libcusolver()), cusolverStatus_t,
                    (cusolverDnHandle_t, cusolver_int_t, cusolver_int_t, CuPtr{Cdouble},
                     cusolver_int_t, CuPtr{cusolver_int_t}, CuPtr{Cdouble}, cusolver_int_t,
@@ -569,7 +569,7 @@ end
 
 @checked function cusolverDnSSgesv_bufferSize(handle, n, nrhs, dA, ldda, dipiv, dB, lddb,
                                               dX, lddx, dWorkspace, lwork_bytes)
-    initialize_api()
+    initialize_context()
     ccall((:cusolverDnSSgesv_bufferSize, libcusolver()), cusolverStatus_t,
                    (cusolverDnHandle_t, cusolver_int_t, cusolver_int_t, CuPtr{Cfloat},
                     cusolver_int_t, CuPtr{cusolver_int_t}, CuPtr{Cfloat}, cusolver_int_t,
@@ -580,7 +580,7 @@ end
 
 @checked function cusolverDnSHgesv_bufferSize(handle, n, nrhs, dA, ldda, dipiv, dB, lddb,
                                               dX, lddx, dWorkspace, lwork_bytes)
-    initialize_api()
+    initialize_context()
     ccall((:cusolverDnSHgesv_bufferSize, libcusolver()), cusolverStatus_t,
                    (cusolverDnHandle_t, cusolver_int_t, cusolver_int_t, CuPtr{Cfloat},
                     cusolver_int_t, CuPtr{cusolver_int_t}, CuPtr{Cfloat}, cusolver_int_t,
@@ -591,7 +591,7 @@ end
 
 @checked function cusolverDnSBgesv_bufferSize(handle, n, nrhs, dA, ldda, dipiv, dB, lddb,
                                               dX, lddx, dWorkspace, lwork_bytes)
-    initialize_api()
+    initialize_context()
     ccall((:cusolverDnSBgesv_bufferSize, libcusolver()), cusolverStatus_t,
                    (cusolverDnHandle_t, cusolver_int_t, cusolver_int_t, CuPtr{Cfloat},
                     cusolver_int_t, CuPtr{cusolver_int_t}, CuPtr{Cfloat}, cusolver_int_t,
@@ -602,7 +602,7 @@ end
 
 @checked function cusolverDnSXgesv_bufferSize(handle, n, nrhs, dA, ldda, dipiv, dB, lddb,
                                               dX, lddx, dWorkspace, lwork_bytes)
-    initialize_api()
+    initialize_context()
     ccall((:cusolverDnSXgesv_bufferSize, libcusolver()), cusolverStatus_t,
                    (cusolverDnHandle_t, cusolver_int_t, cusolver_int_t, CuPtr{Cfloat},
                     cusolver_int_t, CuPtr{cusolver_int_t}, CuPtr{Cfloat}, cusolver_int_t,
@@ -613,7 +613,7 @@ end
 
 @checked function cusolverDnZZgels(handle, m, n, nrhs, dA, ldda, dB, lddb, dX, lddx,
                                    dWorkspace, lwork_bytes, iter, d_info)
-    initialize_api()
+    initialize_context()
     ccall((:cusolverDnZZgels, libcusolver()), cusolverStatus_t,
                    (cusolverDnHandle_t, cusolver_int_t, cusolver_int_t, cusolver_int_t,
                     CuPtr{cuDoubleComplex}, cusolver_int_t, CuPtr{cuDoubleComplex},
@@ -625,7 +625,7 @@ end
 
 @checked function cusolverDnZCgels(handle, m, n, nrhs, dA, ldda, dB, lddb, dX, lddx,
                                    dWorkspace, lwork_bytes, iter, d_info)
-    initialize_api()
+    initialize_context()
     ccall((:cusolverDnZCgels, libcusolver()), cusolverStatus_t,
                    (cusolverDnHandle_t, cusolver_int_t, cusolver_int_t, cusolver_int_t,
                     CuPtr{cuDoubleComplex}, cusolver_int_t, CuPtr{cuDoubleComplex},
@@ -637,7 +637,7 @@ end
 
 @checked function cusolverDnZKgels(handle, m, n, nrhs, dA, ldda, dB, lddb, dX, lddx,
                                    dWorkspace, lwork_bytes, iter, d_info)
-    initialize_api()
+    initialize_context()
     ccall((:cusolverDnZKgels, libcusolver()), cusolverStatus_t,
                    (cusolverDnHandle_t, cusolver_int_t, cusolver_int_t, cusolver_int_t,
                     CuPtr{cuDoubleComplex}, cusolver_int_t, CuPtr{cuDoubleComplex},
@@ -649,7 +649,7 @@ end
 
 @checked function cusolverDnZEgels(handle, m, n, nrhs, dA, ldda, dB, lddb, dX, lddx,
                                    dWorkspace, lwork_bytes, iter, d_info)
-    initialize_api()
+    initialize_context()
     ccall((:cusolverDnZEgels, libcusolver()), cusolverStatus_t,
                    (cusolverDnHandle_t, cusolver_int_t, cusolver_int_t, cusolver_int_t,
                     CuPtr{cuDoubleComplex}, cusolver_int_t, CuPtr{cuDoubleComplex},
@@ -661,7 +661,7 @@ end
 
 @checked function cusolverDnZYgels(handle, m, n, nrhs, dA, ldda, dB, lddb, dX, lddx,
                                    dWorkspace, lwork_bytes, iter, d_info)
-    initialize_api()
+    initialize_context()
     ccall((:cusolverDnZYgels, libcusolver()), cusolverStatus_t,
                    (cusolverDnHandle_t, cusolver_int_t, cusolver_int_t, cusolver_int_t,
                     CuPtr{cuDoubleComplex}, cusolver_int_t, CuPtr{cuDoubleComplex},
@@ -673,7 +673,7 @@ end
 
 @checked function cusolverDnCCgels(handle, m, n, nrhs, dA, ldda, dB, lddb, dX, lddx,
                                    dWorkspace, lwork_bytes, iter, d_info)
-    initialize_api()
+    initialize_context()
     ccall((:cusolverDnCCgels, libcusolver()), cusolverStatus_t,
                    (cusolverDnHandle_t, cusolver_int_t, cusolver_int_t, cusolver_int_t,
                     CuPtr{cuComplex}, cusolver_int_t, CuPtr{cuComplex}, cusolver_int_t,
@@ -685,7 +685,7 @@ end
 
 @checked function cusolverDnCKgels(handle, m, n, nrhs, dA, ldda, dB, lddb, dX, lddx,
                                    dWorkspace, lwork_bytes, iter, d_info)
-    initialize_api()
+    initialize_context()
     ccall((:cusolverDnCKgels, libcusolver()), cusolverStatus_t,
                    (cusolverDnHandle_t, cusolver_int_t, cusolver_int_t, cusolver_int_t,
                     CuPtr{cuComplex}, cusolver_int_t, CuPtr{cuComplex}, cusolver_int_t,
@@ -697,7 +697,7 @@ end
 
 @checked function cusolverDnCEgels(handle, m, n, nrhs, dA, ldda, dB, lddb, dX, lddx,
                                    dWorkspace, lwork_bytes, iter, d_info)
-    initialize_api()
+    initialize_context()
     ccall((:cusolverDnCEgels, libcusolver()), cusolverStatus_t,
                    (cusolverDnHandle_t, cusolver_int_t, cusolver_int_t, cusolver_int_t,
                     CuPtr{cuComplex}, cusolver_int_t, CuPtr{cuComplex}, cusolver_int_t,
@@ -709,7 +709,7 @@ end
 
 @checked function cusolverDnCYgels(handle, m, n, nrhs, dA, ldda, dB, lddb, dX, lddx,
                                    dWorkspace, lwork_bytes, iter, d_info)
-    initialize_api()
+    initialize_context()
     ccall((:cusolverDnCYgels, libcusolver()), cusolverStatus_t,
                    (cusolverDnHandle_t, cusolver_int_t, cusolver_int_t, cusolver_int_t,
                     CuPtr{cuComplex}, cusolver_int_t, CuPtr{cuComplex}, cusolver_int_t,
@@ -721,7 +721,7 @@ end
 
 @checked function cusolverDnDDgels(handle, m, n, nrhs, dA, ldda, dB, lddb, dX, lddx,
                                    dWorkspace, lwork_bytes, iter, d_info)
-    initialize_api()
+    initialize_context()
     ccall((:cusolverDnDDgels, libcusolver()), cusolverStatus_t,
                    (cusolverDnHandle_t, cusolver_int_t, cusolver_int_t, cusolver_int_t,
                     CuPtr{Cdouble}, cusolver_int_t, CuPtr{Cdouble}, cusolver_int_t,
@@ -733,7 +733,7 @@ end
 
 @checked function cusolverDnDSgels(handle, m, n, nrhs, dA, ldda, dB, lddb, dX, lddx,
                                    dWorkspace, lwork_bytes, iter, d_info)
-    initialize_api()
+    initialize_context()
     ccall((:cusolverDnDSgels, libcusolver()), cusolverStatus_t,
                    (cusolverDnHandle_t, cusolver_int_t, cusolver_int_t, cusolver_int_t,
                     CuPtr{Cdouble}, cusolver_int_t, CuPtr{Cdouble}, cusolver_int_t,
@@ -745,7 +745,7 @@ end
 
 @checked function cusolverDnDHgels(handle, m, n, nrhs, dA, ldda, dB, lddb, dX, lddx,
                                    dWorkspace, lwork_bytes, iter, d_info)
-    initialize_api()
+    initialize_context()
     ccall((:cusolverDnDHgels, libcusolver()), cusolverStatus_t,
                    (cusolverDnHandle_t, cusolver_int_t, cusolver_int_t, cusolver_int_t,
                     CuPtr{Cdouble}, cusolver_int_t, CuPtr{Cdouble}, cusolver_int_t,
@@ -757,7 +757,7 @@ end
 
 @checked function cusolverDnDBgels(handle, m, n, nrhs, dA, ldda, dB, lddb, dX, lddx,
                                    dWorkspace, lwork_bytes, iter, d_info)
-    initialize_api()
+    initialize_context()
     ccall((:cusolverDnDBgels, libcusolver()), cusolverStatus_t,
                    (cusolverDnHandle_t, cusolver_int_t, cusolver_int_t, cusolver_int_t,
                     CuPtr{Cdouble}, cusolver_int_t, CuPtr{Cdouble}, cusolver_int_t,
@@ -769,7 +769,7 @@ end
 
 @checked function cusolverDnDXgels(handle, m, n, nrhs, dA, ldda, dB, lddb, dX, lddx,
                                    dWorkspace, lwork_bytes, iter, d_info)
-    initialize_api()
+    initialize_context()
     ccall((:cusolverDnDXgels, libcusolver()), cusolverStatus_t,
                    (cusolverDnHandle_t, cusolver_int_t, cusolver_int_t, cusolver_int_t,
                     CuPtr{Cdouble}, cusolver_int_t, CuPtr{Cdouble}, cusolver_int_t,
@@ -781,7 +781,7 @@ end
 
 @checked function cusolverDnSSgels(handle, m, n, nrhs, dA, ldda, dB, lddb, dX, lddx,
                                    dWorkspace, lwork_bytes, iter, d_info)
-    initialize_api()
+    initialize_context()
     ccall((:cusolverDnSSgels, libcusolver()), cusolverStatus_t,
                    (cusolverDnHandle_t, cusolver_int_t, cusolver_int_t, cusolver_int_t,
                     CuPtr{Cfloat}, cusolver_int_t, CuPtr{Cfloat}, cusolver_int_t,
@@ -793,7 +793,7 @@ end
 
 @checked function cusolverDnSHgels(handle, m, n, nrhs, dA, ldda, dB, lddb, dX, lddx,
                                    dWorkspace, lwork_bytes, iter, d_info)
-    initialize_api()
+    initialize_context()
     ccall((:cusolverDnSHgels, libcusolver()), cusolverStatus_t,
                    (cusolverDnHandle_t, cusolver_int_t, cusolver_int_t, cusolver_int_t,
                     CuPtr{Cfloat}, cusolver_int_t, CuPtr{Cfloat}, cusolver_int_t,
@@ -805,7 +805,7 @@ end
 
 @checked function cusolverDnSBgels(handle, m, n, nrhs, dA, ldda, dB, lddb, dX, lddx,
                                    dWorkspace, lwork_bytes, iter, d_info)
-    initialize_api()
+    initialize_context()
     ccall((:cusolverDnSBgels, libcusolver()), cusolverStatus_t,
                    (cusolverDnHandle_t, cusolver_int_t, cusolver_int_t, cusolver_int_t,
                     CuPtr{Cfloat}, cusolver_int_t, CuPtr{Cfloat}, cusolver_int_t,
@@ -817,7 +817,7 @@ end
 
 @checked function cusolverDnSXgels(handle, m, n, nrhs, dA, ldda, dB, lddb, dX, lddx,
                                    dWorkspace, lwork_bytes, iter, d_info)
-    initialize_api()
+    initialize_context()
     ccall((:cusolverDnSXgels, libcusolver()), cusolverStatus_t,
                    (cusolverDnHandle_t, cusolver_int_t, cusolver_int_t, cusolver_int_t,
                     CuPtr{Cfloat}, cusolver_int_t, CuPtr{Cfloat}, cusolver_int_t,
@@ -829,7 +829,7 @@ end
 
 @checked function cusolverDnZZgels_bufferSize(handle, m, n, nrhs, dA, ldda, dB, lddb, dX,
                                               lddx, dWorkspace, lwork_bytes)
-    initialize_api()
+    initialize_context()
     ccall((:cusolverDnZZgels_bufferSize, libcusolver()), cusolverStatus_t,
                    (cusolverDnHandle_t, cusolver_int_t, cusolver_int_t, cusolver_int_t,
                     CuPtr{cuDoubleComplex}, cusolver_int_t, CuPtr{cuDoubleComplex},
@@ -841,7 +841,7 @@ end
 
 @checked function cusolverDnZCgels_bufferSize(handle, m, n, nrhs, dA, ldda, dB, lddb, dX,
                                               lddx, dWorkspace, lwork_bytes)
-    initialize_api()
+    initialize_context()
     ccall((:cusolverDnZCgels_bufferSize, libcusolver()), cusolverStatus_t,
                    (cusolverDnHandle_t, cusolver_int_t, cusolver_int_t, cusolver_int_t,
                     CuPtr{cuDoubleComplex}, cusolver_int_t, CuPtr{cuDoubleComplex},
@@ -853,7 +853,7 @@ end
 
 @checked function cusolverDnZKgels_bufferSize(handle, m, n, nrhs, dA, ldda, dB, lddb, dX,
                                               lddx, dWorkspace, lwork_bytes)
-    initialize_api()
+    initialize_context()
     ccall((:cusolverDnZKgels_bufferSize, libcusolver()), cusolverStatus_t,
                    (cusolverDnHandle_t, cusolver_int_t, cusolver_int_t, cusolver_int_t,
                     CuPtr{cuDoubleComplex}, cusolver_int_t, CuPtr{cuDoubleComplex},
@@ -865,7 +865,7 @@ end
 
 @checked function cusolverDnZEgels_bufferSize(handle, m, n, nrhs, dA, ldda, dB, lddb, dX,
                                               lddx, dWorkspace, lwork_bytes)
-    initialize_api()
+    initialize_context()
     ccall((:cusolverDnZEgels_bufferSize, libcusolver()), cusolverStatus_t,
                    (cusolverDnHandle_t, cusolver_int_t, cusolver_int_t, cusolver_int_t,
                     CuPtr{cuDoubleComplex}, cusolver_int_t, CuPtr{cuDoubleComplex},
@@ -877,7 +877,7 @@ end
 
 @checked function cusolverDnZYgels_bufferSize(handle, m, n, nrhs, dA, ldda, dB, lddb, dX,
                                               lddx, dWorkspace, lwork_bytes)
-    initialize_api()
+    initialize_context()
     ccall((:cusolverDnZYgels_bufferSize, libcusolver()), cusolverStatus_t,
                    (cusolverDnHandle_t, cusolver_int_t, cusolver_int_t, cusolver_int_t,
                     CuPtr{cuDoubleComplex}, cusolver_int_t, CuPtr{cuDoubleComplex},
@@ -889,7 +889,7 @@ end
 
 @checked function cusolverDnCCgels_bufferSize(handle, m, n, nrhs, dA, ldda, dB, lddb, dX,
                                               lddx, dWorkspace, lwork_bytes)
-    initialize_api()
+    initialize_context()
     ccall((:cusolverDnCCgels_bufferSize, libcusolver()), cusolverStatus_t,
                    (cusolverDnHandle_t, cusolver_int_t, cusolver_int_t, cusolver_int_t,
                     CuPtr{cuComplex}, cusolver_int_t, CuPtr{cuComplex}, cusolver_int_t,
@@ -900,7 +900,7 @@ end
 
 @checked function cusolverDnCKgels_bufferSize(handle, m, n, nrhs, dA, ldda, dB, lddb, dX,
                                               lddx, dWorkspace, lwork_bytes)
-    initialize_api()
+    initialize_context()
     ccall((:cusolverDnCKgels_bufferSize, libcusolver()), cusolverStatus_t,
                    (cusolverDnHandle_t, cusolver_int_t, cusolver_int_t, cusolver_int_t,
                     CuPtr{cuComplex}, cusolver_int_t, CuPtr{cuComplex}, cusolver_int_t,
@@ -911,7 +911,7 @@ end
 
 @checked function cusolverDnCEgels_bufferSize(handle, m, n, nrhs, dA, ldda, dB, lddb, dX,
                                               lddx, dWorkspace, lwork_bytes)
-    initialize_api()
+    initialize_context()
     ccall((:cusolverDnCEgels_bufferSize, libcusolver()), cusolverStatus_t,
                    (cusolverDnHandle_t, cusolver_int_t, cusolver_int_t, cusolver_int_t,
                     CuPtr{cuComplex}, cusolver_int_t, CuPtr{cuComplex}, cusolver_int_t,
@@ -922,7 +922,7 @@ end
 
 @checked function cusolverDnCYgels_bufferSize(handle, m, n, nrhs, dA, ldda, dB, lddb, dX,
                                               lddx, dWorkspace, lwork_bytes)
-    initialize_api()
+    initialize_context()
     ccall((:cusolverDnCYgels_bufferSize, libcusolver()), cusolverStatus_t,
                    (cusolverDnHandle_t, cusolver_int_t, cusolver_int_t, cusolver_int_t,
                     CuPtr{cuComplex}, cusolver_int_t, CuPtr{cuComplex}, cusolver_int_t,
@@ -933,7 +933,7 @@ end
 
 @checked function cusolverDnDDgels_bufferSize(handle, m, n, nrhs, dA, ldda, dB, lddb, dX,
                                               lddx, dWorkspace, lwork_bytes)
-    initialize_api()
+    initialize_context()
     ccall((:cusolverDnDDgels_bufferSize, libcusolver()), cusolverStatus_t,
                    (cusolverDnHandle_t, cusolver_int_t, cusolver_int_t, cusolver_int_t,
                     CuPtr{Cdouble}, cusolver_int_t, CuPtr{Cdouble}, cusolver_int_t,
@@ -944,7 +944,7 @@ end
 
 @checked function cusolverDnDSgels_bufferSize(handle, m, n, nrhs, dA, ldda, dB, lddb, dX,
                                               lddx, dWorkspace, lwork_bytes)
-    initialize_api()
+    initialize_context()
     ccall((:cusolverDnDSgels_bufferSize, libcusolver()), cusolverStatus_t,
                    (cusolverDnHandle_t, cusolver_int_t, cusolver_int_t, cusolver_int_t,
                     CuPtr{Cdouble}, cusolver_int_t, CuPtr{Cdouble}, cusolver_int_t,
@@ -955,7 +955,7 @@ end
 
 @checked function cusolverDnDHgels_bufferSize(handle, m, n, nrhs, dA, ldda, dB, lddb, dX,
                                               lddx, dWorkspace, lwork_bytes)
-    initialize_api()
+    initialize_context()
     ccall((:cusolverDnDHgels_bufferSize, libcusolver()), cusolverStatus_t,
                    (cusolverDnHandle_t, cusolver_int_t, cusolver_int_t, cusolver_int_t,
                     CuPtr{Cdouble}, cusolver_int_t, CuPtr{Cdouble}, cusolver_int_t,
@@ -966,7 +966,7 @@ end
 
 @checked function cusolverDnDBgels_bufferSize(handle, m, n, nrhs, dA, ldda, dB, lddb, dX,
                                               lddx, dWorkspace, lwork_bytes)
-    initialize_api()
+    initialize_context()
     ccall((:cusolverDnDBgels_bufferSize, libcusolver()), cusolverStatus_t,
                    (cusolverDnHandle_t, cusolver_int_t, cusolver_int_t, cusolver_int_t,
                     CuPtr{Cdouble}, cusolver_int_t, CuPtr{Cdouble}, cusolver_int_t,
@@ -977,7 +977,7 @@ end
 
 @checked function cusolverDnDXgels_bufferSize(handle, m, n, nrhs, dA, ldda, dB, lddb, dX,
                                               lddx, dWorkspace, lwork_bytes)
-    initialize_api()
+    initialize_context()
     ccall((:cusolverDnDXgels_bufferSize, libcusolver()), cusolverStatus_t,
                    (cusolverDnHandle_t, cusolver_int_t, cusolver_int_t, cusolver_int_t,
                     CuPtr{Cdouble}, cusolver_int_t, CuPtr{Cdouble}, cusolver_int_t,
@@ -988,7 +988,7 @@ end
 
 @checked function cusolverDnSSgels_bufferSize(handle, m, n, nrhs, dA, ldda, dB, lddb, dX,
                                               lddx, dWorkspace, lwork_bytes)
-    initialize_api()
+    initialize_context()
     ccall((:cusolverDnSSgels_bufferSize, libcusolver()), cusolverStatus_t,
                    (cusolverDnHandle_t, cusolver_int_t, cusolver_int_t, cusolver_int_t,
                     CuPtr{Cfloat}, cusolver_int_t, CuPtr{Cfloat}, cusolver_int_t,
@@ -999,7 +999,7 @@ end
 
 @checked function cusolverDnSHgels_bufferSize(handle, m, n, nrhs, dA, ldda, dB, lddb, dX,
                                               lddx, dWorkspace, lwork_bytes)
-    initialize_api()
+    initialize_context()
     ccall((:cusolverDnSHgels_bufferSize, libcusolver()), cusolverStatus_t,
                    (cusolverDnHandle_t, cusolver_int_t, cusolver_int_t, cusolver_int_t,
                     CuPtr{Cfloat}, cusolver_int_t, CuPtr{Cfloat}, cusolver_int_t,
@@ -1010,7 +1010,7 @@ end
 
 @checked function cusolverDnSBgels_bufferSize(handle, m, n, nrhs, dA, ldda, dB, lddb, dX,
                                               lddx, dWorkspace, lwork_bytes)
-    initialize_api()
+    initialize_context()
     ccall((:cusolverDnSBgels_bufferSize, libcusolver()), cusolverStatus_t,
                    (cusolverDnHandle_t, cusolver_int_t, cusolver_int_t, cusolver_int_t,
                     CuPtr{Cfloat}, cusolver_int_t, CuPtr{Cfloat}, cusolver_int_t,
@@ -1021,7 +1021,7 @@ end
 
 @checked function cusolverDnSXgels_bufferSize(handle, m, n, nrhs, dA, ldda, dB, lddb, dX,
                                               lddx, dWorkspace, lwork_bytes)
-    initialize_api()
+    initialize_context()
     ccall((:cusolverDnSXgels_bufferSize, libcusolver()), cusolverStatus_t,
                    (cusolverDnHandle_t, cusolver_int_t, cusolver_int_t, cusolver_int_t,
                     CuPtr{Cfloat}, cusolver_int_t, CuPtr{Cfloat}, cusolver_int_t,
@@ -1033,7 +1033,7 @@ end
 @checked function cusolverDnIRSXgesv(handle, gesv_irs_params, gesv_irs_infos, n, nrhs, dA,
                                      ldda, dB, lddb, dX, lddx, dWorkspace, lwork_bytes,
                                      niters, d_info)
-    initialize_api()
+    initialize_context()
     ccall((:cusolverDnIRSXgesv, libcusolver()), cusolverStatus_t,
                    (cusolverDnHandle_t, cusolverDnIRSParams_t, cusolverDnIRSInfos_t,
                     cusolver_int_t, cusolver_int_t, CuPtr{Cvoid}, cusolver_int_t,
@@ -1044,7 +1044,7 @@ end
 end
 
 @checked function cusolverDnIRSXgesv_bufferSize(handle, params, n, nrhs, lwork_bytes)
-    initialize_api()
+    initialize_context()
     ccall((:cusolverDnIRSXgesv_bufferSize, libcusolver()), cusolverStatus_t,
                    (cusolverDnHandle_t, cusolverDnIRSParams_t, cusolver_int_t,
                     cusolver_int_t, Ptr{Csize_t}),
@@ -1054,7 +1054,7 @@ end
 @checked function cusolverDnIRSXgels(handle, gels_irs_params, gels_irs_infos, m, n, nrhs,
                                      dA, ldda, dB, lddb, dX, lddx, dWorkspace, lwork_bytes,
                                      niters, d_info)
-    initialize_api()
+    initialize_context()
     ccall((:cusolverDnIRSXgels, libcusolver()), cusolverStatus_t,
                    (cusolverDnHandle_t, cusolverDnIRSParams_t, cusolverDnIRSInfos_t,
                     cusolver_int_t, cusolver_int_t, cusolver_int_t, CuPtr{Cvoid},
@@ -1066,7 +1066,7 @@ end
 end
 
 @checked function cusolverDnIRSXgels_bufferSize(handle, params, m, n, nrhs, lwork_bytes)
-    initialize_api()
+    initialize_context()
     ccall((:cusolverDnIRSXgels_bufferSize, libcusolver()), cusolverStatus_t,
                    (cusolverDnHandle_t, cusolverDnIRSParams_t, cusolver_int_t,
                     cusolver_int_t, cusolver_int_t, Ptr{Csize_t}),
@@ -1074,7 +1074,7 @@ end
 end
 
 @checked function cusolverDnSpotrf_bufferSize(handle, uplo, n, A, lda, Lwork)
-    initialize_api()
+    initialize_context()
     ccall((:cusolverDnSpotrf_bufferSize, libcusolver()), cusolverStatus_t,
                    (cusolverDnHandle_t, cublasFillMode_t, Cint, CuPtr{Cfloat}, Cint,
                     Ptr{Cint}),
@@ -1082,7 +1082,7 @@ end
 end
 
 @checked function cusolverDnDpotrf_bufferSize(handle, uplo, n, A, lda, Lwork)
-    initialize_api()
+    initialize_context()
     ccall((:cusolverDnDpotrf_bufferSize, libcusolver()), cusolverStatus_t,
                    (cusolverDnHandle_t, cublasFillMode_t, Cint, CuPtr{Cdouble}, Cint,
                     Ptr{Cint}),
@@ -1090,7 +1090,7 @@ end
 end
 
 @checked function cusolverDnCpotrf_bufferSize(handle, uplo, n, A, lda, Lwork)
-    initialize_api()
+    initialize_context()
     ccall((:cusolverDnCpotrf_bufferSize, libcusolver()), cusolverStatus_t,
                    (cusolverDnHandle_t, cublasFillMode_t, Cint, CuPtr{cuComplex}, Cint,
                     Ptr{Cint}),
@@ -1098,7 +1098,7 @@ end
 end
 
 @checked function cusolverDnZpotrf_bufferSize(handle, uplo, n, A, lda, Lwork)
-    initialize_api()
+    initialize_context()
     ccall((:cusolverDnZpotrf_bufferSize, libcusolver()), cusolverStatus_t,
                    (cusolverDnHandle_t, cublasFillMode_t, Cint, CuPtr{cuDoubleComplex},
                     Cint, Ptr{Cint}),
@@ -1106,7 +1106,7 @@ end
 end
 
 @checked function cusolverDnSpotrf(handle, uplo, n, A, lda, Workspace, Lwork, devInfo)
-    initialize_api()
+    initialize_context()
     ccall((:cusolverDnSpotrf, libcusolver()), cusolverStatus_t,
                    (cusolverDnHandle_t, cublasFillMode_t, Cint, CuPtr{Cfloat}, Cint,
                     CuPtr{Cfloat}, Cint, CuPtr{Cint}),
@@ -1114,7 +1114,7 @@ end
 end
 
 @checked function cusolverDnDpotrf(handle, uplo, n, A, lda, Workspace, Lwork, devInfo)
-    initialize_api()
+    initialize_context()
     ccall((:cusolverDnDpotrf, libcusolver()), cusolverStatus_t,
                    (cusolverDnHandle_t, cublasFillMode_t, Cint, CuPtr{Cdouble}, Cint,
                     CuPtr{Cdouble}, Cint, CuPtr{Cint}),
@@ -1122,7 +1122,7 @@ end
 end
 
 @checked function cusolverDnCpotrf(handle, uplo, n, A, lda, Workspace, Lwork, devInfo)
-    initialize_api()
+    initialize_context()
     ccall((:cusolverDnCpotrf, libcusolver()), cusolverStatus_t,
                    (cusolverDnHandle_t, cublasFillMode_t, Cint, CuPtr{cuComplex}, Cint,
                     CuPtr{cuComplex}, Cint, CuPtr{Cint}),
@@ -1130,7 +1130,7 @@ end
 end
 
 @checked function cusolverDnZpotrf(handle, uplo, n, A, lda, Workspace, Lwork, devInfo)
-    initialize_api()
+    initialize_context()
     ccall((:cusolverDnZpotrf, libcusolver()), cusolverStatus_t,
                    (cusolverDnHandle_t, cublasFillMode_t, Cint, CuPtr{cuDoubleComplex},
                     Cint, CuPtr{cuDoubleComplex}, Cint, CuPtr{Cint}),
@@ -1138,7 +1138,7 @@ end
 end
 
 @checked function cusolverDnSpotrs(handle, uplo, n, nrhs, A, lda, B, ldb, devInfo)
-    initialize_api()
+    initialize_context()
     ccall((:cusolverDnSpotrs, libcusolver()), cusolverStatus_t,
                    (cusolverDnHandle_t, cublasFillMode_t, Cint, Cint, CuPtr{Cfloat}, Cint,
                     CuPtr{Cfloat}, Cint, CuPtr{Cint}),
@@ -1146,7 +1146,7 @@ end
 end
 
 @checked function cusolverDnDpotrs(handle, uplo, n, nrhs, A, lda, B, ldb, devInfo)
-    initialize_api()
+    initialize_context()
     ccall((:cusolverDnDpotrs, libcusolver()), cusolverStatus_t,
                    (cusolverDnHandle_t, cublasFillMode_t, Cint, Cint, CuPtr{Cdouble},
                     Cint, CuPtr{Cdouble}, Cint, CuPtr{Cint}),
@@ -1154,7 +1154,7 @@ end
 end
 
 @checked function cusolverDnCpotrs(handle, uplo, n, nrhs, A, lda, B, ldb, devInfo)
-    initialize_api()
+    initialize_context()
     ccall((:cusolverDnCpotrs, libcusolver()), cusolverStatus_t,
                    (cusolverDnHandle_t, cublasFillMode_t, Cint, Cint, CuPtr{cuComplex},
                     Cint, CuPtr{cuComplex}, Cint, CuPtr{Cint}),
@@ -1162,7 +1162,7 @@ end
 end
 
 @checked function cusolverDnZpotrs(handle, uplo, n, nrhs, A, lda, B, ldb, devInfo)
-    initialize_api()
+    initialize_context()
     ccall((:cusolverDnZpotrs, libcusolver()), cusolverStatus_t,
                    (cusolverDnHandle_t, cublasFillMode_t, Cint, Cint,
                     CuPtr{cuDoubleComplex}, Cint, CuPtr{cuDoubleComplex}, Cint, CuPtr{Cint}),
@@ -1170,7 +1170,7 @@ end
 end
 
 @checked function cusolverDnSpotrfBatched(handle, uplo, n, Aarray, lda, infoArray, batchSize)
-    initialize_api()
+    initialize_context()
     ccall((:cusolverDnSpotrfBatched, libcusolver()), cusolverStatus_t,
                    (cusolverDnHandle_t, cublasFillMode_t, Cint, CuPtr{Ptr{Cfloat}}, Cint,
                     CuPtr{Cint}, Cint),
@@ -1178,7 +1178,7 @@ end
 end
 
 @checked function cusolverDnDpotrfBatched(handle, uplo, n, Aarray, lda, infoArray, batchSize)
-    initialize_api()
+    initialize_context()
     ccall((:cusolverDnDpotrfBatched, libcusolver()), cusolverStatus_t,
                    (cusolverDnHandle_t, cublasFillMode_t, Cint, CuPtr{Ptr{Cdouble}}, Cint,
                     CuPtr{Cint}, Cint),
@@ -1186,7 +1186,7 @@ end
 end
 
 @checked function cusolverDnCpotrfBatched(handle, uplo, n, Aarray, lda, infoArray, batchSize)
-    initialize_api()
+    initialize_context()
     ccall((:cusolverDnCpotrfBatched, libcusolver()), cusolverStatus_t,
                    (cusolverDnHandle_t, cublasFillMode_t, Cint, CuPtr{Ptr{cuComplex}},
                     Cint, CuPtr{Cint}, Cint),
@@ -1194,7 +1194,7 @@ end
 end
 
 @checked function cusolverDnZpotrfBatched(handle, uplo, n, Aarray, lda, infoArray, batchSize)
-    initialize_api()
+    initialize_context()
     ccall((:cusolverDnZpotrfBatched, libcusolver()), cusolverStatus_t,
                    (cusolverDnHandle_t, cublasFillMode_t, Cint,
                     CuPtr{Ptr{cuDoubleComplex}}, Cint, CuPtr{Cint}, Cint),
@@ -1203,7 +1203,7 @@ end
 
 @checked function cusolverDnSpotrsBatched(handle, uplo, n, nrhs, A, lda, B, ldb, d_info,
                                           batchSize)
-    initialize_api()
+    initialize_context()
     ccall((:cusolverDnSpotrsBatched, libcusolver()), cusolverStatus_t,
                    (cusolverDnHandle_t, cublasFillMode_t, Cint, Cint, CuPtr{Ptr{Cfloat}},
                     Cint, CuPtr{Ptr{Cfloat}}, Cint, CuPtr{Cint}, Cint),
@@ -1212,7 +1212,7 @@ end
 
 @checked function cusolverDnDpotrsBatched(handle, uplo, n, nrhs, A, lda, B, ldb, d_info,
                                           batchSize)
-    initialize_api()
+    initialize_context()
     ccall((:cusolverDnDpotrsBatched, libcusolver()), cusolverStatus_t,
                    (cusolverDnHandle_t, cublasFillMode_t, Cint, Cint, CuPtr{Ptr{Cdouble}},
                     Cint, CuPtr{Ptr{Cdouble}}, Cint, CuPtr{Cint}, Cint),
@@ -1221,7 +1221,7 @@ end
 
 @checked function cusolverDnCpotrsBatched(handle, uplo, n, nrhs, A, lda, B, ldb, d_info,
                                           batchSize)
-    initialize_api()
+    initialize_context()
     ccall((:cusolverDnCpotrsBatched, libcusolver()), cusolverStatus_t,
                    (cusolverDnHandle_t, cublasFillMode_t, Cint, Cint,
                     CuPtr{Ptr{cuComplex}}, Cint, CuPtr{Ptr{cuComplex}}, Cint, CuPtr{Cint},
@@ -1231,7 +1231,7 @@ end
 
 @checked function cusolverDnZpotrsBatched(handle, uplo, n, nrhs, A, lda, B, ldb, d_info,
                                           batchSize)
-    initialize_api()
+    initialize_context()
     ccall((:cusolverDnZpotrsBatched, libcusolver()), cusolverStatus_t,
                    (cusolverDnHandle_t, cublasFillMode_t, Cint, Cint,
                     CuPtr{Ptr{cuDoubleComplex}}, Cint, CuPtr{Ptr{cuDoubleComplex}}, Cint,
@@ -1240,7 +1240,7 @@ end
 end
 
 @checked function cusolverDnSpotri_bufferSize(handle, uplo, n, A, lda, lwork)
-    initialize_api()
+    initialize_context()
     ccall((:cusolverDnSpotri_bufferSize, libcusolver()), cusolverStatus_t,
                    (cusolverDnHandle_t, cublasFillMode_t, Cint, CuPtr{Cfloat}, Cint,
                     Ptr{Cint}),
@@ -1248,7 +1248,7 @@ end
 end
 
 @checked function cusolverDnDpotri_bufferSize(handle, uplo, n, A, lda, lwork)
-    initialize_api()
+    initialize_context()
     ccall((:cusolverDnDpotri_bufferSize, libcusolver()), cusolverStatus_t,
                    (cusolverDnHandle_t, cublasFillMode_t, Cint, CuPtr{Cdouble}, Cint,
                     Ptr{Cint}),
@@ -1256,7 +1256,7 @@ end
 end
 
 @checked function cusolverDnCpotri_bufferSize(handle, uplo, n, A, lda, lwork)
-    initialize_api()
+    initialize_context()
     ccall((:cusolverDnCpotri_bufferSize, libcusolver()), cusolverStatus_t,
                    (cusolverDnHandle_t, cublasFillMode_t, Cint, CuPtr{cuComplex}, Cint,
                     Ptr{Cint}),
@@ -1264,7 +1264,7 @@ end
 end
 
 @checked function cusolverDnZpotri_bufferSize(handle, uplo, n, A, lda, lwork)
-    initialize_api()
+    initialize_context()
     ccall((:cusolverDnZpotri_bufferSize, libcusolver()), cusolverStatus_t,
                    (cusolverDnHandle_t, cublasFillMode_t, Cint, CuPtr{cuDoubleComplex},
                     Cint, Ptr{Cint}),
@@ -1272,7 +1272,7 @@ end
 end
 
 @checked function cusolverDnSpotri(handle, uplo, n, A, lda, work, lwork, devInfo)
-    initialize_api()
+    initialize_context()
     ccall((:cusolverDnSpotri, libcusolver()), cusolverStatus_t,
                    (cusolverDnHandle_t, cublasFillMode_t, Cint, CuPtr{Cfloat}, Cint,
                     CuPtr{Cfloat}, Cint, CuPtr{Cint}),
@@ -1280,7 +1280,7 @@ end
 end
 
 @checked function cusolverDnDpotri(handle, uplo, n, A, lda, work, lwork, devInfo)
-    initialize_api()
+    initialize_context()
     ccall((:cusolverDnDpotri, libcusolver()), cusolverStatus_t,
                    (cusolverDnHandle_t, cublasFillMode_t, Cint, CuPtr{Cdouble}, Cint,
                     CuPtr{Cdouble}, Cint, CuPtr{Cint}),
@@ -1288,7 +1288,7 @@ end
 end
 
 @checked function cusolverDnCpotri(handle, uplo, n, A, lda, work, lwork, devInfo)
-    initialize_api()
+    initialize_context()
     ccall((:cusolverDnCpotri, libcusolver()), cusolverStatus_t,
                    (cusolverDnHandle_t, cublasFillMode_t, Cint, CuPtr{cuComplex}, Cint,
                     CuPtr{cuComplex}, Cint, CuPtr{Cint}),
@@ -1296,7 +1296,7 @@ end
 end
 
 @checked function cusolverDnZpotri(handle, uplo, n, A, lda, work, lwork, devInfo)
-    initialize_api()
+    initialize_context()
     ccall((:cusolverDnZpotri, libcusolver()), cusolverStatus_t,
                    (cusolverDnHandle_t, cublasFillMode_t, Cint, CuPtr{cuDoubleComplex},
                     Cint, CuPtr{cuDoubleComplex}, Cint, CuPtr{Cint}),
@@ -1304,7 +1304,7 @@ end
 end
 
 @checked function cusolverDnStrtri_bufferSize(handle, uplo, diag, n, A, lda, lwork)
-    initialize_api()
+    initialize_context()
     ccall((:cusolverDnStrtri_bufferSize, libcusolver()), cusolverStatus_t,
                    (cusolverDnHandle_t, cublasFillMode_t, cublasDiagType_t, Cint,
                     CuPtr{Cfloat}, Cint, Ptr{Cint}),
@@ -1312,7 +1312,7 @@ end
 end
 
 @checked function cusolverDnDtrtri_bufferSize(handle, uplo, diag, n, A, lda, lwork)
-    initialize_api()
+    initialize_context()
     ccall((:cusolverDnDtrtri_bufferSize, libcusolver()), cusolverStatus_t,
                    (cusolverDnHandle_t, cublasFillMode_t, cublasDiagType_t, Cint,
                     CuPtr{Cdouble}, Cint, Ptr{Cint}),
@@ -1320,7 +1320,7 @@ end
 end
 
 @checked function cusolverDnCtrtri_bufferSize(handle, uplo, diag, n, A, lda, lwork)
-    initialize_api()
+    initialize_context()
     ccall((:cusolverDnCtrtri_bufferSize, libcusolver()), cusolverStatus_t,
                    (cusolverDnHandle_t, cublasFillMode_t, cublasDiagType_t, Cint,
                     CuPtr{cuComplex}, Cint, Ptr{Cint}),
@@ -1328,7 +1328,7 @@ end
 end
 
 @checked function cusolverDnZtrtri_bufferSize(handle, uplo, diag, n, A, lda, lwork)
-    initialize_api()
+    initialize_context()
     ccall((:cusolverDnZtrtri_bufferSize, libcusolver()), cusolverStatus_t,
                    (cusolverDnHandle_t, cublasFillMode_t, cublasDiagType_t, Cint,
                     CuPtr{cuDoubleComplex}, Cint, Ptr{Cint}),
@@ -1336,7 +1336,7 @@ end
 end
 
 @checked function cusolverDnStrtri(handle, uplo, diag, n, A, lda, work, lwork, devInfo)
-    initialize_api()
+    initialize_context()
     ccall((:cusolverDnStrtri, libcusolver()), cusolverStatus_t,
                    (cusolverDnHandle_t, cublasFillMode_t, cublasDiagType_t, Cint,
                     CuPtr{Cfloat}, Cint, CuPtr{Cfloat}, Cint, CuPtr{Cint}),
@@ -1344,7 +1344,7 @@ end
 end
 
 @checked function cusolverDnDtrtri(handle, uplo, diag, n, A, lda, work, lwork, devInfo)
-    initialize_api()
+    initialize_context()
     ccall((:cusolverDnDtrtri, libcusolver()), cusolverStatus_t,
                    (cusolverDnHandle_t, cublasFillMode_t, cublasDiagType_t, Cint,
                     CuPtr{Cdouble}, Cint, CuPtr{Cdouble}, Cint, CuPtr{Cint}),
@@ -1352,7 +1352,7 @@ end
 end
 
 @checked function cusolverDnCtrtri(handle, uplo, diag, n, A, lda, work, lwork, devInfo)
-    initialize_api()
+    initialize_context()
     ccall((:cusolverDnCtrtri, libcusolver()), cusolverStatus_t,
                    (cusolverDnHandle_t, cublasFillMode_t, cublasDiagType_t, Cint,
                     CuPtr{cuComplex}, Cint, CuPtr{cuComplex}, Cint, CuPtr{Cint}),
@@ -1360,7 +1360,7 @@ end
 end
 
 @checked function cusolverDnZtrtri(handle, uplo, diag, n, A, lda, work, lwork, devInfo)
-    initialize_api()
+    initialize_context()
     ccall((:cusolverDnZtrtri, libcusolver()), cusolverStatus_t,
                    (cusolverDnHandle_t, cublasFillMode_t, cublasDiagType_t, Cint,
                     CuPtr{cuDoubleComplex}, Cint, CuPtr{cuDoubleComplex}, Cint, CuPtr{Cint}),
@@ -1368,7 +1368,7 @@ end
 end
 
 @checked function cusolverDnSlauum_bufferSize(handle, uplo, n, A, lda, lwork)
-    initialize_api()
+    initialize_context()
     ccall((:cusolverDnSlauum_bufferSize, libcusolver()), cusolverStatus_t,
                    (cusolverDnHandle_t, cublasFillMode_t, Cint, CuPtr{Cfloat}, Cint,
                     Ptr{Cint}),
@@ -1376,7 +1376,7 @@ end
 end
 
 @checked function cusolverDnDlauum_bufferSize(handle, uplo, n, A, lda, lwork)
-    initialize_api()
+    initialize_context()
     ccall((:cusolverDnDlauum_bufferSize, libcusolver()), cusolverStatus_t,
                    (cusolverDnHandle_t, cublasFillMode_t, Cint, CuPtr{Cdouble}, Cint,
                     Ptr{Cint}),
@@ -1384,7 +1384,7 @@ end
 end
 
 @checked function cusolverDnClauum_bufferSize(handle, uplo, n, A, lda, lwork)
-    initialize_api()
+    initialize_context()
     ccall((:cusolverDnClauum_bufferSize, libcusolver()), cusolverStatus_t,
                    (cusolverDnHandle_t, cublasFillMode_t, Cint, CuPtr{cuComplex}, Cint,
                     Ptr{Cint}),
@@ -1392,7 +1392,7 @@ end
 end
 
 @checked function cusolverDnZlauum_bufferSize(handle, uplo, n, A, lda, lwork)
-    initialize_api()
+    initialize_context()
     ccall((:cusolverDnZlauum_bufferSize, libcusolver()), cusolverStatus_t,
                    (cusolverDnHandle_t, cublasFillMode_t, Cint, CuPtr{cuDoubleComplex},
                     Cint, Ptr{Cint}),
@@ -1400,7 +1400,7 @@ end
 end
 
 @checked function cusolverDnSlauum(handle, uplo, n, A, lda, work, lwork, devInfo)
-    initialize_api()
+    initialize_context()
     ccall((:cusolverDnSlauum, libcusolver()), cusolverStatus_t,
                    (cusolverDnHandle_t, cublasFillMode_t, Cint, CuPtr{Cfloat}, Cint,
                     CuPtr{Cfloat}, Cint, CuPtr{Cint}),
@@ -1408,7 +1408,7 @@ end
 end
 
 @checked function cusolverDnDlauum(handle, uplo, n, A, lda, work, lwork, devInfo)
-    initialize_api()
+    initialize_context()
     ccall((:cusolverDnDlauum, libcusolver()), cusolverStatus_t,
                    (cusolverDnHandle_t, cublasFillMode_t, Cint, CuPtr{Cdouble}, Cint,
                     CuPtr{Cdouble}, Cint, CuPtr{Cint}),
@@ -1416,7 +1416,7 @@ end
 end
 
 @checked function cusolverDnClauum(handle, uplo, n, A, lda, work, lwork, devInfo)
-    initialize_api()
+    initialize_context()
     ccall((:cusolverDnClauum, libcusolver()), cusolverStatus_t,
                    (cusolverDnHandle_t, cublasFillMode_t, Cint, CuPtr{cuComplex}, Cint,
                     CuPtr{cuComplex}, Cint, CuPtr{Cint}),
@@ -1424,7 +1424,7 @@ end
 end
 
 @checked function cusolverDnZlauum(handle, uplo, n, A, lda, work, lwork, devInfo)
-    initialize_api()
+    initialize_context()
     ccall((:cusolverDnZlauum, libcusolver()), cusolverStatus_t,
                    (cusolverDnHandle_t, cublasFillMode_t, Cint, CuPtr{cuDoubleComplex},
                     Cint, CuPtr{cuDoubleComplex}, Cint, CuPtr{Cint}),
@@ -1432,28 +1432,28 @@ end
 end
 
 @checked function cusolverDnSgetrf_bufferSize(handle, m, n, A, lda, Lwork)
-    initialize_api()
+    initialize_context()
     ccall((:cusolverDnSgetrf_bufferSize, libcusolver()), cusolverStatus_t,
                    (cusolverDnHandle_t, Cint, Cint, CuPtr{Cfloat}, Cint, Ptr{Cint}),
                    handle, m, n, A, lda, Lwork)
 end
 
 @checked function cusolverDnDgetrf_bufferSize(handle, m, n, A, lda, Lwork)
-    initialize_api()
+    initialize_context()
     ccall((:cusolverDnDgetrf_bufferSize, libcusolver()), cusolverStatus_t,
                    (cusolverDnHandle_t, Cint, Cint, CuPtr{Cdouble}, Cint, Ptr{Cint}),
                    handle, m, n, A, lda, Lwork)
 end
 
 @checked function cusolverDnCgetrf_bufferSize(handle, m, n, A, lda, Lwork)
-    initialize_api()
+    initialize_context()
     ccall((:cusolverDnCgetrf_bufferSize, libcusolver()), cusolverStatus_t,
                    (cusolverDnHandle_t, Cint, Cint, CuPtr{cuComplex}, Cint, Ptr{Cint}),
                    handle, m, n, A, lda, Lwork)
 end
 
 @checked function cusolverDnZgetrf_bufferSize(handle, m, n, A, lda, Lwork)
-    initialize_api()
+    initialize_context()
     ccall((:cusolverDnZgetrf_bufferSize, libcusolver()), cusolverStatus_t,
                    (cusolverDnHandle_t, Cint, Cint, CuPtr{cuDoubleComplex}, Cint,
                     Ptr{Cint}),
@@ -1461,7 +1461,7 @@ end
 end
 
 @checked function cusolverDnSgetrf(handle, m, n, A, lda, Workspace, devIpiv, devInfo)
-    initialize_api()
+    initialize_context()
     ccall((:cusolverDnSgetrf, libcusolver()), cusolverStatus_t,
                    (cusolverDnHandle_t, Cint, Cint, CuPtr{Cfloat}, Cint, CuPtr{Cfloat},
                     CuPtr{Cint}, CuPtr{Cint}),
@@ -1469,7 +1469,7 @@ end
 end
 
 @checked function cusolverDnDgetrf(handle, m, n, A, lda, Workspace, devIpiv, devInfo)
-    initialize_api()
+    initialize_context()
     ccall((:cusolverDnDgetrf, libcusolver()), cusolverStatus_t,
                    (cusolverDnHandle_t, Cint, Cint, CuPtr{Cdouble}, Cint, CuPtr{Cdouble},
                     CuPtr{Cint}, CuPtr{Cint}),
@@ -1477,7 +1477,7 @@ end
 end
 
 @checked function cusolverDnCgetrf(handle, m, n, A, lda, Workspace, devIpiv, devInfo)
-    initialize_api()
+    initialize_context()
     ccall((:cusolverDnCgetrf, libcusolver()), cusolverStatus_t,
                    (cusolverDnHandle_t, Cint, Cint, CuPtr{cuComplex}, Cint,
                     CuPtr{cuComplex}, CuPtr{Cint}, CuPtr{Cint}),
@@ -1485,7 +1485,7 @@ end
 end
 
 @checked function cusolverDnZgetrf(handle, m, n, A, lda, Workspace, devIpiv, devInfo)
-    initialize_api()
+    initialize_context()
     ccall((:cusolverDnZgetrf, libcusolver()), cusolverStatus_t,
                    (cusolverDnHandle_t, Cint, Cint, CuPtr{cuDoubleComplex}, Cint,
                     CuPtr{cuDoubleComplex}, CuPtr{Cint}, CuPtr{Cint}),
@@ -1493,7 +1493,7 @@ end
 end
 
 @checked function cusolverDnSlaswp(handle, n, A, lda, k1, k2, devIpiv, incx)
-    initialize_api()
+    initialize_context()
     ccall((:cusolverDnSlaswp, libcusolver()), cusolverStatus_t,
                    (cusolverDnHandle_t, Cint, CuPtr{Cfloat}, Cint, Cint, Cint,
                     CuPtr{Cint}, Cint),
@@ -1501,7 +1501,7 @@ end
 end
 
 @checked function cusolverDnDlaswp(handle, n, A, lda, k1, k2, devIpiv, incx)
-    initialize_api()
+    initialize_context()
     ccall((:cusolverDnDlaswp, libcusolver()), cusolverStatus_t,
                    (cusolverDnHandle_t, Cint, CuPtr{Cdouble}, Cint, Cint, Cint,
                     CuPtr{Cint}, Cint),
@@ -1509,7 +1509,7 @@ end
 end
 
 @checked function cusolverDnClaswp(handle, n, A, lda, k1, k2, devIpiv, incx)
-    initialize_api()
+    initialize_context()
     ccall((:cusolverDnClaswp, libcusolver()), cusolverStatus_t,
                    (cusolverDnHandle_t, Cint, CuPtr{cuComplex}, Cint, Cint, Cint,
                     CuPtr{Cint}, Cint),
@@ -1517,7 +1517,7 @@ end
 end
 
 @checked function cusolverDnZlaswp(handle, n, A, lda, k1, k2, devIpiv, incx)
-    initialize_api()
+    initialize_context()
     ccall((:cusolverDnZlaswp, libcusolver()), cusolverStatus_t,
                    (cusolverDnHandle_t, Cint, CuPtr{cuDoubleComplex}, Cint, Cint, Cint,
                     CuPtr{Cint}, Cint),
@@ -1525,7 +1525,7 @@ end
 end
 
 @checked function cusolverDnSgetrs(handle, trans, n, nrhs, A, lda, devIpiv, B, ldb, devInfo)
-    initialize_api()
+    initialize_context()
     ccall((:cusolverDnSgetrs, libcusolver()), cusolverStatus_t,
                    (cusolverDnHandle_t, cublasOperation_t, Cint, Cint, CuPtr{Cfloat},
                     Cint, CuPtr{Cint}, CuPtr{Cfloat}, Cint, CuPtr{Cint}),
@@ -1533,7 +1533,7 @@ end
 end
 
 @checked function cusolverDnDgetrs(handle, trans, n, nrhs, A, lda, devIpiv, B, ldb, devInfo)
-    initialize_api()
+    initialize_context()
     ccall((:cusolverDnDgetrs, libcusolver()), cusolverStatus_t,
                    (cusolverDnHandle_t, cublasOperation_t, Cint, Cint, CuPtr{Cdouble},
                     Cint, CuPtr{Cint}, CuPtr{Cdouble}, Cint, CuPtr{Cint}),
@@ -1541,7 +1541,7 @@ end
 end
 
 @checked function cusolverDnCgetrs(handle, trans, n, nrhs, A, lda, devIpiv, B, ldb, devInfo)
-    initialize_api()
+    initialize_context()
     ccall((:cusolverDnCgetrs, libcusolver()), cusolverStatus_t,
                    (cusolverDnHandle_t, cublasOperation_t, Cint, Cint, CuPtr{cuComplex},
                     Cint, CuPtr{Cint}, CuPtr{cuComplex}, Cint, CuPtr{Cint}),
@@ -1549,7 +1549,7 @@ end
 end
 
 @checked function cusolverDnZgetrs(handle, trans, n, nrhs, A, lda, devIpiv, B, ldb, devInfo)
-    initialize_api()
+    initialize_context()
     ccall((:cusolverDnZgetrs, libcusolver()), cusolverStatus_t,
                    (cusolverDnHandle_t, cublasOperation_t, Cint, Cint,
                     CuPtr{cuDoubleComplex}, Cint, CuPtr{Cint}, CuPtr{cuDoubleComplex},
@@ -1558,28 +1558,28 @@ end
 end
 
 @checked function cusolverDnSgeqrf_bufferSize(handle, m, n, A, lda, lwork)
-    initialize_api()
+    initialize_context()
     ccall((:cusolverDnSgeqrf_bufferSize, libcusolver()), cusolverStatus_t,
                    (cusolverDnHandle_t, Cint, Cint, CuPtr{Cfloat}, Cint, Ptr{Cint}),
                    handle, m, n, A, lda, lwork)
 end
 
 @checked function cusolverDnDgeqrf_bufferSize(handle, m, n, A, lda, lwork)
-    initialize_api()
+    initialize_context()
     ccall((:cusolverDnDgeqrf_bufferSize, libcusolver()), cusolverStatus_t,
                    (cusolverDnHandle_t, Cint, Cint, CuPtr{Cdouble}, Cint, Ptr{Cint}),
                    handle, m, n, A, lda, lwork)
 end
 
 @checked function cusolverDnCgeqrf_bufferSize(handle, m, n, A, lda, lwork)
-    initialize_api()
+    initialize_context()
     ccall((:cusolverDnCgeqrf_bufferSize, libcusolver()), cusolverStatus_t,
                    (cusolverDnHandle_t, Cint, Cint, CuPtr{cuComplex}, Cint, Ptr{Cint}),
                    handle, m, n, A, lda, lwork)
 end
 
 @checked function cusolverDnZgeqrf_bufferSize(handle, m, n, A, lda, lwork)
-    initialize_api()
+    initialize_context()
     ccall((:cusolverDnZgeqrf_bufferSize, libcusolver()), cusolverStatus_t,
                    (cusolverDnHandle_t, Cint, Cint, CuPtr{cuDoubleComplex}, Cint,
                     Ptr{Cint}),
@@ -1587,7 +1587,7 @@ end
 end
 
 @checked function cusolverDnSgeqrf(handle, m, n, A, lda, TAU, Workspace, Lwork, devInfo)
-    initialize_api()
+    initialize_context()
     ccall((:cusolverDnSgeqrf, libcusolver()), cusolverStatus_t,
                    (cusolverDnHandle_t, Cint, Cint, CuPtr{Cfloat}, Cint, CuPtr{Cfloat},
                     CuPtr{Cfloat}, Cint, CuPtr{Cint}),
@@ -1595,7 +1595,7 @@ end
 end
 
 @checked function cusolverDnDgeqrf(handle, m, n, A, lda, TAU, Workspace, Lwork, devInfo)
-    initialize_api()
+    initialize_context()
     ccall((:cusolverDnDgeqrf, libcusolver()), cusolverStatus_t,
                    (cusolverDnHandle_t, Cint, Cint, CuPtr{Cdouble}, Cint, CuPtr{Cdouble},
                     CuPtr{Cdouble}, Cint, CuPtr{Cint}),
@@ -1603,7 +1603,7 @@ end
 end
 
 @checked function cusolverDnCgeqrf(handle, m, n, A, lda, TAU, Workspace, Lwork, devInfo)
-    initialize_api()
+    initialize_context()
     ccall((:cusolverDnCgeqrf, libcusolver()), cusolverStatus_t,
                    (cusolverDnHandle_t, Cint, Cint, CuPtr{cuComplex}, Cint,
                     CuPtr{cuComplex}, CuPtr{cuComplex}, Cint, CuPtr{Cint}),
@@ -1611,7 +1611,7 @@ end
 end
 
 @checked function cusolverDnZgeqrf(handle, m, n, A, lda, TAU, Workspace, Lwork, devInfo)
-    initialize_api()
+    initialize_context()
     ccall((:cusolverDnZgeqrf, libcusolver()), cusolverStatus_t,
                    (cusolverDnHandle_t, Cint, Cint, CuPtr{cuDoubleComplex}, Cint,
                     CuPtr{cuDoubleComplex}, CuPtr{cuDoubleComplex}, Cint, CuPtr{Cint}),
@@ -1619,7 +1619,7 @@ end
 end
 
 @checked function cusolverDnSorgqr_bufferSize(handle, m, n, k, A, lda, tau, lwork)
-    initialize_api()
+    initialize_context()
     ccall((:cusolverDnSorgqr_bufferSize, libcusolver()), cusolverStatus_t,
                    (cusolverDnHandle_t, Cint, Cint, Cint, CuPtr{Cfloat}, Cint,
                     CuPtr{Cfloat}, Ptr{Cint}),
@@ -1627,7 +1627,7 @@ end
 end
 
 @checked function cusolverDnDorgqr_bufferSize(handle, m, n, k, A, lda, tau, lwork)
-    initialize_api()
+    initialize_context()
     ccall((:cusolverDnDorgqr_bufferSize, libcusolver()), cusolverStatus_t,
                    (cusolverDnHandle_t, Cint, Cint, Cint, CuPtr{Cdouble}, Cint,
                     CuPtr{Cdouble}, Ptr{Cint}),
@@ -1635,7 +1635,7 @@ end
 end
 
 @checked function cusolverDnCungqr_bufferSize(handle, m, n, k, A, lda, tau, lwork)
-    initialize_api()
+    initialize_context()
     ccall((:cusolverDnCungqr_bufferSize, libcusolver()), cusolverStatus_t,
                    (cusolverDnHandle_t, Cint, Cint, Cint, CuPtr{cuComplex}, Cint,
                     CuPtr{cuComplex}, Ptr{Cint}),
@@ -1643,7 +1643,7 @@ end
 end
 
 @checked function cusolverDnZungqr_bufferSize(handle, m, n, k, A, lda, tau, lwork)
-    initialize_api()
+    initialize_context()
     ccall((:cusolverDnZungqr_bufferSize, libcusolver()), cusolverStatus_t,
                    (cusolverDnHandle_t, Cint, Cint, Cint, CuPtr{cuDoubleComplex}, Cint,
                     CuPtr{cuDoubleComplex}, Ptr{Cint}),
@@ -1651,7 +1651,7 @@ end
 end
 
 @checked function cusolverDnSorgqr(handle, m, n, k, A, lda, tau, work, lwork, info)
-    initialize_api()
+    initialize_context()
     ccall((:cusolverDnSorgqr, libcusolver()), cusolverStatus_t,
                    (cusolverDnHandle_t, Cint, Cint, Cint, CuPtr{Cfloat}, Cint,
                     CuPtr{Cfloat}, CuPtr{Cfloat}, Cint, CuPtr{Cint}),
@@ -1659,7 +1659,7 @@ end
 end
 
 @checked function cusolverDnDorgqr(handle, m, n, k, A, lda, tau, work, lwork, info)
-    initialize_api()
+    initialize_context()
     ccall((:cusolverDnDorgqr, libcusolver()), cusolverStatus_t,
                    (cusolverDnHandle_t, Cint, Cint, Cint, CuPtr{Cdouble}, Cint,
                     CuPtr{Cdouble}, CuPtr{Cdouble}, Cint, CuPtr{Cint}),
@@ -1667,7 +1667,7 @@ end
 end
 
 @checked function cusolverDnCungqr(handle, m, n, k, A, lda, tau, work, lwork, info)
-    initialize_api()
+    initialize_context()
     ccall((:cusolverDnCungqr, libcusolver()), cusolverStatus_t,
                    (cusolverDnHandle_t, Cint, Cint, Cint, CuPtr{cuComplex}, Cint,
                     CuPtr{cuComplex}, CuPtr{cuComplex}, Cint, CuPtr{Cint}),
@@ -1675,7 +1675,7 @@ end
 end
 
 @checked function cusolverDnZungqr(handle, m, n, k, A, lda, tau, work, lwork, info)
-    initialize_api()
+    initialize_context()
     ccall((:cusolverDnZungqr, libcusolver()), cusolverStatus_t,
                    (cusolverDnHandle_t, Cint, Cint, Cint, CuPtr{cuDoubleComplex}, Cint,
                     CuPtr{cuDoubleComplex}, CuPtr{cuDoubleComplex}, Cint, CuPtr{Cint}),
@@ -1684,7 +1684,7 @@ end
 
 @checked function cusolverDnSormqr_bufferSize(handle, side, trans, m, n, k, A, lda, tau, C,
                                               ldc, lwork)
-    initialize_api()
+    initialize_context()
     ccall((:cusolverDnSormqr_bufferSize, libcusolver()), cusolverStatus_t,
                    (cusolverDnHandle_t, cublasSideMode_t, cublasOperation_t, Cint, Cint,
                     Cint, CuPtr{Cfloat}, Cint, CuPtr{Cfloat}, CuPtr{Cfloat}, Cint,
@@ -1694,7 +1694,7 @@ end
 
 @checked function cusolverDnDormqr_bufferSize(handle, side, trans, m, n, k, A, lda, tau, C,
                                               ldc, lwork)
-    initialize_api()
+    initialize_context()
     ccall((:cusolverDnDormqr_bufferSize, libcusolver()), cusolverStatus_t,
                    (cusolverDnHandle_t, cublasSideMode_t, cublasOperation_t, Cint, Cint,
                     Cint, CuPtr{Cdouble}, Cint, CuPtr{Cdouble}, CuPtr{Cdouble}, Cint,
@@ -1704,7 +1704,7 @@ end
 
 @checked function cusolverDnCunmqr_bufferSize(handle, side, trans, m, n, k, A, lda, tau, C,
                                               ldc, lwork)
-    initialize_api()
+    initialize_context()
     ccall((:cusolverDnCunmqr_bufferSize, libcusolver()), cusolverStatus_t,
                    (cusolverDnHandle_t, cublasSideMode_t, cublasOperation_t, Cint, Cint,
                     Cint, CuPtr{cuComplex}, Cint, CuPtr{cuComplex}, CuPtr{cuComplex}, Cint,
@@ -1714,7 +1714,7 @@ end
 
 @checked function cusolverDnZunmqr_bufferSize(handle, side, trans, m, n, k, A, lda, tau, C,
                                               ldc, lwork)
-    initialize_api()
+    initialize_context()
     ccall((:cusolverDnZunmqr_bufferSize, libcusolver()), cusolverStatus_t,
                    (cusolverDnHandle_t, cublasSideMode_t, cublasOperation_t, Cint, Cint,
                     Cint, CuPtr{cuDoubleComplex}, Cint, CuPtr{cuDoubleComplex},
@@ -1724,7 +1724,7 @@ end
 
 @checked function cusolverDnSormqr(handle, side, trans, m, n, k, A, lda, tau, C, ldc, work,
                                    lwork, devInfo)
-    initialize_api()
+    initialize_context()
     ccall((:cusolverDnSormqr, libcusolver()), cusolverStatus_t,
                    (cusolverDnHandle_t, cublasSideMode_t, cublasOperation_t, Cint, Cint,
                     Cint, CuPtr{Cfloat}, Cint, CuPtr{Cfloat}, CuPtr{Cfloat}, Cint,
@@ -1734,7 +1734,7 @@ end
 
 @checked function cusolverDnDormqr(handle, side, trans, m, n, k, A, lda, tau, C, ldc, work,
                                    lwork, devInfo)
-    initialize_api()
+    initialize_context()
     ccall((:cusolverDnDormqr, libcusolver()), cusolverStatus_t,
                    (cusolverDnHandle_t, cublasSideMode_t, cublasOperation_t, Cint, Cint,
                     Cint, CuPtr{Cdouble}, Cint, CuPtr{Cdouble}, CuPtr{Cdouble}, Cint,
@@ -1744,7 +1744,7 @@ end
 
 @checked function cusolverDnCunmqr(handle, side, trans, m, n, k, A, lda, tau, C, ldc, work,
                                    lwork, devInfo)
-    initialize_api()
+    initialize_context()
     ccall((:cusolverDnCunmqr, libcusolver()), cusolverStatus_t,
                    (cusolverDnHandle_t, cublasSideMode_t, cublasOperation_t, Cint, Cint,
                     Cint, CuPtr{cuComplex}, Cint, CuPtr{cuComplex}, CuPtr{cuComplex}, Cint,
@@ -1754,7 +1754,7 @@ end
 
 @checked function cusolverDnZunmqr(handle, side, trans, m, n, k, A, lda, tau, C, ldc, work,
                                    lwork, devInfo)
-    initialize_api()
+    initialize_context()
     ccall((:cusolverDnZunmqr, libcusolver()), cusolverStatus_t,
                    (cusolverDnHandle_t, cublasSideMode_t, cublasOperation_t, Cint, Cint,
                     Cint, CuPtr{cuDoubleComplex}, Cint, CuPtr{cuDoubleComplex},
@@ -1763,35 +1763,35 @@ end
 end
 
 @checked function cusolverDnSsytrf_bufferSize(handle, n, A, lda, lwork)
-    initialize_api()
+    initialize_context()
     ccall((:cusolverDnSsytrf_bufferSize, libcusolver()), cusolverStatus_t,
                    (cusolverDnHandle_t, Cint, CuPtr{Cfloat}, Cint, Ptr{Cint}),
                    handle, n, A, lda, lwork)
 end
 
 @checked function cusolverDnDsytrf_bufferSize(handle, n, A, lda, lwork)
-    initialize_api()
+    initialize_context()
     ccall((:cusolverDnDsytrf_bufferSize, libcusolver()), cusolverStatus_t,
                    (cusolverDnHandle_t, Cint, CuPtr{Cdouble}, Cint, Ptr{Cint}),
                    handle, n, A, lda, lwork)
 end
 
 @checked function cusolverDnCsytrf_bufferSize(handle, n, A, lda, lwork)
-    initialize_api()
+    initialize_context()
     ccall((:cusolverDnCsytrf_bufferSize, libcusolver()), cusolverStatus_t,
                    (cusolverDnHandle_t, Cint, CuPtr{cuComplex}, Cint, Ptr{Cint}),
                    handle, n, A, lda, lwork)
 end
 
 @checked function cusolverDnZsytrf_bufferSize(handle, n, A, lda, lwork)
-    initialize_api()
+    initialize_context()
     ccall((:cusolverDnZsytrf_bufferSize, libcusolver()), cusolverStatus_t,
                    (cusolverDnHandle_t, Cint, CuPtr{cuDoubleComplex}, Cint, Ptr{Cint}),
                    handle, n, A, lda, lwork)
 end
 
 @checked function cusolverDnSsytrf(handle, uplo, n, A, lda, ipiv, work, lwork, info)
-    initialize_api()
+    initialize_context()
     ccall((:cusolverDnSsytrf, libcusolver()), cusolverStatus_t,
                    (cusolverDnHandle_t, cublasFillMode_t, Cint, CuPtr{Cfloat}, Cint,
                     CuPtr{Cint}, CuPtr{Cfloat}, Cint, CuPtr{Cint}),
@@ -1799,7 +1799,7 @@ end
 end
 
 @checked function cusolverDnDsytrf(handle, uplo, n, A, lda, ipiv, work, lwork, info)
-    initialize_api()
+    initialize_context()
     ccall((:cusolverDnDsytrf, libcusolver()), cusolverStatus_t,
                    (cusolverDnHandle_t, cublasFillMode_t, Cint, CuPtr{Cdouble}, Cint,
                     CuPtr{Cint}, CuPtr{Cdouble}, Cint, CuPtr{Cint}),
@@ -1807,7 +1807,7 @@ end
 end
 
 @checked function cusolverDnCsytrf(handle, uplo, n, A, lda, ipiv, work, lwork, info)
-    initialize_api()
+    initialize_context()
     ccall((:cusolverDnCsytrf, libcusolver()), cusolverStatus_t,
                    (cusolverDnHandle_t, cublasFillMode_t, Cint, CuPtr{cuComplex}, Cint,
                     CuPtr{Cint}, CuPtr{cuComplex}, Cint, CuPtr{Cint}),
@@ -1815,7 +1815,7 @@ end
 end
 
 @checked function cusolverDnZsytrf(handle, uplo, n, A, lda, ipiv, work, lwork, info)
-    initialize_api()
+    initialize_context()
     ccall((:cusolverDnZsytrf, libcusolver()), cusolverStatus_t,
                    (cusolverDnHandle_t, cublasFillMode_t, Cint, CuPtr{cuDoubleComplex},
                     Cint, CuPtr{Cint}, CuPtr{cuDoubleComplex}, Cint, CuPtr{Cint}),
@@ -1824,7 +1824,7 @@ end
 
 @checked function cusolverDnSsytrs_bufferSize(handle, uplo, n, nrhs, A, lda, ipiv, B, ldb,
                                               lwork)
-    initialize_api()
+    initialize_context()
     ccall((:cusolverDnSsytrs_bufferSize, libcusolver()), cusolverStatus_t,
                    (cusolverDnHandle_t, cublasFillMode_t, Cint, Cint, CuPtr{Cfloat}, Cint,
                     CuPtr{Cint}, CuPtr{Cfloat}, Cint, Ptr{Cint}),
@@ -1833,7 +1833,7 @@ end
 
 @checked function cusolverDnDsytrs_bufferSize(handle, uplo, n, nrhs, A, lda, ipiv, B, ldb,
                                               lwork)
-    initialize_api()
+    initialize_context()
     ccall((:cusolverDnDsytrs_bufferSize, libcusolver()), cusolverStatus_t,
                    (cusolverDnHandle_t, cublasFillMode_t, Cint, Cint, CuPtr{Cdouble},
                     Cint, CuPtr{Cint}, CuPtr{Cdouble}, Cint, Ptr{Cint}),
@@ -1842,7 +1842,7 @@ end
 
 @checked function cusolverDnCsytrs_bufferSize(handle, uplo, n, nrhs, A, lda, ipiv, B, ldb,
                                               lwork)
-    initialize_api()
+    initialize_context()
     ccall((:cusolverDnCsytrs_bufferSize, libcusolver()), cusolverStatus_t,
                    (cusolverDnHandle_t, cublasFillMode_t, Cint, Cint, CuPtr{cuComplex},
                     Cint, CuPtr{Cint}, CuPtr{cuComplex}, Cint, Ptr{Cint}),
@@ -1851,7 +1851,7 @@ end
 
 @checked function cusolverDnZsytrs_bufferSize(handle, uplo, n, nrhs, A, lda, ipiv, B, ldb,
                                               lwork)
-    initialize_api()
+    initialize_context()
     ccall((:cusolverDnZsytrs_bufferSize, libcusolver()), cusolverStatus_t,
                    (cusolverDnHandle_t, cublasFillMode_t, Cint, Cint,
                     CuPtr{cuDoubleComplex}, Cint, CuPtr{Cint}, CuPtr{cuDoubleComplex},
@@ -1861,7 +1861,7 @@ end
 
 @checked function cusolverDnSsytrs(handle, uplo, n, nrhs, A, lda, ipiv, B, ldb, work,
                                    lwork, info)
-    initialize_api()
+    initialize_context()
     ccall((:cusolverDnSsytrs, libcusolver()), cusolverStatus_t,
                    (cusolverDnHandle_t, cublasFillMode_t, Cint, Cint, CuPtr{Cfloat}, Cint,
                     CuPtr{Cint}, CuPtr{Cfloat}, Cint, CuPtr{Cfloat}, Cint, CuPtr{Cint}),
@@ -1870,7 +1870,7 @@ end
 
 @checked function cusolverDnDsytrs(handle, uplo, n, nrhs, A, lda, ipiv, B, ldb, work,
                                    lwork, info)
-    initialize_api()
+    initialize_context()
     ccall((:cusolverDnDsytrs, libcusolver()), cusolverStatus_t,
                    (cusolverDnHandle_t, cublasFillMode_t, Cint, Cint, CuPtr{Cdouble},
                     Cint, CuPtr{Cint}, CuPtr{Cdouble}, Cint, CuPtr{Cdouble}, Cint,
@@ -1880,7 +1880,7 @@ end
 
 @checked function cusolverDnCsytrs(handle, uplo, n, nrhs, A, lda, ipiv, B, ldb, work,
                                    lwork, info)
-    initialize_api()
+    initialize_context()
     ccall((:cusolverDnCsytrs, libcusolver()), cusolverStatus_t,
                    (cusolverDnHandle_t, cublasFillMode_t, Cint, Cint, CuPtr{cuComplex},
                     Cint, CuPtr{Cint}, CuPtr{cuComplex}, Cint, CuPtr{cuComplex}, Cint,
@@ -1890,7 +1890,7 @@ end
 
 @checked function cusolverDnZsytrs(handle, uplo, n, nrhs, A, lda, ipiv, B, ldb, work,
                                    lwork, info)
-    initialize_api()
+    initialize_context()
     ccall((:cusolverDnZsytrs, libcusolver()), cusolverStatus_t,
                    (cusolverDnHandle_t, cublasFillMode_t, Cint, Cint,
                     CuPtr{cuDoubleComplex}, Cint, CuPtr{Cint}, CuPtr{cuDoubleComplex},
@@ -1899,7 +1899,7 @@ end
 end
 
 @checked function cusolverDnSsytri_bufferSize(handle, uplo, n, A, lda, ipiv, lwork)
-    initialize_api()
+    initialize_context()
     ccall((:cusolverDnSsytri_bufferSize, libcusolver()), cusolverStatus_t,
                    (cusolverDnHandle_t, cublasFillMode_t, Cint, CuPtr{Cfloat}, Cint,
                     CuPtr{Cint}, Ptr{Cint}),
@@ -1907,7 +1907,7 @@ end
 end
 
 @checked function cusolverDnDsytri_bufferSize(handle, uplo, n, A, lda, ipiv, lwork)
-    initialize_api()
+    initialize_context()
     ccall((:cusolverDnDsytri_bufferSize, libcusolver()), cusolverStatus_t,
                    (cusolverDnHandle_t, cublasFillMode_t, Cint, CuPtr{Cdouble}, Cint,
                     CuPtr{Cint}, Ptr{Cint}),
@@ -1915,7 +1915,7 @@ end
 end
 
 @checked function cusolverDnCsytri_bufferSize(handle, uplo, n, A, lda, ipiv, lwork)
-    initialize_api()
+    initialize_context()
     ccall((:cusolverDnCsytri_bufferSize, libcusolver()), cusolverStatus_t,
                    (cusolverDnHandle_t, cublasFillMode_t, Cint, CuPtr{cuComplex}, Cint,
                     CuPtr{Cint}, Ptr{Cint}),
@@ -1923,7 +1923,7 @@ end
 end
 
 @checked function cusolverDnZsytri_bufferSize(handle, uplo, n, A, lda, ipiv, lwork)
-    initialize_api()
+    initialize_context()
     ccall((:cusolverDnZsytri_bufferSize, libcusolver()), cusolverStatus_t,
                    (cusolverDnHandle_t, cublasFillMode_t, Cint, CuPtr{cuDoubleComplex},
                     Cint, CuPtr{Cint}, Ptr{Cint}),
@@ -1931,7 +1931,7 @@ end
 end
 
 @checked function cusolverDnSsytri(handle, uplo, n, A, lda, ipiv, work, lwork, info)
-    initialize_api()
+    initialize_context()
     ccall((:cusolverDnSsytri, libcusolver()), cusolverStatus_t,
                    (cusolverDnHandle_t, cublasFillMode_t, Cint, CuPtr{Cfloat}, Cint,
                     CuPtr{Cint}, CuPtr{Cfloat}, Cint, CuPtr{Cint}),
@@ -1939,7 +1939,7 @@ end
 end
 
 @checked function cusolverDnDsytri(handle, uplo, n, A, lda, ipiv, work, lwork, info)
-    initialize_api()
+    initialize_context()
     ccall((:cusolverDnDsytri, libcusolver()), cusolverStatus_t,
                    (cusolverDnHandle_t, cublasFillMode_t, Cint, CuPtr{Cdouble}, Cint,
                     CuPtr{Cint}, CuPtr{Cdouble}, Cint, CuPtr{Cint}),
@@ -1947,7 +1947,7 @@ end
 end
 
 @checked function cusolverDnCsytri(handle, uplo, n, A, lda, ipiv, work, lwork, info)
-    initialize_api()
+    initialize_context()
     ccall((:cusolverDnCsytri, libcusolver()), cusolverStatus_t,
                    (cusolverDnHandle_t, cublasFillMode_t, Cint, CuPtr{cuComplex}, Cint,
                     CuPtr{Cint}, CuPtr{cuComplex}, Cint, CuPtr{Cint}),
@@ -1955,7 +1955,7 @@ end
 end
 
 @checked function cusolverDnZsytri(handle, uplo, n, A, lda, ipiv, work, lwork, info)
-    initialize_api()
+    initialize_context()
     ccall((:cusolverDnZsytri, libcusolver()), cusolverStatus_t,
                    (cusolverDnHandle_t, cublasFillMode_t, Cint, CuPtr{cuDoubleComplex},
                     Cint, CuPtr{Cint}, CuPtr{cuDoubleComplex}, Cint, CuPtr{Cint}),
@@ -1963,28 +1963,28 @@ end
 end
 
 @checked function cusolverDnSgebrd_bufferSize(handle, m, n, Lwork)
-    initialize_api()
+    initialize_context()
     ccall((:cusolverDnSgebrd_bufferSize, libcusolver()), cusolverStatus_t,
                    (cusolverDnHandle_t, Cint, Cint, Ptr{Cint}),
                    handle, m, n, Lwork)
 end
 
 @checked function cusolverDnDgebrd_bufferSize(handle, m, n, Lwork)
-    initialize_api()
+    initialize_context()
     ccall((:cusolverDnDgebrd_bufferSize, libcusolver()), cusolverStatus_t,
                    (cusolverDnHandle_t, Cint, Cint, Ptr{Cint}),
                    handle, m, n, Lwork)
 end
 
 @checked function cusolverDnCgebrd_bufferSize(handle, m, n, Lwork)
-    initialize_api()
+    initialize_context()
     ccall((:cusolverDnCgebrd_bufferSize, libcusolver()), cusolverStatus_t,
                    (cusolverDnHandle_t, Cint, Cint, Ptr{Cint}),
                    handle, m, n, Lwork)
 end
 
 @checked function cusolverDnZgebrd_bufferSize(handle, m, n, Lwork)
-    initialize_api()
+    initialize_context()
     ccall((:cusolverDnZgebrd_bufferSize, libcusolver()), cusolverStatus_t,
                    (cusolverDnHandle_t, Cint, Cint, Ptr{Cint}),
                    handle, m, n, Lwork)
@@ -1992,7 +1992,7 @@ end
 
 @checked function cusolverDnSgebrd(handle, m, n, A, lda, D, E, TAUQ, TAUP, Work, Lwork,
                                    devInfo)
-    initialize_api()
+    initialize_context()
     ccall((:cusolverDnSgebrd, libcusolver()), cusolverStatus_t,
                    (cusolverDnHandle_t, Cint, Cint, CuPtr{Cfloat}, Cint, CuPtr{Cfloat},
                     CuPtr{Cfloat}, CuPtr{Cfloat}, CuPtr{Cfloat}, CuPtr{Cfloat}, Cint,
@@ -2002,7 +2002,7 @@ end
 
 @checked function cusolverDnDgebrd(handle, m, n, A, lda, D, E, TAUQ, TAUP, Work, Lwork,
                                    devInfo)
-    initialize_api()
+    initialize_context()
     ccall((:cusolverDnDgebrd, libcusolver()), cusolverStatus_t,
                    (cusolverDnHandle_t, Cint, Cint, CuPtr{Cdouble}, Cint, CuPtr{Cdouble},
                     CuPtr{Cdouble}, CuPtr{Cdouble}, CuPtr{Cdouble}, CuPtr{Cdouble}, Cint,
@@ -2012,7 +2012,7 @@ end
 
 @checked function cusolverDnCgebrd(handle, m, n, A, lda, D, E, TAUQ, TAUP, Work, Lwork,
                                    devInfo)
-    initialize_api()
+    initialize_context()
     ccall((:cusolverDnCgebrd, libcusolver()), cusolverStatus_t,
                    (cusolverDnHandle_t, Cint, Cint, CuPtr{cuComplex}, Cint, CuPtr{Cfloat},
                     CuPtr{Cfloat}, CuPtr{cuComplex}, CuPtr{cuComplex}, CuPtr{cuComplex},
@@ -2022,7 +2022,7 @@ end
 
 @checked function cusolverDnZgebrd(handle, m, n, A, lda, D, E, TAUQ, TAUP, Work, Lwork,
                                    devInfo)
-    initialize_api()
+    initialize_context()
     ccall((:cusolverDnZgebrd, libcusolver()), cusolverStatus_t,
                    (cusolverDnHandle_t, Cint, Cint, CuPtr{cuDoubleComplex}, Cint,
                     CuPtr{Cdouble}, CuPtr{Cdouble}, CuPtr{cuDoubleComplex},
@@ -2031,7 +2031,7 @@ end
 end
 
 @checked function cusolverDnSorgbr_bufferSize(handle, side, m, n, k, A, lda, tau, lwork)
-    initialize_api()
+    initialize_context()
     ccall((:cusolverDnSorgbr_bufferSize, libcusolver()), cusolverStatus_t,
                    (cusolverDnHandle_t, cublasSideMode_t, Cint, Cint, Cint, CuPtr{Cfloat},
                     Cint, CuPtr{Cfloat}, Ptr{Cint}),
@@ -2039,7 +2039,7 @@ end
 end
 
 @checked function cusolverDnDorgbr_bufferSize(handle, side, m, n, k, A, lda, tau, lwork)
-    initialize_api()
+    initialize_context()
     ccall((:cusolverDnDorgbr_bufferSize, libcusolver()), cusolverStatus_t,
                    (cusolverDnHandle_t, cublasSideMode_t, Cint, Cint, Cint,
                     CuPtr{Cdouble}, Cint, CuPtr{Cdouble}, Ptr{Cint}),
@@ -2047,7 +2047,7 @@ end
 end
 
 @checked function cusolverDnCungbr_bufferSize(handle, side, m, n, k, A, lda, tau, lwork)
-    initialize_api()
+    initialize_context()
     ccall((:cusolverDnCungbr_bufferSize, libcusolver()), cusolverStatus_t,
                    (cusolverDnHandle_t, cublasSideMode_t, Cint, Cint, Cint,
                     CuPtr{cuComplex}, Cint, CuPtr{cuComplex}, Ptr{Cint}),
@@ -2055,7 +2055,7 @@ end
 end
 
 @checked function cusolverDnZungbr_bufferSize(handle, side, m, n, k, A, lda, tau, lwork)
-    initialize_api()
+    initialize_context()
     ccall((:cusolverDnZungbr_bufferSize, libcusolver()), cusolverStatus_t,
                    (cusolverDnHandle_t, cublasSideMode_t, Cint, Cint, Cint,
                     CuPtr{cuDoubleComplex}, Cint, CuPtr{cuDoubleComplex}, Ptr{Cint}),
@@ -2063,7 +2063,7 @@ end
 end
 
 @checked function cusolverDnSorgbr(handle, side, m, n, k, A, lda, tau, work, lwork, info)
-    initialize_api()
+    initialize_context()
     ccall((:cusolverDnSorgbr, libcusolver()), cusolverStatus_t,
                    (cusolverDnHandle_t, cublasSideMode_t, Cint, Cint, Cint, CuPtr{Cfloat},
                     Cint, CuPtr{Cfloat}, CuPtr{Cfloat}, Cint, CuPtr{Cint}),
@@ -2071,7 +2071,7 @@ end
 end
 
 @checked function cusolverDnDorgbr(handle, side, m, n, k, A, lda, tau, work, lwork, info)
-    initialize_api()
+    initialize_context()
     ccall((:cusolverDnDorgbr, libcusolver()), cusolverStatus_t,
                    (cusolverDnHandle_t, cublasSideMode_t, Cint, Cint, Cint,
                     CuPtr{Cdouble}, Cint, CuPtr{Cdouble}, CuPtr{Cdouble}, Cint, CuPtr{Cint}),
@@ -2079,7 +2079,7 @@ end
 end
 
 @checked function cusolverDnCungbr(handle, side, m, n, k, A, lda, tau, work, lwork, info)
-    initialize_api()
+    initialize_context()
     ccall((:cusolverDnCungbr, libcusolver()), cusolverStatus_t,
                    (cusolverDnHandle_t, cublasSideMode_t, Cint, Cint, Cint,
                     CuPtr{cuComplex}, Cint, CuPtr{cuComplex}, CuPtr{cuComplex}, Cint,
@@ -2088,7 +2088,7 @@ end
 end
 
 @checked function cusolverDnZungbr(handle, side, m, n, k, A, lda, tau, work, lwork, info)
-    initialize_api()
+    initialize_context()
     ccall((:cusolverDnZungbr, libcusolver()), cusolverStatus_t,
                    (cusolverDnHandle_t, cublasSideMode_t, Cint, Cint, Cint,
                     CuPtr{cuDoubleComplex}, Cint, CuPtr{cuDoubleComplex},
@@ -2097,7 +2097,7 @@ end
 end
 
 @checked function cusolverDnSsytrd_bufferSize(handle, uplo, n, A, lda, d, e, tau, lwork)
-    initialize_api()
+    initialize_context()
     ccall((:cusolverDnSsytrd_bufferSize, libcusolver()), cusolverStatus_t,
                    (cusolverDnHandle_t, cublasFillMode_t, Cint, CuPtr{Cfloat}, Cint,
                     CuPtr{Cfloat}, CuPtr{Cfloat}, CuPtr{Cfloat}, Ptr{Cint}),
@@ -2105,7 +2105,7 @@ end
 end
 
 @checked function cusolverDnDsytrd_bufferSize(handle, uplo, n, A, lda, d, e, tau, lwork)
-    initialize_api()
+    initialize_context()
     ccall((:cusolverDnDsytrd_bufferSize, libcusolver()), cusolverStatus_t,
                    (cusolverDnHandle_t, cublasFillMode_t, Cint, CuPtr{Cdouble}, Cint,
                     CuPtr{Cdouble}, CuPtr{Cdouble}, CuPtr{Cdouble}, Ptr{Cint}),
@@ -2113,7 +2113,7 @@ end
 end
 
 @checked function cusolverDnChetrd_bufferSize(handle, uplo, n, A, lda, d, e, tau, lwork)
-    initialize_api()
+    initialize_context()
     ccall((:cusolverDnChetrd_bufferSize, libcusolver()), cusolverStatus_t,
                    (cusolverDnHandle_t, cublasFillMode_t, Cint, CuPtr{cuComplex}, Cint,
                     CuPtr{Cfloat}, CuPtr{Cfloat}, CuPtr{cuComplex}, Ptr{Cint}),
@@ -2121,7 +2121,7 @@ end
 end
 
 @checked function cusolverDnZhetrd_bufferSize(handle, uplo, n, A, lda, d, e, tau, lwork)
-    initialize_api()
+    initialize_context()
     ccall((:cusolverDnZhetrd_bufferSize, libcusolver()), cusolverStatus_t,
                    (cusolverDnHandle_t, cublasFillMode_t, Cint, CuPtr{cuDoubleComplex},
                     Cint, CuPtr{Cdouble}, CuPtr{Cdouble}, CuPtr{cuDoubleComplex}, Ptr{Cint}),
@@ -2129,7 +2129,7 @@ end
 end
 
 @checked function cusolverDnSsytrd(handle, uplo, n, A, lda, d, e, tau, work, lwork, info)
-    initialize_api()
+    initialize_context()
     ccall((:cusolverDnSsytrd, libcusolver()), cusolverStatus_t,
                    (cusolverDnHandle_t, cublasFillMode_t, Cint, CuPtr{Cfloat}, Cint,
                     CuPtr{Cfloat}, CuPtr{Cfloat}, CuPtr{Cfloat}, CuPtr{Cfloat}, Cint,
@@ -2138,7 +2138,7 @@ end
 end
 
 @checked function cusolverDnDsytrd(handle, uplo, n, A, lda, d, e, tau, work, lwork, info)
-    initialize_api()
+    initialize_context()
     ccall((:cusolverDnDsytrd, libcusolver()), cusolverStatus_t,
                    (cusolverDnHandle_t, cublasFillMode_t, Cint, CuPtr{Cdouble}, Cint,
                     CuPtr{Cdouble}, CuPtr{Cdouble}, CuPtr{Cdouble}, CuPtr{Cdouble}, Cint,
@@ -2147,7 +2147,7 @@ end
 end
 
 @checked function cusolverDnChetrd(handle, uplo, n, A, lda, d, e, tau, work, lwork, info)
-    initialize_api()
+    initialize_context()
     ccall((:cusolverDnChetrd, libcusolver()), cusolverStatus_t,
                    (cusolverDnHandle_t, cublasFillMode_t, Cint, CuPtr{cuComplex}, Cint,
                     CuPtr{Cfloat}, CuPtr{Cfloat}, CuPtr{cuComplex}, CuPtr{cuComplex}, Cint,
@@ -2156,7 +2156,7 @@ end
 end
 
 @checked function cusolverDnZhetrd(handle, uplo, n, A, lda, d, e, tau, work, lwork, info)
-    initialize_api()
+    initialize_context()
     ccall((:cusolverDnZhetrd, libcusolver()), cusolverStatus_t,
                    (cusolverDnHandle_t, cublasFillMode_t, Cint, CuPtr{cuDoubleComplex},
                     Cint, CuPtr{Cdouble}, CuPtr{Cdouble}, CuPtr{cuDoubleComplex},
@@ -2165,7 +2165,7 @@ end
 end
 
 @checked function cusolverDnSorgtr_bufferSize(handle, uplo, n, A, lda, tau, lwork)
-    initialize_api()
+    initialize_context()
     ccall((:cusolverDnSorgtr_bufferSize, libcusolver()), cusolverStatus_t,
                    (cusolverDnHandle_t, cublasFillMode_t, Cint, CuPtr{Cfloat}, Cint,
                     CuPtr{Cfloat}, Ptr{Cint}),
@@ -2173,7 +2173,7 @@ end
 end
 
 @checked function cusolverDnDorgtr_bufferSize(handle, uplo, n, A, lda, tau, lwork)
-    initialize_api()
+    initialize_context()
     ccall((:cusolverDnDorgtr_bufferSize, libcusolver()), cusolverStatus_t,
                    (cusolverDnHandle_t, cublasFillMode_t, Cint, CuPtr{Cdouble}, Cint,
                     CuPtr{Cdouble}, Ptr{Cint}),
@@ -2181,7 +2181,7 @@ end
 end
 
 @checked function cusolverDnCungtr_bufferSize(handle, uplo, n, A, lda, tau, lwork)
-    initialize_api()
+    initialize_context()
     ccall((:cusolverDnCungtr_bufferSize, libcusolver()), cusolverStatus_t,
                    (cusolverDnHandle_t, cublasFillMode_t, Cint, CuPtr{cuComplex}, Cint,
                     CuPtr{cuComplex}, Ptr{Cint}),
@@ -2189,7 +2189,7 @@ end
 end
 
 @checked function cusolverDnZungtr_bufferSize(handle, uplo, n, A, lda, tau, lwork)
-    initialize_api()
+    initialize_context()
     ccall((:cusolverDnZungtr_bufferSize, libcusolver()), cusolverStatus_t,
                    (cusolverDnHandle_t, cublasFillMode_t, Cint, CuPtr{cuDoubleComplex},
                     Cint, CuPtr{cuDoubleComplex}, Ptr{Cint}),
@@ -2197,7 +2197,7 @@ end
 end
 
 @checked function cusolverDnSorgtr(handle, uplo, n, A, lda, tau, work, lwork, info)
-    initialize_api()
+    initialize_context()
     ccall((:cusolverDnSorgtr, libcusolver()), cusolverStatus_t,
                    (cusolverDnHandle_t, cublasFillMode_t, Cint, CuPtr{Cfloat}, Cint,
                     CuPtr{Cfloat}, CuPtr{Cfloat}, Cint, CuPtr{Cint}),
@@ -2205,7 +2205,7 @@ end
 end
 
 @checked function cusolverDnDorgtr(handle, uplo, n, A, lda, tau, work, lwork, info)
-    initialize_api()
+    initialize_context()
     ccall((:cusolverDnDorgtr, libcusolver()), cusolverStatus_t,
                    (cusolverDnHandle_t, cublasFillMode_t, Cint, CuPtr{Cdouble}, Cint,
                     CuPtr{Cdouble}, CuPtr{Cdouble}, Cint, CuPtr{Cint}),
@@ -2213,7 +2213,7 @@ end
 end
 
 @checked function cusolverDnCungtr(handle, uplo, n, A, lda, tau, work, lwork, info)
-    initialize_api()
+    initialize_context()
     ccall((:cusolverDnCungtr, libcusolver()), cusolverStatus_t,
                    (cusolverDnHandle_t, cublasFillMode_t, Cint, CuPtr{cuComplex}, Cint,
                     CuPtr{cuComplex}, CuPtr{cuComplex}, Cint, CuPtr{Cint}),
@@ -2221,7 +2221,7 @@ end
 end
 
 @checked function cusolverDnZungtr(handle, uplo, n, A, lda, tau, work, lwork, info)
-    initialize_api()
+    initialize_context()
     ccall((:cusolverDnZungtr, libcusolver()), cusolverStatus_t,
                    (cusolverDnHandle_t, cublasFillMode_t, Cint, CuPtr{cuDoubleComplex},
                     Cint, CuPtr{cuDoubleComplex}, CuPtr{cuDoubleComplex}, Cint, CuPtr{Cint}),
@@ -2230,7 +2230,7 @@ end
 
 @checked function cusolverDnSormtr_bufferSize(handle, side, uplo, trans, m, n, A, lda, tau,
                                               C, ldc, lwork)
-    initialize_api()
+    initialize_context()
     ccall((:cusolverDnSormtr_bufferSize, libcusolver()), cusolverStatus_t,
                    (cusolverDnHandle_t, cublasSideMode_t, cublasFillMode_t,
                     cublasOperation_t, Cint, Cint, CuPtr{Cfloat}, Cint, CuPtr{Cfloat},
@@ -2240,7 +2240,7 @@ end
 
 @checked function cusolverDnDormtr_bufferSize(handle, side, uplo, trans, m, n, A, lda, tau,
                                               C, ldc, lwork)
-    initialize_api()
+    initialize_context()
     ccall((:cusolverDnDormtr_bufferSize, libcusolver()), cusolverStatus_t,
                    (cusolverDnHandle_t, cublasSideMode_t, cublasFillMode_t,
                     cublasOperation_t, Cint, Cint, CuPtr{Cdouble}, Cint, CuPtr{Cdouble},
@@ -2250,7 +2250,7 @@ end
 
 @checked function cusolverDnCunmtr_bufferSize(handle, side, uplo, trans, m, n, A, lda, tau,
                                               C, ldc, lwork)
-    initialize_api()
+    initialize_context()
     ccall((:cusolverDnCunmtr_bufferSize, libcusolver()), cusolverStatus_t,
                    (cusolverDnHandle_t, cublasSideMode_t, cublasFillMode_t,
                     cublasOperation_t, Cint, Cint, CuPtr{cuComplex}, Cint,
@@ -2260,7 +2260,7 @@ end
 
 @checked function cusolverDnZunmtr_bufferSize(handle, side, uplo, trans, m, n, A, lda, tau,
                                               C, ldc, lwork)
-    initialize_api()
+    initialize_context()
     ccall((:cusolverDnZunmtr_bufferSize, libcusolver()), cusolverStatus_t,
                    (cusolverDnHandle_t, cublasSideMode_t, cublasFillMode_t,
                     cublasOperation_t, Cint, Cint, CuPtr{cuDoubleComplex}, Cint,
@@ -2270,7 +2270,7 @@ end
 
 @checked function cusolverDnSormtr(handle, side, uplo, trans, m, n, A, lda, tau, C, ldc,
                                    work, lwork, info)
-    initialize_api()
+    initialize_context()
     ccall((:cusolverDnSormtr, libcusolver()), cusolverStatus_t,
                    (cusolverDnHandle_t, cublasSideMode_t, cublasFillMode_t,
                     cublasOperation_t, Cint, Cint, CuPtr{Cfloat}, Cint, CuPtr{Cfloat},
@@ -2280,7 +2280,7 @@ end
 
 @checked function cusolverDnDormtr(handle, side, uplo, trans, m, n, A, lda, tau, C, ldc,
                                    work, lwork, info)
-    initialize_api()
+    initialize_context()
     ccall((:cusolverDnDormtr, libcusolver()), cusolverStatus_t,
                    (cusolverDnHandle_t, cublasSideMode_t, cublasFillMode_t,
                     cublasOperation_t, Cint, Cint, CuPtr{Cdouble}, Cint, CuPtr{Cdouble},
@@ -2290,7 +2290,7 @@ end
 
 @checked function cusolverDnCunmtr(handle, side, uplo, trans, m, n, A, lda, tau, C, ldc,
                                    work, lwork, info)
-    initialize_api()
+    initialize_context()
     ccall((:cusolverDnCunmtr, libcusolver()), cusolverStatus_t,
                    (cusolverDnHandle_t, cublasSideMode_t, cublasFillMode_t,
                     cublasOperation_t, Cint, Cint, CuPtr{cuComplex}, Cint,
@@ -2301,7 +2301,7 @@ end
 
 @checked function cusolverDnZunmtr(handle, side, uplo, trans, m, n, A, lda, tau, C, ldc,
                                    work, lwork, info)
-    initialize_api()
+    initialize_context()
     ccall((:cusolverDnZunmtr, libcusolver()), cusolverStatus_t,
                    (cusolverDnHandle_t, cublasSideMode_t, cublasFillMode_t,
                     cublasOperation_t, Cint, Cint, CuPtr{cuDoubleComplex}, Cint,
@@ -2311,28 +2311,28 @@ end
 end
 
 @checked function cusolverDnSgesvd_bufferSize(handle, m, n, lwork)
-    initialize_api()
+    initialize_context()
     ccall((:cusolverDnSgesvd_bufferSize, libcusolver()), cusolverStatus_t,
                    (cusolverDnHandle_t, Cint, Cint, Ptr{Cint}),
                    handle, m, n, lwork)
 end
 
 @checked function cusolverDnDgesvd_bufferSize(handle, m, n, lwork)
-    initialize_api()
+    initialize_context()
     ccall((:cusolverDnDgesvd_bufferSize, libcusolver()), cusolverStatus_t,
                    (cusolverDnHandle_t, Cint, Cint, Ptr{Cint}),
                    handle, m, n, lwork)
 end
 
 @checked function cusolverDnCgesvd_bufferSize(handle, m, n, lwork)
-    initialize_api()
+    initialize_context()
     ccall((:cusolverDnCgesvd_bufferSize, libcusolver()), cusolverStatus_t,
                    (cusolverDnHandle_t, Cint, Cint, Ptr{Cint}),
                    handle, m, n, lwork)
 end
 
 @checked function cusolverDnZgesvd_bufferSize(handle, m, n, lwork)
-    initialize_api()
+    initialize_context()
     ccall((:cusolverDnZgesvd_bufferSize, libcusolver()), cusolverStatus_t,
                    (cusolverDnHandle_t, Cint, Cint, Ptr{Cint}),
                    handle, m, n, lwork)
@@ -2340,7 +2340,7 @@ end
 
 @checked function cusolverDnSgesvd(handle, jobu, jobvt, m, n, A, lda, S, U, ldu, VT, ldvt,
                                    work, lwork, rwork, info)
-    initialize_api()
+    initialize_context()
     ccall((:cusolverDnSgesvd, libcusolver()), cusolverStatus_t,
                    (cusolverDnHandle_t, UInt8, UInt8, Cint, Cint, CuPtr{Cfloat}, Cint,
                     CuPtr{Cfloat}, CuPtr{Cfloat}, Cint, CuPtr{Cfloat}, Cint, CuPtr{Cfloat},
@@ -2351,7 +2351,7 @@ end
 
 @checked function cusolverDnDgesvd(handle, jobu, jobvt, m, n, A, lda, S, U, ldu, VT, ldvt,
                                    work, lwork, rwork, info)
-    initialize_api()
+    initialize_context()
     ccall((:cusolverDnDgesvd, libcusolver()), cusolverStatus_t,
                    (cusolverDnHandle_t, UInt8, UInt8, Cint, Cint, CuPtr{Cdouble}, Cint,
                     CuPtr{Cdouble}, CuPtr{Cdouble}, Cint, CuPtr{Cdouble}, Cint,
@@ -2362,7 +2362,7 @@ end
 
 @checked function cusolverDnCgesvd(handle, jobu, jobvt, m, n, A, lda, S, U, ldu, VT, ldvt,
                                    work, lwork, rwork, info)
-    initialize_api()
+    initialize_context()
     ccall((:cusolverDnCgesvd, libcusolver()), cusolverStatus_t,
                    (cusolverDnHandle_t, UInt8, UInt8, Cint, Cint, CuPtr{cuComplex}, Cint,
                     CuPtr{Cfloat}, CuPtr{cuComplex}, Cint, CuPtr{cuComplex}, Cint,
@@ -2373,7 +2373,7 @@ end
 
 @checked function cusolverDnZgesvd(handle, jobu, jobvt, m, n, A, lda, S, U, ldu, VT, ldvt,
                                    work, lwork, rwork, info)
-    initialize_api()
+    initialize_context()
     ccall((:cusolverDnZgesvd, libcusolver()), cusolverStatus_t,
                    (cusolverDnHandle_t, UInt8, UInt8, Cint, Cint, CuPtr{cuDoubleComplex},
                     Cint, CuPtr{Cdouble}, CuPtr{cuDoubleComplex}, Cint,
@@ -2384,7 +2384,7 @@ end
 end
 
 @checked function cusolverDnSsyevd_bufferSize(handle, jobz, uplo, n, A, lda, W, lwork)
-    initialize_api()
+    initialize_context()
     ccall((:cusolverDnSsyevd_bufferSize, libcusolver()), cusolverStatus_t,
                    (cusolverDnHandle_t, cusolverEigMode_t, cublasFillMode_t, Cint,
                     CuPtr{Cfloat}, Cint, CuPtr{Cfloat}, Ptr{Cint}),
@@ -2392,7 +2392,7 @@ end
 end
 
 @checked function cusolverDnDsyevd_bufferSize(handle, jobz, uplo, n, A, lda, W, lwork)
-    initialize_api()
+    initialize_context()
     ccall((:cusolverDnDsyevd_bufferSize, libcusolver()), cusolverStatus_t,
                    (cusolverDnHandle_t, cusolverEigMode_t, cublasFillMode_t, Cint,
                     CuPtr{Cdouble}, Cint, CuPtr{Cdouble}, Ptr{Cint}),
@@ -2400,7 +2400,7 @@ end
 end
 
 @checked function cusolverDnCheevd_bufferSize(handle, jobz, uplo, n, A, lda, W, lwork)
-    initialize_api()
+    initialize_context()
     ccall((:cusolverDnCheevd_bufferSize, libcusolver()), cusolverStatus_t,
                    (cusolverDnHandle_t, cusolverEigMode_t, cublasFillMode_t, Cint,
                     CuPtr{cuComplex}, Cint, CuPtr{Cfloat}, Ptr{Cint}),
@@ -2408,7 +2408,7 @@ end
 end
 
 @checked function cusolverDnZheevd_bufferSize(handle, jobz, uplo, n, A, lda, W, lwork)
-    initialize_api()
+    initialize_context()
     ccall((:cusolverDnZheevd_bufferSize, libcusolver()), cusolverStatus_t,
                    (cusolverDnHandle_t, cusolverEigMode_t, cublasFillMode_t, Cint,
                     CuPtr{cuDoubleComplex}, Cint, CuPtr{Cdouble}, Ptr{Cint}),
@@ -2416,7 +2416,7 @@ end
 end
 
 @checked function cusolverDnSsyevd(handle, jobz, uplo, n, A, lda, W, work, lwork, info)
-    initialize_api()
+    initialize_context()
     ccall((:cusolverDnSsyevd, libcusolver()), cusolverStatus_t,
                    (cusolverDnHandle_t, cusolverEigMode_t, cublasFillMode_t, Cint,
                     CuPtr{Cfloat}, Cint, CuPtr{Cfloat}, CuPtr{Cfloat}, Cint, CuPtr{Cint}),
@@ -2424,7 +2424,7 @@ end
 end
 
 @checked function cusolverDnDsyevd(handle, jobz, uplo, n, A, lda, W, work, lwork, info)
-    initialize_api()
+    initialize_context()
     ccall((:cusolverDnDsyevd, libcusolver()), cusolverStatus_t,
                    (cusolverDnHandle_t, cusolverEigMode_t, cublasFillMode_t, Cint,
                     CuPtr{Cdouble}, Cint, CuPtr{Cdouble}, CuPtr{Cdouble}, Cint, CuPtr{Cint}),
@@ -2432,7 +2432,7 @@ end
 end
 
 @checked function cusolverDnCheevd(handle, jobz, uplo, n, A, lda, W, work, lwork, info)
-    initialize_api()
+    initialize_context()
     ccall((:cusolverDnCheevd, libcusolver()), cusolverStatus_t,
                    (cusolverDnHandle_t, cusolverEigMode_t, cublasFillMode_t, Cint,
                     CuPtr{cuComplex}, Cint, CuPtr{Cfloat}, CuPtr{cuComplex}, Cint,
@@ -2441,7 +2441,7 @@ end
 end
 
 @checked function cusolverDnZheevd(handle, jobz, uplo, n, A, lda, W, work, lwork, info)
-    initialize_api()
+    initialize_context()
     ccall((:cusolverDnZheevd, libcusolver()), cusolverStatus_t,
                    (cusolverDnHandle_t, cusolverEigMode_t, cublasFillMode_t, Cint,
                     CuPtr{cuDoubleComplex}, Cint, CuPtr{Cdouble}, CuPtr{cuDoubleComplex},
@@ -2451,7 +2451,7 @@ end
 
 @checked function cusolverDnSsyevdx_bufferSize(handle, jobz, range, uplo, n, A, lda, vl,
                                                vu, il, iu, meig, W, lwork)
-    initialize_api()
+    initialize_context()
     ccall((:cusolverDnSsyevdx_bufferSize, libcusolver()), cusolverStatus_t,
                    (cusolverDnHandle_t, cusolverEigMode_t, cusolverEigRange_t,
                     cublasFillMode_t, Cint, CuPtr{Cfloat}, Cint, Cfloat, Cfloat, Cint,
@@ -2461,7 +2461,7 @@ end
 
 @checked function cusolverDnDsyevdx_bufferSize(handle, jobz, range, uplo, n, A, lda, vl,
                                                vu, il, iu, meig, W, lwork)
-    initialize_api()
+    initialize_context()
     ccall((:cusolverDnDsyevdx_bufferSize, libcusolver()), cusolverStatus_t,
                    (cusolverDnHandle_t, cusolverEigMode_t, cusolverEigRange_t,
                     cublasFillMode_t, Cint, CuPtr{Cdouble}, Cint, Cdouble, Cdouble, Cint,
@@ -2471,7 +2471,7 @@ end
 
 @checked function cusolverDnCheevdx_bufferSize(handle, jobz, range, uplo, n, A, lda, vl,
                                                vu, il, iu, meig, W, lwork)
-    initialize_api()
+    initialize_context()
     ccall((:cusolverDnCheevdx_bufferSize, libcusolver()), cusolverStatus_t,
                    (cusolverDnHandle_t, cusolverEigMode_t, cusolverEigRange_t,
                     cublasFillMode_t, Cint, CuPtr{cuComplex}, Cint, Cfloat, Cfloat, Cint,
@@ -2481,7 +2481,7 @@ end
 
 @checked function cusolverDnZheevdx_bufferSize(handle, jobz, range, uplo, n, A, lda, vl,
                                                vu, il, iu, meig, W, lwork)
-    initialize_api()
+    initialize_context()
     ccall((:cusolverDnZheevdx_bufferSize, libcusolver()), cusolverStatus_t,
                    (cusolverDnHandle_t, cusolverEigMode_t, cusolverEigRange_t,
                     cublasFillMode_t, Cint, CuPtr{cuDoubleComplex}, Cint, Cdouble, Cdouble,
@@ -2491,7 +2491,7 @@ end
 
 @checked function cusolverDnSsyevdx(handle, jobz, range, uplo, n, A, lda, vl, vu, il, iu,
                                     meig, W, work, lwork, info)
-    initialize_api()
+    initialize_context()
     ccall((:cusolverDnSsyevdx, libcusolver()), cusolverStatus_t,
                    (cusolverDnHandle_t, cusolverEigMode_t, cusolverEigRange_t,
                     cublasFillMode_t, Cint, CuPtr{Cfloat}, Cint, Cfloat, Cfloat, Cint,
@@ -2502,7 +2502,7 @@ end
 
 @checked function cusolverDnDsyevdx(handle, jobz, range, uplo, n, A, lda, vl, vu, il, iu,
                                     meig, W, work, lwork, info)
-    initialize_api()
+    initialize_context()
     ccall((:cusolverDnDsyevdx, libcusolver()), cusolverStatus_t,
                    (cusolverDnHandle_t, cusolverEigMode_t, cusolverEigRange_t,
                     cublasFillMode_t, Cint, CuPtr{Cdouble}, Cint, Cdouble, Cdouble, Cint,
@@ -2513,7 +2513,7 @@ end
 
 @checked function cusolverDnCheevdx(handle, jobz, range, uplo, n, A, lda, vl, vu, il, iu,
                                     meig, W, work, lwork, info)
-    initialize_api()
+    initialize_context()
     ccall((:cusolverDnCheevdx, libcusolver()), cusolverStatus_t,
                    (cusolverDnHandle_t, cusolverEigMode_t, cusolverEigRange_t,
                     cublasFillMode_t, Cint, CuPtr{cuComplex}, Cint, Cfloat, Cfloat, Cint,
@@ -2524,7 +2524,7 @@ end
 
 @checked function cusolverDnZheevdx(handle, jobz, range, uplo, n, A, lda, vl, vu, il, iu,
                                     meig, W, work, lwork, info)
-    initialize_api()
+    initialize_context()
     ccall((:cusolverDnZheevdx, libcusolver()), cusolverStatus_t,
                    (cusolverDnHandle_t, cusolverEigMode_t, cusolverEigRange_t,
                     cublasFillMode_t, Cint, CuPtr{cuDoubleComplex}, Cint, Cdouble, Cdouble,
@@ -2536,7 +2536,7 @@ end
 
 @checked function cusolverDnSsygvdx_bufferSize(handle, itype, jobz, range, uplo, n, A, lda,
                                                B, ldb, vl, vu, il, iu, meig, W, lwork)
-    initialize_api()
+    initialize_context()
     ccall((:cusolverDnSsygvdx_bufferSize, libcusolver()), cusolverStatus_t,
                    (cusolverDnHandle_t, cusolverEigType_t, cusolverEigMode_t,
                     cusolverEigRange_t, cublasFillMode_t, Cint, CuPtr{Cfloat}, Cint,
@@ -2548,7 +2548,7 @@ end
 
 @checked function cusolverDnDsygvdx_bufferSize(handle, itype, jobz, range, uplo, n, A, lda,
                                                B, ldb, vl, vu, il, iu, meig, W, lwork)
-    initialize_api()
+    initialize_context()
     ccall((:cusolverDnDsygvdx_bufferSize, libcusolver()), cusolverStatus_t,
                    (cusolverDnHandle_t, cusolverEigType_t, cusolverEigMode_t,
                     cusolverEigRange_t, cublasFillMode_t, Cint, CuPtr{Cdouble}, Cint,
@@ -2560,7 +2560,7 @@ end
 
 @checked function cusolverDnChegvdx_bufferSize(handle, itype, jobz, range, uplo, n, A, lda,
                                                B, ldb, vl, vu, il, iu, meig, W, lwork)
-    initialize_api()
+    initialize_context()
     ccall((:cusolverDnChegvdx_bufferSize, libcusolver()), cusolverStatus_t,
                    (cusolverDnHandle_t, cusolverEigType_t, cusolverEigMode_t,
                     cusolverEigRange_t, cublasFillMode_t, Cint, CuPtr{cuComplex}, Cint,
@@ -2572,7 +2572,7 @@ end
 
 @checked function cusolverDnZhegvdx_bufferSize(handle, itype, jobz, range, uplo, n, A, lda,
                                                B, ldb, vl, vu, il, iu, meig, W, lwork)
-    initialize_api()
+    initialize_context()
     ccall((:cusolverDnZhegvdx_bufferSize, libcusolver()), cusolverStatus_t,
                    (cusolverDnHandle_t, cusolverEigType_t, cusolverEigMode_t,
                     cusolverEigRange_t, cublasFillMode_t, Cint, CuPtr{cuDoubleComplex},
@@ -2584,7 +2584,7 @@ end
 
 @checked function cusolverDnSsygvdx(handle, itype, jobz, range, uplo, n, A, lda, B, ldb,
                                     vl, vu, il, iu, meig, W, work, lwork, info)
-    initialize_api()
+    initialize_context()
     ccall((:cusolverDnSsygvdx, libcusolver()), cusolverStatus_t,
                    (cusolverDnHandle_t, cusolverEigType_t, cusolverEigMode_t,
                     cusolverEigRange_t, cublasFillMode_t, Cint, CuPtr{Cfloat}, Cint,
@@ -2596,7 +2596,7 @@ end
 
 @checked function cusolverDnDsygvdx(handle, itype, jobz, range, uplo, n, A, lda, B, ldb,
                                     vl, vu, il, iu, meig, W, work, lwork, info)
-    initialize_api()
+    initialize_context()
     ccall((:cusolverDnDsygvdx, libcusolver()), cusolverStatus_t,
                    (cusolverDnHandle_t, cusolverEigType_t, cusolverEigMode_t,
                     cusolverEigRange_t, cublasFillMode_t, Cint, CuPtr{Cdouble}, Cint,
@@ -2608,7 +2608,7 @@ end
 
 @checked function cusolverDnChegvdx(handle, itype, jobz, range, uplo, n, A, lda, B, ldb,
                                     vl, vu, il, iu, meig, W, work, lwork, info)
-    initialize_api()
+    initialize_context()
     ccall((:cusolverDnChegvdx, libcusolver()), cusolverStatus_t,
                    (cusolverDnHandle_t, cusolverEigType_t, cusolverEigMode_t,
                     cusolverEigRange_t, cublasFillMode_t, Cint, CuPtr{cuComplex}, Cint,
@@ -2620,7 +2620,7 @@ end
 
 @checked function cusolverDnZhegvdx(handle, itype, jobz, range, uplo, n, A, lda, B, ldb,
                                     vl, vu, il, iu, meig, W, work, lwork, info)
-    initialize_api()
+    initialize_context()
     ccall((:cusolverDnZhegvdx, libcusolver()), cusolverStatus_t,
                    (cusolverDnHandle_t, cusolverEigType_t, cusolverEigMode_t,
                     cusolverEigRange_t, cublasFillMode_t, Cint, CuPtr{cuDoubleComplex},
@@ -2632,7 +2632,7 @@ end
 
 @checked function cusolverDnSsygvd_bufferSize(handle, itype, jobz, uplo, n, A, lda, B, ldb,
                                               W, lwork)
-    initialize_api()
+    initialize_context()
     ccall((:cusolverDnSsygvd_bufferSize, libcusolver()), cusolverStatus_t,
                    (cusolverDnHandle_t, cusolverEigType_t, cusolverEigMode_t,
                     cublasFillMode_t, Cint, CuPtr{Cfloat}, Cint, CuPtr{Cfloat}, Cint,
@@ -2642,7 +2642,7 @@ end
 
 @checked function cusolverDnDsygvd_bufferSize(handle, itype, jobz, uplo, n, A, lda, B, ldb,
                                               W, lwork)
-    initialize_api()
+    initialize_context()
     ccall((:cusolverDnDsygvd_bufferSize, libcusolver()), cusolverStatus_t,
                    (cusolverDnHandle_t, cusolverEigType_t, cusolverEigMode_t,
                     cublasFillMode_t, Cint, CuPtr{Cdouble}, Cint, CuPtr{Cdouble}, Cint,
@@ -2652,7 +2652,7 @@ end
 
 @checked function cusolverDnChegvd_bufferSize(handle, itype, jobz, uplo, n, A, lda, B, ldb,
                                               W, lwork)
-    initialize_api()
+    initialize_context()
     ccall((:cusolverDnChegvd_bufferSize, libcusolver()), cusolverStatus_t,
                    (cusolverDnHandle_t, cusolverEigType_t, cusolverEigMode_t,
                     cublasFillMode_t, Cint, CuPtr{cuComplex}, Cint, CuPtr{cuComplex}, Cint,
@@ -2662,7 +2662,7 @@ end
 
 @checked function cusolverDnZhegvd_bufferSize(handle, itype, jobz, uplo, n, A, lda, B, ldb,
                                               W, lwork)
-    initialize_api()
+    initialize_context()
     ccall((:cusolverDnZhegvd_bufferSize, libcusolver()), cusolverStatus_t,
                    (cusolverDnHandle_t, cusolverEigType_t, cusolverEigMode_t,
                     cublasFillMode_t, Cint, CuPtr{cuDoubleComplex}, Cint,
@@ -2672,7 +2672,7 @@ end
 
 @checked function cusolverDnSsygvd(handle, itype, jobz, uplo, n, A, lda, B, ldb, W, work,
                                    lwork, info)
-    initialize_api()
+    initialize_context()
     ccall((:cusolverDnSsygvd, libcusolver()), cusolverStatus_t,
                    (cusolverDnHandle_t, cusolverEigType_t, cusolverEigMode_t,
                     cublasFillMode_t, Cint, CuPtr{Cfloat}, Cint, CuPtr{Cfloat}, Cint,
@@ -2682,7 +2682,7 @@ end
 
 @checked function cusolverDnDsygvd(handle, itype, jobz, uplo, n, A, lda, B, ldb, W, work,
                                    lwork, info)
-    initialize_api()
+    initialize_context()
     ccall((:cusolverDnDsygvd, libcusolver()), cusolverStatus_t,
                    (cusolverDnHandle_t, cusolverEigType_t, cusolverEigMode_t,
                     cublasFillMode_t, Cint, CuPtr{Cdouble}, Cint, CuPtr{Cdouble}, Cint,
@@ -2692,7 +2692,7 @@ end
 
 @checked function cusolverDnChegvd(handle, itype, jobz, uplo, n, A, lda, B, ldb, W, work,
                                    lwork, info)
-    initialize_api()
+    initialize_context()
     ccall((:cusolverDnChegvd, libcusolver()), cusolverStatus_t,
                    (cusolverDnHandle_t, cusolverEigType_t, cusolverEigMode_t,
                     cublasFillMode_t, Cint, CuPtr{cuComplex}, Cint, CuPtr{cuComplex}, Cint,
@@ -2702,7 +2702,7 @@ end
 
 @checked function cusolverDnZhegvd(handle, itype, jobz, uplo, n, A, lda, B, ldb, W, work,
                                    lwork, info)
-    initialize_api()
+    initialize_context()
     ccall((:cusolverDnZhegvd, libcusolver()), cusolverStatus_t,
                    (cusolverDnHandle_t, cusolverEigType_t, cusolverEigMode_t,
                     cublasFillMode_t, Cint, CuPtr{cuDoubleComplex}, Cint,
@@ -2712,49 +2712,49 @@ end
 end
 
 @checked function cusolverDnCreateSyevjInfo(info)
-    initialize_api()
+    initialize_context()
     ccall((:cusolverDnCreateSyevjInfo, libcusolver()), cusolverStatus_t,
                    (Ptr{syevjInfo_t},),
                    info)
 end
 
 @checked function cusolverDnDestroySyevjInfo(info)
-    initialize_api()
+    initialize_context()
     ccall((:cusolverDnDestroySyevjInfo, libcusolver()), cusolverStatus_t,
                    (syevjInfo_t,),
                    info)
 end
 
 @checked function cusolverDnXsyevjSetTolerance(info, tolerance)
-    initialize_api()
+    initialize_context()
     ccall((:cusolverDnXsyevjSetTolerance, libcusolver()), cusolverStatus_t,
                    (syevjInfo_t, Cdouble),
                    info, tolerance)
 end
 
 @checked function cusolverDnXsyevjSetMaxSweeps(info, max_sweeps)
-    initialize_api()
+    initialize_context()
     ccall((:cusolverDnXsyevjSetMaxSweeps, libcusolver()), cusolverStatus_t,
                    (syevjInfo_t, Cint),
                    info, max_sweeps)
 end
 
 @checked function cusolverDnXsyevjSetSortEig(info, sort_eig)
-    initialize_api()
+    initialize_context()
     ccall((:cusolverDnXsyevjSetSortEig, libcusolver()), cusolverStatus_t,
                    (syevjInfo_t, Cint),
                    info, sort_eig)
 end
 
 @checked function cusolverDnXsyevjGetResidual(handle, info, residual)
-    initialize_api()
+    initialize_context()
     ccall((:cusolverDnXsyevjGetResidual, libcusolver()), cusolverStatus_t,
                    (cusolverDnHandle_t, syevjInfo_t, Ptr{Cdouble}),
                    handle, info, residual)
 end
 
 @checked function cusolverDnXsyevjGetSweeps(handle, info, executed_sweeps)
-    initialize_api()
+    initialize_context()
     ccall((:cusolverDnXsyevjGetSweeps, libcusolver()), cusolverStatus_t,
                    (cusolverDnHandle_t, syevjInfo_t, Ptr{Cint}),
                    handle, info, executed_sweeps)
@@ -2762,7 +2762,7 @@ end
 
 @checked function cusolverDnSsyevjBatched_bufferSize(handle, jobz, uplo, n, A, lda, W,
                                                      lwork, params, batchSize)
-    initialize_api()
+    initialize_context()
     ccall((:cusolverDnSsyevjBatched_bufferSize, libcusolver()), cusolverStatus_t,
                    (cusolverDnHandle_t, cusolverEigMode_t, cublasFillMode_t, Cint,
                     CuPtr{Cfloat}, Cint, CuPtr{Cfloat}, Ptr{Cint}, syevjInfo_t, Cint),
@@ -2771,7 +2771,7 @@ end
 
 @checked function cusolverDnDsyevjBatched_bufferSize(handle, jobz, uplo, n, A, lda, W,
                                                      lwork, params, batchSize)
-    initialize_api()
+    initialize_context()
     ccall((:cusolverDnDsyevjBatched_bufferSize, libcusolver()), cusolverStatus_t,
                    (cusolverDnHandle_t, cusolverEigMode_t, cublasFillMode_t, Cint,
                     CuPtr{Cdouble}, Cint, CuPtr{Cdouble}, Ptr{Cint}, syevjInfo_t, Cint),
@@ -2780,7 +2780,7 @@ end
 
 @checked function cusolverDnCheevjBatched_bufferSize(handle, jobz, uplo, n, A, lda, W,
                                                      lwork, params, batchSize)
-    initialize_api()
+    initialize_context()
     ccall((:cusolverDnCheevjBatched_bufferSize, libcusolver()), cusolverStatus_t,
                    (cusolverDnHandle_t, cusolverEigMode_t, cublasFillMode_t, Cint,
                     CuPtr{cuComplex}, Cint, CuPtr{Cfloat}, Ptr{Cint}, syevjInfo_t, Cint),
@@ -2789,7 +2789,7 @@ end
 
 @checked function cusolverDnZheevjBatched_bufferSize(handle, jobz, uplo, n, A, lda, W,
                                                      lwork, params, batchSize)
-    initialize_api()
+    initialize_context()
     ccall((:cusolverDnZheevjBatched_bufferSize, libcusolver()), cusolverStatus_t,
                    (cusolverDnHandle_t, cusolverEigMode_t, cublasFillMode_t, Cint,
                     CuPtr{cuDoubleComplex}, Cint, CuPtr{Cdouble}, Ptr{Cint}, syevjInfo_t,
@@ -2799,7 +2799,7 @@ end
 
 @checked function cusolverDnSsyevjBatched(handle, jobz, uplo, n, A, lda, W, work, lwork,
                                           info, params, batchSize)
-    initialize_api()
+    initialize_context()
     ccall((:cusolverDnSsyevjBatched, libcusolver()), cusolverStatus_t,
                    (cusolverDnHandle_t, cusolverEigMode_t, cublasFillMode_t, Cint,
                     CuPtr{Cfloat}, Cint, CuPtr{Cfloat}, CuPtr{Cfloat}, Cint, CuPtr{Cint},
@@ -2809,7 +2809,7 @@ end
 
 @checked function cusolverDnDsyevjBatched(handle, jobz, uplo, n, A, lda, W, work, lwork,
                                           info, params, batchSize)
-    initialize_api()
+    initialize_context()
     ccall((:cusolverDnDsyevjBatched, libcusolver()), cusolverStatus_t,
                    (cusolverDnHandle_t, cusolverEigMode_t, cublasFillMode_t, Cint,
                     CuPtr{Cdouble}, Cint, CuPtr{Cdouble}, CuPtr{Cdouble}, Cint,
@@ -2819,7 +2819,7 @@ end
 
 @checked function cusolverDnCheevjBatched(handle, jobz, uplo, n, A, lda, W, work, lwork,
                                           info, params, batchSize)
-    initialize_api()
+    initialize_context()
     ccall((:cusolverDnCheevjBatched, libcusolver()), cusolverStatus_t,
                    (cusolverDnHandle_t, cusolverEigMode_t, cublasFillMode_t, Cint,
                     CuPtr{cuComplex}, Cint, CuPtr{Cfloat}, CuPtr{cuComplex}, Cint,
@@ -2829,7 +2829,7 @@ end
 
 @checked function cusolverDnZheevjBatched(handle, jobz, uplo, n, A, lda, W, work, lwork,
                                           info, params, batchSize)
-    initialize_api()
+    initialize_context()
     ccall((:cusolverDnZheevjBatched, libcusolver()), cusolverStatus_t,
                    (cusolverDnHandle_t, cusolverEigMode_t, cublasFillMode_t, Cint,
                     CuPtr{cuDoubleComplex}, Cint, CuPtr{Cdouble}, CuPtr{cuDoubleComplex},
@@ -2839,7 +2839,7 @@ end
 
 @checked function cusolverDnSsyevj_bufferSize(handle, jobz, uplo, n, A, lda, W, lwork,
                                               params)
-    initialize_api()
+    initialize_context()
     ccall((:cusolverDnSsyevj_bufferSize, libcusolver()), cusolverStatus_t,
                    (cusolverDnHandle_t, cusolverEigMode_t, cublasFillMode_t, Cint,
                     CuPtr{Cfloat}, Cint, CuPtr{Cfloat}, Ptr{Cint}, syevjInfo_t),
@@ -2848,7 +2848,7 @@ end
 
 @checked function cusolverDnDsyevj_bufferSize(handle, jobz, uplo, n, A, lda, W, lwork,
                                               params)
-    initialize_api()
+    initialize_context()
     ccall((:cusolverDnDsyevj_bufferSize, libcusolver()), cusolverStatus_t,
                    (cusolverDnHandle_t, cusolverEigMode_t, cublasFillMode_t, Cint,
                     CuPtr{Cdouble}, Cint, CuPtr{Cdouble}, Ptr{Cint}, syevjInfo_t),
@@ -2857,7 +2857,7 @@ end
 
 @checked function cusolverDnCheevj_bufferSize(handle, jobz, uplo, n, A, lda, W, lwork,
                                               params)
-    initialize_api()
+    initialize_context()
     ccall((:cusolverDnCheevj_bufferSize, libcusolver()), cusolverStatus_t,
                    (cusolverDnHandle_t, cusolverEigMode_t, cublasFillMode_t, Cint,
                     CuPtr{cuComplex}, Cint, CuPtr{Cfloat}, Ptr{Cint}, syevjInfo_t),
@@ -2866,7 +2866,7 @@ end
 
 @checked function cusolverDnZheevj_bufferSize(handle, jobz, uplo, n, A, lda, W, lwork,
                                               params)
-    initialize_api()
+    initialize_context()
     ccall((:cusolverDnZheevj_bufferSize, libcusolver()), cusolverStatus_t,
                    (cusolverDnHandle_t, cusolverEigMode_t, cublasFillMode_t, Cint,
                     CuPtr{cuDoubleComplex}, Cint, CuPtr{Cdouble}, Ptr{Cint}, syevjInfo_t),
@@ -2875,7 +2875,7 @@ end
 
 @checked function cusolverDnSsyevj(handle, jobz, uplo, n, A, lda, W, work, lwork, info,
                                    params)
-    initialize_api()
+    initialize_context()
     ccall((:cusolverDnSsyevj, libcusolver()), cusolverStatus_t,
                    (cusolverDnHandle_t, cusolverEigMode_t, cublasFillMode_t, Cint,
                     CuPtr{Cfloat}, Cint, CuPtr{Cfloat}, CuPtr{Cfloat}, Cint, CuPtr{Cint},
@@ -2885,7 +2885,7 @@ end
 
 @checked function cusolverDnDsyevj(handle, jobz, uplo, n, A, lda, W, work, lwork, info,
                                    params)
-    initialize_api()
+    initialize_context()
     ccall((:cusolverDnDsyevj, libcusolver()), cusolverStatus_t,
                    (cusolverDnHandle_t, cusolverEigMode_t, cublasFillMode_t, Cint,
                     CuPtr{Cdouble}, Cint, CuPtr{Cdouble}, CuPtr{Cdouble}, Cint,
@@ -2895,7 +2895,7 @@ end
 
 @checked function cusolverDnCheevj(handle, jobz, uplo, n, A, lda, W, work, lwork, info,
                                    params)
-    initialize_api()
+    initialize_context()
     ccall((:cusolverDnCheevj, libcusolver()), cusolverStatus_t,
                    (cusolverDnHandle_t, cusolverEigMode_t, cublasFillMode_t, Cint,
                     CuPtr{cuComplex}, Cint, CuPtr{Cfloat}, CuPtr{cuComplex}, Cint,
@@ -2905,7 +2905,7 @@ end
 
 @checked function cusolverDnZheevj(handle, jobz, uplo, n, A, lda, W, work, lwork, info,
                                    params)
-    initialize_api()
+    initialize_context()
     ccall((:cusolverDnZheevj, libcusolver()), cusolverStatus_t,
                    (cusolverDnHandle_t, cusolverEigMode_t, cublasFillMode_t, Cint,
                     CuPtr{cuDoubleComplex}, Cint, CuPtr{Cdouble}, CuPtr{cuDoubleComplex},
@@ -2915,7 +2915,7 @@ end
 
 @checked function cusolverDnSsygvj_bufferSize(handle, itype, jobz, uplo, n, A, lda, B, ldb,
                                               W, lwork, params)
-    initialize_api()
+    initialize_context()
     ccall((:cusolverDnSsygvj_bufferSize, libcusolver()), cusolverStatus_t,
                    (cusolverDnHandle_t, cusolverEigType_t, cusolverEigMode_t,
                     cublasFillMode_t, Cint, CuPtr{Cfloat}, Cint, CuPtr{Cfloat}, Cint,
@@ -2925,7 +2925,7 @@ end
 
 @checked function cusolverDnDsygvj_bufferSize(handle, itype, jobz, uplo, n, A, lda, B, ldb,
                                               W, lwork, params)
-    initialize_api()
+    initialize_context()
     ccall((:cusolverDnDsygvj_bufferSize, libcusolver()), cusolverStatus_t,
                    (cusolverDnHandle_t, cusolverEigType_t, cusolverEigMode_t,
                     cublasFillMode_t, Cint, CuPtr{Cdouble}, Cint, CuPtr{Cdouble}, Cint,
@@ -2935,7 +2935,7 @@ end
 
 @checked function cusolverDnChegvj_bufferSize(handle, itype, jobz, uplo, n, A, lda, B, ldb,
                                               W, lwork, params)
-    initialize_api()
+    initialize_context()
     ccall((:cusolverDnChegvj_bufferSize, libcusolver()), cusolverStatus_t,
                    (cusolverDnHandle_t, cusolverEigType_t, cusolverEigMode_t,
                     cublasFillMode_t, Cint, CuPtr{cuComplex}, Cint, CuPtr{cuComplex}, Cint,
@@ -2945,7 +2945,7 @@ end
 
 @checked function cusolverDnZhegvj_bufferSize(handle, itype, jobz, uplo, n, A, lda, B, ldb,
                                               W, lwork, params)
-    initialize_api()
+    initialize_context()
     ccall((:cusolverDnZhegvj_bufferSize, libcusolver()), cusolverStatus_t,
                    (cusolverDnHandle_t, cusolverEigType_t, cusolverEigMode_t,
                     cublasFillMode_t, Cint, CuPtr{cuDoubleComplex}, Cint,
@@ -2955,7 +2955,7 @@ end
 
 @checked function cusolverDnSsygvj(handle, itype, jobz, uplo, n, A, lda, B, ldb, W, work,
                                    lwork, info, params)
-    initialize_api()
+    initialize_context()
     ccall((:cusolverDnSsygvj, libcusolver()), cusolverStatus_t,
                    (cusolverDnHandle_t, cusolverEigType_t, cusolverEigMode_t,
                     cublasFillMode_t, Cint, CuPtr{Cfloat}, Cint, CuPtr{Cfloat}, Cint,
@@ -2966,7 +2966,7 @@ end
 
 @checked function cusolverDnDsygvj(handle, itype, jobz, uplo, n, A, lda, B, ldb, W, work,
                                    lwork, info, params)
-    initialize_api()
+    initialize_context()
     ccall((:cusolverDnDsygvj, libcusolver()), cusolverStatus_t,
                    (cusolverDnHandle_t, cusolverEigType_t, cusolverEigMode_t,
                     cublasFillMode_t, Cint, CuPtr{Cdouble}, Cint, CuPtr{Cdouble}, Cint,
@@ -2977,7 +2977,7 @@ end
 
 @checked function cusolverDnChegvj(handle, itype, jobz, uplo, n, A, lda, B, ldb, W, work,
                                    lwork, info, params)
-    initialize_api()
+    initialize_context()
     ccall((:cusolverDnChegvj, libcusolver()), cusolverStatus_t,
                    (cusolverDnHandle_t, cusolverEigType_t, cusolverEigMode_t,
                     cublasFillMode_t, Cint, CuPtr{cuComplex}, Cint, CuPtr{cuComplex}, Cint,
@@ -2988,7 +2988,7 @@ end
 
 @checked function cusolverDnZhegvj(handle, itype, jobz, uplo, n, A, lda, B, ldb, W, work,
                                    lwork, info, params)
-    initialize_api()
+    initialize_context()
     ccall((:cusolverDnZhegvj, libcusolver()), cusolverStatus_t,
                    (cusolverDnHandle_t, cusolverEigType_t, cusolverEigMode_t,
                     cublasFillMode_t, Cint, CuPtr{cuDoubleComplex}, Cint,
@@ -2999,49 +2999,49 @@ end
 end
 
 @checked function cusolverDnCreateGesvdjInfo(info)
-    initialize_api()
+    initialize_context()
     ccall((:cusolverDnCreateGesvdjInfo, libcusolver()), cusolverStatus_t,
                    (Ptr{gesvdjInfo_t},),
                    info)
 end
 
 @checked function cusolverDnDestroyGesvdjInfo(info)
-    initialize_api()
+    initialize_context()
     ccall((:cusolverDnDestroyGesvdjInfo, libcusolver()), cusolverStatus_t,
                    (gesvdjInfo_t,),
                    info)
 end
 
 @checked function cusolverDnXgesvdjSetTolerance(info, tolerance)
-    initialize_api()
+    initialize_context()
     ccall((:cusolverDnXgesvdjSetTolerance, libcusolver()), cusolverStatus_t,
                    (gesvdjInfo_t, Cdouble),
                    info, tolerance)
 end
 
 @checked function cusolverDnXgesvdjSetMaxSweeps(info, max_sweeps)
-    initialize_api()
+    initialize_context()
     ccall((:cusolverDnXgesvdjSetMaxSweeps, libcusolver()), cusolverStatus_t,
                    (gesvdjInfo_t, Cint),
                    info, max_sweeps)
 end
 
 @checked function cusolverDnXgesvdjSetSortEig(info, sort_svd)
-    initialize_api()
+    initialize_context()
     ccall((:cusolverDnXgesvdjSetSortEig, libcusolver()), cusolverStatus_t,
                    (gesvdjInfo_t, Cint),
                    info, sort_svd)
 end
 
 @checked function cusolverDnXgesvdjGetResidual(handle, info, residual)
-    initialize_api()
+    initialize_context()
     ccall((:cusolverDnXgesvdjGetResidual, libcusolver()), cusolverStatus_t,
                    (cusolverDnHandle_t, gesvdjInfo_t, Ptr{Cdouble}),
                    handle, info, residual)
 end
 
 @checked function cusolverDnXgesvdjGetSweeps(handle, info, executed_sweeps)
-    initialize_api()
+    initialize_context()
     ccall((:cusolverDnXgesvdjGetSweeps, libcusolver()), cusolverStatus_t,
                    (cusolverDnHandle_t, gesvdjInfo_t, Ptr{Cint}),
                    handle, info, executed_sweeps)
@@ -3049,7 +3049,7 @@ end
 
 @checked function cusolverDnSgesvdjBatched_bufferSize(handle, jobz, m, n, A, lda, S, U,
                                                       ldu, V, ldv, lwork, params, batchSize)
-    initialize_api()
+    initialize_context()
     ccall((:cusolverDnSgesvdjBatched_bufferSize, libcusolver()), cusolverStatus_t,
                    (cusolverDnHandle_t, cusolverEigMode_t, Cint, Cint, CuPtr{Cfloat},
                     Cint, CuPtr{Cfloat}, CuPtr{Cfloat}, Cint, CuPtr{Cfloat}, Cint,
@@ -3059,7 +3059,7 @@ end
 
 @checked function cusolverDnDgesvdjBatched_bufferSize(handle, jobz, m, n, A, lda, S, U,
                                                       ldu, V, ldv, lwork, params, batchSize)
-    initialize_api()
+    initialize_context()
     ccall((:cusolverDnDgesvdjBatched_bufferSize, libcusolver()), cusolverStatus_t,
                    (cusolverDnHandle_t, cusolverEigMode_t, Cint, Cint, CuPtr{Cdouble},
                     Cint, CuPtr{Cdouble}, CuPtr{Cdouble}, Cint, CuPtr{Cdouble}, Cint,
@@ -3069,7 +3069,7 @@ end
 
 @checked function cusolverDnCgesvdjBatched_bufferSize(handle, jobz, m, n, A, lda, S, U,
                                                       ldu, V, ldv, lwork, params, batchSize)
-    initialize_api()
+    initialize_context()
     ccall((:cusolverDnCgesvdjBatched_bufferSize, libcusolver()), cusolverStatus_t,
                    (cusolverDnHandle_t, cusolverEigMode_t, Cint, Cint, CuPtr{cuComplex},
                     Cint, CuPtr{Cfloat}, CuPtr{cuComplex}, Cint, CuPtr{cuComplex}, Cint,
@@ -3079,7 +3079,7 @@ end
 
 @checked function cusolverDnZgesvdjBatched_bufferSize(handle, jobz, m, n, A, lda, S, U,
                                                       ldu, V, ldv, lwork, params, batchSize)
-    initialize_api()
+    initialize_context()
     ccall((:cusolverDnZgesvdjBatched_bufferSize, libcusolver()), cusolverStatus_t,
                    (cusolverDnHandle_t, cusolverEigMode_t, Cint, Cint,
                     CuPtr{cuDoubleComplex}, Cint, CuPtr{Cdouble}, CuPtr{cuDoubleComplex},
@@ -3089,7 +3089,7 @@ end
 
 @checked function cusolverDnSgesvdjBatched(handle, jobz, m, n, A, lda, S, U, ldu, V, ldv,
                                            work, lwork, info, params, batchSize)
-    initialize_api()
+    initialize_context()
     ccall((:cusolverDnSgesvdjBatched, libcusolver()), cusolverStatus_t,
                    (cusolverDnHandle_t, cusolverEigMode_t, Cint, Cint, CuPtr{Cfloat},
                     Cint, CuPtr{Cfloat}, CuPtr{Cfloat}, Cint, CuPtr{Cfloat}, Cint,
@@ -3100,7 +3100,7 @@ end
 
 @checked function cusolverDnDgesvdjBatched(handle, jobz, m, n, A, lda, S, U, ldu, V, ldv,
                                            work, lwork, info, params, batchSize)
-    initialize_api()
+    initialize_context()
     ccall((:cusolverDnDgesvdjBatched, libcusolver()), cusolverStatus_t,
                    (cusolverDnHandle_t, cusolverEigMode_t, Cint, Cint, CuPtr{Cdouble},
                     Cint, CuPtr{Cdouble}, CuPtr{Cdouble}, Cint, CuPtr{Cdouble}, Cint,
@@ -3111,7 +3111,7 @@ end
 
 @checked function cusolverDnCgesvdjBatched(handle, jobz, m, n, A, lda, S, U, ldu, V, ldv,
                                            work, lwork, info, params, batchSize)
-    initialize_api()
+    initialize_context()
     ccall((:cusolverDnCgesvdjBatched, libcusolver()), cusolverStatus_t,
                    (cusolverDnHandle_t, cusolverEigMode_t, Cint, Cint, CuPtr{cuComplex},
                     Cint, CuPtr{Cfloat}, CuPtr{cuComplex}, Cint, CuPtr{cuComplex}, Cint,
@@ -3122,7 +3122,7 @@ end
 
 @checked function cusolverDnZgesvdjBatched(handle, jobz, m, n, A, lda, S, U, ldu, V, ldv,
                                            work, lwork, info, params, batchSize)
-    initialize_api()
+    initialize_context()
     ccall((:cusolverDnZgesvdjBatched, libcusolver()), cusolverStatus_t,
                    (cusolverDnHandle_t, cusolverEigMode_t, Cint, Cint,
                     CuPtr{cuDoubleComplex}, Cint, CuPtr{Cdouble}, CuPtr{cuDoubleComplex},
@@ -3134,7 +3134,7 @@ end
 
 @checked function cusolverDnSgesvdj_bufferSize(handle, jobz, econ, m, n, A, lda, S, U, ldu,
                                                V, ldv, lwork, params)
-    initialize_api()
+    initialize_context()
     ccall((:cusolverDnSgesvdj_bufferSize, libcusolver()), cusolverStatus_t,
                    (cusolverDnHandle_t, cusolverEigMode_t, Cint, Cint, Cint,
                     CuPtr{Cfloat}, Cint, CuPtr{Cfloat}, CuPtr{Cfloat}, Cint, CuPtr{Cfloat},
@@ -3144,7 +3144,7 @@ end
 
 @checked function cusolverDnDgesvdj_bufferSize(handle, jobz, econ, m, n, A, lda, S, U, ldu,
                                                V, ldv, lwork, params)
-    initialize_api()
+    initialize_context()
     ccall((:cusolverDnDgesvdj_bufferSize, libcusolver()), cusolverStatus_t,
                    (cusolverDnHandle_t, cusolverEigMode_t, Cint, Cint, Cint,
                     CuPtr{Cdouble}, Cint, CuPtr{Cdouble}, CuPtr{Cdouble}, Cint,
@@ -3154,7 +3154,7 @@ end
 
 @checked function cusolverDnCgesvdj_bufferSize(handle, jobz, econ, m, n, A, lda, S, U, ldu,
                                                V, ldv, lwork, params)
-    initialize_api()
+    initialize_context()
     ccall((:cusolverDnCgesvdj_bufferSize, libcusolver()), cusolverStatus_t,
                    (cusolverDnHandle_t, cusolverEigMode_t, Cint, Cint, Cint,
                     CuPtr{cuComplex}, Cint, CuPtr{Cfloat}, CuPtr{cuComplex}, Cint,
@@ -3164,7 +3164,7 @@ end
 
 @checked function cusolverDnZgesvdj_bufferSize(handle, jobz, econ, m, n, A, lda, S, U, ldu,
                                                V, ldv, lwork, params)
-    initialize_api()
+    initialize_context()
     ccall((:cusolverDnZgesvdj_bufferSize, libcusolver()), cusolverStatus_t,
                    (cusolverDnHandle_t, cusolverEigMode_t, Cint, Cint, Cint,
                     CuPtr{cuDoubleComplex}, Cint, CuPtr{Cdouble}, CuPtr{cuDoubleComplex},
@@ -3174,7 +3174,7 @@ end
 
 @checked function cusolverDnSgesvdj(handle, jobz, econ, m, n, A, lda, S, U, ldu, V, ldv,
                                     work, lwork, info, params)
-    initialize_api()
+    initialize_context()
     ccall((:cusolverDnSgesvdj, libcusolver()), cusolverStatus_t,
                    (cusolverDnHandle_t, cusolverEigMode_t, Cint, Cint, Cint,
                     CuPtr{Cfloat}, Cint, CuPtr{Cfloat}, CuPtr{Cfloat}, Cint, CuPtr{Cfloat},
@@ -3185,7 +3185,7 @@ end
 
 @checked function cusolverDnDgesvdj(handle, jobz, econ, m, n, A, lda, S, U, ldu, V, ldv,
                                     work, lwork, info, params)
-    initialize_api()
+    initialize_context()
     ccall((:cusolverDnDgesvdj, libcusolver()), cusolverStatus_t,
                    (cusolverDnHandle_t, cusolverEigMode_t, Cint, Cint, Cint,
                     CuPtr{Cdouble}, Cint, CuPtr{Cdouble}, CuPtr{Cdouble}, Cint,
@@ -3196,7 +3196,7 @@ end
 
 @checked function cusolverDnCgesvdj(handle, jobz, econ, m, n, A, lda, S, U, ldu, V, ldv,
                                     work, lwork, info, params)
-    initialize_api()
+    initialize_context()
     ccall((:cusolverDnCgesvdj, libcusolver()), cusolverStatus_t,
                    (cusolverDnHandle_t, cusolverEigMode_t, Cint, Cint, Cint,
                     CuPtr{cuComplex}, Cint, CuPtr{Cfloat}, CuPtr{cuComplex}, Cint,
@@ -3208,7 +3208,7 @@ end
 
 @checked function cusolverDnZgesvdj(handle, jobz, econ, m, n, A, lda, S, U, ldu, V, ldv,
                                     work, lwork, info, params)
-    initialize_api()
+    initialize_context()
     ccall((:cusolverDnZgesvdj, libcusolver()), cusolverStatus_t,
                    (cusolverDnHandle_t, cusolverEigMode_t, Cint, Cint, Cint,
                     CuPtr{cuDoubleComplex}, Cint, CuPtr{Cdouble}, CuPtr{cuDoubleComplex},
@@ -3222,7 +3222,7 @@ end
                                                              lda, strideA, d_S, strideS,
                                                              d_U, ldu, strideU, d_V, ldv,
                                                              strideV, lwork, batchSize)
-    initialize_api()
+    initialize_context()
     ccall((:cusolverDnSgesvdaStridedBatched_bufferSize, libcusolver()), cusolverStatus_t,
                    (cusolverDnHandle_t, cusolverEigMode_t, Cint, Cint, Cint,
                     CuPtr{Cfloat}, Cint, Clonglong, CuPtr{Cfloat}, Clonglong,
@@ -3236,7 +3236,7 @@ end
                                                              lda, strideA, d_S, strideS,
                                                              d_U, ldu, strideU, d_V, ldv,
                                                              strideV, lwork, batchSize)
-    initialize_api()
+    initialize_context()
     ccall((:cusolverDnDgesvdaStridedBatched_bufferSize, libcusolver()), cusolverStatus_t,
                    (cusolverDnHandle_t, cusolverEigMode_t, Cint, Cint, Cint,
                     CuPtr{Cdouble}, Cint, Clonglong, CuPtr{Cdouble}, Clonglong,
@@ -3250,7 +3250,7 @@ end
                                                              lda, strideA, d_S, strideS,
                                                              d_U, ldu, strideU, d_V, ldv,
                                                              strideV, lwork, batchSize)
-    initialize_api()
+    initialize_context()
     ccall((:cusolverDnCgesvdaStridedBatched_bufferSize, libcusolver()), cusolverStatus_t,
                    (cusolverDnHandle_t, cusolverEigMode_t, Cint, Cint, Cint,
                     CuPtr{cuComplex}, Cint, Clonglong, CuPtr{Cfloat}, Clonglong,
@@ -3264,7 +3264,7 @@ end
                                                              lda, strideA, d_S, strideS,
                                                              d_U, ldu, strideU, d_V, ldv,
                                                              strideV, lwork, batchSize)
-    initialize_api()
+    initialize_context()
     ccall((:cusolverDnZgesvdaStridedBatched_bufferSize, libcusolver()), cusolverStatus_t,
                    (cusolverDnHandle_t, cusolverEigMode_t, Cint, Cint, Cint,
                     CuPtr{cuDoubleComplex}, Cint, Clonglong, CuPtr{Cdouble}, Clonglong,
@@ -3278,7 +3278,7 @@ end
                                                   strideA, d_S, strideS, d_U, ldu, strideU,
                                                   d_V, ldv, strideV, d_work, lwork, d_info,
                                                   h_R_nrmF, batchSize)
-    initialize_api()
+    initialize_context()
     ccall((:cusolverDnSgesvdaStridedBatched, libcusolver()), cusolverStatus_t,
                    (cusolverDnHandle_t, cusolverEigMode_t, Cint, Cint, Cint,
                     CuPtr{Cfloat}, Cint, Clonglong, CuPtr{Cfloat}, Clonglong,
@@ -3292,7 +3292,7 @@ end
                                                   strideA, d_S, strideS, d_U, ldu, strideU,
                                                   d_V, ldv, strideV, d_work, lwork, d_info,
                                                   h_R_nrmF, batchSize)
-    initialize_api()
+    initialize_context()
     ccall((:cusolverDnDgesvdaStridedBatched, libcusolver()), cusolverStatus_t,
                    (cusolverDnHandle_t, cusolverEigMode_t, Cint, Cint, Cint,
                     CuPtr{Cdouble}, Cint, Clonglong, CuPtr{Cdouble}, Clonglong,
@@ -3306,7 +3306,7 @@ end
                                                   strideA, d_S, strideS, d_U, ldu, strideU,
                                                   d_V, ldv, strideV, d_work, lwork, d_info,
                                                   h_R_nrmF, batchSize)
-    initialize_api()
+    initialize_context()
     ccall((:cusolverDnCgesvdaStridedBatched, libcusolver()), cusolverStatus_t,
                    (cusolverDnHandle_t, cusolverEigMode_t, Cint, Cint, Cint,
                     CuPtr{cuComplex}, Cint, Clonglong, CuPtr{Cfloat}, Clonglong,
@@ -3320,7 +3320,7 @@ end
                                                   strideA, d_S, strideS, d_U, ldu, strideU,
                                                   d_V, ldv, strideV, d_work, lwork, d_info,
                                                   h_R_nrmF, batchSize)
-    initialize_api()
+    initialize_context()
     ccall((:cusolverDnZgesvdaStridedBatched, libcusolver()), cusolverStatus_t,
                    (cusolverDnHandle_t, cusolverEigMode_t, Cint, Cint, Cint,
                     CuPtr{cuDoubleComplex}, Cint, Clonglong, CuPtr{Cdouble}, Clonglong,
@@ -3332,21 +3332,21 @@ end
 end
 
 @checked function cusolverDnCreateParams(params)
-    initialize_api()
+    initialize_context()
     ccall((:cusolverDnCreateParams, libcusolver()), cusolverStatus_t,
                    (Ptr{cusolverDnParams_t},),
                    params)
 end
 
 @checked function cusolverDnDestroyParams(params)
-    initialize_api()
+    initialize_context()
     ccall((:cusolverDnDestroyParams, libcusolver()), cusolverStatus_t,
                    (cusolverDnParams_t,),
                    params)
 end
 
 @checked function cusolverDnSetAdvOptions(params, _function, algo)
-    initialize_api()
+    initialize_context()
     ccall((:cusolverDnSetAdvOptions, libcusolver()), cusolverStatus_t,
                    (cusolverDnParams_t, cusolverDnFunction_t, cusolverAlgMode_t),
                    params, _function, algo)
@@ -3354,7 +3354,7 @@ end
 
 @checked function cusolverDnPotrf_bufferSize(handle, params, uplo, n, dataTypeA, A, lda,
                                              computeType, workspaceInBytes)
-    initialize_api()
+    initialize_context()
     ccall((:cusolverDnPotrf_bufferSize, libcusolver()), cusolverStatus_t,
                    (cusolverDnHandle_t, cusolverDnParams_t, cublasFillMode_t, Int64,
                     cudaDataType, CuPtr{Cvoid}, Int64, cudaDataType, Ptr{Csize_t}),
@@ -3364,7 +3364,7 @@ end
 
 @checked function cusolverDnPotrf(handle, params, uplo, n, dataTypeA, A, lda, computeType,
                                   pBuffer, workspaceInBytes, info)
-    initialize_api()
+    initialize_context()
     ccall((:cusolverDnPotrf, libcusolver()), cusolverStatus_t,
                    (cusolverDnHandle_t, cusolverDnParams_t, cublasFillMode_t, Int64,
                     cudaDataType, CuPtr{Cvoid}, Int64, cudaDataType, CuPtr{Cvoid}, Csize_t,
@@ -3375,7 +3375,7 @@ end
 
 @checked function cusolverDnPotrs(handle, params, uplo, n, nrhs, dataTypeA, A, lda,
                                   dataTypeB, B, ldb, info)
-    initialize_api()
+    initialize_context()
     ccall((:cusolverDnPotrs, libcusolver()), cusolverStatus_t,
                    (cusolverDnHandle_t, cusolverDnParams_t, cublasFillMode_t, Int64,
                     Int64, cudaDataType, CuPtr{Cvoid}, Int64, cudaDataType, CuPtr{Cvoid},
@@ -3386,7 +3386,7 @@ end
 
 @checked function cusolverDnGeqrf_bufferSize(handle, params, m, n, dataTypeA, A, lda,
                                              dataTypeTau, tau, computeType, workspaceInBytes)
-    initialize_api()
+    initialize_context()
     ccall((:cusolverDnGeqrf_bufferSize, libcusolver()), cusolverStatus_t,
                    (cusolverDnHandle_t, cusolverDnParams_t, Int64, Int64, cudaDataType,
                     CuPtr{Cvoid}, Int64, cudaDataType, CuPtr{Cvoid}, cudaDataType,
@@ -3397,7 +3397,7 @@ end
 
 @checked function cusolverDnGeqrf(handle, params, m, n, dataTypeA, A, lda, dataTypeTau,
                                   tau, computeType, pBuffer, workspaceInBytes, info)
-    initialize_api()
+    initialize_context()
     ccall((:cusolverDnGeqrf, libcusolver()), cusolverStatus_t,
                    (cusolverDnHandle_t, cusolverDnParams_t, Int64, Int64, cudaDataType,
                     CuPtr{Cvoid}, Int64, cudaDataType, CuPtr{Cvoid}, cudaDataType,
@@ -3408,7 +3408,7 @@ end
 
 @checked function cusolverDnGetrf_bufferSize(handle, params, m, n, dataTypeA, A, lda,
                                              computeType, workspaceInBytes)
-    initialize_api()
+    initialize_context()
     ccall((:cusolverDnGetrf_bufferSize, libcusolver()), cusolverStatus_t,
                    (cusolverDnHandle_t, cusolverDnParams_t, Int64, Int64, cudaDataType,
                     CuPtr{Cvoid}, Int64, cudaDataType, Ptr{Csize_t}),
@@ -3417,7 +3417,7 @@ end
 
 @checked function cusolverDnGetrf(handle, params, m, n, dataTypeA, A, lda, ipiv,
                                   computeType, pBuffer, workspaceInBytes, info)
-    initialize_api()
+    initialize_context()
     ccall((:cusolverDnGetrf, libcusolver()), cusolverStatus_t,
                    (cusolverDnHandle_t, cusolverDnParams_t, Int64, Int64, cudaDataType,
                     CuPtr{Cvoid}, Int64, CuPtr{Int64}, cudaDataType, CuPtr{Cvoid}, Csize_t,
@@ -3428,7 +3428,7 @@ end
 
 @checked function cusolverDnGetrs(handle, params, trans, n, nrhs, dataTypeA, A, lda, ipiv,
                                   dataTypeB, B, ldb, info)
-    initialize_api()
+    initialize_context()
     ccall((:cusolverDnGetrs, libcusolver()), cusolverStatus_t,
                    (cusolverDnHandle_t, cusolverDnParams_t, cublasOperation_t, Int64,
                     Int64, cudaDataType, CuPtr{Cvoid}, Int64, CuPtr{Int64}, cudaDataType,
@@ -3440,7 +3440,7 @@ end
 @checked function cusolverDnSyevd_bufferSize(handle, params, jobz, uplo, n, dataTypeA, A,
                                              lda, dataTypeW, W, computeType,
                                              workspaceInBytes)
-    initialize_api()
+    initialize_context()
     ccall((:cusolverDnSyevd_bufferSize, libcusolver()), cusolverStatus_t,
                    (cusolverDnHandle_t, cusolverDnParams_t, cusolverEigMode_t,
                     cublasFillMode_t, Int64, cudaDataType, CuPtr{Cvoid}, Int64,
@@ -3451,7 +3451,7 @@ end
 
 @checked function cusolverDnSyevd(handle, params, jobz, uplo, n, dataTypeA, A, lda,
                                   dataTypeW, W, computeType, pBuffer, workspaceInBytes, info)
-    initialize_api()
+    initialize_context()
     ccall((:cusolverDnSyevd, libcusolver()), cusolverStatus_t,
                    (cusolverDnHandle_t, cusolverDnParams_t, cusolverEigMode_t,
                     cublasFillMode_t, Int64, cudaDataType, CuPtr{Cvoid}, Int64,
@@ -3464,7 +3464,7 @@ end
 @checked function cusolverDnSyevdx_bufferSize(handle, params, jobz, range, uplo, n,
                                               dataTypeA, A, lda, vl, vu, il, iu, h_meig,
                                               dataTypeW, W, computeType, workspaceInBytes)
-    initialize_api()
+    initialize_context()
     ccall((:cusolverDnSyevdx_bufferSize, libcusolver()), cusolverStatus_t,
                    (cusolverDnHandle_t, cusolverDnParams_t, cusolverEigMode_t,
                     cusolverEigRange_t, cublasFillMode_t, Int64, cudaDataType,
@@ -3477,7 +3477,7 @@ end
 @checked function cusolverDnSyevdx(handle, params, jobz, range, uplo, n, dataTypeA, A, lda,
                                    vl, vu, il, iu, meig64, dataTypeW, W, computeType,
                                    pBuffer, workspaceInBytes, info)
-    initialize_api()
+    initialize_context()
     ccall((:cusolverDnSyevdx, libcusolver()), cusolverStatus_t,
                    (cusolverDnHandle_t, cusolverDnParams_t, cusolverEigMode_t,
                     cusolverEigRange_t, cublasFillMode_t, Int64, cudaDataType,
@@ -3492,7 +3492,7 @@ end
                                              A, lda, dataTypeS, S, dataTypeU, U, ldu,
                                              dataTypeVT, VT, ldvt, computeType,
                                              workspaceInBytes)
-    initialize_api()
+    initialize_context()
     ccall((:cusolverDnGesvd_bufferSize, libcusolver()), cusolverStatus_t,
                    (cusolverDnHandle_t, cusolverDnParams_t, UInt8, UInt8, Int64, Int64,
                     cudaDataType, CuPtr{Cvoid}, Int64, cudaDataType, CuPtr{Cvoid},
@@ -3505,7 +3505,7 @@ end
 @checked function cusolverDnGesvd(handle, params, jobu, jobvt, m, n, dataTypeA, A, lda,
                                   dataTypeS, S, dataTypeU, U, ldu, dataTypeVT, VT, ldvt,
                                   computeType, pBuffer, workspaceInBytes, info)
-    initialize_api()
+    initialize_context()
     ccall((:cusolverDnGesvd, libcusolver()), cusolverStatus_t,
                    (cusolverDnHandle_t, cusolverDnParams_t, UInt8, UInt8, Int64, Int64,
                     cudaDataType, CuPtr{Cvoid}, Int64, cudaDataType, CuPtr{Cvoid},
@@ -3519,28 +3519,28 @@ end
 # Automatically generated using Clang.jl
 
 @checked function cusolverSpCreate(handle)
-    initialize_api()
+    initialize_context()
     ccall((:cusolverSpCreate, libcusolver()), cusolverStatus_t,
                    (Ptr{cusolverSpHandle_t},),
                    handle)
 end
 
 @checked function cusolverSpDestroy(handle)
-    initialize_api()
+    initialize_context()
     ccall((:cusolverSpDestroy, libcusolver()), cusolverStatus_t,
                    (cusolverSpHandle_t,),
                    handle)
 end
 
 @checked function cusolverSpSetStream(handle, streamId)
-    initialize_api()
+    initialize_context()
     ccall((:cusolverSpSetStream, libcusolver()), cusolverStatus_t,
                    (cusolverSpHandle_t, CUstream),
                    handle, streamId)
 end
 
 @checked function cusolverSpGetStream(handle, streamId)
-    initialize_api()
+    initialize_context()
     ccall((:cusolverSpGetStream, libcusolver()), cusolverStatus_t,
                    (cusolverSpHandle_t, Ptr{CUstream}),
                    handle, streamId)
@@ -3548,7 +3548,7 @@ end
 
 @checked function cusolverSpXcsrissymHost(handle, m, nnzA, descrA, csrRowPtrA, csrEndPtrA,
                                           csrColIndA, issym)
-    initialize_api()
+    initialize_context()
     ccall((:cusolverSpXcsrissymHost, libcusolver()), cusolverStatus_t,
                    (cusolverSpHandle_t, Cint, Cint, cusparseMatDescr_t, Ptr{Cint},
                     Ptr{Cint}, Ptr{Cint}, Ptr{Cint}),
@@ -3557,7 +3557,7 @@ end
 
 @checked function cusolverSpScsrlsvluHost(handle, n, nnzA, descrA, csrValA, csrRowPtrA,
                                           csrColIndA, b, tol, reorder, x, singularity)
-    initialize_api()
+    initialize_context()
     ccall((:cusolverSpScsrlsvluHost, libcusolver()), cusolverStatus_t,
                    (cusolverSpHandle_t, Cint, Cint, cusparseMatDescr_t, Ptr{Cfloat},
                     Ptr{Cint}, Ptr{Cint}, Ptr{Cfloat}, Cfloat, Cint, Ptr{Cfloat}, Ptr{Cint}),
@@ -3567,7 +3567,7 @@ end
 
 @checked function cusolverSpDcsrlsvluHost(handle, n, nnzA, descrA, csrValA, csrRowPtrA,
                                           csrColIndA, b, tol, reorder, x, singularity)
-    initialize_api()
+    initialize_context()
     ccall((:cusolverSpDcsrlsvluHost, libcusolver()), cusolverStatus_t,
                    (cusolverSpHandle_t, Cint, Cint, cusparseMatDescr_t, Ptr{Cdouble},
                     Ptr{Cint}, Ptr{Cint}, Ptr{Cdouble}, Cdouble, Cint, Ptr{Cdouble},
@@ -3578,7 +3578,7 @@ end
 
 @checked function cusolverSpCcsrlsvluHost(handle, n, nnzA, descrA, csrValA, csrRowPtrA,
                                           csrColIndA, b, tol, reorder, x, singularity)
-    initialize_api()
+    initialize_context()
     ccall((:cusolverSpCcsrlsvluHost, libcusolver()), cusolverStatus_t,
                    (cusolverSpHandle_t, Cint, Cint, cusparseMatDescr_t, Ptr{cuComplex},
                     Ptr{Cint}, Ptr{Cint}, Ptr{cuComplex}, Cfloat, Cint, Ptr{cuComplex},
@@ -3589,7 +3589,7 @@ end
 
 @checked function cusolverSpZcsrlsvluHost(handle, n, nnzA, descrA, csrValA, csrRowPtrA,
                                           csrColIndA, b, tol, reorder, x, singularity)
-    initialize_api()
+    initialize_context()
     ccall((:cusolverSpZcsrlsvluHost, libcusolver()), cusolverStatus_t,
                    (cusolverSpHandle_t, Cint, Cint, cusparseMatDescr_t,
                     Ptr{cuDoubleComplex}, Ptr{Cint}, Ptr{Cint}, Ptr{cuDoubleComplex},
@@ -3600,7 +3600,7 @@ end
 
 @checked function cusolverSpScsrlsvqr(handle, m, nnz, descrA, csrVal, csrRowPtr, csrColInd,
                                       b, tol, reorder, x, singularity)
-    initialize_api()
+    initialize_context()
     ccall((:cusolverSpScsrlsvqr, libcusolver()), cusolverStatus_t,
                    (cusolverSpHandle_t, Cint, Cint, cusparseMatDescr_t, CuPtr{Cfloat},
                     CuPtr{Cint}, CuPtr{Cint}, CuPtr{Cfloat}, Cfloat, Cint, CuPtr{Cfloat},
@@ -3611,7 +3611,7 @@ end
 
 @checked function cusolverSpDcsrlsvqr(handle, m, nnz, descrA, csrVal, csrRowPtr, csrColInd,
                                       b, tol, reorder, x, singularity)
-    initialize_api()
+    initialize_context()
     ccall((:cusolverSpDcsrlsvqr, libcusolver()), cusolverStatus_t,
                    (cusolverSpHandle_t, Cint, Cint, cusparseMatDescr_t, CuPtr{Cdouble},
                     CuPtr{Cint}, CuPtr{Cint}, CuPtr{Cdouble}, Cdouble, Cint,
@@ -3622,7 +3622,7 @@ end
 
 @checked function cusolverSpCcsrlsvqr(handle, m, nnz, descrA, csrVal, csrRowPtr, csrColInd,
                                       b, tol, reorder, x, singularity)
-    initialize_api()
+    initialize_context()
     ccall((:cusolverSpCcsrlsvqr, libcusolver()), cusolverStatus_t,
                    (cusolverSpHandle_t, Cint, Cint, cusparseMatDescr_t, CuPtr{cuComplex},
                     CuPtr{Cint}, CuPtr{Cint}, CuPtr{cuComplex}, Cfloat, Cint,
@@ -3633,7 +3633,7 @@ end
 
 @checked function cusolverSpZcsrlsvqr(handle, m, nnz, descrA, csrVal, csrRowPtr, csrColInd,
                                       b, tol, reorder, x, singularity)
-    initialize_api()
+    initialize_context()
     ccall((:cusolverSpZcsrlsvqr, libcusolver()), cusolverStatus_t,
                    (cusolverSpHandle_t, Cint, Cint, cusparseMatDescr_t,
                     CuPtr{cuDoubleComplex}, CuPtr{Cint}, CuPtr{Cint},
@@ -3645,7 +3645,7 @@ end
 
 @checked function cusolverSpScsrlsvqrHost(handle, m, nnz, descrA, csrValA, csrRowPtrA,
                                           csrColIndA, b, tol, reorder, x, singularity)
-    initialize_api()
+    initialize_context()
     ccall((:cusolverSpScsrlsvqrHost, libcusolver()), cusolverStatus_t,
                    (cusolverSpHandle_t, Cint, Cint, cusparseMatDescr_t, Ptr{Cfloat},
                     Ptr{Cint}, Ptr{Cint}, Ptr{Cfloat}, Cfloat, Cint, Ptr{Cfloat}, Ptr{Cint}),
@@ -3655,7 +3655,7 @@ end
 
 @checked function cusolverSpDcsrlsvqrHost(handle, m, nnz, descrA, csrValA, csrRowPtrA,
                                           csrColIndA, b, tol, reorder, x, singularity)
-    initialize_api()
+    initialize_context()
     ccall((:cusolverSpDcsrlsvqrHost, libcusolver()), cusolverStatus_t,
                    (cusolverSpHandle_t, Cint, Cint, cusparseMatDescr_t, Ptr{Cdouble},
                     Ptr{Cint}, Ptr{Cint}, Ptr{Cdouble}, Cdouble, Cint, Ptr{Cdouble},
@@ -3666,7 +3666,7 @@ end
 
 @checked function cusolverSpCcsrlsvqrHost(handle, m, nnz, descrA, csrValA, csrRowPtrA,
                                           csrColIndA, b, tol, reorder, x, singularity)
-    initialize_api()
+    initialize_context()
     ccall((:cusolverSpCcsrlsvqrHost, libcusolver()), cusolverStatus_t,
                    (cusolverSpHandle_t, Cint, Cint, cusparseMatDescr_t, Ptr{cuComplex},
                     Ptr{Cint}, Ptr{Cint}, Ptr{cuComplex}, Cfloat, Cint, Ptr{cuComplex},
@@ -3677,7 +3677,7 @@ end
 
 @checked function cusolverSpZcsrlsvqrHost(handle, m, nnz, descrA, csrValA, csrRowPtrA,
                                           csrColIndA, b, tol, reorder, x, singularity)
-    initialize_api()
+    initialize_context()
     ccall((:cusolverSpZcsrlsvqrHost, libcusolver()), cusolverStatus_t,
                    (cusolverSpHandle_t, Cint, Cint, cusparseMatDescr_t,
                     Ptr{cuDoubleComplex}, Ptr{Cint}, Ptr{Cint}, Ptr{cuDoubleComplex},
@@ -3688,7 +3688,7 @@ end
 
 @checked function cusolverSpScsrlsvcholHost(handle, m, nnz, descrA, csrVal, csrRowPtr,
                                             csrColInd, b, tol, reorder, x, singularity)
-    initialize_api()
+    initialize_context()
     ccall((:cusolverSpScsrlsvcholHost, libcusolver()), cusolverStatus_t,
                    (cusolverSpHandle_t, Cint, Cint, cusparseMatDescr_t, Ptr{Cfloat},
                     Ptr{Cint}, Ptr{Cint}, Ptr{Cfloat}, Cfloat, Cint, Ptr{Cfloat}, Ptr{Cint}),
@@ -3698,7 +3698,7 @@ end
 
 @checked function cusolverSpDcsrlsvcholHost(handle, m, nnz, descrA, csrVal, csrRowPtr,
                                             csrColInd, b, tol, reorder, x, singularity)
-    initialize_api()
+    initialize_context()
     ccall((:cusolverSpDcsrlsvcholHost, libcusolver()), cusolverStatus_t,
                    (cusolverSpHandle_t, Cint, Cint, cusparseMatDescr_t, Ptr{Cdouble},
                     Ptr{Cint}, Ptr{Cint}, Ptr{Cdouble}, Cdouble, Cint, Ptr{Cdouble},
@@ -3709,7 +3709,7 @@ end
 
 @checked function cusolverSpCcsrlsvcholHost(handle, m, nnz, descrA, csrVal, csrRowPtr,
                                             csrColInd, b, tol, reorder, x, singularity)
-    initialize_api()
+    initialize_context()
     ccall((:cusolverSpCcsrlsvcholHost, libcusolver()), cusolverStatus_t,
                    (cusolverSpHandle_t, Cint, Cint, cusparseMatDescr_t, Ptr{cuComplex},
                     Ptr{Cint}, Ptr{Cint}, Ptr{cuComplex}, Cfloat, Cint, Ptr{cuComplex},
@@ -3720,7 +3720,7 @@ end
 
 @checked function cusolverSpZcsrlsvcholHost(handle, m, nnz, descrA, csrVal, csrRowPtr,
                                             csrColInd, b, tol, reorder, x, singularity)
-    initialize_api()
+    initialize_context()
     ccall((:cusolverSpZcsrlsvcholHost, libcusolver()), cusolverStatus_t,
                    (cusolverSpHandle_t, Cint, Cint, cusparseMatDescr_t,
                     Ptr{cuDoubleComplex}, Ptr{Cint}, Ptr{Cint}, Ptr{cuDoubleComplex},
@@ -3731,7 +3731,7 @@ end
 
 @checked function cusolverSpScsrlsvchol(handle, m, nnz, descrA, csrVal, csrRowPtr,
                                         csrColInd, b, tol, reorder, x, singularity)
-    initialize_api()
+    initialize_context()
     ccall((:cusolverSpScsrlsvchol, libcusolver()), cusolverStatus_t,
                    (cusolverSpHandle_t, Cint, Cint, cusparseMatDescr_t, CuPtr{Cfloat},
                     CuPtr{Cint}, CuPtr{Cint}, CuPtr{Cfloat}, Cfloat, Cint, CuPtr{Cfloat},
@@ -3742,7 +3742,7 @@ end
 
 @checked function cusolverSpDcsrlsvchol(handle, m, nnz, descrA, csrVal, csrRowPtr,
                                         csrColInd, b, tol, reorder, x, singularity)
-    initialize_api()
+    initialize_context()
     ccall((:cusolverSpDcsrlsvchol, libcusolver()), cusolverStatus_t,
                    (cusolverSpHandle_t, Cint, Cint, cusparseMatDescr_t, CuPtr{Cdouble},
                     CuPtr{Cint}, CuPtr{Cint}, CuPtr{Cdouble}, Cdouble, Cint,
@@ -3753,7 +3753,7 @@ end
 
 @checked function cusolverSpCcsrlsvchol(handle, m, nnz, descrA, csrVal, csrRowPtr,
                                         csrColInd, b, tol, reorder, x, singularity)
-    initialize_api()
+    initialize_context()
     ccall((:cusolverSpCcsrlsvchol, libcusolver()), cusolverStatus_t,
                    (cusolverSpHandle_t, Cint, Cint, cusparseMatDescr_t, CuPtr{cuComplex},
                     CuPtr{Cint}, CuPtr{Cint}, CuPtr{cuComplex}, Cfloat, Cint,
@@ -3764,7 +3764,7 @@ end
 
 @checked function cusolverSpZcsrlsvchol(handle, m, nnz, descrA, csrVal, csrRowPtr,
                                         csrColInd, b, tol, reorder, x, singularity)
-    initialize_api()
+    initialize_context()
     ccall((:cusolverSpZcsrlsvchol, libcusolver()), cusolverStatus_t,
                    (cusolverSpHandle_t, Cint, Cint, cusparseMatDescr_t,
                     CuPtr{cuDoubleComplex}, CuPtr{Cint}, CuPtr{Cint},
@@ -3776,7 +3776,7 @@ end
 
 @checked function cusolverSpScsrlsqvqrHost(handle, m, n, nnz, descrA, csrValA, csrRowPtrA,
                                            csrColIndA, b, tol, rankA, x, p, min_norm)
-    initialize_api()
+    initialize_context()
     ccall((:cusolverSpScsrlsqvqrHost, libcusolver()), cusolverStatus_t,
                    (cusolverSpHandle_t, Cint, Cint, Cint, cusparseMatDescr_t, Ptr{Cfloat},
                     Ptr{Cint}, Ptr{Cint}, Ptr{Cfloat}, Cfloat, Ptr{Cint}, Ptr{Cfloat},
@@ -3787,7 +3787,7 @@ end
 
 @checked function cusolverSpDcsrlsqvqrHost(handle, m, n, nnz, descrA, csrValA, csrRowPtrA,
                                            csrColIndA, b, tol, rankA, x, p, min_norm)
-    initialize_api()
+    initialize_context()
     ccall((:cusolverSpDcsrlsqvqrHost, libcusolver()), cusolverStatus_t,
                    (cusolverSpHandle_t, Cint, Cint, Cint, cusparseMatDescr_t,
                     Ptr{Cdouble}, Ptr{Cint}, Ptr{Cint}, Ptr{Cdouble}, Cdouble, Ptr{Cint},
@@ -3798,7 +3798,7 @@ end
 
 @checked function cusolverSpCcsrlsqvqrHost(handle, m, n, nnz, descrA, csrValA, csrRowPtrA,
                                            csrColIndA, b, tol, rankA, x, p, min_norm)
-    initialize_api()
+    initialize_context()
     ccall((:cusolverSpCcsrlsqvqrHost, libcusolver()), cusolverStatus_t,
                    (cusolverSpHandle_t, Cint, Cint, Cint, cusparseMatDescr_t,
                     Ptr{cuComplex}, Ptr{Cint}, Ptr{Cint}, Ptr{cuComplex}, Cfloat,
@@ -3809,7 +3809,7 @@ end
 
 @checked function cusolverSpZcsrlsqvqrHost(handle, m, n, nnz, descrA, csrValA, csrRowPtrA,
                                            csrColIndA, b, tol, rankA, x, p, min_norm)
-    initialize_api()
+    initialize_context()
     ccall((:cusolverSpZcsrlsqvqrHost, libcusolver()), cusolverStatus_t,
                    (cusolverSpHandle_t, Cint, Cint, Cint, cusparseMatDescr_t,
                     Ptr{cuDoubleComplex}, Ptr{Cint}, Ptr{Cint}, Ptr{cuDoubleComplex},
@@ -3820,7 +3820,7 @@ end
 
 @checked function cusolverSpScsreigvsiHost(handle, m, nnz, descrA, csrValA, csrRowPtrA,
                                            csrColIndA, mu0, x0, maxite, tol, mu, x)
-    initialize_api()
+    initialize_context()
     ccall((:cusolverSpScsreigvsiHost, libcusolver()), cusolverStatus_t,
                    (cusolverSpHandle_t, Cint, Cint, cusparseMatDescr_t, Ptr{Cfloat},
                     Ptr{Cint}, Ptr{Cint}, Cfloat, Ptr{Cfloat}, Cint, Cfloat, Ptr{Cfloat},
@@ -3831,7 +3831,7 @@ end
 
 @checked function cusolverSpDcsreigvsiHost(handle, m, nnz, descrA, csrValA, csrRowPtrA,
                                            csrColIndA, mu0, x0, maxite, tol, mu, x)
-    initialize_api()
+    initialize_context()
     ccall((:cusolverSpDcsreigvsiHost, libcusolver()), cusolverStatus_t,
                    (cusolverSpHandle_t, Cint, Cint, cusparseMatDescr_t, Ptr{Cdouble},
                     Ptr{Cint}, Ptr{Cint}, Cdouble, Ptr{Cdouble}, Cint, Cdouble,
@@ -3842,7 +3842,7 @@ end
 
 @checked function cusolverSpCcsreigvsiHost(handle, m, nnz, descrA, csrValA, csrRowPtrA,
                                            csrColIndA, mu0, x0, maxite, tol, mu, x)
-    initialize_api()
+    initialize_context()
     ccall((:cusolverSpCcsreigvsiHost, libcusolver()), cusolverStatus_t,
                    (cusolverSpHandle_t, Cint, Cint, cusparseMatDescr_t, Ptr{cuComplex},
                     Ptr{Cint}, Ptr{Cint}, cuComplex, Ptr{cuComplex}, Cint, Cfloat,
@@ -3853,7 +3853,7 @@ end
 
 @checked function cusolverSpZcsreigvsiHost(handle, m, nnz, descrA, csrValA, csrRowPtrA,
                                            csrColIndA, mu0, x0, maxite, tol, mu, x)
-    initialize_api()
+    initialize_context()
     ccall((:cusolverSpZcsreigvsiHost, libcusolver()), cusolverStatus_t,
                    (cusolverSpHandle_t, Cint, Cint, cusparseMatDescr_t,
                     Ptr{cuDoubleComplex}, Ptr{Cint}, Ptr{Cint}, cuDoubleComplex,
@@ -3865,7 +3865,7 @@ end
 
 @checked function cusolverSpScsreigvsi(handle, m, nnz, descrA, csrValA, csrRowPtrA,
                                        csrColIndA, mu0, x0, maxite, eps, mu, x)
-    initialize_api()
+    initialize_context()
     ccall((:cusolverSpScsreigvsi, libcusolver()), cusolverStatus_t,
                    (cusolverSpHandle_t, Cint, Cint, cusparseMatDescr_t, CuPtr{Cfloat},
                     CuPtr{Cint}, CuPtr{Cint}, Cfloat, CuPtr{Cfloat}, Cint, Cfloat,
@@ -3876,7 +3876,7 @@ end
 
 @checked function cusolverSpDcsreigvsi(handle, m, nnz, descrA, csrValA, csrRowPtrA,
                                        csrColIndA, mu0, x0, maxite, eps, mu, x)
-    initialize_api()
+    initialize_context()
     ccall((:cusolverSpDcsreigvsi, libcusolver()), cusolverStatus_t,
                    (cusolverSpHandle_t, Cint, Cint, cusparseMatDescr_t, CuPtr{Cdouble},
                     CuPtr{Cint}, CuPtr{Cint}, Cdouble, CuPtr{Cdouble}, Cint, Cdouble,
@@ -3887,7 +3887,7 @@ end
 
 @checked function cusolverSpCcsreigvsi(handle, m, nnz, descrA, csrValA, csrRowPtrA,
                                        csrColIndA, mu0, x0, maxite, eps, mu, x)
-    initialize_api()
+    initialize_context()
     ccall((:cusolverSpCcsreigvsi, libcusolver()), cusolverStatus_t,
                    (cusolverSpHandle_t, Cint, Cint, cusparseMatDescr_t, CuPtr{cuComplex},
                     CuPtr{Cint}, CuPtr{Cint}, cuComplex, CuPtr{cuComplex}, Cint, Cfloat,
@@ -3898,7 +3898,7 @@ end
 
 @checked function cusolverSpZcsreigvsi(handle, m, nnz, descrA, csrValA, csrRowPtrA,
                                        csrColIndA, mu0, x0, maxite, eps, mu, x)
-    initialize_api()
+    initialize_context()
     ccall((:cusolverSpZcsreigvsi, libcusolver()), cusolverStatus_t,
                    (cusolverSpHandle_t, Cint, Cint, cusparseMatDescr_t,
                     CuPtr{cuDoubleComplex}, CuPtr{Cint}, CuPtr{Cint}, cuDoubleComplex,
@@ -3911,7 +3911,7 @@ end
 @checked function cusolverSpScsreigsHost(handle, m, nnz, descrA, csrValA, csrRowPtrA,
                                          csrColIndA, left_bottom_corner,
                                          right_upper_corner, num_eigs)
-    initialize_api()
+    initialize_context()
     ccall((:cusolverSpScsreigsHost, libcusolver()), cusolverStatus_t,
                    (cusolverSpHandle_t, Cint, Cint, cusparseMatDescr_t, Ptr{Cfloat},
                     Ptr{Cint}, Ptr{Cint}, cuComplex, cuComplex, Ptr{Cint}),
@@ -3922,7 +3922,7 @@ end
 @checked function cusolverSpDcsreigsHost(handle, m, nnz, descrA, csrValA, csrRowPtrA,
                                          csrColIndA, left_bottom_corner,
                                          right_upper_corner, num_eigs)
-    initialize_api()
+    initialize_context()
     ccall((:cusolverSpDcsreigsHost, libcusolver()), cusolverStatus_t,
                    (cusolverSpHandle_t, Cint, Cint, cusparseMatDescr_t, Ptr{Cdouble},
                     Ptr{Cint}, Ptr{Cint}, cuDoubleComplex, cuDoubleComplex, Ptr{Cint}),
@@ -3933,7 +3933,7 @@ end
 @checked function cusolverSpCcsreigsHost(handle, m, nnz, descrA, csrValA, csrRowPtrA,
                                          csrColIndA, left_bottom_corner,
                                          right_upper_corner, num_eigs)
-    initialize_api()
+    initialize_context()
     ccall((:cusolverSpCcsreigsHost, libcusolver()), cusolverStatus_t,
                    (cusolverSpHandle_t, Cint, Cint, cusparseMatDescr_t, Ptr{cuComplex},
                     Ptr{Cint}, Ptr{Cint}, cuComplex, cuComplex, Ptr{Cint}),
@@ -3944,7 +3944,7 @@ end
 @checked function cusolverSpZcsreigsHost(handle, m, nnz, descrA, csrValA, csrRowPtrA,
                                          csrColIndA, left_bottom_corner,
                                          right_upper_corner, num_eigs)
-    initialize_api()
+    initialize_context()
     ccall((:cusolverSpZcsreigsHost, libcusolver()), cusolverStatus_t,
                    (cusolverSpHandle_t, Cint, Cint, cusparseMatDescr_t,
                     Ptr{cuDoubleComplex}, Ptr{Cint}, Ptr{Cint}, cuDoubleComplex,
@@ -3955,7 +3955,7 @@ end
 
 @checked function cusolverSpXcsrsymrcmHost(handle, n, nnzA, descrA, csrRowPtrA, csrColIndA,
                                            p)
-    initialize_api()
+    initialize_context()
     ccall((:cusolverSpXcsrsymrcmHost, libcusolver()), cusolverStatus_t,
                    (cusolverSpHandle_t, Cint, Cint, cusparseMatDescr_t, Ptr{Cint},
                     Ptr{Cint}, Ptr{Cint}),
@@ -3964,7 +3964,7 @@ end
 
 @checked function cusolverSpXcsrsymmdqHost(handle, n, nnzA, descrA, csrRowPtrA, csrColIndA,
                                            p)
-    initialize_api()
+    initialize_context()
     ccall((:cusolverSpXcsrsymmdqHost, libcusolver()), cusolverStatus_t,
                    (cusolverSpHandle_t, Cint, Cint, cusparseMatDescr_t, Ptr{Cint},
                     Ptr{Cint}, Ptr{Cint}),
@@ -3973,7 +3973,7 @@ end
 
 @checked function cusolverSpXcsrsymamdHost(handle, n, nnzA, descrA, csrRowPtrA, csrColIndA,
                                            p)
-    initialize_api()
+    initialize_context()
     ccall((:cusolverSpXcsrsymamdHost, libcusolver()), cusolverStatus_t,
                    (cusolverSpHandle_t, Cint, Cint, cusparseMatDescr_t, Ptr{Cint},
                     Ptr{Cint}, Ptr{Cint}),
@@ -3982,7 +3982,7 @@ end
 
 @checked function cusolverSpXcsrmetisndHost(handle, n, nnzA, descrA, csrRowPtrA,
                                             csrColIndA, options, p)
-    initialize_api()
+    initialize_context()
     ccall((:cusolverSpXcsrmetisndHost, libcusolver()), cusolverStatus_t,
                    (cusolverSpHandle_t, Cint, Cint, cusparseMatDescr_t, Ptr{Cint},
                     Ptr{Cint}, Ptr{Int64}, Ptr{Cint}),
@@ -3991,7 +3991,7 @@ end
 
 @checked function cusolverSpScsrzfdHost(handle, n, nnz, descrA, csrValA, csrRowPtrA,
                                         csrColIndA, P, numnz)
-    initialize_api()
+    initialize_context()
     ccall((:cusolverSpScsrzfdHost, libcusolver()), cusolverStatus_t,
                    (cusolverSpHandle_t, Cint, Cint, cusparseMatDescr_t, Ptr{Cfloat},
                     Ptr{Cint}, Ptr{Cint}, Ptr{Cint}, Ptr{Cint}),
@@ -4000,7 +4000,7 @@ end
 
 @checked function cusolverSpDcsrzfdHost(handle, n, nnz, descrA, csrValA, csrRowPtrA,
                                         csrColIndA, P, numnz)
-    initialize_api()
+    initialize_context()
     ccall((:cusolverSpDcsrzfdHost, libcusolver()), cusolverStatus_t,
                    (cusolverSpHandle_t, Cint, Cint, cusparseMatDescr_t, Ptr{Cdouble},
                     CuPtr{Cint}, CuPtr{Cint}, Ptr{Cint}, Ptr{Cint}),
@@ -4009,7 +4009,7 @@ end
 
 @checked function cusolverSpCcsrzfdHost(handle, n, nnz, descrA, csrValA, csrRowPtrA,
                                         csrColIndA, P, numnz)
-    initialize_api()
+    initialize_context()
     ccall((:cusolverSpCcsrzfdHost, libcusolver()), cusolverStatus_t,
                    (cusolverSpHandle_t, Cint, Cint, cusparseMatDescr_t, Ptr{cuComplex},
                     Ptr{Cint}, Ptr{Cint}, Ptr{Cint}, Ptr{Cint}),
@@ -4018,7 +4018,7 @@ end
 
 @checked function cusolverSpZcsrzfdHost(handle, n, nnz, descrA, csrValA, csrRowPtrA,
                                         csrColIndA, P, numnz)
-    initialize_api()
+    initialize_context()
     ccall((:cusolverSpZcsrzfdHost, libcusolver()), cusolverStatus_t,
                    (cusolverSpHandle_t, Cint, Cint, cusparseMatDescr_t,
                     Ptr{cuDoubleComplex}, Ptr{Cint}, Ptr{Cint}, Ptr{Cint}, Ptr{Cint}),
@@ -4027,7 +4027,7 @@ end
 
 @checked function cusolverSpXcsrperm_bufferSizeHost(handle, m, n, nnzA, descrA, csrRowPtrA,
                                                     csrColIndA, p, q, bufferSizeInBytes)
-    initialize_api()
+    initialize_context()
     ccall((:cusolverSpXcsrperm_bufferSizeHost, libcusolver()), cusolverStatus_t,
                    (cusolverSpHandle_t, Cint, Cint, Cint, cusparseMatDescr_t, Ptr{Cint},
                     Ptr{Cint}, Ptr{Cint}, Ptr{Cint}, Ptr{Csize_t}),
@@ -4037,7 +4037,7 @@ end
 
 @checked function cusolverSpXcsrpermHost(handle, m, n, nnzA, descrA, csrRowPtrA,
                                          csrColIndA, p, q, map, pBuffer)
-    initialize_api()
+    initialize_context()
     ccall((:cusolverSpXcsrpermHost, libcusolver()), cusolverStatus_t,
                    (cusolverSpHandle_t, Cint, Cint, Cint, cusparseMatDescr_t, Ptr{Cint},
                     Ptr{Cint}, Ptr{Cint}, Ptr{Cint}, Ptr{Cint}, Ptr{Cvoid}),
@@ -4045,14 +4045,14 @@ end
 end
 
 @checked function cusolverSpCreateCsrqrInfo(info)
-    initialize_api()
+    initialize_context()
     ccall((:cusolverSpCreateCsrqrInfo, libcusolver()), cusolverStatus_t,
                    (Ptr{csrqrInfo_t},),
                    info)
 end
 
 @checked function cusolverSpDestroyCsrqrInfo(info)
-    initialize_api()
+    initialize_context()
     ccall((:cusolverSpDestroyCsrqrInfo, libcusolver()), cusolverStatus_t,
                    (csrqrInfo_t,),
                    info)
@@ -4060,7 +4060,7 @@ end
 
 @checked function cusolverSpXcsrqrAnalysisBatched(handle, m, n, nnzA, descrA, csrRowPtrA,
                                                   csrColIndA, info)
-    initialize_api()
+    initialize_context()
     ccall((:cusolverSpXcsrqrAnalysisBatched, libcusolver()), cusolverStatus_t,
                    (cusolverSpHandle_t, Cint, Cint, Cint, cusparseMatDescr_t, CuPtr{Cint},
                     CuPtr{Cint}, csrqrInfo_t),
@@ -4070,7 +4070,7 @@ end
 @checked function cusolverSpScsrqrBufferInfoBatched(handle, m, n, nnz, descrA, csrVal,
                                                     csrRowPtr, csrColInd, batchSize, info,
                                                     internalDataInBytes, workspaceInBytes)
-    initialize_api()
+    initialize_context()
     ccall((:cusolverSpScsrqrBufferInfoBatched, libcusolver()), cusolverStatus_t,
                    (cusolverSpHandle_t, Cint, Cint, Cint, cusparseMatDescr_t,
                     CuPtr{Cfloat}, CuPtr{Cint}, CuPtr{Cint}, Cint, csrqrInfo_t,
@@ -4082,7 +4082,7 @@ end
 @checked function cusolverSpDcsrqrBufferInfoBatched(handle, m, n, nnz, descrA, csrVal,
                                                     csrRowPtr, csrColInd, batchSize, info,
                                                     internalDataInBytes, workspaceInBytes)
-    initialize_api()
+    initialize_context()
     ccall((:cusolverSpDcsrqrBufferInfoBatched, libcusolver()), cusolverStatus_t,
                    (cusolverSpHandle_t, Cint, Cint, Cint, cusparseMatDescr_t,
                     CuPtr{Cdouble}, CuPtr{Cint}, CuPtr{Cint}, Cint, csrqrInfo_t,
@@ -4094,7 +4094,7 @@ end
 @checked function cusolverSpCcsrqrBufferInfoBatched(handle, m, n, nnz, descrA, csrVal,
                                                     csrRowPtr, csrColInd, batchSize, info,
                                                     internalDataInBytes, workspaceInBytes)
-    initialize_api()
+    initialize_context()
     ccall((:cusolverSpCcsrqrBufferInfoBatched, libcusolver()), cusolverStatus_t,
                    (cusolverSpHandle_t, Cint, Cint, Cint, cusparseMatDescr_t,
                     CuPtr{cuComplex}, CuPtr{Cint}, CuPtr{Cint}, Cint, csrqrInfo_t,
@@ -4106,7 +4106,7 @@ end
 @checked function cusolverSpZcsrqrBufferInfoBatched(handle, m, n, nnz, descrA, csrVal,
                                                     csrRowPtr, csrColInd, batchSize, info,
                                                     internalDataInBytes, workspaceInBytes)
-    initialize_api()
+    initialize_context()
     ccall((:cusolverSpZcsrqrBufferInfoBatched, libcusolver()), cusolverStatus_t,
                    (cusolverSpHandle_t, Cint, Cint, Cint, cusparseMatDescr_t,
                     CuPtr{cuDoubleComplex}, CuPtr{Cint}, CuPtr{Cint}, Cint, csrqrInfo_t,
@@ -4117,7 +4117,7 @@ end
 
 @checked function cusolverSpScsrqrsvBatched(handle, m, n, nnz, descrA, csrValA, csrRowPtrA,
                                             csrColIndA, b, x, batchSize, info, pBuffer)
-    initialize_api()
+    initialize_context()
     ccall((:cusolverSpScsrqrsvBatched, libcusolver()), cusolverStatus_t,
                    (cusolverSpHandle_t, Cint, Cint, Cint, cusparseMatDescr_t,
                     CuPtr{Cfloat}, CuPtr{Cint}, CuPtr{Cint}, CuPtr{Cfloat}, CuPtr{Cfloat},
@@ -4128,7 +4128,7 @@ end
 
 @checked function cusolverSpDcsrqrsvBatched(handle, m, n, nnz, descrA, csrValA, csrRowPtrA,
                                             csrColIndA, b, x, batchSize, info, pBuffer)
-    initialize_api()
+    initialize_context()
     ccall((:cusolverSpDcsrqrsvBatched, libcusolver()), cusolverStatus_t,
                    (cusolverSpHandle_t, Cint, Cint, Cint, cusparseMatDescr_t,
                     CuPtr{Cdouble}, CuPtr{Cint}, CuPtr{Cint}, CuPtr{Cdouble},
@@ -4139,7 +4139,7 @@ end
 
 @checked function cusolverSpCcsrqrsvBatched(handle, m, n, nnz, descrA, csrValA, csrRowPtrA,
                                             csrColIndA, b, x, batchSize, info, pBuffer)
-    initialize_api()
+    initialize_context()
     ccall((:cusolverSpCcsrqrsvBatched, libcusolver()), cusolverStatus_t,
                    (cusolverSpHandle_t, Cint, Cint, Cint, cusparseMatDescr_t,
                     CuPtr{cuComplex}, CuPtr{Cint}, CuPtr{Cint}, CuPtr{cuComplex},
@@ -4150,7 +4150,7 @@ end
 
 @checked function cusolverSpZcsrqrsvBatched(handle, m, n, nnz, descrA, csrValA, csrRowPtrA,
                                             csrColIndA, b, x, batchSize, info, pBuffer)
-    initialize_api()
+    initialize_context()
     ccall((:cusolverSpZcsrqrsvBatched, libcusolver()), cusolverStatus_t,
                    (cusolverSpHandle_t, Cint, Cint, Cint, cusparseMatDescr_t,
                     CuPtr{cuDoubleComplex}, CuPtr{Cint}, CuPtr{Cint},
@@ -4163,115 +4163,115 @@ end
 ## Added in CUDA 11.1
 
 @checked function cusolverDnXpotrf_bufferSize(handle, params, uplo, n, dataTypeA, A, lda, computeType, workspaceInBytesOnDevice, workspaceInBytesOnHost)
-    initialize_api()
+    initialize_context()
     ccall((:cusolverDnXpotrf_bufferSize, libcusolver()), cusolverStatus_t, (cusolverDnHandle_t, cusolverDnParams_t, cublasFillMode_t, Int64, cudaDataType, CuPtr{Cvoid}, Int64, cudaDataType, Ptr{Csize_t}, Ptr{Csize_t}), handle, params, uplo, n, dataTypeA, A, lda, computeType, workspaceInBytesOnDevice, workspaceInBytesOnHost)
 end
 
 @checked function cusolverDnXgetrs(handle, params, trans, n, nrhs, dataTypeA, A, lda, ipiv, dataTypeB, B, ldb, info)
-    initialize_api()
+    initialize_context()
     ccall((:cusolverDnXgetrs, libcusolver()), cusolverStatus_t, (cusolverDnHandle_t, cusolverDnParams_t, cublasOperation_t, Int64, Int64, cudaDataType, CuPtr{Cvoid}, Int64, CuPtr{Int64}, cudaDataType, CuPtr{Cvoid}, Int64, CuPtr{Cint}), handle, params, trans, n, nrhs, dataTypeA, A, lda, ipiv, dataTypeB, B, ldb, info)
 end
 
 @checked function cusolverDnXgesvdp(handle, params, jobz, econ, m, n, dataTypeA, A, lda, dataTypeS, S, dataTypeU, U, ldu, dataTypeV, V, ldv, computeType, bufferOnDevice, workspaceInBytesOnDevice, bufferOnHost, workspaceInBytesOnHost, d_info, h_err_sigma)
-    initialize_api()
+    initialize_context()
     ccall((:cusolverDnXgesvdp, libcusolver()), cusolverStatus_t, (cusolverDnHandle_t, cusolverDnParams_t, cusolverEigMode_t, Cint, Int64, Int64, cudaDataType, CuPtr{Cvoid}, Int64, cudaDataType, CuPtr{Cvoid}, cudaDataType, CuPtr{Cvoid}, Int64, cudaDataType, CuPtr{Cvoid}, Int64, cudaDataType, CuPtr{Cvoid}, Csize_t, Ptr{Cvoid}, Csize_t, CuPtr{Cint}, Ptr{Cdouble}), handle, params, jobz, econ, m, n, dataTypeA, A, lda, dataTypeS, S, dataTypeU, U, ldu, dataTypeV, V, ldv, computeType, bufferOnDevice, workspaceInBytesOnDevice, bufferOnHost, workspaceInBytesOnHost, d_info, h_err_sigma)
 end
 
 @checked function cusolverDnXgesvd(handle, params, jobu, jobvt, m, n, dataTypeA, A, lda, dataTypeS, S, dataTypeU, U, ldu, dataTypeVT, VT, ldvt, computeType, bufferOnDevice, workspaceInBytesOnDevice, bufferOnHost, workspaceInBytesOnHost, info)
-    initialize_api()
+    initialize_context()
     ccall((:cusolverDnXgesvd, libcusolver()), cusolverStatus_t, (cusolverDnHandle_t, cusolverDnParams_t, UInt8, UInt8, Int64, Int64, cudaDataType, CuPtr{Cvoid}, Int64, cudaDataType, CuPtr{Cvoid}, cudaDataType, CuPtr{Cvoid}, Int64, cudaDataType, CuPtr{Cvoid}, Int64, cudaDataType, CuPtr{Cvoid}, Csize_t, Ptr{Cvoid}, Csize_t, CuPtr{Cint}), handle, params, jobu, jobvt, m, n, dataTypeA, A, lda, dataTypeS, S, dataTypeU, U, ldu, dataTypeVT, VT, ldvt, computeType, bufferOnDevice, workspaceInBytesOnDevice, bufferOnHost, workspaceInBytesOnHost, info)
 end
 
 @checked function cusolverDnXsyevdx_bufferSize(handle, params, jobz, range, uplo, n, dataTypeA, A, lda, vl, vu, il, iu, h_meig, dataTypeW, W, computeType, workspaceInBytesOnDevice, workspaceInBytesOnHost)
-    initialize_api()
+    initialize_context()
     ccall((:cusolverDnXsyevdx_bufferSize, libcusolver()), cusolverStatus_t, (cusolverDnHandle_t, cusolverDnParams_t, cusolverEigMode_t, cusolverEigRange_t, cublasFillMode_t, Int64, cudaDataType, CuPtr{Cvoid}, Int64, CuPtr{Cvoid}, CuPtr{Cvoid}, Int64, Int64, CuPtr{Int64}, cudaDataType, CuPtr{Cvoid}, cudaDataType, Ptr{Csize_t}, Ptr{Csize_t}), handle, params, jobz, range, uplo, n, dataTypeA, A, lda, vl, vu, il, iu, h_meig, dataTypeW, W, computeType, workspaceInBytesOnDevice, workspaceInBytesOnHost)
 end
 
 @checked function cusolverDnXpotrs(handle, params, uplo, n, nrhs, dataTypeA, A, lda, dataTypeB, B, ldb, info)
-    initialize_api()
+    initialize_context()
     ccall((:cusolverDnXpotrs, libcusolver()), cusolverStatus_t, (cusolverDnHandle_t, cusolverDnParams_t, cublasFillMode_t, Int64, Int64, cudaDataType, CuPtr{Cvoid}, Int64, cudaDataType, CuPtr{Cvoid}, Int64, CuPtr{Cint}), handle, params, uplo, n, nrhs, dataTypeA, A, lda, dataTypeB, B, ldb, info)
 end
 
 @checked function cusolverDnXgetrf_bufferSize(handle, params, m, n, dataTypeA, A, lda, computeType, workspaceInBytesOnDevice, workspaceInBytesOnHost)
-    initialize_api()
+    initialize_context()
     ccall((:cusolverDnXgetrf_bufferSize, libcusolver()), cusolverStatus_t, (cusolverDnHandle_t, cusolverDnParams_t, Int64, Int64, cudaDataType, CuPtr{Cvoid}, Int64, cudaDataType, Ptr{Csize_t}, Ptr{Csize_t}), handle, params, m, n, dataTypeA, A, lda, computeType, workspaceInBytesOnDevice, workspaceInBytesOnHost)
 end
 
 @checked function cusolverDnXgesvdp_bufferSize(handle, params, jobz, econ, m, n, dataTypeA, A, lda, dataTypeS, S, dataTypeU, U, ldu, dataTypeV, V, ldv, computeType, workspaceInBytesOnDevice, workspaceInBytesOnHost)
-    initialize_api()
+    initialize_context()
     ccall((:cusolverDnXgesvdp_bufferSize, libcusolver()), cusolverStatus_t, (cusolverDnHandle_t, cusolverDnParams_t, cusolverEigMode_t, Cint, Int64, Int64, cudaDataType, CuPtr{Cvoid}, Int64, cudaDataType, CuPtr{Cvoid}, cudaDataType, CuPtr{Cvoid}, Int64, cudaDataType, CuPtr{Cvoid}, Int64, cudaDataType, Ptr{Csize_t}, Ptr{Csize_t}), handle, params, jobz, econ, m, n, dataTypeA, A, lda, dataTypeS, S, dataTypeU, U, ldu, dataTypeV, V, ldv, computeType, workspaceInBytesOnDevice, workspaceInBytesOnHost)
 end
 
 @checked function cusolverDnXgesvd_bufferSize(handle, params, jobu, jobvt, m, n, dataTypeA, A, lda, dataTypeS, S, dataTypeU, U, ldu, dataTypeVT, VT, ldvt, computeType, workspaceInBytesOnDevice, workspaceInBytesOnHost)
-    initialize_api()
+    initialize_context()
     ccall((:cusolverDnXgesvd_bufferSize, libcusolver()), cusolverStatus_t, (cusolverDnHandle_t, cusolverDnParams_t, UInt8, UInt8, Int64, Int64, cudaDataType, CuPtr{Cvoid}, Int64, cudaDataType, CuPtr{Cvoid}, cudaDataType, CuPtr{Cvoid}, Int64, cudaDataType, CuPtr{Cvoid}, Int64, cudaDataType, Ptr{Csize_t}, Ptr{Csize_t}), handle, params, jobu, jobvt, m, n, dataTypeA, A, lda, dataTypeS, S, dataTypeU, U, ldu, dataTypeVT, VT, ldvt, computeType, workspaceInBytesOnDevice, workspaceInBytesOnHost)
 end
 
 @checked function cusolverDnXgeqrf_bufferSize(handle, params, m, n, dataTypeA, A, lda, dataTypeTau, tau, computeType, workspaceInBytesOnDevice, workspaceInBytesOnHost)
-    initialize_api()
+    initialize_context()
     ccall((:cusolverDnXgeqrf_bufferSize, libcusolver()), cusolverStatus_t, (cusolverDnHandle_t, cusolverDnParams_t, Int64, Int64, cudaDataType, CuPtr{Cvoid}, Int64, cudaDataType, CuPtr{Cvoid}, cudaDataType, Ptr{Csize_t}, Ptr{Csize_t}), handle, params, m, n, dataTypeA, A, lda, dataTypeTau, tau, computeType, workspaceInBytesOnDevice, workspaceInBytesOnHost)
 end
 
 @checked function cusolverDnXsyevdx(handle, params, jobz, range, uplo, n, dataTypeA, A, lda, vl, vu, il, iu, meig64, dataTypeW, W, computeType, bufferOnDevice, workspaceInBytesOnDevice, bufferOnHost, workspaceInBytesOnHost, info)
-    initialize_api()
+    initialize_context()
     ccall((:cusolverDnXsyevdx, libcusolver()), cusolverStatus_t, (cusolverDnHandle_t, cusolverDnParams_t, cusolverEigMode_t, cusolverEigRange_t, cublasFillMode_t, Int64, cudaDataType, CuPtr{Cvoid}, Int64, CuPtr{Cvoid}, CuPtr{Cvoid}, Int64, Int64, CuPtr{Int64}, cudaDataType, CuPtr{Cvoid}, cudaDataType, CuPtr{Cvoid}, Csize_t, Ptr{Cvoid}, Csize_t, CuPtr{Cint}), handle, params, jobz, range, uplo, n, dataTypeA, A, lda, vl, vu, il, iu, meig64, dataTypeW, W, computeType, bufferOnDevice, workspaceInBytesOnDevice, bufferOnHost, workspaceInBytesOnHost, info)
 end
 
 @checked function cusolverDnXgetrf(handle, params, m, n, dataTypeA, A, lda, ipiv, computeType, bufferOnDevice, workspaceInBytesOnDevice, bufferOnHost, workspaceInBytesOnHost, info)
-    initialize_api()
+    initialize_context()
     ccall((:cusolverDnXgetrf, libcusolver()), cusolverStatus_t, (cusolverDnHandle_t, cusolverDnParams_t, Int64, Int64, cudaDataType, CuPtr{Cvoid}, Int64, CuPtr{Int64}, cudaDataType, CuPtr{Cvoid}, Csize_t, Ptr{Cvoid}, Csize_t, CuPtr{Cint}), handle, params, m, n, dataTypeA, A, lda, ipiv, computeType, bufferOnDevice, workspaceInBytesOnDevice, bufferOnHost, workspaceInBytesOnHost, info)
 end
 
 @checked function cusolverDnXsyevd_bufferSize(handle, params, jobz, uplo, n, dataTypeA, A, lda, dataTypeW, W, computeType, workspaceInBytesOnDevice, workspaceInBytesOnHost)
-    initialize_api()
+    initialize_context()
     ccall((:cusolverDnXsyevd_bufferSize, libcusolver()), cusolverStatus_t, (cusolverDnHandle_t, cusolverDnParams_t, cusolverEigMode_t, cublasFillMode_t, Int64, cudaDataType, CuPtr{Cvoid}, Int64, cudaDataType, CuPtr{Cvoid}, cudaDataType, Ptr{Csize_t}, Ptr{Csize_t}), handle, params, jobz, uplo, n, dataTypeA, A, lda, dataTypeW, W, computeType, workspaceInBytesOnDevice, workspaceInBytesOnHost)
 end
 
 @checked function cusolverDnXpotrf(handle, params, uplo, n, dataTypeA, A, lda, computeType, bufferOnDevice, workspaceInBytesOnDevice, bufferOnHost, workspaceInBytesOnHost, info)
-    initialize_api()
+    initialize_context()
     ccall((:cusolverDnXpotrf, libcusolver()), cusolverStatus_t, (cusolverDnHandle_t, cusolverDnParams_t, cublasFillMode_t, Int64, cudaDataType, CuPtr{Cvoid}, Int64, cudaDataType, CuPtr{Cvoid}, Csize_t, Ptr{Cvoid}, Csize_t, CuPtr{Cint}), handle, params, uplo, n, dataTypeA, A, lda, computeType, bufferOnDevice, workspaceInBytesOnDevice, bufferOnHost, workspaceInBytesOnHost, info)
 end
 
 @checked function cusolverDnXgeqrf(handle, params, m, n, dataTypeA, A, lda, dataTypeTau, tau, computeType, bufferOnDevice, workspaceInBytesOnDevice, bufferOnHost, workspaceInBytesOnHost, info)
-    initialize_api()
+    initialize_context()
     ccall((:cusolverDnXgeqrf, libcusolver()), cusolverStatus_t, (cusolverDnHandle_t, cusolverDnParams_t, Int64, Int64, cudaDataType, CuPtr{Cvoid}, Int64, cudaDataType, CuPtr{Cvoid}, cudaDataType, CuPtr{Cvoid}, Csize_t, Ptr{Cvoid}, Csize_t, CuPtr{Cint}), handle, params, m, n, dataTypeA, A, lda, dataTypeTau, tau, computeType, bufferOnDevice, workspaceInBytesOnDevice, bufferOnHost, workspaceInBytesOnHost, info)
 end
 
 @checked function cusolverDnXsyevd(handle, params, jobz, uplo, n, dataTypeA, A, lda, dataTypeW, W, computeType, bufferOnDevice, workspaceInBytesOnDevice, bufferOnHost, workspaceInBytesOnHost, info)
-    initialize_api()
+    initialize_context()
     ccall((:cusolverDnXsyevd, libcusolver()), cusolverStatus_t, (cusolverDnHandle_t, cusolverDnParams_t, cusolverEigMode_t, cublasFillMode_t, Int64, cudaDataType, CuPtr{Cvoid}, Int64, cudaDataType, CuPtr{Cvoid}, cudaDataType, CuPtr{Cvoid}, Csize_t, Ptr{Cvoid}, Csize_t, CuPtr{Cint}), handle, params, jobz, uplo, n, dataTypeA, A, lda, dataTypeW, W, computeType, bufferOnDevice, workspaceInBytesOnDevice, bufferOnHost, workspaceInBytesOnHost, info)
 end
 
 ## Added in CUDA 11.2
 
 @checked function cusolverDnXgesvdr(handle, params, jobu, jobv, m, n, k, p, niters, dataTypeA, A, lda, dataTypeSrand, Srand, dataTypeUrand, Urand, ldUrand, dataTypeVrand, Vrand, ldVrand, computeType, bufferOnDevice, workspaceInBytesOnDevice, bufferOnHost, workspaceInBytesOnHost, d_info)
-    initialize_api()
+    initialize_context()
     ccall((:cusolverDnXgesvdr, libcusolver), cusolverStatus_t, (cusolverDnHandle_t, cusolverDnParams_t, UInt8, UInt8, Int64, Int64, Int64, Int64, Int64, cudaDataType, CuPtr{Cvoid}, Int64, cudaDataType, CuPtr{Cvoid}, cudaDataType, CuPtr{Cvoid}, Int64, cudaDataType, CuPtr{Cvoid}, Int64, cudaDataType, CuPtr{Cvoid}, Csize_t, Ptr{Cvoid}, Csize_t, CuPtr{Cint}), handle, params, jobu, jobv, m, n, k, p, niters, dataTypeA, A, lda, dataTypeSrand, Srand, dataTypeUrand, Urand, ldUrand, dataTypeVrand, Vrand, ldVrand, computeType, bufferOnDevice, workspaceInBytesOnDevice, bufferOnHost, workspaceInBytesOnHost, d_info)
 end
 
 @checked function cusolverDnXgesvdr_bufferSize(handle, params, jobu, jobv, m, n, k, p, niters, dataTypeA, A, lda, dataTypeSrand, Srand, dataTypeUrand, Urand, ldUrand, dataTypeVrand, Vrand, ldVrand, computeType, workspaceInBytesOnDevice, workspaceInBytesOnHost)
-    initialize_api()
+    initialize_context()
     ccall((:cusolverDnXgesvdr_bufferSize, libcusolver), cusolverStatus_t, (cusolverDnHandle_t, cusolverDnParams_t, UInt8, UInt8, Int64, Int64, Int64, Int64, Int64, cudaDataType, CuPtr{Cvoid}, Int64, cudaDataType, CuPtr{Cvoid}, cudaDataType, CuPtr{Cvoid}, Int64, cudaDataType, CuPtr{Cvoid}, Int64, cudaDataType, CuPtr{Csize_t}, Ptr{Csize_t}), handle, params, jobu, jobv, m, n, k, p, niters, dataTypeA, A, lda, dataTypeSrand, Srand, dataTypeUrand, Urand, ldUrand, dataTypeVrand, Vrand, ldVrand, computeType, workspaceInBytesOnDevice, workspaceInBytesOnHost)
 end
 
 ## from cusolverMg.h
 
 @checked function cusolverMgCreate(handle)
-    initialize_api()
+    initialize_context()
     ccall((:cusolverMgCreate, libcusolvermg()), cusolverStatus_t,
                    (Ptr{cusolverMgHandle_t},),
                    handle)
 end
 
 @checked function cusolverMgDestroy(handle)
-    initialize_api()
+    initialize_context()
     ccall((:cusolverMgDestroy, libcusolvermg()), cusolverStatus_t,
                    (cusolverMgHandle_t,),
                    handle)
 end
 
 @checked function cusolverMgDeviceSelect(handle, nbDevices, deviceId)
-    initialize_api()
+    initialize_context()
     ccall((:cusolverMgDeviceSelect, libcusolvermg()), cusolverStatus_t,
                    (cusolverMgHandle_t, Cint, Ptr{Cint}),
                    handle, nbDevices, deviceId)
@@ -4279,7 +4279,7 @@ end
 
 @checked function cusolverMgCreateDeviceGrid(grid, numRowDevices, numColDevices, deviceId,
                                              mapping)
-    initialize_api()
+    initialize_context()
     ccall((:cusolverMgCreateDeviceGrid, libcusolvermg()), cusolverStatus_t,
                    (Ptr{cudaLibMgGrid_t}, Int32, Int32, Ptr{Int32},
                     cusolverMgGridMapping_t),
@@ -4287,7 +4287,7 @@ end
 end
 
 @checked function cusolverMgDestroyGrid(grid)
-    initialize_api()
+    initialize_context()
     ccall((:cusolverMgDestroyGrid, libcusolvermg()), cusolverStatus_t,
                    (cudaLibMgGrid_t,),
                    grid)
@@ -4295,7 +4295,7 @@ end
 
 @checked function cusolverMgCreateMatrixDesc(desc, numRows, numCols, rowBlockSize,
                                              colBlockSize, dataType, grid)
-    initialize_api()
+    initialize_context()
     ccall((:cusolverMgCreateMatrixDesc, libcusolvermg()), cusolverStatus_t,
                    (Ptr{cudaLibMgMatrixDesc_t}, Int64, Int64, Int64, Int64, cudaDataType,
                     cudaLibMgGrid_t),
@@ -4303,7 +4303,7 @@ end
 end
 
 @checked function cusolverMgDestroyMatrixDesc(desc)
-    initialize_api()
+    initialize_context()
     ccall((:cusolverMgDestroyMatrixDesc, libcusolvermg()), cusolverStatus_t,
                    (cudaLibMgMatrixDesc_t,),
                    desc)
@@ -4311,7 +4311,7 @@ end
 
 @checked function cusolverMgSyevd_bufferSize(handle, jobz, uplo, N, array_d_A, IA, JA,
                                              descrA, W, dataTypeW, computeType, lwork)
-    initialize_api()
+    initialize_context()
     ccall((:cusolverMgSyevd_bufferSize, libcusolvermg()), cusolverStatus_t,
                    (cusolverMgHandle_t, cusolverEigMode_t, cublasFillMode_t, Cint,
                     Ptr{CuPtr{Cvoid}}, Cint, Cint, cudaLibMgMatrixDesc_t, Ptr{Cvoid},
@@ -4322,7 +4322,7 @@ end
 
 @checked function cusolverMgSyevd(handle, jobz, uplo, N, array_d_A, IA, JA, descrA, W,
                                   dataTypeW, computeType, array_d_work, lwork, info)
-    initialize_api()
+    initialize_context()
     ccall((:cusolverMgSyevd, libcusolvermg()), cusolverStatus_t,
                    (cusolverMgHandle_t, cusolverEigMode_t, cublasFillMode_t, Cint,
                     Ptr{CuPtr{Cvoid}}, Cint, Cint, cudaLibMgMatrixDesc_t, Ptr{Cvoid},
@@ -4333,7 +4333,7 @@ end
 
 @checked function cusolverMgGetrf_bufferSize(handle, M, N, array_d_A, IA, JA, descrA,
                                              array_d_IPIV, computeType, lwork)
-    initialize_api()
+    initialize_context()
     ccall((:cusolverMgGetrf_bufferSize, libcusolvermg()), cusolverStatus_t,
                    (cusolverMgHandle_t, Cint, Cint, Ptr{CuPtr{Cvoid}}, Cint, Cint,
                     cudaLibMgMatrixDesc_t, Ptr{CuPtr{Cint}}, cudaDataType, Ptr{Int64}),
@@ -4343,7 +4343,7 @@ end
 
 @checked function cusolverMgGetrf(handle, M, N, array_d_A, IA, JA, descrA, array_d_IPIV,
                                   computeType, array_d_work, lwork, info)
-    initialize_api()
+    initialize_context()
     ccall((:cusolverMgGetrf, libcusolvermg()), cusolverStatus_t,
                    (cusolverMgHandle_t, Cint, Cint, Ptr{CuPtr{Cvoid}}, Cint, Cint,
                     cudaLibMgMatrixDesc_t, Ptr{CuPtr{Cint}}, cudaDataType, Ptr{CuPtr{Cvoid}},
@@ -4355,7 +4355,7 @@ end
 @checked function cusolverMgGetrs_bufferSize(handle, TRANS, N, NRHS, array_d_A, IA, JA,
                                              descrA, array_d_IPIV, array_d_B, IB, JB,
                                              descrB, computeType, lwork)
-    initialize_api()
+    initialize_context()
     ccall((:cusolverMgGetrs_bufferSize, libcusolvermg()), cusolverStatus_t,
                    (cusolverMgHandle_t, cublasOperation_t, Cint, Cint, Ptr{CuPtr{Cvoid}},
                     Cint, Cint, cudaLibMgMatrixDesc_t, Ptr{CuPtr{Cint}}, Ptr{CuPtr{Cvoid}},
@@ -4367,7 +4367,7 @@ end
 @checked function cusolverMgGetrs(handle, TRANS, N, NRHS, array_d_A, IA, JA, descrA,
                                   array_d_IPIV, array_d_B, IB, JB, descrB, computeType,
                                   array_d_work, lwork, info)
-    initialize_api()
+    initialize_context()
     ccall((:cusolverMgGetrs, libcusolvermg()), cusolverStatus_t,
                    (cusolverMgHandle_t, cublasOperation_t, Cint, Cint, Ptr{CuPtr{Cvoid}},
                     Cint, Cint, cudaLibMgMatrixDesc_t, Ptr{CuPtr{Cint}}, Ptr{CuPtr{Cvoid}},
@@ -4379,7 +4379,7 @@ end
 
 @checked function cusolverMgPotrf_bufferSize(handle, uplo, N, array_d_A, IA, JA, descrA,
                                              computeType, lwork)
-    initialize_api()
+    initialize_context()
     ccall((:cusolverMgPotrf_bufferSize, libcusolvermg()), cusolverStatus_t,
                    (cusolverMgHandle_t, cublasFillMode_t, Cint, Ptr{CuPtr{Cvoid}}, Cint,
                     Cint, cudaLibMgMatrixDesc_t, cudaDataType, Ptr{Int64}),
@@ -4388,7 +4388,7 @@ end
 
 @checked function cusolverMgPotrf(handle, uplo, N, array_d_A, IA, JA, descrA, computeType,
                                   array_d_work, lwork, h_info)
-    initialize_api()
+    initialize_context()
     ccall((:cusolverMgPotrf, libcusolvermg()), cusolverStatus_t,
                    (cusolverMgHandle_t, cublasFillMode_t, Cint, Ptr{CuPtr{Cvoid}}, Cint,
                     Cint, cudaLibMgMatrixDesc_t, cudaDataType, Ptr{CuPtr{Cvoid}}, Int64,
@@ -4400,7 +4400,7 @@ end
 @checked function cusolverMgPotrs_bufferSize(handle, uplo, n, nrhs, array_d_A, IA, JA,
                                              descrA, array_d_B, IB, JB, descrB,
                                              computeType, lwork)
-    initialize_api()
+    initialize_context()
     ccall((:cusolverMgPotrs_bufferSize, libcusolvermg()), cusolverStatus_t,
                    (cusolverMgHandle_t, cublasFillMode_t, Cint, Cint, Ptr{CuPtr{Cvoid}},
                     Cint, Cint, cudaLibMgMatrixDesc_t, Ptr{CuPtr{Cvoid}}, Cint, Cint,
@@ -4412,7 +4412,7 @@ end
 @checked function cusolverMgPotrs(handle, uplo, n, nrhs, array_d_A, IA, JA, descrA,
                                   array_d_B, IB, JB, descrB, computeType, array_d_work,
                                   lwork, h_info)
-    initialize_api()
+    initialize_context()
     ccall((:cusolverMgPotrs, libcusolvermg()), cusolverStatus_t,
                    (cusolverMgHandle_t, cublasFillMode_t, Cint, Cint, Ptr{CuPtr{Cvoid}},
                     Cint, Cint, cudaLibMgMatrixDesc_t, Ptr{CuPtr{Cvoid}}, Cint, Cint,
@@ -4423,7 +4423,7 @@ end
 
 @checked function cusolverMgPotri_bufferSize(handle, uplo, N, array_d_A, IA, JA, descrA,
                                              computeType, lwork)
-    initialize_api()
+    initialize_context()
     ccall((:cusolverMgPotri_bufferSize, libcusolvermg()), cusolverStatus_t,
                    (cusolverMgHandle_t, cublasFillMode_t, Cint, Ptr{CuPtr{Cvoid}}, Cint,
                     Cint, cudaLibMgMatrixDesc_t, cudaDataType, Ptr{Int64}),
@@ -4432,7 +4432,7 @@ end
 
 @checked function cusolverMgPotri(handle, uplo, N, array_d_A, IA, JA, descrA, computeType,
                                   array_d_work, lwork, h_info)
-    initialize_api()
+    initialize_context()
     ccall((:cusolverMgPotri, libcusolvermg()), cusolverStatus_t,
                    (cusolverMgHandle_t, cublasFillMode_t, Cint, Ptr{CuPtr{Cvoid}}, Cint,
                     Cint, cudaLibMgMatrixDesc_t, cudaDataType, Ptr{CuPtr{Cvoid}}, Int64,

--- a/lib/cusparse/CUSPARSE.jl
+++ b/lib/cusparse/CUSPARSE.jl
@@ -4,7 +4,7 @@ using ..APIUtils
 
 using ..CUDA
 using ..CUDA: CUstream, cuComplex, cuDoubleComplex, libraryPropertyType, cudaDataType
-using ..CUDA: libcusparse, unsafe_free!, @retry_reclaim, @context!
+using ..CUDA: libcusparse, unsafe_free!, @retry_reclaim, @context!, initialize_context
 
 using CEnum: @cenum
 

--- a/lib/cusparse/error.jl
+++ b/lib/cusparse/error.jl
@@ -25,10 +25,6 @@ description(err::CUSPARSEError) = unsafe_string(cusparseGetErrorString(err))
     end
 end
 
-function initialize_api()
-    CUDA.prepare_cuda_state()
-end
-
 macro check(ex, errs...)
     check = :(isequal(err, CUSPARSE_STATUS_ALLOC_FAILED))
     for err in errs

--- a/lib/cusparse/libcusparse.jl
+++ b/lib/cusparse/libcusparse.jl
@@ -2,14 +2,14 @@
 # Automatically generated using Clang.jl
 
 @checked function cusparseCreate(handle)
-    initialize_api()
+    initialize_context()
     ccall((:cusparseCreate, libcusparse()), cusparseStatus_t,
                    (Ptr{cusparseHandle_t},),
                    handle)
 end
 
 @checked function cusparseDestroy(handle)
-    initialize_api()
+    initialize_context()
     ccall((:cusparseDestroy, libcusparse()), cusparseStatus_t,
                    (cusparseHandle_t,),
                    handle)
@@ -40,266 +40,266 @@ function cusparseGetErrorString(status)
 end
 
 @checked function cusparseSetStream(handle, streamId)
-    initialize_api()
+    initialize_context()
     ccall((:cusparseSetStream, libcusparse()), cusparseStatus_t,
                    (cusparseHandle_t, CUstream),
                    handle, streamId)
 end
 
 @checked function cusparseGetStream(handle, streamId)
-    initialize_api()
+    initialize_context()
     ccall((:cusparseGetStream, libcusparse()), cusparseStatus_t,
                    (cusparseHandle_t, Ptr{CUstream}),
                    handle, streamId)
 end
 
 @checked function cusparseGetPointerMode(handle, mode)
-    initialize_api()
+    initialize_context()
     ccall((:cusparseGetPointerMode, libcusparse()), cusparseStatus_t,
                    (cusparseHandle_t, Ptr{cusparsePointerMode_t}),
                    handle, mode)
 end
 
 @checked function cusparseSetPointerMode(handle, mode)
-    initialize_api()
+    initialize_context()
     ccall((:cusparseSetPointerMode, libcusparse()), cusparseStatus_t,
                    (cusparseHandle_t, cusparsePointerMode_t),
                    handle, mode)
 end
 
 @checked function cusparseCreateMatDescr(descrA)
-    initialize_api()
+    initialize_context()
     ccall((:cusparseCreateMatDescr, libcusparse()), cusparseStatus_t,
                    (Ptr{cusparseMatDescr_t},),
                    descrA)
 end
 
 @checked function cusparseDestroyMatDescr(descrA)
-    initialize_api()
+    initialize_context()
     ccall((:cusparseDestroyMatDescr, libcusparse()), cusparseStatus_t,
                    (cusparseMatDescr_t,),
                    descrA)
 end
 
 @checked function cusparseCopyMatDescr(dest, src)
-    initialize_api()
+    initialize_context()
     ccall((:cusparseCopyMatDescr, libcusparse()), cusparseStatus_t,
                    (cusparseMatDescr_t, cusparseMatDescr_t),
                    dest, src)
 end
 
 @checked function cusparseSetMatType(descrA, type)
-    initialize_api()
+    initialize_context()
     ccall((:cusparseSetMatType, libcusparse()), cusparseStatus_t,
                    (cusparseMatDescr_t, cusparseMatrixType_t),
                    descrA, type)
 end
 
 function cusparseGetMatType(descrA)
-    initialize_api()
+    initialize_context()
     ccall((:cusparseGetMatType, libcusparse()), cusparseMatrixType_t,
                    (cusparseMatDescr_t,),
                    descrA)
 end
 
 @checked function cusparseSetMatFillMode(descrA, fillMode)
-    initialize_api()
+    initialize_context()
     ccall((:cusparseSetMatFillMode, libcusparse()), cusparseStatus_t,
                    (cusparseMatDescr_t, cusparseFillMode_t),
                    descrA, fillMode)
 end
 
 function cusparseGetMatFillMode(descrA)
-    initialize_api()
+    initialize_context()
     ccall((:cusparseGetMatFillMode, libcusparse()), cusparseFillMode_t,
                    (cusparseMatDescr_t,),
                    descrA)
 end
 
 @checked function cusparseSetMatDiagType(descrA, diagType)
-    initialize_api()
+    initialize_context()
     ccall((:cusparseSetMatDiagType, libcusparse()), cusparseStatus_t,
                    (cusparseMatDescr_t, cusparseDiagType_t),
                    descrA, diagType)
 end
 
 function cusparseGetMatDiagType(descrA)
-    initialize_api()
+    initialize_context()
     ccall((:cusparseGetMatDiagType, libcusparse()), cusparseDiagType_t,
                    (cusparseMatDescr_t,),
                    descrA)
 end
 
 @checked function cusparseSetMatIndexBase(descrA, base)
-    initialize_api()
+    initialize_context()
     ccall((:cusparseSetMatIndexBase, libcusparse()), cusparseStatus_t,
                    (cusparseMatDescr_t, cusparseIndexBase_t),
                    descrA, base)
 end
 
 function cusparseGetMatIndexBase(descrA)
-    initialize_api()
+    initialize_context()
     ccall((:cusparseGetMatIndexBase, libcusparse()), cusparseIndexBase_t,
                    (cusparseMatDescr_t,),
                    descrA)
 end
 
 @checked function cusparseCreateCsrsv2Info(info)
-    initialize_api()
+    initialize_context()
     ccall((:cusparseCreateCsrsv2Info, libcusparse()), cusparseStatus_t,
                    (Ptr{csrsv2Info_t},),
                    info)
 end
 
 @checked function cusparseDestroyCsrsv2Info(info)
-    initialize_api()
+    initialize_context()
     ccall((:cusparseDestroyCsrsv2Info, libcusparse()), cusparseStatus_t,
                    (csrsv2Info_t,),
                    info)
 end
 
 @checked function cusparseCreateCsric02Info(info)
-    initialize_api()
+    initialize_context()
     ccall((:cusparseCreateCsric02Info, libcusparse()), cusparseStatus_t,
                    (Ptr{csric02Info_t},),
                    info)
 end
 
 @checked function cusparseDestroyCsric02Info(info)
-    initialize_api()
+    initialize_context()
     ccall((:cusparseDestroyCsric02Info, libcusparse()), cusparseStatus_t,
                    (csric02Info_t,),
                    info)
 end
 
 @checked function cusparseCreateBsric02Info(info)
-    initialize_api()
+    initialize_context()
     ccall((:cusparseCreateBsric02Info, libcusparse()), cusparseStatus_t,
                    (Ptr{bsric02Info_t},),
                    info)
 end
 
 @checked function cusparseDestroyBsric02Info(info)
-    initialize_api()
+    initialize_context()
     ccall((:cusparseDestroyBsric02Info, libcusparse()), cusparseStatus_t,
                    (bsric02Info_t,),
                    info)
 end
 
 @checked function cusparseCreateCsrilu02Info(info)
-    initialize_api()
+    initialize_context()
     ccall((:cusparseCreateCsrilu02Info, libcusparse()), cusparseStatus_t,
                    (Ptr{csrilu02Info_t},),
                    info)
 end
 
 @checked function cusparseDestroyCsrilu02Info(info)
-    initialize_api()
+    initialize_context()
     ccall((:cusparseDestroyCsrilu02Info, libcusparse()), cusparseStatus_t,
                    (csrilu02Info_t,),
                    info)
 end
 
 @checked function cusparseCreateBsrilu02Info(info)
-    initialize_api()
+    initialize_context()
     ccall((:cusparseCreateBsrilu02Info, libcusparse()), cusparseStatus_t,
                    (Ptr{bsrilu02Info_t},),
                    info)
 end
 
 @checked function cusparseDestroyBsrilu02Info(info)
-    initialize_api()
+    initialize_context()
     ccall((:cusparseDestroyBsrilu02Info, libcusparse()), cusparseStatus_t,
                    (bsrilu02Info_t,),
                    info)
 end
 
 @checked function cusparseCreateBsrsv2Info(info)
-    initialize_api()
+    initialize_context()
     ccall((:cusparseCreateBsrsv2Info, libcusparse()), cusparseStatus_t,
                    (Ptr{bsrsv2Info_t},),
                    info)
 end
 
 @checked function cusparseDestroyBsrsv2Info(info)
-    initialize_api()
+    initialize_context()
     ccall((:cusparseDestroyBsrsv2Info, libcusparse()), cusparseStatus_t,
                    (bsrsv2Info_t,),
                    info)
 end
 
 @checked function cusparseCreateBsrsm2Info(info)
-    initialize_api()
+    initialize_context()
     ccall((:cusparseCreateBsrsm2Info, libcusparse()), cusparseStatus_t,
                    (Ptr{bsrsm2Info_t},),
                    info)
 end
 
 @checked function cusparseDestroyBsrsm2Info(info)
-    initialize_api()
+    initialize_context()
     ccall((:cusparseDestroyBsrsm2Info, libcusparse()), cusparseStatus_t,
                    (bsrsm2Info_t,),
                    info)
 end
 
 @checked function cusparseCreateCsru2csrInfo(info)
-    initialize_api()
+    initialize_context()
     ccall((:cusparseCreateCsru2csrInfo, libcusparse()), cusparseStatus_t,
                    (Ptr{csru2csrInfo_t},),
                    info)
 end
 
 @checked function cusparseDestroyCsru2csrInfo(info)
-    initialize_api()
+    initialize_context()
     ccall((:cusparseDestroyCsru2csrInfo, libcusparse()), cusparseStatus_t,
                    (csru2csrInfo_t,),
                    info)
 end
 
 @checked function cusparseCreateColorInfo(info)
-    initialize_api()
+    initialize_context()
     ccall((:cusparseCreateColorInfo, libcusparse()), cusparseStatus_t,
                    (Ptr{cusparseColorInfo_t},),
                    info)
 end
 
 @checked function cusparseDestroyColorInfo(info)
-    initialize_api()
+    initialize_context()
     ccall((:cusparseDestroyColorInfo, libcusparse()), cusparseStatus_t,
                    (cusparseColorInfo_t,),
                    info)
 end
 
 @checked function cusparseSetColorAlgs(info, alg)
-    initialize_api()
+    initialize_context()
     ccall((:cusparseSetColorAlgs, libcusparse()), cusparseStatus_t,
                    (cusparseColorInfo_t, cusparseColorAlg_t),
                    info, alg)
 end
 
 @checked function cusparseGetColorAlgs(info, alg)
-    initialize_api()
+    initialize_context()
     ccall((:cusparseGetColorAlgs, libcusparse()), cusparseStatus_t,
                    (cusparseColorInfo_t, Ptr{cusparseColorAlg_t}),
                    info, alg)
 end
 
 @checked function cusparseCreatePruneInfo(info)
-    initialize_api()
+    initialize_context()
     ccall((:cusparseCreatePruneInfo, libcusparse()), cusparseStatus_t,
                    (Ptr{pruneInfo_t},),
                    info)
 end
 
 @checked function cusparseDestroyPruneInfo(info)
-    initialize_api()
+    initialize_context()
     ccall((:cusparseDestroyPruneInfo, libcusparse()), cusparseStatus_t,
                    (pruneInfo_t,),
                    info)
 end
 
 @checked function cusparseSaxpyi(handle, nnz, alpha, xVal, xInd, y, idxBase)
-    initialize_api()
+    initialize_context()
     ccall((:cusparseSaxpyi, libcusparse()), cusparseStatus_t,
                    (cusparseHandle_t, Cint, Ref{Cfloat}, CuPtr{Cfloat}, CuPtr{Cint},
                     CuPtr{Cfloat}, cusparseIndexBase_t),
@@ -307,7 +307,7 @@ end
 end
 
 @checked function cusparseDaxpyi(handle, nnz, alpha, xVal, xInd, y, idxBase)
-    initialize_api()
+    initialize_context()
     ccall((:cusparseDaxpyi, libcusparse()), cusparseStatus_t,
                    (cusparseHandle_t, Cint, Ref{Cdouble}, CuPtr{Cdouble}, CuPtr{Cint},
                     CuPtr{Cdouble}, cusparseIndexBase_t),
@@ -315,7 +315,7 @@ end
 end
 
 @checked function cusparseCaxpyi(handle, nnz, alpha, xVal, xInd, y, idxBase)
-    initialize_api()
+    initialize_context()
     ccall((:cusparseCaxpyi, libcusparse()), cusparseStatus_t,
                    (cusparseHandle_t, Cint, Ref{cuComplex}, CuPtr{cuComplex}, CuPtr{Cint},
                     CuPtr{cuComplex}, cusparseIndexBase_t),
@@ -323,7 +323,7 @@ end
 end
 
 @checked function cusparseZaxpyi(handle, nnz, alpha, xVal, xInd, y, idxBase)
-    initialize_api()
+    initialize_context()
     ccall((:cusparseZaxpyi, libcusparse()), cusparseStatus_t,
                    (cusparseHandle_t, Cint, Ref{cuDoubleComplex}, CuPtr{cuDoubleComplex},
                     CuPtr{Cint}, CuPtr{cuDoubleComplex}, cusparseIndexBase_t),
@@ -331,7 +331,7 @@ end
 end
 
 @checked function cusparseSgthr(handle, nnz, y, xVal, xInd, idxBase)
-    initialize_api()
+    initialize_context()
     ccall((:cusparseSgthr, libcusparse()), cusparseStatus_t,
                    (cusparseHandle_t, Cint, CuPtr{Cfloat}, CuPtr{Cfloat}, CuPtr{Cint},
                     cusparseIndexBase_t),
@@ -339,7 +339,7 @@ end
 end
 
 @checked function cusparseDgthr(handle, nnz, y, xVal, xInd, idxBase)
-    initialize_api()
+    initialize_context()
     ccall((:cusparseDgthr, libcusparse()), cusparseStatus_t,
                    (cusparseHandle_t, Cint, CuPtr{Cdouble}, CuPtr{Cdouble}, CuPtr{Cint},
                     cusparseIndexBase_t),
@@ -347,7 +347,7 @@ end
 end
 
 @checked function cusparseCgthr(handle, nnz, y, xVal, xInd, idxBase)
-    initialize_api()
+    initialize_context()
     ccall((:cusparseCgthr, libcusparse()), cusparseStatus_t,
                    (cusparseHandle_t, Cint, CuPtr{cuComplex}, CuPtr{cuComplex},
                     CuPtr{Cint}, cusparseIndexBase_t),
@@ -355,7 +355,7 @@ end
 end
 
 @checked function cusparseZgthr(handle, nnz, y, xVal, xInd, idxBase)
-    initialize_api()
+    initialize_context()
     ccall((:cusparseZgthr, libcusparse()), cusparseStatus_t,
                    (cusparseHandle_t, Cint, CuPtr{cuDoubleComplex},
                     CuPtr{cuDoubleComplex}, CuPtr{Cint}, cusparseIndexBase_t),
@@ -363,7 +363,7 @@ end
 end
 
 @checked function cusparseSgthrz(handle, nnz, y, xVal, xInd, idxBase)
-    initialize_api()
+    initialize_context()
     ccall((:cusparseSgthrz, libcusparse()), cusparseStatus_t,
                    (cusparseHandle_t, Cint, CuPtr{Cfloat}, CuPtr{Cfloat}, CuPtr{Cint},
                     cusparseIndexBase_t),
@@ -371,7 +371,7 @@ end
 end
 
 @checked function cusparseDgthrz(handle, nnz, y, xVal, xInd, idxBase)
-    initialize_api()
+    initialize_context()
     ccall((:cusparseDgthrz, libcusparse()), cusparseStatus_t,
                    (cusparseHandle_t, Cint, CuPtr{Cdouble}, CuPtr{Cdouble}, CuPtr{Cint},
                     cusparseIndexBase_t),
@@ -379,7 +379,7 @@ end
 end
 
 @checked function cusparseCgthrz(handle, nnz, y, xVal, xInd, idxBase)
-    initialize_api()
+    initialize_context()
     ccall((:cusparseCgthrz, libcusparse()), cusparseStatus_t,
                    (cusparseHandle_t, Cint, CuPtr{cuComplex}, CuPtr{cuComplex},
                     CuPtr{Cint}, cusparseIndexBase_t),
@@ -387,7 +387,7 @@ end
 end
 
 @checked function cusparseZgthrz(handle, nnz, y, xVal, xInd, idxBase)
-    initialize_api()
+    initialize_context()
     ccall((:cusparseZgthrz, libcusparse()), cusparseStatus_t,
                    (cusparseHandle_t, Cint, CuPtr{cuDoubleComplex},
                     CuPtr{cuDoubleComplex}, CuPtr{Cint}, cusparseIndexBase_t),
@@ -395,7 +395,7 @@ end
 end
 
 @checked function cusparseSsctr(handle, nnz, xVal, xInd, y, idxBase)
-    initialize_api()
+    initialize_context()
     ccall((:cusparseSsctr, libcusparse()), cusparseStatus_t,
                    (cusparseHandle_t, Cint, CuPtr{Cfloat}, CuPtr{Cint}, CuPtr{Cfloat},
                     cusparseIndexBase_t),
@@ -403,7 +403,7 @@ end
 end
 
 @checked function cusparseDsctr(handle, nnz, xVal, xInd, y, idxBase)
-    initialize_api()
+    initialize_context()
     ccall((:cusparseDsctr, libcusparse()), cusparseStatus_t,
                    (cusparseHandle_t, Cint, CuPtr{Cdouble}, CuPtr{Cint}, CuPtr{Cdouble},
                     cusparseIndexBase_t),
@@ -411,7 +411,7 @@ end
 end
 
 @checked function cusparseCsctr(handle, nnz, xVal, xInd, y, idxBase)
-    initialize_api()
+    initialize_context()
     ccall((:cusparseCsctr, libcusparse()), cusparseStatus_t,
                    (cusparseHandle_t, Cint, CuPtr{cuComplex}, CuPtr{Cint},
                     CuPtr{cuComplex}, cusparseIndexBase_t),
@@ -419,7 +419,7 @@ end
 end
 
 @checked function cusparseZsctr(handle, nnz, xVal, xInd, y, idxBase)
-    initialize_api()
+    initialize_context()
     ccall((:cusparseZsctr, libcusparse()), cusparseStatus_t,
                    (cusparseHandle_t, Cint, CuPtr{cuDoubleComplex}, CuPtr{Cint},
                     CuPtr{cuDoubleComplex}, cusparseIndexBase_t),
@@ -427,7 +427,7 @@ end
 end
 
 @checked function cusparseSroti(handle, nnz, xVal, xInd, y, c, s, idxBase)
-    initialize_api()
+    initialize_context()
     ccall((:cusparseSroti, libcusparse()), cusparseStatus_t,
                    (cusparseHandle_t, Cint, CuPtr{Cfloat}, CuPtr{Cint}, CuPtr{Cfloat},
                     Ref{Cfloat}, Ref{Cfloat}, cusparseIndexBase_t),
@@ -435,7 +435,7 @@ end
 end
 
 @checked function cusparseDroti(handle, nnz, xVal, xInd, y, c, s, idxBase)
-    initialize_api()
+    initialize_context()
     ccall((:cusparseDroti, libcusparse()), cusparseStatus_t,
                    (cusparseHandle_t, Cint, CuPtr{Cdouble}, CuPtr{Cint}, CuPtr{Cdouble},
                     Ref{Cdouble}, Ref{Cdouble}, cusparseIndexBase_t),
@@ -444,7 +444,7 @@ end
 
 @checked function cusparseSgemvi(handle, transA, m, n, alpha, A, lda, nnz, xVal, xInd,
                                  beta, y, idxBase, pBuffer)
-    initialize_api()
+    initialize_context()
     ccall((:cusparseSgemvi, libcusparse()), cusparseStatus_t,
                    (cusparseHandle_t, cusparseOperation_t, Cint, Cint, Ref{Cfloat},
                     CuPtr{Cfloat}, Cint, Cint, CuPtr{Cfloat}, CuPtr{Cint}, Ref{Cfloat},
@@ -454,7 +454,7 @@ end
 end
 
 @checked function cusparseSgemvi_bufferSize(handle, transA, m, n, nnz, pBufferSize)
-    initialize_api()
+    initialize_context()
     ccall((:cusparseSgemvi_bufferSize, libcusparse()), cusparseStatus_t,
                    (cusparseHandle_t, cusparseOperation_t, Cint, Cint, Cint, Ptr{Cint}),
                    handle, transA, m, n, nnz, pBufferSize)
@@ -462,7 +462,7 @@ end
 
 @checked function cusparseDgemvi(handle, transA, m, n, alpha, A, lda, nnz, xVal, xInd,
                                  beta, y, idxBase, pBuffer)
-    initialize_api()
+    initialize_context()
     ccall((:cusparseDgemvi, libcusparse()), cusparseStatus_t,
                    (cusparseHandle_t, cusparseOperation_t, Cint, Cint, Ref{Cdouble},
                     CuPtr{Cdouble}, Cint, Cint, CuPtr{Cdouble}, CuPtr{Cint}, Ref{Cdouble},
@@ -472,7 +472,7 @@ end
 end
 
 @checked function cusparseDgemvi_bufferSize(handle, transA, m, n, nnz, pBufferSize)
-    initialize_api()
+    initialize_context()
     ccall((:cusparseDgemvi_bufferSize, libcusparse()), cusparseStatus_t,
                    (cusparseHandle_t, cusparseOperation_t, Cint, Cint, Cint, Ptr{Cint}),
                    handle, transA, m, n, nnz, pBufferSize)
@@ -480,7 +480,7 @@ end
 
 @checked function cusparseCgemvi(handle, transA, m, n, alpha, A, lda, nnz, xVal, xInd,
                                  beta, y, idxBase, pBuffer)
-    initialize_api()
+    initialize_context()
     ccall((:cusparseCgemvi, libcusparse()), cusparseStatus_t,
                    (cusparseHandle_t, cusparseOperation_t, Cint, Cint, Ref{cuComplex},
                     CuPtr{cuComplex}, Cint, Cint, CuPtr{cuComplex}, CuPtr{Cint},
@@ -490,7 +490,7 @@ end
 end
 
 @checked function cusparseCgemvi_bufferSize(handle, transA, m, n, nnz, pBufferSize)
-    initialize_api()
+    initialize_context()
     ccall((:cusparseCgemvi_bufferSize, libcusparse()), cusparseStatus_t,
                    (cusparseHandle_t, cusparseOperation_t, Cint, Cint, Cint, Ptr{Cint}),
                    handle, transA, m, n, nnz, pBufferSize)
@@ -498,7 +498,7 @@ end
 
 @checked function cusparseZgemvi(handle, transA, m, n, alpha, A, lda, nnz, xVal, xInd,
                                  beta, y, idxBase, pBuffer)
-    initialize_api()
+    initialize_context()
     ccall((:cusparseZgemvi, libcusparse()), cusparseStatus_t,
                    (cusparseHandle_t, cusparseOperation_t, Cint, Cint,
                     Ref{cuDoubleComplex}, CuPtr{cuDoubleComplex}, Cint, Cint,
@@ -509,7 +509,7 @@ end
 end
 
 @checked function cusparseZgemvi_bufferSize(handle, transA, m, n, nnz, pBufferSize)
-    initialize_api()
+    initialize_context()
     ccall((:cusparseZgemvi_bufferSize, libcusparse()), cusparseStatus_t,
                    (cusparseHandle_t, cusparseOperation_t, Cint, Cint, Cint, Ptr{Cint}),
                    handle, transA, m, n, nnz, pBufferSize)
@@ -520,7 +520,7 @@ end
                                              csrRowPtrA, csrColIndA, x, xtype, beta,
                                              betatype, y, ytype, executiontype,
                                              bufferSizeInBytes)
-    initialize_api()
+    initialize_context()
     ccall((:cusparseCsrmvEx_bufferSize, libcusparse()), cusparseStatus_t,
                    (cusparseHandle_t, cusparseAlgMode_t, cusparseOperation_t, Cint, Cint,
                     Cint, Ptr{Cvoid}, cudaDataType, cusparseMatDescr_t, CuPtr{Cvoid},
@@ -535,7 +535,7 @@ end
 @checked function cusparseCsrmvEx(handle, alg, transA, m, n, nnz, alpha, alphatype, descrA,
                                   csrValA, csrValAtype, csrRowPtrA, csrColIndA, x, xtype,
                                   beta, betatype, y, ytype, executiontype, buffer)
-    initialize_api()
+    initialize_context()
     ccall((:cusparseCsrmvEx, libcusparse()), cusparseStatus_t,
                    (cusparseHandle_t, cusparseAlgMode_t, cusparseOperation_t, Cint, Cint,
                     Cint, Ptr{Cvoid}, cudaDataType, cusparseMatDescr_t, CuPtr{Cvoid},
@@ -550,7 +550,7 @@ end
 @checked function cusparseSbsrmv(handle, dirA, transA, mb, nb, nnzb, alpha, descrA,
                                  bsrSortedValA, bsrSortedRowPtrA, bsrSortedColIndA,
                                  blockDim, x, beta, y)
-    initialize_api()
+    initialize_context()
     ccall((:cusparseSbsrmv, libcusparse()), cusparseStatus_t,
                    (cusparseHandle_t, cusparseDirection_t, cusparseOperation_t, Cint,
                     Cint, Cint, Ref{Cfloat}, cusparseMatDescr_t, CuPtr{Cfloat},
@@ -563,7 +563,7 @@ end
 @checked function cusparseDbsrmv(handle, dirA, transA, mb, nb, nnzb, alpha, descrA,
                                  bsrSortedValA, bsrSortedRowPtrA, bsrSortedColIndA,
                                  blockDim, x, beta, y)
-    initialize_api()
+    initialize_context()
     ccall((:cusparseDbsrmv, libcusparse()), cusparseStatus_t,
                    (cusparseHandle_t, cusparseDirection_t, cusparseOperation_t, Cint,
                     Cint, Cint, Ref{Cdouble}, cusparseMatDescr_t, CuPtr{Cdouble},
@@ -576,7 +576,7 @@ end
 @checked function cusparseCbsrmv(handle, dirA, transA, mb, nb, nnzb, alpha, descrA,
                                  bsrSortedValA, bsrSortedRowPtrA, bsrSortedColIndA,
                                  blockDim, x, beta, y)
-    initialize_api()
+    initialize_context()
     ccall((:cusparseCbsrmv, libcusparse()), cusparseStatus_t,
                    (cusparseHandle_t, cusparseDirection_t, cusparseOperation_t, Cint,
                     Cint, Cint, Ref{cuComplex}, cusparseMatDescr_t, CuPtr{cuComplex},
@@ -589,7 +589,7 @@ end
 @checked function cusparseZbsrmv(handle, dirA, transA, mb, nb, nnzb, alpha, descrA,
                                  bsrSortedValA, bsrSortedRowPtrA, bsrSortedColIndA,
                                  blockDim, x, beta, y)
-    initialize_api()
+    initialize_context()
     ccall((:cusparseZbsrmv, libcusparse()), cusparseStatus_t,
                    (cusparseHandle_t, cusparseDirection_t, cusparseOperation_t, Cint,
                     Cint, Cint, Ref{cuDoubleComplex}, cusparseMatDescr_t,
@@ -603,7 +603,7 @@ end
                                   descrA, bsrSortedValA, bsrSortedMaskPtrA,
                                   bsrSortedRowPtrA, bsrSortedEndPtrA, bsrSortedColIndA,
                                   blockDim, x, beta, y)
-    initialize_api()
+    initialize_context()
     ccall((:cusparseSbsrxmv, libcusparse()), cusparseStatus_t,
                    (cusparseHandle_t, cusparseDirection_t, cusparseOperation_t, Cint,
                     Cint, Cint, Cint, Ref{Cfloat}, cusparseMatDescr_t, CuPtr{Cfloat},
@@ -618,7 +618,7 @@ end
                                   descrA, bsrSortedValA, bsrSortedMaskPtrA,
                                   bsrSortedRowPtrA, bsrSortedEndPtrA, bsrSortedColIndA,
                                   blockDim, x, beta, y)
-    initialize_api()
+    initialize_context()
     ccall((:cusparseDbsrxmv, libcusparse()), cusparseStatus_t,
                    (cusparseHandle_t, cusparseDirection_t, cusparseOperation_t, Cint,
                     Cint, Cint, Cint, Ref{Cdouble}, cusparseMatDescr_t, CuPtr{Cdouble},
@@ -633,7 +633,7 @@ end
                                   descrA, bsrSortedValA, bsrSortedMaskPtrA,
                                   bsrSortedRowPtrA, bsrSortedEndPtrA, bsrSortedColIndA,
                                   blockDim, x, beta, y)
-    initialize_api()
+    initialize_context()
     ccall((:cusparseCbsrxmv, libcusparse()), cusparseStatus_t,
                    (cusparseHandle_t, cusparseDirection_t, cusparseOperation_t, Cint,
                     Cint, Cint, Cint, Ref{cuComplex}, cusparseMatDescr_t, CuPtr{cuComplex},
@@ -648,7 +648,7 @@ end
                                   descrA, bsrSortedValA, bsrSortedMaskPtrA,
                                   bsrSortedRowPtrA, bsrSortedEndPtrA, bsrSortedColIndA,
                                   blockDim, x, beta, y)
-    initialize_api()
+    initialize_context()
     ccall((:cusparseZbsrxmv, libcusparse()), cusparseStatus_t,
                    (cusparseHandle_t, cusparseDirection_t, cusparseOperation_t, Cint,
                     Cint, Cint, Cint, Ref{cuDoubleComplex}, cusparseMatDescr_t,
@@ -661,7 +661,7 @@ end
 end
 
 @checked function cusparseXcsrsv2_zeroPivot(handle, info, position)
-    initialize_api()
+    initialize_context()
     ccall((:cusparseXcsrsv2_zeroPivot, libcusparse()), cusparseStatus_t,
                    (cusparseHandle_t, csrsv2Info_t, Ptr{Cint}),
                    handle, info, position)
@@ -670,7 +670,7 @@ end
 @checked function cusparseScsrsv2_bufferSize(handle, transA, m, nnz, descrA, csrSortedValA,
                                              csrSortedRowPtrA, csrSortedColIndA, info,
                                              pBufferSizeInBytes)
-    initialize_api()
+    initialize_context()
     ccall((:cusparseScsrsv2_bufferSize, libcusparse()), cusparseStatus_t,
                    (cusparseHandle_t, cusparseOperation_t, Cint, Cint, cusparseMatDescr_t,
                     CuPtr{Cfloat}, CuPtr{Cint}, CuPtr{Cint}, csrsv2Info_t, Ptr{Cint}),
@@ -681,7 +681,7 @@ end
 @checked function cusparseDcsrsv2_bufferSize(handle, transA, m, nnz, descrA, csrSortedValA,
                                              csrSortedRowPtrA, csrSortedColIndA, info,
                                              pBufferSizeInBytes)
-    initialize_api()
+    initialize_context()
     ccall((:cusparseDcsrsv2_bufferSize, libcusparse()), cusparseStatus_t,
                    (cusparseHandle_t, cusparseOperation_t, Cint, Cint, cusparseMatDescr_t,
                     CuPtr{Cdouble}, CuPtr{Cint}, CuPtr{Cint}, csrsv2Info_t, Ptr{Cint}),
@@ -692,7 +692,7 @@ end
 @checked function cusparseCcsrsv2_bufferSize(handle, transA, m, nnz, descrA, csrSortedValA,
                                              csrSortedRowPtrA, csrSortedColIndA, info,
                                              pBufferSizeInBytes)
-    initialize_api()
+    initialize_context()
     ccall((:cusparseCcsrsv2_bufferSize, libcusparse()), cusparseStatus_t,
                    (cusparseHandle_t, cusparseOperation_t, Cint, Cint, cusparseMatDescr_t,
                     CuPtr{cuComplex}, CuPtr{Cint}, CuPtr{Cint}, csrsv2Info_t, Ptr{Cint}),
@@ -703,7 +703,7 @@ end
 @checked function cusparseZcsrsv2_bufferSize(handle, transA, m, nnz, descrA, csrSortedValA,
                                              csrSortedRowPtrA, csrSortedColIndA, info,
                                              pBufferSizeInBytes)
-    initialize_api()
+    initialize_context()
     ccall((:cusparseZcsrsv2_bufferSize, libcusparse()), cusparseStatus_t,
                    (cusparseHandle_t, cusparseOperation_t, Cint, Cint, cusparseMatDescr_t,
                     CuPtr{cuDoubleComplex}, CuPtr{Cint}, CuPtr{Cint}, csrsv2Info_t,
@@ -715,7 +715,7 @@ end
 @checked function cusparseScsrsv2_bufferSizeExt(handle, transA, m, nnz, descrA,
                                                 csrSortedValA, csrSortedRowPtrA,
                                                 csrSortedColIndA, info, pBufferSize)
-    initialize_api()
+    initialize_context()
     ccall((:cusparseScsrsv2_bufferSizeExt, libcusparse()), cusparseStatus_t,
                    (cusparseHandle_t, cusparseOperation_t, Cint, Cint, cusparseMatDescr_t,
                     CuPtr{Cfloat}, CuPtr{Cint}, CuPtr{Cint}, csrsv2Info_t, Ptr{Csize_t}),
@@ -726,7 +726,7 @@ end
 @checked function cusparseDcsrsv2_bufferSizeExt(handle, transA, m, nnz, descrA,
                                                 csrSortedValA, csrSortedRowPtrA,
                                                 csrSortedColIndA, info, pBufferSize)
-    initialize_api()
+    initialize_context()
     ccall((:cusparseDcsrsv2_bufferSizeExt, libcusparse()), cusparseStatus_t,
                    (cusparseHandle_t, cusparseOperation_t, Cint, Cint, cusparseMatDescr_t,
                     CuPtr{Cdouble}, CuPtr{Cint}, CuPtr{Cint}, csrsv2Info_t, Ptr{Csize_t}),
@@ -737,7 +737,7 @@ end
 @checked function cusparseCcsrsv2_bufferSizeExt(handle, transA, m, nnz, descrA,
                                                 csrSortedValA, csrSortedRowPtrA,
                                                 csrSortedColIndA, info, pBufferSize)
-    initialize_api()
+    initialize_context()
     ccall((:cusparseCcsrsv2_bufferSizeExt, libcusparse()), cusparseStatus_t,
                    (cusparseHandle_t, cusparseOperation_t, Cint, Cint, cusparseMatDescr_t,
                     CuPtr{cuComplex}, CuPtr{Cint}, CuPtr{Cint}, csrsv2Info_t, Ptr{Csize_t}),
@@ -748,7 +748,7 @@ end
 @checked function cusparseZcsrsv2_bufferSizeExt(handle, transA, m, nnz, descrA,
                                                 csrSortedValA, csrSortedRowPtrA,
                                                 csrSortedColIndA, info, pBufferSize)
-    initialize_api()
+    initialize_context()
     ccall((:cusparseZcsrsv2_bufferSizeExt, libcusparse()), cusparseStatus_t,
                    (cusparseHandle_t, cusparseOperation_t, Cint, Cint, cusparseMatDescr_t,
                     CuPtr{cuDoubleComplex}, CuPtr{Cint}, CuPtr{Cint}, csrsv2Info_t,
@@ -760,7 +760,7 @@ end
 @checked function cusparseScsrsv2_analysis(handle, transA, m, nnz, descrA, csrSortedValA,
                                            csrSortedRowPtrA, csrSortedColIndA, info,
                                            policy, pBuffer)
-    initialize_api()
+    initialize_context()
     ccall((:cusparseScsrsv2_analysis, libcusparse()), cusparseStatus_t,
                    (cusparseHandle_t, cusparseOperation_t, Cint, Cint, cusparseMatDescr_t,
                     CuPtr{Cfloat}, CuPtr{Cint}, CuPtr{Cint}, csrsv2Info_t,
@@ -772,7 +772,7 @@ end
 @checked function cusparseDcsrsv2_analysis(handle, transA, m, nnz, descrA, csrSortedValA,
                                            csrSortedRowPtrA, csrSortedColIndA, info,
                                            policy, pBuffer)
-    initialize_api()
+    initialize_context()
     ccall((:cusparseDcsrsv2_analysis, libcusparse()), cusparseStatus_t,
                    (cusparseHandle_t, cusparseOperation_t, Cint, Cint, cusparseMatDescr_t,
                     CuPtr{Cdouble}, CuPtr{Cint}, CuPtr{Cint}, csrsv2Info_t,
@@ -784,7 +784,7 @@ end
 @checked function cusparseCcsrsv2_analysis(handle, transA, m, nnz, descrA, csrSortedValA,
                                            csrSortedRowPtrA, csrSortedColIndA, info,
                                            policy, pBuffer)
-    initialize_api()
+    initialize_context()
     ccall((:cusparseCcsrsv2_analysis, libcusparse()), cusparseStatus_t,
                    (cusparseHandle_t, cusparseOperation_t, Cint, Cint, cusparseMatDescr_t,
                     CuPtr{cuComplex}, CuPtr{Cint}, CuPtr{Cint}, csrsv2Info_t,
@@ -796,7 +796,7 @@ end
 @checked function cusparseZcsrsv2_analysis(handle, transA, m, nnz, descrA, csrSortedValA,
                                            csrSortedRowPtrA, csrSortedColIndA, info,
                                            policy, pBuffer)
-    initialize_api()
+    initialize_context()
     ccall((:cusparseZcsrsv2_analysis, libcusparse()), cusparseStatus_t,
                    (cusparseHandle_t, cusparseOperation_t, Cint, Cint, cusparseMatDescr_t,
                     CuPtr{cuDoubleComplex}, CuPtr{Cint}, CuPtr{Cint}, csrsv2Info_t,
@@ -808,7 +808,7 @@ end
 @checked function cusparseScsrsv2_solve(handle, transA, m, nnz, alpha, descrA,
                                         csrSortedValA, csrSortedRowPtrA, csrSortedColIndA,
                                         info, f, x, policy, pBuffer)
-    initialize_api()
+    initialize_context()
     ccall((:cusparseScsrsv2_solve, libcusparse()), cusparseStatus_t,
                    (cusparseHandle_t, cusparseOperation_t, Cint, Cint, Ref{Cfloat},
                     cusparseMatDescr_t, CuPtr{Cfloat}, CuPtr{Cint}, CuPtr{Cint},
@@ -821,7 +821,7 @@ end
 @checked function cusparseDcsrsv2_solve(handle, transA, m, nnz, alpha, descrA,
                                         csrSortedValA, csrSortedRowPtrA, csrSortedColIndA,
                                         info, f, x, policy, pBuffer)
-    initialize_api()
+    initialize_context()
     ccall((:cusparseDcsrsv2_solve, libcusparse()), cusparseStatus_t,
                    (cusparseHandle_t, cusparseOperation_t, Cint, Cint, Ref{Cdouble},
                     cusparseMatDescr_t, CuPtr{Cdouble}, CuPtr{Cint}, CuPtr{Cint},
@@ -834,7 +834,7 @@ end
 @checked function cusparseCcsrsv2_solve(handle, transA, m, nnz, alpha, descrA,
                                         csrSortedValA, csrSortedRowPtrA, csrSortedColIndA,
                                         info, f, x, policy, pBuffer)
-    initialize_api()
+    initialize_context()
     ccall((:cusparseCcsrsv2_solve, libcusparse()), cusparseStatus_t,
                    (cusparseHandle_t, cusparseOperation_t, Cint, Cint, Ref{cuComplex},
                     cusparseMatDescr_t, CuPtr{cuComplex}, CuPtr{Cint}, CuPtr{Cint},
@@ -847,7 +847,7 @@ end
 @checked function cusparseZcsrsv2_solve(handle, transA, m, nnz, alpha, descrA,
                                         csrSortedValA, csrSortedRowPtrA, csrSortedColIndA,
                                         info, f, x, policy, pBuffer)
-    initialize_api()
+    initialize_context()
     ccall((:cusparseZcsrsv2_solve, libcusparse()), cusparseStatus_t,
                    (cusparseHandle_t, cusparseOperation_t, Cint, Cint,
                     Ref{cuDoubleComplex}, cusparseMatDescr_t, CuPtr{cuDoubleComplex},
@@ -858,7 +858,7 @@ end
 end
 
 @checked function cusparseXbsrsv2_zeroPivot(handle, info, position)
-    initialize_api()
+    initialize_context()
     ccall((:cusparseXbsrsv2_zeroPivot, libcusparse()), cusparseStatus_t,
                    (cusparseHandle_t, bsrsv2Info_t, Ptr{Cint}),
                    handle, info, position)
@@ -868,7 +868,7 @@ end
                                              bsrSortedValA, bsrSortedRowPtrA,
                                              bsrSortedColIndA, blockDim, info,
                                              pBufferSizeInBytes)
-    initialize_api()
+    initialize_context()
     ccall((:cusparseSbsrsv2_bufferSize, libcusparse()), cusparseStatus_t,
                    (cusparseHandle_t, cusparseDirection_t, cusparseOperation_t, Cint,
                     Cint, cusparseMatDescr_t, CuPtr{Cfloat}, CuPtr{Cint}, CuPtr{Cint},
@@ -881,7 +881,7 @@ end
                                              bsrSortedValA, bsrSortedRowPtrA,
                                              bsrSortedColIndA, blockDim, info,
                                              pBufferSizeInBytes)
-    initialize_api()
+    initialize_context()
     ccall((:cusparseDbsrsv2_bufferSize, libcusparse()), cusparseStatus_t,
                    (cusparseHandle_t, cusparseDirection_t, cusparseOperation_t, Cint,
                     Cint, cusparseMatDescr_t, CuPtr{Cdouble}, CuPtr{Cint}, CuPtr{Cint},
@@ -894,7 +894,7 @@ end
                                              bsrSortedValA, bsrSortedRowPtrA,
                                              bsrSortedColIndA, blockDim, info,
                                              pBufferSizeInBytes)
-    initialize_api()
+    initialize_context()
     ccall((:cusparseCbsrsv2_bufferSize, libcusparse()), cusparseStatus_t,
                    (cusparseHandle_t, cusparseDirection_t, cusparseOperation_t, Cint,
                     Cint, cusparseMatDescr_t, CuPtr{cuComplex}, CuPtr{Cint}, CuPtr{Cint},
@@ -907,7 +907,7 @@ end
                                              bsrSortedValA, bsrSortedRowPtrA,
                                              bsrSortedColIndA, blockDim, info,
                                              pBufferSizeInBytes)
-    initialize_api()
+    initialize_context()
     ccall((:cusparseZbsrsv2_bufferSize, libcusparse()), cusparseStatus_t,
                    (cusparseHandle_t, cusparseDirection_t, cusparseOperation_t, Cint,
                     Cint, cusparseMatDescr_t, CuPtr{cuDoubleComplex}, CuPtr{Cint},
@@ -920,7 +920,7 @@ end
                                                 bsrSortedValA, bsrSortedRowPtrA,
                                                 bsrSortedColIndA, blockSize, info,
                                                 pBufferSize)
-    initialize_api()
+    initialize_context()
     ccall((:cusparseSbsrsv2_bufferSizeExt, libcusparse()), cusparseStatus_t,
                    (cusparseHandle_t, cusparseDirection_t, cusparseOperation_t, Cint,
                     Cint, cusparseMatDescr_t, CuPtr{Cfloat}, CuPtr{Cint}, CuPtr{Cint},
@@ -933,7 +933,7 @@ end
                                                 bsrSortedValA, bsrSortedRowPtrA,
                                                 bsrSortedColIndA, blockSize, info,
                                                 pBufferSize)
-    initialize_api()
+    initialize_context()
     ccall((:cusparseDbsrsv2_bufferSizeExt, libcusparse()), cusparseStatus_t,
                    (cusparseHandle_t, cusparseDirection_t, cusparseOperation_t, Cint,
                     Cint, cusparseMatDescr_t, CuPtr{Cdouble}, CuPtr{Cint}, CuPtr{Cint},
@@ -946,7 +946,7 @@ end
                                                 bsrSortedValA, bsrSortedRowPtrA,
                                                 bsrSortedColIndA, blockSize, info,
                                                 pBufferSize)
-    initialize_api()
+    initialize_context()
     ccall((:cusparseCbsrsv2_bufferSizeExt, libcusparse()), cusparseStatus_t,
                    (cusparseHandle_t, cusparseDirection_t, cusparseOperation_t, Cint,
                     Cint, cusparseMatDescr_t, CuPtr{cuComplex}, CuPtr{Cint}, CuPtr{Cint},
@@ -959,7 +959,7 @@ end
                                                 bsrSortedValA, bsrSortedRowPtrA,
                                                 bsrSortedColIndA, blockSize, info,
                                                 pBufferSize)
-    initialize_api()
+    initialize_context()
     ccall((:cusparseZbsrsv2_bufferSizeExt, libcusparse()), cusparseStatus_t,
                    (cusparseHandle_t, cusparseDirection_t, cusparseOperation_t, Cint,
                     Cint, cusparseMatDescr_t, CuPtr{cuDoubleComplex}, CuPtr{Cint},
@@ -971,7 +971,7 @@ end
 @checked function cusparseSbsrsv2_analysis(handle, dirA, transA, mb, nnzb, descrA,
                                            bsrSortedValA, bsrSortedRowPtrA,
                                            bsrSortedColIndA, blockDim, info, policy, pBuffer)
-    initialize_api()
+    initialize_context()
     ccall((:cusparseSbsrsv2_analysis, libcusparse()), cusparseStatus_t,
                    (cusparseHandle_t, cusparseDirection_t, cusparseOperation_t, Cint,
                     Cint, cusparseMatDescr_t, CuPtr{Cfloat}, CuPtr{Cint}, CuPtr{Cint},
@@ -983,7 +983,7 @@ end
 @checked function cusparseDbsrsv2_analysis(handle, dirA, transA, mb, nnzb, descrA,
                                            bsrSortedValA, bsrSortedRowPtrA,
                                            bsrSortedColIndA, blockDim, info, policy, pBuffer)
-    initialize_api()
+    initialize_context()
     ccall((:cusparseDbsrsv2_analysis, libcusparse()), cusparseStatus_t,
                    (cusparseHandle_t, cusparseDirection_t, cusparseOperation_t, Cint,
                     Cint, cusparseMatDescr_t, CuPtr{Cdouble}, CuPtr{Cint}, CuPtr{Cint},
@@ -995,7 +995,7 @@ end
 @checked function cusparseCbsrsv2_analysis(handle, dirA, transA, mb, nnzb, descrA,
                                            bsrSortedValA, bsrSortedRowPtrA,
                                            bsrSortedColIndA, blockDim, info, policy, pBuffer)
-    initialize_api()
+    initialize_context()
     ccall((:cusparseCbsrsv2_analysis, libcusparse()), cusparseStatus_t,
                    (cusparseHandle_t, cusparseDirection_t, cusparseOperation_t, Cint,
                     Cint, cusparseMatDescr_t, CuPtr{cuComplex}, CuPtr{Cint}, CuPtr{Cint},
@@ -1007,7 +1007,7 @@ end
 @checked function cusparseZbsrsv2_analysis(handle, dirA, transA, mb, nnzb, descrA,
                                            bsrSortedValA, bsrSortedRowPtrA,
                                            bsrSortedColIndA, blockDim, info, policy, pBuffer)
-    initialize_api()
+    initialize_context()
     ccall((:cusparseZbsrsv2_analysis, libcusparse()), cusparseStatus_t,
                    (cusparseHandle_t, cusparseDirection_t, cusparseOperation_t, Cint,
                     Cint, cusparseMatDescr_t, CuPtr{cuDoubleComplex}, CuPtr{Cint},
@@ -1019,7 +1019,7 @@ end
 @checked function cusparseSbsrsv2_solve(handle, dirA, transA, mb, nnzb, alpha, descrA,
                                         bsrSortedValA, bsrSortedRowPtrA, bsrSortedColIndA,
                                         blockDim, info, f, x, policy, pBuffer)
-    initialize_api()
+    initialize_context()
     ccall((:cusparseSbsrsv2_solve, libcusparse()), cusparseStatus_t,
                    (cusparseHandle_t, cusparseDirection_t, cusparseOperation_t, Cint,
                     Cint, Ref{Cfloat}, cusparseMatDescr_t, CuPtr{Cfloat}, CuPtr{Cint},
@@ -1033,7 +1033,7 @@ end
 @checked function cusparseDbsrsv2_solve(handle, dirA, transA, mb, nnzb, alpha, descrA,
                                         bsrSortedValA, bsrSortedRowPtrA, bsrSortedColIndA,
                                         blockDim, info, f, x, policy, pBuffer)
-    initialize_api()
+    initialize_context()
     ccall((:cusparseDbsrsv2_solve, libcusparse()), cusparseStatus_t,
                    (cusparseHandle_t, cusparseDirection_t, cusparseOperation_t, Cint,
                     Cint, Ref{Cdouble}, cusparseMatDescr_t, CuPtr{Cdouble}, CuPtr{Cint},
@@ -1047,7 +1047,7 @@ end
 @checked function cusparseCbsrsv2_solve(handle, dirA, transA, mb, nnzb, alpha, descrA,
                                         bsrSortedValA, bsrSortedRowPtrA, bsrSortedColIndA,
                                         blockDim, info, f, x, policy, pBuffer)
-    initialize_api()
+    initialize_context()
     ccall((:cusparseCbsrsv2_solve, libcusparse()), cusparseStatus_t,
                    (cusparseHandle_t, cusparseDirection_t, cusparseOperation_t, Cint,
                     Cint, Ref{cuComplex}, cusparseMatDescr_t, CuPtr{cuComplex},
@@ -1061,7 +1061,7 @@ end
 @checked function cusparseZbsrsv2_solve(handle, dirA, transA, mb, nnzb, alpha, descrA,
                                         bsrSortedValA, bsrSortedRowPtrA, bsrSortedColIndA,
                                         blockDim, info, f, x, policy, pBuffer)
-    initialize_api()
+    initialize_context()
     ccall((:cusparseZbsrsv2_solve, libcusparse()), cusparseStatus_t,
                    (cusparseHandle_t, cusparseDirection_t, cusparseOperation_t, Cint,
                     Cint, Ref{cuDoubleComplex}, cusparseMatDescr_t, CuPtr{cuDoubleComplex},
@@ -1075,7 +1075,7 @@ end
 @checked function cusparseSbsrmm(handle, dirA, transA, transB, mb, n, kb, nnzb, alpha,
                                  descrA, bsrSortedValA, bsrSortedRowPtrA, bsrSortedColIndA,
                                  blockSize, B, ldb, beta, C, ldc)
-    initialize_api()
+    initialize_context()
     ccall((:cusparseSbsrmm, libcusparse()), cusparseStatus_t,
                    (cusparseHandle_t, cusparseDirection_t, cusparseOperation_t,
                     cusparseOperation_t, Cint, Cint, Cint, Cint, Ref{Cfloat},
@@ -1089,7 +1089,7 @@ end
 @checked function cusparseDbsrmm(handle, dirA, transA, transB, mb, n, kb, nnzb, alpha,
                                  descrA, bsrSortedValA, bsrSortedRowPtrA, bsrSortedColIndA,
                                  blockSize, B, ldb, beta, C, ldc)
-    initialize_api()
+    initialize_context()
     ccall((:cusparseDbsrmm, libcusparse()), cusparseStatus_t,
                    (cusparseHandle_t, cusparseDirection_t, cusparseOperation_t,
                     cusparseOperation_t, Cint, Cint, Cint, Cint, Ref{Cdouble},
@@ -1103,7 +1103,7 @@ end
 @checked function cusparseCbsrmm(handle, dirA, transA, transB, mb, n, kb, nnzb, alpha,
                                  descrA, bsrSortedValA, bsrSortedRowPtrA, bsrSortedColIndA,
                                  blockSize, B, ldb, beta, C, ldc)
-    initialize_api()
+    initialize_context()
     ccall((:cusparseCbsrmm, libcusparse()), cusparseStatus_t,
                    (cusparseHandle_t, cusparseDirection_t, cusparseOperation_t,
                     cusparseOperation_t, Cint, Cint, Cint, Cint, Ref{cuComplex},
@@ -1117,7 +1117,7 @@ end
 @checked function cusparseZbsrmm(handle, dirA, transA, transB, mb, n, kb, nnzb, alpha,
                                  descrA, bsrSortedValA, bsrSortedRowPtrA, bsrSortedColIndA,
                                  blockSize, B, ldb, beta, C, ldc)
-    initialize_api()
+    initialize_context()
     ccall((:cusparseZbsrmm, libcusparse()), cusparseStatus_t,
                    (cusparseHandle_t, cusparseDirection_t, cusparseOperation_t,
                     cusparseOperation_t, Cint, Cint, Cint, Cint, Ref{cuDoubleComplex},
@@ -1131,7 +1131,7 @@ end
 
 @checked function cusparseSgemmi(handle, m, n, k, nnz, alpha, A, lda, cscValB, cscColPtrB,
                                  cscRowIndB, beta, C, ldc)
-    initialize_api()
+    initialize_context()
     ccall((:cusparseSgemmi, libcusparse()), cusparseStatus_t,
                    (cusparseHandle_t, Cint, Cint, Cint, Cint, Ref{Cfloat}, CuPtr{Cfloat},
                     Cint, CuPtr{Cfloat}, CuPtr{Cint}, CuPtr{Cint}, Ref{Cfloat},
@@ -1142,7 +1142,7 @@ end
 
 @checked function cusparseDgemmi(handle, m, n, k, nnz, alpha, A, lda, cscValB, cscColPtrB,
                                  cscRowIndB, beta, C, ldc)
-    initialize_api()
+    initialize_context()
     ccall((:cusparseDgemmi, libcusparse()), cusparseStatus_t,
                    (cusparseHandle_t, Cint, Cint, Cint, Cint, Ref{Cdouble},
                     CuPtr{Cdouble}, Cint, CuPtr{Cdouble}, CuPtr{Cint}, CuPtr{Cint},
@@ -1153,7 +1153,7 @@ end
 
 @checked function cusparseCgemmi(handle, m, n, k, nnz, alpha, A, lda, cscValB, cscColPtrB,
                                  cscRowIndB, beta, C, ldc)
-    initialize_api()
+    initialize_context()
     ccall((:cusparseCgemmi, libcusparse()), cusparseStatus_t,
                    (cusparseHandle_t, Cint, Cint, Cint, Cint, Ref{cuComplex},
                     CuPtr{cuComplex}, Cint, CuPtr{cuComplex}, CuPtr{Cint}, CuPtr{Cint},
@@ -1164,7 +1164,7 @@ end
 
 @checked function cusparseZgemmi(handle, m, n, k, nnz, alpha, A, lda, cscValB, cscColPtrB,
                                  cscRowIndB, beta, C, ldc)
-    initialize_api()
+    initialize_context()
     ccall((:cusparseZgemmi, libcusparse()), cusparseStatus_t,
                    (cusparseHandle_t, Cint, Cint, Cint, Cint, Ref{cuDoubleComplex},
                     CuPtr{cuDoubleComplex}, Cint, CuPtr{cuDoubleComplex}, CuPtr{Cint},
@@ -1174,21 +1174,21 @@ end
 end
 
 @checked function cusparseCreateCsrsm2Info(info)
-    initialize_api()
+    initialize_context()
     ccall((:cusparseCreateCsrsm2Info, libcusparse()), cusparseStatus_t,
                    (Ptr{csrsm2Info_t},),
                    info)
 end
 
 @checked function cusparseDestroyCsrsm2Info(info)
-    initialize_api()
+    initialize_context()
     ccall((:cusparseDestroyCsrsm2Info, libcusparse()), cusparseStatus_t,
                    (csrsm2Info_t,),
                    info)
 end
 
 @checked function cusparseXcsrsm2_zeroPivot(handle, info, position)
-    initialize_api()
+    initialize_context()
     ccall((:cusparseXcsrsm2_zeroPivot, libcusparse()), cusparseStatus_t,
                    (cusparseHandle_t, csrsm2Info_t, Ptr{Cint}),
                    handle, info, position)
@@ -1198,7 +1198,7 @@ end
                                                 alpha, descrA, csrSortedValA,
                                                 csrSortedRowPtrA, csrSortedColIndA, B, ldb,
                                                 info, policy, pBufferSize)
-    initialize_api()
+    initialize_context()
     ccall((:cusparseScsrsm2_bufferSizeExt, libcusparse()), cusparseStatus_t,
                    (cusparseHandle_t, Cint, cusparseOperation_t, cusparseOperation_t,
                     Cint, Cint, Cint, Ref{Cfloat}, cusparseMatDescr_t, CuPtr{Cfloat},
@@ -1213,7 +1213,7 @@ end
                                                 alpha, descrA, csrSortedValA,
                                                 csrSortedRowPtrA, csrSortedColIndA, B, ldb,
                                                 info, policy, pBufferSize)
-    initialize_api()
+    initialize_context()
     ccall((:cusparseDcsrsm2_bufferSizeExt, libcusparse()), cusparseStatus_t,
                    (cusparseHandle_t, Cint, cusparseOperation_t, cusparseOperation_t,
                     Cint, Cint, Cint, Ref{Cdouble}, cusparseMatDescr_t, CuPtr{Cdouble},
@@ -1228,7 +1228,7 @@ end
                                                 alpha, descrA, csrSortedValA,
                                                 csrSortedRowPtrA, csrSortedColIndA, B, ldb,
                                                 info, policy, pBufferSize)
-    initialize_api()
+    initialize_context()
     ccall((:cusparseCcsrsm2_bufferSizeExt, libcusparse()), cusparseStatus_t,
                    (cusparseHandle_t, Cint, cusparseOperation_t, cusparseOperation_t,
                     Cint, Cint, Cint, Ref{cuComplex}, cusparseMatDescr_t, CuPtr{cuComplex},
@@ -1243,7 +1243,7 @@ end
                                                 alpha, descrA, csrSortedValA,
                                                 csrSortedRowPtrA, csrSortedColIndA, B, ldb,
                                                 info, policy, pBufferSize)
-    initialize_api()
+    initialize_context()
     ccall((:cusparseZcsrsm2_bufferSizeExt, libcusparse()), cusparseStatus_t,
                    (cusparseHandle_t, Cint, cusparseOperation_t, cusparseOperation_t,
                     Cint, Cint, Cint, Ref{cuDoubleComplex}, cusparseMatDescr_t,
@@ -1258,7 +1258,7 @@ end
 @checked function cusparseScsrsm2_analysis(handle, algo, transA, transB, m, nrhs, nnz,
                                            alpha, descrA, csrSortedValA, csrSortedRowPtrA,
                                            csrSortedColIndA, B, ldb, info, policy, pBuffer)
-    initialize_api()
+    initialize_context()
     ccall((:cusparseScsrsm2_analysis, libcusparse()), cusparseStatus_t,
                    (cusparseHandle_t, Cint, cusparseOperation_t, cusparseOperation_t,
                     Cint, Cint, Cint, Ref{Cfloat}, cusparseMatDescr_t, CuPtr{Cfloat},
@@ -1272,7 +1272,7 @@ end
 @checked function cusparseDcsrsm2_analysis(handle, algo, transA, transB, m, nrhs, nnz,
                                            alpha, descrA, csrSortedValA, csrSortedRowPtrA,
                                            csrSortedColIndA, B, ldb, info, policy, pBuffer)
-    initialize_api()
+    initialize_context()
     ccall((:cusparseDcsrsm2_analysis, libcusparse()), cusparseStatus_t,
                    (cusparseHandle_t, Cint, cusparseOperation_t, cusparseOperation_t,
                     Cint, Cint, Cint, Ref{Cdouble}, cusparseMatDescr_t, CuPtr{Cdouble},
@@ -1286,7 +1286,7 @@ end
 @checked function cusparseCcsrsm2_analysis(handle, algo, transA, transB, m, nrhs, nnz,
                                            alpha, descrA, csrSortedValA, csrSortedRowPtrA,
                                            csrSortedColIndA, B, ldb, info, policy, pBuffer)
-    initialize_api()
+    initialize_context()
     ccall((:cusparseCcsrsm2_analysis, libcusparse()), cusparseStatus_t,
                    (cusparseHandle_t, Cint, cusparseOperation_t, cusparseOperation_t,
                     Cint, Cint, Cint, Ref{cuComplex}, cusparseMatDescr_t, CuPtr{cuComplex},
@@ -1300,7 +1300,7 @@ end
 @checked function cusparseZcsrsm2_analysis(handle, algo, transA, transB, m, nrhs, nnz,
                                            alpha, descrA, csrSortedValA, csrSortedRowPtrA,
                                            csrSortedColIndA, B, ldb, info, policy, pBuffer)
-    initialize_api()
+    initialize_context()
     ccall((:cusparseZcsrsm2_analysis, libcusparse()), cusparseStatus_t,
                    (cusparseHandle_t, Cint, cusparseOperation_t, cusparseOperation_t,
                     Cint, Cint, Cint, Ref{cuDoubleComplex}, cusparseMatDescr_t,
@@ -1315,7 +1315,7 @@ end
 @checked function cusparseScsrsm2_solve(handle, algo, transA, transB, m, nrhs, nnz, alpha,
                                         descrA, csrSortedValA, csrSortedRowPtrA,
                                         csrSortedColIndA, B, ldb, info, policy, pBuffer)
-    initialize_api()
+    initialize_context()
     ccall((:cusparseScsrsm2_solve, libcusparse()), cusparseStatus_t,
                    (cusparseHandle_t, Cint, cusparseOperation_t, cusparseOperation_t,
                     Cint, Cint, Cint, Ref{Cfloat}, cusparseMatDescr_t, CuPtr{Cfloat},
@@ -1329,7 +1329,7 @@ end
 @checked function cusparseDcsrsm2_solve(handle, algo, transA, transB, m, nrhs, nnz, alpha,
                                         descrA, csrSortedValA, csrSortedRowPtrA,
                                         csrSortedColIndA, B, ldb, info, policy, pBuffer)
-    initialize_api()
+    initialize_context()
     ccall((:cusparseDcsrsm2_solve, libcusparse()), cusparseStatus_t,
                    (cusparseHandle_t, Cint, cusparseOperation_t, cusparseOperation_t,
                     Cint, Cint, Cint, Ref{Cdouble}, cusparseMatDescr_t, CuPtr{Cdouble},
@@ -1343,7 +1343,7 @@ end
 @checked function cusparseCcsrsm2_solve(handle, algo, transA, transB, m, nrhs, nnz, alpha,
                                         descrA, csrSortedValA, csrSortedRowPtrA,
                                         csrSortedColIndA, B, ldb, info, policy, pBuffer)
-    initialize_api()
+    initialize_context()
     ccall((:cusparseCcsrsm2_solve, libcusparse()), cusparseStatus_t,
                    (cusparseHandle_t, Cint, cusparseOperation_t, cusparseOperation_t,
                     Cint, Cint, Cint, Ref{cuComplex}, cusparseMatDescr_t, CuPtr{cuComplex},
@@ -1357,7 +1357,7 @@ end
 @checked function cusparseZcsrsm2_solve(handle, algo, transA, transB, m, nrhs, nnz, alpha,
                                         descrA, csrSortedValA, csrSortedRowPtrA,
                                         csrSortedColIndA, B, ldb, info, policy, pBuffer)
-    initialize_api()
+    initialize_context()
     ccall((:cusparseZcsrsm2_solve, libcusparse()), cusparseStatus_t,
                    (cusparseHandle_t, Cint, cusparseOperation_t, cusparseOperation_t,
                     Cint, Cint, Cint, Ref{cuDoubleComplex}, cusparseMatDescr_t,
@@ -1370,7 +1370,7 @@ end
 end
 
 @checked function cusparseXbsrsm2_zeroPivot(handle, info, position)
-    initialize_api()
+    initialize_context()
     ccall((:cusparseXbsrsm2_zeroPivot, libcusparse()), cusparseStatus_t,
                    (cusparseHandle_t, bsrsm2Info_t, Ptr{Cint}),
                    handle, info, position)
@@ -1380,7 +1380,7 @@ end
                                              descrA, bsrSortedVal, bsrSortedRowPtr,
                                              bsrSortedColInd, blockSize, info,
                                              pBufferSizeInBytes)
-    initialize_api()
+    initialize_context()
     ccall((:cusparseSbsrsm2_bufferSize, libcusparse()), cusparseStatus_t,
                    (cusparseHandle_t, cusparseDirection_t, cusparseOperation_t,
                     cusparseOperation_t, Cint, Cint, Cint, cusparseMatDescr_t,
@@ -1393,7 +1393,7 @@ end
                                              descrA, bsrSortedVal, bsrSortedRowPtr,
                                              bsrSortedColInd, blockSize, info,
                                              pBufferSizeInBytes)
-    initialize_api()
+    initialize_context()
     ccall((:cusparseDbsrsm2_bufferSize, libcusparse()), cusparseStatus_t,
                    (cusparseHandle_t, cusparseDirection_t, cusparseOperation_t,
                     cusparseOperation_t, Cint, Cint, Cint, cusparseMatDescr_t,
@@ -1406,7 +1406,7 @@ end
                                              descrA, bsrSortedVal, bsrSortedRowPtr,
                                              bsrSortedColInd, blockSize, info,
                                              pBufferSizeInBytes)
-    initialize_api()
+    initialize_context()
     ccall((:cusparseCbsrsm2_bufferSize, libcusparse()), cusparseStatus_t,
                    (cusparseHandle_t, cusparseDirection_t, cusparseOperation_t,
                     cusparseOperation_t, Cint, Cint, Cint, cusparseMatDescr_t,
@@ -1420,7 +1420,7 @@ end
                                              descrA, bsrSortedVal, bsrSortedRowPtr,
                                              bsrSortedColInd, blockSize, info,
                                              pBufferSizeInBytes)
-    initialize_api()
+    initialize_context()
     ccall((:cusparseZbsrsm2_bufferSize, libcusparse()), cusparseStatus_t,
                    (cusparseHandle_t, cusparseDirection_t, cusparseOperation_t,
                     cusparseOperation_t, Cint, Cint, Cint, cusparseMatDescr_t,
@@ -1434,7 +1434,7 @@ end
                                                 descrA, bsrSortedVal, bsrSortedRowPtr,
                                                 bsrSortedColInd, blockSize, info,
                                                 pBufferSize)
-    initialize_api()
+    initialize_context()
     ccall((:cusparseSbsrsm2_bufferSizeExt, libcusparse()), cusparseStatus_t,
                    (cusparseHandle_t, cusparseDirection_t, cusparseOperation_t,
                     cusparseOperation_t, Cint, Cint, Cint, cusparseMatDescr_t,
@@ -1448,7 +1448,7 @@ end
                                                 descrA, bsrSortedVal, bsrSortedRowPtr,
                                                 bsrSortedColInd, blockSize, info,
                                                 pBufferSize)
-    initialize_api()
+    initialize_context()
     ccall((:cusparseDbsrsm2_bufferSizeExt, libcusparse()), cusparseStatus_t,
                    (cusparseHandle_t, cusparseDirection_t, cusparseOperation_t,
                     cusparseOperation_t, Cint, Cint, Cint, cusparseMatDescr_t,
@@ -1462,7 +1462,7 @@ end
                                                 descrA, bsrSortedVal, bsrSortedRowPtr,
                                                 bsrSortedColInd, blockSize, info,
                                                 pBufferSize)
-    initialize_api()
+    initialize_context()
     ccall((:cusparseCbsrsm2_bufferSizeExt, libcusparse()), cusparseStatus_t,
                    (cusparseHandle_t, cusparseDirection_t, cusparseOperation_t,
                     cusparseOperation_t, Cint, Cint, Cint, cusparseMatDescr_t,
@@ -1476,7 +1476,7 @@ end
                                                 descrA, bsrSortedVal, bsrSortedRowPtr,
                                                 bsrSortedColInd, blockSize, info,
                                                 pBufferSize)
-    initialize_api()
+    initialize_context()
     ccall((:cusparseZbsrsm2_bufferSizeExt, libcusparse()), cusparseStatus_t,
                    (cusparseHandle_t, cusparseDirection_t, cusparseOperation_t,
                     cusparseOperation_t, Cint, Cint, Cint, cusparseMatDescr_t,
@@ -1489,7 +1489,7 @@ end
 @checked function cusparseSbsrsm2_analysis(handle, dirA, transA, transXY, mb, n, nnzb,
                                            descrA, bsrSortedVal, bsrSortedRowPtr,
                                            bsrSortedColInd, blockSize, info, policy, pBuffer)
-    initialize_api()
+    initialize_context()
     ccall((:cusparseSbsrsm2_analysis, libcusparse()), cusparseStatus_t,
                    (cusparseHandle_t, cusparseDirection_t, cusparseOperation_t,
                     cusparseOperation_t, Cint, Cint, Cint, cusparseMatDescr_t,
@@ -1502,7 +1502,7 @@ end
 @checked function cusparseDbsrsm2_analysis(handle, dirA, transA, transXY, mb, n, nnzb,
                                            descrA, bsrSortedVal, bsrSortedRowPtr,
                                            bsrSortedColInd, blockSize, info, policy, pBuffer)
-    initialize_api()
+    initialize_context()
     ccall((:cusparseDbsrsm2_analysis, libcusparse()), cusparseStatus_t,
                    (cusparseHandle_t, cusparseDirection_t, cusparseOperation_t,
                     cusparseOperation_t, Cint, Cint, Cint, cusparseMatDescr_t,
@@ -1515,7 +1515,7 @@ end
 @checked function cusparseCbsrsm2_analysis(handle, dirA, transA, transXY, mb, n, nnzb,
                                            descrA, bsrSortedVal, bsrSortedRowPtr,
                                            bsrSortedColInd, blockSize, info, policy, pBuffer)
-    initialize_api()
+    initialize_context()
     ccall((:cusparseCbsrsm2_analysis, libcusparse()), cusparseStatus_t,
                    (cusparseHandle_t, cusparseDirection_t, cusparseOperation_t,
                     cusparseOperation_t, Cint, Cint, Cint, cusparseMatDescr_t,
@@ -1528,7 +1528,7 @@ end
 @checked function cusparseZbsrsm2_analysis(handle, dirA, transA, transXY, mb, n, nnzb,
                                            descrA, bsrSortedVal, bsrSortedRowPtr,
                                            bsrSortedColInd, blockSize, info, policy, pBuffer)
-    initialize_api()
+    initialize_context()
     ccall((:cusparseZbsrsm2_analysis, libcusparse()), cusparseStatus_t,
                    (cusparseHandle_t, cusparseDirection_t, cusparseOperation_t,
                     cusparseOperation_t, Cint, Cint, Cint, cusparseMatDescr_t,
@@ -1542,7 +1542,7 @@ end
                                         descrA, bsrSortedVal, bsrSortedRowPtr,
                                         bsrSortedColInd, blockSize, info, B, ldb, X, ldx,
                                         policy, pBuffer)
-    initialize_api()
+    initialize_context()
     ccall((:cusparseSbsrsm2_solve, libcusparse()), cusparseStatus_t,
                    (cusparseHandle_t, cusparseDirection_t, cusparseOperation_t,
                     cusparseOperation_t, Cint, Cint, Cint, Ref{Cfloat}, cusparseMatDescr_t,
@@ -1558,7 +1558,7 @@ end
                                         descrA, bsrSortedVal, bsrSortedRowPtr,
                                         bsrSortedColInd, blockSize, info, B, ldb, X, ldx,
                                         policy, pBuffer)
-    initialize_api()
+    initialize_context()
     ccall((:cusparseDbsrsm2_solve, libcusparse()), cusparseStatus_t,
                    (cusparseHandle_t, cusparseDirection_t, cusparseOperation_t,
                     cusparseOperation_t, Cint, Cint, Cint, Ref{Cdouble},
@@ -1574,7 +1574,7 @@ end
                                         descrA, bsrSortedVal, bsrSortedRowPtr,
                                         bsrSortedColInd, blockSize, info, B, ldb, X, ldx,
                                         policy, pBuffer)
-    initialize_api()
+    initialize_context()
     ccall((:cusparseCbsrsm2_solve, libcusparse()), cusparseStatus_t,
                    (cusparseHandle_t, cusparseDirection_t, cusparseOperation_t,
                     cusparseOperation_t, Cint, Cint, Cint, Ref{cuComplex},
@@ -1590,7 +1590,7 @@ end
                                         descrA, bsrSortedVal, bsrSortedRowPtr,
                                         bsrSortedColInd, blockSize, info, B, ldb, X, ldx,
                                         policy, pBuffer)
-    initialize_api()
+    initialize_context()
     ccall((:cusparseZbsrsm2_solve, libcusparse()), cusparseStatus_t,
                    (cusparseHandle_t, cusparseDirection_t, cusparseOperation_t,
                     cusparseOperation_t, Cint, Cint, Cint, Ref{cuDoubleComplex},
@@ -1603,28 +1603,28 @@ end
 end
 
 @checked function cusparseScsrilu02_numericBoost(handle, info, enable_boost, tol, boost_val)
-    initialize_api()
+    initialize_context()
     ccall((:cusparseScsrilu02_numericBoost, libcusparse()), cusparseStatus_t,
                    (cusparseHandle_t, csrilu02Info_t, Cint, Ptr{Cdouble}, Ptr{Cfloat}),
                    handle, info, enable_boost, tol, boost_val)
 end
 
 @checked function cusparseDcsrilu02_numericBoost(handle, info, enable_boost, tol, boost_val)
-    initialize_api()
+    initialize_context()
     ccall((:cusparseDcsrilu02_numericBoost, libcusparse()), cusparseStatus_t,
                    (cusparseHandle_t, csrilu02Info_t, Cint, Ptr{Cdouble}, Ptr{Cdouble}),
                    handle, info, enable_boost, tol, boost_val)
 end
 
 @checked function cusparseCcsrilu02_numericBoost(handle, info, enable_boost, tol, boost_val)
-    initialize_api()
+    initialize_context()
     ccall((:cusparseCcsrilu02_numericBoost, libcusparse()), cusparseStatus_t,
                    (cusparseHandle_t, csrilu02Info_t, Cint, Ptr{Cdouble}, Ptr{cuComplex}),
                    handle, info, enable_boost, tol, boost_val)
 end
 
 @checked function cusparseZcsrilu02_numericBoost(handle, info, enable_boost, tol, boost_val)
-    initialize_api()
+    initialize_context()
     ccall((:cusparseZcsrilu02_numericBoost, libcusparse()), cusparseStatus_t,
                    (cusparseHandle_t, csrilu02Info_t, Cint, Ptr{Cdouble},
                     Ptr{cuDoubleComplex}),
@@ -1632,7 +1632,7 @@ end
 end
 
 @checked function cusparseXcsrilu02_zeroPivot(handle, info, position)
-    initialize_api()
+    initialize_context()
     ccall((:cusparseXcsrilu02_zeroPivot, libcusparse()), cusparseStatus_t,
                    (cusparseHandle_t, csrilu02Info_t, Ptr{Cint}),
                    handle, info, position)
@@ -1641,7 +1641,7 @@ end
 @checked function cusparseScsrilu02_bufferSize(handle, m, nnz, descrA, csrSortedValA,
                                                csrSortedRowPtrA, csrSortedColIndA, info,
                                                pBufferSizeInBytes)
-    initialize_api()
+    initialize_context()
     ccall((:cusparseScsrilu02_bufferSize, libcusparse()), cusparseStatus_t,
                    (cusparseHandle_t, Cint, Cint, cusparseMatDescr_t, CuPtr{Cfloat},
                     CuPtr{Cint}, CuPtr{Cint}, csrilu02Info_t, Ptr{Cint}),
@@ -1652,7 +1652,7 @@ end
 @checked function cusparseDcsrilu02_bufferSize(handle, m, nnz, descrA, csrSortedValA,
                                                csrSortedRowPtrA, csrSortedColIndA, info,
                                                pBufferSizeInBytes)
-    initialize_api()
+    initialize_context()
     ccall((:cusparseDcsrilu02_bufferSize, libcusparse()), cusparseStatus_t,
                    (cusparseHandle_t, Cint, Cint, cusparseMatDescr_t, CuPtr{Cdouble},
                     CuPtr{Cint}, CuPtr{Cint}, csrilu02Info_t, Ptr{Cint}),
@@ -1663,7 +1663,7 @@ end
 @checked function cusparseCcsrilu02_bufferSize(handle, m, nnz, descrA, csrSortedValA,
                                                csrSortedRowPtrA, csrSortedColIndA, info,
                                                pBufferSizeInBytes)
-    initialize_api()
+    initialize_context()
     ccall((:cusparseCcsrilu02_bufferSize, libcusparse()), cusparseStatus_t,
                    (cusparseHandle_t, Cint, Cint, cusparseMatDescr_t, CuPtr{cuComplex},
                     CuPtr{Cint}, CuPtr{Cint}, csrilu02Info_t, Ptr{Cint}),
@@ -1674,7 +1674,7 @@ end
 @checked function cusparseZcsrilu02_bufferSize(handle, m, nnz, descrA, csrSortedValA,
                                                csrSortedRowPtrA, csrSortedColIndA, info,
                                                pBufferSizeInBytes)
-    initialize_api()
+    initialize_context()
     ccall((:cusparseZcsrilu02_bufferSize, libcusparse()), cusparseStatus_t,
                    (cusparseHandle_t, Cint, Cint, cusparseMatDescr_t,
                     CuPtr{cuDoubleComplex}, CuPtr{Cint}, CuPtr{Cint}, csrilu02Info_t,
@@ -1686,7 +1686,7 @@ end
 @checked function cusparseScsrilu02_bufferSizeExt(handle, m, nnz, descrA, csrSortedVal,
                                                   csrSortedRowPtr, csrSortedColInd, info,
                                                   pBufferSize)
-    initialize_api()
+    initialize_context()
     ccall((:cusparseScsrilu02_bufferSizeExt, libcusparse()), cusparseStatus_t,
                    (cusparseHandle_t, Cint, Cint, cusparseMatDescr_t, CuPtr{Cfloat},
                     CuPtr{Cint}, CuPtr{Cint}, csrilu02Info_t, Ptr{Csize_t}),
@@ -1697,7 +1697,7 @@ end
 @checked function cusparseDcsrilu02_bufferSizeExt(handle, m, nnz, descrA, csrSortedVal,
                                                   csrSortedRowPtr, csrSortedColInd, info,
                                                   pBufferSize)
-    initialize_api()
+    initialize_context()
     ccall((:cusparseDcsrilu02_bufferSizeExt, libcusparse()), cusparseStatus_t,
                    (cusparseHandle_t, Cint, Cint, cusparseMatDescr_t, CuPtr{Cdouble},
                     CuPtr{Cint}, CuPtr{Cint}, csrilu02Info_t, Ptr{Csize_t}),
@@ -1708,7 +1708,7 @@ end
 @checked function cusparseCcsrilu02_bufferSizeExt(handle, m, nnz, descrA, csrSortedVal,
                                                   csrSortedRowPtr, csrSortedColInd, info,
                                                   pBufferSize)
-    initialize_api()
+    initialize_context()
     ccall((:cusparseCcsrilu02_bufferSizeExt, libcusparse()), cusparseStatus_t,
                    (cusparseHandle_t, Cint, Cint, cusparseMatDescr_t, CuPtr{cuComplex},
                     CuPtr{Cint}, CuPtr{Cint}, csrilu02Info_t, Ptr{Csize_t}),
@@ -1719,7 +1719,7 @@ end
 @checked function cusparseZcsrilu02_bufferSizeExt(handle, m, nnz, descrA, csrSortedVal,
                                                   csrSortedRowPtr, csrSortedColInd, info,
                                                   pBufferSize)
-    initialize_api()
+    initialize_context()
     ccall((:cusparseZcsrilu02_bufferSizeExt, libcusparse()), cusparseStatus_t,
                    (cusparseHandle_t, Cint, Cint, cusparseMatDescr_t,
                     CuPtr{cuDoubleComplex}, CuPtr{Cint}, CuPtr{Cint}, csrilu02Info_t,
@@ -1731,7 +1731,7 @@ end
 @checked function cusparseScsrilu02_analysis(handle, m, nnz, descrA, csrSortedValA,
                                              csrSortedRowPtrA, csrSortedColIndA, info,
                                              policy, pBuffer)
-    initialize_api()
+    initialize_context()
     ccall((:cusparseScsrilu02_analysis, libcusparse()), cusparseStatus_t,
                    (cusparseHandle_t, Cint, Cint, cusparseMatDescr_t, CuPtr{Cfloat},
                     CuPtr{Cint}, CuPtr{Cint}, csrilu02Info_t, cusparseSolvePolicy_t,
@@ -1743,7 +1743,7 @@ end
 @checked function cusparseDcsrilu02_analysis(handle, m, nnz, descrA, csrSortedValA,
                                              csrSortedRowPtrA, csrSortedColIndA, info,
                                              policy, pBuffer)
-    initialize_api()
+    initialize_context()
     ccall((:cusparseDcsrilu02_analysis, libcusparse()), cusparseStatus_t,
                    (cusparseHandle_t, Cint, Cint, cusparseMatDescr_t, CuPtr{Cdouble},
                     CuPtr{Cint}, CuPtr{Cint}, csrilu02Info_t, cusparseSolvePolicy_t,
@@ -1755,7 +1755,7 @@ end
 @checked function cusparseCcsrilu02_analysis(handle, m, nnz, descrA, csrSortedValA,
                                              csrSortedRowPtrA, csrSortedColIndA, info,
                                              policy, pBuffer)
-    initialize_api()
+    initialize_context()
     ccall((:cusparseCcsrilu02_analysis, libcusparse()), cusparseStatus_t,
                    (cusparseHandle_t, Cint, Cint, cusparseMatDescr_t, CuPtr{cuComplex},
                     CuPtr{Cint}, CuPtr{Cint}, csrilu02Info_t, cusparseSolvePolicy_t,
@@ -1767,7 +1767,7 @@ end
 @checked function cusparseZcsrilu02_analysis(handle, m, nnz, descrA, csrSortedValA,
                                              csrSortedRowPtrA, csrSortedColIndA, info,
                                              policy, pBuffer)
-    initialize_api()
+    initialize_context()
     ccall((:cusparseZcsrilu02_analysis, libcusparse()), cusparseStatus_t,
                    (cusparseHandle_t, Cint, Cint, cusparseMatDescr_t,
                     CuPtr{cuDoubleComplex}, CuPtr{Cint}, CuPtr{Cint}, csrilu02Info_t,
@@ -1779,7 +1779,7 @@ end
 @checked function cusparseScsrilu02(handle, m, nnz, descrA, csrSortedValA_valM,
                                     csrSortedRowPtrA, csrSortedColIndA, info, policy,
                                     pBuffer)
-    initialize_api()
+    initialize_context()
     ccall((:cusparseScsrilu02, libcusparse()), cusparseStatus_t,
                    (cusparseHandle_t, Cint, Cint, cusparseMatDescr_t, CuPtr{Cfloat},
                     CuPtr{Cint}, CuPtr{Cint}, csrilu02Info_t, cusparseSolvePolicy_t,
@@ -1791,7 +1791,7 @@ end
 @checked function cusparseDcsrilu02(handle, m, nnz, descrA, csrSortedValA_valM,
                                     csrSortedRowPtrA, csrSortedColIndA, info, policy,
                                     pBuffer)
-    initialize_api()
+    initialize_context()
     ccall((:cusparseDcsrilu02, libcusparse()), cusparseStatus_t,
                    (cusparseHandle_t, Cint, Cint, cusparseMatDescr_t, CuPtr{Cdouble},
                     CuPtr{Cint}, CuPtr{Cint}, csrilu02Info_t, cusparseSolvePolicy_t,
@@ -1803,7 +1803,7 @@ end
 @checked function cusparseCcsrilu02(handle, m, nnz, descrA, csrSortedValA_valM,
                                     csrSortedRowPtrA, csrSortedColIndA, info, policy,
                                     pBuffer)
-    initialize_api()
+    initialize_context()
     ccall((:cusparseCcsrilu02, libcusparse()), cusparseStatus_t,
                    (cusparseHandle_t, Cint, Cint, cusparseMatDescr_t, CuPtr{cuComplex},
                     CuPtr{Cint}, CuPtr{Cint}, csrilu02Info_t, cusparseSolvePolicy_t,
@@ -1815,7 +1815,7 @@ end
 @checked function cusparseZcsrilu02(handle, m, nnz, descrA, csrSortedValA_valM,
                                     csrSortedRowPtrA, csrSortedColIndA, info, policy,
                                     pBuffer)
-    initialize_api()
+    initialize_context()
     ccall((:cusparseZcsrilu02, libcusparse()), cusparseStatus_t,
                    (cusparseHandle_t, Cint, Cint, cusparseMatDescr_t,
                     CuPtr{cuDoubleComplex}, CuPtr{Cint}, CuPtr{Cint}, csrilu02Info_t,
@@ -1825,28 +1825,28 @@ end
 end
 
 @checked function cusparseSbsrilu02_numericBoost(handle, info, enable_boost, tol, boost_val)
-    initialize_api()
+    initialize_context()
     ccall((:cusparseSbsrilu02_numericBoost, libcusparse()), cusparseStatus_t,
                    (cusparseHandle_t, bsrilu02Info_t, Cint, Ptr{Cdouble}, Ptr{Cfloat}),
                    handle, info, enable_boost, tol, boost_val)
 end
 
 @checked function cusparseDbsrilu02_numericBoost(handle, info, enable_boost, tol, boost_val)
-    initialize_api()
+    initialize_context()
     ccall((:cusparseDbsrilu02_numericBoost, libcusparse()), cusparseStatus_t,
                    (cusparseHandle_t, bsrilu02Info_t, Cint, Ptr{Cdouble}, Ptr{Cdouble}),
                    handle, info, enable_boost, tol, boost_val)
 end
 
 @checked function cusparseCbsrilu02_numericBoost(handle, info, enable_boost, tol, boost_val)
-    initialize_api()
+    initialize_context()
     ccall((:cusparseCbsrilu02_numericBoost, libcusparse()), cusparseStatus_t,
                    (cusparseHandle_t, bsrilu02Info_t, Cint, Ptr{Cdouble}, Ptr{cuComplex}),
                    handle, info, enable_boost, tol, boost_val)
 end
 
 @checked function cusparseZbsrilu02_numericBoost(handle, info, enable_boost, tol, boost_val)
-    initialize_api()
+    initialize_context()
     ccall((:cusparseZbsrilu02_numericBoost, libcusparse()), cusparseStatus_t,
                    (cusparseHandle_t, bsrilu02Info_t, Cint, Ptr{Cdouble},
                     Ptr{cuDoubleComplex}),
@@ -1854,7 +1854,7 @@ end
 end
 
 @checked function cusparseXbsrilu02_zeroPivot(handle, info, position)
-    initialize_api()
+    initialize_context()
     ccall((:cusparseXbsrilu02_zeroPivot, libcusparse()), cusparseStatus_t,
                    (cusparseHandle_t, bsrilu02Info_t, Ptr{Cint}),
                    handle, info, position)
@@ -1864,7 +1864,7 @@ end
                                                bsrSortedVal, bsrSortedRowPtr,
                                                bsrSortedColInd, blockDim, info,
                                                pBufferSizeInBytes)
-    initialize_api()
+    initialize_context()
     ccall((:cusparseSbsrilu02_bufferSize, libcusparse()), cusparseStatus_t,
                    (cusparseHandle_t, cusparseDirection_t, Cint, Cint, cusparseMatDescr_t,
                     CuPtr{Cfloat}, CuPtr{Cint}, CuPtr{Cint}, Cint, bsrilu02Info_t,
@@ -1877,7 +1877,7 @@ end
                                                bsrSortedVal, bsrSortedRowPtr,
                                                bsrSortedColInd, blockDim, info,
                                                pBufferSizeInBytes)
-    initialize_api()
+    initialize_context()
     ccall((:cusparseDbsrilu02_bufferSize, libcusparse()), cusparseStatus_t,
                    (cusparseHandle_t, cusparseDirection_t, Cint, Cint, cusparseMatDescr_t,
                     CuPtr{Cdouble}, CuPtr{Cint}, CuPtr{Cint}, Cint, bsrilu02Info_t,
@@ -1890,7 +1890,7 @@ end
                                                bsrSortedVal, bsrSortedRowPtr,
                                                bsrSortedColInd, blockDim, info,
                                                pBufferSizeInBytes)
-    initialize_api()
+    initialize_context()
     ccall((:cusparseCbsrilu02_bufferSize, libcusparse()), cusparseStatus_t,
                    (cusparseHandle_t, cusparseDirection_t, Cint, Cint, cusparseMatDescr_t,
                     CuPtr{cuComplex}, CuPtr{Cint}, CuPtr{Cint}, Cint, bsrilu02Info_t,
@@ -1903,7 +1903,7 @@ end
                                                bsrSortedVal, bsrSortedRowPtr,
                                                bsrSortedColInd, blockDim, info,
                                                pBufferSizeInBytes)
-    initialize_api()
+    initialize_context()
     ccall((:cusparseZbsrilu02_bufferSize, libcusparse()), cusparseStatus_t,
                    (cusparseHandle_t, cusparseDirection_t, Cint, Cint, cusparseMatDescr_t,
                     CuPtr{cuDoubleComplex}, CuPtr{Cint}, CuPtr{Cint}, Cint, bsrilu02Info_t,
@@ -1916,7 +1916,7 @@ end
                                                   bsrSortedVal, bsrSortedRowPtr,
                                                   bsrSortedColInd, blockSize, info,
                                                   pBufferSize)
-    initialize_api()
+    initialize_context()
     ccall((:cusparseSbsrilu02_bufferSizeExt, libcusparse()), cusparseStatus_t,
                    (cusparseHandle_t, cusparseDirection_t, Cint, Cint, cusparseMatDescr_t,
                     CuPtr{Cfloat}, CuPtr{Cint}, CuPtr{Cint}, Cint, bsrilu02Info_t,
@@ -1929,7 +1929,7 @@ end
                                                   bsrSortedVal, bsrSortedRowPtr,
                                                   bsrSortedColInd, blockSize, info,
                                                   pBufferSize)
-    initialize_api()
+    initialize_context()
     ccall((:cusparseDbsrilu02_bufferSizeExt, libcusparse()), cusparseStatus_t,
                    (cusparseHandle_t, cusparseDirection_t, Cint, Cint, cusparseMatDescr_t,
                     CuPtr{Cdouble}, CuPtr{Cint}, CuPtr{Cint}, Cint, bsrilu02Info_t,
@@ -1942,7 +1942,7 @@ end
                                                   bsrSortedVal, bsrSortedRowPtr,
                                                   bsrSortedColInd, blockSize, info,
                                                   pBufferSize)
-    initialize_api()
+    initialize_context()
     ccall((:cusparseCbsrilu02_bufferSizeExt, libcusparse()), cusparseStatus_t,
                    (cusparseHandle_t, cusparseDirection_t, Cint, Cint, cusparseMatDescr_t,
                     CuPtr{cuComplex}, CuPtr{Cint}, CuPtr{Cint}, Cint, bsrilu02Info_t,
@@ -1955,7 +1955,7 @@ end
                                                   bsrSortedVal, bsrSortedRowPtr,
                                                   bsrSortedColInd, blockSize, info,
                                                   pBufferSize)
-    initialize_api()
+    initialize_context()
     ccall((:cusparseZbsrilu02_bufferSizeExt, libcusparse()), cusparseStatus_t,
                    (cusparseHandle_t, cusparseDirection_t, Cint, Cint, cusparseMatDescr_t,
                     CuPtr{cuDoubleComplex}, CuPtr{Cint}, CuPtr{Cint}, Cint, bsrilu02Info_t,
@@ -1967,7 +1967,7 @@ end
 @checked function cusparseSbsrilu02_analysis(handle, dirA, mb, nnzb, descrA, bsrSortedVal,
                                              bsrSortedRowPtr, bsrSortedColInd, blockDim,
                                              info, policy, pBuffer)
-    initialize_api()
+    initialize_context()
     ccall((:cusparseSbsrilu02_analysis, libcusparse()), cusparseStatus_t,
                    (cusparseHandle_t, cusparseDirection_t, Cint, Cint, cusparseMatDescr_t,
                     CuPtr{Cfloat}, CuPtr{Cint}, CuPtr{Cint}, Cint, bsrilu02Info_t,
@@ -1979,7 +1979,7 @@ end
 @checked function cusparseDbsrilu02_analysis(handle, dirA, mb, nnzb, descrA, bsrSortedVal,
                                              bsrSortedRowPtr, bsrSortedColInd, blockDim,
                                              info, policy, pBuffer)
-    initialize_api()
+    initialize_context()
     ccall((:cusparseDbsrilu02_analysis, libcusparse()), cusparseStatus_t,
                    (cusparseHandle_t, cusparseDirection_t, Cint, Cint, cusparseMatDescr_t,
                     CuPtr{Cdouble}, CuPtr{Cint}, CuPtr{Cint}, Cint, bsrilu02Info_t,
@@ -1991,7 +1991,7 @@ end
 @checked function cusparseCbsrilu02_analysis(handle, dirA, mb, nnzb, descrA, bsrSortedVal,
                                              bsrSortedRowPtr, bsrSortedColInd, blockDim,
                                              info, policy, pBuffer)
-    initialize_api()
+    initialize_context()
     ccall((:cusparseCbsrilu02_analysis, libcusparse()), cusparseStatus_t,
                    (cusparseHandle_t, cusparseDirection_t, Cint, Cint, cusparseMatDescr_t,
                     CuPtr{cuComplex}, CuPtr{Cint}, CuPtr{Cint}, Cint, bsrilu02Info_t,
@@ -2003,7 +2003,7 @@ end
 @checked function cusparseZbsrilu02_analysis(handle, dirA, mb, nnzb, descrA, bsrSortedVal,
                                              bsrSortedRowPtr, bsrSortedColInd, blockDim,
                                              info, policy, pBuffer)
-    initialize_api()
+    initialize_context()
     ccall((:cusparseZbsrilu02_analysis, libcusparse()), cusparseStatus_t,
                    (cusparseHandle_t, cusparseDirection_t, Cint, Cint, cusparseMatDescr_t,
                     CuPtr{cuDoubleComplex}, CuPtr{Cint}, CuPtr{Cint}, Cint, bsrilu02Info_t,
@@ -2015,7 +2015,7 @@ end
 @checked function cusparseSbsrilu02(handle, dirA, mb, nnzb, descrA, bsrSortedVal,
                                     bsrSortedRowPtr, bsrSortedColInd, blockDim, info,
                                     policy, pBuffer)
-    initialize_api()
+    initialize_context()
     ccall((:cusparseSbsrilu02, libcusparse()), cusparseStatus_t,
                    (cusparseHandle_t, cusparseDirection_t, Cint, Cint, cusparseMatDescr_t,
                     CuPtr{Cfloat}, CuPtr{Cint}, CuPtr{Cint}, Cint, bsrilu02Info_t,
@@ -2027,7 +2027,7 @@ end
 @checked function cusparseDbsrilu02(handle, dirA, mb, nnzb, descrA, bsrSortedVal,
                                     bsrSortedRowPtr, bsrSortedColInd, blockDim, info,
                                     policy, pBuffer)
-    initialize_api()
+    initialize_context()
     ccall((:cusparseDbsrilu02, libcusparse()), cusparseStatus_t,
                    (cusparseHandle_t, cusparseDirection_t, Cint, Cint, cusparseMatDescr_t,
                     CuPtr{Cdouble}, CuPtr{Cint}, CuPtr{Cint}, Cint, bsrilu02Info_t,
@@ -2039,7 +2039,7 @@ end
 @checked function cusparseCbsrilu02(handle, dirA, mb, nnzb, descrA, bsrSortedVal,
                                     bsrSortedRowPtr, bsrSortedColInd, blockDim, info,
                                     policy, pBuffer)
-    initialize_api()
+    initialize_context()
     ccall((:cusparseCbsrilu02, libcusparse()), cusparseStatus_t,
                    (cusparseHandle_t, cusparseDirection_t, Cint, Cint, cusparseMatDescr_t,
                     CuPtr{cuComplex}, CuPtr{Cint}, CuPtr{Cint}, Cint, bsrilu02Info_t,
@@ -2051,7 +2051,7 @@ end
 @checked function cusparseZbsrilu02(handle, dirA, mb, nnzb, descrA, bsrSortedVal,
                                     bsrSortedRowPtr, bsrSortedColInd, blockDim, info,
                                     policy, pBuffer)
-    initialize_api()
+    initialize_context()
     ccall((:cusparseZbsrilu02, libcusparse()), cusparseStatus_t,
                    (cusparseHandle_t, cusparseDirection_t, Cint, Cint, cusparseMatDescr_t,
                     CuPtr{cuDoubleComplex}, CuPtr{Cint}, CuPtr{Cint}, Cint, bsrilu02Info_t,
@@ -2061,7 +2061,7 @@ end
 end
 
 @checked function cusparseXcsric02_zeroPivot(handle, info, position)
-    initialize_api()
+    initialize_context()
     ccall((:cusparseXcsric02_zeroPivot, libcusparse()), cusparseStatus_t,
                    (cusparseHandle_t, csric02Info_t, Ptr{Cint}),
                    handle, info, position)
@@ -2070,7 +2070,7 @@ end
 @checked function cusparseScsric02_bufferSize(handle, m, nnz, descrA, csrSortedValA,
                                               csrSortedRowPtrA, csrSortedColIndA, info,
                                               pBufferSizeInBytes)
-    initialize_api()
+    initialize_context()
     ccall((:cusparseScsric02_bufferSize, libcusparse()), cusparseStatus_t,
                    (cusparseHandle_t, Cint, Cint, cusparseMatDescr_t, CuPtr{Cfloat},
                     CuPtr{Cint}, CuPtr{Cint}, csric02Info_t, Ptr{Cint}),
@@ -2081,7 +2081,7 @@ end
 @checked function cusparseDcsric02_bufferSize(handle, m, nnz, descrA, csrSortedValA,
                                               csrSortedRowPtrA, csrSortedColIndA, info,
                                               pBufferSizeInBytes)
-    initialize_api()
+    initialize_context()
     ccall((:cusparseDcsric02_bufferSize, libcusparse()), cusparseStatus_t,
                    (cusparseHandle_t, Cint, Cint, cusparseMatDescr_t, CuPtr{Cdouble},
                     CuPtr{Cint}, CuPtr{Cint}, csric02Info_t, Ptr{Cint}),
@@ -2092,7 +2092,7 @@ end
 @checked function cusparseCcsric02_bufferSize(handle, m, nnz, descrA, csrSortedValA,
                                               csrSortedRowPtrA, csrSortedColIndA, info,
                                               pBufferSizeInBytes)
-    initialize_api()
+    initialize_context()
     ccall((:cusparseCcsric02_bufferSize, libcusparse()), cusparseStatus_t,
                    (cusparseHandle_t, Cint, Cint, cusparseMatDescr_t, CuPtr{cuComplex},
                     CuPtr{Cint}, CuPtr{Cint}, csric02Info_t, Ptr{Cint}),
@@ -2103,7 +2103,7 @@ end
 @checked function cusparseZcsric02_bufferSize(handle, m, nnz, descrA, csrSortedValA,
                                               csrSortedRowPtrA, csrSortedColIndA, info,
                                               pBufferSizeInBytes)
-    initialize_api()
+    initialize_context()
     ccall((:cusparseZcsric02_bufferSize, libcusparse()), cusparseStatus_t,
                    (cusparseHandle_t, Cint, Cint, cusparseMatDescr_t,
                     CuPtr{cuDoubleComplex}, CuPtr{Cint}, CuPtr{Cint}, csric02Info_t,
@@ -2115,7 +2115,7 @@ end
 @checked function cusparseScsric02_bufferSizeExt(handle, m, nnz, descrA, csrSortedVal,
                                                  csrSortedRowPtr, csrSortedColInd, info,
                                                  pBufferSize)
-    initialize_api()
+    initialize_context()
     ccall((:cusparseScsric02_bufferSizeExt, libcusparse()), cusparseStatus_t,
                    (cusparseHandle_t, Cint, Cint, cusparseMatDescr_t, CuPtr{Cfloat},
                     CuPtr{Cint}, CuPtr{Cint}, csric02Info_t, Ptr{Csize_t}),
@@ -2126,7 +2126,7 @@ end
 @checked function cusparseDcsric02_bufferSizeExt(handle, m, nnz, descrA, csrSortedVal,
                                                  csrSortedRowPtr, csrSortedColInd, info,
                                                  pBufferSize)
-    initialize_api()
+    initialize_context()
     ccall((:cusparseDcsric02_bufferSizeExt, libcusparse()), cusparseStatus_t,
                    (cusparseHandle_t, Cint, Cint, cusparseMatDescr_t, CuPtr{Cdouble},
                     CuPtr{Cint}, CuPtr{Cint}, csric02Info_t, Ptr{Csize_t}),
@@ -2137,7 +2137,7 @@ end
 @checked function cusparseCcsric02_bufferSizeExt(handle, m, nnz, descrA, csrSortedVal,
                                                  csrSortedRowPtr, csrSortedColInd, info,
                                                  pBufferSize)
-    initialize_api()
+    initialize_context()
     ccall((:cusparseCcsric02_bufferSizeExt, libcusparse()), cusparseStatus_t,
                    (cusparseHandle_t, Cint, Cint, cusparseMatDescr_t, CuPtr{cuComplex},
                     CuPtr{Cint}, CuPtr{Cint}, csric02Info_t, Ptr{Csize_t}),
@@ -2148,7 +2148,7 @@ end
 @checked function cusparseZcsric02_bufferSizeExt(handle, m, nnz, descrA, csrSortedVal,
                                                  csrSortedRowPtr, csrSortedColInd, info,
                                                  pBufferSize)
-    initialize_api()
+    initialize_context()
     ccall((:cusparseZcsric02_bufferSizeExt, libcusparse()), cusparseStatus_t,
                    (cusparseHandle_t, Cint, Cint, cusparseMatDescr_t,
                     CuPtr{cuDoubleComplex}, CuPtr{Cint}, CuPtr{Cint}, csric02Info_t,
@@ -2160,7 +2160,7 @@ end
 @checked function cusparseScsric02_analysis(handle, m, nnz, descrA, csrSortedValA,
                                             csrSortedRowPtrA, csrSortedColIndA, info,
                                             policy, pBuffer)
-    initialize_api()
+    initialize_context()
     ccall((:cusparseScsric02_analysis, libcusparse()), cusparseStatus_t,
                    (cusparseHandle_t, Cint, Cint, cusparseMatDescr_t, CuPtr{Cfloat},
                     CuPtr{Cint}, CuPtr{Cint}, csric02Info_t, cusparseSolvePolicy_t,
@@ -2172,7 +2172,7 @@ end
 @checked function cusparseDcsric02_analysis(handle, m, nnz, descrA, csrSortedValA,
                                             csrSortedRowPtrA, csrSortedColIndA, info,
                                             policy, pBuffer)
-    initialize_api()
+    initialize_context()
     ccall((:cusparseDcsric02_analysis, libcusparse()), cusparseStatus_t,
                    (cusparseHandle_t, Cint, Cint, cusparseMatDescr_t, CuPtr{Cdouble},
                     CuPtr{Cint}, CuPtr{Cint}, csric02Info_t, cusparseSolvePolicy_t,
@@ -2184,7 +2184,7 @@ end
 @checked function cusparseCcsric02_analysis(handle, m, nnz, descrA, csrSortedValA,
                                             csrSortedRowPtrA, csrSortedColIndA, info,
                                             policy, pBuffer)
-    initialize_api()
+    initialize_context()
     ccall((:cusparseCcsric02_analysis, libcusparse()), cusparseStatus_t,
                    (cusparseHandle_t, Cint, Cint, cusparseMatDescr_t, CuPtr{cuComplex},
                     CuPtr{Cint}, CuPtr{Cint}, csric02Info_t, cusparseSolvePolicy_t,
@@ -2196,7 +2196,7 @@ end
 @checked function cusparseZcsric02_analysis(handle, m, nnz, descrA, csrSortedValA,
                                             csrSortedRowPtrA, csrSortedColIndA, info,
                                             policy, pBuffer)
-    initialize_api()
+    initialize_context()
     ccall((:cusparseZcsric02_analysis, libcusparse()), cusparseStatus_t,
                    (cusparseHandle_t, Cint, Cint, cusparseMatDescr_t,
                     CuPtr{cuDoubleComplex}, CuPtr{Cint}, CuPtr{Cint}, csric02Info_t,
@@ -2207,7 +2207,7 @@ end
 
 @checked function cusparseScsric02(handle, m, nnz, descrA, csrSortedValA_valM,
                                    csrSortedRowPtrA, csrSortedColIndA, info, policy, pBuffer)
-    initialize_api()
+    initialize_context()
     ccall((:cusparseScsric02, libcusparse()), cusparseStatus_t,
                    (cusparseHandle_t, Cint, Cint, cusparseMatDescr_t, CuPtr{Cfloat},
                     CuPtr{Cint}, CuPtr{Cint}, csric02Info_t, cusparseSolvePolicy_t,
@@ -2218,7 +2218,7 @@ end
 
 @checked function cusparseDcsric02(handle, m, nnz, descrA, csrSortedValA_valM,
                                    csrSortedRowPtrA, csrSortedColIndA, info, policy, pBuffer)
-    initialize_api()
+    initialize_context()
     ccall((:cusparseDcsric02, libcusparse()), cusparseStatus_t,
                    (cusparseHandle_t, Cint, Cint, cusparseMatDescr_t, CuPtr{Cdouble},
                     CuPtr{Cint}, CuPtr{Cint}, csric02Info_t, cusparseSolvePolicy_t,
@@ -2229,7 +2229,7 @@ end
 
 @checked function cusparseCcsric02(handle, m, nnz, descrA, csrSortedValA_valM,
                                    csrSortedRowPtrA, csrSortedColIndA, info, policy, pBuffer)
-    initialize_api()
+    initialize_context()
     ccall((:cusparseCcsric02, libcusparse()), cusparseStatus_t,
                    (cusparseHandle_t, Cint, Cint, cusparseMatDescr_t, CuPtr{cuComplex},
                     CuPtr{Cint}, CuPtr{Cint}, csric02Info_t, cusparseSolvePolicy_t,
@@ -2240,7 +2240,7 @@ end
 
 @checked function cusparseZcsric02(handle, m, nnz, descrA, csrSortedValA_valM,
                                    csrSortedRowPtrA, csrSortedColIndA, info, policy, pBuffer)
-    initialize_api()
+    initialize_context()
     ccall((:cusparseZcsric02, libcusparse()), cusparseStatus_t,
                    (cusparseHandle_t, Cint, Cint, cusparseMatDescr_t,
                     CuPtr{cuDoubleComplex}, CuPtr{Cint}, CuPtr{Cint}, csric02Info_t,
@@ -2250,7 +2250,7 @@ end
 end
 
 @checked function cusparseXbsric02_zeroPivot(handle, info, position)
-    initialize_api()
+    initialize_context()
     ccall((:cusparseXbsric02_zeroPivot, libcusparse()), cusparseStatus_t,
                    (cusparseHandle_t, bsric02Info_t, Ptr{Cint}),
                    handle, info, position)
@@ -2259,7 +2259,7 @@ end
 @checked function cusparseSbsric02_bufferSize(handle, dirA, mb, nnzb, descrA, bsrSortedVal,
                                               bsrSortedRowPtr, bsrSortedColInd, blockDim,
                                               info, pBufferSizeInBytes)
-    initialize_api()
+    initialize_context()
     ccall((:cusparseSbsric02_bufferSize, libcusparse()), cusparseStatus_t,
                    (cusparseHandle_t, cusparseDirection_t, Cint, Cint, cusparseMatDescr_t,
                     CuPtr{Cfloat}, CuPtr{Cint}, CuPtr{Cint}, Cint, bsric02Info_t, Ptr{Cint}),
@@ -2270,7 +2270,7 @@ end
 @checked function cusparseDbsric02_bufferSize(handle, dirA, mb, nnzb, descrA, bsrSortedVal,
                                               bsrSortedRowPtr, bsrSortedColInd, blockDim,
                                               info, pBufferSizeInBytes)
-    initialize_api()
+    initialize_context()
     ccall((:cusparseDbsric02_bufferSize, libcusparse()), cusparseStatus_t,
                    (cusparseHandle_t, cusparseDirection_t, Cint, Cint, cusparseMatDescr_t,
                     CuPtr{Cdouble}, CuPtr{Cint}, CuPtr{Cint}, Cint, bsric02Info_t,
@@ -2282,7 +2282,7 @@ end
 @checked function cusparseCbsric02_bufferSize(handle, dirA, mb, nnzb, descrA, bsrSortedVal,
                                               bsrSortedRowPtr, bsrSortedColInd, blockDim,
                                               info, pBufferSizeInBytes)
-    initialize_api()
+    initialize_context()
     ccall((:cusparseCbsric02_bufferSize, libcusparse()), cusparseStatus_t,
                    (cusparseHandle_t, cusparseDirection_t, Cint, Cint, cusparseMatDescr_t,
                     CuPtr{cuComplex}, CuPtr{Cint}, CuPtr{Cint}, Cint, bsric02Info_t,
@@ -2294,7 +2294,7 @@ end
 @checked function cusparseZbsric02_bufferSize(handle, dirA, mb, nnzb, descrA, bsrSortedVal,
                                               bsrSortedRowPtr, bsrSortedColInd, blockDim,
                                               info, pBufferSizeInBytes)
-    initialize_api()
+    initialize_context()
     ccall((:cusparseZbsric02_bufferSize, libcusparse()), cusparseStatus_t,
                    (cusparseHandle_t, cusparseDirection_t, Cint, Cint, cusparseMatDescr_t,
                     CuPtr{cuDoubleComplex}, CuPtr{Cint}, CuPtr{Cint}, Cint, bsric02Info_t,
@@ -2307,7 +2307,7 @@ end
                                                  bsrSortedVal, bsrSortedRowPtr,
                                                  bsrSortedColInd, blockSize, info,
                                                  pBufferSize)
-    initialize_api()
+    initialize_context()
     ccall((:cusparseSbsric02_bufferSizeExt, libcusparse()), cusparseStatus_t,
                    (cusparseHandle_t, cusparseDirection_t, Cint, Cint, cusparseMatDescr_t,
                     CuPtr{Cfloat}, CuPtr{Cint}, CuPtr{Cint}, Cint, bsric02Info_t,
@@ -2320,7 +2320,7 @@ end
                                                  bsrSortedVal, bsrSortedRowPtr,
                                                  bsrSortedColInd, blockSize, info,
                                                  pBufferSize)
-    initialize_api()
+    initialize_context()
     ccall((:cusparseDbsric02_bufferSizeExt, libcusparse()), cusparseStatus_t,
                    (cusparseHandle_t, cusparseDirection_t, Cint, Cint, cusparseMatDescr_t,
                     CuPtr{Cdouble}, CuPtr{Cint}, CuPtr{Cint}, Cint, bsric02Info_t,
@@ -2333,7 +2333,7 @@ end
                                                  bsrSortedVal, bsrSortedRowPtr,
                                                  bsrSortedColInd, blockSize, info,
                                                  pBufferSize)
-    initialize_api()
+    initialize_context()
     ccall((:cusparseCbsric02_bufferSizeExt, libcusparse()), cusparseStatus_t,
                    (cusparseHandle_t, cusparseDirection_t, Cint, Cint, cusparseMatDescr_t,
                     CuPtr{cuComplex}, CuPtr{Cint}, CuPtr{Cint}, Cint, bsric02Info_t,
@@ -2346,7 +2346,7 @@ end
                                                  bsrSortedVal, bsrSortedRowPtr,
                                                  bsrSortedColInd, blockSize, info,
                                                  pBufferSize)
-    initialize_api()
+    initialize_context()
     ccall((:cusparseZbsric02_bufferSizeExt, libcusparse()), cusparseStatus_t,
                    (cusparseHandle_t, cusparseDirection_t, Cint, Cint, cusparseMatDescr_t,
                     CuPtr{cuDoubleComplex}, CuPtr{Cint}, CuPtr{Cint}, Cint, bsric02Info_t,
@@ -2358,7 +2358,7 @@ end
 @checked function cusparseSbsric02_analysis(handle, dirA, mb, nnzb, descrA, bsrSortedVal,
                                             bsrSortedRowPtr, bsrSortedColInd, blockDim,
                                             info, policy, pInputBuffer)
-    initialize_api()
+    initialize_context()
     ccall((:cusparseSbsric02_analysis, libcusparse()), cusparseStatus_t,
                    (cusparseHandle_t, cusparseDirection_t, Cint, Cint, cusparseMatDescr_t,
                     CuPtr{Cfloat}, CuPtr{Cint}, CuPtr{Cint}, Cint, bsric02Info_t,
@@ -2370,7 +2370,7 @@ end
 @checked function cusparseDbsric02_analysis(handle, dirA, mb, nnzb, descrA, bsrSortedVal,
                                             bsrSortedRowPtr, bsrSortedColInd, blockDim,
                                             info, policy, pInputBuffer)
-    initialize_api()
+    initialize_context()
     ccall((:cusparseDbsric02_analysis, libcusparse()), cusparseStatus_t,
                    (cusparseHandle_t, cusparseDirection_t, Cint, Cint, cusparseMatDescr_t,
                     CuPtr{Cdouble}, CuPtr{Cint}, CuPtr{Cint}, Cint, bsric02Info_t,
@@ -2382,7 +2382,7 @@ end
 @checked function cusparseCbsric02_analysis(handle, dirA, mb, nnzb, descrA, bsrSortedVal,
                                             bsrSortedRowPtr, bsrSortedColInd, blockDim,
                                             info, policy, pInputBuffer)
-    initialize_api()
+    initialize_context()
     ccall((:cusparseCbsric02_analysis, libcusparse()), cusparseStatus_t,
                    (cusparseHandle_t, cusparseDirection_t, Cint, Cint, cusparseMatDescr_t,
                     CuPtr{cuComplex}, CuPtr{Cint}, CuPtr{Cint}, Cint, bsric02Info_t,
@@ -2394,7 +2394,7 @@ end
 @checked function cusparseZbsric02_analysis(handle, dirA, mb, nnzb, descrA, bsrSortedVal,
                                             bsrSortedRowPtr, bsrSortedColInd, blockDim,
                                             info, policy, pInputBuffer)
-    initialize_api()
+    initialize_context()
     ccall((:cusparseZbsric02_analysis, libcusparse()), cusparseStatus_t,
                    (cusparseHandle_t, cusparseDirection_t, Cint, Cint, cusparseMatDescr_t,
                     CuPtr{cuDoubleComplex}, CuPtr{Cint}, CuPtr{Cint}, Cint, bsric02Info_t,
@@ -2406,7 +2406,7 @@ end
 @checked function cusparseSbsric02(handle, dirA, mb, nnzb, descrA, bsrSortedVal,
                                    bsrSortedRowPtr, bsrSortedColInd, blockDim, info,
                                    policy, pBuffer)
-    initialize_api()
+    initialize_context()
     ccall((:cusparseSbsric02, libcusparse()), cusparseStatus_t,
                    (cusparseHandle_t, cusparseDirection_t, Cint, Cint, cusparseMatDescr_t,
                     CuPtr{Cfloat}, CuPtr{Cint}, CuPtr{Cint}, Cint, bsric02Info_t,
@@ -2418,7 +2418,7 @@ end
 @checked function cusparseDbsric02(handle, dirA, mb, nnzb, descrA, bsrSortedVal,
                                    bsrSortedRowPtr, bsrSortedColInd, blockDim, info,
                                    policy, pBuffer)
-    initialize_api()
+    initialize_context()
     ccall((:cusparseDbsric02, libcusparse()), cusparseStatus_t,
                    (cusparseHandle_t, cusparseDirection_t, Cint, Cint, cusparseMatDescr_t,
                     CuPtr{Cdouble}, CuPtr{Cint}, CuPtr{Cint}, Cint, bsric02Info_t,
@@ -2430,7 +2430,7 @@ end
 @checked function cusparseCbsric02(handle, dirA, mb, nnzb, descrA, bsrSortedVal,
                                    bsrSortedRowPtr, bsrSortedColInd, blockDim, info,
                                    policy, pBuffer)
-    initialize_api()
+    initialize_context()
     ccall((:cusparseCbsric02, libcusparse()), cusparseStatus_t,
                    (cusparseHandle_t, cusparseDirection_t, Cint, Cint, cusparseMatDescr_t,
                     CuPtr{cuComplex}, CuPtr{Cint}, CuPtr{Cint}, Cint, bsric02Info_t,
@@ -2442,7 +2442,7 @@ end
 @checked function cusparseZbsric02(handle, dirA, mb, nnzb, descrA, bsrSortedVal,
                                    bsrSortedRowPtr, bsrSortedColInd, blockDim, info,
                                    policy, pBuffer)
-    initialize_api()
+    initialize_context()
     ccall((:cusparseZbsric02, libcusparse()), cusparseStatus_t,
                    (cusparseHandle_t, cusparseDirection_t, Cint, Cint, cusparseMatDescr_t,
                     CuPtr{cuDoubleComplex}, CuPtr{Cint}, CuPtr{Cint}, Cint, bsric02Info_t,
@@ -2453,7 +2453,7 @@ end
 
 @checked function cusparseSgtsv2_bufferSizeExt(handle, m, n, dl, d, du, B, ldb,
                                                bufferSizeInBytes)
-    initialize_api()
+    initialize_context()
     ccall((:cusparseSgtsv2_bufferSizeExt, libcusparse()), cusparseStatus_t,
                    (cusparseHandle_t, Cint, Cint, CuPtr{Cfloat}, CuPtr{Cfloat},
                     CuPtr{Cfloat}, CuPtr{Cfloat}, Cint, Ptr{Csize_t}),
@@ -2462,7 +2462,7 @@ end
 
 @checked function cusparseDgtsv2_bufferSizeExt(handle, m, n, dl, d, du, B, ldb,
                                                bufferSizeInBytes)
-    initialize_api()
+    initialize_context()
     ccall((:cusparseDgtsv2_bufferSizeExt, libcusparse()), cusparseStatus_t,
                    (cusparseHandle_t, Cint, Cint, CuPtr{Cdouble}, CuPtr{Cdouble},
                     CuPtr{Cdouble}, CuPtr{Cdouble}, Cint, Ptr{Csize_t}),
@@ -2471,7 +2471,7 @@ end
 
 @checked function cusparseCgtsv2_bufferSizeExt(handle, m, n, dl, d, du, B, ldb,
                                                bufferSizeInBytes)
-    initialize_api()
+    initialize_context()
     ccall((:cusparseCgtsv2_bufferSizeExt, libcusparse()), cusparseStatus_t,
                    (cusparseHandle_t, Cint, Cint, CuPtr{cuComplex}, CuPtr{cuComplex},
                     CuPtr{cuComplex}, CuPtr{cuComplex}, Cint, Ptr{Csize_t}),
@@ -2480,7 +2480,7 @@ end
 
 @checked function cusparseZgtsv2_bufferSizeExt(handle, m, n, dl, d, du, B, ldb,
                                                bufferSizeInBytes)
-    initialize_api()
+    initialize_context()
     ccall((:cusparseZgtsv2_bufferSizeExt, libcusparse()), cusparseStatus_t,
                    (cusparseHandle_t, Cint, Cint, CuPtr{cuDoubleComplex},
                     CuPtr{cuDoubleComplex}, CuPtr{cuDoubleComplex}, CuPtr{cuDoubleComplex},
@@ -2489,7 +2489,7 @@ end
 end
 
 @checked function cusparseSgtsv2(handle, m, n, dl, d, du, B, ldb, pBuffer)
-    initialize_api()
+    initialize_context()
     ccall((:cusparseSgtsv2, libcusparse()), cusparseStatus_t,
                    (cusparseHandle_t, Cint, Cint, CuPtr{Cfloat}, CuPtr{Cfloat},
                     CuPtr{Cfloat}, CuPtr{Cfloat}, Cint, CuPtr{Cvoid}),
@@ -2497,7 +2497,7 @@ end
 end
 
 @checked function cusparseDgtsv2(handle, m, n, dl, d, du, B, ldb, pBuffer)
-    initialize_api()
+    initialize_context()
     ccall((:cusparseDgtsv2, libcusparse()), cusparseStatus_t,
                    (cusparseHandle_t, Cint, Cint, CuPtr{Cdouble}, CuPtr{Cdouble},
                     CuPtr{Cdouble}, CuPtr{Cdouble}, Cint, CuPtr{Cvoid}),
@@ -2505,7 +2505,7 @@ end
 end
 
 @checked function cusparseCgtsv2(handle, m, n, dl, d, du, B, ldb, pBuffer)
-    initialize_api()
+    initialize_context()
     ccall((:cusparseCgtsv2, libcusparse()), cusparseStatus_t,
                    (cusparseHandle_t, Cint, Cint, CuPtr{cuComplex}, CuPtr{cuComplex},
                     CuPtr{cuComplex}, CuPtr{cuComplex}, Cint, CuPtr{Cvoid}),
@@ -2513,7 +2513,7 @@ end
 end
 
 @checked function cusparseZgtsv2(handle, m, n, dl, d, du, B, ldb, pBuffer)
-    initialize_api()
+    initialize_context()
     ccall((:cusparseZgtsv2, libcusparse()), cusparseStatus_t,
                    (cusparseHandle_t, Cint, Cint, CuPtr{cuDoubleComplex},
                     CuPtr{cuDoubleComplex}, CuPtr{cuDoubleComplex}, CuPtr{cuDoubleComplex},
@@ -2523,7 +2523,7 @@ end
 
 @checked function cusparseSgtsv2_nopivot_bufferSizeExt(handle, m, n, dl, d, du, B, ldb,
                                                        bufferSizeInBytes)
-    initialize_api()
+    initialize_context()
     ccall((:cusparseSgtsv2_nopivot_bufferSizeExt, libcusparse()), cusparseStatus_t,
                    (cusparseHandle_t, Cint, Cint, CuPtr{Cfloat}, CuPtr{Cfloat},
                     CuPtr{Cfloat}, CuPtr{Cfloat}, Cint, Ptr{Csize_t}),
@@ -2532,7 +2532,7 @@ end
 
 @checked function cusparseDgtsv2_nopivot_bufferSizeExt(handle, m, n, dl, d, du, B, ldb,
                                                        bufferSizeInBytes)
-    initialize_api()
+    initialize_context()
     ccall((:cusparseDgtsv2_nopivot_bufferSizeExt, libcusparse()), cusparseStatus_t,
                    (cusparseHandle_t, Cint, Cint, CuPtr{Cdouble}, CuPtr{Cdouble},
                     CuPtr{Cdouble}, CuPtr{Cdouble}, Cint, Ptr{Csize_t}),
@@ -2541,7 +2541,7 @@ end
 
 @checked function cusparseCgtsv2_nopivot_bufferSizeExt(handle, m, n, dl, d, du, B, ldb,
                                                        bufferSizeInBytes)
-    initialize_api()
+    initialize_context()
     ccall((:cusparseCgtsv2_nopivot_bufferSizeExt, libcusparse()), cusparseStatus_t,
                    (cusparseHandle_t, Cint, Cint, CuPtr{cuComplex}, CuPtr{cuComplex},
                     CuPtr{cuComplex}, CuPtr{cuComplex}, Cint, Ptr{Csize_t}),
@@ -2550,7 +2550,7 @@ end
 
 @checked function cusparseZgtsv2_nopivot_bufferSizeExt(handle, m, n, dl, d, du, B, ldb,
                                                        bufferSizeInBytes)
-    initialize_api()
+    initialize_context()
     ccall((:cusparseZgtsv2_nopivot_bufferSizeExt, libcusparse()), cusparseStatus_t,
                    (cusparseHandle_t, Cint, Cint, CuPtr{cuDoubleComplex},
                     CuPtr{cuDoubleComplex}, CuPtr{cuDoubleComplex}, CuPtr{cuDoubleComplex},
@@ -2559,7 +2559,7 @@ end
 end
 
 @checked function cusparseSgtsv2_nopivot(handle, m, n, dl, d, du, B, ldb, pBuffer)
-    initialize_api()
+    initialize_context()
     ccall((:cusparseSgtsv2_nopivot, libcusparse()), cusparseStatus_t,
                    (cusparseHandle_t, Cint, Cint, CuPtr{Cfloat}, CuPtr{Cfloat},
                     CuPtr{Cfloat}, CuPtr{Cfloat}, Cint, CuPtr{Cvoid}),
@@ -2567,7 +2567,7 @@ end
 end
 
 @checked function cusparseDgtsv2_nopivot(handle, m, n, dl, d, du, B, ldb, pBuffer)
-    initialize_api()
+    initialize_context()
     ccall((:cusparseDgtsv2_nopivot, libcusparse()), cusparseStatus_t,
                    (cusparseHandle_t, Cint, Cint, CuPtr{Cdouble}, CuPtr{Cdouble},
                     CuPtr{Cdouble}, CuPtr{Cdouble}, Cint, CuPtr{Cvoid}),
@@ -2575,7 +2575,7 @@ end
 end
 
 @checked function cusparseCgtsv2_nopivot(handle, m, n, dl, d, du, B, ldb, pBuffer)
-    initialize_api()
+    initialize_context()
     ccall((:cusparseCgtsv2_nopivot, libcusparse()), cusparseStatus_t,
                    (cusparseHandle_t, Cint, Cint, CuPtr{cuComplex}, CuPtr{cuComplex},
                     CuPtr{cuComplex}, CuPtr{cuComplex}, Cint, CuPtr{Cvoid}),
@@ -2583,7 +2583,7 @@ end
 end
 
 @checked function cusparseZgtsv2_nopivot(handle, m, n, dl, d, du, B, ldb, pBuffer)
-    initialize_api()
+    initialize_context()
     ccall((:cusparseZgtsv2_nopivot, libcusparse()), cusparseStatus_t,
                    (cusparseHandle_t, Cint, Cint, CuPtr{cuDoubleComplex},
                     CuPtr{cuDoubleComplex}, CuPtr{cuDoubleComplex}, CuPtr{cuDoubleComplex},
@@ -2594,7 +2594,7 @@ end
 @checked function cusparseSgtsv2StridedBatch_bufferSizeExt(handle, m, dl, d, du, x,
                                                            batchCount, batchStride,
                                                            bufferSizeInBytes)
-    initialize_api()
+    initialize_context()
     ccall((:cusparseSgtsv2StridedBatch_bufferSizeExt, libcusparse()), cusparseStatus_t,
                    (cusparseHandle_t, Cint, CuPtr{Cfloat}, CuPtr{Cfloat}, CuPtr{Cfloat},
                     CuPtr{Cfloat}, Cint, Cint, Ptr{Csize_t}),
@@ -2604,7 +2604,7 @@ end
 @checked function cusparseDgtsv2StridedBatch_bufferSizeExt(handle, m, dl, d, du, x,
                                                            batchCount, batchStride,
                                                            bufferSizeInBytes)
-    initialize_api()
+    initialize_context()
     ccall((:cusparseDgtsv2StridedBatch_bufferSizeExt, libcusparse()), cusparseStatus_t,
                    (cusparseHandle_t, Cint, CuPtr{Cdouble}, CuPtr{Cdouble},
                     CuPtr{Cdouble}, CuPtr{Cdouble}, Cint, Cint, Ptr{Csize_t}),
@@ -2614,7 +2614,7 @@ end
 @checked function cusparseCgtsv2StridedBatch_bufferSizeExt(handle, m, dl, d, du, x,
                                                            batchCount, batchStride,
                                                            bufferSizeInBytes)
-    initialize_api()
+    initialize_context()
     ccall((:cusparseCgtsv2StridedBatch_bufferSizeExt, libcusparse()), cusparseStatus_t,
                    (cusparseHandle_t, Cint, CuPtr{cuComplex}, CuPtr{cuComplex},
                     CuPtr{cuComplex}, CuPtr{cuComplex}, Cint, Cint, Ptr{Csize_t}),
@@ -2624,7 +2624,7 @@ end
 @checked function cusparseZgtsv2StridedBatch_bufferSizeExt(handle, m, dl, d, du, x,
                                                            batchCount, batchStride,
                                                            bufferSizeInBytes)
-    initialize_api()
+    initialize_context()
     ccall((:cusparseZgtsv2StridedBatch_bufferSizeExt, libcusparse()), cusparseStatus_t,
                    (cusparseHandle_t, Cint, CuPtr{cuDoubleComplex},
                     CuPtr{cuDoubleComplex}, CuPtr{cuDoubleComplex}, CuPtr{cuDoubleComplex},
@@ -2634,7 +2634,7 @@ end
 
 @checked function cusparseSgtsv2StridedBatch(handle, m, dl, d, du, x, batchCount,
                                              batchStride, pBuffer)
-    initialize_api()
+    initialize_context()
     ccall((:cusparseSgtsv2StridedBatch, libcusparse()), cusparseStatus_t,
                    (cusparseHandle_t, Cint, CuPtr{Cfloat}, CuPtr{Cfloat}, CuPtr{Cfloat},
                     CuPtr{Cfloat}, Cint, Cint, CuPtr{Cvoid}),
@@ -2643,7 +2643,7 @@ end
 
 @checked function cusparseDgtsv2StridedBatch(handle, m, dl, d, du, x, batchCount,
                                              batchStride, pBuffer)
-    initialize_api()
+    initialize_context()
     ccall((:cusparseDgtsv2StridedBatch, libcusparse()), cusparseStatus_t,
                    (cusparseHandle_t, Cint, CuPtr{Cdouble}, CuPtr{Cdouble},
                     CuPtr{Cdouble}, CuPtr{Cdouble}, Cint, Cint, CuPtr{Cvoid}),
@@ -2652,7 +2652,7 @@ end
 
 @checked function cusparseCgtsv2StridedBatch(handle, m, dl, d, du, x, batchCount,
                                              batchStride, pBuffer)
-    initialize_api()
+    initialize_context()
     ccall((:cusparseCgtsv2StridedBatch, libcusparse()), cusparseStatus_t,
                    (cusparseHandle_t, Cint, CuPtr{cuComplex}, CuPtr{cuComplex},
                     CuPtr{cuComplex}, CuPtr{cuComplex}, Cint, Cint, CuPtr{Cvoid}),
@@ -2661,7 +2661,7 @@ end
 
 @checked function cusparseZgtsv2StridedBatch(handle, m, dl, d, du, x, batchCount,
                                              batchStride, pBuffer)
-    initialize_api()
+    initialize_context()
     ccall((:cusparseZgtsv2StridedBatch, libcusparse()), cusparseStatus_t,
                    (cusparseHandle_t, Cint, CuPtr{cuDoubleComplex},
                     CuPtr{cuDoubleComplex}, CuPtr{cuDoubleComplex}, CuPtr{cuDoubleComplex},
@@ -2672,7 +2672,7 @@ end
 @checked function cusparseSgtsvInterleavedBatch_bufferSizeExt(handle, algo, m, dl, d, du,
                                                               x, batchCount,
                                                               pBufferSizeInBytes)
-    initialize_api()
+    initialize_context()
     ccall((:cusparseSgtsvInterleavedBatch_bufferSizeExt, libcusparse()), cusparseStatus_t,
                    (cusparseHandle_t, Cint, Cint, CuPtr{Cfloat}, CuPtr{Cfloat},
                     CuPtr{Cfloat}, CuPtr{Cfloat}, Cint, Ptr{Csize_t}),
@@ -2682,7 +2682,7 @@ end
 @checked function cusparseDgtsvInterleavedBatch_bufferSizeExt(handle, algo, m, dl, d, du,
                                                               x, batchCount,
                                                               pBufferSizeInBytes)
-    initialize_api()
+    initialize_context()
     ccall((:cusparseDgtsvInterleavedBatch_bufferSizeExt, libcusparse()), cusparseStatus_t,
                    (cusparseHandle_t, Cint, Cint, CuPtr{Cdouble}, CuPtr{Cdouble},
                     CuPtr{Cdouble}, CuPtr{Cdouble}, Cint, Ptr{Csize_t}),
@@ -2692,7 +2692,7 @@ end
 @checked function cusparseCgtsvInterleavedBatch_bufferSizeExt(handle, algo, m, dl, d, du,
                                                               x, batchCount,
                                                               pBufferSizeInBytes)
-    initialize_api()
+    initialize_context()
     ccall((:cusparseCgtsvInterleavedBatch_bufferSizeExt, libcusparse()), cusparseStatus_t,
                    (cusparseHandle_t, Cint, Cint, CuPtr{cuComplex}, CuPtr{cuComplex},
                     CuPtr{cuComplex}, CuPtr{cuComplex}, Cint, Ptr{Csize_t}),
@@ -2702,7 +2702,7 @@ end
 @checked function cusparseZgtsvInterleavedBatch_bufferSizeExt(handle, algo, m, dl, d, du,
                                                               x, batchCount,
                                                               pBufferSizeInBytes)
-    initialize_api()
+    initialize_context()
     ccall((:cusparseZgtsvInterleavedBatch_bufferSizeExt, libcusparse()), cusparseStatus_t,
                    (cusparseHandle_t, Cint, Cint, CuPtr{cuDoubleComplex},
                     CuPtr{cuDoubleComplex}, CuPtr{cuDoubleComplex}, CuPtr{cuDoubleComplex},
@@ -2712,7 +2712,7 @@ end
 
 @checked function cusparseSgtsvInterleavedBatch(handle, algo, m, dl, d, du, x, batchCount,
                                                 pBuffer)
-    initialize_api()
+    initialize_context()
     ccall((:cusparseSgtsvInterleavedBatch, libcusparse()), cusparseStatus_t,
                    (cusparseHandle_t, Cint, Cint, CuPtr{Cfloat}, CuPtr{Cfloat},
                     CuPtr{Cfloat}, CuPtr{Cfloat}, Cint, CuPtr{Cvoid}),
@@ -2721,7 +2721,7 @@ end
 
 @checked function cusparseDgtsvInterleavedBatch(handle, algo, m, dl, d, du, x, batchCount,
                                                 pBuffer)
-    initialize_api()
+    initialize_context()
     ccall((:cusparseDgtsvInterleavedBatch, libcusparse()), cusparseStatus_t,
                    (cusparseHandle_t, Cint, Cint, CuPtr{Cdouble}, CuPtr{Cdouble},
                     CuPtr{Cdouble}, CuPtr{Cdouble}, Cint, CuPtr{Cvoid}),
@@ -2730,7 +2730,7 @@ end
 
 @checked function cusparseCgtsvInterleavedBatch(handle, algo, m, dl, d, du, x, batchCount,
                                                 pBuffer)
-    initialize_api()
+    initialize_context()
     ccall((:cusparseCgtsvInterleavedBatch, libcusparse()), cusparseStatus_t,
                    (cusparseHandle_t, Cint, Cint, CuPtr{cuComplex}, CuPtr{cuComplex},
                     CuPtr{cuComplex}, CuPtr{cuComplex}, Cint, CuPtr{Cvoid}),
@@ -2739,7 +2739,7 @@ end
 
 @checked function cusparseZgtsvInterleavedBatch(handle, algo, m, dl, d, du, x, batchCount,
                                                 pBuffer)
-    initialize_api()
+    initialize_context()
     ccall((:cusparseZgtsvInterleavedBatch, libcusparse()), cusparseStatus_t,
                    (cusparseHandle_t, Cint, Cint, CuPtr{cuDoubleComplex},
                     CuPtr{cuDoubleComplex}, CuPtr{cuDoubleComplex}, CuPtr{cuDoubleComplex},
@@ -2750,7 +2750,7 @@ end
 @checked function cusparseSgpsvInterleavedBatch_bufferSizeExt(handle, algo, m, ds, dl, d,
                                                               du, dw, x, batchCount,
                                                               pBufferSizeInBytes)
-    initialize_api()
+    initialize_context()
     ccall((:cusparseSgpsvInterleavedBatch_bufferSizeExt, libcusparse()), cusparseStatus_t,
                    (cusparseHandle_t, Cint, Cint, CuPtr{Cfloat}, CuPtr{Cfloat},
                     CuPtr{Cfloat}, CuPtr{Cfloat}, CuPtr{Cfloat}, CuPtr{Cfloat}, Cint,
@@ -2761,7 +2761,7 @@ end
 @checked function cusparseDgpsvInterleavedBatch_bufferSizeExt(handle, algo, m, ds, dl, d,
                                                               du, dw, x, batchCount,
                                                               pBufferSizeInBytes)
-    initialize_api()
+    initialize_context()
     ccall((:cusparseDgpsvInterleavedBatch_bufferSizeExt, libcusparse()), cusparseStatus_t,
                    (cusparseHandle_t, Cint, Cint, CuPtr{Cdouble}, CuPtr{Cdouble},
                     CuPtr{Cdouble}, CuPtr{Cdouble}, CuPtr{Cdouble}, CuPtr{Cdouble}, Cint,
@@ -2772,7 +2772,7 @@ end
 @checked function cusparseCgpsvInterleavedBatch_bufferSizeExt(handle, algo, m, ds, dl, d,
                                                               du, dw, x, batchCount,
                                                               pBufferSizeInBytes)
-    initialize_api()
+    initialize_context()
     ccall((:cusparseCgpsvInterleavedBatch_bufferSizeExt, libcusparse()), cusparseStatus_t,
                    (cusparseHandle_t, Cint, Cint, CuPtr{cuComplex}, CuPtr{cuComplex},
                     CuPtr{cuComplex}, CuPtr{cuComplex}, CuPtr{cuComplex}, CuPtr{cuComplex},
@@ -2783,7 +2783,7 @@ end
 @checked function cusparseZgpsvInterleavedBatch_bufferSizeExt(handle, algo, m, ds, dl, d,
                                                               du, dw, x, batchCount,
                                                               pBufferSizeInBytes)
-    initialize_api()
+    initialize_context()
     ccall((:cusparseZgpsvInterleavedBatch_bufferSizeExt, libcusparse()), cusparseStatus_t,
                    (cusparseHandle_t, Cint, Cint, CuPtr{cuDoubleComplex},
                     CuPtr{cuDoubleComplex}, CuPtr{cuDoubleComplex}, CuPtr{cuDoubleComplex},
@@ -2793,7 +2793,7 @@ end
 
 @checked function cusparseSgpsvInterleavedBatch(handle, algo, m, ds, dl, d, du, dw, x,
                                                 batchCount, pBuffer)
-    initialize_api()
+    initialize_context()
     ccall((:cusparseSgpsvInterleavedBatch, libcusparse()), cusparseStatus_t,
                    (cusparseHandle_t, Cint, Cint, CuPtr{Cfloat}, CuPtr{Cfloat},
                     CuPtr{Cfloat}, CuPtr{Cfloat}, CuPtr{Cfloat}, CuPtr{Cfloat}, Cint,
@@ -2803,7 +2803,7 @@ end
 
 @checked function cusparseDgpsvInterleavedBatch(handle, algo, m, ds, dl, d, du, dw, x,
                                                 batchCount, pBuffer)
-    initialize_api()
+    initialize_context()
     ccall((:cusparseDgpsvInterleavedBatch, libcusparse()), cusparseStatus_t,
                    (cusparseHandle_t, Cint, Cint, CuPtr{Cdouble}, CuPtr{Cdouble},
                     CuPtr{Cdouble}, CuPtr{Cdouble}, CuPtr{Cdouble}, CuPtr{Cdouble}, Cint,
@@ -2813,7 +2813,7 @@ end
 
 @checked function cusparseCgpsvInterleavedBatch(handle, algo, m, ds, dl, d, du, dw, x,
                                                 batchCount, pBuffer)
-    initialize_api()
+    initialize_context()
     ccall((:cusparseCgpsvInterleavedBatch, libcusparse()), cusparseStatus_t,
                    (cusparseHandle_t, Cint, Cint, CuPtr{cuComplex}, CuPtr{cuComplex},
                     CuPtr{cuComplex}, CuPtr{cuComplex}, CuPtr{cuComplex}, CuPtr{cuComplex},
@@ -2823,7 +2823,7 @@ end
 
 @checked function cusparseZgpsvInterleavedBatch(handle, algo, m, ds, dl, d, du, dw, x,
                                                 batchCount, pBuffer)
-    initialize_api()
+    initialize_context()
     ccall((:cusparseZgpsvInterleavedBatch, libcusparse()), cusparseStatus_t,
                    (cusparseHandle_t, Cint, Cint, CuPtr{cuDoubleComplex},
                     CuPtr{cuDoubleComplex}, CuPtr{cuDoubleComplex}, CuPtr{cuDoubleComplex},
@@ -2832,14 +2832,14 @@ end
 end
 
 @checked function cusparseCreateCsrgemm2Info(info)
-    initialize_api()
+    initialize_context()
     ccall((:cusparseCreateCsrgemm2Info, libcusparse()), cusparseStatus_t,
                    (Ptr{csrgemm2Info_t},),
                    info)
 end
 
 @checked function cusparseDestroyCsrgemm2Info(info)
-    initialize_api()
+    initialize_context()
     ccall((:cusparseDestroyCsrgemm2Info, libcusparse()), cusparseStatus_t,
                    (csrgemm2Info_t,),
                    info)
@@ -2851,7 +2851,7 @@ end
                                                   csrSortedColIndB, beta, descrD, nnzD,
                                                   csrSortedRowPtrD, csrSortedColIndD, info,
                                                   pBufferSizeInBytes)
-    initialize_api()
+    initialize_context()
     ccall((:cusparseScsrgemm2_bufferSizeExt, libcusparse()), cusparseStatus_t,
                    (cusparseHandle_t, Cint, Cint, Cint, Ref{Cfloat}, cusparseMatDescr_t,
                     Cint, CuPtr{Cint}, CuPtr{Cint}, cusparseMatDescr_t, Cint, CuPtr{Cint},
@@ -2869,7 +2869,7 @@ end
                                                   csrSortedColIndB, beta, descrD, nnzD,
                                                   csrSortedRowPtrD, csrSortedColIndD, info,
                                                   pBufferSizeInBytes)
-    initialize_api()
+    initialize_context()
     ccall((:cusparseDcsrgemm2_bufferSizeExt, libcusparse()), cusparseStatus_t,
                    (cusparseHandle_t, Cint, Cint, Cint, Ref{Cdouble}, cusparseMatDescr_t,
                     Cint, CuPtr{Cint}, CuPtr{Cint}, cusparseMatDescr_t, Cint, CuPtr{Cint},
@@ -2887,7 +2887,7 @@ end
                                                   csrSortedColIndB, beta, descrD, nnzD,
                                                   csrSortedRowPtrD, csrSortedColIndD, info,
                                                   pBufferSizeInBytes)
-    initialize_api()
+    initialize_context()
     ccall((:cusparseCcsrgemm2_bufferSizeExt, libcusparse()), cusparseStatus_t,
                    (cusparseHandle_t, Cint, Cint, Cint, Ref{cuComplex},
                     cusparseMatDescr_t, Cint, CuPtr{Cint}, CuPtr{Cint}, cusparseMatDescr_t,
@@ -2905,7 +2905,7 @@ end
                                                   csrSortedColIndB, beta, descrD, nnzD,
                                                   csrSortedRowPtrD, csrSortedColIndD, info,
                                                   pBufferSizeInBytes)
-    initialize_api()
+    initialize_context()
     ccall((:cusparseZcsrgemm2_bufferSizeExt, libcusparse()), cusparseStatus_t,
                    (cusparseHandle_t, Cint, Cint, Cint, Ref{cuDoubleComplex},
                     cusparseMatDescr_t, Cint, CuPtr{Cint}, CuPtr{Cint}, cusparseMatDescr_t,
@@ -2923,7 +2923,7 @@ end
                                        csrSortedColIndB, descrD, nnzD, csrSortedRowPtrD,
                                        csrSortedColIndD, descrC, csrSortedRowPtrC,
                                        nnzTotalDevHostPtr, info, pBuffer)
-    initialize_api()
+    initialize_context()
     ccall((:cusparseXcsrgemm2Nnz, libcusparse()), cusparseStatus_t,
                    (cusparseHandle_t, Cint, Cint, Cint, cusparseMatDescr_t, Cint,
                     CuPtr{Cint}, CuPtr{Cint}, cusparseMatDescr_t, Cint, CuPtr{Cint},
@@ -2942,7 +2942,7 @@ end
                                     beta, descrD, nnzD, csrSortedValD, csrSortedRowPtrD,
                                     csrSortedColIndD, descrC, csrSortedValC,
                                     csrSortedRowPtrC, csrSortedColIndC, info, pBuffer)
-    initialize_api()
+    initialize_context()
     ccall((:cusparseScsrgemm2, libcusparse()), cusparseStatus_t,
                    (cusparseHandle_t, Cint, Cint, Cint, Ref{Cfloat}, cusparseMatDescr_t,
                     Cint, CuPtr{Cfloat}, CuPtr{Cint}, CuPtr{Cint}, cusparseMatDescr_t,
@@ -2963,7 +2963,7 @@ end
                                     beta, descrD, nnzD, csrSortedValD, csrSortedRowPtrD,
                                     csrSortedColIndD, descrC, csrSortedValC,
                                     csrSortedRowPtrC, csrSortedColIndC, info, pBuffer)
-    initialize_api()
+    initialize_context()
     ccall((:cusparseDcsrgemm2, libcusparse()), cusparseStatus_t,
                    (cusparseHandle_t, Cint, Cint, Cint, Ref{Cdouble}, cusparseMatDescr_t,
                     Cint, CuPtr{Cdouble}, CuPtr{Cint}, CuPtr{Cint}, cusparseMatDescr_t,
@@ -2984,7 +2984,7 @@ end
                                     beta, descrD, nnzD, csrSortedValD, csrSortedRowPtrD,
                                     csrSortedColIndD, descrC, csrSortedValC,
                                     csrSortedRowPtrC, csrSortedColIndC, info, pBuffer)
-    initialize_api()
+    initialize_context()
     ccall((:cusparseCcsrgemm2, libcusparse()), cusparseStatus_t,
                    (cusparseHandle_t, Cint, Cint, Cint, Ref{cuComplex},
                     cusparseMatDescr_t, Cint, CuPtr{cuComplex}, CuPtr{Cint}, CuPtr{Cint},
@@ -3005,7 +3005,7 @@ end
                                     beta, descrD, nnzD, csrSortedValD, csrSortedRowPtrD,
                                     csrSortedColIndD, descrC, csrSortedValC,
                                     csrSortedRowPtrC, csrSortedColIndC, info, pBuffer)
-    initialize_api()
+    initialize_context()
     ccall((:cusparseZcsrgemm2, libcusparse()), cusparseStatus_t,
                    (cusparseHandle_t, Cint, Cint, Cint, Ref{cuDoubleComplex},
                     cusparseMatDescr_t, Cint, CuPtr{cuDoubleComplex}, CuPtr{Cint},
@@ -3028,7 +3028,7 @@ end
                                                   csrSortedColIndB, descrC, csrSortedValC,
                                                   csrSortedRowPtrC, csrSortedColIndC,
                                                   pBufferSizeInBytes)
-    initialize_api()
+    initialize_context()
     ccall((:cusparseScsrgeam2_bufferSizeExt, libcusparse()), cusparseStatus_t,
                    (cusparseHandle_t, Cint, Cint, Ref{Cfloat}, cusparseMatDescr_t, Cint,
                     CuPtr{Cfloat}, CuPtr{Cint}, CuPtr{Cint}, Ref{Cfloat},
@@ -3048,7 +3048,7 @@ end
                                                   csrSortedColIndB, descrC, csrSortedValC,
                                                   csrSortedRowPtrC, csrSortedColIndC,
                                                   pBufferSizeInBytes)
-    initialize_api()
+    initialize_context()
     ccall((:cusparseDcsrgeam2_bufferSizeExt, libcusparse()), cusparseStatus_t,
                    (cusparseHandle_t, Cint, Cint, Ref{Cdouble}, cusparseMatDescr_t, Cint,
                     CuPtr{Cdouble}, CuPtr{Cint}, CuPtr{Cint}, Ref{Cdouble},
@@ -3068,7 +3068,7 @@ end
                                                   csrSortedColIndB, descrC, csrSortedValC,
                                                   csrSortedRowPtrC, csrSortedColIndC,
                                                   pBufferSizeInBytes)
-    initialize_api()
+    initialize_context()
     ccall((:cusparseCcsrgeam2_bufferSizeExt, libcusparse()), cusparseStatus_t,
                    (cusparseHandle_t, Cint, Cint, Ref{cuComplex}, cusparseMatDescr_t,
                     Cint, CuPtr{cuComplex}, CuPtr{Cint}, CuPtr{Cint}, Ref{cuComplex},
@@ -3088,7 +3088,7 @@ end
                                                   csrSortedColIndB, descrC, csrSortedValC,
                                                   csrSortedRowPtrC, csrSortedColIndC,
                                                   pBufferSizeInBytes)
-    initialize_api()
+    initialize_context()
     ccall((:cusparseZcsrgeam2_bufferSizeExt, libcusparse()), cusparseStatus_t,
                    (cusparseHandle_t, Cint, Cint, Ref{cuDoubleComplex},
                     cusparseMatDescr_t, Cint, CuPtr{cuDoubleComplex}, CuPtr{Cint},
@@ -3105,7 +3105,7 @@ end
                                        csrSortedColIndA, descrB, nnzB, csrSortedRowPtrB,
                                        csrSortedColIndB, descrC, csrSortedRowPtrC,
                                        nnzTotalDevHostPtr, workspace)
-    initialize_api()
+    initialize_context()
     ccall((:cusparseXcsrgeam2Nnz, libcusparse()), cusparseStatus_t,
                    (cusparseHandle_t, Cint, Cint, cusparseMatDescr_t, Cint, CuPtr{Cint},
                     CuPtr{Cint}, cusparseMatDescr_t, Cint, CuPtr{Cint}, CuPtr{Cint},
@@ -3120,7 +3120,7 @@ end
                                     csrSortedValB, csrSortedRowPtrB, csrSortedColIndB,
                                     descrC, csrSortedValC, csrSortedRowPtrC,
                                     csrSortedColIndC, pBuffer)
-    initialize_api()
+    initialize_context()
     ccall((:cusparseScsrgeam2, libcusparse()), cusparseStatus_t,
                    (cusparseHandle_t, Cint, Cint, Ref{Cfloat}, cusparseMatDescr_t, Cint,
                     CuPtr{Cfloat}, CuPtr{Cint}, CuPtr{Cint}, Ref{Cfloat},
@@ -3138,7 +3138,7 @@ end
                                     csrSortedValB, csrSortedRowPtrB, csrSortedColIndB,
                                     descrC, csrSortedValC, csrSortedRowPtrC,
                                     csrSortedColIndC, pBuffer)
-    initialize_api()
+    initialize_context()
     ccall((:cusparseDcsrgeam2, libcusparse()), cusparseStatus_t,
                    (cusparseHandle_t, Cint, Cint, Ref{Cdouble}, cusparseMatDescr_t, Cint,
                     CuPtr{Cdouble}, CuPtr{Cint}, CuPtr{Cint}, Ref{Cdouble},
@@ -3156,7 +3156,7 @@ end
                                     csrSortedValB, csrSortedRowPtrB, csrSortedColIndB,
                                     descrC, csrSortedValC, csrSortedRowPtrC,
                                     csrSortedColIndC, pBuffer)
-    initialize_api()
+    initialize_context()
     ccall((:cusparseCcsrgeam2, libcusparse()), cusparseStatus_t,
                    (cusparseHandle_t, Cint, Cint, Ref{cuComplex}, cusparseMatDescr_t,
                     Cint, CuPtr{cuComplex}, CuPtr{Cint}, CuPtr{Cint}, Ref{cuComplex},
@@ -3174,7 +3174,7 @@ end
                                     csrSortedValB, csrSortedRowPtrB, csrSortedColIndB,
                                     descrC, csrSortedValC, csrSortedRowPtrC,
                                     csrSortedColIndC, pBuffer)
-    initialize_api()
+    initialize_context()
     ccall((:cusparseZcsrgeam2, libcusparse()), cusparseStatus_t,
                    (cusparseHandle_t, Cint, Cint, Ref{cuDoubleComplex},
                     cusparseMatDescr_t, Cint, CuPtr{cuDoubleComplex}, CuPtr{Cint},
@@ -3190,7 +3190,7 @@ end
 @checked function cusparseScsrcolor(handle, m, nnz, descrA, csrSortedValA,
                                     csrSortedRowPtrA, csrSortedColIndA, fractionToColor,
                                     ncolors, coloring, reordering, info)
-    initialize_api()
+    initialize_context()
     ccall((:cusparseScsrcolor, libcusparse()), cusparseStatus_t,
                    (cusparseHandle_t, Cint, Cint, cusparseMatDescr_t, CuPtr{Cfloat},
                     CuPtr{Cint}, CuPtr{Cint}, Ptr{Cfloat}, Ptr{Cint}, CuPtr{Cint},
@@ -3202,7 +3202,7 @@ end
 @checked function cusparseDcsrcolor(handle, m, nnz, descrA, csrSortedValA,
                                     csrSortedRowPtrA, csrSortedColIndA, fractionToColor,
                                     ncolors, coloring, reordering, info)
-    initialize_api()
+    initialize_context()
     ccall((:cusparseDcsrcolor, libcusparse()), cusparseStatus_t,
                    (cusparseHandle_t, Cint, Cint, cusparseMatDescr_t, CuPtr{Cdouble},
                     CuPtr{Cint}, CuPtr{Cint}, Ptr{Cdouble}, Ptr{Cint}, CuPtr{Cint},
@@ -3214,7 +3214,7 @@ end
 @checked function cusparseCcsrcolor(handle, m, nnz, descrA, csrSortedValA,
                                     csrSortedRowPtrA, csrSortedColIndA, fractionToColor,
                                     ncolors, coloring, reordering, info)
-    initialize_api()
+    initialize_context()
     ccall((:cusparseCcsrcolor, libcusparse()), cusparseStatus_t,
                    (cusparseHandle_t, Cint, Cint, cusparseMatDescr_t, CuPtr{cuComplex},
                     CuPtr{Cint}, CuPtr{Cint}, Ptr{Cfloat}, Ptr{Cint}, CuPtr{Cint},
@@ -3226,7 +3226,7 @@ end
 @checked function cusparseZcsrcolor(handle, m, nnz, descrA, csrSortedValA,
                                     csrSortedRowPtrA, csrSortedColIndA, fractionToColor,
                                     ncolors, coloring, reordering, info)
-    initialize_api()
+    initialize_context()
     ccall((:cusparseZcsrcolor, libcusparse()), cusparseStatus_t,
                    (cusparseHandle_t, Cint, Cint, cusparseMatDescr_t,
                     CuPtr{cuDoubleComplex}, CuPtr{Cint}, CuPtr{Cint}, Ptr{Cdouble},
@@ -3237,7 +3237,7 @@ end
 
 @checked function cusparseSnnz(handle, dirA, m, n, descrA, A, lda, nnzPerRowCol,
                                nnzTotalDevHostPtr)
-    initialize_api()
+    initialize_context()
     ccall((:cusparseSnnz, libcusparse()), cusparseStatus_t,
                    (cusparseHandle_t, cusparseDirection_t, Cint, Cint, cusparseMatDescr_t,
                     CuPtr{Cfloat}, Cint, CuPtr{Cint}, PtrOrCuPtr{Cint}),
@@ -3246,7 +3246,7 @@ end
 
 @checked function cusparseDnnz(handle, dirA, m, n, descrA, A, lda, nnzPerRowCol,
                                nnzTotalDevHostPtr)
-    initialize_api()
+    initialize_context()
     ccall((:cusparseDnnz, libcusparse()), cusparseStatus_t,
                    (cusparseHandle_t, cusparseDirection_t, Cint, Cint, cusparseMatDescr_t,
                     CuPtr{Cdouble}, Cint, CuPtr{Cint}, PtrOrCuPtr{Cint}),
@@ -3255,7 +3255,7 @@ end
 
 @checked function cusparseCnnz(handle, dirA, m, n, descrA, A, lda, nnzPerRowCol,
                                nnzTotalDevHostPtr)
-    initialize_api()
+    initialize_context()
     ccall((:cusparseCnnz, libcusparse()), cusparseStatus_t,
                    (cusparseHandle_t, cusparseDirection_t, Cint, Cint, cusparseMatDescr_t,
                     CuPtr{cuComplex}, Cint, CuPtr{Cint}, PtrOrCuPtr{Cint}),
@@ -3264,7 +3264,7 @@ end
 
 @checked function cusparseZnnz(handle, dirA, m, n, descrA, A, lda, nnzPerRowCol,
                                nnzTotalDevHostPtr)
-    initialize_api()
+    initialize_context()
     ccall((:cusparseZnnz, libcusparse()), cusparseStatus_t,
                    (cusparseHandle_t, cusparseDirection_t, Cint, Cint, cusparseMatDescr_t,
                     CuPtr{cuDoubleComplex}, Cint, CuPtr{Cint}, PtrOrCuPtr{Cint}),
@@ -3273,7 +3273,7 @@ end
 
 @checked function cusparseSnnz_compress(handle, m, descr, csrSortedValA, csrSortedRowPtrA,
                                         nnzPerRow, nnzC, tol)
-    initialize_api()
+    initialize_context()
     ccall((:cusparseSnnz_compress, libcusparse()), cusparseStatus_t,
                    (cusparseHandle_t, Cint, cusparseMatDescr_t, CuPtr{Cfloat},
                     CuPtr{Cint}, CuPtr{Cint}, PtrOrCuPtr{Cint}, Cfloat),
@@ -3282,7 +3282,7 @@ end
 
 @checked function cusparseDnnz_compress(handle, m, descr, csrSortedValA, csrSortedRowPtrA,
                                         nnzPerRow, nnzC, tol)
-    initialize_api()
+    initialize_context()
     ccall((:cusparseDnnz_compress, libcusparse()), cusparseStatus_t,
                    (cusparseHandle_t, Cint, cusparseMatDescr_t, CuPtr{Cdouble},
                     CuPtr{Cint}, CuPtr{Cint}, PtrOrCuPtr{Cint}, Cdouble),
@@ -3291,7 +3291,7 @@ end
 
 @checked function cusparseCnnz_compress(handle, m, descr, csrSortedValA, csrSortedRowPtrA,
                                         nnzPerRow, nnzC, tol)
-    initialize_api()
+    initialize_context()
     ccall((:cusparseCnnz_compress, libcusparse()), cusparseStatus_t,
                    (cusparseHandle_t, Cint, cusparseMatDescr_t, CuPtr{cuComplex},
                     CuPtr{Cint}, CuPtr{Cint}, PtrOrCuPtr{Cint}, cuComplex),
@@ -3300,7 +3300,7 @@ end
 
 @checked function cusparseZnnz_compress(handle, m, descr, csrSortedValA, csrSortedRowPtrA,
                                         nnzPerRow, nnzC, tol)
-    initialize_api()
+    initialize_context()
     ccall((:cusparseZnnz_compress, libcusparse()), cusparseStatus_t,
                    (cusparseHandle_t, Cint, cusparseMatDescr_t, CuPtr{cuDoubleComplex},
                     CuPtr{Cint}, CuPtr{Cint}, PtrOrCuPtr{Cint}, cuDoubleComplex),
@@ -3311,7 +3311,7 @@ end
                                             csrSortedColIndA, csrSortedRowPtrA, nnzA,
                                             nnzPerRow, csrSortedValC, csrSortedColIndC,
                                             csrSortedRowPtrC, tol)
-    initialize_api()
+    initialize_context()
     ccall((:cusparseScsr2csr_compress, libcusparse()), cusparseStatus_t,
                    (cusparseHandle_t, Cint, Cint, cusparseMatDescr_t, CuPtr{Cfloat},
                     CuPtr{Cint}, CuPtr{Cint}, Cint, CuPtr{Cint}, CuPtr{Cfloat},
@@ -3324,7 +3324,7 @@ end
                                             csrSortedColIndA, csrSortedRowPtrA, nnzA,
                                             nnzPerRow, csrSortedValC, csrSortedColIndC,
                                             csrSortedRowPtrC, tol)
-    initialize_api()
+    initialize_context()
     ccall((:cusparseDcsr2csr_compress, libcusparse()), cusparseStatus_t,
                    (cusparseHandle_t, Cint, Cint, cusparseMatDescr_t, CuPtr{Cdouble},
                     CuPtr{Cint}, CuPtr{Cint}, Cint, CuPtr{Cint}, CuPtr{Cdouble},
@@ -3337,7 +3337,7 @@ end
                                             csrSortedColIndA, csrSortedRowPtrA, nnzA,
                                             nnzPerRow, csrSortedValC, csrSortedColIndC,
                                             csrSortedRowPtrC, tol)
-    initialize_api()
+    initialize_context()
     ccall((:cusparseCcsr2csr_compress, libcusparse()), cusparseStatus_t,
                    (cusparseHandle_t, Cint, Cint, cusparseMatDescr_t, CuPtr{cuComplex},
                     CuPtr{Cint}, CuPtr{Cint}, Cint, CuPtr{Cint}, CuPtr{cuComplex},
@@ -3350,7 +3350,7 @@ end
                                             csrSortedColIndA, csrSortedRowPtrA, nnzA,
                                             nnzPerRow, csrSortedValC, csrSortedColIndC,
                                             csrSortedRowPtrC, tol)
-    initialize_api()
+    initialize_context()
     ccall((:cusparseZcsr2csr_compress, libcusparse()), cusparseStatus_t,
                    (cusparseHandle_t, Cint, Cint, cusparseMatDescr_t,
                     CuPtr{cuDoubleComplex}, CuPtr{Cint}, CuPtr{Cint}, Cint, CuPtr{Cint},
@@ -3361,7 +3361,7 @@ end
 
 @checked function cusparseSdense2csr(handle, m, n, descrA, A, lda, nnzPerRow,
                                      csrSortedValA, csrSortedRowPtrA, csrSortedColIndA)
-    initialize_api()
+    initialize_context()
     ccall((:cusparseSdense2csr, libcusparse()), cusparseStatus_t,
                    (cusparseHandle_t, Cint, Cint, cusparseMatDescr_t, CuPtr{Cfloat}, Cint,
                     CuPtr{Cint}, CuPtr{Cfloat}, CuPtr{Cint}, CuPtr{Cint}),
@@ -3371,7 +3371,7 @@ end
 
 @checked function cusparseDdense2csr(handle, m, n, descrA, A, lda, nnzPerRow,
                                      csrSortedValA, csrSortedRowPtrA, csrSortedColIndA)
-    initialize_api()
+    initialize_context()
     ccall((:cusparseDdense2csr, libcusparse()), cusparseStatus_t,
                    (cusparseHandle_t, Cint, Cint, cusparseMatDescr_t, CuPtr{Cdouble},
                     Cint, CuPtr{Cint}, CuPtr{Cdouble}, CuPtr{Cint}, CuPtr{Cint}),
@@ -3381,7 +3381,7 @@ end
 
 @checked function cusparseCdense2csr(handle, m, n, descrA, A, lda, nnzPerRow,
                                      csrSortedValA, csrSortedRowPtrA, csrSortedColIndA)
-    initialize_api()
+    initialize_context()
     ccall((:cusparseCdense2csr, libcusparse()), cusparseStatus_t,
                    (cusparseHandle_t, Cint, Cint, cusparseMatDescr_t, CuPtr{cuComplex},
                     Cint, CuPtr{Cint}, CuPtr{cuComplex}, CuPtr{Cint}, CuPtr{Cint}),
@@ -3391,7 +3391,7 @@ end
 
 @checked function cusparseZdense2csr(handle, m, n, descrA, A, lda, nnzPerRow,
                                      csrSortedValA, csrSortedRowPtrA, csrSortedColIndA)
-    initialize_api()
+    initialize_context()
     ccall((:cusparseZdense2csr, libcusparse()), cusparseStatus_t,
                    (cusparseHandle_t, Cint, Cint, cusparseMatDescr_t,
                     CuPtr{cuDoubleComplex}, Cint, CuPtr{Cint}, CuPtr{cuDoubleComplex},
@@ -3402,7 +3402,7 @@ end
 
 @checked function cusparseScsr2dense(handle, m, n, descrA, csrSortedValA, csrSortedRowPtrA,
                                      csrSortedColIndA, A, lda)
-    initialize_api()
+    initialize_context()
     ccall((:cusparseScsr2dense, libcusparse()), cusparseStatus_t,
                    (cusparseHandle_t, Cint, Cint, cusparseMatDescr_t, CuPtr{Cfloat},
                     CuPtr{Cint}, CuPtr{Cint}, CuPtr{Cfloat}, Cint),
@@ -3412,7 +3412,7 @@ end
 
 @checked function cusparseDcsr2dense(handle, m, n, descrA, csrSortedValA, csrSortedRowPtrA,
                                      csrSortedColIndA, A, lda)
-    initialize_api()
+    initialize_context()
     ccall((:cusparseDcsr2dense, libcusparse()), cusparseStatus_t,
                    (cusparseHandle_t, Cint, Cint, cusparseMatDescr_t, CuPtr{Cdouble},
                     CuPtr{Cint}, CuPtr{Cint}, CuPtr{Cdouble}, Cint),
@@ -3422,7 +3422,7 @@ end
 
 @checked function cusparseCcsr2dense(handle, m, n, descrA, csrSortedValA, csrSortedRowPtrA,
                                      csrSortedColIndA, A, lda)
-    initialize_api()
+    initialize_context()
     ccall((:cusparseCcsr2dense, libcusparse()), cusparseStatus_t,
                    (cusparseHandle_t, Cint, Cint, cusparseMatDescr_t, CuPtr{cuComplex},
                     CuPtr{Cint}, CuPtr{Cint}, CuPtr{cuComplex}, Cint),
@@ -3432,7 +3432,7 @@ end
 
 @checked function cusparseZcsr2dense(handle, m, n, descrA, csrSortedValA, csrSortedRowPtrA,
                                      csrSortedColIndA, A, lda)
-    initialize_api()
+    initialize_context()
     ccall((:cusparseZcsr2dense, libcusparse()), cusparseStatus_t,
                    (cusparseHandle_t, Cint, Cint, cusparseMatDescr_t,
                     CuPtr{cuDoubleComplex}, CuPtr{Cint}, CuPtr{Cint},
@@ -3443,7 +3443,7 @@ end
 
 @checked function cusparseSdense2csc(handle, m, n, descrA, A, lda, nnzPerCol,
                                      cscSortedValA, cscSortedRowIndA, cscSortedColPtrA)
-    initialize_api()
+    initialize_context()
     ccall((:cusparseSdense2csc, libcusparse()), cusparseStatus_t,
                    (cusparseHandle_t, Cint, Cint, cusparseMatDescr_t, CuPtr{Cfloat}, Cint,
                     CuPtr{Cint}, CuPtr{Cfloat}, CuPtr{Cint}, CuPtr{Cint}),
@@ -3453,7 +3453,7 @@ end
 
 @checked function cusparseDdense2csc(handle, m, n, descrA, A, lda, nnzPerCol,
                                      cscSortedValA, cscSortedRowIndA, cscSortedColPtrA)
-    initialize_api()
+    initialize_context()
     ccall((:cusparseDdense2csc, libcusparse()), cusparseStatus_t,
                    (cusparseHandle_t, Cint, Cint, cusparseMatDescr_t, CuPtr{Cdouble},
                     Cint, CuPtr{Cint}, CuPtr{Cdouble}, CuPtr{Cint}, CuPtr{Cint}),
@@ -3463,7 +3463,7 @@ end
 
 @checked function cusparseCdense2csc(handle, m, n, descrA, A, lda, nnzPerCol,
                                      cscSortedValA, cscSortedRowIndA, cscSortedColPtrA)
-    initialize_api()
+    initialize_context()
     ccall((:cusparseCdense2csc, libcusparse()), cusparseStatus_t,
                    (cusparseHandle_t, Cint, Cint, cusparseMatDescr_t, CuPtr{cuComplex},
                     Cint, CuPtr{Cint}, CuPtr{cuComplex}, CuPtr{Cint}, CuPtr{Cint}),
@@ -3473,7 +3473,7 @@ end
 
 @checked function cusparseZdense2csc(handle, m, n, descrA, A, lda, nnzPerCol,
                                      cscSortedValA, cscSortedRowIndA, cscSortedColPtrA)
-    initialize_api()
+    initialize_context()
     ccall((:cusparseZdense2csc, libcusparse()), cusparseStatus_t,
                    (cusparseHandle_t, Cint, Cint, cusparseMatDescr_t,
                     CuPtr{cuDoubleComplex}, Cint, CuPtr{Cint}, CuPtr{cuDoubleComplex},
@@ -3484,7 +3484,7 @@ end
 
 @checked function cusparseScsc2dense(handle, m, n, descrA, cscSortedValA, cscSortedRowIndA,
                                      cscSortedColPtrA, A, lda)
-    initialize_api()
+    initialize_context()
     ccall((:cusparseScsc2dense, libcusparse()), cusparseStatus_t,
                    (cusparseHandle_t, Cint, Cint, cusparseMatDescr_t, CuPtr{Cfloat},
                     CuPtr{Cint}, CuPtr{Cint}, CuPtr{Cfloat}, Cint),
@@ -3494,7 +3494,7 @@ end
 
 @checked function cusparseDcsc2dense(handle, m, n, descrA, cscSortedValA, cscSortedRowIndA,
                                      cscSortedColPtrA, A, lda)
-    initialize_api()
+    initialize_context()
     ccall((:cusparseDcsc2dense, libcusparse()), cusparseStatus_t,
                    (cusparseHandle_t, Cint, Cint, cusparseMatDescr_t, CuPtr{Cdouble},
                     CuPtr{Cint}, CuPtr{Cint}, CuPtr{Cdouble}, Cint),
@@ -3504,7 +3504,7 @@ end
 
 @checked function cusparseCcsc2dense(handle, m, n, descrA, cscSortedValA, cscSortedRowIndA,
                                      cscSortedColPtrA, A, lda)
-    initialize_api()
+    initialize_context()
     ccall((:cusparseCcsc2dense, libcusparse()), cusparseStatus_t,
                    (cusparseHandle_t, Cint, Cint, cusparseMatDescr_t, CuPtr{cuComplex},
                     CuPtr{Cint}, CuPtr{Cint}, CuPtr{cuComplex}, Cint),
@@ -3514,7 +3514,7 @@ end
 
 @checked function cusparseZcsc2dense(handle, m, n, descrA, cscSortedValA, cscSortedRowIndA,
                                      cscSortedColPtrA, A, lda)
-    initialize_api()
+    initialize_context()
     ccall((:cusparseZcsc2dense, libcusparse()), cusparseStatus_t,
                    (cusparseHandle_t, Cint, Cint, cusparseMatDescr_t,
                     CuPtr{cuDoubleComplex}, CuPtr{Cint}, CuPtr{Cint},
@@ -3524,7 +3524,7 @@ end
 end
 
 @checked function cusparseXcoo2csr(handle, cooRowInd, nnz, m, csrSortedRowPtr, idxBase)
-    initialize_api()
+    initialize_context()
     ccall((:cusparseXcoo2csr, libcusparse()), cusparseStatus_t,
                    (cusparseHandle_t, CuPtr{Cint}, Cint, Cint, CuPtr{Cint},
                     cusparseIndexBase_t),
@@ -3532,7 +3532,7 @@ end
 end
 
 @checked function cusparseXcsr2coo(handle, csrSortedRowPtr, nnz, m, cooRowInd, idxBase)
-    initialize_api()
+    initialize_context()
     ccall((:cusparseXcsr2coo, libcusparse()), cusparseStatus_t,
                    (cusparseHandle_t, CuPtr{Cint}, Cint, Cint, CuPtr{Cint},
                     cusparseIndexBase_t),
@@ -3542,7 +3542,7 @@ end
 @checked function cusparseXcsr2bsrNnz(handle, dirA, m, n, descrA, csrSortedRowPtrA,
                                       csrSortedColIndA, blockDim, descrC, bsrSortedRowPtrC,
                                       nnzTotalDevHostPtr)
-    initialize_api()
+    initialize_context()
     ccall((:cusparseXcsr2bsrNnz, libcusparse()), cusparseStatus_t,
                    (cusparseHandle_t, cusparseDirection_t, Cint, Cint, cusparseMatDescr_t,
                     CuPtr{Cint}, CuPtr{Cint}, Cint, cusparseMatDescr_t, CuPtr{Cint},
@@ -3554,7 +3554,7 @@ end
 @checked function cusparseScsr2bsr(handle, dirA, m, n, descrA, csrSortedValA,
                                    csrSortedRowPtrA, csrSortedColIndA, blockDim, descrC,
                                    bsrSortedValC, bsrSortedRowPtrC, bsrSortedColIndC)
-    initialize_api()
+    initialize_context()
     ccall((:cusparseScsr2bsr, libcusparse()), cusparseStatus_t,
                    (cusparseHandle_t, cusparseDirection_t, Cint, Cint, cusparseMatDescr_t,
                     CuPtr{Cfloat}, CuPtr{Cint}, CuPtr{Cint}, Cint, cusparseMatDescr_t,
@@ -3567,7 +3567,7 @@ end
 @checked function cusparseDcsr2bsr(handle, dirA, m, n, descrA, csrSortedValA,
                                    csrSortedRowPtrA, csrSortedColIndA, blockDim, descrC,
                                    bsrSortedValC, bsrSortedRowPtrC, bsrSortedColIndC)
-    initialize_api()
+    initialize_context()
     ccall((:cusparseDcsr2bsr, libcusparse()), cusparseStatus_t,
                    (cusparseHandle_t, cusparseDirection_t, Cint, Cint, cusparseMatDescr_t,
                     CuPtr{Cdouble}, CuPtr{Cint}, CuPtr{Cint}, Cint, cusparseMatDescr_t,
@@ -3580,7 +3580,7 @@ end
 @checked function cusparseCcsr2bsr(handle, dirA, m, n, descrA, csrSortedValA,
                                    csrSortedRowPtrA, csrSortedColIndA, blockDim, descrC,
                                    bsrSortedValC, bsrSortedRowPtrC, bsrSortedColIndC)
-    initialize_api()
+    initialize_context()
     ccall((:cusparseCcsr2bsr, libcusparse()), cusparseStatus_t,
                    (cusparseHandle_t, cusparseDirection_t, Cint, Cint, cusparseMatDescr_t,
                     CuPtr{cuComplex}, CuPtr{Cint}, CuPtr{Cint}, Cint, cusparseMatDescr_t,
@@ -3593,7 +3593,7 @@ end
 @checked function cusparseZcsr2bsr(handle, dirA, m, n, descrA, csrSortedValA,
                                    csrSortedRowPtrA, csrSortedColIndA, blockDim, descrC,
                                    bsrSortedValC, bsrSortedRowPtrC, bsrSortedColIndC)
-    initialize_api()
+    initialize_context()
     ccall((:cusparseZcsr2bsr, libcusparse()), cusparseStatus_t,
                    (cusparseHandle_t, cusparseDirection_t, Cint, Cint, cusparseMatDescr_t,
                     CuPtr{cuDoubleComplex}, CuPtr{Cint}, CuPtr{Cint}, Cint,
@@ -3606,7 +3606,7 @@ end
 @checked function cusparseSbsr2csr(handle, dirA, mb, nb, descrA, bsrSortedValA,
                                    bsrSortedRowPtrA, bsrSortedColIndA, blockDim, descrC,
                                    csrSortedValC, csrSortedRowPtrC, csrSortedColIndC)
-    initialize_api()
+    initialize_context()
     ccall((:cusparseSbsr2csr, libcusparse()), cusparseStatus_t,
                    (cusparseHandle_t, cusparseDirection_t, Cint, Cint, cusparseMatDescr_t,
                     CuPtr{Cfloat}, CuPtr{Cint}, CuPtr{Cint}, Cint, cusparseMatDescr_t,
@@ -3619,7 +3619,7 @@ end
 @checked function cusparseDbsr2csr(handle, dirA, mb, nb, descrA, bsrSortedValA,
                                    bsrSortedRowPtrA, bsrSortedColIndA, blockDim, descrC,
                                    csrSortedValC, csrSortedRowPtrC, csrSortedColIndC)
-    initialize_api()
+    initialize_context()
     ccall((:cusparseDbsr2csr, libcusparse()), cusparseStatus_t,
                    (cusparseHandle_t, cusparseDirection_t, Cint, Cint, cusparseMatDescr_t,
                     CuPtr{Cdouble}, CuPtr{Cint}, CuPtr{Cint}, Cint, cusparseMatDescr_t,
@@ -3632,7 +3632,7 @@ end
 @checked function cusparseCbsr2csr(handle, dirA, mb, nb, descrA, bsrSortedValA,
                                    bsrSortedRowPtrA, bsrSortedColIndA, blockDim, descrC,
                                    csrSortedValC, csrSortedRowPtrC, csrSortedColIndC)
-    initialize_api()
+    initialize_context()
     ccall((:cusparseCbsr2csr, libcusparse()), cusparseStatus_t,
                    (cusparseHandle_t, cusparseDirection_t, Cint, Cint, cusparseMatDescr_t,
                     CuPtr{cuComplex}, CuPtr{Cint}, CuPtr{Cint}, Cint, cusparseMatDescr_t,
@@ -3645,7 +3645,7 @@ end
 @checked function cusparseZbsr2csr(handle, dirA, mb, nb, descrA, bsrSortedValA,
                                    bsrSortedRowPtrA, bsrSortedColIndA, blockDim, descrC,
                                    csrSortedValC, csrSortedRowPtrC, csrSortedColIndC)
-    initialize_api()
+    initialize_context()
     ccall((:cusparseZbsr2csr, libcusparse()), cusparseStatus_t,
                    (cusparseHandle_t, cusparseDirection_t, Cint, Cint, cusparseMatDescr_t,
                     CuPtr{cuDoubleComplex}, CuPtr{Cint}, CuPtr{Cint}, Cint,
@@ -3659,7 +3659,7 @@ end
                                                   bsrSortedRowPtr, bsrSortedColInd,
                                                   rowBlockDim, colBlockDim,
                                                   pBufferSizeInBytes)
-    initialize_api()
+    initialize_context()
     ccall((:cusparseSgebsr2gebsc_bufferSize, libcusparse()), cusparseStatus_t,
                    (cusparseHandle_t, Cint, Cint, Cint, CuPtr{Cfloat}, CuPtr{Cint},
                     CuPtr{Cint}, Cint, Cint, Ptr{Cint}),
@@ -3671,7 +3671,7 @@ end
                                                   bsrSortedRowPtr, bsrSortedColInd,
                                                   rowBlockDim, colBlockDim,
                                                   pBufferSizeInBytes)
-    initialize_api()
+    initialize_context()
     ccall((:cusparseDgebsr2gebsc_bufferSize, libcusparse()), cusparseStatus_t,
                    (cusparseHandle_t, Cint, Cint, Cint, CuPtr{Cdouble}, CuPtr{Cint},
                     CuPtr{Cint}, Cint, Cint, Ptr{Cint}),
@@ -3683,7 +3683,7 @@ end
                                                   bsrSortedRowPtr, bsrSortedColInd,
                                                   rowBlockDim, colBlockDim,
                                                   pBufferSizeInBytes)
-    initialize_api()
+    initialize_context()
     ccall((:cusparseCgebsr2gebsc_bufferSize, libcusparse()), cusparseStatus_t,
                    (cusparseHandle_t, Cint, Cint, Cint, CuPtr{cuComplex}, CuPtr{Cint},
                     CuPtr{Cint}, Cint, Cint, Ptr{Cint}),
@@ -3695,7 +3695,7 @@ end
                                                   bsrSortedRowPtr, bsrSortedColInd,
                                                   rowBlockDim, colBlockDim,
                                                   pBufferSizeInBytes)
-    initialize_api()
+    initialize_context()
     ccall((:cusparseZgebsr2gebsc_bufferSize, libcusparse()), cusparseStatus_t,
                    (cusparseHandle_t, Cint, Cint, Cint, CuPtr{cuDoubleComplex},
                     CuPtr{Cint}, CuPtr{Cint}, Cint, Cint, Ptr{Cint}),
@@ -3706,7 +3706,7 @@ end
 @checked function cusparseSgebsr2gebsc_bufferSizeExt(handle, mb, nb, nnzb, bsrSortedVal,
                                                      bsrSortedRowPtr, bsrSortedColInd,
                                                      rowBlockDim, colBlockDim, pBufferSize)
-    initialize_api()
+    initialize_context()
     ccall((:cusparseSgebsr2gebsc_bufferSizeExt, libcusparse()), cusparseStatus_t,
                    (cusparseHandle_t, Cint, Cint, Cint, CuPtr{Cfloat}, CuPtr{Cint},
                     CuPtr{Cint}, Cint, Cint, Ptr{Csize_t}),
@@ -3717,7 +3717,7 @@ end
 @checked function cusparseDgebsr2gebsc_bufferSizeExt(handle, mb, nb, nnzb, bsrSortedVal,
                                                      bsrSortedRowPtr, bsrSortedColInd,
                                                      rowBlockDim, colBlockDim, pBufferSize)
-    initialize_api()
+    initialize_context()
     ccall((:cusparseDgebsr2gebsc_bufferSizeExt, libcusparse()), cusparseStatus_t,
                    (cusparseHandle_t, Cint, Cint, Cint, CuPtr{Cdouble}, CuPtr{Cint},
                     CuPtr{Cint}, Cint, Cint, Ptr{Csize_t}),
@@ -3728,7 +3728,7 @@ end
 @checked function cusparseCgebsr2gebsc_bufferSizeExt(handle, mb, nb, nnzb, bsrSortedVal,
                                                      bsrSortedRowPtr, bsrSortedColInd,
                                                      rowBlockDim, colBlockDim, pBufferSize)
-    initialize_api()
+    initialize_context()
     ccall((:cusparseCgebsr2gebsc_bufferSizeExt, libcusparse()), cusparseStatus_t,
                    (cusparseHandle_t, Cint, Cint, Cint, CuPtr{cuComplex}, CuPtr{Cint},
                     CuPtr{Cint}, Cint, Cint, Ptr{Csize_t}),
@@ -3739,7 +3739,7 @@ end
 @checked function cusparseZgebsr2gebsc_bufferSizeExt(handle, mb, nb, nnzb, bsrSortedVal,
                                                      bsrSortedRowPtr, bsrSortedColInd,
                                                      rowBlockDim, colBlockDim, pBufferSize)
-    initialize_api()
+    initialize_context()
     ccall((:cusparseZgebsr2gebsc_bufferSizeExt, libcusparse()), cusparseStatus_t,
                    (cusparseHandle_t, Cint, Cint, Cint, CuPtr{cuDoubleComplex},
                     CuPtr{Cint}, CuPtr{Cint}, Cint, Cint, Ptr{Csize_t}),
@@ -3750,7 +3750,7 @@ end
 @checked function cusparseSgebsr2gebsc(handle, mb, nb, nnzb, bsrSortedVal, bsrSortedRowPtr,
                                        bsrSortedColInd, rowBlockDim, colBlockDim, bscVal,
                                        bscRowInd, bscColPtr, copyValues, idxBase, pBuffer)
-    initialize_api()
+    initialize_context()
     ccall((:cusparseSgebsr2gebsc, libcusparse()), cusparseStatus_t,
                    (cusparseHandle_t, Cint, Cint, Cint, CuPtr{Cfloat}, CuPtr{Cint},
                     CuPtr{Cint}, Cint, Cint, CuPtr{Cfloat}, CuPtr{Cint}, CuPtr{Cint},
@@ -3763,7 +3763,7 @@ end
 @checked function cusparseDgebsr2gebsc(handle, mb, nb, nnzb, bsrSortedVal, bsrSortedRowPtr,
                                        bsrSortedColInd, rowBlockDim, colBlockDim, bscVal,
                                        bscRowInd, bscColPtr, copyValues, idxBase, pBuffer)
-    initialize_api()
+    initialize_context()
     ccall((:cusparseDgebsr2gebsc, libcusparse()), cusparseStatus_t,
                    (cusparseHandle_t, Cint, Cint, Cint, CuPtr{Cdouble}, CuPtr{Cint},
                     CuPtr{Cint}, Cint, Cint, CuPtr{Cdouble}, CuPtr{Cint}, CuPtr{Cint},
@@ -3776,7 +3776,7 @@ end
 @checked function cusparseCgebsr2gebsc(handle, mb, nb, nnzb, bsrSortedVal, bsrSortedRowPtr,
                                        bsrSortedColInd, rowBlockDim, colBlockDim, bscVal,
                                        bscRowInd, bscColPtr, copyValues, idxBase, pBuffer)
-    initialize_api()
+    initialize_context()
     ccall((:cusparseCgebsr2gebsc, libcusparse()), cusparseStatus_t,
                    (cusparseHandle_t, Cint, Cint, Cint, CuPtr{cuComplex}, CuPtr{Cint},
                     CuPtr{Cint}, Cint, Cint, CuPtr{cuComplex}, CuPtr{Cint}, CuPtr{Cint},
@@ -3789,7 +3789,7 @@ end
 @checked function cusparseZgebsr2gebsc(handle, mb, nb, nnzb, bsrSortedVal, bsrSortedRowPtr,
                                        bsrSortedColInd, rowBlockDim, colBlockDim, bscVal,
                                        bscRowInd, bscColPtr, copyValues, idxBase, pBuffer)
-    initialize_api()
+    initialize_context()
     ccall((:cusparseZgebsr2gebsc, libcusparse()), cusparseStatus_t,
                    (cusparseHandle_t, Cint, Cint, Cint, CuPtr{cuDoubleComplex},
                     CuPtr{Cint}, CuPtr{Cint}, Cint, Cint, CuPtr{cuDoubleComplex},
@@ -3803,7 +3803,7 @@ end
 @checked function cusparseXgebsr2csr(handle, dirA, mb, nb, descrA, bsrSortedRowPtrA,
                                      bsrSortedColIndA, rowBlockDim, colBlockDim, descrC,
                                      csrSortedRowPtrC, csrSortedColIndC)
-    initialize_api()
+    initialize_context()
     ccall((:cusparseXgebsr2csr, libcusparse()), cusparseStatus_t,
                    (cusparseHandle_t, cusparseDirection_t, Cint, Cint, cusparseMatDescr_t,
                     CuPtr{Cint}, CuPtr{Cint}, Cint, Cint, cusparseMatDescr_t, CuPtr{Cint},
@@ -3816,7 +3816,7 @@ end
                                      bsrSortedRowPtrA, bsrSortedColIndA, rowBlockDim,
                                      colBlockDim, descrC, csrSortedValC, csrSortedRowPtrC,
                                      csrSortedColIndC)
-    initialize_api()
+    initialize_context()
     ccall((:cusparseSgebsr2csr, libcusparse()), cusparseStatus_t,
                    (cusparseHandle_t, cusparseDirection_t, Cint, Cint, cusparseMatDescr_t,
                     CuPtr{Cfloat}, CuPtr{Cint}, CuPtr{Cint}, Cint, Cint,
@@ -3830,7 +3830,7 @@ end
                                      bsrSortedRowPtrA, bsrSortedColIndA, rowBlockDim,
                                      colBlockDim, descrC, csrSortedValC, csrSortedRowPtrC,
                                      csrSortedColIndC)
-    initialize_api()
+    initialize_context()
     ccall((:cusparseDgebsr2csr, libcusparse()), cusparseStatus_t,
                    (cusparseHandle_t, cusparseDirection_t, Cint, Cint, cusparseMatDescr_t,
                     CuPtr{Cdouble}, CuPtr{Cint}, CuPtr{Cint}, Cint, Cint,
@@ -3844,7 +3844,7 @@ end
                                      bsrSortedRowPtrA, bsrSortedColIndA, rowBlockDim,
                                      colBlockDim, descrC, csrSortedValC, csrSortedRowPtrC,
                                      csrSortedColIndC)
-    initialize_api()
+    initialize_context()
     ccall((:cusparseCgebsr2csr, libcusparse()), cusparseStatus_t,
                    (cusparseHandle_t, cusparseDirection_t, Cint, Cint, cusparseMatDescr_t,
                     CuPtr{cuComplex}, CuPtr{Cint}, CuPtr{Cint}, Cint, Cint,
@@ -3858,7 +3858,7 @@ end
                                      bsrSortedRowPtrA, bsrSortedColIndA, rowBlockDim,
                                      colBlockDim, descrC, csrSortedValC, csrSortedRowPtrC,
                                      csrSortedColIndC)
-    initialize_api()
+    initialize_context()
     ccall((:cusparseZgebsr2csr, libcusparse()), cusparseStatus_t,
                    (cusparseHandle_t, cusparseDirection_t, Cint, Cint, cusparseMatDescr_t,
                     CuPtr{cuDoubleComplex}, CuPtr{Cint}, CuPtr{Cint}, Cint, Cint,
@@ -3871,7 +3871,7 @@ end
 @checked function cusparseScsr2gebsr_bufferSize(handle, dirA, m, n, descrA, csrSortedValA,
                                                 csrSortedRowPtrA, csrSortedColIndA,
                                                 rowBlockDim, colBlockDim, pBufferSizeInBytes)
-    initialize_api()
+    initialize_context()
     ccall((:cusparseScsr2gebsr_bufferSize, libcusparse()), cusparseStatus_t,
                    (cusparseHandle_t, cusparseDirection_t, Cint, Cint, cusparseMatDescr_t,
                     CuPtr{Cfloat}, CuPtr{Cint}, CuPtr{Cint}, Cint, Cint, Ptr{Cint}),
@@ -3882,7 +3882,7 @@ end
 @checked function cusparseDcsr2gebsr_bufferSize(handle, dirA, m, n, descrA, csrSortedValA,
                                                 csrSortedRowPtrA, csrSortedColIndA,
                                                 rowBlockDim, colBlockDim, pBufferSizeInBytes)
-    initialize_api()
+    initialize_context()
     ccall((:cusparseDcsr2gebsr_bufferSize, libcusparse()), cusparseStatus_t,
                    (cusparseHandle_t, cusparseDirection_t, Cint, Cint, cusparseMatDescr_t,
                     CuPtr{Cdouble}, CuPtr{Cint}, CuPtr{Cint}, Cint, Cint, Ptr{Cint}),
@@ -3893,7 +3893,7 @@ end
 @checked function cusparseCcsr2gebsr_bufferSize(handle, dirA, m, n, descrA, csrSortedValA,
                                                 csrSortedRowPtrA, csrSortedColIndA,
                                                 rowBlockDim, colBlockDim, pBufferSizeInBytes)
-    initialize_api()
+    initialize_context()
     ccall((:cusparseCcsr2gebsr_bufferSize, libcusparse()), cusparseStatus_t,
                    (cusparseHandle_t, cusparseDirection_t, Cint, Cint, cusparseMatDescr_t,
                     CuPtr{cuComplex}, CuPtr{Cint}, CuPtr{Cint}, Cint, Cint, Ptr{Cint}),
@@ -3904,7 +3904,7 @@ end
 @checked function cusparseZcsr2gebsr_bufferSize(handle, dirA, m, n, descrA, csrSortedValA,
                                                 csrSortedRowPtrA, csrSortedColIndA,
                                                 rowBlockDim, colBlockDim, pBufferSizeInBytes)
-    initialize_api()
+    initialize_context()
     ccall((:cusparseZcsr2gebsr_bufferSize, libcusparse()), cusparseStatus_t,
                    (cusparseHandle_t, cusparseDirection_t, Cint, Cint, cusparseMatDescr_t,
                     CuPtr{cuDoubleComplex}, CuPtr{Cint}, CuPtr{Cint}, Cint, Cint, Ptr{Cint}),
@@ -3916,7 +3916,7 @@ end
                                                    csrSortedValA, csrSortedRowPtrA,
                                                    csrSortedColIndA, rowBlockDim,
                                                    colBlockDim, pBufferSize)
-    initialize_api()
+    initialize_context()
     ccall((:cusparseScsr2gebsr_bufferSizeExt, libcusparse()), cusparseStatus_t,
                    (cusparseHandle_t, cusparseDirection_t, Cint, Cint, cusparseMatDescr_t,
                     CuPtr{Cfloat}, CuPtr{Cint}, CuPtr{Cint}, Cint, Cint, Ptr{Csize_t}),
@@ -3928,7 +3928,7 @@ end
                                                    csrSortedValA, csrSortedRowPtrA,
                                                    csrSortedColIndA, rowBlockDim,
                                                    colBlockDim, pBufferSize)
-    initialize_api()
+    initialize_context()
     ccall((:cusparseDcsr2gebsr_bufferSizeExt, libcusparse()), cusparseStatus_t,
                    (cusparseHandle_t, cusparseDirection_t, Cint, Cint, cusparseMatDescr_t,
                     CuPtr{Cdouble}, CuPtr{Cint}, CuPtr{Cint}, Cint, Cint, Ptr{Csize_t}),
@@ -3940,7 +3940,7 @@ end
                                                    csrSortedValA, csrSortedRowPtrA,
                                                    csrSortedColIndA, rowBlockDim,
                                                    colBlockDim, pBufferSize)
-    initialize_api()
+    initialize_context()
     ccall((:cusparseCcsr2gebsr_bufferSizeExt, libcusparse()), cusparseStatus_t,
                    (cusparseHandle_t, cusparseDirection_t, Cint, Cint, cusparseMatDescr_t,
                     CuPtr{cuComplex}, CuPtr{Cint}, CuPtr{Cint}, Cint, Cint, Ptr{Csize_t}),
@@ -3952,7 +3952,7 @@ end
                                                    csrSortedValA, csrSortedRowPtrA,
                                                    csrSortedColIndA, rowBlockDim,
                                                    colBlockDim, pBufferSize)
-    initialize_api()
+    initialize_context()
     ccall((:cusparseZcsr2gebsr_bufferSizeExt, libcusparse()), cusparseStatus_t,
                    (cusparseHandle_t, cusparseDirection_t, Cint, Cint, cusparseMatDescr_t,
                     CuPtr{cuDoubleComplex}, CuPtr{Cint}, CuPtr{Cint}, Cint, Cint,
@@ -3965,7 +3965,7 @@ end
                                         csrSortedColIndA, descrC, bsrSortedRowPtrC,
                                         rowBlockDim, colBlockDim, nnzTotalDevHostPtr,
                                         pBuffer)
-    initialize_api()
+    initialize_context()
     ccall((:cusparseXcsr2gebsrNnz, libcusparse()), cusparseStatus_t,
                    (cusparseHandle_t, cusparseDirection_t, Cint, Cint, cusparseMatDescr_t,
                     CuPtr{Cint}, CuPtr{Cint}, cusparseMatDescr_t, CuPtr{Cint}, Cint, Cint,
@@ -3978,7 +3978,7 @@ end
                                      csrSortedRowPtrA, csrSortedColIndA, descrC,
                                      bsrSortedValC, bsrSortedRowPtrC, bsrSortedColIndC,
                                      rowBlockDim, colBlockDim, pBuffer)
-    initialize_api()
+    initialize_context()
     ccall((:cusparseScsr2gebsr, libcusparse()), cusparseStatus_t,
                    (cusparseHandle_t, cusparseDirection_t, Cint, Cint, cusparseMatDescr_t,
                     CuPtr{Cfloat}, CuPtr{Cint}, CuPtr{Cint}, cusparseMatDescr_t,
@@ -3992,7 +3992,7 @@ end
                                      csrSortedRowPtrA, csrSortedColIndA, descrC,
                                      bsrSortedValC, bsrSortedRowPtrC, bsrSortedColIndC,
                                      rowBlockDim, colBlockDim, pBuffer)
-    initialize_api()
+    initialize_context()
     ccall((:cusparseDcsr2gebsr, libcusparse()), cusparseStatus_t,
                    (cusparseHandle_t, cusparseDirection_t, Cint, Cint, cusparseMatDescr_t,
                     CuPtr{Cdouble}, CuPtr{Cint}, CuPtr{Cint}, cusparseMatDescr_t,
@@ -4006,7 +4006,7 @@ end
                                      csrSortedRowPtrA, csrSortedColIndA, descrC,
                                      bsrSortedValC, bsrSortedRowPtrC, bsrSortedColIndC,
                                      rowBlockDim, colBlockDim, pBuffer)
-    initialize_api()
+    initialize_context()
     ccall((:cusparseCcsr2gebsr, libcusparse()), cusparseStatus_t,
                    (cusparseHandle_t, cusparseDirection_t, Cint, Cint, cusparseMatDescr_t,
                     CuPtr{cuComplex}, CuPtr{Cint}, CuPtr{Cint}, cusparseMatDescr_t,
@@ -4020,7 +4020,7 @@ end
                                      csrSortedRowPtrA, csrSortedColIndA, descrC,
                                      bsrSortedValC, bsrSortedRowPtrC, bsrSortedColIndC,
                                      rowBlockDim, colBlockDim, pBuffer)
-    initialize_api()
+    initialize_context()
     ccall((:cusparseZcsr2gebsr, libcusparse()), cusparseStatus_t,
                    (cusparseHandle_t, cusparseDirection_t, Cint, Cint, cusparseMatDescr_t,
                     CuPtr{cuDoubleComplex}, CuPtr{Cint}, CuPtr{Cint}, cusparseMatDescr_t,
@@ -4036,7 +4036,7 @@ end
                                                   bsrSortedColIndA, rowBlockDimA,
                                                   colBlockDimA, rowBlockDimC, colBlockDimC,
                                                   pBufferSizeInBytes)
-    initialize_api()
+    initialize_context()
     ccall((:cusparseSgebsr2gebsr_bufferSize, libcusparse()), cusparseStatus_t,
                    (cusparseHandle_t, cusparseDirection_t, Cint, Cint, Cint,
                     cusparseMatDescr_t, CuPtr{Cfloat}, CuPtr{Cint}, CuPtr{Cint}, Cint,
@@ -4051,7 +4051,7 @@ end
                                                   bsrSortedColIndA, rowBlockDimA,
                                                   colBlockDimA, rowBlockDimC, colBlockDimC,
                                                   pBufferSizeInBytes)
-    initialize_api()
+    initialize_context()
     ccall((:cusparseDgebsr2gebsr_bufferSize, libcusparse()), cusparseStatus_t,
                    (cusparseHandle_t, cusparseDirection_t, Cint, Cint, Cint,
                     cusparseMatDescr_t, CuPtr{Cdouble}, CuPtr{Cint}, CuPtr{Cint}, Cint,
@@ -4066,7 +4066,7 @@ end
                                                   bsrSortedColIndA, rowBlockDimA,
                                                   colBlockDimA, rowBlockDimC, colBlockDimC,
                                                   pBufferSizeInBytes)
-    initialize_api()
+    initialize_context()
     ccall((:cusparseCgebsr2gebsr_bufferSize, libcusparse()), cusparseStatus_t,
                    (cusparseHandle_t, cusparseDirection_t, Cint, Cint, Cint,
                     cusparseMatDescr_t, CuPtr{cuComplex}, CuPtr{Cint}, CuPtr{Cint}, Cint,
@@ -4081,7 +4081,7 @@ end
                                                   bsrSortedColIndA, rowBlockDimA,
                                                   colBlockDimA, rowBlockDimC, colBlockDimC,
                                                   pBufferSizeInBytes)
-    initialize_api()
+    initialize_context()
     ccall((:cusparseZgebsr2gebsr_bufferSize, libcusparse()), cusparseStatus_t,
                    (cusparseHandle_t, cusparseDirection_t, Cint, Cint, Cint,
                     cusparseMatDescr_t, CuPtr{cuDoubleComplex}, CuPtr{Cint}, CuPtr{Cint},
@@ -4096,7 +4096,7 @@ end
                                                      bsrSortedColIndA, rowBlockDimA,
                                                      colBlockDimA, rowBlockDimC,
                                                      colBlockDimC, pBufferSize)
-    initialize_api()
+    initialize_context()
     ccall((:cusparseSgebsr2gebsr_bufferSizeExt, libcusparse()), cusparseStatus_t,
                    (cusparseHandle_t, cusparseDirection_t, Cint, Cint, Cint,
                     cusparseMatDescr_t, CuPtr{Cfloat}, CuPtr{Cint}, CuPtr{Cint}, Cint,
@@ -4111,7 +4111,7 @@ end
                                                      bsrSortedColIndA, rowBlockDimA,
                                                      colBlockDimA, rowBlockDimC,
                                                      colBlockDimC, pBufferSize)
-    initialize_api()
+    initialize_context()
     ccall((:cusparseDgebsr2gebsr_bufferSizeExt, libcusparse()), cusparseStatus_t,
                    (cusparseHandle_t, cusparseDirection_t, Cint, Cint, Cint,
                     cusparseMatDescr_t, CuPtr{Cdouble}, CuPtr{Cint}, CuPtr{Cint}, Cint,
@@ -4126,7 +4126,7 @@ end
                                                      bsrSortedColIndA, rowBlockDimA,
                                                      colBlockDimA, rowBlockDimC,
                                                      colBlockDimC, pBufferSize)
-    initialize_api()
+    initialize_context()
     ccall((:cusparseCgebsr2gebsr_bufferSizeExt, libcusparse()), cusparseStatus_t,
                    (cusparseHandle_t, cusparseDirection_t, Cint, Cint, Cint,
                     cusparseMatDescr_t, CuPtr{cuComplex}, CuPtr{Cint}, CuPtr{Cint}, Cint,
@@ -4141,7 +4141,7 @@ end
                                                      bsrSortedColIndA, rowBlockDimA,
                                                      colBlockDimA, rowBlockDimC,
                                                      colBlockDimC, pBufferSize)
-    initialize_api()
+    initialize_context()
     ccall((:cusparseZgebsr2gebsr_bufferSizeExt, libcusparse()), cusparseStatus_t,
                    (cusparseHandle_t, cusparseDirection_t, Cint, Cint, Cint,
                     cusparseMatDescr_t, CuPtr{cuDoubleComplex}, CuPtr{Cint}, CuPtr{Cint},
@@ -4156,7 +4156,7 @@ end
                                           colBlockDimA, descrC, bsrSortedRowPtrC,
                                           rowBlockDimC, colBlockDimC, nnzTotalDevHostPtr,
                                           pBuffer)
-    initialize_api()
+    initialize_context()
     ccall((:cusparseXgebsr2gebsrNnz, libcusparse()), cusparseStatus_t,
                    (cusparseHandle_t, cusparseDirection_t, Cint, Cint, Cint,
                     cusparseMatDescr_t, CuPtr{Cint}, CuPtr{Cint}, Cint, Cint,
@@ -4172,7 +4172,7 @@ end
                                        colBlockDimA, descrC, bsrSortedValC,
                                        bsrSortedRowPtrC, bsrSortedColIndC, rowBlockDimC,
                                        colBlockDimC, pBuffer)
-    initialize_api()
+    initialize_context()
     ccall((:cusparseSgebsr2gebsr, libcusparse()), cusparseStatus_t,
                    (cusparseHandle_t, cusparseDirection_t, Cint, Cint, Cint,
                     cusparseMatDescr_t, CuPtr{Cfloat}, CuPtr{Cint}, CuPtr{Cint}, Cint,
@@ -4188,7 +4188,7 @@ end
                                        colBlockDimA, descrC, bsrSortedValC,
                                        bsrSortedRowPtrC, bsrSortedColIndC, rowBlockDimC,
                                        colBlockDimC, pBuffer)
-    initialize_api()
+    initialize_context()
     ccall((:cusparseDgebsr2gebsr, libcusparse()), cusparseStatus_t,
                    (cusparseHandle_t, cusparseDirection_t, Cint, Cint, Cint,
                     cusparseMatDescr_t, CuPtr{Cdouble}, CuPtr{Cint}, CuPtr{Cint}, Cint,
@@ -4204,7 +4204,7 @@ end
                                        colBlockDimA, descrC, bsrSortedValC,
                                        bsrSortedRowPtrC, bsrSortedColIndC, rowBlockDimC,
                                        colBlockDimC, pBuffer)
-    initialize_api()
+    initialize_context()
     ccall((:cusparseCgebsr2gebsr, libcusparse()), cusparseStatus_t,
                    (cusparseHandle_t, cusparseDirection_t, Cint, Cint, Cint,
                     cusparseMatDescr_t, CuPtr{cuComplex}, CuPtr{Cint}, CuPtr{Cint}, Cint,
@@ -4220,7 +4220,7 @@ end
                                        colBlockDimA, descrC, bsrSortedValC,
                                        bsrSortedRowPtrC, bsrSortedColIndC, rowBlockDimC,
                                        colBlockDimC, pBuffer)
-    initialize_api()
+    initialize_context()
     ccall((:cusparseZgebsr2gebsr, libcusparse()), cusparseStatus_t,
                    (cusparseHandle_t, cusparseDirection_t, Cint, Cint, Cint,
                     cusparseMatDescr_t, CuPtr{cuDoubleComplex}, CuPtr{Cint}, CuPtr{Cint},
@@ -4232,7 +4232,7 @@ end
 end
 
 @checked function cusparseCreateIdentityPermutation(handle, n, p)
-    initialize_api()
+    initialize_context()
     ccall((:cusparseCreateIdentityPermutation, libcusparse()), cusparseStatus_t,
                    (cusparseHandle_t, Cint, CuPtr{Cint}),
                    handle, n, p)
@@ -4240,7 +4240,7 @@ end
 
 @checked function cusparseXcoosort_bufferSizeExt(handle, m, n, nnz, cooRowsA, cooColsA,
                                                  pBufferSizeInBytes)
-    initialize_api()
+    initialize_context()
     ccall((:cusparseXcoosort_bufferSizeExt, libcusparse()), cusparseStatus_t,
                    (cusparseHandle_t, Cint, Cint, Cint, CuPtr{Cint}, CuPtr{Cint},
                     Ptr{Csize_t}),
@@ -4248,7 +4248,7 @@ end
 end
 
 @checked function cusparseXcoosortByRow(handle, m, n, nnz, cooRowsA, cooColsA, P, pBuffer)
-    initialize_api()
+    initialize_context()
     ccall((:cusparseXcoosortByRow, libcusparse()), cusparseStatus_t,
                    (cusparseHandle_t, Cint, Cint, Cint, CuPtr{Cint}, CuPtr{Cint},
                     CuPtr{Cint}, CuPtr{Cvoid}),
@@ -4256,7 +4256,7 @@ end
 end
 
 @checked function cusparseXcoosortByColumn(handle, m, n, nnz, cooRowsA, cooColsA, P, pBuffer)
-    initialize_api()
+    initialize_context()
     ccall((:cusparseXcoosortByColumn, libcusparse()), cusparseStatus_t,
                    (cusparseHandle_t, Cint, Cint, Cint, CuPtr{Cint}, CuPtr{Cint},
                     CuPtr{Cint}, CuPtr{Cvoid}),
@@ -4265,7 +4265,7 @@ end
 
 @checked function cusparseXcsrsort_bufferSizeExt(handle, m, n, nnz, csrRowPtrA, csrColIndA,
                                                  pBufferSizeInBytes)
-    initialize_api()
+    initialize_context()
     ccall((:cusparseXcsrsort_bufferSizeExt, libcusparse()), cusparseStatus_t,
                    (cusparseHandle_t, Cint, Cint, Cint, CuPtr{Cint}, CuPtr{Cint},
                     Ptr{Csize_t}),
@@ -4274,7 +4274,7 @@ end
 
 @checked function cusparseXcsrsort(handle, m, n, nnz, descrA, csrRowPtrA, csrColIndA, P,
                                    pBuffer)
-    initialize_api()
+    initialize_context()
     ccall((:cusparseXcsrsort, libcusparse()), cusparseStatus_t,
                    (cusparseHandle_t, Cint, Cint, Cint, cusparseMatDescr_t, CuPtr{Cint},
                     CuPtr{Cint}, CuPtr{Cint}, CuPtr{Cvoid}),
@@ -4283,7 +4283,7 @@ end
 
 @checked function cusparseXcscsort_bufferSizeExt(handle, m, n, nnz, cscColPtrA, cscRowIndA,
                                                  pBufferSizeInBytes)
-    initialize_api()
+    initialize_context()
     ccall((:cusparseXcscsort_bufferSizeExt, libcusparse()), cusparseStatus_t,
                    (cusparseHandle_t, Cint, Cint, Cint, CuPtr{Cint}, CuPtr{Cint},
                     Ptr{Csize_t}),
@@ -4292,7 +4292,7 @@ end
 
 @checked function cusparseXcscsort(handle, m, n, nnz, descrA, cscColPtrA, cscRowIndA, P,
                                    pBuffer)
-    initialize_api()
+    initialize_context()
     ccall((:cusparseXcscsort, libcusparse()), cusparseStatus_t,
                    (cusparseHandle_t, Cint, Cint, Cint, cusparseMatDescr_t, CuPtr{Cint},
                     CuPtr{Cint}, CuPtr{Cint}, CuPtr{Cvoid}),
@@ -4301,7 +4301,7 @@ end
 
 @checked function cusparseScsru2csr_bufferSizeExt(handle, m, n, nnz, csrVal, csrRowPtr,
                                                   csrColInd, info, pBufferSizeInBytes)
-    initialize_api()
+    initialize_context()
     ccall((:cusparseScsru2csr_bufferSizeExt, libcusparse()), cusparseStatus_t,
                    (cusparseHandle_t, Cint, Cint, Cint, CuPtr{Cfloat}, CuPtr{Cint},
                     CuPtr{Cint}, csru2csrInfo_t, Ptr{Csize_t}),
@@ -4311,7 +4311,7 @@ end
 
 @checked function cusparseDcsru2csr_bufferSizeExt(handle, m, n, nnz, csrVal, csrRowPtr,
                                                   csrColInd, info, pBufferSizeInBytes)
-    initialize_api()
+    initialize_context()
     ccall((:cusparseDcsru2csr_bufferSizeExt, libcusparse()), cusparseStatus_t,
                    (cusparseHandle_t, Cint, Cint, Cint, CuPtr{Cdouble}, CuPtr{Cint},
                     CuPtr{Cint}, csru2csrInfo_t, Ptr{Csize_t}),
@@ -4321,7 +4321,7 @@ end
 
 @checked function cusparseCcsru2csr_bufferSizeExt(handle, m, n, nnz, csrVal, csrRowPtr,
                                                   csrColInd, info, pBufferSizeInBytes)
-    initialize_api()
+    initialize_context()
     ccall((:cusparseCcsru2csr_bufferSizeExt, libcusparse()), cusparseStatus_t,
                    (cusparseHandle_t, Cint, Cint, Cint, CuPtr{cuComplex}, CuPtr{Cint},
                     CuPtr{Cint}, csru2csrInfo_t, Ptr{Csize_t}),
@@ -4331,7 +4331,7 @@ end
 
 @checked function cusparseZcsru2csr_bufferSizeExt(handle, m, n, nnz, csrVal, csrRowPtr,
                                                   csrColInd, info, pBufferSizeInBytes)
-    initialize_api()
+    initialize_context()
     ccall((:cusparseZcsru2csr_bufferSizeExt, libcusparse()), cusparseStatus_t,
                    (cusparseHandle_t, Cint, Cint, Cint, CuPtr{cuDoubleComplex},
                     CuPtr{Cint}, CuPtr{Cint}, csru2csrInfo_t, Ptr{Csize_t}),
@@ -4341,7 +4341,7 @@ end
 
 @checked function cusparseScsru2csr(handle, m, n, nnz, descrA, csrVal, csrRowPtr,
                                     csrColInd, info, pBuffer)
-    initialize_api()
+    initialize_context()
     ccall((:cusparseScsru2csr, libcusparse()), cusparseStatus_t,
                    (cusparseHandle_t, Cint, Cint, Cint, cusparseMatDescr_t, CuPtr{Cfloat},
                     CuPtr{Cint}, CuPtr{Cint}, csru2csrInfo_t, CuPtr{Cvoid}),
@@ -4350,7 +4350,7 @@ end
 
 @checked function cusparseDcsru2csr(handle, m, n, nnz, descrA, csrVal, csrRowPtr,
                                     csrColInd, info, pBuffer)
-    initialize_api()
+    initialize_context()
     ccall((:cusparseDcsru2csr, libcusparse()), cusparseStatus_t,
                    (cusparseHandle_t, Cint, Cint, Cint, cusparseMatDescr_t,
                     CuPtr{Cdouble}, CuPtr{Cint}, CuPtr{Cint}, csru2csrInfo_t, CuPtr{Cvoid}),
@@ -4359,7 +4359,7 @@ end
 
 @checked function cusparseCcsru2csr(handle, m, n, nnz, descrA, csrVal, csrRowPtr,
                                     csrColInd, info, pBuffer)
-    initialize_api()
+    initialize_context()
     ccall((:cusparseCcsru2csr, libcusparse()), cusparseStatus_t,
                    (cusparseHandle_t, Cint, Cint, Cint, cusparseMatDescr_t,
                     CuPtr{cuComplex}, CuPtr{Cint}, CuPtr{Cint}, csru2csrInfo_t,
@@ -4369,7 +4369,7 @@ end
 
 @checked function cusparseZcsru2csr(handle, m, n, nnz, descrA, csrVal, csrRowPtr,
                                     csrColInd, info, pBuffer)
-    initialize_api()
+    initialize_context()
     ccall((:cusparseZcsru2csr, libcusparse()), cusparseStatus_t,
                    (cusparseHandle_t, Cint, Cint, Cint, cusparseMatDescr_t,
                     CuPtr{cuDoubleComplex}, CuPtr{Cint}, CuPtr{Cint}, csru2csrInfo_t,
@@ -4379,7 +4379,7 @@ end
 
 @checked function cusparseScsr2csru(handle, m, n, nnz, descrA, csrVal, csrRowPtr,
                                     csrColInd, info, pBuffer)
-    initialize_api()
+    initialize_context()
     ccall((:cusparseScsr2csru, libcusparse()), cusparseStatus_t,
                    (cusparseHandle_t, Cint, Cint, Cint, cusparseMatDescr_t, CuPtr{Cfloat},
                     CuPtr{Cint}, CuPtr{Cint}, csru2csrInfo_t, CuPtr{Cvoid}),
@@ -4388,7 +4388,7 @@ end
 
 @checked function cusparseDcsr2csru(handle, m, n, nnz, descrA, csrVal, csrRowPtr,
                                     csrColInd, info, pBuffer)
-    initialize_api()
+    initialize_context()
     ccall((:cusparseDcsr2csru, libcusparse()), cusparseStatus_t,
                    (cusparseHandle_t, Cint, Cint, Cint, cusparseMatDescr_t,
                     CuPtr{Cdouble}, CuPtr{Cint}, CuPtr{Cint}, csru2csrInfo_t, CuPtr{Cvoid}),
@@ -4397,7 +4397,7 @@ end
 
 @checked function cusparseCcsr2csru(handle, m, n, nnz, descrA, csrVal, csrRowPtr,
                                     csrColInd, info, pBuffer)
-    initialize_api()
+    initialize_context()
     ccall((:cusparseCcsr2csru, libcusparse()), cusparseStatus_t,
                    (cusparseHandle_t, Cint, Cint, Cint, cusparseMatDescr_t,
                     CuPtr{cuComplex}, CuPtr{Cint}, CuPtr{Cint}, csru2csrInfo_t,
@@ -4407,7 +4407,7 @@ end
 
 @checked function cusparseZcsr2csru(handle, m, n, nnz, descrA, csrVal, csrRowPtr,
                                     csrColInd, info, pBuffer)
-    initialize_api()
+    initialize_context()
     ccall((:cusparseZcsr2csru, libcusparse()), cusparseStatus_t,
                    (cusparseHandle_t, Cint, Cint, Cint, cusparseMatDescr_t,
                     CuPtr{cuDoubleComplex}, CuPtr{Cint}, CuPtr{Cint}, csru2csrInfo_t,
@@ -4419,7 +4419,7 @@ end
                                                         descrC, csrSortedValC,
                                                         csrSortedRowPtrC, csrSortedColIndC,
                                                         pBufferSizeInBytes)
-    initialize_api()
+    initialize_context()
     ccall((:cusparseSpruneDense2csr_bufferSizeExt, libcusparse()), cusparseStatus_t,
                    (cusparseHandle_t, Cint, Cint, CuPtr{Cfloat}, Cint, Ptr{Cfloat},
                     cusparseMatDescr_t, CuPtr{Cfloat}, CuPtr{Cint}, CuPtr{Cint},
@@ -4432,7 +4432,7 @@ end
                                                         descrC, csrSortedValC,
                                                         csrSortedRowPtrC, csrSortedColIndC,
                                                         pBufferSizeInBytes)
-    initialize_api()
+    initialize_context()
     ccall((:cusparseDpruneDense2csr_bufferSizeExt, libcusparse()), cusparseStatus_t,
                    (cusparseHandle_t, Cint, Cint, CuPtr{Cdouble}, Cint, Ptr{Cdouble},
                     cusparseMatDescr_t, CuPtr{Cdouble}, CuPtr{Cint}, CuPtr{Cint},
@@ -4443,7 +4443,7 @@ end
 
 @checked function cusparseSpruneDense2csrNnz(handle, m, n, A, lda, threshold, descrC,
                                              csrRowPtrC, nnzTotalDevHostPtr, pBuffer)
-    initialize_api()
+    initialize_context()
     ccall((:cusparseSpruneDense2csrNnz, libcusparse()), cusparseStatus_t,
                    (cusparseHandle_t, Cint, Cint, CuPtr{Cfloat}, Cint, Ptr{Cfloat},
                     cusparseMatDescr_t, CuPtr{Cint}, PtrOrCuPtr{Cint}, CuPtr{Cvoid}),
@@ -4453,7 +4453,7 @@ end
 
 @checked function cusparseDpruneDense2csrNnz(handle, m, n, A, lda, threshold, descrC,
                                              csrSortedRowPtrC, nnzTotalDevHostPtr, pBuffer)
-    initialize_api()
+    initialize_context()
     ccall((:cusparseDpruneDense2csrNnz, libcusparse()), cusparseStatus_t,
                    (cusparseHandle_t, Cint, Cint, CuPtr{Cdouble}, Cint, Ptr{Cdouble},
                     cusparseMatDescr_t, CuPtr{Cint}, PtrOrCuPtr{Cint}, CuPtr{Cvoid}),
@@ -4464,7 +4464,7 @@ end
 @checked function cusparseSpruneDense2csr(handle, m, n, A, lda, threshold, descrC,
                                           csrSortedValC, csrSortedRowPtrC,
                                           csrSortedColIndC, pBuffer)
-    initialize_api()
+    initialize_context()
     ccall((:cusparseSpruneDense2csr, libcusparse()), cusparseStatus_t,
                    (cusparseHandle_t, Cint, Cint, CuPtr{Cfloat}, Cint, Ptr{Cfloat},
                     cusparseMatDescr_t, CuPtr{Cfloat}, CuPtr{Cint}, CuPtr{Cint},
@@ -4476,7 +4476,7 @@ end
 @checked function cusparseDpruneDense2csr(handle, m, n, A, lda, threshold, descrC,
                                           csrSortedValC, csrSortedRowPtrC,
                                           csrSortedColIndC, pBuffer)
-    initialize_api()
+    initialize_context()
     ccall((:cusparseDpruneDense2csr, libcusparse()), cusparseStatus_t,
                    (cusparseHandle_t, Cint, Cint, CuPtr{Cdouble}, Cint, Ptr{Cdouble},
                     cusparseMatDescr_t, CuPtr{Cdouble}, CuPtr{Cint}, CuPtr{Cint},
@@ -4490,7 +4490,7 @@ end
                                                       csrSortedColIndA, threshold, descrC,
                                                       csrSortedValC, csrSortedRowPtrC,
                                                       csrSortedColIndC, pBufferSizeInBytes)
-    initialize_api()
+    initialize_context()
     ccall((:cusparseSpruneCsr2csr_bufferSizeExt, libcusparse()), cusparseStatus_t,
                    (cusparseHandle_t, Cint, Cint, Cint, cusparseMatDescr_t, CuPtr{Cfloat},
                     CuPtr{Cint}, CuPtr{Cint}, Ptr{Cfloat}, cusparseMatDescr_t,
@@ -4505,7 +4505,7 @@ end
                                                       csrSortedColIndA, threshold, descrC,
                                                       csrSortedValC, csrSortedRowPtrC,
                                                       csrSortedColIndC, pBufferSizeInBytes)
-    initialize_api()
+    initialize_context()
     ccall((:cusparseDpruneCsr2csr_bufferSizeExt, libcusparse()), cusparseStatus_t,
                    (cusparseHandle_t, Cint, Cint, Cint, cusparseMatDescr_t,
                     CuPtr{Cdouble}, CuPtr{Cint}, CuPtr{Cint}, Ptr{Cdouble},
@@ -4520,7 +4520,7 @@ end
                                            csrSortedRowPtrA, csrSortedColIndA, threshold,
                                            descrC, csrSortedRowPtrC, nnzTotalDevHostPtr,
                                            pBuffer)
-    initialize_api()
+    initialize_context()
     ccall((:cusparseSpruneCsr2csrNnz, libcusparse()), cusparseStatus_t,
                    (cusparseHandle_t, Cint, Cint, Cint, cusparseMatDescr_t, CuPtr{Cfloat},
                     CuPtr{Cint}, CuPtr{Cint}, Ptr{Cfloat}, cusparseMatDescr_t, CuPtr{Cint},
@@ -4534,7 +4534,7 @@ end
                                            csrSortedRowPtrA, csrSortedColIndA, threshold,
                                            descrC, csrSortedRowPtrC, nnzTotalDevHostPtr,
                                            pBuffer)
-    initialize_api()
+    initialize_context()
     ccall((:cusparseDpruneCsr2csrNnz, libcusparse()), cusparseStatus_t,
                    (cusparseHandle_t, Cint, Cint, Cint, cusparseMatDescr_t,
                     CuPtr{Cdouble}, CuPtr{Cint}, CuPtr{Cint}, Ptr{Cdouble},
@@ -4548,7 +4548,7 @@ end
                                         csrSortedRowPtrA, csrSortedColIndA, threshold,
                                         descrC, csrSortedValC, csrSortedRowPtrC,
                                         csrSortedColIndC, pBuffer)
-    initialize_api()
+    initialize_context()
     ccall((:cusparseSpruneCsr2csr, libcusparse()), cusparseStatus_t,
                    (cusparseHandle_t, Cint, Cint, Cint, cusparseMatDescr_t, CuPtr{Cfloat},
                     CuPtr{Cint}, CuPtr{Cint}, Ptr{Cfloat}, cusparseMatDescr_t,
@@ -4562,7 +4562,7 @@ end
                                         csrSortedRowPtrA, csrSortedColIndA, threshold,
                                         descrC, csrSortedValC, csrSortedRowPtrC,
                                         csrSortedColIndC, pBuffer)
-    initialize_api()
+    initialize_context()
     ccall((:cusparseDpruneCsr2csr, libcusparse()), cusparseStatus_t,
                    (cusparseHandle_t, Cint, Cint, Cint, cusparseMatDescr_t,
                     CuPtr{Cdouble}, CuPtr{Cint}, CuPtr{Cint}, Ptr{Cdouble},
@@ -4579,7 +4579,7 @@ end
                                                                     csrSortedRowPtrC,
                                                                     csrSortedColIndC, info,
                                                                     pBufferSizeInBytes)
-    initialize_api()
+    initialize_context()
     ccall((:cusparseSpruneDense2csrByPercentage_bufferSizeExt, libcusparse()), cusparseStatus_t,
                    (cusparseHandle_t, Cint, Cint, CuPtr{Cfloat}, Cint, Cfloat,
                     cusparseMatDescr_t, CuPtr{Cfloat}, CuPtr{Cint}, CuPtr{Cint},
@@ -4594,7 +4594,7 @@ end
                                                                     csrSortedRowPtrC,
                                                                     csrSortedColIndC, info,
                                                                     pBufferSizeInBytes)
-    initialize_api()
+    initialize_context()
     ccall((:cusparseDpruneDense2csrByPercentage_bufferSizeExt, libcusparse()), cusparseStatus_t,
                    (cusparseHandle_t, Cint, Cint, CuPtr{Cdouble}, Cint, Cfloat,
                     cusparseMatDescr_t, CuPtr{Cdouble}, CuPtr{Cint}, CuPtr{Cint},
@@ -4606,7 +4606,7 @@ end
 @checked function cusparseSpruneDense2csrNnzByPercentage(handle, m, n, A, lda, percentage,
                                                          descrC, csrRowPtrC,
                                                          nnzTotalDevHostPtr, info, pBuffer)
-    initialize_api()
+    initialize_context()
     ccall((:cusparseSpruneDense2csrNnzByPercentage, libcusparse()), cusparseStatus_t,
                    (cusparseHandle_t, Cint, Cint, CuPtr{Cfloat}, Cint, Cfloat,
                     cusparseMatDescr_t, CuPtr{Cint}, PtrOrCuPtr{Cint}, pruneInfo_t,
@@ -4618,7 +4618,7 @@ end
 @checked function cusparseDpruneDense2csrNnzByPercentage(handle, m, n, A, lda, percentage,
                                                          descrC, csrRowPtrC,
                                                          nnzTotalDevHostPtr, info, pBuffer)
-    initialize_api()
+    initialize_context()
     ccall((:cusparseDpruneDense2csrNnzByPercentage, libcusparse()), cusparseStatus_t,
                    (cusparseHandle_t, Cint, Cint, CuPtr{Cdouble}, Cint, Cfloat,
                     cusparseMatDescr_t, CuPtr{Cint}, PtrOrCuPtr{Cint}, pruneInfo_t,
@@ -4631,7 +4631,7 @@ end
                                                       descrC, csrSortedValC,
                                                       csrSortedRowPtrC, csrSortedColIndC,
                                                       info, pBuffer)
-    initialize_api()
+    initialize_context()
     ccall((:cusparseSpruneDense2csrByPercentage, libcusparse()), cusparseStatus_t,
                    (cusparseHandle_t, Cint, Cint, CuPtr{Cfloat}, Cint, Cfloat,
                     cusparseMatDescr_t, CuPtr{Cfloat}, CuPtr{Cint}, CuPtr{Cint},
@@ -4644,7 +4644,7 @@ end
                                                       descrC, csrSortedValC,
                                                       csrSortedRowPtrC, csrSortedColIndC,
                                                       info, pBuffer)
-    initialize_api()
+    initialize_context()
     ccall((:cusparseDpruneDense2csrByPercentage, libcusparse()), cusparseStatus_t,
                    (cusparseHandle_t, Cint, Cint, CuPtr{Cdouble}, Cint, Cfloat,
                     cusparseMatDescr_t, CuPtr{Cdouble}, CuPtr{Cint}, CuPtr{Cint},
@@ -4662,7 +4662,7 @@ end
                                                                   csrSortedRowPtrC,
                                                                   csrSortedColIndC, info,
                                                                   pBufferSizeInBytes)
-    initialize_api()
+    initialize_context()
     ccall((:cusparseSpruneCsr2csrByPercentage_bufferSizeExt, libcusparse()), cusparseStatus_t,
                    (cusparseHandle_t, Cint, Cint, Cint, cusparseMatDescr_t, CuPtr{Cfloat},
                     CuPtr{Cint}, CuPtr{Cint}, Cfloat, cusparseMatDescr_t, CuPtr{Cfloat},
@@ -4681,7 +4681,7 @@ end
                                                                   csrSortedRowPtrC,
                                                                   csrSortedColIndC, info,
                                                                   pBufferSizeInBytes)
-    initialize_api()
+    initialize_context()
     ccall((:cusparseDpruneCsr2csrByPercentage_bufferSizeExt, libcusparse()), cusparseStatus_t,
                    (cusparseHandle_t, Cint, Cint, Cint, cusparseMatDescr_t,
                     CuPtr{Cdouble}, CuPtr{Cint}, CuPtr{Cint}, Cfloat, cusparseMatDescr_t,
@@ -4696,7 +4696,7 @@ end
                                                        csrSortedColIndA, percentage,
                                                        descrC, csrSortedRowPtrC,
                                                        nnzTotalDevHostPtr, info, pBuffer)
-    initialize_api()
+    initialize_context()
     ccall((:cusparseSpruneCsr2csrNnzByPercentage, libcusparse()), cusparseStatus_t,
                    (cusparseHandle_t, Cint, Cint, Cint, cusparseMatDescr_t, CuPtr{Cfloat},
                     CuPtr{Cint}, CuPtr{Cint}, Cfloat, cusparseMatDescr_t, CuPtr{Cint},
@@ -4711,7 +4711,7 @@ end
                                                        csrSortedColIndA, percentage,
                                                        descrC, csrSortedRowPtrC,
                                                        nnzTotalDevHostPtr, info, pBuffer)
-    initialize_api()
+    initialize_context()
     ccall((:cusparseDpruneCsr2csrNnzByPercentage, libcusparse()), cusparseStatus_t,
                    (cusparseHandle_t, Cint, Cint, Cint, cusparseMatDescr_t,
                     CuPtr{Cdouble}, CuPtr{Cint}, CuPtr{Cint}, Cfloat, cusparseMatDescr_t,
@@ -4726,7 +4726,7 @@ end
                                                     csrSortedColIndA, percentage, descrC,
                                                     csrSortedValC, csrSortedRowPtrC,
                                                     csrSortedColIndC, info, pBuffer)
-    initialize_api()
+    initialize_context()
     ccall((:cusparseSpruneCsr2csrByPercentage, libcusparse()), cusparseStatus_t,
                    (cusparseHandle_t, Cint, Cint, Cint, cusparseMatDescr_t, CuPtr{Cfloat},
                     CuPtr{Cint}, CuPtr{Cint}, Cfloat, cusparseMatDescr_t, CuPtr{Cfloat},
@@ -4741,7 +4741,7 @@ end
                                                     csrSortedColIndA, percentage, descrC,
                                                     csrSortedValC, csrSortedRowPtrC,
                                                     csrSortedColIndC, info, pBuffer)
-    initialize_api()
+    initialize_context()
     ccall((:cusparseDpruneCsr2csrByPercentage, libcusparse()), cusparseStatus_t,
                    (cusparseHandle_t, Cint, Cint, Cint, cusparseMatDescr_t,
                     CuPtr{Cdouble}, CuPtr{Cint}, CuPtr{Cint}, Cfloat, cusparseMatDescr_t,
@@ -4754,7 +4754,7 @@ end
 @checked function cusparseCsr2cscEx2(handle, m, n, nnz, csrVal, csrRowPtr, csrColInd,
                                      cscVal, cscColPtr, cscRowInd, valType, copyValues,
                                      idxBase, alg, buffer)
-    initialize_api()
+    initialize_context()
     ccall((:cusparseCsr2cscEx2, libcusparse()), cusparseStatus_t,
                    (cusparseHandle_t, Cint, Cint, Cint, CuPtr{Cvoid}, CuPtr{Cint},
                     CuPtr{Cint}, CuPtr{Cvoid}, CuPtr{Cint}, CuPtr{Cint}, cudaDataType,
@@ -4768,7 +4768,7 @@ end
                                                 csrColInd, cscVal, cscColPtr, cscRowInd,
                                                 valType, copyValues, idxBase, alg,
                                                 bufferSize)
-    initialize_api()
+    initialize_context()
     ccall((:cusparseCsr2cscEx2_bufferSize, libcusparse()), cusparseStatus_t,
                    (cusparseHandle_t, Cint, Cint, Cint, CuPtr{Cvoid}, CuPtr{Cint},
                     CuPtr{Cint}, CuPtr{Cvoid}, CuPtr{Cint}, CuPtr{Cint}, cudaDataType,
@@ -4780,7 +4780,7 @@ end
 
 @checked function cusparseCreateSpVec(spVecDescr, size, nnz, indices, values, idxType,
                                       idxBase, valueType)
-    initialize_api()
+    initialize_context()
     ccall((:cusparseCreateSpVec, libcusparse()), cusparseStatus_t,
                    (Ptr{cusparseSpVecDescr_t}, Int64, Int64, CuPtr{Cvoid}, CuPtr{Cvoid},
                     cusparseIndexType_t, cusparseIndexBase_t, cudaDataType),
@@ -4788,7 +4788,7 @@ end
 end
 
 @checked function cusparseDestroySpVec(spVecDescr)
-    initialize_api()
+    initialize_context()
     ccall((:cusparseDestroySpVec, libcusparse()), cusparseStatus_t,
                    (cusparseSpVecDescr_t,),
                    spVecDescr)
@@ -4796,7 +4796,7 @@ end
 
 @checked function cusparseSpVecGet(spVecDescr, size, nnz, indices, values, idxType,
                                    idxBase, valueType)
-    initialize_api()
+    initialize_context()
     ccall((:cusparseSpVecGet, libcusparse()), cusparseStatus_t,
                    (cusparseSpVecDescr_t, Ptr{Int64}, Ptr{Int64}, CuPtr{Ptr{Cvoid}},
                     CuPtr{Ptr{Cvoid}}, Ptr{cusparseIndexType_t}, Ptr{cusparseIndexBase_t},
@@ -4805,119 +4805,119 @@ end
 end
 
 @checked function cusparseSpVecGetIndexBase(spVecDescr, idxBase)
-    initialize_api()
+    initialize_context()
     ccall((:cusparseSpVecGetIndexBase, libcusparse()), cusparseStatus_t,
                    (cusparseSpVecDescr_t, Ptr{cusparseIndexBase_t}),
                    spVecDescr, idxBase)
 end
 
 @checked function cusparseSpVecGetValues(spVecDescr, values)
-    initialize_api()
+    initialize_context()
     ccall((:cusparseSpVecGetValues, libcusparse()), cusparseStatus_t,
                    (cusparseSpVecDescr_t, CuPtr{Ptr{Cvoid}}),
                    spVecDescr, values)
 end
 
 @checked function cusparseSpVecSetValues(spVecDescr, values)
-    initialize_api()
+    initialize_context()
     ccall((:cusparseSpVecSetValues, libcusparse()), cusparseStatus_t,
                    (cusparseSpVecDescr_t, CuPtr{Cvoid}),
                    spVecDescr, values)
 end
 
 @checked function cusparseCreateDnVec(dnVecDescr, size, values, valueType)
-    initialize_api()
+    initialize_context()
     ccall((:cusparseCreateDnVec, libcusparse()), cusparseStatus_t,
                    (Ptr{cusparseDnVecDescr_t}, Int64, CuPtr{Cvoid}, cudaDataType),
                    dnVecDescr, size, values, valueType)
 end
 
 @checked function cusparseDestroyDnVec(dnVecDescr)
-    initialize_api()
+    initialize_context()
     ccall((:cusparseDestroyDnVec, libcusparse()), cusparseStatus_t,
                    (cusparseDnVecDescr_t,),
                    dnVecDescr)
 end
 
 @checked function cusparseDnVecGet(dnVecDescr, size, values, valueType)
-    initialize_api()
+    initialize_context()
     ccall((:cusparseDnVecGet, libcusparse()), cusparseStatus_t,
                    (cusparseDnVecDescr_t, Ptr{Int64}, CuPtr{Ptr{Cvoid}}, Ptr{cudaDataType}),
                    dnVecDescr, size, values, valueType)
 end
 
 @checked function cusparseDnVecGetValues(dnVecDescr, values)
-    initialize_api()
+    initialize_context()
     ccall((:cusparseDnVecGetValues, libcusparse()), cusparseStatus_t,
                    (cusparseDnVecDescr_t, CuPtr{Ptr{Cvoid}}),
                    dnVecDescr, values)
 end
 
 @checked function cusparseDnVecSetValues(dnVecDescr, values)
-    initialize_api()
+    initialize_context()
     ccall((:cusparseDnVecSetValues, libcusparse()), cusparseStatus_t,
                    (cusparseDnVecDescr_t, CuPtr{Cvoid}),
                    dnVecDescr, values)
 end
 
 @checked function cusparseDestroySpMat(spMatDescr)
-    initialize_api()
+    initialize_context()
     ccall((:cusparseDestroySpMat, libcusparse()), cusparseStatus_t,
                    (cusparseSpMatDescr_t,),
                    spMatDescr)
 end
 
 @checked function cusparseSpMatGetFormat(spMatDescr, format)
-    initialize_api()
+    initialize_context()
     ccall((:cusparseSpMatGetFormat, libcusparse()), cusparseStatus_t,
                    (cusparseSpMatDescr_t, Ptr{cusparseFormat_t}),
                    spMatDescr, format)
 end
 
 @checked function cusparseSpMatGetIndexBase(spMatDescr, idxBase)
-    initialize_api()
+    initialize_context()
     ccall((:cusparseSpMatGetIndexBase, libcusparse()), cusparseStatus_t,
                    (cusparseSpMatDescr_t, Ptr{cusparseIndexBase_t}),
                    spMatDescr, idxBase)
 end
 
 @checked function cusparseSpMatGetValues(spMatDescr, values)
-    initialize_api()
+    initialize_context()
     ccall((:cusparseSpMatGetValues, libcusparse()), cusparseStatus_t,
                    (cusparseSpMatDescr_t, CuPtr{Ptr{Cvoid}}),
                    spMatDescr, values)
 end
 
 @checked function cusparseSpMatSetValues(spMatDescr, values)
-    initialize_api()
+    initialize_context()
     ccall((:cusparseSpMatSetValues, libcusparse()), cusparseStatus_t,
                    (cusparseSpMatDescr_t, CuPtr{Cvoid}),
                    spMatDescr, values)
 end
 
 @checked function cusparseSpMatGetSize(spMatDescr, rows, cols, nnz)
-    initialize_api()
+    initialize_context()
     ccall((:cusparseSpMatGetSize, libcusparse()), cusparseStatus_t,
                    (cusparseSpMatDescr_t, Ptr{Int64}, Ptr{Int64}, Ptr{Int64}),
                    spMatDescr, rows, cols, nnz)
 end
 
 @checked function cusparseSpMatSetStridedBatch(spMatDescr, batchCount)
-    initialize_api()
+    initialize_context()
     ccall((:cusparseSpMatSetStridedBatch, libcusparse()), cusparseStatus_t,
                    (cusparseSpMatDescr_t, Cint),
                    spMatDescr, batchCount)
 end
 
 @checked function cusparseSpMatGetStridedBatch(spMatDescr, batchCount)
-    initialize_api()
+    initialize_context()
     ccall((:cusparseSpMatGetStridedBatch, libcusparse()), cusparseStatus_t,
                    (cusparseSpMatDescr_t, Ptr{Cint}),
                    spMatDescr, batchCount)
 end
 
 @checked function cusparseCooSetStridedBatch(spMatDescr, batchCount, batchStride)
-    initialize_api()
+    initialize_context()
     ccall((:cusparseCooSetStridedBatch, libcusparse()), cusparseStatus_t,
                    (cusparseSpMatDescr_t, Cint, Int64),
                    spMatDescr, batchCount, batchStride)
@@ -4925,7 +4925,7 @@ end
 
 @checked function cusparseCsrSetStridedBatch(spMatDescr, batchCount, offsetsBatchStride,
                                              columnsValuesBatchStride)
-    initialize_api()
+    initialize_context()
     ccall((:cusparseCsrSetStridedBatch, libcusparse()), cusparseStatus_t,
                    (cusparseSpMatDescr_t, Cint, Int64, Int64),
                    spMatDescr, batchCount, offsetsBatchStride, columnsValuesBatchStride)
@@ -4934,7 +4934,7 @@ end
 @checked function cusparseCreateCsr(spMatDescr, rows, cols, nnz, csrRowOffsets, csrColInd,
                                     csrValues, csrRowOffsetsType, csrColIndType, idxBase,
                                     valueType)
-    initialize_api()
+    initialize_context()
     ccall((:cusparseCreateCsr, libcusparse()), cusparseStatus_t,
                    (Ptr{cusparseSpMatDescr_t}, Int64, Int64, Int64, CuPtr{Cvoid},
                     CuPtr{Cvoid}, CuPtr{Cvoid}, cusparseIndexType_t, cusparseIndexType_t,
@@ -4946,7 +4946,7 @@ end
 @checked function cusparseCsrGet(spMatDescr, rows, cols, nnz, csrRowOffsets, csrColInd,
                                  csrValues, csrRowOffsetsType, csrColIndType, idxBase,
                                  valueType)
-    initialize_api()
+    initialize_context()
     ccall((:cusparseCsrGet, libcusparse()), cusparseStatus_t,
                    (cusparseSpMatDescr_t, Ptr{Int64}, Ptr{Int64}, Ptr{Int64},
                     CuPtr{Ptr{Cvoid}}, CuPtr{Ptr{Cvoid}}, CuPtr{Ptr{Cvoid}},
@@ -4957,7 +4957,7 @@ end
 end
 
 @checked function cusparseCsrSetPointers(spMatDescr, csrRowOffsets, csrColInd, csrValues)
-    initialize_api()
+    initialize_context()
     ccall((:cusparseCsrSetPointers, libcusparse()), cusparseStatus_t,
                    (cusparseSpMatDescr_t, CuPtr{Cvoid}, CuPtr{Cvoid}, CuPtr{Cvoid}),
                    spMatDescr, csrRowOffsets, csrColInd, csrValues)
@@ -4965,7 +4965,7 @@ end
 
 @checked function cusparseCreateCoo(spMatDescr, rows, cols, nnz, cooRowInd, cooColInd,
                                     cooValues, cooIdxType, idxBase, valueType)
-    initialize_api()
+    initialize_context()
     ccall((:cusparseCreateCoo, libcusparse()), cusparseStatus_t,
                    (Ptr{cusparseSpMatDescr_t}, Int64, Int64, Int64, CuPtr{Cvoid},
                     CuPtr{Cvoid}, CuPtr{Cvoid}, cusparseIndexType_t, cusparseIndexBase_t,
@@ -4976,7 +4976,7 @@ end
 
 @checked function cusparseCreateCooAoS(spMatDescr, rows, cols, nnz, cooInd, cooValues,
                                        cooIdxType, idxBase, valueType)
-    initialize_api()
+    initialize_context()
     ccall((:cusparseCreateCooAoS, libcusparse()), cusparseStatus_t,
                    (Ptr{cusparseSpMatDescr_t}, Int64, Int64, Int64, CuPtr{Cvoid},
                     CuPtr{Cvoid}, cusparseIndexType_t, cusparseIndexBase_t, cudaDataType),
@@ -4986,7 +4986,7 @@ end
 
 @checked function cusparseCooGet(spMatDescr, rows, cols, nnz, cooRowInd, cooColInd,
                                  cooValues, idxType, idxBase, valueType)
-    initialize_api()
+    initialize_context()
     ccall((:cusparseCooGet, libcusparse()), cusparseStatus_t,
                    (cusparseSpMatDescr_t, Ptr{Int64}, Ptr{Int64}, Ptr{Int64},
                     CuPtr{Ptr{Cvoid}}, CuPtr{Ptr{Cvoid}}, CuPtr{Ptr{Cvoid}},
@@ -4997,7 +4997,7 @@ end
 
 @checked function cusparseCooAoSGet(spMatDescr, rows, cols, nnz, cooInd, cooValues,
                                     idxType, idxBase, valueType)
-    initialize_api()
+    initialize_context()
     ccall((:cusparseCooAoSGet, libcusparse()), cusparseStatus_t,
                    (cusparseSpMatDescr_t, Ptr{Int64}, Ptr{Int64}, Ptr{Int64},
                     CuPtr{Ptr{Cvoid}}, CuPtr{Ptr{Cvoid}}, Ptr{cusparseIndexType_t},
@@ -5007,7 +5007,7 @@ end
 end
 
 @checked function cusparseCreateDnMat(dnMatDescr, rows, cols, ld, values, valueType, order)
-    initialize_api()
+    initialize_context()
     ccall((:cusparseCreateDnMat, libcusparse()), cusparseStatus_t,
                    (Ptr{cusparseDnMatDescr_t}, Int64, Int64, Int64, CuPtr{Cvoid},
                     cudaDataType, cusparseOrder_t),
@@ -5015,14 +5015,14 @@ end
 end
 
 @checked function cusparseDestroyDnMat(dnMatDescr)
-    initialize_api()
+    initialize_context()
     ccall((:cusparseDestroyDnMat, libcusparse()), cusparseStatus_t,
                    (cusparseDnMatDescr_t,),
                    dnMatDescr)
 end
 
 @checked function cusparseDnMatGet(dnMatDescr, rows, cols, ld, values, type, order)
-    initialize_api()
+    initialize_context()
     ccall((:cusparseDnMatGet, libcusparse()), cusparseStatus_t,
                    (cusparseDnMatDescr_t, Ptr{Int64}, Ptr{Int64}, Ptr{Int64},
                     CuPtr{Ptr{Cvoid}}, Ptr{cudaDataType}, Ptr{cusparseOrder_t}),
@@ -5030,35 +5030,35 @@ end
 end
 
 @checked function cusparseDnMatGetValues(dnMatDescr, values)
-    initialize_api()
+    initialize_context()
     ccall((:cusparseDnMatGetValues, libcusparse()), cusparseStatus_t,
                    (cusparseDnMatDescr_t, CuPtr{Ptr{Cvoid}}),
                    dnMatDescr, values)
 end
 
 @checked function cusparseDnMatSetValues(dnMatDescr, values)
-    initialize_api()
+    initialize_context()
     ccall((:cusparseDnMatSetValues, libcusparse()), cusparseStatus_t,
                    (cusparseDnMatDescr_t, CuPtr{Cvoid}),
                    dnMatDescr, values)
 end
 
 @checked function cusparseDnMatSetStridedBatch(dnMatDescr, batchCount, batchStride)
-    initialize_api()
+    initialize_context()
     ccall((:cusparseDnMatSetStridedBatch, libcusparse()), cusparseStatus_t,
                    (cusparseDnMatDescr_t, Cint, Int64),
                    dnMatDescr, batchCount, batchStride)
 end
 
 @checked function cusparseDnMatGetStridedBatch(dnMatDescr, batchCount, batchStride)
-    initialize_api()
+    initialize_context()
     ccall((:cusparseDnMatGetStridedBatch, libcusparse()), cusparseStatus_t,
                    (cusparseDnMatDescr_t, Ptr{Cint}, Ptr{Int64}),
                    dnMatDescr, batchCount, batchStride)
 end
 
 @checked function cusparseAxpby(handle, alpha, vecX, beta, vecY)
-    initialize_api()
+    initialize_context()
     ccall((:cusparseAxpby, libcusparse()), cusparseStatus_t,
                    (cusparseHandle_t, PtrOrCuPtr{Cvoid}, cusparseSpVecDescr_t,
                     PtrOrCuPtr{Cvoid}, cusparseDnVecDescr_t),
@@ -5066,21 +5066,21 @@ end
 end
 
 @checked function cusparseGather(handle, vecY, vecX)
-    initialize_api()
+    initialize_context()
     ccall((:cusparseGather, libcusparse()), cusparseStatus_t,
                    (cusparseHandle_t, cusparseDnVecDescr_t, cusparseSpVecDescr_t),
                    handle, vecY, vecX)
 end
 
 @checked function cusparseScatter(handle, vecX, vecY)
-    initialize_api()
+    initialize_context()
     ccall((:cusparseScatter, libcusparse()), cusparseStatus_t,
                    (cusparseHandle_t, cusparseSpVecDescr_t, cusparseDnVecDescr_t),
                    handle, vecX, vecY)
 end
 
 @checked function cusparseRot(handle, c_coeff, s_coeff, vecX, vecY)
-    initialize_api()
+    initialize_context()
     ccall((:cusparseRot, libcusparse()), cusparseStatus_t,
                    (cusparseHandle_t, PtrOrCuPtr{Cvoid}, PtrOrCuPtr{Cvoid},
                     cusparseSpVecDescr_t, cusparseDnVecDescr_t),
@@ -5089,7 +5089,7 @@ end
 
 @checked function cusparseSpVV_bufferSize(handle, opX, vecX, vecY, result, computeType,
                                           bufferSize)
-    initialize_api()
+    initialize_context()
     ccall((:cusparseSpVV_bufferSize, libcusparse()), cusparseStatus_t,
                    (cusparseHandle_t, cusparseOperation_t, cusparseSpVecDescr_t,
                     cusparseDnVecDescr_t, PtrOrCuPtr{Cvoid}, cudaDataType, Ptr{Csize_t}),
@@ -5097,7 +5097,7 @@ end
 end
 
 @checked function cusparseSpVV(handle, opX, vecX, vecY, result, computeType, externalBuffer)
-    initialize_api()
+    initialize_context()
     ccall((:cusparseSpVV, libcusparse()), cusparseStatus_t,
                    (cusparseHandle_t, cusparseOperation_t, cusparseSpVecDescr_t,
                     cusparseDnVecDescr_t, PtrOrCuPtr{Cvoid}, cudaDataType, CuPtr{Cvoid}),
@@ -5106,7 +5106,7 @@ end
 
 @checked function cusparseSpMV(handle, opA, alpha, matA, vecX, beta, vecY, computeType,
                                alg, externalBuffer)
-    initialize_api()
+    initialize_context()
     ccall((:cusparseSpMV, libcusparse()), cusparseStatus_t,
                    (cusparseHandle_t, cusparseOperation_t, PtrOrCuPtr{Cvoid},
                     cusparseSpMatDescr_t, cusparseDnVecDescr_t, PtrOrCuPtr{Cvoid},
@@ -5117,7 +5117,7 @@ end
 
 @checked function cusparseSpMV_bufferSize(handle, opA, alpha, matA, vecX, beta, vecY,
                                           computeType, alg, bufferSize)
-    initialize_api()
+    initialize_context()
     ccall((:cusparseSpMV_bufferSize, libcusparse()), cusparseStatus_t,
                    (cusparseHandle_t, cusparseOperation_t, Ptr{Cvoid},
                     cusparseSpMatDescr_t, cusparseDnVecDescr_t, Ptr{Cvoid},
@@ -5128,7 +5128,7 @@ end
 
 @checked function cusparseSpMM(handle, opA, opB, alpha, matA, matB, beta, matC,
                                computeType, alg, externalBuffer)
-    initialize_api()
+    initialize_context()
     ccall((:cusparseSpMM, libcusparse()), cusparseStatus_t,
                    (cusparseHandle_t, cusparseOperation_t, cusparseOperation_t,
                     PtrOrCuPtr{Cvoid}, cusparseSpMatDescr_t, cusparseDnMatDescr_t,
@@ -5140,7 +5140,7 @@ end
 
 @checked function cusparseSpMM_bufferSize(handle, opA, opB, alpha, matA, matB, beta, matC,
                                           computeType, alg, bufferSize)
-    initialize_api()
+    initialize_context()
     ccall((:cusparseSpMM_bufferSize, libcusparse()), cusparseStatus_t,
                    (cusparseHandle_t, cusparseOperation_t, cusparseOperation_t,
                     PtrOrCuPtr{Cvoid}, cusparseSpMatDescr_t, cusparseDnMatDescr_t, PtrOrCuPtr{Cvoid},
@@ -5150,14 +5150,14 @@ end
 end
 
 @checked function cusparseSpGEMM_createDescr(descr)
-    initialize_api()
+    initialize_context()
     ccall((:cusparseSpGEMM_createDescr, libcusparse()), cusparseStatus_t,
                    (Ptr{cusparseSpGEMMDescr_t},),
                    descr)
 end
 
 @checked function cusparseSpGEMM_destroyDescr(descr)
-    initialize_api()
+    initialize_context()
     ccall((:cusparseSpGEMM_destroyDescr, libcusparse()), cusparseStatus_t,
                    (cusparseSpGEMMDescr_t,),
                    descr)
@@ -5166,7 +5166,7 @@ end
 @checked function cusparseSpGEMM_workEstimation(handle, opA, opB, alpha, matA, matB, beta,
                                                 matC, computeType, alg, spgemmDescr,
                                                 bufferSize1, externalBuffer1)
-    initialize_api()
+    initialize_context()
     ccall((:cusparseSpGEMM_workEstimation, libcusparse()), cusparseStatus_t,
                    (cusparseHandle_t, cusparseOperation_t, cusparseOperation_t,
                     PtrOrCuPtr{Cvoid}, cusparseSpMatDescr_t, cusparseSpMatDescr_t,
@@ -5179,7 +5179,7 @@ end
 @checked function cusparseSpGEMM_compute(handle, opA, opB, alpha, matA, matB, beta, matC,
                                          computeType, alg, spgemmDescr, bufferSize2,
                                          externalBuffer2)
-    initialize_api()
+    initialize_context()
     ccall((:cusparseSpGEMM_compute, libcusparse()), cusparseStatus_t,
                    (cusparseHandle_t, cusparseOperation_t, cusparseOperation_t,
                     PtrOrCuPtr{Cvoid}, cusparseSpMatDescr_t, cusparseSpMatDescr_t,
@@ -5191,7 +5191,7 @@ end
 
 @checked function cusparseSpGEMM_copy(handle, opA, opB, alpha, matA, matB, beta, matC,
                                       computeType, alg, spgemmDescr)
-    initialize_api()
+    initialize_context()
     ccall((:cusparseSpGEMM_copy, libcusparse()), cusparseStatus_t,
                    (cusparseHandle_t, cusparseOperation_t, cusparseOperation_t,
                     PtrOrCuPtr{Cvoid}, cusparseSpMatDescr_t, cusparseSpMatDescr_t,
@@ -5203,7 +5203,7 @@ end
 
 @checked function cusparseConstrainedGeMM(handle, opA, opB, alpha, matA, matB, beta, matC,
                                           computeType, externalBuffer)
-    initialize_api()
+    initialize_context()
     ccall((:cusparseConstrainedGeMM, libcusparse()), cusparseStatus_t,
                    (cusparseHandle_t, cusparseOperation_t, cusparseOperation_t,
                     PtrOrCuPtr{Cvoid}, cusparseDnMatDescr_t, cusparseDnMatDescr_t,
@@ -5214,7 +5214,7 @@ end
 
 @checked function cusparseConstrainedGeMM_bufferSize(handle, opA, opB, alpha, matA, matB,
                                                      beta, matC, computeType, bufferSize)
-    initialize_api()
+    initialize_context()
     ccall((:cusparseConstrainedGeMM_bufferSize, libcusparse()), cusparseStatus_t,
                    (cusparseHandle_t, cusparseOperation_t, cusparseOperation_t,
                     Ptr{Cvoid}, cusparseDnMatDescr_t, cusparseDnMatDescr_t, Ptr{Cvoid},
@@ -5226,74 +5226,74 @@ end
 ## Added in CUDA 11.1
 
 @checked function cusparseSparseToDense(handle, matA, matB, alg, buffer)
-    initialize_api()
+    initialize_context()
     ccall((:cusparseSparseToDense, libcusparse()), cusparseStatus_t, (cusparseHandle_t, cusparseSpMatDescr_t, cusparseDnMatDescr_t, cusparseSparseToDenseAlg_t, CuPtr{Cvoid}), handle, matA, matB, alg, buffer)
 end
 
 @checked function cusparseCscSetPointers(spMatDescr, cscColOffsets, cscRowInd, cscValues)
-    initialize_api()
+    initialize_context()
     ccall((:cusparseCscSetPointers, libcusparse()), cusparseStatus_t, (cusparseSpMatDescr_t, Ptr{Cvoid}, Ptr{Cvoid}, Ptr{Cvoid}), spMatDescr, cscColOffsets, cscRowInd, cscValues)
 end
 
 @checked function cusparseCreateCsc(spMatDescr, rows, cols, nnz, csrColOffsets, csrRowInd, csrValues, csrColOffsetsType, csrRowIndType, idxBase, valueType)
-    initialize_api()
+    initialize_context()
     ccall((:cusparseCreateCsc, libcusparse()), cusparseStatus_t, (Ptr{cusparseSpMatDescr_t}, Int64, Int64, Int64, CuPtr{Cvoid}, CuPtr{Cvoid}, CuPtr{Cvoid}, cusparseIndexType_t, cusparseIndexType_t, cusparseIndexBase_t, cudaDataType), spMatDescr, rows, cols, nnz, csrColOffsets, csrRowInd, csrValues, csrColOffsetsType, csrRowIndType, idxBase, valueType)
 end
 
 @checked function cusparseDenseToSparse_bufferSize(handle, matA, matB, alg, bufferSize)
-    initialize_api()
+    initialize_context()
     ccall((:cusparseDenseToSparse_bufferSize, libcusparse()), cusparseStatus_t, (cusparseHandle_t, cusparseDnMatDescr_t, cusparseSpMatDescr_t, cusparseDenseToSparseAlg_t, Ptr{Csize_t}), handle, matA, matB, alg, bufferSize)
 end
 
 @checked function cusparseDenseToSparse_convert(handle, matA, matB, alg, buffer)
-    initialize_api()
+    initialize_context()
     ccall((:cusparseDenseToSparse_convert, libcusparse()), cusparseStatus_t, (cusparseHandle_t, cusparseDnMatDescr_t, cusparseSpMatDescr_t, cusparseDenseToSparseAlg_t, Ptr{Cvoid}), handle, matA, matB, alg, buffer)
 end
 
 @checked function cusparseSparseToDense_bufferSize(handle, matA, matB, alg, bufferSize)
-    initialize_api()
+    initialize_context()
     ccall((:cusparseSparseToDense_bufferSize, libcusparse()), cusparseStatus_t, (cusparseHandle_t, cusparseSpMatDescr_t, cusparseDnMatDescr_t, cusparseSparseToDenseAlg_t, Ptr{Csize_t}), handle, matA, matB, alg, bufferSize)
 end
 
 @checked function cusparseDenseToSparse_analysis(handle, matA, matB, alg, buffer)
-    initialize_api()
+    initialize_context()
     ccall((:cusparseDenseToSparse_analysis, libcusparse()), cusparseStatus_t, (cusparseHandle_t, cusparseDnMatDescr_t, cusparseSpMatDescr_t, cusparseDenseToSparseAlg_t, Ptr{Cvoid}), handle, matA, matB, alg, buffer)
 end
 
 @checked function cusparseCooSetPointers(spMatDescr, cooRows, cooColumns, cooValues)
-    initialize_api()
+    initialize_context()
     ccall((:cusparseCooSetPointers, libcusparse()), cusparseStatus_t, (cusparseSpMatDescr_t, Ptr{Cvoid}, Ptr{Cvoid}, Ptr{Cvoid}), spMatDescr, cooRows, cooColumns, cooValues)
 end
 
 ## Added in CUDA 11.2
 
 @checked function cusparseCreateBlockedEll(spMatDescr, rows, cols, ellBlockSize, ellCols, ellColInd, ellValue, ellIdxType, idxBase, valueType)
-    initialize_api()
+    initialize_context()
     ccall((:cusparseCreateBlockedEll, libcusparse), cusparseStatus_t, (Ptr{cusparseSpMatDescr_t}, Int64, Int64, Int64, Int64, CuPtr{Cvoid}, CuPtr{Cvoid}, cusparseIndexType_t, cusparseIndexBase_t, cudaDataType), spMatDescr, rows, cols, ellBlockSize, ellCols, ellColInd, ellValue, ellIdxType, idxBase, valueType)
 end
 
 @checked function cusparseSDDMM_bufferSize(handle, opA, opB, alpha, matA, matB, beta, matC, computeType, alg, bufferSize)
-    initialize_api()
+    initialize_context()
     ccall((:cusparseSDDMM_bufferSize, libcusparse), cusparseStatus_t, (cusparseHandle_t, cusparseOperation_t, cusparseOperation_t, PtrOrCuPtr{Cvoid}, cusparseDnMatDescr_t, cusparseDnMatDescr_t, PtrOrCuPtr{Cvoid}, cusparseSpMatDescr_t, cudaDataType, cusparseSDDMMAlg_t, Ptr{Csize_t}), handle, opA, opB, alpha, matA, matB, beta, matC, computeType, alg, bufferSize)
 end
 
 @checked function cusparseBlockedEllGet(spMatDescr, rows, cols, ellBlockSize, ellCols, ellColInd, ellValue, ellIdxType, idxBase, valueType)
-    initialize_api()
+    initialize_context()
     ccall((:cusparseBlockedEllGet, libcusparse), cusparseStatus_t, (cusparseSpMatDescr_t, Ptr{Int64}, Ptr{Int64}, Ptr{Int64}, Ptr{Int64}, CuPtr{Ptr{Cvoid}}, CuPtr{Ptr{Cvoid}}, Ptr{cusparseIndexType_t}, Ptr{cusparseIndexBase_t}, Ptr{cudaDataType}), spMatDescr, rows, cols, ellBlockSize, ellCols, ellColInd, ellValue, ellIdxType, idxBase, valueType)
 end
 
 @checked function cusparseSpMM_preprocess(handle, opA, opB, alpha, matA, matB, beta, matC, computeType, alg, externalBuffer)
-    initialize_api()
+    initialize_context()
     ccall((:cusparseSpMM_preprocess, libcusparse), cusparseStatus_t, (cusparseHandle_t, cusparseOperation_t, cusparseOperation_t, PtrOrCuPtr{Cvoid}, cusparseSpMatDescr_t, cusparseDnMatDescr_t, PtrOrCuPtr{Cvoid}, cusparseDnMatDescr_t, cudaDataType, cusparseSpMMAlg_t, CuPtr{Cvoid}), handle, opA, opB, alpha, matA, matB, beta, matC, computeType, alg, externalBuffer)
 end
 
 @checked function cusparseSDDMM_preprocess(handle, opA, opB, alpha, matA, matB, beta, matC, computeType, alg, externalBuffer)
-    initialize_api()
+    initialize_context()
     ccall((:cusparseSDDMM_preprocess, libcusparse), cusparseStatus_t, (cusparseHandle_t, cusparseOperation_t, cusparseOperation_t, PtrOrCuPtr{Cvoid}, cusparseDnMatDescr_t, cusparseDnMatDescr_t, PtrOrCuPtr{Cvoid}, cusparseSpMatDescr_t, cudaDataType, cusparseSDDMMAlg_t, CuPtr{Cvoid}), handle, opA, opB, alpha, matA, matB, beta, matC, computeType, alg, externalBuffer)
 end
 
 @checked function cusparseSDDMM(handle, opA, opB, alpha, matA, matB, beta, matC, computeType, alg, externalBuffer)
-    initialize_api()
+    initialize_context()
     ccall((:cusparseSDDMM, libcusparse), cusparseStatus_t, (cusparseHandle_t, cusparseOperation_t, cusparseOperation_t, PtrOrCuPtr{Cvoid}, cusparseDnMatDescr_t, cusparseDnMatDescr_t, PtrOrCuPtr{Cvoid}, cusparseSpMatDescr_t, cudaDataType, cusparseSDDMMAlg_t, CuPtr{Cvoid}), handle, opA, opB, alpha, matA, matB, beta, matC, computeType, alg, externalBuffer)
 end
 

--- a/lib/cusparse/libcusparse_deprecated.jl
+++ b/lib/cusparse/libcusparse_deprecated.jl
@@ -3,7 +3,7 @@
 @checked function cusparseScsr2csc(handle, m, n, nnz, csrSortedVal, csrSortedRowPtr,
                                    csrSortedColInd, cscSortedVal, cscSortedRowInd,
                                    cscSortedColPtr, copyValues, idxBase)
-    initialize_api()
+    initialize_context()
     ccall((:cusparseScsr2csc, libcusparse()), cusparseStatus_t,
                    (cusparseHandle_t, Cint, Cint, Cint, CuPtr{Cfloat}, CuPtr{Cint},
                     CuPtr{Cint}, CuPtr{Cfloat}, CuPtr{Cint}, CuPtr{Cint}, cusparseAction_t,
@@ -15,7 +15,7 @@ end
 @checked function cusparseDcsr2csc(handle, m, n, nnz, csrSortedVal, csrSortedRowPtr,
                                    csrSortedColInd, cscSortedVal, cscSortedRowInd,
                                    cscSortedColPtr, copyValues, idxBase)
-    initialize_api()
+    initialize_context()
     ccall((:cusparseDcsr2csc, libcusparse()), cusparseStatus_t,
                    (cusparseHandle_t, Cint, Cint, Cint, CuPtr{Cdouble}, CuPtr{Cint},
                     CuPtr{Cint}, CuPtr{Cdouble}, CuPtr{Cint}, CuPtr{Cint},
@@ -27,7 +27,7 @@ end
 @checked function cusparseCcsr2csc(handle, m, n, nnz, csrSortedVal, csrSortedRowPtr,
                                    csrSortedColInd, cscSortedVal, cscSortedRowInd,
                                    cscSortedColPtr, copyValues, idxBase)
-    initialize_api()
+    initialize_context()
     ccall((:cusparseCcsr2csc, libcusparse()), cusparseStatus_t,
                    (cusparseHandle_t, Cint, Cint, Cint, CuPtr{cuComplex}, CuPtr{Cint},
                     CuPtr{Cint}, CuPtr{cuComplex}, CuPtr{Cint}, CuPtr{Cint},
@@ -39,7 +39,7 @@ end
 @checked function cusparseZcsr2csc(handle, m, n, nnz, csrSortedVal, csrSortedRowPtr,
                                    csrSortedColInd, cscSortedVal, cscSortedRowInd,
                                    cscSortedColPtr, copyValues, idxBase)
-    initialize_api()
+    initialize_context()
     ccall((:cusparseZcsr2csc, libcusparse()), cusparseStatus_t,
                    (cusparseHandle_t, Cint, Cint, Cint, CuPtr{cuDoubleComplex},
                     CuPtr{Cint}, CuPtr{Cint}, CuPtr{cuDoubleComplex}, CuPtr{Cint},
@@ -51,7 +51,7 @@ end
 @checked function cusparseScsrmm2(handle, transA, transB, m, n, k, nnz, alpha, descrA,
                                   csrSortedValA, csrSortedRowPtrA, csrSortedColIndA, B,
                                   ldb, beta, C, ldc)
-    initialize_api()
+    initialize_context()
     ccall((:cusparseScsrmm2, libcusparse()), cusparseStatus_t,
                    (cusparseHandle_t, cusparseOperation_t, cusparseOperation_t, Cint,
                     Cint, Cint, Cint, Ref{Cfloat}, cusparseMatDescr_t, CuPtr{Cfloat},
@@ -64,7 +64,7 @@ end
 @checked function cusparseDcsrmm2(handle, transA, transB, m, n, k, nnz, alpha, descrA,
                                   csrSortedValA, csrSortedRowPtrA, csrSortedColIndA, B,
                                   ldb, beta, C, ldc)
-    initialize_api()
+    initialize_context()
     ccall((:cusparseDcsrmm2, libcusparse()), cusparseStatus_t,
                    (cusparseHandle_t, cusparseOperation_t, cusparseOperation_t, Cint,
                     Cint, Cint, Cint, Ref{Cdouble}, cusparseMatDescr_t, CuPtr{Cdouble},
@@ -77,7 +77,7 @@ end
 @checked function cusparseCcsrmm2(handle, transA, transB, m, n, k, nnz, alpha, descrA,
                                   csrSortedValA, csrSortedRowPtrA, csrSortedColIndA, B,
                                   ldb, beta, C, ldc)
-    initialize_api()
+    initialize_context()
     ccall((:cusparseCcsrmm2, libcusparse()), cusparseStatus_t,
                    (cusparseHandle_t, cusparseOperation_t, cusparseOperation_t, Cint,
                     Cint, Cint, Cint, Ref{cuComplex}, cusparseMatDescr_t, CuPtr{cuComplex},
@@ -90,7 +90,7 @@ end
 @checked function cusparseZcsrmm2(handle, transA, transB, m, n, k, nnz, alpha, descrA,
                                   csrSortedValA, csrSortedRowPtrA, csrSortedColIndA, B,
                                   ldb, beta, C, ldc)
-    initialize_api()
+    initialize_context()
     ccall((:cusparseZcsrmm2, libcusparse()), cusparseStatus_t,
                    (cusparseHandle_t, cusparseOperation_t, cusparseOperation_t, Cint,
                     Cint, Cint, Cint, Ref{cuDoubleComplex}, cusparseMatDescr_t,

--- a/lib/cutensor/CUTENSOR.jl
+++ b/lib/cutensor/CUTENSOR.jl
@@ -4,7 +4,7 @@ using ..APIUtils
 
 using ..CUDA
 using ..CUDA: CUstream, cudaDataType
-using ..CUDA: libcutensor,  @retry_reclaim
+using ..CUDA: libcutensor,  @retry_reclaim, initialize_context
 
 using CEnum: @cenum
 

--- a/lib/cutensor/error.jl
+++ b/lib/cutensor/error.jl
@@ -59,10 +59,6 @@ end
     end
 end
 
-function initialize_api()
-    CUDA.prepare_cuda_state()
-end
-
 macro check(ex, errs...)
     check = :(isequal(err, CUTENSOR_STATUS_ALLOC_FAILED))
     for err in errs

--- a/lib/cutensor/libcutensor.jl
+++ b/lib/cutensor/libcutensor.jl
@@ -2,7 +2,7 @@
 # Automatically generated using Clang.jl
 
 @checked function cutensorInit(handle)
-    initialize_api()
+    initialize_context()
     ccall((:cutensorInit, libcutensor()), cutensorStatus_t,
                    (Ptr{cutensorHandle_t},),
                    handle)
@@ -10,7 +10,7 @@ end
 
 @checked function cutensorInitTensorDescriptor(handle, desc, numModes, extent, stride,
                                                dataType, unaryOp)
-    initialize_api()
+    initialize_context()
     ccall((:cutensorInitTensorDescriptor, libcutensor()), cutensorStatus_t,
                    (Ptr{cutensorHandle_t}, Ptr{cutensorTensorDescriptor_t}, UInt32,
                     Ptr{Int64}, Ptr{Int64}, cudaDataType_t, cutensorOperator_t),
@@ -20,7 +20,7 @@ end
 @checked function cutensorElementwiseTrinary(handle, alpha, A, descA, modeA, beta, B,
                                              descB, modeB, gamma, C, descC, modeC, D,
                                              descD, modeD, opAB, opABC, typeScalar, stream)
-    initialize_api()
+    initialize_context()
     ccall((:cutensorElementwiseTrinary, libcutensor()), cutensorStatus_t,
                    (Ptr{cutensorHandle_t}, Ptr{Cvoid}, PtrOrCuPtr{Cvoid},
                     Ptr{cutensorTensorDescriptor_t}, Ptr{Int32}, Ptr{Cvoid},
@@ -36,7 +36,7 @@ end
 @checked function cutensorElementwiseBinary(handle, alpha, A, descA, modeA, gamma, C,
                                             descC, modeC, D, descD, modeD, opAC,
                                             typeScalar, stream)
-    initialize_api()
+    initialize_context()
     ccall((:cutensorElementwiseBinary, libcutensor()), cutensorStatus_t,
                    (Ptr{cutensorHandle_t}, Ptr{Cvoid}, PtrOrCuPtr{Cvoid},
                     Ptr{cutensorTensorDescriptor_t}, Ptr{Int32}, Ptr{Cvoid},
@@ -49,7 +49,7 @@ end
 
 @checked function cutensorPermutation(handle, alpha, A, descA, modeA, B, descB, modeB,
                                       typeScalar, stream)
-    initialize_api()
+    initialize_context()
     ccall((:cutensorPermutation, libcutensor()), cutensorStatus_t,
                    (Ptr{cutensorHandle_t}, Ptr{Cvoid}, PtrOrCuPtr{Cvoid},
                     Ptr{cutensorTensorDescriptor_t}, Ptr{Int32}, PtrOrCuPtr{Cvoid},
@@ -62,7 +62,7 @@ end
                                                     alignmentRequirementB, descC, modeC,
                                                     alignmentRequirementC, descD, modeD,
                                                     alignmentRequirementD, computeType)
-    initialize_api()
+    initialize_context()
     ccall((:cutensorInitContractionDescriptor, libcutensor()), cutensorStatus_t,
                    (Ptr{cutensorHandle_t}, Ptr{cutensorContractionDescriptor_t},
                     Ptr{cutensorTensorDescriptor_t}, Ptr{Int32}, UInt32,
@@ -76,14 +76,14 @@ end
 end
 
 @checked function cutensorInitContractionFind(handle, find, algo)
-    initialize_api()
+    initialize_context()
     ccall((:cutensorInitContractionFind, libcutensor()), cutensorStatus_t,
                    (Ptr{cutensorHandle_t}, Ptr{cutensorContractionFind_t}, cutensorAlgo_t),
                    handle, find, algo)
 end
 
 @checked function cutensorContractionGetWorkspace(handle, desc, find, pref, workspaceSize)
-    initialize_api()
+    initialize_context()
     ccall((:cutensorContractionGetWorkspace, libcutensor()), cutensorStatus_t,
                    (Ptr{cutensorHandle_t}, Ptr{cutensorContractionDescriptor_t},
                     Ptr{cutensorContractionFind_t}, cutensorWorksizePreference_t,
@@ -92,7 +92,7 @@ end
 end
 
 @checked function cutensorInitContractionPlan(handle, plan, desc, find, workspaceSize)
-    initialize_api()
+    initialize_context()
     ccall((:cutensorInitContractionPlan, libcutensor()), cutensorStatus_t,
                    (Ptr{cutensorHandle_t}, Ptr{cutensorContractionPlan_t},
                     Ptr{cutensorContractionDescriptor_t}, Ptr{cutensorContractionFind_t},
@@ -102,7 +102,7 @@ end
 
 @checked function cutensorContraction(handle, plan, alpha, A, B, beta, C, D, workspace,
                                       workspaceSize, stream)
-    initialize_api()
+    initialize_context()
     ccall((:cutensorContraction, libcutensor()), cutensorStatus_t,
                    (Ptr{cutensorHandle_t}, Ptr{cutensorContractionPlan_t}, Ptr{Cvoid},
                     PtrOrCuPtr{Cvoid}, PtrOrCuPtr{Cvoid}, Ptr{Cvoid}, PtrOrCuPtr{Cvoid},
@@ -111,7 +111,7 @@ end
 end
 
 @checked function cutensorContractionMaxAlgos(maxNumAlgos)
-    initialize_api()
+    initialize_context()
     ccall((:cutensorContractionMaxAlgos, libcutensor()), cutensorStatus_t,
                    (Ptr{Int32},),
                    maxNumAlgos)
@@ -120,7 +120,7 @@ end
 @checked function cutensorReduction(handle, alpha, A, descA, modeA, beta, C, descC, modeC,
                                     D, descD, modeD, opReduce, minTypeCompute, workspace,
                                     workspaceSize, stream)
-    initialize_api()
+    initialize_context()
     ccall((:cutensorReduction, libcutensor()), cutensorStatus_t,
                    (Ptr{cutensorHandle_t}, Ptr{Cvoid}, PtrOrCuPtr{Cvoid},
                     Ptr{cutensorTensorDescriptor_t}, Ptr{Int32}, Ptr{Cvoid},
@@ -135,7 +135,7 @@ end
 @checked function cutensorReductionGetWorkspace(handle, A, descA_, modeA, C, descC_, modeC,
                                                 D, descD_, modeD, opReduce, typeCompute,
                                                 workspaceSize)
-    initialize_api()
+    initialize_context()
     ccall((:cutensorReductionGetWorkspace, libcutensor()), cutensorStatus_t,
                    (Ptr{cutensorHandle_t}, PtrOrCuPtr{Cvoid},
                     Ptr{cutensorTensorDescriptor_t}, Ptr{Int32}, PtrOrCuPtr{Cvoid},
@@ -147,7 +147,7 @@ end
 end
 
 @checked function cutensorGetAlignmentRequirement(handle, ptr, desc, alignmentRequirement)
-    initialize_api()
+    initialize_context()
     ccall((:cutensorGetAlignmentRequirement, libcutensor()), cutensorStatus_t,
                    (Ptr{cutensorHandle_t}, PtrOrCuPtr{Cvoid},
                     Ptr{cutensorTensorDescriptor_t}, Ptr{UInt32}),
@@ -172,31 +172,31 @@ end
 ## added in CUTENSOR 1.2
 
 @checked function cutensorHandleWriteCacheToFile(handle, filename)
-    initialize_api()
+    initialize_context()
     ccall((:cutensorHandleWriteCacheToFile, libcutensor()), cutensorStatus_t, (Ptr{cutensorHandle_t}, Ptr{UInt8}), handle, filename)
 end
 
 @checked function cutensorContractionFindSetAttribute(handle, find, attr, buf, sizeInBytes)
-    initialize_api()
+    initialize_context()
     ccall((:cutensorContractionFindSetAttribute, libcutensor()), cutensorStatus_t, (Ptr{cutensorHandle_t}, Ptr{cutensorContractionFind_t}, cutensorContractionFindAttributes_t, Ptr{Cvoid}, Csize_t), handle, find, attr, buf, sizeInBytes)
 end
 
 @checked function cutensorHandleReadCacheFromFile(handle, filename, numCachelinesRead)
-    initialize_api()
+    initialize_context()
     ccall((:cutensorHandleReadCacheFromFile, libcutensor()), cutensorStatus_t, (Ptr{cutensorHandle_t}, Ptr{UInt8}, Ref{UInt32}), handle, filename, numCachelinesRead)
 end
 
 @checked function cutensorContractionDescriptorSetAttribute(handle, desc, attr, buf, sizeInBytes)
-    initialize_api()
+    initialize_context()
     ccall((:cutensorContractionDescriptorSetAttribute, libcutensor()), cutensorStatus_t, (Ptr{cutensorHandle_t}, Ptr{cutensorContractionDescriptor_t}, cutensorContractionDescriptorAttributes_t, Ptr{Cvoid}, Csize_t), handle, desc, attr, buf, sizeInBytes)
 end
 
 @checked function cutensorHandleDetachPlanCachelines(handle)
-    initialize_api()
+    initialize_context()
     ccall((:cutensorHandleDetachPlanCachelines, libcutensor()), cutensorStatus_t, (Ptr{cutensorHandle_t},), handle)
 end
 
 @checked function cutensorHandleAttachPlanCachelines(handle, cachelines, numCachelines)
-    initialize_api()
+    initialize_context()
     ccall((:cutensorHandleAttachPlanCachelines, libcutensor()), cutensorStatus_t, (Ptr{cutensorHandle_t}, Ptr{cutensorPlanCacheline_t}, UInt32), handle, cachelines, numCachelines)
 end

--- a/lib/nvml/NVML.jl
+++ b/lib/nvml/NVML.jl
@@ -34,7 +34,7 @@ function has_nvml()
 
         # JuliaGPU/CUDA.jl#860: initialization can fail on Windows
         try
-            initialize_api()
+            initialize_context()
         catch err
             @error "Cannot use NVML, as it failed to initialize" exception=(err, catch_backtrace())
             return false

--- a/lib/nvml/error.jl
+++ b/lib/nvml/error.jl
@@ -22,7 +22,7 @@ description(err::NVMLError) = unsafe_string(nvmlErrorString(err))
 end
 
 const initialized = Ref(false)
-function initialize_api()
+function initialize_context()
     if !initialized[]
         res = unsafe_nvmlInitWithFlags(0)
         if res !== NVML_SUCCESS

--- a/lib/nvml/libnvml.jl
+++ b/lib/nvml/libnvml.jl
@@ -22,224 +22,224 @@ function nvmlErrorString(result)
 end
 
 @checked function nvmlSystemGetDriverVersion(version, length)
-    initialize_api()
+    initialize_context()
     ccall((:nvmlSystemGetDriverVersion, libnvml()), nvmlReturn_t,
                    (Cstring, UInt32),
                    version, length)
 end
 
 @checked function nvmlSystemGetNVMLVersion(version, length)
-    initialize_api()
+    initialize_context()
     ccall((:nvmlSystemGetNVMLVersion, libnvml()), nvmlReturn_t,
                    (Cstring, UInt32),
                    version, length)
 end
 
 @checked function nvmlSystemGetCudaDriverVersion(cudaDriverVersion)
-    initialize_api()
+    initialize_context()
     ccall((:nvmlSystemGetCudaDriverVersion, libnvml()), nvmlReturn_t,
                    (Ptr{Cint},),
                    cudaDriverVersion)
 end
 
 @checked function nvmlSystemGetCudaDriverVersion_v2(cudaDriverVersion)
-    initialize_api()
+    initialize_context()
     ccall((:nvmlSystemGetCudaDriverVersion_v2, libnvml()), nvmlReturn_t,
                    (Ptr{Cint},),
                    cudaDriverVersion)
 end
 
 @checked function nvmlSystemGetProcessName(pid, name, length)
-    initialize_api()
+    initialize_context()
     ccall((:nvmlSystemGetProcessName, libnvml()), nvmlReturn_t,
                    (UInt32, Cstring, UInt32),
                    pid, name, length)
 end
 
 @checked function nvmlUnitGetCount(unitCount)
-    initialize_api()
+    initialize_context()
     ccall((:nvmlUnitGetCount, libnvml()), nvmlReturn_t,
                    (Ptr{UInt32},),
                    unitCount)
 end
 
 @checked function nvmlUnitGetHandleByIndex(index, unit)
-    initialize_api()
+    initialize_context()
     ccall((:nvmlUnitGetHandleByIndex, libnvml()), nvmlReturn_t,
                    (UInt32, Ptr{nvmlUnit_t}),
                    index, unit)
 end
 
 @checked function nvmlUnitGetUnitInfo(unit, info)
-    initialize_api()
+    initialize_context()
     ccall((:nvmlUnitGetUnitInfo, libnvml()), nvmlReturn_t,
                    (nvmlUnit_t, Ptr{nvmlUnitInfo_t}),
                    unit, info)
 end
 
 @checked function nvmlUnitGetLedState(unit, state)
-    initialize_api()
+    initialize_context()
     ccall((:nvmlUnitGetLedState, libnvml()), nvmlReturn_t,
                    (nvmlUnit_t, Ptr{nvmlLedState_t}),
                    unit, state)
 end
 
 @checked function nvmlUnitGetPsuInfo(unit, psu)
-    initialize_api()
+    initialize_context()
     ccall((:nvmlUnitGetPsuInfo, libnvml()), nvmlReturn_t,
                    (nvmlUnit_t, Ptr{nvmlPSUInfo_t}),
                    unit, psu)
 end
 
 @checked function nvmlUnitGetTemperature(unit, type, temp)
-    initialize_api()
+    initialize_context()
     ccall((:nvmlUnitGetTemperature, libnvml()), nvmlReturn_t,
                    (nvmlUnit_t, UInt32, Ptr{UInt32}),
                    unit, type, temp)
 end
 
 @checked function nvmlUnitGetFanSpeedInfo(unit, fanSpeeds)
-    initialize_api()
+    initialize_context()
     ccall((:nvmlUnitGetFanSpeedInfo, libnvml()), nvmlReturn_t,
                    (nvmlUnit_t, Ptr{nvmlUnitFanSpeeds_t}),
                    unit, fanSpeeds)
 end
 
 @checked function nvmlUnitGetDevices(unit, deviceCount, devices)
-    initialize_api()
+    initialize_context()
     ccall((:nvmlUnitGetDevices, libnvml()), nvmlReturn_t,
                    (nvmlUnit_t, Ptr{UInt32}, Ptr{nvmlDevice_t}),
                    unit, deviceCount, devices)
 end
 
 @checked function nvmlSystemGetHicVersion(hwbcCount, hwbcEntries)
-    initialize_api()
+    initialize_context()
     ccall((:nvmlSystemGetHicVersion, libnvml()), nvmlReturn_t,
                    (Ptr{UInt32}, Ptr{nvmlHwbcEntry_t}),
                    hwbcCount, hwbcEntries)
 end
 
 @checked function nvmlDeviceGetCount_v2(deviceCount)
-    initialize_api()
+    initialize_context()
     ccall((:nvmlDeviceGetCount_v2, libnvml()), nvmlReturn_t,
                    (Ptr{UInt32},),
                    deviceCount)
 end
 
 @checked function nvmlDeviceGetHandleByIndex_v2(index, device)
-    initialize_api()
+    initialize_context()
     ccall((:nvmlDeviceGetHandleByIndex_v2, libnvml()), nvmlReturn_t,
                    (UInt32, Ptr{nvmlDevice_t}),
                    index, device)
 end
 
 @checked function nvmlDeviceGetHandleBySerial(serial, device)
-    initialize_api()
+    initialize_context()
     ccall((:nvmlDeviceGetHandleBySerial, libnvml()), nvmlReturn_t,
                    (Cstring, Ptr{nvmlDevice_t}),
                    serial, device)
 end
 
 @checked function nvmlDeviceGetHandleByUUID(uuid, device)
-    initialize_api()
+    initialize_context()
     ccall((:nvmlDeviceGetHandleByUUID, libnvml()), nvmlReturn_t,
                    (Cstring, Ptr{nvmlDevice_t}),
                    uuid, device)
 end
 
 @checked function nvmlDeviceGetHandleByPciBusId_v2(pciBusId, device)
-    initialize_api()
+    initialize_context()
     ccall((:nvmlDeviceGetHandleByPciBusId_v2, libnvml()), nvmlReturn_t,
                    (Cstring, Ptr{nvmlDevice_t}),
                    pciBusId, device)
 end
 
 @checked function nvmlDeviceGetName(device, name, length)
-    initialize_api()
+    initialize_context()
     ccall((:nvmlDeviceGetName, libnvml()), nvmlReturn_t,
                    (nvmlDevice_t, Cstring, UInt32),
                    device, name, length)
 end
 
 @checked function nvmlDeviceGetBrand(device, type)
-    initialize_api()
+    initialize_context()
     ccall((:nvmlDeviceGetBrand, libnvml()), nvmlReturn_t,
                    (nvmlDevice_t, Ptr{nvmlBrandType_t}),
                    device, type)
 end
 
 @checked function nvmlDeviceGetIndex(device, index)
-    initialize_api()
+    initialize_context()
     ccall((:nvmlDeviceGetIndex, libnvml()), nvmlReturn_t,
                    (nvmlDevice_t, Ptr{UInt32}),
                    device, index)
 end
 
 @checked function nvmlDeviceGetSerial(device, serial, length)
-    initialize_api()
+    initialize_context()
     ccall((:nvmlDeviceGetSerial, libnvml()), nvmlReturn_t,
                    (nvmlDevice_t, Cstring, UInt32),
                    device, serial, length)
 end
 
 @checked function nvmlDeviceGetMemoryAffinity(device, nodeSetSize, nodeSet, scope)
-    initialize_api()
+    initialize_context()
     ccall((:nvmlDeviceGetMemoryAffinity, libnvml()), nvmlReturn_t,
                    (nvmlDevice_t, UInt32, Ptr{Culong}, nvmlAffinityScope_t),
                    device, nodeSetSize, nodeSet, scope)
 end
 
 @checked function nvmlDeviceGetCpuAffinityWithinScope(device, cpuSetSize, cpuSet, scope)
-    initialize_api()
+    initialize_context()
     ccall((:nvmlDeviceGetCpuAffinityWithinScope, libnvml()), nvmlReturn_t,
                    (nvmlDevice_t, UInt32, Ptr{Culong}, nvmlAffinityScope_t),
                    device, cpuSetSize, cpuSet, scope)
 end
 
 @checked function nvmlDeviceGetCpuAffinity(device, cpuSetSize, cpuSet)
-    initialize_api()
+    initialize_context()
     ccall((:nvmlDeviceGetCpuAffinity, libnvml()), nvmlReturn_t,
                    (nvmlDevice_t, UInt32, Ptr{Culong}),
                    device, cpuSetSize, cpuSet)
 end
 
 @checked function nvmlDeviceSetCpuAffinity(device)
-    initialize_api()
+    initialize_context()
     ccall((:nvmlDeviceSetCpuAffinity, libnvml()), nvmlReturn_t,
                    (nvmlDevice_t,),
                    device)
 end
 
 @checked function nvmlDeviceClearCpuAffinity(device)
-    initialize_api()
+    initialize_context()
     ccall((:nvmlDeviceClearCpuAffinity, libnvml()), nvmlReturn_t,
                    (nvmlDevice_t,),
                    device)
 end
 
 @checked function nvmlDeviceGetTopologyCommonAncestor(device1, device2, pathInfo)
-    initialize_api()
+    initialize_context()
     ccall((:nvmlDeviceGetTopologyCommonAncestor, libnvml()), nvmlReturn_t,
                    (nvmlDevice_t, nvmlDevice_t, Ptr{nvmlGpuTopologyLevel_t}),
                    device1, device2, pathInfo)
 end
 
 @checked function nvmlDeviceGetTopologyNearestGpus(device, level, count, deviceArray)
-    initialize_api()
+    initialize_context()
     ccall((:nvmlDeviceGetTopologyNearestGpus, libnvml()), nvmlReturn_t,
                    (nvmlDevice_t, nvmlGpuTopologyLevel_t, Ptr{UInt32}, Ptr{nvmlDevice_t}),
                    device, level, count, deviceArray)
 end
 
 @checked function nvmlSystemGetTopologyGpuSet(cpuNumber, count, deviceArray)
-    initialize_api()
+    initialize_context()
     ccall((:nvmlSystemGetTopologyGpuSet, libnvml()), nvmlReturn_t,
                    (UInt32, Ptr{UInt32}, Ptr{nvmlDevice_t}),
                    cpuNumber, count, deviceArray)
 end
 
 @checked function nvmlDeviceGetP2PStatus(device1, device2, p2pIndex, p2pStatus)
-    initialize_api()
+    initialize_context()
     ccall((:nvmlDeviceGetP2PStatus, libnvml()), nvmlReturn_t,
                    (nvmlDevice_t, nvmlDevice_t, nvmlGpuP2PCapsIndex_t,
                     Ptr{nvmlGpuP2PStatus_t}),
@@ -247,182 +247,182 @@ end
 end
 
 @checked function nvmlDeviceGetUUID(device, uuid, length)
-    initialize_api()
+    initialize_context()
     ccall((:nvmlDeviceGetUUID, libnvml()), nvmlReturn_t,
                    (nvmlDevice_t, Cstring, UInt32),
                    device, uuid, length)
 end
 
 @checked function nvmlVgpuInstanceGetMdevUUID(vgpuInstance, mdevUuid, size)
-    initialize_api()
+    initialize_context()
     ccall((:nvmlVgpuInstanceGetMdevUUID, libnvml()), nvmlReturn_t,
                    (nvmlVgpuInstance_t, Cstring, UInt32),
                    vgpuInstance, mdevUuid, size)
 end
 
 @checked function nvmlDeviceGetMinorNumber(device, minorNumber)
-    initialize_api()
+    initialize_context()
     ccall((:nvmlDeviceGetMinorNumber, libnvml()), nvmlReturn_t,
                    (nvmlDevice_t, Ptr{UInt32}),
                    device, minorNumber)
 end
 
 @checked function nvmlDeviceGetBoardPartNumber(device, partNumber, length)
-    initialize_api()
+    initialize_context()
     ccall((:nvmlDeviceGetBoardPartNumber, libnvml()), nvmlReturn_t,
                    (nvmlDevice_t, Cstring, UInt32),
                    device, partNumber, length)
 end
 
 @checked function nvmlDeviceGetInforomVersion(device, object, version, length)
-    initialize_api()
+    initialize_context()
     ccall((:nvmlDeviceGetInforomVersion, libnvml()), nvmlReturn_t,
                    (nvmlDevice_t, nvmlInforomObject_t, Cstring, UInt32),
                    device, object, version, length)
 end
 
 @checked function nvmlDeviceGetInforomImageVersion(device, version, length)
-    initialize_api()
+    initialize_context()
     ccall((:nvmlDeviceGetInforomImageVersion, libnvml()), nvmlReturn_t,
                    (nvmlDevice_t, Cstring, UInt32),
                    device, version, length)
 end
 
 @checked function nvmlDeviceGetInforomConfigurationChecksum(device, checksum)
-    initialize_api()
+    initialize_context()
     ccall((:nvmlDeviceGetInforomConfigurationChecksum, libnvml()), nvmlReturn_t,
                    (nvmlDevice_t, Ptr{UInt32}),
                    device, checksum)
 end
 
 @checked function nvmlDeviceValidateInforom(device)
-    initialize_api()
+    initialize_context()
     ccall((:nvmlDeviceValidateInforom, libnvml()), nvmlReturn_t,
                    (nvmlDevice_t,),
                    device)
 end
 
 @checked function nvmlDeviceGetDisplayMode(device, display)
-    initialize_api()
+    initialize_context()
     ccall((:nvmlDeviceGetDisplayMode, libnvml()), nvmlReturn_t,
                    (nvmlDevice_t, Ptr{nvmlEnableState_t}),
                    device, display)
 end
 
 @checked function nvmlDeviceGetDisplayActive(device, isActive)
-    initialize_api()
+    initialize_context()
     ccall((:nvmlDeviceGetDisplayActive, libnvml()), nvmlReturn_t,
                    (nvmlDevice_t, Ptr{nvmlEnableState_t}),
                    device, isActive)
 end
 
 @checked function nvmlDeviceGetPersistenceMode(device, mode)
-    initialize_api()
+    initialize_context()
     ccall((:nvmlDeviceGetPersistenceMode, libnvml()), nvmlReturn_t,
                    (nvmlDevice_t, Ptr{nvmlEnableState_t}),
                    device, mode)
 end
 
 @checked function nvmlDeviceGetPciInfo_v3(device, pci)
-    initialize_api()
+    initialize_context()
     ccall((:nvmlDeviceGetPciInfo_v3, libnvml()), nvmlReturn_t,
                    (nvmlDevice_t, Ptr{nvmlPciInfo_t}),
                    device, pci)
 end
 
 @checked function nvmlDeviceGetMaxPcieLinkGeneration(device, maxLinkGen)
-    initialize_api()
+    initialize_context()
     ccall((:nvmlDeviceGetMaxPcieLinkGeneration, libnvml()), nvmlReturn_t,
                    (nvmlDevice_t, Ptr{UInt32}),
                    device, maxLinkGen)
 end
 
 @checked function nvmlDeviceGetMaxPcieLinkWidth(device, maxLinkWidth)
-    initialize_api()
+    initialize_context()
     ccall((:nvmlDeviceGetMaxPcieLinkWidth, libnvml()), nvmlReturn_t,
                    (nvmlDevice_t, Ptr{UInt32}),
                    device, maxLinkWidth)
 end
 
 @checked function nvmlDeviceGetCurrPcieLinkGeneration(device, currLinkGen)
-    initialize_api()
+    initialize_context()
     ccall((:nvmlDeviceGetCurrPcieLinkGeneration, libnvml()), nvmlReturn_t,
                    (nvmlDevice_t, Ptr{UInt32}),
                    device, currLinkGen)
 end
 
 @checked function nvmlDeviceGetCurrPcieLinkWidth(device, currLinkWidth)
-    initialize_api()
+    initialize_context()
     ccall((:nvmlDeviceGetCurrPcieLinkWidth, libnvml()), nvmlReturn_t,
                    (nvmlDevice_t, Ptr{UInt32}),
                    device, currLinkWidth)
 end
 
 @checked function nvmlDeviceGetPcieThroughput(device, counter, value)
-    initialize_api()
+    initialize_context()
     ccall((:nvmlDeviceGetPcieThroughput, libnvml()), nvmlReturn_t,
                    (nvmlDevice_t, nvmlPcieUtilCounter_t, Ptr{UInt32}),
                    device, counter, value)
 end
 
 @checked function nvmlDeviceGetPcieReplayCounter(device, value)
-    initialize_api()
+    initialize_context()
     ccall((:nvmlDeviceGetPcieReplayCounter, libnvml()), nvmlReturn_t,
                    (nvmlDevice_t, Ptr{UInt32}),
                    device, value)
 end
 
 @checked function nvmlDeviceGetClockInfo(device, type, clock)
-    initialize_api()
+    initialize_context()
     ccall((:nvmlDeviceGetClockInfo, libnvml()), nvmlReturn_t,
                    (nvmlDevice_t, nvmlClockType_t, Ptr{UInt32}),
                    device, type, clock)
 end
 
 @checked function nvmlDeviceGetMaxClockInfo(device, type, clock)
-    initialize_api()
+    initialize_context()
     ccall((:nvmlDeviceGetMaxClockInfo, libnvml()), nvmlReturn_t,
                    (nvmlDevice_t, nvmlClockType_t, Ptr{UInt32}),
                    device, type, clock)
 end
 
 @checked function nvmlDeviceGetApplicationsClock(device, clockType, clockMHz)
-    initialize_api()
+    initialize_context()
     ccall((:nvmlDeviceGetApplicationsClock, libnvml()), nvmlReturn_t,
                    (nvmlDevice_t, nvmlClockType_t, Ptr{UInt32}),
                    device, clockType, clockMHz)
 end
 
 @checked function nvmlDeviceGetDefaultApplicationsClock(device, clockType, clockMHz)
-    initialize_api()
+    initialize_context()
     ccall((:nvmlDeviceGetDefaultApplicationsClock, libnvml()), nvmlReturn_t,
                    (nvmlDevice_t, nvmlClockType_t, Ptr{UInt32}),
                    device, clockType, clockMHz)
 end
 
 @checked function nvmlDeviceResetApplicationsClocks(device)
-    initialize_api()
+    initialize_context()
     ccall((:nvmlDeviceResetApplicationsClocks, libnvml()), nvmlReturn_t,
                    (nvmlDevice_t,),
                    device)
 end
 
 @checked function nvmlDeviceGetClock(device, clockType, clockId, clockMHz)
-    initialize_api()
+    initialize_context()
     ccall((:nvmlDeviceGetClock, libnvml()), nvmlReturn_t,
                    (nvmlDevice_t, nvmlClockType_t, nvmlClockId_t, Ptr{UInt32}),
                    device, clockType, clockId, clockMHz)
 end
 
 @checked function nvmlDeviceGetMaxCustomerBoostClock(device, clockType, clockMHz)
-    initialize_api()
+    initialize_context()
     ccall((:nvmlDeviceGetMaxCustomerBoostClock, libnvml()), nvmlReturn_t,
                    (nvmlDevice_t, nvmlClockType_t, Ptr{UInt32}),
                    device, clockType, clockMHz)
 end
 
 @checked function nvmlDeviceGetSupportedMemoryClocks(device, count, clocksMHz)
-    initialize_api()
+    initialize_context()
     ccall((:nvmlDeviceGetSupportedMemoryClocks, libnvml()), nvmlReturn_t,
                    (nvmlDevice_t, Ptr{UInt32}, Ptr{UInt32}),
                    device, count, clocksMHz)
@@ -430,70 +430,70 @@ end
 
 @checked function nvmlDeviceGetSupportedGraphicsClocks(device, memoryClockMHz, count,
                                                        clocksMHz)
-    initialize_api()
+    initialize_context()
     ccall((:nvmlDeviceGetSupportedGraphicsClocks, libnvml()), nvmlReturn_t,
                    (nvmlDevice_t, UInt32, Ptr{UInt32}, Ptr{UInt32}),
                    device, memoryClockMHz, count, clocksMHz)
 end
 
 @checked function nvmlDeviceGetAutoBoostedClocksEnabled(device, isEnabled, defaultIsEnabled)
-    initialize_api()
+    initialize_context()
     ccall((:nvmlDeviceGetAutoBoostedClocksEnabled, libnvml()), nvmlReturn_t,
                    (nvmlDevice_t, Ptr{nvmlEnableState_t}, Ptr{nvmlEnableState_t}),
                    device, isEnabled, defaultIsEnabled)
 end
 
 @checked function nvmlDeviceSetAutoBoostedClocksEnabled(device, enabled)
-    initialize_api()
+    initialize_context()
     ccall((:nvmlDeviceSetAutoBoostedClocksEnabled, libnvml()), nvmlReturn_t,
                    (nvmlDevice_t, nvmlEnableState_t),
                    device, enabled)
 end
 
 @checked function nvmlDeviceSetDefaultAutoBoostedClocksEnabled(device, enabled, flags)
-    initialize_api()
+    initialize_context()
     ccall((:nvmlDeviceSetDefaultAutoBoostedClocksEnabled, libnvml()), nvmlReturn_t,
                    (nvmlDevice_t, nvmlEnableState_t, UInt32),
                    device, enabled, flags)
 end
 
 @checked function nvmlDeviceGetFanSpeed(device, speed)
-    initialize_api()
+    initialize_context()
     ccall((:nvmlDeviceGetFanSpeed, libnvml()), nvmlReturn_t,
                    (nvmlDevice_t, Ptr{UInt32}),
                    device, speed)
 end
 
 @checked function nvmlDeviceGetFanSpeed_v2(device, fan, speed)
-    initialize_api()
+    initialize_context()
     ccall((:nvmlDeviceGetFanSpeed_v2, libnvml()), nvmlReturn_t,
                    (nvmlDevice_t, UInt32, Ptr{UInt32}),
                    device, fan, speed)
 end
 
 @checked function nvmlDeviceGetTemperature(device, sensorType, temp)
-    initialize_api()
+    initialize_context()
     ccall((:nvmlDeviceGetTemperature, libnvml()), nvmlReturn_t,
                    (nvmlDevice_t, nvmlTemperatureSensors_t, Ptr{UInt32}),
                    device, sensorType, temp)
 end
 
 @checked function nvmlDeviceGetTemperatureThreshold(device, thresholdType, temp)
-    initialize_api()
+    initialize_context()
     ccall((:nvmlDeviceGetTemperatureThreshold, libnvml()), nvmlReturn_t,
                    (nvmlDevice_t, nvmlTemperatureThresholds_t, Ptr{UInt32}),
                    device, thresholdType, temp)
 end
 
 @checked function nvmlDeviceGetPerformanceState(device, pState)
-    initialize_api()
+    initialize_context()
     ccall((:nvmlDeviceGetPerformanceState, libnvml()), nvmlReturn_t,
                    (nvmlDevice_t, Ptr{nvmlPstates_t}),
                    device, pState)
 end
 
 @checked function nvmlDeviceGetCurrentClocksThrottleReasons(device, clocksThrottleReasons)
-    initialize_api()
+    initialize_context()
     ccall((:nvmlDeviceGetCurrentClocksThrottleReasons, libnvml()), nvmlReturn_t,
                    (nvmlDevice_t, Ptr{Culonglong}),
                    device, clocksThrottleReasons)
@@ -501,119 +501,119 @@ end
 
 @checked function nvmlDeviceGetSupportedClocksThrottleReasons(device,
                                                               supportedClocksThrottleReasons)
-    initialize_api()
+    initialize_context()
     ccall((:nvmlDeviceGetSupportedClocksThrottleReasons, libnvml()), nvmlReturn_t,
                    (nvmlDevice_t, Ptr{Culonglong}),
                    device, supportedClocksThrottleReasons)
 end
 
 @checked function nvmlDeviceGetPowerState(device, pState)
-    initialize_api()
+    initialize_context()
     ccall((:nvmlDeviceGetPowerState, libnvml()), nvmlReturn_t,
                    (nvmlDevice_t, Ptr{nvmlPstates_t}),
                    device, pState)
 end
 
 @checked function nvmlDeviceGetPowerManagementMode(device, mode)
-    initialize_api()
+    initialize_context()
     ccall((:nvmlDeviceGetPowerManagementMode, libnvml()), nvmlReturn_t,
                    (nvmlDevice_t, Ptr{nvmlEnableState_t}),
                    device, mode)
 end
 
 @checked function nvmlDeviceGetPowerManagementLimit(device, limit)
-    initialize_api()
+    initialize_context()
     ccall((:nvmlDeviceGetPowerManagementLimit, libnvml()), nvmlReturn_t,
                    (nvmlDevice_t, Ptr{UInt32}),
                    device, limit)
 end
 
 @checked function nvmlDeviceGetPowerManagementLimitConstraints(device, minLimit, maxLimit)
-    initialize_api()
+    initialize_context()
     ccall((:nvmlDeviceGetPowerManagementLimitConstraints, libnvml()), nvmlReturn_t,
                    (nvmlDevice_t, Ptr{UInt32}, Ptr{UInt32}),
                    device, minLimit, maxLimit)
 end
 
 @checked function nvmlDeviceGetPowerManagementDefaultLimit(device, defaultLimit)
-    initialize_api()
+    initialize_context()
     ccall((:nvmlDeviceGetPowerManagementDefaultLimit, libnvml()), nvmlReturn_t,
                    (nvmlDevice_t, Ptr{UInt32}),
                    device, defaultLimit)
 end
 
 @checked function nvmlDeviceGetPowerUsage(device, power)
-    initialize_api()
+    initialize_context()
     ccall((:nvmlDeviceGetPowerUsage, libnvml()), nvmlReturn_t,
                    (nvmlDevice_t, Ptr{UInt32}),
                    device, power)
 end
 
 @checked function nvmlDeviceGetTotalEnergyConsumption(device, energy)
-    initialize_api()
+    initialize_context()
     ccall((:nvmlDeviceGetTotalEnergyConsumption, libnvml()), nvmlReturn_t,
                    (nvmlDevice_t, Ptr{Culonglong}),
                    device, energy)
 end
 
 @checked function nvmlDeviceGetEnforcedPowerLimit(device, limit)
-    initialize_api()
+    initialize_context()
     ccall((:nvmlDeviceGetEnforcedPowerLimit, libnvml()), nvmlReturn_t,
                    (nvmlDevice_t, Ptr{UInt32}),
                    device, limit)
 end
 
 @checked function nvmlDeviceGetGpuOperationMode(device, current, pending)
-    initialize_api()
+    initialize_context()
     ccall((:nvmlDeviceGetGpuOperationMode, libnvml()), nvmlReturn_t,
                    (nvmlDevice_t, Ptr{nvmlGpuOperationMode_t}, Ptr{nvmlGpuOperationMode_t}),
                    device, current, pending)
 end
 
 @checked function nvmlDeviceGetMemoryInfo(device, memory)
-    initialize_api()
+    initialize_context()
     ccall((:nvmlDeviceGetMemoryInfo, libnvml()), nvmlReturn_t,
                    (nvmlDevice_t, Ptr{nvmlMemory_t}),
                    device, memory)
 end
 
 @checked function nvmlDeviceGetComputeMode(device, mode)
-    initialize_api()
+    initialize_context()
     ccall((:nvmlDeviceGetComputeMode, libnvml()), nvmlReturn_t,
                    (nvmlDevice_t, Ptr{nvmlComputeMode_t}),
                    device, mode)
 end
 
 @checked function nvmlDeviceGetCudaComputeCapability(device, major, minor)
-    initialize_api()
+    initialize_context()
     ccall((:nvmlDeviceGetCudaComputeCapability, libnvml()), nvmlReturn_t,
                    (nvmlDevice_t, Ptr{Cint}, Ptr{Cint}),
                    device, major, minor)
 end
 
 @checked function nvmlDeviceGetEccMode(device, current, pending)
-    initialize_api()
+    initialize_context()
     ccall((:nvmlDeviceGetEccMode, libnvml()), nvmlReturn_t,
                    (nvmlDevice_t, Ptr{nvmlEnableState_t}, Ptr{nvmlEnableState_t}),
                    device, current, pending)
 end
 
 @checked function nvmlDeviceGetBoardId(device, boardId)
-    initialize_api()
+    initialize_context()
     ccall((:nvmlDeviceGetBoardId, libnvml()), nvmlReturn_t,
                    (nvmlDevice_t, Ptr{UInt32}),
                    device, boardId)
 end
 
 @checked function nvmlDeviceGetMultiGpuBoard(device, multiGpuBool)
-    initialize_api()
+    initialize_context()
     ccall((:nvmlDeviceGetMultiGpuBoard, libnvml()), nvmlReturn_t,
                    (nvmlDevice_t, Ptr{UInt32}),
                    device, multiGpuBool)
 end
 
 @checked function nvmlDeviceGetTotalEccErrors(device, errorType, counterType, eccCounts)
-    initialize_api()
+    initialize_context()
     ccall((:nvmlDeviceGetTotalEccErrors, libnvml()), nvmlReturn_t,
                    (nvmlDevice_t, nvmlMemoryErrorType_t, nvmlEccCounterType_t,
                     Ptr{Culonglong}),
@@ -621,7 +621,7 @@ end
 end
 
 @checked function nvmlDeviceGetDetailedEccErrors(device, errorType, counterType, eccCounts)
-    initialize_api()
+    initialize_context()
     ccall((:nvmlDeviceGetDetailedEccErrors, libnvml()), nvmlReturn_t,
                    (nvmlDevice_t, nvmlMemoryErrorType_t, nvmlEccCounterType_t,
                     Ptr{nvmlEccErrorCounts_t}),
@@ -630,7 +630,7 @@ end
 
 @checked function nvmlDeviceGetMemoryErrorCounter(device, errorType, counterType,
                                                   locationType, count)
-    initialize_api()
+    initialize_context()
     ccall((:nvmlDeviceGetMemoryErrorCounter, libnvml()), nvmlReturn_t,
                    (nvmlDevice_t, nvmlMemoryErrorType_t, nvmlEccCounterType_t,
                     nvmlMemoryLocation_t, Ptr{Culonglong}),
@@ -638,91 +638,91 @@ end
 end
 
 @checked function nvmlDeviceGetUtilizationRates(device, utilization)
-    initialize_api()
+    initialize_context()
     ccall((:nvmlDeviceGetUtilizationRates, libnvml()), nvmlReturn_t,
                    (nvmlDevice_t, Ptr{nvmlUtilization_t}),
                    device, utilization)
 end
 
 @checked function nvmlDeviceGetEncoderUtilization(device, utilization, samplingPeriodUs)
-    initialize_api()
+    initialize_context()
     ccall((:nvmlDeviceGetEncoderUtilization, libnvml()), nvmlReturn_t,
                    (nvmlDevice_t, Ptr{UInt32}, Ptr{UInt32}),
                    device, utilization, samplingPeriodUs)
 end
 
 @checked function nvmlDeviceGetEncoderCapacity(device, encoderQueryType, encoderCapacity)
-    initialize_api()
+    initialize_context()
     ccall((:nvmlDeviceGetEncoderCapacity, libnvml()), nvmlReturn_t,
                    (nvmlDevice_t, nvmlEncoderType_t, Ptr{UInt32}),
                    device, encoderQueryType, encoderCapacity)
 end
 
 @checked function nvmlDeviceGetEncoderStats(device, sessionCount, averageFps, averageLatency)
-    initialize_api()
+    initialize_context()
     ccall((:nvmlDeviceGetEncoderStats, libnvml()), nvmlReturn_t,
                    (nvmlDevice_t, Ptr{UInt32}, Ptr{UInt32}, Ptr{UInt32}),
                    device, sessionCount, averageFps, averageLatency)
 end
 
 @checked function nvmlDeviceGetEncoderSessions(device, sessionCount, sessionInfos)
-    initialize_api()
+    initialize_context()
     ccall((:nvmlDeviceGetEncoderSessions, libnvml()), nvmlReturn_t,
                    (nvmlDevice_t, Ptr{UInt32}, Ptr{nvmlEncoderSessionInfo_t}),
                    device, sessionCount, sessionInfos)
 end
 
 @checked function nvmlDeviceGetDecoderUtilization(device, utilization, samplingPeriodUs)
-    initialize_api()
+    initialize_context()
     ccall((:nvmlDeviceGetDecoderUtilization, libnvml()), nvmlReturn_t,
                    (nvmlDevice_t, Ptr{UInt32}, Ptr{UInt32}),
                    device, utilization, samplingPeriodUs)
 end
 
 @checked function nvmlDeviceGetFBCStats(device, fbcStats)
-    initialize_api()
+    initialize_context()
     ccall((:nvmlDeviceGetFBCStats, libnvml()), nvmlReturn_t,
                    (nvmlDevice_t, Ptr{nvmlFBCStats_t}),
                    device, fbcStats)
 end
 
 @checked function nvmlDeviceGetFBCSessions(device, sessionCount, sessionInfo)
-    initialize_api()
+    initialize_context()
     ccall((:nvmlDeviceGetFBCSessions, libnvml()), nvmlReturn_t,
                    (nvmlDevice_t, Ptr{UInt32}, Ptr{nvmlFBCSessionInfo_t}),
                    device, sessionCount, sessionInfo)
 end
 
 @checked function nvmlDeviceGetDriverModel(device, current, pending)
-    initialize_api()
+    initialize_context()
     ccall((:nvmlDeviceGetDriverModel, libnvml()), nvmlReturn_t,
                    (nvmlDevice_t, Ptr{nvmlDriverModel_t}, Ptr{nvmlDriverModel_t}),
                    device, current, pending)
 end
 
 @checked function nvmlDeviceGetVbiosVersion(device, version, length)
-    initialize_api()
+    initialize_context()
     ccall((:nvmlDeviceGetVbiosVersion, libnvml()), nvmlReturn_t,
                    (nvmlDevice_t, Cstring, UInt32),
                    device, version, length)
 end
 
 @checked function nvmlDeviceGetBridgeChipInfo(device, bridgeHierarchy)
-    initialize_api()
+    initialize_context()
     ccall((:nvmlDeviceGetBridgeChipInfo, libnvml()), nvmlReturn_t,
                    (nvmlDevice_t, Ptr{nvmlBridgeChipHierarchy_t}),
                    device, bridgeHierarchy)
 end
 
 @checked function nvmlDeviceOnSameBoard(device1, device2, onSameBoard)
-    initialize_api()
+    initialize_context()
     ccall((:nvmlDeviceOnSameBoard, libnvml()), nvmlReturn_t,
                    (nvmlDevice_t, nvmlDevice_t, Ptr{Cint}),
                    device1, device2, onSameBoard)
 end
 
 @checked function nvmlDeviceGetAPIRestriction(device, apiType, isRestricted)
-    initialize_api()
+    initialize_context()
     ccall((:nvmlDeviceGetAPIRestriction, libnvml()), nvmlReturn_t,
                    (nvmlDevice_t, nvmlRestrictedAPI_t, Ptr{nvmlEnableState_t}),
                    device, apiType, isRestricted)
@@ -730,7 +730,7 @@ end
 
 @checked function nvmlDeviceGetSamples(device, type, lastSeenTimeStamp, sampleValType,
                                        sampleCount, samples)
-    initialize_api()
+    initialize_context()
     ccall((:nvmlDeviceGetSamples, libnvml()), nvmlReturn_t,
                    (nvmlDevice_t, nvmlSamplingType_t, Culonglong, Ptr{nvmlValueType_t},
                     Ptr{UInt32}, Ptr{nvmlSample_t}),
@@ -738,49 +738,49 @@ end
 end
 
 @checked function nvmlDeviceGetBAR1MemoryInfo(device, bar1Memory)
-    initialize_api()
+    initialize_context()
     ccall((:nvmlDeviceGetBAR1MemoryInfo, libnvml()), nvmlReturn_t,
                    (nvmlDevice_t, Ptr{nvmlBAR1Memory_t}),
                    device, bar1Memory)
 end
 
 @checked function nvmlDeviceGetViolationStatus(device, perfPolicyType, violTime)
-    initialize_api()
+    initialize_context()
     ccall((:nvmlDeviceGetViolationStatus, libnvml()), nvmlReturn_t,
                    (nvmlDevice_t, nvmlPerfPolicyType_t, Ptr{nvmlViolationTime_t}),
                    device, perfPolicyType, violTime)
 end
 
 @checked function nvmlDeviceGetAccountingMode(device, mode)
-    initialize_api()
+    initialize_context()
     ccall((:nvmlDeviceGetAccountingMode, libnvml()), nvmlReturn_t,
                    (nvmlDevice_t, Ptr{nvmlEnableState_t}),
                    device, mode)
 end
 
 @checked function nvmlDeviceGetAccountingStats(device, pid, stats)
-    initialize_api()
+    initialize_context()
     ccall((:nvmlDeviceGetAccountingStats, libnvml()), nvmlReturn_t,
                    (nvmlDevice_t, UInt32, Ptr{nvmlAccountingStats_t}),
                    device, pid, stats)
 end
 
 @checked function nvmlDeviceGetAccountingPids(device, count, pids)
-    initialize_api()
+    initialize_context()
     ccall((:nvmlDeviceGetAccountingPids, libnvml()), nvmlReturn_t,
                    (nvmlDevice_t, Ptr{UInt32}, Ptr{UInt32}),
                    device, count, pids)
 end
 
 @checked function nvmlDeviceGetAccountingBufferSize(device, bufferSize)
-    initialize_api()
+    initialize_context()
     ccall((:nvmlDeviceGetAccountingBufferSize, libnvml()), nvmlReturn_t,
                    (nvmlDevice_t, Ptr{UInt32}),
                    device, bufferSize)
 end
 
 @checked function nvmlDeviceGetRetiredPages(device, cause, pageCount, addresses)
-    initialize_api()
+    initialize_context()
     ccall((:nvmlDeviceGetRetiredPages, libnvml()), nvmlReturn_t,
                    (nvmlDevice_t, nvmlPageRetirementCause_t, Ptr{UInt32}, Ptr{Culonglong}),
                    device, cause, pageCount, addresses)
@@ -788,7 +788,7 @@ end
 
 @checked function nvmlDeviceGetRetiredPages_v2(device, cause, pageCount, addresses,
                                                timestamps)
-    initialize_api()
+    initialize_context()
     ccall((:nvmlDeviceGetRetiredPages_v2, libnvml()), nvmlReturn_t,
                    (nvmlDevice_t, nvmlPageRetirementCause_t, Ptr{UInt32}, Ptr{Culonglong},
                     Ptr{Culonglong}),
@@ -796,7 +796,7 @@ end
 end
 
 @checked function nvmlDeviceGetRetiredPagesPendingStatus(device, isPending)
-    initialize_api()
+    initialize_context()
     ccall((:nvmlDeviceGetRetiredPagesPendingStatus, libnvml()), nvmlReturn_t,
                    (nvmlDevice_t, Ptr{nvmlEnableState_t}),
                    device, isPending)
@@ -804,154 +804,154 @@ end
 
 @checked function nvmlDeviceGetRemappedRows(device, corrRows, uncRows, isPending,
                                             failureOccurred)
-    initialize_api()
+    initialize_context()
     ccall((:nvmlDeviceGetRemappedRows, libnvml()), nvmlReturn_t,
                    (nvmlDevice_t, Ptr{UInt32}, Ptr{UInt32}, Ptr{UInt32}, Ptr{UInt32}),
                    device, corrRows, uncRows, isPending, failureOccurred)
 end
 
 @checked function nvmlDeviceGetArchitecture(device, arch)
-    initialize_api()
+    initialize_context()
     ccall((:nvmlDeviceGetArchitecture, libnvml()), nvmlReturn_t,
                    (nvmlDevice_t, Ptr{nvmlDeviceArchitecture_t}),
                    device, arch)
 end
 
 @checked function nvmlUnitSetLedState(unit, color)
-    initialize_api()
+    initialize_context()
     ccall((:nvmlUnitSetLedState, libnvml()), nvmlReturn_t,
                    (nvmlUnit_t, nvmlLedColor_t),
                    unit, color)
 end
 
 @checked function nvmlDeviceSetPersistenceMode(device, mode)
-    initialize_api()
+    initialize_context()
     ccall((:nvmlDeviceSetPersistenceMode, libnvml()), nvmlReturn_t,
                    (nvmlDevice_t, nvmlEnableState_t),
                    device, mode)
 end
 
 @checked function nvmlDeviceSetComputeMode(device, mode)
-    initialize_api()
+    initialize_context()
     ccall((:nvmlDeviceSetComputeMode, libnvml()), nvmlReturn_t,
                    (nvmlDevice_t, nvmlComputeMode_t),
                    device, mode)
 end
 
 @checked function nvmlDeviceSetEccMode(device, ecc)
-    initialize_api()
+    initialize_context()
     ccall((:nvmlDeviceSetEccMode, libnvml()), nvmlReturn_t,
                    (nvmlDevice_t, nvmlEnableState_t),
                    device, ecc)
 end
 
 @checked function nvmlDeviceClearEccErrorCounts(device, counterType)
-    initialize_api()
+    initialize_context()
     ccall((:nvmlDeviceClearEccErrorCounts, libnvml()), nvmlReturn_t,
                    (nvmlDevice_t, nvmlEccCounterType_t),
                    device, counterType)
 end
 
 @checked function nvmlDeviceSetDriverModel(device, driverModel, flags)
-    initialize_api()
+    initialize_context()
     ccall((:nvmlDeviceSetDriverModel, libnvml()), nvmlReturn_t,
                    (nvmlDevice_t, nvmlDriverModel_t, UInt32),
                    device, driverModel, flags)
 end
 
 @checked function nvmlDeviceSetGpuLockedClocks(device, minGpuClockMHz, maxGpuClockMHz)
-    initialize_api()
+    initialize_context()
     ccall((:nvmlDeviceSetGpuLockedClocks, libnvml()), nvmlReturn_t,
                    (nvmlDevice_t, UInt32, UInt32),
                    device, minGpuClockMHz, maxGpuClockMHz)
 end
 
 @checked function nvmlDeviceResetGpuLockedClocks(device)
-    initialize_api()
+    initialize_context()
     ccall((:nvmlDeviceResetGpuLockedClocks, libnvml()), nvmlReturn_t,
                    (nvmlDevice_t,),
                    device)
 end
 
 @checked function nvmlDeviceSetApplicationsClocks(device, memClockMHz, graphicsClockMHz)
-    initialize_api()
+    initialize_context()
     ccall((:nvmlDeviceSetApplicationsClocks, libnvml()), nvmlReturn_t,
                    (nvmlDevice_t, UInt32, UInt32),
                    device, memClockMHz, graphicsClockMHz)
 end
 
 @checked function nvmlDeviceSetPowerManagementLimit(device, limit)
-    initialize_api()
+    initialize_context()
     ccall((:nvmlDeviceSetPowerManagementLimit, libnvml()), nvmlReturn_t,
                    (nvmlDevice_t, UInt32),
                    device, limit)
 end
 
 @checked function nvmlDeviceSetGpuOperationMode(device, mode)
-    initialize_api()
+    initialize_context()
     ccall((:nvmlDeviceSetGpuOperationMode, libnvml()), nvmlReturn_t,
                    (nvmlDevice_t, nvmlGpuOperationMode_t),
                    device, mode)
 end
 
 @checked function nvmlDeviceSetAPIRestriction(device, apiType, isRestricted)
-    initialize_api()
+    initialize_context()
     ccall((:nvmlDeviceSetAPIRestriction, libnvml()), nvmlReturn_t,
                    (nvmlDevice_t, nvmlRestrictedAPI_t, nvmlEnableState_t),
                    device, apiType, isRestricted)
 end
 
 @checked function nvmlDeviceSetAccountingMode(device, mode)
-    initialize_api()
+    initialize_context()
     ccall((:nvmlDeviceSetAccountingMode, libnvml()), nvmlReturn_t,
                    (nvmlDevice_t, nvmlEnableState_t),
                    device, mode)
 end
 
 @checked function nvmlDeviceClearAccountingPids(device)
-    initialize_api()
+    initialize_context()
     ccall((:nvmlDeviceClearAccountingPids, libnvml()), nvmlReturn_t,
                    (nvmlDevice_t,),
                    device)
 end
 
 @checked function nvmlDeviceGetNvLinkState(device, link, isActive)
-    initialize_api()
+    initialize_context()
     ccall((:nvmlDeviceGetNvLinkState, libnvml()), nvmlReturn_t,
                    (nvmlDevice_t, UInt32, Ptr{nvmlEnableState_t}),
                    device, link, isActive)
 end
 
 @checked function nvmlDeviceGetNvLinkVersion(device, link, version)
-    initialize_api()
+    initialize_context()
     ccall((:nvmlDeviceGetNvLinkVersion, libnvml()), nvmlReturn_t,
                    (nvmlDevice_t, UInt32, Ptr{UInt32}),
                    device, link, version)
 end
 
 @checked function nvmlDeviceGetNvLinkCapability(device, link, capability, capResult)
-    initialize_api()
+    initialize_context()
     ccall((:nvmlDeviceGetNvLinkCapability, libnvml()), nvmlReturn_t,
                    (nvmlDevice_t, UInt32, nvmlNvLinkCapability_t, Ptr{UInt32}),
                    device, link, capability, capResult)
 end
 
 @checked function nvmlDeviceGetNvLinkRemotePciInfo_v2(device, link, pci)
-    initialize_api()
+    initialize_context()
     ccall((:nvmlDeviceGetNvLinkRemotePciInfo_v2, libnvml()), nvmlReturn_t,
                    (nvmlDevice_t, UInt32, Ptr{nvmlPciInfo_t}),
                    device, link, pci)
 end
 
 @checked function nvmlDeviceGetNvLinkErrorCounter(device, link, counter, counterValue)
-    initialize_api()
+    initialize_context()
     ccall((:nvmlDeviceGetNvLinkErrorCounter, libnvml()), nvmlReturn_t,
                    (nvmlDevice_t, UInt32, nvmlNvLinkErrorCounter_t, Ptr{Culonglong}),
                    device, link, counter, counterValue)
 end
 
 @checked function nvmlDeviceResetNvLinkErrorCounters(device, link)
-    initialize_api()
+    initialize_context()
     ccall((:nvmlDeviceResetNvLinkErrorCounters, libnvml()), nvmlReturn_t,
                    (nvmlDevice_t, UInt32),
                    device, link)
@@ -959,7 +959,7 @@ end
 
 @checked function nvmlDeviceSetNvLinkUtilizationControl(device, link, counter, control,
                                                         reset)
-    initialize_api()
+    initialize_context()
     ccall((:nvmlDeviceSetNvLinkUtilizationControl, libnvml()), nvmlReturn_t,
                    (nvmlDevice_t, UInt32, UInt32, Ptr{nvmlNvLinkUtilizationControl_t},
                     UInt32),
@@ -967,7 +967,7 @@ end
 end
 
 @checked function nvmlDeviceGetNvLinkUtilizationControl(device, link, counter, control)
-    initialize_api()
+    initialize_context()
     ccall((:nvmlDeviceGetNvLinkUtilizationControl, libnvml()), nvmlReturn_t,
                    (nvmlDevice_t, UInt32, UInt32, Ptr{nvmlNvLinkUtilizationControl_t}),
                    device, link, counter, control)
@@ -975,119 +975,119 @@ end
 
 @checked function nvmlDeviceGetNvLinkUtilizationCounter(device, link, counter, rxcounter,
                                                         txcounter)
-    initialize_api()
+    initialize_context()
     ccall((:nvmlDeviceGetNvLinkUtilizationCounter, libnvml()), nvmlReturn_t,
                    (nvmlDevice_t, UInt32, UInt32, Ptr{Culonglong}, Ptr{Culonglong}),
                    device, link, counter, rxcounter, txcounter)
 end
 
 @checked function nvmlDeviceFreezeNvLinkUtilizationCounter(device, link, counter, freeze)
-    initialize_api()
+    initialize_context()
     ccall((:nvmlDeviceFreezeNvLinkUtilizationCounter, libnvml()), nvmlReturn_t,
                    (nvmlDevice_t, UInt32, UInt32, nvmlEnableState_t),
                    device, link, counter, freeze)
 end
 
 @checked function nvmlDeviceResetNvLinkUtilizationCounter(device, link, counter)
-    initialize_api()
+    initialize_context()
     ccall((:nvmlDeviceResetNvLinkUtilizationCounter, libnvml()), nvmlReturn_t,
                    (nvmlDevice_t, UInt32, UInt32),
                    device, link, counter)
 end
 
 @checked function nvmlEventSetCreate(set)
-    initialize_api()
+    initialize_context()
     ccall((:nvmlEventSetCreate, libnvml()), nvmlReturn_t,
                    (Ptr{nvmlEventSet_t},),
                    set)
 end
 
 @checked function nvmlDeviceRegisterEvents(device, eventTypes, set)
-    initialize_api()
+    initialize_context()
     ccall((:nvmlDeviceRegisterEvents, libnvml()), nvmlReturn_t,
                    (nvmlDevice_t, Culonglong, nvmlEventSet_t),
                    device, eventTypes, set)
 end
 
 @checked function nvmlDeviceGetSupportedEventTypes(device, eventTypes)
-    initialize_api()
+    initialize_context()
     ccall((:nvmlDeviceGetSupportedEventTypes, libnvml()), nvmlReturn_t,
                    (nvmlDevice_t, Ptr{Culonglong}),
                    device, eventTypes)
 end
 
 @checked function nvmlEventSetWait_v2(set, data, timeoutms)
-    initialize_api()
+    initialize_context()
     ccall((:nvmlEventSetWait_v2, libnvml()), nvmlReturn_t,
                    (nvmlEventSet_t, Ptr{nvmlEventData_t}, UInt32),
                    set, data, timeoutms)
 end
 
 @checked function nvmlEventSetFree(set)
-    initialize_api()
+    initialize_context()
     ccall((:nvmlEventSetFree, libnvml()), nvmlReturn_t,
                    (nvmlEventSet_t,),
                    set)
 end
 
 @checked function nvmlDeviceModifyDrainState(pciInfo, newState)
-    initialize_api()
+    initialize_context()
     ccall((:nvmlDeviceModifyDrainState, libnvml()), nvmlReturn_t,
                    (Ptr{nvmlPciInfo_t}, nvmlEnableState_t),
                    pciInfo, newState)
 end
 
 @checked function nvmlDeviceQueryDrainState(pciInfo, currentState)
-    initialize_api()
+    initialize_context()
     ccall((:nvmlDeviceQueryDrainState, libnvml()), nvmlReturn_t,
                    (Ptr{nvmlPciInfo_t}, Ptr{nvmlEnableState_t}),
                    pciInfo, currentState)
 end
 
 @checked function nvmlDeviceRemoveGpu_v2(pciInfo, gpuState, linkState)
-    initialize_api()
+    initialize_context()
     ccall((:nvmlDeviceRemoveGpu_v2, libnvml()), nvmlReturn_t,
                    (Ptr{nvmlPciInfo_t}, nvmlDetachGpuState_t, nvmlPcieLinkState_t),
                    pciInfo, gpuState, linkState)
 end
 
 @checked function nvmlDeviceDiscoverGpus(pciInfo)
-    initialize_api()
+    initialize_context()
     ccall((:nvmlDeviceDiscoverGpus, libnvml()), nvmlReturn_t,
                    (Ptr{nvmlPciInfo_t},),
                    pciInfo)
 end
 
 @checked function nvmlDeviceGetFieldValues(device, valuesCount, values)
-    initialize_api()
+    initialize_context()
     ccall((:nvmlDeviceGetFieldValues, libnvml()), nvmlReturn_t,
                    (nvmlDevice_t, Cint, Ptr{nvmlFieldValue_t}),
                    device, valuesCount, values)
 end
 
 @checked function nvmlDeviceGetVirtualizationMode(device, pVirtualMode)
-    initialize_api()
+    initialize_context()
     ccall((:nvmlDeviceGetVirtualizationMode, libnvml()), nvmlReturn_t,
                    (nvmlDevice_t, Ptr{nvmlGpuVirtualizationMode_t}),
                    device, pVirtualMode)
 end
 
 @checked function nvmlDeviceGetHostVgpuMode(device, pHostVgpuMode)
-    initialize_api()
+    initialize_context()
     ccall((:nvmlDeviceGetHostVgpuMode, libnvml()), nvmlReturn_t,
                    (nvmlDevice_t, Ptr{nvmlHostVgpuMode_t}),
                    device, pHostVgpuMode)
 end
 
 @checked function nvmlDeviceSetVirtualizationMode(device, virtualMode)
-    initialize_api()
+    initialize_context()
     ccall((:nvmlDeviceSetVirtualizationMode, libnvml()), nvmlReturn_t,
                    (nvmlDevice_t, nvmlGpuVirtualizationMode_t),
                    device, virtualMode)
 end
 
 @checked function nvmlDeviceGetGridLicensableFeatures_v3(device, pGridLicensableFeatures)
-    initialize_api()
+    initialize_context()
     ccall((:nvmlDeviceGetGridLicensableFeatures_v3, libnvml()), nvmlReturn_t,
                    (nvmlDevice_t, Ptr{nvmlGridLicensableFeatures_t}),
                    device, pGridLicensableFeatures)
@@ -1095,7 +1095,7 @@ end
 
 @checked function nvmlDeviceGetProcessUtilization(device, utilization, processSamplesCount,
                                                   lastSeenTimeStamp)
-    initialize_api()
+    initialize_context()
     ccall((:nvmlDeviceGetProcessUtilization, libnvml()), nvmlReturn_t,
                    (nvmlDevice_t, Ptr{nvmlProcessUtilizationSample_t}, Ptr{UInt32},
                     Culonglong),
@@ -1103,161 +1103,161 @@ end
 end
 
 @checked function nvmlDeviceGetSupportedVgpus(device, vgpuCount, vgpuTypeIds)
-    initialize_api()
+    initialize_context()
     ccall((:nvmlDeviceGetSupportedVgpus, libnvml()), nvmlReturn_t,
                    (nvmlDevice_t, Ptr{UInt32}, Ptr{nvmlVgpuTypeId_t}),
                    device, vgpuCount, vgpuTypeIds)
 end
 
 @checked function nvmlDeviceGetCreatableVgpus(device, vgpuCount, vgpuTypeIds)
-    initialize_api()
+    initialize_context()
     ccall((:nvmlDeviceGetCreatableVgpus, libnvml()), nvmlReturn_t,
                    (nvmlDevice_t, Ptr{UInt32}, Ptr{nvmlVgpuTypeId_t}),
                    device, vgpuCount, vgpuTypeIds)
 end
 
 @checked function nvmlVgpuTypeGetClass(vgpuTypeId, vgpuTypeClass, size)
-    initialize_api()
+    initialize_context()
     ccall((:nvmlVgpuTypeGetClass, libnvml()), nvmlReturn_t,
                    (nvmlVgpuTypeId_t, Cstring, Ptr{UInt32}),
                    vgpuTypeId, vgpuTypeClass, size)
 end
 
 @checked function nvmlVgpuTypeGetName(vgpuTypeId, vgpuTypeName, size)
-    initialize_api()
+    initialize_context()
     ccall((:nvmlVgpuTypeGetName, libnvml()), nvmlReturn_t,
                    (nvmlVgpuTypeId_t, Cstring, Ptr{UInt32}),
                    vgpuTypeId, vgpuTypeName, size)
 end
 
 @checked function nvmlVgpuTypeGetDeviceID(vgpuTypeId, deviceID, subsystemID)
-    initialize_api()
+    initialize_context()
     ccall((:nvmlVgpuTypeGetDeviceID, libnvml()), nvmlReturn_t,
                    (nvmlVgpuTypeId_t, Ptr{Culonglong}, Ptr{Culonglong}),
                    vgpuTypeId, deviceID, subsystemID)
 end
 
 @checked function nvmlVgpuTypeGetFramebufferSize(vgpuTypeId, fbSize)
-    initialize_api()
+    initialize_context()
     ccall((:nvmlVgpuTypeGetFramebufferSize, libnvml()), nvmlReturn_t,
                    (nvmlVgpuTypeId_t, Ptr{Culonglong}),
                    vgpuTypeId, fbSize)
 end
 
 @checked function nvmlVgpuTypeGetNumDisplayHeads(vgpuTypeId, numDisplayHeads)
-    initialize_api()
+    initialize_context()
     ccall((:nvmlVgpuTypeGetNumDisplayHeads, libnvml()), nvmlReturn_t,
                    (nvmlVgpuTypeId_t, Ptr{UInt32}),
                    vgpuTypeId, numDisplayHeads)
 end
 
 @checked function nvmlVgpuTypeGetResolution(vgpuTypeId, displayIndex, xdim, ydim)
-    initialize_api()
+    initialize_context()
     ccall((:nvmlVgpuTypeGetResolution, libnvml()), nvmlReturn_t,
                    (nvmlVgpuTypeId_t, UInt32, Ptr{UInt32}, Ptr{UInt32}),
                    vgpuTypeId, displayIndex, xdim, ydim)
 end
 
 @checked function nvmlVgpuTypeGetLicense(vgpuTypeId, vgpuTypeLicenseString, size)
-    initialize_api()
+    initialize_context()
     ccall((:nvmlVgpuTypeGetLicense, libnvml()), nvmlReturn_t,
                    (nvmlVgpuTypeId_t, Cstring, UInt32),
                    vgpuTypeId, vgpuTypeLicenseString, size)
 end
 
 @checked function nvmlVgpuTypeGetFrameRateLimit(vgpuTypeId, frameRateLimit)
-    initialize_api()
+    initialize_context()
     ccall((:nvmlVgpuTypeGetFrameRateLimit, libnvml()), nvmlReturn_t,
                    (nvmlVgpuTypeId_t, Ptr{UInt32}),
                    vgpuTypeId, frameRateLimit)
 end
 
 @checked function nvmlVgpuTypeGetMaxInstances(device, vgpuTypeId, vgpuInstanceCount)
-    initialize_api()
+    initialize_context()
     ccall((:nvmlVgpuTypeGetMaxInstances, libnvml()), nvmlReturn_t,
                    (nvmlDevice_t, nvmlVgpuTypeId_t, Ptr{UInt32}),
                    device, vgpuTypeId, vgpuInstanceCount)
 end
 
 @checked function nvmlVgpuTypeGetMaxInstancesPerVm(vgpuTypeId, vgpuInstanceCountPerVm)
-    initialize_api()
+    initialize_context()
     ccall((:nvmlVgpuTypeGetMaxInstancesPerVm, libnvml()), nvmlReturn_t,
                    (nvmlVgpuTypeId_t, Ptr{UInt32}),
                    vgpuTypeId, vgpuInstanceCountPerVm)
 end
 
 @checked function nvmlDeviceGetActiveVgpus(device, vgpuCount, vgpuInstances)
-    initialize_api()
+    initialize_context()
     ccall((:nvmlDeviceGetActiveVgpus, libnvml()), nvmlReturn_t,
                    (nvmlDevice_t, Ptr{UInt32}, Ptr{nvmlVgpuInstance_t}),
                    device, vgpuCount, vgpuInstances)
 end
 
 @checked function nvmlVgpuInstanceGetVmID(vgpuInstance, vmId, size, vmIdType)
-    initialize_api()
+    initialize_context()
     ccall((:nvmlVgpuInstanceGetVmID, libnvml()), nvmlReturn_t,
                    (nvmlVgpuInstance_t, Cstring, UInt32, Ptr{nvmlVgpuVmIdType_t}),
                    vgpuInstance, vmId, size, vmIdType)
 end
 
 @checked function nvmlVgpuInstanceGetUUID(vgpuInstance, uuid, size)
-    initialize_api()
+    initialize_context()
     ccall((:nvmlVgpuInstanceGetUUID, libnvml()), nvmlReturn_t,
                    (nvmlVgpuInstance_t, Cstring, UInt32),
                    vgpuInstance, uuid, size)
 end
 
 @checked function nvmlVgpuInstanceGetVmDriverVersion(vgpuInstance, version, length)
-    initialize_api()
+    initialize_context()
     ccall((:nvmlVgpuInstanceGetVmDriverVersion, libnvml()), nvmlReturn_t,
                    (nvmlVgpuInstance_t, Cstring, UInt32),
                    vgpuInstance, version, length)
 end
 
 @checked function nvmlVgpuInstanceGetFbUsage(vgpuInstance, fbUsage)
-    initialize_api()
+    initialize_context()
     ccall((:nvmlVgpuInstanceGetFbUsage, libnvml()), nvmlReturn_t,
                    (nvmlVgpuInstance_t, Ptr{Culonglong}),
                    vgpuInstance, fbUsage)
 end
 
 @checked function nvmlVgpuInstanceGetLicenseStatus(vgpuInstance, licensed)
-    initialize_api()
+    initialize_context()
     ccall((:nvmlVgpuInstanceGetLicenseStatus, libnvml()), nvmlReturn_t,
                    (nvmlVgpuInstance_t, Ptr{UInt32}),
                    vgpuInstance, licensed)
 end
 
 @checked function nvmlVgpuInstanceGetType(vgpuInstance, vgpuTypeId)
-    initialize_api()
+    initialize_context()
     ccall((:nvmlVgpuInstanceGetType, libnvml()), nvmlReturn_t,
                    (nvmlVgpuInstance_t, Ptr{nvmlVgpuTypeId_t}),
                    vgpuInstance, vgpuTypeId)
 end
 
 @checked function nvmlVgpuInstanceGetFrameRateLimit(vgpuInstance, frameRateLimit)
-    initialize_api()
+    initialize_context()
     ccall((:nvmlVgpuInstanceGetFrameRateLimit, libnvml()), nvmlReturn_t,
                    (nvmlVgpuInstance_t, Ptr{UInt32}),
                    vgpuInstance, frameRateLimit)
 end
 
 @checked function nvmlVgpuInstanceGetEccMode(vgpuInstance, eccMode)
-    initialize_api()
+    initialize_context()
     ccall((:nvmlVgpuInstanceGetEccMode, libnvml()), nvmlReturn_t,
                    (nvmlVgpuInstance_t, Ptr{nvmlEnableState_t}),
                    vgpuInstance, eccMode)
 end
 
 @checked function nvmlVgpuInstanceGetEncoderCapacity(vgpuInstance, encoderCapacity)
-    initialize_api()
+    initialize_context()
     ccall((:nvmlVgpuInstanceGetEncoderCapacity, libnvml()), nvmlReturn_t,
                    (nvmlVgpuInstance_t, Ptr{UInt32}),
                    vgpuInstance, encoderCapacity)
 end
 
 @checked function nvmlVgpuInstanceSetEncoderCapacity(vgpuInstance, encoderCapacity)
-    initialize_api()
+    initialize_context()
     ccall((:nvmlVgpuInstanceSetEncoderCapacity, libnvml()), nvmlReturn_t,
                    (nvmlVgpuInstance_t, UInt32),
                    vgpuInstance, encoderCapacity)
@@ -1265,49 +1265,49 @@ end
 
 @checked function nvmlVgpuInstanceGetEncoderStats(vgpuInstance, sessionCount, averageFps,
                                                   averageLatency)
-    initialize_api()
+    initialize_context()
     ccall((:nvmlVgpuInstanceGetEncoderStats, libnvml()), nvmlReturn_t,
                    (nvmlVgpuInstance_t, Ptr{UInt32}, Ptr{UInt32}, Ptr{UInt32}),
                    vgpuInstance, sessionCount, averageFps, averageLatency)
 end
 
 @checked function nvmlVgpuInstanceGetEncoderSessions(vgpuInstance, sessionCount, sessionInfo)
-    initialize_api()
+    initialize_context()
     ccall((:nvmlVgpuInstanceGetEncoderSessions, libnvml()), nvmlReturn_t,
                    (nvmlVgpuInstance_t, Ptr{UInt32}, Ptr{nvmlEncoderSessionInfo_t}),
                    vgpuInstance, sessionCount, sessionInfo)
 end
 
 @checked function nvmlVgpuInstanceGetFBCStats(vgpuInstance, fbcStats)
-    initialize_api()
+    initialize_context()
     ccall((:nvmlVgpuInstanceGetFBCStats, libnvml()), nvmlReturn_t,
                    (nvmlVgpuInstance_t, Ptr{nvmlFBCStats_t}),
                    vgpuInstance, fbcStats)
 end
 
 @checked function nvmlVgpuInstanceGetFBCSessions(vgpuInstance, sessionCount, sessionInfo)
-    initialize_api()
+    initialize_context()
     ccall((:nvmlVgpuInstanceGetFBCSessions, libnvml()), nvmlReturn_t,
                    (nvmlVgpuInstance_t, Ptr{UInt32}, Ptr{nvmlFBCSessionInfo_t}),
                    vgpuInstance, sessionCount, sessionInfo)
 end
 
 @checked function nvmlVgpuInstanceGetMetadata(vgpuInstance, vgpuMetadata, bufferSize)
-    initialize_api()
+    initialize_context()
     ccall((:nvmlVgpuInstanceGetMetadata, libnvml()), nvmlReturn_t,
                    (nvmlVgpuInstance_t, Ptr{nvmlVgpuMetadata_t}, Ptr{UInt32}),
                    vgpuInstance, vgpuMetadata, bufferSize)
 end
 
 @checked function nvmlDeviceGetVgpuMetadata(device, pgpuMetadata, bufferSize)
-    initialize_api()
+    initialize_context()
     ccall((:nvmlDeviceGetVgpuMetadata, libnvml()), nvmlReturn_t,
                    (nvmlDevice_t, Ptr{nvmlVgpuPgpuMetadata_t}, Ptr{UInt32}),
                    device, pgpuMetadata, bufferSize)
 end
 
 @checked function nvmlGetVgpuCompatibility(vgpuMetadata, pgpuMetadata, compatibilityInfo)
-    initialize_api()
+    initialize_context()
     ccall((:nvmlGetVgpuCompatibility, libnvml()), nvmlReturn_t,
                    (Ptr{nvmlVgpuMetadata_t}, Ptr{nvmlVgpuPgpuMetadata_t},
                     Ptr{nvmlVgpuPgpuCompatibility_t}),
@@ -1315,21 +1315,21 @@ end
 end
 
 @checked function nvmlDeviceGetPgpuMetadataString(device, pgpuMetadata, bufferSize)
-    initialize_api()
+    initialize_context()
     ccall((:nvmlDeviceGetPgpuMetadataString, libnvml()), nvmlReturn_t,
                    (nvmlDevice_t, Cstring, Ptr{UInt32}),
                    device, pgpuMetadata, bufferSize)
 end
 
 @checked function nvmlGetVgpuVersion(supported, current)
-    initialize_api()
+    initialize_context()
     ccall((:nvmlGetVgpuVersion, libnvml()), nvmlReturn_t,
                    (Ptr{nvmlVgpuVersion_t}, Ptr{nvmlVgpuVersion_t}),
                    supported, current)
 end
 
 @checked function nvmlSetVgpuVersion(vgpuVersion)
-    initialize_api()
+    initialize_context()
     ccall((:nvmlSetVgpuVersion, libnvml()), nvmlReturn_t,
                    (Ptr{nvmlVgpuVersion_t},),
                    vgpuVersion)
@@ -1337,7 +1337,7 @@ end
 
 @checked function nvmlDeviceGetVgpuUtilization(device, lastSeenTimeStamp, sampleValType,
                                                vgpuInstanceSamplesCount, utilizationSamples)
-    initialize_api()
+    initialize_context()
     ccall((:nvmlDeviceGetVgpuUtilization, libnvml()), nvmlReturn_t,
                    (nvmlDevice_t, Culonglong, Ptr{nvmlValueType_t}, Ptr{UInt32},
                     Ptr{nvmlVgpuInstanceUtilizationSample_t}),
@@ -1348,7 +1348,7 @@ end
 @checked function nvmlDeviceGetVgpuProcessUtilization(device, lastSeenTimeStamp,
                                                       vgpuProcessSamplesCount,
                                                       utilizationSamples)
-    initialize_api()
+    initialize_context()
     ccall((:nvmlDeviceGetVgpuProcessUtilization, libnvml()), nvmlReturn_t,
                    (nvmlDevice_t, Culonglong, Ptr{UInt32},
                     Ptr{nvmlVgpuProcessUtilizationSample_t}),
@@ -1356,63 +1356,63 @@ end
 end
 
 @checked function nvmlVgpuInstanceGetAccountingMode(vgpuInstance, mode)
-    initialize_api()
+    initialize_context()
     ccall((:nvmlVgpuInstanceGetAccountingMode, libnvml()), nvmlReturn_t,
                    (nvmlVgpuInstance_t, Ptr{nvmlEnableState_t}),
                    vgpuInstance, mode)
 end
 
 @checked function nvmlVgpuInstanceGetAccountingPids(vgpuInstance, count, pids)
-    initialize_api()
+    initialize_context()
     ccall((:nvmlVgpuInstanceGetAccountingPids, libnvml()), nvmlReturn_t,
                    (nvmlVgpuInstance_t, Ptr{UInt32}, Ptr{UInt32}),
                    vgpuInstance, count, pids)
 end
 
 @checked function nvmlVgpuInstanceGetAccountingStats(vgpuInstance, pid, stats)
-    initialize_api()
+    initialize_context()
     ccall((:nvmlVgpuInstanceGetAccountingStats, libnvml()), nvmlReturn_t,
                    (nvmlVgpuInstance_t, UInt32, Ptr{nvmlAccountingStats_t}),
                    vgpuInstance, pid, stats)
 end
 
 @checked function nvmlVgpuInstanceClearAccountingPids(vgpuInstance)
-    initialize_api()
+    initialize_context()
     ccall((:nvmlVgpuInstanceClearAccountingPids, libnvml()), nvmlReturn_t,
                    (nvmlVgpuInstance_t,),
                    vgpuInstance)
 end
 
 @checked function nvmlGetBlacklistDeviceCount(deviceCount)
-    initialize_api()
+    initialize_context()
     ccall((:nvmlGetBlacklistDeviceCount, libnvml()), nvmlReturn_t,
                    (Ptr{UInt32},),
                    deviceCount)
 end
 
 @checked function nvmlGetBlacklistDeviceInfoByIndex(index, info)
-    initialize_api()
+    initialize_context()
     ccall((:nvmlGetBlacklistDeviceInfoByIndex, libnvml()), nvmlReturn_t,
                    (UInt32, Ptr{nvmlBlacklistDeviceInfo_t}),
                    index, info)
 end
 
 @checked function nvmlDeviceSetMigMode(device, mode, activationStatus)
-    initialize_api()
+    initialize_context()
     ccall((:nvmlDeviceSetMigMode, libnvml()), nvmlReturn_t,
                    (nvmlDevice_t, UInt32, Ptr{nvmlReturn_t}),
                    device, mode, activationStatus)
 end
 
 @checked function nvmlDeviceGetMigMode(device, currentMode, pendingMode)
-    initialize_api()
+    initialize_context()
     ccall((:nvmlDeviceGetMigMode, libnvml()), nvmlReturn_t,
                    (nvmlDevice_t, Ptr{UInt32}, Ptr{UInt32}),
                    device, currentMode, pendingMode)
 end
 
 @checked function nvmlDeviceGetGpuInstanceProfileInfo(device, profile, info)
-    initialize_api()
+    initialize_context()
     ccall((:nvmlDeviceGetGpuInstanceProfileInfo, libnvml()), nvmlReturn_t,
                    (nvmlDevice_t, UInt32, Ptr{nvmlGpuInstanceProfileInfo_t}),
                    device, profile, info)
@@ -1420,49 +1420,49 @@ end
 
 @checked function nvmlDeviceGetGpuInstancePossiblePlacements(device, profileId, placements,
                                                              count)
-    initialize_api()
+    initialize_context()
     ccall((:nvmlDeviceGetGpuInstancePossiblePlacements, libnvml()), nvmlReturn_t,
                    (nvmlDevice_t, UInt32, Ptr{nvmlGpuInstancePlacement_t}, Ptr{UInt32}),
                    device, profileId, placements, count)
 end
 
 @checked function nvmlDeviceGetGpuInstanceRemainingCapacity(device, profileId, count)
-    initialize_api()
+    initialize_context()
     ccall((:nvmlDeviceGetGpuInstanceRemainingCapacity, libnvml()), nvmlReturn_t,
                    (nvmlDevice_t, UInt32, Ptr{UInt32}),
                    device, profileId, count)
 end
 
 @checked function nvmlDeviceCreateGpuInstance(device, profileId, gpuInstance)
-    initialize_api()
+    initialize_context()
     ccall((:nvmlDeviceCreateGpuInstance, libnvml()), nvmlReturn_t,
                    (nvmlDevice_t, UInt32, Ptr{nvmlGpuInstance_t}),
                    device, profileId, gpuInstance)
 end
 
 @checked function nvmlGpuInstanceDestroy(gpuInstance)
-    initialize_api()
+    initialize_context()
     ccall((:nvmlGpuInstanceDestroy, libnvml()), nvmlReturn_t,
                    (nvmlGpuInstance_t,),
                    gpuInstance)
 end
 
 @checked function nvmlDeviceGetGpuInstances(device, profileId, gpuInstances, count)
-    initialize_api()
+    initialize_context()
     ccall((:nvmlDeviceGetGpuInstances, libnvml()), nvmlReturn_t,
                    (nvmlDevice_t, UInt32, Ptr{nvmlGpuInstance_t}, Ptr{UInt32}),
                    device, profileId, gpuInstances, count)
 end
 
 @checked function nvmlDeviceGetGpuInstanceById(device, id, gpuInstance)
-    initialize_api()
+    initialize_context()
     ccall((:nvmlDeviceGetGpuInstanceById, libnvml()), nvmlReturn_t,
                    (nvmlDevice_t, UInt32, Ptr{nvmlGpuInstance_t}),
                    device, id, gpuInstance)
 end
 
 @checked function nvmlGpuInstanceGetInfo(gpuInstance, info)
-    initialize_api()
+    initialize_context()
     ccall((:nvmlGpuInstanceGetInfo, libnvml()), nvmlReturn_t,
                    (nvmlGpuInstance_t, Ptr{nvmlGpuInstanceInfo_t}),
                    gpuInstance, info)
@@ -1470,7 +1470,7 @@ end
 
 @checked function nvmlGpuInstanceGetComputeInstanceProfileInfo(gpuInstance, profile,
                                                                engProfile, info)
-    initialize_api()
+    initialize_context()
     ccall((:nvmlGpuInstanceGetComputeInstanceProfileInfo, libnvml()), nvmlReturn_t,
                    (nvmlGpuInstance_t, UInt32, UInt32,
                     Ptr{nvmlComputeInstanceProfileInfo_t}),
@@ -1479,7 +1479,7 @@ end
 
 @checked function nvmlGpuInstanceGetComputeInstanceRemainingCapacity(gpuInstance,
                                                                      profileId, count)
-    initialize_api()
+    initialize_context()
     ccall((:nvmlGpuInstanceGetComputeInstanceRemainingCapacity, libnvml()), nvmlReturn_t,
                    (nvmlGpuInstance_t, UInt32, Ptr{UInt32}),
                    gpuInstance, profileId, count)
@@ -1487,14 +1487,14 @@ end
 
 @checked function nvmlGpuInstanceCreateComputeInstance(gpuInstance, profileId,
                                                        computeInstance)
-    initialize_api()
+    initialize_context()
     ccall((:nvmlGpuInstanceCreateComputeInstance, libnvml()), nvmlReturn_t,
                    (nvmlGpuInstance_t, UInt32, Ptr{nvmlComputeInstance_t}),
                    gpuInstance, profileId, computeInstance)
 end
 
 @checked function nvmlComputeInstanceDestroy(computeInstance)
-    initialize_api()
+    initialize_context()
     ccall((:nvmlComputeInstanceDestroy, libnvml()), nvmlReturn_t,
                    (nvmlComputeInstance_t,),
                    computeInstance)
@@ -1502,56 +1502,56 @@ end
 
 @checked function nvmlGpuInstanceGetComputeInstances(gpuInstance, profileId,
                                                      computeInstances, count)
-    initialize_api()
+    initialize_context()
     ccall((:nvmlGpuInstanceGetComputeInstances, libnvml()), nvmlReturn_t,
                    (nvmlGpuInstance_t, UInt32, Ptr{nvmlComputeInstance_t}, Ptr{UInt32}),
                    gpuInstance, profileId, computeInstances, count)
 end
 
 @checked function nvmlGpuInstanceGetComputeInstanceById(gpuInstance, id, computeInstance)
-    initialize_api()
+    initialize_context()
     ccall((:nvmlGpuInstanceGetComputeInstanceById, libnvml()), nvmlReturn_t,
                    (nvmlGpuInstance_t, UInt32, Ptr{nvmlComputeInstance_t}),
                    gpuInstance, id, computeInstance)
 end
 
 @checked function nvmlDeviceIsMigDeviceHandle(device, isMigDevice)
-    initialize_api()
+    initialize_context()
     ccall((:nvmlDeviceIsMigDeviceHandle, libnvml()), nvmlReturn_t,
                    (nvmlDevice_t, Ptr{UInt32}),
                    device, isMigDevice)
 end
 
 @checked function nvmlDeviceGetGpuInstanceId(device, id)
-    initialize_api()
+    initialize_context()
     ccall((:nvmlDeviceGetGpuInstanceId, libnvml()), nvmlReturn_t,
                    (nvmlDevice_t, Ptr{UInt32}),
                    device, id)
 end
 
 @checked function nvmlDeviceGetComputeInstanceId(device, id)
-    initialize_api()
+    initialize_context()
     ccall((:nvmlDeviceGetComputeInstanceId, libnvml()), nvmlReturn_t,
                    (nvmlDevice_t, Ptr{UInt32}),
                    device, id)
 end
 
 @checked function nvmlDeviceGetMaxMigDeviceCount(device, count)
-    initialize_api()
+    initialize_context()
     ccall((:nvmlDeviceGetMaxMigDeviceCount, libnvml()), nvmlReturn_t,
                    (nvmlDevice_t, Ptr{UInt32}),
                    device, count)
 end
 
 @checked function nvmlDeviceGetMigDeviceHandleByIndex(device, index, migDevice)
-    initialize_api()
+    initialize_context()
     ccall((:nvmlDeviceGetMigDeviceHandleByIndex, libnvml()), nvmlReturn_t,
                    (nvmlDevice_t, UInt32, Ptr{nvmlDevice_t}),
                    device, index, migDevice)
 end
 
 @checked function nvmlDeviceGetDeviceHandleFromMigDeviceHandle(migDevice, device)
-    initialize_api()
+    initialize_context()
     ccall((:nvmlDeviceGetDeviceHandleFromMigDeviceHandle, libnvml()), nvmlReturn_t,
                    (nvmlDevice_t, Ptr{nvmlDevice_t}),
                    migDevice, device)
@@ -1560,51 +1560,51 @@ end
 ## Added in CUDA 11.1
 
 @checked function nvmlDeviceGetGraphicsRunningProcesses_v2(device, infoCount, infos)
-    initialize_api()
+    initialize_context()
     ccall((:nvmlDeviceGetGraphicsRunningProcesses_v2, libnvml()), nvmlReturn_t, (nvmlDevice_t, Ptr{UInt32}, Ptr{nvmlProcessInfo_t}), device, infoCount, infos)
 end
 
 @checked function nvmlVgpuTypeGetGpuInstanceProfileId(vgpuTypeId, gpuInstanceProfileId)
-    initialize_api()
+    initialize_context()
     ccall((:nvmlVgpuTypeGetGpuInstanceProfileId, libnvml()), nvmlReturn_t, (nvmlVgpuTypeId_t, Ptr{UInt32}), vgpuTypeId, gpuInstanceProfileId)
 end
 
 @checked function nvmlDeviceGetAttributes_v2(device, attributes)
-    initialize_api()
+    initialize_context()
     ccall((:nvmlDeviceGetAttributes_v2, libnvml()), nvmlReturn_t, (nvmlDevice_t, Ptr{nvmlDeviceAttributes_t}), device, attributes)
 end
 
 @checked function nvmlDeviceGetRowRemapperHistogram(device, values)
-    initialize_api()
+    initialize_context()
     ccall((:nvmlDeviceGetRowRemapperHistogram, libnvml()), nvmlReturn_t, (nvmlDevice_t, Ptr{nvmlRowRemapperHistogramValues_t}), device, values)
 end
 
 @checked function nvmlDeviceGetComputeRunningProcesses_v2(device, infoCount, infos)
-    initialize_api()
+    initialize_context()
     ccall((:nvmlDeviceGetComputeRunningProcesses_v2, libnvml()), nvmlReturn_t, (nvmlDevice_t, Ptr{UInt32}, Ptr{nvmlProcessInfo_t}), device, infoCount, infos)
 end
 
 ## Added in CUDA 11.2
 
 @checked function nvmlComputeInstanceGetInfo_v2(computeInstance, info)
-    initialize_api()
+    initialize_context()
     ccall((:nvmlComputeInstanceGetInfo_v2, libnvml()), nvmlReturn_t, (nvmlComputeInstance_t, Ptr{nvmlComputeInstanceInfo_t}), computeInstance, info)
 end
 
 @checked function nvmlVgpuInstanceGetGpuInstanceId(vgpuInstance, gpuInstanceId)
-    initialize_api()
+    initialize_context()
     ccall((:nvmlVgpuInstanceGetGpuInstanceId, libnvml()), nvmlReturn_t, (nvmlVgpuInstance_t, Ptr{UInt32}), vgpuInstance, gpuInstanceId)
 end
 
 @checked function nvmlDeviceSetTemperatureThreshold(device, thresholdType, temp)
-    initialize_api()
+    initialize_context()
     ccall((:nvmlDeviceSetTemperatureThreshold, libnvml()), nvmlReturn_t, (nvmlDevice_t, nvmlTemperatureThresholds_t, Ptr{Cint}), device, thresholdType, temp)
 end
 
 ## Added in CUDA 11.2 Update 2
 
 @checked function nvmlDeviceCreateGpuInstanceWithPlacement(device, profileId, placement, gpuInstance)
-    initialize_api()
+    initialize_context()
     ccall((:nvmlDeviceCreateGpuInstanceWithPlacement, libnvml), nvmlReturn_t, (nvmlDevice_t, UInt32, Ptr{nvmlGpuInstancePlacement_t}, Ptr{nvmlGpuInstance_t}), device, profileId, placement, gpuInstance)
 end
 

--- a/lib/nvml/libnvml_deprecated.jl
+++ b/lib/nvml/libnvml_deprecated.jl
@@ -12,7 +12,7 @@ end
 const nvmlDeviceAttributesV1_t = nvmlDeviceAttributesV1_st
 
 @checked function nvmlDeviceGetAttributes(device, attributes)
-    initialize_api()
+    initialize_context()
     ccall((:nvmlDeviceGetAttributes, libnvml()), nvmlReturn_t,
                    (nvmlDevice_t, Ptr{nvmlDeviceAttributesV1_t}),
                    device, attributes)
@@ -26,14 +26,14 @@ end
 const nvmlProcessInfoV1_t = nvmlProcessInfoV1_st
 
 @checked function nvmlDeviceGetComputeRunningProcesses(device, infoCount, infos)
-    initialize_api()
+    initialize_context()
     ccall((:nvmlDeviceGetComputeRunningProcesses, libnvml()), nvmlReturn_t,
                    (nvmlDevice_t, Ptr{UInt32}, Ptr{nvmlProcessInfoV1_t}),
                    device, infoCount, infos)
 end
 
 @checked function nvmlDeviceGetGraphicsRunningProcesses(device, infoCount, infos)
-    initialize_api()
+    initialize_context()
     ccall((:nvmlDeviceGetGraphicsRunningProcesses, libnvml()), nvmlReturn_t,
                    (nvmlDevice_t, Ptr{UInt32}, Ptr{nvmlProcessInfoV1_t}),
                    device, infoCount, infos)
@@ -51,7 +51,7 @@ end
 const nvmlComputeInstanceInfoV1_t = nvmlComputeInstanceInfoV1_st
 
 @checked function nvmlComputeInstanceGetInfo(computeInstance, info)
-    initialize_api()
+    initialize_context()
     ccall((:nvmlComputeInstanceGetInfo, libnvml()), nvmlReturn_t,
                    (nvmlComputeInstance_t, Ptr{nvmlComputeInstanceInfoV1_t}),
                    computeInstance, info)

--- a/lib/nvtx/NVTX.jl
+++ b/lib/nvtx/NVTX.jl
@@ -10,7 +10,7 @@ using ExprTools: splitdef, combinedef
 
 
 # core library
-initialize_api() = return
+initialize_context() = return
 include("libnvtx_common.jl")
 include("libnvtx.jl")
 

--- a/lib/nvtx/libnvtx.jl
+++ b/lib/nvtx/libnvtx.jl
@@ -2,208 +2,208 @@
 # Automatically generated using Clang.jl
 
 function nvtxInitialize(reserved)
-    initialize_api()
+    initialize_context()
     ccall((:nvtxInitialize, libnvtx()), Cvoid,
                    (Ptr{Cvoid},),
                    reserved)
 end
 
 function nvtxDomainMarkEx(domain, eventAttrib)
-    initialize_api()
+    initialize_context()
     ccall((:nvtxDomainMarkEx, libnvtx()), Cvoid,
                    (nvtxDomainHandle_t, Ptr{nvtxEventAttributes_t}),
                    domain, eventAttrib)
 end
 
 function nvtxMarkEx(eventAttrib)
-    initialize_api()
+    initialize_context()
     ccall((:nvtxMarkEx, libnvtx()), Cvoid,
                    (Ptr{nvtxEventAttributes_t},),
                    eventAttrib)
 end
 
 function nvtxMarkA(message)
-    initialize_api()
+    initialize_context()
     ccall((:nvtxMarkA, libnvtx()), Cvoid,
                    (Cstring,),
                    message)
 end
 
 function nvtxMarkW(message)
-    initialize_api()
+    initialize_context()
     ccall((:nvtxMarkW, libnvtx()), Cvoid,
                    (Ptr{Cwchar_t},),
                    message)
 end
 
 function nvtxDomainRangeStartEx(domain, eventAttrib)
-    initialize_api()
+    initialize_context()
     ccall((:nvtxDomainRangeStartEx, libnvtx()), nvtxRangeId_t,
                    (nvtxDomainHandle_t, Ptr{nvtxEventAttributes_t}),
                    domain, eventAttrib)
 end
 
 function nvtxRangeStartEx(eventAttrib)
-    initialize_api()
+    initialize_context()
     ccall((:nvtxRangeStartEx, libnvtx()), nvtxRangeId_t,
                    (Ptr{nvtxEventAttributes_t},),
                    eventAttrib)
 end
 
 function nvtxRangeStartA(message)
-    initialize_api()
+    initialize_context()
     ccall((:nvtxRangeStartA, libnvtx()), nvtxRangeId_t,
                    (Cstring,),
                    message)
 end
 
 function nvtxRangeStartW(message)
-    initialize_api()
+    initialize_context()
     ccall((:nvtxRangeStartW, libnvtx()), nvtxRangeId_t,
                    (Ptr{Cwchar_t},),
                    message)
 end
 
 function nvtxDomainRangeEnd(domain, id)
-    initialize_api()
+    initialize_context()
     ccall((:nvtxDomainRangeEnd, libnvtx()), Cvoid,
                    (nvtxDomainHandle_t, nvtxRangeId_t),
                    domain, id)
 end
 
 function nvtxRangeEnd(id)
-    initialize_api()
+    initialize_context()
     ccall((:nvtxRangeEnd, libnvtx()), Cvoid,
                    (nvtxRangeId_t,),
                    id)
 end
 
 function nvtxDomainRangePushEx(domain, eventAttrib)
-    initialize_api()
+    initialize_context()
     ccall((:nvtxDomainRangePushEx, libnvtx()), Cint,
                    (nvtxDomainHandle_t, Ptr{nvtxEventAttributes_t}),
                    domain, eventAttrib)
 end
 
 function nvtxRangePushEx(eventAttrib)
-    initialize_api()
+    initialize_context()
     ccall((:nvtxRangePushEx, libnvtx()), Cint,
                    (Ptr{nvtxEventAttributes_t},),
                    eventAttrib)
 end
 
 function nvtxRangePushA(message)
-    initialize_api()
+    initialize_context()
     ccall((:nvtxRangePushA, libnvtx()), Cint,
                    (Cstring,),
                    message)
 end
 
 function nvtxRangePushW(message)
-    initialize_api()
+    initialize_context()
     ccall((:nvtxRangePushW, libnvtx()), Cint,
                    (Ptr{Cwchar_t},),
                    message)
 end
 
 function nvtxDomainRangePop(domain)
-    initialize_api()
+    initialize_context()
     ccall((:nvtxDomainRangePop, libnvtx()), Cint,
                    (nvtxDomainHandle_t,),
                    domain)
 end
 
 function nvtxRangePop()
-    initialize_api()
+    initialize_context()
     ccall((:nvtxRangePop, libnvtx()), Cint, ())
 end
 
 function nvtxDomainResourceCreate(domain, attribs)
-    initialize_api()
+    initialize_context()
     ccall((:nvtxDomainResourceCreate, libnvtx()), nvtxResourceHandle_t,
                    (nvtxDomainHandle_t, Ptr{nvtxResourceAttributes_t}),
                    domain, attribs)
 end
 
 function nvtxDomainResourceDestroy(resource)
-    initialize_api()
+    initialize_context()
     ccall((:nvtxDomainResourceDestroy, libnvtx()), Cvoid,
                    (nvtxResourceHandle_t,),
                    resource)
 end
 
 function nvtxDomainNameCategoryA(domain, category, name)
-    initialize_api()
+    initialize_context()
     ccall((:nvtxDomainNameCategoryA, libnvtx()), Cvoid,
                    (nvtxDomainHandle_t, UInt32, Cstring),
                    domain, category, name)
 end
 
 function nvtxDomainNameCategoryW(domain, category, name)
-    initialize_api()
+    initialize_context()
     ccall((:nvtxDomainNameCategoryW, libnvtx()), Cvoid,
                    (nvtxDomainHandle_t, UInt32, Ptr{Cwchar_t}),
                    domain, category, name)
 end
 
 function nvtxNameCategoryA(category, name)
-    initialize_api()
+    initialize_context()
     ccall((:nvtxNameCategoryA, libnvtx()), Cvoid,
                    (UInt32, Cstring),
                    category, name)
 end
 
 function nvtxNameCategoryW(category, name)
-    initialize_api()
+    initialize_context()
     ccall((:nvtxNameCategoryW, libnvtx()), Cvoid,
                    (UInt32, Ptr{Cwchar_t}),
                    category, name)
 end
 
 function nvtxNameOsThreadA(threadId, name)
-    initialize_api()
+    initialize_context()
     ccall((:nvtxNameOsThreadA, libnvtx()), Cvoid,
                    (UInt32, Cstring),
                    threadId, name)
 end
 
 function nvtxNameOsThreadW(threadId, name)
-    initialize_api()
+    initialize_context()
     ccall((:nvtxNameOsThreadW, libnvtx()), Cvoid,
                    (UInt32, Ptr{Cwchar_t}),
                    threadId, name)
 end
 
 function nvtxDomainRegisterStringA(domain, string)
-    initialize_api()
+    initialize_context()
     ccall((:nvtxDomainRegisterStringA, libnvtx()), nvtxStringHandle_t,
                    (nvtxDomainHandle_t, Cstring),
                    domain, string)
 end
 
 function nvtxDomainRegisterStringW(domain, string)
-    initialize_api()
+    initialize_context()
     ccall((:nvtxDomainRegisterStringW, libnvtx()), nvtxStringHandle_t,
                    (nvtxDomainHandle_t, Ptr{Cwchar_t}),
                    domain, string)
 end
 
 function nvtxDomainCreateA(name)
-    initialize_api()
+    initialize_context()
     ccall((:nvtxDomainCreateA, libnvtx()), nvtxDomainHandle_t,
                    (Cstring,),
                    name)
 end
 
 function nvtxDomainCreateW(name)
-    initialize_api()
+    initialize_context()
     ccall((:nvtxDomainCreateW, libnvtx()), nvtxDomainHandle_t,
                    (Ptr{Cwchar_t},),
                    name)
 end
 
 function nvtxDomainDestroy(domain)
-    initialize_api()
+    initialize_context()
     ccall((:nvtxDomainDestroy, libnvtx()), Cvoid,
                    (nvtxDomainHandle_t,),
                    domain)
@@ -212,56 +212,56 @@ end
 # Automatically generated using Clang.jl
 
 function nvtxNameCuDeviceA(device, name)
-    initialize_api()
+    initialize_context()
     ccall((:nvtxNameCuDeviceA, libnvtx()), Cvoid,
                    (CUdevice, Cstring),
                    device, name)
 end
 
 function nvtxNameCuDeviceW(device, name)
-    initialize_api()
+    initialize_context()
     ccall((:nvtxNameCuDeviceW, libnvtx()), Cvoid,
                    (CUdevice, Ptr{Cwchar_t}),
                    device, name)
 end
 
 function nvtxNameCuContextA(context, name)
-    initialize_api()
+    initialize_context()
     ccall((:nvtxNameCuContextA, libnvtx()), Cvoid,
                    (CUcontext, Cstring),
                    context, name)
 end
 
 function nvtxNameCuContextW(context, name)
-    initialize_api()
+    initialize_context()
     ccall((:nvtxNameCuContextW, libnvtx()), Cvoid,
                    (CUcontext, Ptr{Cwchar_t}),
                    context, name)
 end
 
 function nvtxNameCuStreamA(stream, name)
-    initialize_api()
+    initialize_context()
     ccall((:nvtxNameCuStreamA, libnvtx()), Cvoid,
                    (CUstream, Cstring),
                    stream, name)
 end
 
 function nvtxNameCuStreamW(stream, name)
-    initialize_api()
+    initialize_context()
     ccall((:nvtxNameCuStreamW, libnvtx()), Cvoid,
                    (CUstream, Ptr{Cwchar_t}),
                    stream, name)
 end
 
 function nvtxNameCuEventA(event, name)
-    initialize_api()
+    initialize_context()
     ccall((:nvtxNameCuEventA, libnvtx()), Cvoid,
                    (CUevent, Cstring),
                    event, name)
 end
 
 function nvtxNameCuEventW(event, name)
-    initialize_api()
+    initialize_context()
     ccall((:nvtxNameCuEventW, libnvtx()), Cvoid,
                    (CUevent, Ptr{Cwchar_t}),
                    event, name)

--- a/res/wrap/wrap.jl
+++ b/res/wrap/wrap.jl
@@ -118,7 +118,7 @@ function insert_check_pass(x, state)
     end
 end
 
-# insert `initialize_api()` before each function with a `ccall` calling non-whitelisted fns
+# insert `initialize_context()` before each function with a `ccall` calling non-whitelisted fns
 preinit_apicalls = Set{String}([
     # CUDAdrv
     ## error handling
@@ -199,7 +199,7 @@ function insert_init_pass(x, state)
 
         # call the API initializer
         if !in(actual_fun, preinit_apicalls)
-            push!(state.edits, Edit(state.offset, "initialize_api()\n    "))
+            push!(state.edits, Edit(state.offset, "initialize_context()\n    "))
         end
     end
 end

--- a/src/utilities.jl
+++ b/src/utilities.jl
@@ -38,7 +38,8 @@ function versioninfo(io::IO=stdout)
     else
         print(io, "Unknown NVIDIA driver")
     end
-    println(io, ", for CUDA $(version().major).$(version().minor)")
+    println(io, ", for CUDA $(system_version().major).$(system_version().minor)")
+    println(io, "CUDA driver $(version().major).$(version().minor)")
     println(io)
 
     println(io, "Libraries: ")


### PR DESCRIPTION
Allows loading a more recent `libcuda.so` as provided by CUDA_compat_jll. Only works on Linux, and currently the JLL only provides an artifact for x86. Fixes https://github.com/JuliaGPU/CUDA.jl/issues/1071.

Marked as WIP since this doesn't seem to work on the one system that I didn't upgrade to 11.4 yet, where I do have a supposedly compatible RTX card. Trying to load the forward compatible libcuda there results in an error 804 (ERROR_COMPAT_NOT_SUPPORTED_ON_DEVICE). I've filed this with NVIDIA as bug #3394172.