### PR TITLE
Add `CUDA.return_type`

### DIFF
--- a/src/compiler/reflection.jl
+++ b/src/compiler/reflection.jl
@@ -131,6 +131,21 @@ end
 
 const code_ptx = code_native
 
+"""
+    CUDA.return_type(f, tt) -> r::Type
+
+Return a type `r` such that `f(args...)::r` where `args::tt`.
+"""
+function return_type(@nospecialize(func), @nospecialize(tt); kernel::Bool=false,
+                     minthreads=nothing, maxthreads=nothing, blocks_per_sm=nothing,
+                     maxregs=nothing)
+    source = FunctionSpec(func, tt, kernel)
+    target = CUDACompilerTarget(device(); minthreads, maxthreads, blocks_per_sm, maxregs)
+    params = CUDACompilerParams()
+    job = CompilerJob(target, source, params)
+    interp = GPUCompiler.get_interpreter(job)
+    return Core.Compiler.return_type(interp, job.source.f, job.source.tt)
+end
 
 
 #

--- a/src/compiler/reflection.jl
+++ b/src/compiler/reflection.jl
@@ -136,11 +136,9 @@ const code_ptx = code_native
 
 Return a type `r` such that `f(args...)::r` where `args::tt`.
 """
-function return_type(@nospecialize(func), @nospecialize(tt); kernel::Bool=false,
-                     minthreads=nothing, maxthreads=nothing, blocks_per_sm=nothing,
-                     maxregs=nothing)
-    source = FunctionSpec(func, tt, kernel)
-    target = CUDACompilerTarget(device(); minthreads, maxthreads, blocks_per_sm, maxregs)
+function return_type(@nospecialize(func), @nospecialize(tt))
+    source = FunctionSpec(func, tt, true)
+    target = CUDACompilerTarget(device())
     params = CUDACompilerParams()
     job = CompilerJob(target, source, params)
     interp = GPUCompiler.get_interpreter(job)

--- a/test/execution.jl
+++ b/test/execution.jl
@@ -102,6 +102,7 @@ end
     @test CUDA.return_type(identity, Tuple{Int}) === Int
     @test CUDA.return_type(CUDA.sin, Tuple{Float32}) === Float32
     @test CUDA.return_type(getindex, Tuple{CuDeviceArray{Float32,1,1},Int32}) === Float32
+    @test CUDA.return_type(getindex, Tuple{Base.RefValue{Integer}}) === Integer
 end
 
 

--- a/test/execution.jl
+++ b/test/execution.jl
@@ -98,6 +98,10 @@ end
         k = cufunction(dummy, name="mykernel")
         k()
     end)))
+
+    @test CUDA.return_type(identity, Tuple{Int}) === Int
+    @test CUDA.return_type(CUDA.sin, Tuple{Float32}) === Float32
+    @test CUDA.return_type(getindex, Tuple{CuDeviceArray{Float32,1,1},Int32}) === Float32
 end
 
 


### PR DESCRIPTION
This PR adds `CUDA.return_type` which is like `Core.Compiler.return_type` but for kernel code. I think something like this is required for pre-allocating buffers for user-defined functions using kernel-only API. For example, code using `CUDA.arrayref` on a device array cannot be inferred without something like this, IIUC.

I'd like to use an API like this here https://github.com/JuliaFolds/FoldsCUDA.jl/blob/e4fd83e66222350647e659c2be676a7c8136adf3/src/kernels.jl#L107 to allocate the intermediate accumulation result