### PR TITLE
Reverted deepcopy, added test

### DIFF
--- a/src/array.jl
+++ b/src/array.jl
@@ -171,10 +171,7 @@ function Base.copy(a::CuArray{T,N}) where {T,N}
   @inbounds copyto!(b, a)
 end
 
-# XXX: defining deepcopy_internal, as per the deepcopy documentation, results in a ton
-#      of invalidations, so we redefine deepcopy itself (see JuliaGPU/CUDA.jl#632)
-function Base.deepcopy(x::CuArray)
-  dict = IdDict()
+function Base.deepcopy_internal(x::CuArray, dict::IdDict)
   haskey(dict, x) && return dict[x]::typeof(x)
   return dict[x] = copy(x)
 end

--- a/test/array.jl
+++ b/test/array.jl
@@ -538,6 +538,13 @@ end
   @test vec(Array(sum!(view(CUDA.zeros(1,1,1), 1, :, :), CUDA.ones(1,4096)))) == [4096f0]
 end
 
+@testset "issue 1202" begin
+  # test that deepcopying a struct with a CuArray field gets properly deepcopied
+  a = (x = CUDA.zeros(2),)
+  b = deepcopy(a)
+  a.x .= -1
+  @test b.x != a.x
+end
 
 @testset "isbits unions" begin
   # test that the selector bytes are preserved when up and downloading


### PR DESCRIPTION
Reverted method from Base.deepcopy to Base.deepcopy_internal, added a test for deepcopying a struct with a CuArray field. closes #1202 