### PR TITLE
Add explicit strides to CuArray and CuDeviceArray.

### DIFF
--- a/test/codegen.jl
+++ b/test/codegen.jl
@@ -126,7 +126,7 @@ end
         return
     end
 
-    asm = sprint(io->CUDA.code_ptx(io, kernel, NTuple{2,CuDeviceArray{Float32,1,AS.Global}}))
+    asm = sprint(io->CUDA.code_ptx(io, kernel, NTuple{2,DenseCuDeviceArray{Float32,1,AS.Global}}))
     @test !occursin(".local", asm)
 end
 

--- a/test/cublas.jl
+++ b/test/cublas.jl
@@ -602,7 +602,7 @@ end
 
     @testset "gemv! with strided inputs" begin  # JuliaGPU/CUDA.jl#445
         testf(rand(16), rand(4)) do p, b
-            W = @view p[reshape(1:(16),4,4)]
+            W = @view p[reshape(1:16,4,4)]
             W*b
         end
     end

--- a/test/execution.jl
+++ b/test/execution.jl
@@ -1040,7 +1040,7 @@ if capability(device()) >= v"6.0" && attribute(device(), CUDA.DEVICE_ATTRIBUTE_C
 
     # cooperative kernels are additionally limited in the number of blocks that can be launched
     maxBlocks = attribute(device(), CUDA.DEVICE_ATTRIBUTE_MULTIPROCESSOR_COUNT)
-    kernel = cufunction(kernel_vadd, NTuple{3, CuDeviceArray{Float32,2,AS.Global}})
+    kernel = cufunction(kernel_vadd, NTuple{3, DenseCuDeviceArray{Float32,2,AS.Global}})
     maxThreads = CUDA.maxthreads(kernel)
 
     a = rand(Float32, maxBlocks, maxThreads)


### PR DESCRIPTION
Fixes (part of) https://github.com/JuliaGPU/CUDA.jl/issues/1298

I'm not convinced we want this; It puts the burden on CUDA.jl to re-implement a bunch of Base functionality (here, SubArray). But we've already gone down this path by representing contiguous SubArrays, ReshapedArrays, and ReinterpredArrays as CuArray, so maybe we should make that cover all representable cases (i.e., including strided SubArray)?