### PR TITLE
fix zeros and ones for user defined types

### DIFF
--- a/src/array.jl
+++ b/src/array.jl
@@ -549,8 +549,8 @@ Base.getindex(::typeof(cu), xs...) = CuArray([xs...])
 
 ## utilities
 
-zeros(T::Type, dims...) = fill!(CuArray{T}(undef, dims...), 0)
-ones(T::Type, dims...) = fill!(CuArray{T}(undef, dims...), 1)
+zeros(T::Type, dims...) = fill!(CuArray{T}(undef, dims...), zero(T))
+ones(T::Type, dims...) = fill!(CuArray{T}(undef, dims...), one(T))
 zeros(dims...) = zeros(Float32, dims...)
 ones(dims...) = ones(Float32, dims...)
 fill(v, dims...) = fill!(CuArray{typeof(v)}(undef, dims...), v)

--- a/test/array.jl
+++ b/test/array.jl
@@ -64,6 +64,14 @@ import Adapt
   @test collect(CUDA.zeros(2, 2)) == zeros(Float32, 2, 2)
   @test collect(CUDA.ones(2, 2)) == ones(Float32, 2, 2)
 
+  struct A
+    content::Int
+  end
+  Base.zero(::Type{A}) = A(1)
+  Base.one(::Type{A}) = A(2)
+  @test collect(CUDA.zeros(A, 2, 2)) == zeros(A, 2, 2)
+  @test collect(CUDA.ones(A, 2, 2)) == ones(A, 2, 2)
+
   @test collect(CUDA.fill(0, 2, 2)) == zeros(Float32, 2, 2)
   @test collect(CUDA.fill(1, 2, 2)) == ones(Float32, 2, 2)
 end

--- a/test/array.jl
+++ b/test/array.jl
@@ -64,16 +64,22 @@ import Adapt
   @test collect(CUDA.zeros(2, 2)) == zeros(Float32, 2, 2)
   @test collect(CUDA.ones(2, 2)) == ones(Float32, 2, 2)
 
-  struct A
-    content::Int
-  end
-  Base.zero(::Type{A}) = A(1)
-  Base.one(::Type{A}) = A(2)
-  @test collect(CUDA.zeros(A, 2, 2)) == zeros(A, 2, 2)
-  @test collect(CUDA.ones(A, 2, 2)) == ones(A, 2, 2)
-
   @test collect(CUDA.fill(0, 2, 2)) == zeros(Float32, 2, 2)
   @test collect(CUDA.fill(1, 2, 2)) == ones(Float32, 2, 2)
+  
+  let
+    @gensym typnam
+    typ = @eval begin
+      struct $typnam
+        content::Int
+      end
+      Base.zero(::Type{$typnam}) = $typnam(1)
+      Base.one(::Type{$typnam}) = $typnam(2)
+      $typnam
+    end
+    @test collect(CUDA.zeros(typ, 2, 2)) == zeros(typ, 2, 2)
+    @test collect(CUDA.ones(typ, 2, 2)) == ones(typ, 2, 2)
+  end
 end
 
 @testset "adapt" begin


### PR DESCRIPTION
Previous CUDA zeros
```julia
julia> using CUDA, TropicalNumbers

julia> CUDA.zeros(TropicalF64, 2, 2)
2×2 CuArray{TropicalF64, 2, CUDA.Mem.DeviceBuffer}:
 0.0ₜ  0.0ₜ
 0.0ₜ  0.0ₜ

julia> zeros(TropicalF64, 2, 2)
2×2 Matrix{TropicalF64}:
 -Infₜ  -Infₜ
 -Infₜ  -Infₜ
```

Now is ok
```julia
julia> using CUDA, TropicalNumbers
[ Info: Precompiling CUDA [052768ef-5323-5732-b1bb-66c8b64840ba]

julia> CUDA.zeros(TropicalF64, 2, 2)
2×2 CuArray{TropicalF64, 2, CUDA.Mem.DeviceBuffer}:
 -Infₜ  -Infₜ
 -Infₜ  -Infₜ
```