### PR TITLE
Implement (limited) broadcast of sparse arrays

### DIFF
--- a/lib/cusparse/CUSPARSE.jl
+++ b/lib/cusparse/CUSPARSE.jl
@@ -42,6 +42,9 @@ include("generic.jl")
 # high-level integrations
 include("interfaces.jl")
 
+# native functionality
+include("device.jl")
+
 # cache for created, but unused handles
 const idle_handles = HandleCache{CuContext,cusparseHandle_t}()
 

--- a/lib/cusparse/CUSPARSE.jl
+++ b/lib/cusparse/CUSPARSE.jl
@@ -4,7 +4,7 @@ using ..APIUtils
 
 using ..CUDA
 using ..CUDA: CUstream, cuComplex, cuDoubleComplex, libraryPropertyType, cudaDataType
-using ..CUDA: libcusparse, unsafe_free!, @retry_reclaim, initialize_context
+using ..CUDA: libcusparse, unsafe_free!, @retry_reclaim, initialize_context, i32
 
 using CEnum: @cenum
 
@@ -44,6 +44,7 @@ include("interfaces.jl")
 
 # native functionality
 include("device.jl")
+include("broadcast.jl")
 
 # cache for created, but unused handles
 const idle_handles = HandleCache{CuContext,cusparseHandle_t}()

--- a/lib/cusparse/array.jl
+++ b/lib/cusparse/array.jl
@@ -17,12 +17,12 @@ Base.convert(T::Type{<:AbstractCuSparseArray}, m::AbstractArray) = m isa T ? m :
 mutable struct CuSparseVector{Tv, Ti} <: AbstractCuSparseVector{Tv, Ti}
     iPtr::CuVector{Ti}
     nzVal::CuVector{Tv}
-    dims::NTuple{2,Int}
+    len::Int
     nnz::Ti
 
     function CuSparseVector{Tv, Ti}(iPtr::CuVector{<:Integer}, nzVal::CuVector,
-                                dims::Integer) where {Tv, Ti <: Integer}
-        new{Tv, Ti}(iPtr, nzVal, (dims,1), length(nzVal))
+                                    len::Integer) where {Tv, Ti <: Integer}
+        new{Tv, Ti}(iPtr, nzVal, len, length(nzVal))
     end
 end
 
@@ -151,11 +151,13 @@ const CuSparseMatrix{Tv, Ti} = Union{
     CuSparseMatrixCOO{Tv, Ti}
 }
 
+const CuSparseVecOrMat = Union{CuSparseVector,CuSparseMatrix}
+
 
 # NOTE: we use Cint as default Ti on CUDA instead of Int to provide
 # maximum compatiblity to old CUSPARSE APIs
-function CuSparseVector{Tv}(iPtr::CuVector{<:Integer}, nzVal::CuVector, dims::Integer) where {Tv}
-    CuSparseVector{Tv, Cint}(convert(CuVector{Cint}, iPtr), nzVal, dims)
+function CuSparseVector{Tv}(iPtr::CuVector{<:Integer}, nzVal::CuVector, len::Integer) where {Tv}
+    CuSparseVector{Tv, Cint}(convert(CuVector{Cint}, iPtr), nzVal, len)
 end
 
 function CuSparseMatrixCSC{Tv}(colPtr::CuVector{<:Integer}, rowVal::CuVector{<:Integer},
@@ -181,8 +183,8 @@ function CuSparseMatrixCOO{Tv}(rowInd::CuVector{<:Integer}, colInd::CuVector{<:I
 end
 
 ## convenience constructors
-CuSparseVector(iPtr::DenseCuArray{<:Integer}, nzVal::DenseCuArray{T}, dims::Int) where {T} =
-    CuSparseVector{T}(iPtr, nzVal, dims)
+CuSparseVector(iPtr::DenseCuArray{<:Integer}, nzVal::DenseCuArray{T}, len::Int) where {T} =
+    CuSparseVector{T}(iPtr, nzVal, len)
 
 CuSparseMatrixCSC(colPtr::DenseCuArray{<:Integer}, rowVal::DenseCuArray{<:Integer},
                   nzVal::DenseCuArray{T}, dims::NTuple{2,Int}) where {T} =
@@ -198,23 +200,23 @@ CuSparseMatrixBSR(rowPtr::DenseCuArray, colVal::DenseCuArray, nzVal::DenseCuArra
 CuSparseMatrixCOO(rowInd::DenseCuArray, colInd::DenseCuArray, nzVal::DenseCuArray{T}, dims::NTuple{2,Int}, nnz) where T =
     CuSparseMatrixCOO{T}(rowInd, colInd, nzVal, dims, nnz)
 
-Base.similar(Vec::CuSparseVector) = CuSparseVector(copy(nonzeroinds(Vec)), similar(nonzeros(Vec)), Vec.dims[1])
-Base.similar(Mat::CuSparseMatrixCSC) = CuSparseMatrixCSC(copy(Mat.colPtr), copy(rowvals(Mat)), similar(nonzeros(Mat)), Mat.dims)
-Base.similar(Mat::CuSparseMatrixCSR) = CuSparseMatrixCSR(copy(Mat.rowPtr), copy(Mat.colVal), similar(nonzeros(Mat)), Mat.dims)
-Base.similar(Mat::CuSparseMatrixBSR) = CuSparseMatrixBSR(copy(Mat.rowPtr), copy(Mat.colVal), similar(nonzeros(Mat)), Mat.blockDim, Mat.dir, nnz(Mat), Mat.dims)
-Base.similar(Mat::CuSparseMatrixCOO) = CuSparseMatrixCOO(copy(Mat.rowInd), copy(Mat.colInd), similar(nonzeros(Mat)), Mat.dims, nnz(Mat))
+Base.similar(Vec::CuSparseVector) = CuSparseVector(copy(nonzeroinds(Vec)), similar(nonzeros(Vec)), length(Vec))
+Base.similar(Mat::CuSparseMatrixCSC) = CuSparseMatrixCSC(copy(Mat.colPtr), copy(rowvals(Mat)), similar(nonzeros(Mat)), size(Mat))
+Base.similar(Mat::CuSparseMatrixCSR) = CuSparseMatrixCSR(copy(Mat.rowPtr), copy(Mat.colVal), similar(nonzeros(Mat)), size(Mat))
+Base.similar(Mat::CuSparseMatrixBSR) = CuSparseMatrixBSR(copy(Mat.rowPtr), copy(Mat.colVal), similar(nonzeros(Mat)), Mat.blockDim, Mat.dir, nnz(Mat), size(Mat))
+Base.similar(Mat::CuSparseMatrixCOO) = CuSparseMatrixCOO(copy(Mat.rowInd), copy(Mat.colInd), similar(nonzeros(Mat)), size(Mat), nnz(Mat))
 
-Base.similar(Vec::CuSparseVector, T::Type) = CuSparseVector(copy(nonzeroinds(Vec)), similar(nonzeros(Vec), T), Vec.dims[1])
-Base.similar(Mat::CuSparseMatrixCSC, T::Type) = CuSparseMatrixCSC(copy(Mat.colPtr), copy(rowvals(Mat)), similar(nonzeros(Mat), T), Mat.dims)
-Base.similar(Mat::CuSparseMatrixCSR, T::Type) = CuSparseMatrixCSR(copy(Mat.rowPtr), copy(Mat.colVal), similar(nonzeros(Mat), T), Mat.dims)
-Base.similar(Mat::CuSparseMatrixBSR, T::Type) = CuSparseMatrixBSR(copy(Mat.rowPtr), copy(Mat.colVal), similar(nonzeros(Mat), T), Mat.blockDim, Mat.dir, nnz(Mat), Mat.dims)
-Base.similar(Mat::CuSparseMatrixCOO, T::Type) = CuSparseMatrixCOO(copy(Mat.rowInd), copy(Mat.colInd), similar(nonzeros(Mat), T), Mat.dims, nnz(Mat))
+Base.similar(Vec::CuSparseVector, T::Type) = CuSparseVector(copy(nonzeroinds(Vec)), similar(nonzeros(Vec), T), length(Vec))
+Base.similar(Mat::CuSparseMatrixCSC, T::Type) = CuSparseMatrixCSC(copy(Mat.colPtr), copy(rowvals(Mat)), similar(nonzeros(Mat), T), size(Mat))
+Base.similar(Mat::CuSparseMatrixCSR, T::Type) = CuSparseMatrixCSR(copy(Mat.rowPtr), copy(Mat.colVal), similar(nonzeros(Mat), T), size(Mat))
+Base.similar(Mat::CuSparseMatrixBSR, T::Type) = CuSparseMatrixBSR(copy(Mat.rowPtr), copy(Mat.colVal), similar(nonzeros(Mat), T), Mat.blockDim, Mat.dir, nnz(Mat), size(Mat))
+Base.similar(Mat::CuSparseMatrixCOO, T::Type) = CuSparseMatrixCOO(copy(Mat.rowInd), copy(Mat.colInd), similar(nonzeros(Mat), T), size(Mat), nnz(Mat))
 
 
 ## array interface
 
-Base.length(g::CuSparseVector) = prod(g.dims)
-Base.size(g::CuSparseVector) = g.dims
+Base.length(g::CuSparseVector) = g.len
+Base.size(g::CuSparseVector) = (g.len,)
 Base.ndims(g::CuSparseVector) = 1
 
 Base.length(g::CuSparseMatrix) = prod(g.dims)
@@ -223,7 +225,7 @@ Base.ndims(g::CuSparseMatrix) = 2
 
 function Base.size(g::CuSparseVector, d::Integer)
     if d == 1
-        return g.dims[d]
+        return g.len
     elseif d > 1
         return 1
     else
@@ -232,7 +234,7 @@ function Base.size(g::CuSparseVector, d::Integer)
 end
 
 function Base.size(g::CuSparseMatrix, d::Integer)
-    if d in [1, 2]
+    if 1 <= d <= 2
         return g.dims[d]
     elseif d > 1
         return 1
@@ -393,7 +395,7 @@ Adapt.adapt_storage(::Type{Array}, xs::CuSparseMatrixCSC) = SparseMatrixCSC(xs)
 ## copying between sparse GPU arrays
 
 function Base.copyto!(dst::CuSparseVector, src::CuSparseVector)
-    if dst.dims != src.dims
+    if length(dst) != length(src)
         throw(ArgumentError("Inconsistent Sparse Vector size"))
     end
     copyto!(nonzeroinds(dst), nonzeroinds(src))
@@ -403,7 +405,7 @@ function Base.copyto!(dst::CuSparseVector, src::CuSparseVector)
 end
 
 function Base.copyto!(dst::CuSparseMatrixCSC, src::CuSparseMatrixCSC)
-    if dst.dims != src.dims
+    if size(dst) != size(src)
         throw(ArgumentError("Inconsistent Sparse Matrix size"))
     end
     copyto!(dst.colPtr, src.colPtr)
@@ -414,7 +416,7 @@ function Base.copyto!(dst::CuSparseMatrixCSC, src::CuSparseMatrixCSC)
 end
 
 function Base.copyto!(dst::CuSparseMatrixCSR, src::CuSparseMatrixCSR)
-    if dst.dims != src.dims
+    if size(dst) != size(src)
         throw(ArgumentError("Inconsistent Sparse Matrix size"))
     end
     copyto!(dst.rowPtr, src.rowPtr)
@@ -425,7 +427,7 @@ function Base.copyto!(dst::CuSparseMatrixCSR, src::CuSparseMatrixCSR)
 end
 
 function Base.copyto!(dst::CuSparseMatrixBSR, src::CuSparseMatrixBSR)
-    if dst.dims != src.dims
+    if size(dst) != size(src)
         throw(ArgumentError("Inconsistent Sparse Matrix size"))
     end
     copyto!(dst.rowPtr, src.rowPtr)
@@ -437,7 +439,7 @@ function Base.copyto!(dst::CuSparseMatrixBSR, src::CuSparseMatrixBSR)
 end
 
 function Base.copyto!(dst::CuSparseMatrixCOO, src::CuSparseMatrixCOO)
-    if dst.dims != src.dims
+    if size(dst) != size(src)
         throw(ArgumentError("Inconsistent Sparse Matrix size"))
     end
     copyto!(dst.rowInd, src.rowInd)
@@ -500,7 +502,7 @@ function Adapt.adapt_structure(to::CUDA.Adaptor, x::CuSparseVector)
     return CuSparseDeviceVector(
         adapt(to, x.iPtr),
         adapt(to, x.nzVal),
-        x.dims, x.nnz
+        length(x), x.nnz
     )
 end
 
@@ -509,7 +511,7 @@ function Adapt.adapt_structure(to::CUDA.Adaptor, x::CuSparseMatrixCSR)
         adapt(to, x.rowPtr),
         adapt(to, x.colVal),
         adapt(to, x.nzVal),
-        x.dims, x.nnz
+        size(x), x.nnz
     )
 end
 
@@ -518,7 +520,7 @@ function Adapt.adapt_structure(to::CUDA.Adaptor, x::CuSparseMatrixCSC)
         adapt(to, x.colPtr),
         adapt(to, x.rowVal),
         adapt(to, x.nzVal),
-        x.dims, x.nnz
+        size(x), x.nnz
     )
 end
 
@@ -527,7 +529,7 @@ function Adapt.adapt_structure(to::CUDA.Adaptor, x::CuSparseMatrixBSR)
         adapt(to, x.rowPtr),
         adapt(to, x.colVal),
         adapt(to, x.nzVal),
-        x.dims, x.blockDim,
+        size(x), x.blockDim,
         x.dir, x.nnz
     )
 end
@@ -537,6 +539,6 @@ function Adapt.adapt_structure(to::CUDA.Adaptor, x::CuSparseMatrixCOO)
         adapt(to, x.rowInd),
         adapt(to, x.colInd),
         adapt(to, x.nzVal),
-        x.dims, x.nnz
+        size(x), x.nnz
     )
 end

--- a/lib/cusparse/array.jl
+++ b/lib/cusparse/array.jl
@@ -3,7 +3,8 @@
 
 export CuSparseMatrixCSC, CuSparseMatrixCSR, CuSparseMatrixBSR, CuSparseMatrixCOO,
        CuSparseMatrix, AbstractCuSparseMatrix,
-       CuSparseVector
+       CuSparseVector,
+       CuSparseVecOrMat
 
 using LinearAlgebra: BlasFloat
 using SparseArrays: nonzeroinds, dimlub

--- a/lib/cusparse/broadcast.jl
+++ b/lib/cusparse/broadcast.jl
@@ -1,0 +1,349 @@
+using Base.Broadcast: Broadcasted
+
+using CUDA: CuArrayStyle
+
+
+## sparse broadcast style
+
+# broadcast container type promotion for combinations of sparse arrays and other types
+struct CuSparseVecStyle <: Broadcast.AbstractArrayStyle{1} end
+struct CuSparseMatStyle <: Broadcast.AbstractArrayStyle{2} end
+Broadcast.BroadcastStyle(::Type{<:CuSparseVector}) = CuSparseVecStyle()
+Broadcast.BroadcastStyle(::Type{<:CuSparseMatrix}) = CuSparseMatStyle()
+const SPVM = Union{CuSparseVecStyle,CuSparseMatStyle}
+
+# CuSparseVecStyle handles 0-1 dimensions, CuSparseMatStyle 0-2 dimensions.
+# CuSparseVecStyle promotes to CuSparseMatStyle for 2 dimensions.
+# Fall back to DefaultArrayStyle for higher dimensionality.
+CuSparseVecStyle(::Val{0}) = CuSparseVecStyle()
+CuSparseVecStyle(::Val{1}) = CuSparseVecStyle()
+CuSparseVecStyle(::Val{2}) = CuSparseMatStyle()
+CuSparseVecStyle(::Val{N}) where N = Broadcast.DefaultArrayStyle{N}()
+CuSparseMatStyle(::Val{0}) = CuSparseMatStyle()
+CuSparseMatStyle(::Val{1}) = CuSparseMatStyle()
+CuSparseMatStyle(::Val{2}) = CuSparseMatStyle()
+CuSparseMatStyle(::Val{N}) where N = Broadcast.DefaultArrayStyle{N}()
+
+Broadcast.BroadcastStyle(::CuSparseVecStyle, ::CuArrayStyle{1}) = CuSparseVecStyle()
+Broadcast.BroadcastStyle(::CuSparseVecStyle, ::CuArrayStyle{2}) = CuSparseMatStyle()
+Broadcast.BroadcastStyle(::CuSparseMatStyle, ::CuArrayStyle{2}) = CuSparseMatStyle()
+
+# don't wrap sparse arrays with Extruded
+Broadcast.extrude(x::CuSparseVecOrMat) = x
+
+
+## detection of zero-preserving functions
+
+# modified from SparseArrays.jl
+
+# capturescalars takes a function (f) and a tuple of broadcast arguments, and returns a
+# partially-evaluated function and a reduced argument tuple where all scalar operations have
+# been applied already.
+@inline function capturescalars(f, mixedargs)
+    let (passedsrcargstup, makeargs) = _capturescalars(mixedargs...)
+        parevalf = (passed...) -> f(makeargs(passed...)...)
+        return (parevalf, passedsrcargstup)
+    end
+end
+# Work around losing Type{T}s as DataTypes within the tuple that makeargs creates
+@inline capturescalars(f, mixedargs::Tuple{Ref{Type{T}}, Vararg{Any}}) where {T} =
+    capturescalars((args...)->f(T, args...), Base.tail(mixedargs))
+@inline capturescalars(f, mixedargs::Tuple{Ref{Type{T}}, Ref{Type{S}}, Vararg{Any}}) where {T, S} =
+    # This definition is identical to the one above and necessary only for
+    # avoiding method ambiguity.
+    capturescalars((args...)->f(T, args...), Base.tail(mixedargs))
+@inline capturescalars(f, mixedargs::Tuple{CuSparseVecOrMat, Ref{Type{T}}, Vararg{Any}}) where {T} =
+    capturescalars((a1, args...)->f(a1, T, args...), (mixedargs[1], Base.tail(Base.tail(mixedargs))...))
+@inline capturescalars(f, mixedargs::Tuple{Union{Ref,AbstractArray{<:Any,0}}, Ref{Type{T}}, Vararg{Any}}) where {T} =
+    capturescalars((args...)->f(mixedargs[1], T, args...), Base.tail(Base.tail(mixedargs)))
+
+scalararg(::Number) = true
+scalararg(::Any) = false
+scalarwrappedarg(::Union{AbstractArray{<:Any,0},Ref}) = true
+scalarwrappedarg(::Any) = false
+
+@inline function _capturescalars()
+    return (), () -> ()
+end
+@inline function _capturescalars(arg, mixedargs...)
+    let (rest, f) = _capturescalars(mixedargs...)
+        if scalararg(arg)
+            return rest, @inline function(tail...)
+                (arg, f(tail...)...)
+            end # add back scalararg after (in makeargs)
+        elseif scalarwrappedarg(arg)
+            return rest, @inline function(tail...)
+                (arg[], f(tail...)...) # TODO: This can put a Type{T} in a tuple
+            end # unwrap and add back scalararg after (in makeargs)
+        else
+            return (arg, rest...), @inline function(head, tail...)
+                (head, f(tail...)...)
+            end # pass-through to broadcast
+        end
+    end
+end
+@inline function _capturescalars(arg) # this definition is just an optimization (to bottom out the recursion slightly sooner)
+    if scalararg(arg)
+        return (), () -> (arg,) # add scalararg
+    elseif scalarwrappedarg(arg)
+        return (), () -> (arg[],) # unwrap
+    else
+        return (arg,), (head,) -> (head,) # pass-through
+    end
+end
+
+@inline _iszero(x) = x == 0
+@inline _iszero(x::Number) = Base.iszero(x)
+@inline _iszero(x::AbstractArray) = Base.iszero(x)
+@inline _zeros_eltypes(A) = (zero(eltype(A)),)
+@inline _zeros_eltypes(A, Bs...) = (zero(eltype(A)), _zeros_eltypes(Bs...)...)
+
+
+## sparse broadcast implementation
+
+function Broadcast.copy(bc::Broadcasted{<:Union{CuSparseVecStyle,CuSparseMatStyle}})
+    ElType = Broadcast.combine_eltypes(bc.f, bc.args)
+    if !Base.isconcretetype(ElType)
+        error("""GPU sparse broadcast resulted in non-concrete element type $ElType.
+                 This probably means that the function you are broadcasting contains an error or type instability.""")
+    end
+
+    # we only support broadcast involving a single sparse array
+    bc = Broadcast.flatten(bc)
+    sparse_args = findall(bc.args) do arg
+        arg isa CUSPARSE.AbstractCuSparseArray
+    end
+    if length(sparse_args) != 1
+        error("broadcast with multiple sparse arguments not supported")
+    end
+    sparse_arg = sparse_args[1]
+    # XXX: can we handle multiple sparse arguments? problem is that a kernel then can't
+    # simply index one of those and use the same indices for the other sparse inputs. we
+    # could equalize the sparse inputs first, making sure they have values at the maximal
+    # set of indices, but I'm not sure how to implement that operation either.
+
+    # partially-evaluate the function, removing scalars
+    parevalf, passedsrcargstup = capturescalars(bc.f, bc.args)
+    # if all we have left is sparse arrays, we can check if the partially-evaluated function
+    # preserves zeros. if so, we'll only need to apply it to the sparse input arguments.
+    if all(arg->isa(arg, AbstractSparseArray), passedsrcargstup)
+        fofzeros = parevalf(_zeros_eltypes(passedsrcargstup...)...)
+        fpreszeros = _iszero(fofzeros)
+    else
+        fpreszeros = false
+    end
+    dest = if fpreszeros
+        similar(bc.args[sparse_arg], ElType)
+    else
+        # either we have dense inputs, or the function isn't preserving zeros,
+        # so use a dense output to broadcast into.
+        CuArray{ElType}(undef, size(bc.args[sparse_arg]))
+    end
+
+    _copyto!(dest, bc, sparse_arg)
+
+    # TODO: if we had dense inputs, but the function was preserving zeros,
+    #       try to re-sparsify the output?
+end
+
+# TODO
+# function Base.copyto!(dest::AbstractArray, bc::Broadcasted{<:CuSparseMatStyle})
+
+# version of copyto! that deals with a single sparse argument
+function _copyto!(dest, bc, idx)
+    axes(dest) == axes(bc) || Broadcast.throwdm(axes(dest), axes(bc))
+    isempty(dest) && return dest
+
+    # the _copyto! implementations below only process elements of our sparse input array.
+    if isa(dest, AbstractSparseArray)
+        # if we're writing to a sparse output, we'll be using the exact same indices
+        # as from the input. this requires the layout of the sparse array to be identical,
+        # which is too costly to check at run time, so just compare the nnz elements.
+        nnz(dest) == nnz(bc.args[idx]) ||
+          error("Destination of sparse broadcast should have identical layout")
+    else
+        # if we're broadcasting to a dense output -- likely because the function isn't
+        # zero-preserving -- we first broadcast to fill the elements not in our sparse array
+        # by setting those to zero and re-using the dense broadcast implementation
+        nonsparse_args = map(bc.args) do arg
+            # NOTE: this assumes the broadcst is flattened, but not yet preprocessed
+            if arg isa CUSPARSE.AbstractCuSparseArray
+                zero(eltype(arg))
+            else
+                arg
+            end
+        end
+        broadcast!(bc.f, dest, nonsparse_args...)
+    end
+
+    bc′ = Broadcast.preprocess(dest, bc)
+    sparse_arg = bc′.args[idx]
+    other_args = [bc′.args[begin:idx-1]..., bc′.args[idx+1:end]...]
+    _copyto!(typeof(bc.args[idx]), dest, bc′.f, sparse_arg, idx, other_args)
+end
+_copyto!(T::Type, dest, f, sparse_arg, idx, other_args) =
+    error("Broadcast with sparse array of type $T not implemented")
+
+# TODO: broadcast sparse vector with something 2d?
+
+function _copyto!(::Type{<:CuSparseVector}, dest, f, sparse_arg, idx, other_args)
+    function kernel(dest, f, arg, ::Val{idx}, other_args...) where idx
+        # every thread processes a single element
+        i = threadIdx().x + (blockIdx().x - 1i32) * blockDim().x
+        if i > nnz(arg)
+            return
+        end
+
+        # @inbounds begin
+            row = arg.iPtr[i]
+
+            # get the argument values at this index
+            val = arg.nzVal[i]
+            other_vals = Broadcast._getindex(other_args, row)
+
+            # apply the broadcast function
+            output = Broadcast._broadcast_getindex_evalf(f, other_vals[begin:idx-1]...,
+                                                         val, other_vals[idx:end]...)
+
+            # store the result
+            if dest isa AbstractSparseVector
+              dest.nzVal[i] = output
+            else
+              dest[row] = output
+            end
+        # end
+        return
+    end
+
+    cols = nnz(sparse_arg)
+    kernel = @cuda launch=false kernel(dest, f, sparse_arg, Val(idx), other_args...)
+    config = launch_configuration(kernel.fun)
+    threads = min(cols, config.threads)
+    blocks = cld(cols, threads)
+    kernel(dest, f, sparse_arg, Val(idx), other_args...; threads, blocks)
+
+    return dest
+end
+
+function _copyto!(::Type{<:CuSparseMatrixCSC}, dest, f, sparse_arg, idx, other_args)
+    function kernel(dest, f, arg, ::Val{idx}, other_args...) where idx
+        # every thread processes an entire column
+        col = threadIdx().x + (blockIdx().x - 1i32) * blockDim().x
+        if col >= length(arg.colPtr)
+            return
+        end
+
+        # TODO: parallelize across these as well? uncertain, but may yield improvements
+        @inbounds for i in arg.colPtr[col]:arg.colPtr[col+1]-1
+            row = arg.rowVal[i]
+            I = CartesianIndex(row, col)
+
+            # get the argument values at this index
+            val = arg.nzVal[i]
+            other_vals = Broadcast._getindex(other_args, I)
+
+            # apply the broadcast function
+            output = Broadcast._broadcast_getindex_evalf(f, other_vals[begin:idx-1]...,
+                                                         val, other_vals[idx:end]...)
+
+            # store the result
+            if dest isa AbstractSparseMatrix
+              dest.nzVal[i] = output
+            else
+              dest[I] = output
+            end
+        end
+        return
+    end
+
+    cols = length(sparse_arg.colPtr)-1
+    kernel = @cuda launch=false kernel(dest, f, sparse_arg, Val(idx), other_args...)
+    config = launch_configuration(kernel.fun)
+    threads = min(cols, config.threads)
+    blocks = cld(cols, threads)
+    kernel(dest, f, sparse_arg, Val(idx), other_args...; threads, blocks)
+
+    return dest
+end
+
+function _copyto!(::Type{<:CuSparseMatrixCSR}, dest, f, sparse_arg, idx, other_args)
+    function kernel(dest, f, arg, ::Val{idx}, other_args...) where idx
+        # every thread processes an entire row
+        row = threadIdx().x + (blockIdx().x - 1i32) * blockDim().x
+        if row >= length(arg.rowPtr)
+            return
+        end
+
+        # TODO: parallelize across these as well? uncertain, but may yield improvements
+        @inbounds for i in arg.rowPtr[row]:arg.rowPtr[row+1]-1
+            col = arg.colVal[i]
+            I = CartesianIndex(row, col)
+
+            # get the argument values at this index
+            val = arg.nzVal[i]
+            other_vals = Broadcast._getindex(other_args, I)
+
+            # apply the broadcast function
+            output = Broadcast._broadcast_getindex_evalf(f, other_vals[begin:idx-1]...,
+                                                         val, other_vals[idx:end]...)
+
+            # store the result
+            if dest isa AbstractSparseMatrix
+              dest.nzVal[i] = output
+            else
+              dest[I] = output
+            end
+        end
+        return
+    end
+
+    rows = length(sparse_arg.rowPtr)-1
+    kernel = @cuda launch=false kernel(dest, f, sparse_arg, Val(idx), other_args...)
+    config = launch_configuration(kernel.fun)
+    threads = min(rows, config.threads)
+    blocks = cld(rows, threads)
+    kernel(dest, f, sparse_arg, Val(idx), other_args...; threads, blocks)
+
+    return dest
+end
+
+function _copyto!(::Type{<:CuSparseMatrixCOO}, dest, f, sparse_arg, idx, other_args)
+    function kernel(dest, f, arg, ::Val{idx}, other_args...) where idx
+        # every thread processes a single element
+        i = threadIdx().x + (blockIdx().x - 1i32) * blockDim().x
+        if i > nnz(arg)
+            return
+        end
+
+        @inbounds begin
+            row = arg.rowInd[i]
+            col = arg.colInd[i]
+            I = CartesianIndex(row, col)
+
+            # get the argument values at this index
+            val = arg.nzVal[i]
+            other_vals = Broadcast._getindex(other_args, I)
+
+            # apply the broadcast function
+            output = Broadcast._broadcast_getindex_evalf(f, other_vals[begin:idx-1]...,
+                                                         val, other_vals[idx:end]...)
+
+            # store the result
+            if dest isa AbstractSparseMatrix
+              dest.nzVal[i] = output
+            else
+              dest[I] = output
+            end
+        end
+        return
+    end
+
+    nels = nnz(sparse_arg)
+    kernel = @cuda launch=false kernel(dest, f, sparse_arg, Val(idx), other_args...)
+    config = launch_configuration(kernel.fun)
+    threads = min(nels, config.threads)
+    blocks = cld(nels, threads)
+    kernel(dest, f, sparse_arg, Val(idx), other_args...; threads, blocks)
+
+    return dest
+end

--- a/lib/cusparse/device.jl
+++ b/lib/cusparse/device.jl
@@ -14,13 +14,14 @@ export CuSparseDeviceVector, CuSparseDeviceMatrixCSC, CuSparseDeviceMatrixCSR,
 struct CuSparseDeviceVector{Tv,Ti, A} <: AbstractSparseVector{Tv,Ti}
     iPtr::CuDeviceVector{Ti, A}
     nzVal::CuDeviceVector{Tv, A}
-    dims::NTuple{2,Int}
+    len::Int
     nnz::Ti
 end
 
 Base.length(g::CuSparseDeviceVector) = prod(g.dims)
-Base.size(g::CuSparseDeviceVector) = g.dims
+Base.size(g::CuSparseDeviceVector) = (g.len,)
 Base.ndims(g::CuSparseDeviceVector) = 1
+SparseArrays.nnz(g::CuSparseDeviceVector) = g.nnz
 
 struct CuSparseDeviceMatrixCSC{Tv,Ti,A} <: AbstractSparseMatrix{Tv,Ti}
     colPtr::CuDeviceVector{Ti, A}
@@ -33,6 +34,7 @@ end
 Base.length(g::CuSparseDeviceMatrixCSC) = prod(g.dims)
 Base.size(g::CuSparseDeviceMatrixCSC) = g.dims
 Base.ndims(g::CuSparseDeviceMatrixCSC) = 2
+SparseArrays.nnz(g::CuSparseDeviceMatrixCSC) = g.nnz
 
 struct CuSparseDeviceMatrixCSR{Tv,Ti,A} <: AbstractSparseMatrix{Tv,Ti}
     rowPtr::CuDeviceVector{Ti, A}
@@ -45,6 +47,7 @@ end
 Base.length(g::CuSparseDeviceMatrixCSR) = prod(g.dims)
 Base.size(g::CuSparseDeviceMatrixCSR) = g.dims
 Base.ndims(g::CuSparseDeviceMatrixCSR) = 2
+SparseArrays.nnz(g::CuSparseDeviceMatrixCSR) = g.nnz
 
 struct CuSparseDeviceMatrixBSR{Tv,Ti,A} <: AbstractSparseMatrix{Tv,Ti}
     rowPtr::CuDeviceVector{Ti, A}
@@ -59,6 +62,7 @@ end
 Base.length(g::CuSparseDeviceMatrixBSR) = prod(g.dims)
 Base.size(g::CuSparseDeviceMatrixBSR) = g.dims
 Base.ndims(g::CuSparseDeviceMatrixBSR) = 2
+SparseArrays.nnz(g::CuSparseDeviceMatrixBSR) = g.nnz
 
 struct CuSparseDeviceMatrixCOO{Tv,Ti,A} <: AbstractSparseMatrix{Tv,Ti}
     rowInd::CuDeviceVector{Ti, A}
@@ -71,6 +75,7 @@ end
 Base.length(g::CuSparseDeviceMatrixCOO) = prod(g.dims)
 Base.size(g::CuSparseDeviceMatrixCOO) = g.dims
 Base.ndims(g::CuSparseDeviceMatrixCOO) = 2
+SparseArrays.nnz(g::CuSparseDeviceMatrixCOO) = g.nnz
 
 
 # input/output

--- a/lib/cusparse/generic.jl
+++ b/lib/cusparse/generic.jl
@@ -43,7 +43,7 @@ mutable struct CuSparseMatrixDescriptor
         desc_ref = Ref{cusparseSpMatDescr_t}()
         cusparseCreateCsr(
             desc_ref,
-            A.dims..., length(nonzeros(A)),
+            size(A)..., length(nonzeros(A)),
             A.rowPtr, A.colVal, nonzeros(A),
             eltype(A.rowPtr), eltype(A.colVal), IndexBase, eltype(nonzeros(A))
         )
@@ -59,14 +59,14 @@ mutable struct CuSparseMatrixDescriptor
             # so we eagerly convert this to a CSR matrix.
             cusparseCreateCsr(
                 desc_ref,
-                reverse(A.dims)..., length(nonzeros(A)),
+                reverse(size(A))..., length(nonzeros(A)),
                 A.colPtr, rowvals(A), nonzeros(A),
                 eltype(A.colPtr), eltype(rowvals(A)), IndexBase, eltype(nonzeros(A))
             )
         else
             cusparseCreateCsc(
                 desc_ref,
-                A.dims..., length(nonzeros(A)),
+                size(A)..., length(nonzeros(A)),
                 A.colPtr, rowvals(A), nonzeros(A),
                 eltype(A.colPtr), eltype(rowvals(A)), IndexBase, eltype(nonzeros(A))
             )

--- a/lib/cusparse/level1.jl
+++ b/lib/cusparse/level1.jl
@@ -131,7 +131,7 @@ for (fname,elty) in ((:cusparseSsctr, :Float32),
         end
         function sctr(X::CuSparseVector{$elty},
                       index::SparseChar)
-            sctr!(X, CUDA.zeros($elty, X.dims[1]),index)
+            sctr!(X, CUDA.zeros($elty, size(X)[1]),index)
         end
     end
 end

--- a/lib/cusparse/level2.jl
+++ b/lib/cusparse/level2.jl
@@ -25,7 +25,7 @@ for (fname,elty) in ((:cusparseSbsrmv, :Float32),
                      Y::CuVector{$elty},
                      index::SparseChar)
             desc = CuMatrixDescriptor('G', 'L', 'N', index)
-            m,n = A.dims
+            m,n = size(A)
             mb = div(m,A.blockDim)
             nb = div(n,A.blockDim)
             if transa == 'N'
@@ -66,7 +66,7 @@ for (bname,aname,sname,elty) in ((:cusparseSbsrsv2_bufferSize, :cusparseSbsrsv2_
                       X::CuVector{$elty},
                       index::SparseChar)
             desc = CuMatrixDescriptor('G', uplo, diag, index)
-            m,n = A.dims
+            m,n = size(A)
             if m != n
                 throw(DimensionMismatch("A must be square, but has dimensions ($m,$n)!"))
             end
@@ -119,7 +119,7 @@ for (bname,aname,sname,elty) in ((:cusparseScsrsv2_bufferSize, :cusparseScsrsv2_
                       X::CuVector{$elty},
                       index::SparseChar)
             desc = CuMatrixDescriptor('G', uplo, diag, index)
-            m,n = A.dims
+            m,n = size(A)
             if m != n
                 throw(DimensionMismatch("A must be square, but has dimensions ($m,$n)!"))
             end
@@ -179,7 +179,7 @@ for (bname,aname,sname,elty) in ((:cusparseScsrsv2_bufferSize, :cusparseScsrsv2_
                 cuplo = 'L'
             end
             desc = CuMatrixDescriptor('G', cuplo, diag, index)
-            n,m = A.dims
+            n,m = size(A)
             if m != n
                 throw(DimensionMismatch("A must be square, but has dimensions ($m,$n)!"))
             end

--- a/lib/cusparse/level3.jl
+++ b/lib/cusparse/level3.jl
@@ -27,7 +27,7 @@ for (fname,elty) in ((:cusparseSbsrmm, :Float32),
                      C::StridedCuMatrix{$elty},
                      index::SparseChar)
             desc = CuMatrixDescriptor('G', 'L', 'N', index)
-            m,k = A.dims
+            m,k = size(A)
             mb = div(m,A.blockDim)
             kb = div(k,A.blockDim)
             n = size(C)[2]
@@ -70,7 +70,7 @@ for (fname,elty) in ((:cusparseScsrmm2, :Float32),
                 throw(ArgumentError("When using B^T, A can be neither transposed nor adjointed"))
             end
             desc = CuMatrixDescriptor('G', 'L', 'N', index)
-            m,k = A.dims
+            m,k = size(A)
             n = size(C)[2]
             if transa == 'N' && transb == 'N'
                 chkmmdims(B,C,k,n,m,n)
@@ -106,7 +106,7 @@ for (fname,elty) in ((:cusparseScsrmm2, :Float32),
                 ctransa = 'T'
             end
             desc = CuMatrixDescriptor('G', 'L', 'N', index)
-            k,m = A.dims
+            k,m = size(A)
             n = size(C)[2]
             if ctransa == 'N' && transb == 'N'
                 chkmmdims(B,C,k,n,m,n)
@@ -152,7 +152,7 @@ for (bname,aname,sname,elty) in ((:cusparseSbsrsm2_bufferSize, :cusparseSbsrsm2_
                       X::StridedCuMatrix{$elty},
                       index::SparseChar)
             desc = CuMatrixDescriptor('G', uplo, diag, index)
-            m,n = A.dims
+            m,n = size(A)
             if m != n
                  throw(DimensionMismatch("A must be square, but has dimensions ($m,$n)!"))
             end
@@ -212,7 +212,7 @@ for (bname,aname,sname,elty) in ((:cusparseScsrsm2_bufferSizeExt, :cusparseScsrs
                       X::StridedCuMatrix{$elty},
                       index::SparseChar)
             desc = CuMatrixDescriptor('G', uplo, diag, index)
-            m,n = A.dims
+            m,n = size(A)
             if m != n
                 throw(DimensionMismatch("A must be square, but has dimensions ($m,$n)!"))
             end
@@ -280,7 +280,7 @@ for (bname,aname,sname,elty) in ((:cusparseScsrsm2_bufferSizeExt, :cusparseScsrs
                 cuplo = 'L'
             end
             desc = CuMatrixDescriptor('G', cuplo, diag, index)
-            n,m = A.dims
+            n,m = size(A)
             if m != n
                 throw(DimensionMismatch("A must be square, but has dimensions ($n,$m)!"))
             end

--- a/lib/cusparse/preconditioners.jl
+++ b/lib/cusparse/preconditioners.jl
@@ -17,7 +17,7 @@ for (bname,aname,sname,elty) in ((:cusparseScsric02_bufferSize, :cusparseScsric0
         function ic02!(A::CuSparseMatrixCSR{$elty},
                        index::SparseChar)
             desc = CuMatrixDescriptor('G', 'L', 'N', index)
-            m,n = A.dims
+            m,n = size(A)
             if m != n
                 throw(DimensionMismatch("A must be square, but has dimensions ($m,$n)!"))
             end
@@ -58,7 +58,7 @@ for (bname,aname,sname,elty) in ((:cusparseScsric02_bufferSize, :cusparseScsric0
         function ic02!(A::CuSparseMatrixCSC{$elty},
                        index::SparseChar)
             desc = CuMatrixDescriptor('G', 'L', 'N', index)
-            m,n = A.dims
+            m,n = size(A)
             if m != n
                 throw(DimensionMismatch("A must be square, but has dimensions ($m,$n)!"))
             end
@@ -105,7 +105,7 @@ for (bname,aname,sname,elty) in ((:cusparseScsrilu02_bufferSize, :cusparseScsril
         function ilu02!(A::CuSparseMatrixCSR{$elty},
                         index::SparseChar)
             desc = CuMatrixDescriptor('G', 'L', 'N', index)
-            m,n = A.dims
+            m,n = size(A)
             if m != n
                 throw(DimensionMismatch("A must be square, but has dimensions ($m,$n)!"))
             end
@@ -147,7 +147,7 @@ for (bname,aname,sname,elty) in ((:cusparseScsrilu02_bufferSize, :cusparseScsril
         function ilu02!(A::CuSparseMatrixCSC{$elty},
                         index::SparseChar)
             desc = CuMatrixDescriptor('G', 'L', 'N', index)
-            m,n = A.dims
+            m,n = size(A)
             if m != n
                 throw(DimensionMismatch("A must be square, but has dimensions ($m,$n)!"))
             end
@@ -189,7 +189,7 @@ for (bname,aname,sname,elty) in ((:cusparseSbsric02_bufferSize, :cusparseSbsric0
         function ic02!(A::CuSparseMatrixBSR{$elty},
                        index::SparseChar)
             desc = CuMatrixDescriptor('G', 'U', 'N', index)
-            m,n = A.dims
+            m,n = size(A)
             if m != n
                 throw(DimensionMismatch("A must be square, but has dimensions ($m,$n)!"))
             end
@@ -232,7 +232,7 @@ for (bname,aname,sname,elty) in ((:cusparseSbsrilu02_bufferSize, :cusparseSbsril
         function ilu02!(A::CuSparseMatrixBSR{$elty},
                         index::SparseChar)
             desc = CuMatrixDescriptor('G', 'U', 'N', index)
-            m,n = A.dims
+            m,n = size(A)
             if m != n
                 throw(DimensionMismatch("A must be square, but has dimensions ($m,$n)!"))
             end

--- a/src/CUDA.jl
+++ b/src/CUDA.jl
@@ -60,7 +60,6 @@ include("device/intrinsics.jl")
 include("device/runtime.jl")
 include("device/texture.jl")
 include("device/random.jl")
-include("device/sparse.jl")
 include("device/quirks.jl")
 
 # array essentials

--- a/src/CUDA.jl
+++ b/src/CUDA.jl
@@ -82,6 +82,16 @@ include("gpuarrays.jl")
 include("utilities.jl")
 include("texture.jl")
 
+# integrations and specialized functionality
+include("indexing.jl")
+include("broadcast.jl")
+include("mapreduce.jl")
+include("accumulate.jl")
+include("reverse.jl")
+include("linalg.jl")
+include("iterator.jl")
+include("sorting.jl")
+
 # array libraries
 include("../lib/complex.jl")
 include("../lib/library_types.jl")
@@ -94,16 +104,8 @@ include("../lib/cudnn/CUDNN.jl")
 include("../lib/cutensor/CUTENSOR.jl")
 export CUBLAS, CUSPARSE, CUSOLVER, CUFFT, CURAND, CUDNN, CUTENSOR
 
-# integrations and specialized functionality
-include("indexing.jl")
-include("broadcast.jl")
-include("mapreduce.jl")
-include("accumulate.jl")
-include("reverse.jl")
-include("linalg.jl")
-include("iterator.jl")
+# random depends on CURAND
 include("random.jl")
-include("sorting.jl")
 
 # other libraries
 include("../lib/nvml/NVML.jl")

--- a/src/random.jl
+++ b/src/random.jl
@@ -7,6 +7,8 @@ export rand_logn!, rand_poisson!
 
 # native RNG
 
+# TODO: move this into CUSPARSE.jl (like CUSPARSE.jl's native broadcast)
+
 """
     CUDA.RNG()
 

--- a/test/cusparse.jl
+++ b/test/cusparse.jl
@@ -15,7 +15,7 @@ blockdim = 5
     x = sprand(m,0.2)
     d_x = CuSparseVector(x)
     @test length(d_x) == m
-    @test size(d_x)   == (m, 1)
+    @test size(d_x)   == (m,)
     @test size(d_x,1) == m
     @test size(d_x,2) == 1
     @test ndims(d_x)  == 1

--- a/test/cusparse/broadcast.jl
+++ b/test/cusparse/broadcast.jl
@@ -1,0 +1,53 @@
+using CUDA.CUSPARSE, SparseArrays
+
+m,n = 2,3
+p = 0.5
+
+for elty in [Float32]
+    @testset "CuSparseVector" begin
+        x = sprand(elty, m*n, p)
+        dx = CuSparseVector(x)
+
+        # zero-preserving
+        y = x .* 1
+        dy = dx .* 1
+        @test dy isa CuSparseVector{elty}
+        @test y == SparseVector(dy)
+
+        # not zero-preserving
+        y = x .+ 1
+        dy = dx .+ 1
+        @test dy isa CuVector{elty}
+        @test y == Array(dy)
+
+        # involving something dense
+        y = x .* ones(m*n)
+        dy = dx .* CUDA.ones(m*n)
+        @test dy isa CuVector{elty}
+        @test y == Array(dy)
+    end
+
+    # TODO: BSR
+    @testset "$typ" for typ in [CuSparseMatrixCSC, CuSparseMatrixCSR, CuSparseMatrixCOO]
+        x = sprand(elty, m, n, p)
+        dx = typ(x)
+
+        # zero-preserving
+        y = x .* 1
+        dy = dx .* 1
+        @test dy isa typ{elty}
+        @test y == SparseMatrixCSC(dy)
+
+        # not zero-preserving
+        y = x .+ 1
+        dy = dx .+ 1
+        @test dy isa CuArray{elty}
+        @test y == Array(dy)
+
+        # involving something dense
+        y = x .* ones(m, n)
+        dy = dx .* CUDA.ones(m, n)
+        @test dy isa CuArray{elty}
+        @test y == Array(dy)
+    end
+end

--- a/test/cusparse/device.jl
+++ b/test/cusparse/device.jl
@@ -1,9 +1,7 @@
-using Test
-using CUDA
 using CUDA.CUSPARSE
 using SparseArrays
-using CUDA: CuSparseDeviceVector, CuSparseDeviceMatrixCSC, CuSparseDeviceMatrixCSR,
-    CuSparseDeviceMatrixBSR, CuSparseDeviceMatrixCOO
+using CUDA.CUSPARSE: CuSparseDeviceVector, CuSparseDeviceMatrixCSC, CuSparseDeviceMatrixCSR,
+                     CuSparseDeviceMatrixBSR, CuSparseDeviceMatrixCOO
 
 @testset "cudaconvert" begin
     @test isbitstype(CuSparseDeviceVector{Float32, Cint, CUDA.AS.Global})


### PR DESCRIPTION
Demo:

```julia
julia> cu(sparse([1f0 0f0; 1f0 1f0; 0f0 1f0]))
3×2 CUDA.CUSPARSE.CuSparseMatrixCSC{Float32, Int32} with 4 stored entries:
 1.0   ⋅ 
 1.0  1.0
  ⋅   1.0

# best case: retains sparse output with zero-preserving function and scalar inputs
julia> cu(sparse([1f0 0f0; 1f0 1f0; 0f0 1f0])) .* 1
3×2 CUDA.CUSPARSE.CuSparseMatrixCSC{Float32, Int32} with 4 stored entries:
 1.0   ⋅ 
 1.0  1.0
  ⋅   1.0

# with non zero-preserving function, output is dense
julia> cu(sparse([1f0 0f0; 1f0 1f0; 0f0 1f0])) .+ 1
3×2 CuArray{Float32, 2, CUDA.Mem.DeviceBuffer}:
 2.0  1.0
 2.0  2.0
 1.0  2.0

# or when a dense input is involved
julia> cu(sparse([1f0 0f0; 1f0 1f0; 0f0 1f0])) .* CUDA.ones(3,2)
3×2 CuArray{Float32, 2, CUDA.Mem.DeviceBuffer}:
 1.0  0.0
 1.0  1.0
 0.0  1.0
```

Limitations:

- not implemented for BSR
- only supports one sparse input

cc @Roger-luo @ChrisRackauckas 