### PR TITLE
2-arg `show`

### DIFF
--- a/src/array.jl
+++ b/src/array.jl
@@ -510,6 +510,22 @@ Adapt.adapt_storage(::CuArrayAdaptor{B}, xs::AbstractArray{T,N}) where {T<:Union
 @inline cu(xs; unified::Bool=false) = adapt(CuArrayAdaptor{unified ? Mem.UnifiedBuffer : Mem.DeviceBuffer}(), xs)
 Base.getindex(::typeof(cu), xs...) = CuArray([xs...])
 
+## show
+
+function Base.show(io::IO, A::AnyCuArray{T}) where {T}
+  if T <: Union{Float32, ComplexF32}
+    # then no need to write cu(Float32[1.0])
+    io = IOContext(io, :typeinfo => Vector{Float32})
+    print(io, "cu(")
+  elseif T <: Union{AbstractFloat, Complex{<:AbstractFloat}}
+    # then cu(collect(A)) wouldn't produce A, so print CuArray?
+    print(io, "CuArray(")
+  else
+    print(io, "cu(")
+  end
+  invoke(show, Tuple{IO, AbstractArray}, io, A)
+  print(io, ")")
+end
 
 ## utilities
 

--- a/test/array.jl
+++ b/test/array.jl
@@ -741,3 +741,17 @@ if length(devices()) > 1
   end
 end
 end
+
+@testset "show" begin
+  io = IOBuffer()
+  show(io, cu([1f0, 2f0]))  # Float32
+  @test String(take!(io)) == "cu([1.0, 2.0])"
+
+  io = IOBuffer()
+  show(io, CuArray([1.0, 2.0]))  # Float64
+  @test String(take!(io)) == "CuArray([1.0, 2.0])"
+
+  io = IOBuffer()
+  show(io, cu(Int32[1,2])')  # Int32
+  @test String(take!(io)) == "cu(Int32[1 2])"
+end


### PR DESCRIPTION
Closes #1190

Prints the Float32 case most compactly, although perhaps it would be less confusing to write out `cu(Float32[0.7821349, 0.99106485])` in the end? Certainly simpler.
```
julia> x = rand(2)
2-element Vector{Float64}:
 0.7821348955171186
 0.9910648595224902

julia> (f32 = cu(x), f64 = CuArray(x), i32 = CuArray(Int32[1,2,3]))
(f32 = cu([0.7821349, 0.99106485]), f64 = CuArray([0.7821348955171186, 0.9910648595224902]), i32 = cu(Int32[1, 2, 3]))
```