### PR TITLE
fix FFT workarea typo leading to memory corruption

### DIFF
--- a/lib/cufft/fft.jl
+++ b/lib/cufft/fft.jl
@@ -112,7 +112,7 @@ Base.size(p::CuFFTPlan) = p.sz
         new_workarea = similar(plan.workarea)
         cufftSetWorkArea(plan, new_workarea)
         CUDA.unsafe_free!(plan.workarea)
-        plan.workarea = plan.workarea
+        plan.workarea = new_workarea
     end
     return
 end


### PR DESCRIPTION
Guessing this was just a typo? I was getting some memory corruption when using the same plan from different tasks before this fix which was fixed for me with this PR. 