### PR TITLE
Slight changes to pool management

### DIFF
--- a/lib/cudadrv/devices.jl
+++ b/lib/cudadrv/devices.jl
@@ -163,7 +163,7 @@ end
 
 ## attributes
 
-export attribute, warpsize, capability, unified_addressing
+export attribute, warpsize, capability, memory_pools_supported, unified_addressing
 
 """
     attribute(dev::CuDevice, code)
@@ -195,11 +195,10 @@ function capability(dev::CuDevice)
                          attribute(dev, DEVICE_ATTRIBUTE_COMPUTE_CAPABILITY_MINOR))
 end
 
-has_stream_ordered(dev::CuDevice) =
-    @memoize dev::CuDevice begin
-        CUDA.version() >= v"11.2" && !haskey(ENV, "CUDA_MEMCHECK") &&
-        attribute(dev, DEVICE_ATTRIBUTE_MEMORY_POOLS_SUPPORTED) == 1
-    end::Bool
+memory_pools_supported(dev::CuDevice) =
+    CUDA.version() >= v"11.2" &&
+    attribute(dev, DEVICE_ATTRIBUTE_MEMORY_POOLS_SUPPORTED) == 1
+@deprecate has_stream_ordered(dev::CuDevice) memory_pools_supported(dev)
 
 unified_addressing(dev::CuDevice) =
     attribute(dev, DEVICE_ATTRIBUTE_UNIFIED_ADDRESSING) == 1

--- a/lib/cudadrv/memory.jl
+++ b/lib/cudadrv/memory.jl
@@ -68,7 +68,7 @@ GPU, and requires explicit calls to `unsafe_copyto!`, which wraps `cuMemcpy`,
 for access on the CPU.
 """
 function alloc(::Type{DeviceBuffer}, bytesize::Integer;
-               async::Bool=CUDA.has_stream_ordered(device()),
+               async::Bool=memory_pools_supported(device()),
                stream::Union{Nothing,CuStream}=nothing,
                pool::Union{Nothing,CuMemoryPool}=nothing)
     bytesize == 0 && return DeviceBuffer()

--- a/src/pool.jl
+++ b/src/pool.jl
@@ -68,8 +68,7 @@ const __stream_ordered = LazyInitialized{Vector{Bool}}()
 function stream_ordered(dev::CuDevice)
   flags = get!(__stream_ordered) do
     val = Vector{Bool}(undef, ndevices())
-    if version() < v"11.2" || haskey(ENV, "CUDA_MEMCHECK") ||
-       get(ENV, "JULIA_CUDA_MEMORY_POOL", "cuda") == "none"
+    if version() < v"11.2" || get(ENV, "JULIA_CUDA_MEMORY_POOL", "cuda") == "none"
       fill!(val, false)
     else
       for dev in devices()

--- a/src/pool.jl
+++ b/src/pool.jl
@@ -91,6 +91,9 @@ function pool_mark(dev::CuDevice)
   if status[] === nothing
       pool = memory_pool(dev)
 
+      # allow the pool to use up all memory of this device
+      attribute!(memory_pool(dev), MEMPOOL_ATTR_RELEASE_THRESHOLD, typemax(UInt64))
+
       # launch a task to periodically trim the pool
       if isinteractive() && !isassigned(__pool_cleanup)
         __pool_cleanup[] = @async pool_cleanup()

--- a/test/cudadrv.jl
+++ b/test/cudadrv.jl
@@ -455,7 +455,7 @@ for srcTy in [Mem.Device, Mem.Host, Mem.Unified],
 
     # test device with context in which pointer was allocated.
     @test device(typed_pointer(src, T)) == device()
-    if !CUDA.has_stream_ordered(device())
+    if !memory_pools_supported(device())
         # NVIDIA bug #3319609
         @test context(typed_pointer(src, T)) == context()
     end


### PR DESCRIPTION
The most significant change is that the pool is now allowed to use all memory, which should prevent stalls when synchronizing. See https://forums.developer.nvidia.com/t/gpu-stalls-due-to-stream-synchronization-even-when-idle/191761 and https://github.com/under-Peter/OMEinsum.jl/issues/133#issuecomment-1012274634; closes https://github.com/JuliaGPU/CUDA.jl/issues/1320. 

cc @GiggleLiu.

cc @DhairyaLGandhi, this may significantly impact memory-heavy ML workloads. It may also result in non pool-aware applications or libraries to perform worse, so I'd appreciate if you could evaluate this and give some feedback. Note that it does require use of the memory pool, i.e., CUDA 11.2 or higher and not setting `JULIA_CUDA_MEMORY_POOL=none`.