### PR TITLE
improve sparse matrix conversions

### DIFF
--- a/test/cusparse/array.jl
+++ b/test/cusparse/array.jl
@@ -1,0 +1,38 @@
+using CUDA
+using CUDA.CUSPARSE, SparseArrays
+
+
+@testset "Tv=$Tv Ti=$Ti" for Tv in [Float32, Float64, ComplexF32, ComplexF64], Ti in [Int32, Int64]
+    @testset "CuSparseMatrixCOO" begin
+        S = sprand(Tv, 10, 10, 0.1)
+        dS = CuSparseMatrixCOO{Tv, Ti}(S)
+
+        @test collect(dS) ≈ S
+    end
+
+    @testset "CuSparseMatrixCSC" begin
+        S = sprand(Tv, 10, 10, 0.1)
+        dS = CuSparseMatrixCSC{Tv, Ti}(S)
+
+        @test collect(dS) ≈ S
+    end
+
+    @testset "CuSparseMatrixCSR" begin
+       S = transpose(sprand(Tv, 10, 10, 0.1))
+       dS = CuSparseMatrixCSR{Tv, Ti}(S)
+       @test collect(dS) ≈ S
+    end
+end
+using Test
+
+Tv, Ti = Float32, Int64
+S = transpose(sprand(Tv, 10, 10, 0.1))
+dS = CuSparseMatrixCSR{Tv, Int}(S);
+
+CuSparseMatrixCSR{Tv, Int32}(dS)
+dS2 = CuSparseMatrixCSC{Tv}(dS)
+
+
+@which SparseMatrixCSC(dS2)
+collect(dS) ≈ S
+SparseMatrixCSC(dS)


### PR DESCRIPTION
this PR improves the sparse array conversion taking account of the indices type to support explicitly declared type conversion `CuSparseType{Tv, Ti}(dS)`

A few things I'm not sure how to deal with yet:

1. how do we convert `CSR{Tv, Int64}` to CPU types and CSC? it seems CUDA doesn't support this yet, and it seems costing a lot of extra computation to convert CSR to CSC on CPU just for printing? maybe we should have a method `cpu` that convert CSR/BSR to transpose(CSC) on CPU?