### PR TITLE
Fix cuTENSOR contractions not working for FP16 inputs

### DIFF
--- a/lib/cutensor/wrappers.jl
+++ b/lib/cutensor/wrappers.jl
@@ -42,6 +42,7 @@ end
 const scalar_types = Dict(
     (Float16, Float16)          => Float32,
     (Float32, Float16)          => Float32,
+    (Float16, Float32)          => Float32,
     (Float32, Float32)          => Float32,
     (Float64, Float64)          => Float64,
     (Float64, Float32)          => Float64,

--- a/test/cutensor/contractions.jl
+++ b/test/cutensor/contractions.jl
@@ -4,6 +4,7 @@ using LinearAlgebra
 
 eltypes = ( (Float32, Float32, Float32, Float32),
             (Float32, Float32, Float32, Float16),
+            (Float16, Float16, Float16, Float32),
             (ComplexF32, ComplexF32, ComplexF32, ComplexF32),
             (Float64, Float64, Float64, Float64),
             (Float64, Float64, Float64, Float32),


### PR DESCRIPTION
Contractions for FP16 inputs with Volta Tensor Cores (`typeA = CUDA_R_16F`, `typeB = CUDA_R_16F`, `typeC = CUDA_R_16F`, `typeCompute = CUTENSOR_COMPUTE_32F`) didn't work before, due to a missing case in `scalar_types` in `lib/cutensor/wrappers.jl`:

```
ERROR: KeyError: key (Float16, Float32) not found
Stacktrace:
 [1] getindex(h::Dict{Tuple{DataType, DataType}, DataType}, key::Tuple{DataType, DataType})                                                                  
   @ Base ./dict.jl:482
 [2] plan_contraction(A::Union{CuArray, Array}, Ainds::Vector{Char}, opA::CUDA.CUTENSOR.cutensorOperator_t, B::Union{CuArray, Array}, Binds::Vector{Char}, opB::CUDA.CUTENSOR.cutensorOperator_t, C::Union{CuArray, Array}, Cinds::Vector{Char}, opC::CUDA.CUTENSOR.cutensorOperator_t, opOut::CUDA.CUTENSOR.cutensorOperator_t; pref::CUDA.CUTENSOR.cutensorWorksizePreference_t, algo::CUDA.CUTENSOR.cutensorAlgo_t, compute_type::Type)                                               
   @ CUDA.CUTENSOR ~/.julia/packages/CUDA/YpW0k/lib/cutensor/wrappers.jl:310
```

This PR fixes that, and also updates the testsuite accordingly.