### PR TITLE
Optimize memoization helpers.

### DIFF
--- a/lib/utils/threading.jl
+++ b/lib/utils/threading.jl
@@ -42,7 +42,7 @@ struct LazyInitialized{T}
         new(Threads.Atomic{Int}(0), Ref{T}())
 end
 
-function Base.get!(constructor, x::LazyInitialized; hook=nothing)
+@inline function Base.get!(constructor, x::LazyInitialized; hook=nothing)
     while x.guard[] != 2
         initialize!(x, constructor, hook)
     end


### PR DESCRIPTION
CUDA.jl's memoization macro is becoming pretty good with this:

```
julia> using CUDA.APIUtils
```

option 1: just a thread-safe cache

```
julia> foo(dev) = @memoize begin
         42
       end::Int
foo (generic function with 1 method)

julia> @benchmark foo(1)
BenchmarkTools.Trial: 10000 samples with 1000 evaluations.
 Range (min … max):  2.719 ns … 5.250 ns  ┊ GC (min … max): 0.00% … 0.00%
 Time  (median):     2.780 ns             ┊ GC (median):    0.00%
 Time  (mean ± σ):   2.783 ns ± 0.053 ns  ┊ GC (mean ± σ):  0.00% ± 0.00%

                                     ▃      ▆      █      ▇  
  ▃▁▁▁▁▁▁▄▁▁▁▁▁▁▁▁▁▁▁▁▁▄▁▁▁▁▁▁▅▁▁▁▁▁▁█▁▁▁▁▁▁█▁▁▁▁▁▁█▁▁▁▁▁▁█ ▃
  2.72 ns        Histogram: frequency by time        2.8 ns <

 Memory estimate: 0 bytes, allocs estimate: 0.
```

option 2: adding a key to index the cache with

```
julia> foo(dev) = @memoize dev::Int begin
         42
       end::Int

julia> @benchmark foo(1)
BenchmarkTools.Trial: 10000 samples with 1000 evaluations.
 Range (min … max):  4.989 ns … 7.270 ns  ┊ GC (min … max): 0.00% … 0.00%
 Time  (median):     5.110 ns             ┊ GC (median):    0.00%
 Time  (mean ± σ):   5.105 ns ± 0.063 ns  ┊ GC (mean ± σ):  0.00% ± 0.00%

     ▄  ▁             ▄  ▃  ▂  ▂▆  ▁  ▇  ▃█     ▆  ▁▆     ▂ ▂
  ▆▁▁█▁▁█▁▁▁▁▁▁▁▁▁▁▁▁▇█▁▁█▁▁█▁▁██▁▁█▁▁█▁▁██▁▁█▁▁█▁▁██▁▁▄▁▁█ █
  4.99 ns     Histogram: log(frequency) by time     5.16 ns <

 Memory estimate: 0 bytes, allocs estimate: 0.
```

option 3: if we know how many (integer) keys we'll have at most

```
julia> foo(dev) = @memoize dev::Int maxlen=ndevices() begin
         42
       end::Int
foo (generic function with 1 method)

julia> @benchmark foo(1)
BenchmarkTools.Trial: 10000 samples with 1000 evaluations.
 Range (min … max):  2.939 ns … 5.880 ns  ┊ GC (min … max): 0.00% … 0.00%
 Time  (median):     3.010 ns             ┊ GC (median):    0.00%
 Time  (mean ± σ):   3.010 ns ± 0.053 ns  ┊ GC (mean ± σ):  0.00% ± 0.00%

                                    ▂     ▅    █             
  ▃▁▁▁▁▂▃▁▁▁▁▃▁▁▁▁▂▃▁▁▁▁▂▃▁▁▁▁▆▁▁▁▁▂█▁▁▁▁▂█▁▁▁▁█▁▁▁▁▂█▁▁▁▁▃ ▃
  2.94 ns        Histogram: frequency by time       3.04 ns <

 Memory estimate: 0 bytes, allocs estimate: 0.
```

In comparison, Memoize.jl/Memoization.jl are a bit slower, at 10ns, but they are not thread safe. They recommend ThreadSafeDicts instead, which slows performance down to 50ns.

Maybe this is micro-optimization, but CUDA.jl is starting to add `if CUDA.version() >= v"..."` checks everywhere, and I don't want those killing performance.