### PR TITLE
Add additional quirks.

### DIFF
--- a/src/device/utils.jl
+++ b/src/device/utils.jl
@@ -17,6 +17,18 @@ end
 const overrides = Expr[]
 
 macro device_override(ex)
+    if Meta.isexpr(ex, :quote)
+        # TODO: support @device_override @eval ...
+        ex = Base.eval(__module__, ex)
+        # we only support single-expression blocks; strip the line number info
+        @assert Meta.isexpr(ex, :block) && length(ex.args) == 2
+        ex = ex.args[end]
+    end
+    ex = macroexpand(__module__, ex)
+    if Meta.isexpr(ex, :call)
+        @show ex = eval(ex)
+        error()
+    end
     code = quote
         $GPUCompiler.@override(CUDA.method_table, $ex)
     end

--- a/test/execution.jl
+++ b/test/execution.jl
@@ -93,12 +93,6 @@ end
         @test occursin("Body::Union{}", err)
     end
 
-    let
-        range_kernel() = (0.0:0.1:100.0; nothing)
-
-        @test_throws CUDA.InvalidIRError @cuda range_kernel()
-    end
-
     # set name of kernel
     @test occursin("julia_mykernel", sprint(io->(@device_code_llvm io=io begin
         k = cufunction(dummy, name="mykernel")


### PR DESCRIPTION
Support `@device_override quote ... end` to make them possible.

We really need a compiler pass to remove `throw`s, it would remove the need for most of these quirks...