### PR TITLE
Remove debug info hack.

### DIFF
--- a/src/compiler/gpucompiler.jl
+++ b/src/compiler/gpucompiler.jl
@@ -36,7 +36,8 @@ function device_properties(dev)
                 exitable = false
             end
 
-            debuginfo = getenv("JULIA_CUDA_DEBUG_INFO", true)
+            # NVIDIA bug #3305774: ptxas segfaults with our debug info, fixed in 11.5.1
+            debuginfo = toolkit_release() >= v"11.5" # we don't track patch versions...
 
             val[deviceid(dev)+1] =
                 (; cap, ptx, exitable, debuginfo, unreachable)

--- a/test/exceptions.jl
+++ b/test/exceptions.jl
@@ -47,8 +47,7 @@ let (code, out, err) = julia_script(script, `-g1`)
     @test occursin("Run Julia on debug level 2 for device stack traces", out)
 end
 
-let (code, out, err) = julia_script(script, `-g2`,
-                                    "JULIA_CUDA_DEBUG_INFO"=>false) # NVIDIA#3305774
+let (code, out, err) = julia_script(script, `-g2`)
     @test code == 1
     @test occursin(host_error_re, err)
     @test occursin(device_error_re, out)
@@ -70,8 +69,7 @@ script = """
     CUDA.@sync @cuda bar(arr)
 """
 
-let (code, out, err) = julia_script(script, `-g2`,
-                                    "JULIA_CUDA_DEBUG_INFO"=>false) # NVIDIA#3305774
+let (code, out, err) = julia_script(script, `-g2`)
     @test code == 1
     @test occursin(host_error_re, err)
     @test occursin(device_error_re, out)


### PR DESCRIPTION
`ptxas` has been fixed in CUDA 11.5 Update 1.