### PR TITLE
Make nonblocking synchronization robust to errors.

### DIFF
--- a/lib/cudadrv/execution.jl
+++ b/lib/cudadrv/execution.jl
@@ -147,7 +147,8 @@ function launch(f::Base.Callable; stream::CuStream=stream())
         f()
         close(async_cond)
     end
-    # FIXME: protect this from GC
+
+    # the condition object is embedded in a task, so the Julia scheduler keeps it alive
 
     # callback = @cfunction(async_send, Cint, (Ptr{Cvoid},))
     # See https://github.com/JuliaGPU/CUDA.jl/issues/1314.

--- a/lib/cudadrv/stream.jl
+++ b/lib/cudadrv/stream.jl
@@ -162,7 +162,7 @@ end
     dev = device()
     timer = Timer(0; interval=1)
     Base.@sync begin
-        @async try
+        Threads.@spawn try
             device!(dev)
             while true
                 try
@@ -179,7 +179,7 @@ end
             notify(event)
         end
 
-        @async begin
+        Threads.@spawn begin
             Base.wait(event)
             close(timer)
         end

--- a/src/compiler/execution.jl
+++ b/src/compiler/execution.jl
@@ -311,7 +311,7 @@ function run_and_collect(cmd)
     proc = run(pipeline(ignorestatus(cmd); stdout, stderr=stdout), wait=false)
     close(stdout.in)
 
-    reader = @async String(read(stdout))
+    reader = Threads.@spawn String(read(stdout))
     Base.wait(proc)
     log = strip(fetch(reader))
 

--- a/src/pool.jl
+++ b/src/pool.jl
@@ -89,7 +89,7 @@ function pool_mark(dev::CuDevice)
 
       # launch a task to periodically trim the pool
       if isinteractive() && !isassigned(__pool_cleanup)
-        __pool_cleanup[] = @async pool_cleanup()
+        __pool_cleanup[] = errormonitor(Threads.@spawn pool_cleanup())
       end
   end
   status[] = true


### PR DESCRIPTION
Our nonblocking synchronization relied on CUDA notifying an async condition, but that may never happen if the stream encounters an error. Protect against this by using a timer that periodically queries the stream in a regular way.
Fixes https://github.com/JuliaGPU/CUDA.jl/issues/1366, may reveal something in https://github.com/JuliaGPU/CUDA.jl/issues/1350.

cc @vchuravy @tkf