### PR TITLE
Improvements for isbits union shared memory

### DIFF
--- a/src/device/array.jl
+++ b/src/device/array.jl
@@ -116,7 +116,7 @@ end
     unsafe_load(pointer(A), index, Val(align))
 end
 
-@inline @generated function arrayref_union(A::CuDeviceArray{T,AS}, index::Integer) where {T,AS}
+@inline @generated function arrayref_union(A::CuDeviceArray{T,<:Any,AS}, index::Integer) where {T,AS}
     typs = Base.uniontypes(T)
 
     # generate code that conditionally loads a value based on the selector value.
@@ -159,7 +159,7 @@ end
     unsafe_store!(pointer(A), x, index, Val(align))
 end
 
-@inline @generated function arrayset_union(A::CuDeviceArray{T,AS}, x::T, index::Integer) where {T,AS}
+@inline @generated function arrayset_union(A::CuDeviceArray{T,<:Any,AS}, x::T, index::Integer) where {T,AS}
     typs = Base.uniontypes(T)
     sel = findfirst(isequal(x), typs)
 

--- a/src/device/intrinsics/memory_shared.jl
+++ b/src/device/intrinsics/memory_shared.jl
@@ -3,7 +3,7 @@
 export @cuStaticSharedMem, @cuDynamicSharedMem, CuStaticSharedArray, CuDynamicSharedArray
 
 """
-    CuStaticSharedArray(T::Type, dims) -> CuDeviceArray{T,AS.Shared}
+    CuStaticSharedArray(T::Type, dims) -> CuDeviceArray{T,N,AS.Shared}
 
 Get an array of type `T` and dimensions `dims` (either an integer length or tuple shape)
 pointing to a statically-allocated piece of shared memory. The type should be statically
@@ -26,7 +26,7 @@ macro cuStaticSharedMem(T, dims)
 end
 
 """
-    CuDynamicSharedArray(T::Type, dims, offset::Integer=0) -> CuDeviceArray{T,AS.Shared}
+    CuDynamicSharedArray(T::Type, dims, offset::Integer=0) -> CuDeviceArray{T,N,AS.Shared}
 
 Get an array of type `T` and dimensions `dims` (either an integer length or tuple shape)
 pointing to a dynamically-allocated piece of shared memory. The type should be statically

--- a/src/device/intrinsics/memory_shared.jl
+++ b/src/device/intrinsics/memory_shared.jl
@@ -38,7 +38,7 @@ Optionally, an offset parameter indicating how many bytes to add to the base sha
 pointer can be specified. This is useful when dealing with a heterogeneous buffer of dynamic
 shared memory; in the case of a homogeneous multi-part buffer it is preferred to use `view`.
 """
-@inline function CuDynamicSharedArray(::Type{T}, dims, offset=0) where {T}
+@inline function CuDynamicSharedArray(::Type{T}, dims, offset) where {T}
     len = prod(dims)
     @boundscheck if offset+len > dynamic_smem_size()
         throw(BoundsError())
@@ -46,6 +46,9 @@ shared memory; in the case of a homogeneous multi-part buffer it is preferred to
     ptr = emit_shmem(T) + offset
     CuDeviceArray(dims, ptr)
 end
+# XXX: default argument-generated methods do not propagate inboundsness
+Base.@propagate_inbounds CuDynamicSharedArray(::Type{T}, dims) where {T} =
+    CuDynamicSharedArray(T, dims, 0)
 
 macro cuDynamicSharedMem(T, dims, offset=0)
     Base.depwarn("@cuDynamicSharedMem is deprecated, please use the CuDynamicSharedArray function", :CuStaticSharedArray)

--- a/test/device/intrinsics/memory.jl
+++ b/test/device/intrinsics/memory.jl
@@ -33,6 +33,10 @@ n = 256
     @on_device shmem=sizeof(Tuple{Float32, Float32})+8 CuDynamicSharedArray(Tuple{Float32, Float32}, (1,2), 8)
     @on_device shmem=sizeof(Tuple{RGB{Float32}, UInt32})+8 CuDynamicSharedArray(Tuple{RGB{Float32}, UInt32}, 1, 8)
     @on_device shmem=sizeof(Tuple{RGB{Float32}, UInt32})+8 CuDynamicSharedArray(Tuple{RGB{Float32}, UInt32}, (1,2), 8)
+
+    # isbits union arrays
+    @on_device CuStaticSharedArray(Union{Missing,Int}, 1)
+    @on_device shmem=sizeof(Int)+1 CuDynamicSharedArray(Union{Missing,Int}, 1)
 end
 
 

--- a/test/device/intrinsics/memory.jl
+++ b/test/device/intrinsics/memory.jl
@@ -20,19 +20,19 @@ n = 256
 
     # dynamic
     @on_device shmem=sizeof(Float32) CuDynamicSharedArray(Float32, 1)
-    @on_device shmem=sizeof(Float32) CuDynamicSharedArray(Float32, (1, 2))
+    @on_device shmem=sizeof(Float32)*2 CuDynamicSharedArray(Float32, (1, 2))
     @on_device shmem=sizeof(Tuple{Float32, Float32}) CuDynamicSharedArray(Tuple{Float32, Float32}, 1)
-    @on_device shmem=sizeof(Tuple{Float32, Float32}) CuDynamicSharedArray(Tuple{Float32, Float32}, (1,2))
+    @on_device shmem=sizeof(Tuple{Float32, Float32})*2 CuDynamicSharedArray(Tuple{Float32, Float32}, (1,2))
     @on_device shmem=sizeof(Tuple{RGB{Float32}, UInt32}) CuDynamicSharedArray(Tuple{RGB{Float32}, UInt32}, 1)
-    @on_device shmem=sizeof(Tuple{RGB{Float32}, UInt32}) CuDynamicSharedArray(Tuple{RGB{Float32}, UInt32}, (1,2))
+    @on_device shmem=sizeof(Tuple{RGB{Float32}, UInt32})*2 CuDynamicSharedArray(Tuple{RGB{Float32}, UInt32}, (1,2))
 
     # dynamic with offset
     @on_device shmem=sizeof(Float32)+8 CuDynamicSharedArray(Float32, 1, 8)
-    @on_device shmem=sizeof(Float32)+8 CuDynamicSharedArray(Float32, (1,2), 8)
+    @on_device shmem=sizeof(Float32)*2+8 CuDynamicSharedArray(Float32, (1,2), 8)
     @on_device shmem=sizeof(Tuple{Float32, Float32})+8 CuDynamicSharedArray(Tuple{Float32, Float32}, 1, 8)
-    @on_device shmem=sizeof(Tuple{Float32, Float32})+8 CuDynamicSharedArray(Tuple{Float32, Float32}, (1,2), 8)
+    @on_device shmem=sizeof(Tuple{Float32, Float32})*2+8 CuDynamicSharedArray(Tuple{Float32, Float32}, (1,2), 8)
     @on_device shmem=sizeof(Tuple{RGB{Float32}, UInt32})+8 CuDynamicSharedArray(Tuple{RGB{Float32}, UInt32}, 1, 8)
-    @on_device shmem=sizeof(Tuple{RGB{Float32}, UInt32})+8 CuDynamicSharedArray(Tuple{RGB{Float32}, UInt32}, (1,2), 8)
+    @on_device shmem=sizeof(Tuple{RGB{Float32}, UInt32})*2+8 CuDynamicSharedArray(Tuple{RGB{Float32}, UInt32}, (1,2), 8)
 
     # isbits union arrays
     @on_device CuStaticSharedArray(Union{Missing,Int}, 1)


### PR DESCRIPTION
Fixes https://github.com/JuliaGPU/CUDA.jl/issues/1281, but needs a redesign at some point (having to use byte sizes in `shmem` and `offset` really isn't a good API, because isbits union arrays are slightly larger, not matching `sizeof`).

Still needs a test, but let's run CI already.