### PR TITLE
Make the default pool visible when doing P2P

### DIFF
--- a/lib/cudadrv/memory.jl
+++ b/lib/cudadrv/memory.jl
@@ -724,6 +724,10 @@ function maybe_enable_peer_access(src::CuDevice, dst::CuDevice)
             device!(src) do
                 try
                     enable_peer_access(context(dst))
+                    if memory_pools_supported(src)
+                        src_pool = default_memory_pool(src)
+                        access!(src_pool, dst, CUDA.ACCESS_FLAGS_PROT_READWRITE)
+                    end
                     peer_access[][src_idx, dst_idx] = 1
                 catch err
                     @warn "Enabling peer-to-peer access between $src and $dst failed; please file an issue." exception=(err,catch_backtrace())

--- a/lib/cudadrv/pool.jl
+++ b/lib/cudadrv/pool.jl
@@ -1,9 +1,11 @@
 # Stream-orderdered memory allocator
 
-export CuMemoryPool, default_memory_pool, memory_pool, memory_pool!, trim, attribute, attribute!
+export CuMemoryPool, default_memory_pool, memory_pool, memory_pool!, trim,
+       attribute, attribute!, access!
 
 @enum_without_prefix CUmemAllocationType CU_MEM_
 @enum_without_prefix CUmemAllocationHandleType CU_MEM_
+@enum_without_prefix CUmemAccess_flags_enum CU_MEM_
 
 mutable struct CuMemoryPool
     handle::CUmemoryPool
@@ -88,4 +90,20 @@ Sets attribute` attr` on a pointer `ptr` to `val`.
 function attribute!(pool::CuMemoryPool, attr::CUmemPool_attribute, value) where {T}
     cuMemPoolSetAttribute(pool, attr, Ref(value))
     return
+end
+
+
+## pool access
+
+@enum_without_prefix CUmemAccess_flags_enum CU_MEM_
+
+"""
+    access!(pool::CuMemoryPool, dev::CuDevice, flags::CUmemAccess_flags)
+
+Control the visibility of memory pool `pool` on device `dev`.
+"""
+function access!(pool::CuMemoryPool, dev::CuDevice, flags::CUmemAccess_flags)
+    location = CUmemLocation(CU_MEM_LOCATION_TYPE_DEVICE, dev.handle)
+    access = CUmemAccessDesc(location, flags)
+    cuMemPoolSetAccess(pool, Ref(access), 1)
 end


### PR DESCRIPTION
Ref https://gist.github.com/carstenbauer/c482cb14e44246c4186193c50a1f9ac7, cc @carstenbauer @oschulz @lukas-mazur

This does turn up as a DtoD copy in NSight, instead of a PtoP one:

```
 Time (%)  Total Time (ns)  Count  Avg (ns)   Med (ns)   Min (ns)  Max (ns)  StdDev (ns)      Operation     
 --------  ---------------  -----  ---------  ---------  --------  --------  -----------  ------------------
    100.0          473,883      1  473,883.0  473,883.0   473,883   473,883          0.0  [CUDA memcpy DtoD]
```

Performance seems good though.

This is also what TF does: https://github.com/tensorflow/tensorflow/blob/5f6e4b06871ca70f60bf9a7a84e68124f5af68df/tensorflow/core/common_runtime/gpu/gpu_cudamallocasync_allocator.cc#L207-L237