### PR TITLE
add ldiv! for CuQR

### DIFF
--- a/src/linalg.jl
+++ b/src/linalg.jl
@@ -60,3 +60,17 @@ CuMatrix{T}(Q::AbstractQ{S}) where {T,S} = convert(CuArray, Matrix{T}(Q))
 CuMatrix(Q::AbstractQ{T}) where {T} = CuMatrix{T}(Q)
 CuArray{T}(Q::AbstractQ) where {T} = CuMatrix{T}(Q)
 CuArray(Q::AbstractQ) = CuMatrix(Q)
+
+function LinearAlgebra.ldiv!(_qr::CUDA.CUSOLVER.CuQR,b::CUDA.CuArray)
+  _x = UpperTriangular(_qr.R) \ (_qr.Q' * reshape(b,length(b),1))
+  b .= vec(_x)
+  CUDA.unsafe_free!(_x)
+  return b
+end
+
+function LinearAlgebra.ldiv!(x::CUDA.CuArray,_qr::CUDA.CUSOLVER.CuQR,b::CUDA.CuArray)
+  _x = UpperTriangular(_qr.R) \ (_qr.Q' * reshape(b,length(b),1))
+  x .= vec(_x)
+  CUDA.unsafe_free!(_x)
+  return x
+end

--- a/test/linalg.jl
+++ b/test/linalg.jl
@@ -19,3 +19,21 @@ end
     @test isreal(norm(dx, 2))
     @test norm(normalize!(dx)) ≈ 1
 end
+
+@testset "ldiv!" begin
+    A = rand(Float32, 2, 2)
+    Q = qr(A)
+    _Q = qr(cu(A))
+    x = rand(Float32, 2)
+    _x = cu(x)
+    y = similar(x)
+    _y = similar(_x)
+
+    ldiv!(y,Q,x)
+    ldiv!(_y,_Q,_x)
+    @test y ≈ Array(_y)
+
+    ldiv!(Q,x)
+    ldiv!(_Q,_x)
+    @test x ≈ Array(_x)
+end


### PR DESCRIPTION
Quite well-tested since it's an upstream of a code used in DiffEq for a few years in https://github.com/SciML/DiffEqBase.jl/blob/v6.73.2/src/init.jl#L78-L83 . It didn't seem like the triangular solves were wrapped (when I wrote this) so it's actually allocating internally, so maybe that could be improved, but it's at least correct.