### PR TITLE
Allow sorting of tuples of numbers

### DIFF
--- a/src/sorting.jl
+++ b/src/sorting.jl
@@ -73,7 +73,7 @@ Uses block y index to decide which values to operate on.
     sync_threads()
     blockIdx_yz = (blockIdx().z - 1i32) * gridDim().y + blockIdx().y
     idx0 = lo + (blockIdx_yz - 1i32) * blockDim().x + threadIdx().x
-    if idx0 <= hi
+    @inbounds if idx0 <= hi
         val = values[idx0]
         comparison = flex_lt(pivot, val, parity, lt, by)
     end
@@ -737,7 +737,7 @@ Each view is indexed along block x dim: one view per pseudo-block
         @inbounds swap[threadIdx().x, threadIdx().y] = vals[index+one(I)]
     end
     sync_threads()
-    return @view swap[:, threadIdx().y]
+    return @inbounds @view swap[:, threadIdx().y]
 end
 
 """

--- a/test/sorting.jl
+++ b/test/sorting.jl
@@ -302,6 +302,7 @@ end
         @test check_sort!(Float64, 10000, x -> rand(Float64); alg=CUDA.QuickSort)
         @test check_sort!(Float32, 10000, x -> rand(Float32); alg=CUDA.QuickSort)
         @test check_sort!(Float16, 10000, x -> rand(Float16); alg=CUDA.QuickSort)
+        @test check_sort!(Tuple{Int,Int}, 10000, x -> (rand(Int), rand(Int)); alg=CUDA.QuickSort)
 
         # non-uniform distributions
         @test check_sort!(UInt8, 100000, x -> round(255 * rand() ^ 2); alg=CUDA.QuickSort)
@@ -345,6 +346,7 @@ end
         @test check_sort!(Float64, 10000, x -> rand(Float64); alg=CUDA.BitonicSort)
         @test check_sort!(Float32, 10000, x -> rand(Float32); alg=CUDA.BitonicSort)
         @test check_sort!(Float16, 10000, x -> rand(Float16); alg=CUDA.BitonicSort)
+        @test check_sort!(Tuple{Int,Int}, 10000, x -> (rand(Int), rand(Int)); alg=CUDA.BitonicSort)
 
         # test various sizes
         @test check_sort!(Float32, 1, x -> rand(Float32); alg=CUDA.BitonicSort)

--- a/test/sorting.jl
+++ b/test/sorting.jl
@@ -280,6 +280,9 @@ end
     end
 end
 
+# XXX: some tests here make compute-sanitizer hang, but only on CI.
+#      maybe related to the container set-up? try again once we use Sandbox.jl.
+
 @testset "interface" begin
     @testset "quicksort" begin
         # pre-sorted
@@ -302,7 +305,7 @@ end
         @test check_sort!(Float64, 10000, x -> rand(Float64); alg=CUDA.QuickSort)
         @test check_sort!(Float32, 10000, x -> rand(Float32); alg=CUDA.QuickSort)
         @test check_sort!(Float16, 10000, x -> rand(Float16); alg=CUDA.QuickSort)
-        @test check_sort!(Tuple{Int,Int}, 10000, x -> (rand(Int), rand(Int)); alg=CUDA.QuickSort)
+        @not_if_sanitize @test check_sort!(Tuple{Int,Int}, 10000, x -> (rand(Int), rand(Int)); alg=CUDA.QuickSort)
 
         # non-uniform distributions
         @test check_sort!(UInt8, 100000, x -> round(255 * rand() ^ 2); alg=CUDA.QuickSort)
@@ -346,7 +349,7 @@ end
         @test check_sort!(Float64, 10000, x -> rand(Float64); alg=CUDA.BitonicSort)
         @test check_sort!(Float32, 10000, x -> rand(Float32); alg=CUDA.BitonicSort)
         @test check_sort!(Float16, 10000, x -> rand(Float16); alg=CUDA.BitonicSort)
-        @test check_sort!(Tuple{Int,Int}, 10000, x -> (rand(Int), rand(Int)); alg=CUDA.BitonicSort)
+        @not_if_sanitize @test check_sort!(Tuple{Int,Int}, 10000, x -> (rand(Int), rand(Int)); alg=CUDA.BitonicSort)
 
         # test various sizes
         @test check_sort!(Float32, 1, x -> rand(Float32); alg=CUDA.BitonicSort)


### PR DESCRIPTION
This allows `sort` to work on arrays of tuples, motivated by `partialsortperm(x; dims)`-like things in  https://github.com/FluxML/NNlib.jl/pull/353 

It also adds the simplest implementation of `sortperm` using that. Not sure if this is too crude for the package to want to keep? Needs tests, if it is wanted. 