### PR TITLE
Deprecate non-blocking sync, and always call the synchronization API.

### DIFF
--- a/lib/cudadrv/context.jl
+++ b/lib/cudadrv/context.jl
@@ -308,21 +308,43 @@ end
 """
     synchronize(ctx::Context)
 
-Synchronize the current context, waiting for all outstanding operations to complete.
-
-!!! warning
-
-    This is an operation that blocks in the driver, and should be avoided if possible.
-    Instead, use [`device_synchronize()`](@ref) to perform synchronization in Julia.
+Block for the all operations on `ctx` to complete. This is a heavyweight operation,
+typically you only need to call [`synchronize`](@ref) which only synchronizes the stream
+associated with the current task.
 """
 function synchronize(ctx::CuContext)
     push!(CuContext, ctx)
     try
-        cuCtxSynchronize()
-        check_exceptions()
+        nonblocking_synchronize()
     finally
         pop!(CuContext)
     end
+end
+
+# same, but without the context switch
+"""
+    device_synchronize()
+
+Block for the all operations on `ctx` to complete. This is a heavyweight operation,
+typically you only need to call [`synchronize`](@ref) which only synchronizes the stream
+associated with the current task.
+
+On the device, `device_synchronize` acts as a synchronization point for child grids in the
+context of dynamic parallelism.
+"""
+device_synchronize() = nonblocking_synchronize()
+# XXX: can we put the device docstring in dynamic_parallelism.jl?
+
+@inline function nonblocking_synchronize()
+    # perform as much of the sync as possible without blocking in CUDA.
+    # XXX: remove this using a yield callback, or by synchronizing on a dedicated thread?
+    nonblocking_synchronize(legacy_stream())
+
+    # even though the GPU should be idle now, CUDA hooks work to the actual API call.
+    # see NVIDIA bug #3383169 for more details.
+    cuCtxSynchronize()
+
+    check_exceptions()
 end
 
 

--- a/perf/runbenchmarks.jl
+++ b/perf/runbenchmarks.jl
@@ -18,7 +18,7 @@ end
 macro async_benchmarkable(ex...)
     quote
         # use non-blocking sync to reduce overhead
-        @benchmarkable CUDA.@sync blocking=false $(ex...)
+        @benchmarkable CUDA.@sync $(ex...)
     end
 end
 

--- a/src/device/intrinsics/dynamic_parallelism.jl
+++ b/src/device/intrinsics/dynamic_parallelism.jl
@@ -110,7 +110,3 @@ end
 ## synchronization
 
 @device_override device_synchronize() = @check_status cudaDeviceSynchronize()
-@doc """
-On the device, `device_synchronize` acts as a synchronization point for child grids in the
-context of dynamic parallelism.
-""" device_synchronize

--- a/src/pool.jl
+++ b/src/pool.jl
@@ -197,14 +197,8 @@ end
                 gctime += Base.@elapsed GC.gc(true)
             elseif phase == 4
                 synchronize(stream)
-
-                # NVIDIA bug #3383169: non-blocking sync doesn't trigger memory release.
-                cuStreamSynchronize(stream)
             elseif phase == 5
                 device_synchronize()
-
-                # NVIDIA bug #3383169: synchronizing the legacy stream doesn't trigger memory release.
-                cuCtxSynchronize()
             end
 
             buf = actual_alloc(sz; async=true, stream)
@@ -324,18 +318,14 @@ macro retry_reclaim(isfailed, ex)
           #       we do still call our routines to minimize the time we block in libcuda.
           if phase == 1
             synchronize(state.stream)
-            cuStreamSynchronize(state.stream)
           elseif phase == 2
             device_synchronize()
-            synchronize(state.context)
           elseif phase == 3
             GC.gc(false)
             device_synchronize()
-            synchronize(state.context)
           elseif phase == 4
             GC.gc(true)
             device_synchronize()
-            synchronize(state.context)
           elseif phase == 5
             # in case we had a release threshold configured
             trim(memory_pool(state.device))
@@ -456,7 +446,7 @@ macro timed(ex)
         local cpu_time0 = time_ns()
 
         # fine-grained synchronization of the code under analysis
-        local val = @sync blocking=false $(esc(ex))
+        local val = @sync $(esc(ex))
 
         local cpu_time1 = time_ns()
         local cpu_mem_stats1 = Base.gc_num()

--- a/src/utilities.jl
+++ b/src/utilities.jl
@@ -1,9 +1,7 @@
 """
-    @sync [blocking=true] ex
+    @sync ex
 
-Run expression `ex` and synchronize the GPU afterwards. By default, this is a CPU-friendly
-synchronization, i.e. it performs a blocking synchronization without increasing CPU load
-It is also useful for timing code that executes asynchronously.
+Run expression `ex` and synchronize the GPU afterwards.
 
 See also: [`synchronize`](@ref).
 """
@@ -13,12 +11,11 @@ macro sync(ex...)
     kwargs = ex[1:end-1]
 
     # decode keyword arguments
-    blocking = true
     for kwarg in kwargs
         Meta.isexpr(kwarg, :(=)) || error("Invalid keyword argument $kwarg")
         key, val = kwarg.args
         if key == :blocking
-            blocking = val
+            Base.depwarn("the blocking keyword to @sync has been deprecated", :sync)
         else
             error("Unknown keyword argument $kwarg")
         end
@@ -26,7 +23,7 @@ macro sync(ex...)
 
     quote
         local ret = $(esc(code))
-        synchronize(; blocking=$(esc(blocking)))
+        synchronize()
         ret
     end
 end

--- a/test/cudadrv.jl
+++ b/test/cudadrv.jl
@@ -457,7 +457,7 @@ for srcTy in [Mem.Device, Mem.Host, Mem.Unified],
     @test device(typed_pointer(src, T)) == device()
     if !CUDA.has_stream_ordered(device())
         # NVIDIA bug #3319609
-        @test CuContext(typed_pointer(src, T)) == context()
+        @test context(typed_pointer(src, T)) == context()
     end
 
     # test the is-managed attribute
@@ -856,9 +856,7 @@ let s = CuStream(; priority=last(prio))
 end
 
 synchronize()
-synchronize(; blocking=false)
 synchronize(stream())
-synchronize(stream(); blocking=false)
 
 @grab_output show(stdout, stream())
 

--- a/test/utils.jl
+++ b/test/utils.jl
@@ -26,8 +26,6 @@ end
   end
   @test t >= 0
   @test ret == 42
-
-  CUDA.@sync blocking=false begin end
 end
 
 @testset "versioninfo" begin


### PR DESCRIPTION
CUDA uses synchronization calls for certain events, like releasing memory. Adds around 150 ns to a no-op synchronize, which took around 200ns before, so that's not great, but I don't think we have another option. Also, if we were to sync on a separate thread (one of the alternatives do doing both a yielding loop & blocking API call), it's likely that the overhead would be higher anyway.

cc @vchuravy