### PR TITLE
General purpose broadcast for sparse CSR matrices.

### DIFF
--- a/lib/cusparse/CUSPARSE.jl
+++ b/lib/cusparse/CUSPARSE.jl
@@ -4,7 +4,7 @@ using ..APIUtils
 
 using ..CUDA
 using ..CUDA: CUstream, cuComplex, cuDoubleComplex, libraryPropertyType, cudaDataType
-using ..CUDA: libcusparse, unsafe_free!, @retry_reclaim, initialize_context, i32
+using ..CUDA: libcusparse, unsafe_free!, @retry_reclaim, initialize_context, i32, @allowscalar
 
 using CEnum: @cenum
 

--- a/lib/cusparse/broadcast.jl
+++ b/lib/cusparse/broadcast.jl
@@ -99,251 +99,322 @@ end
 @inline _zeros_eltypes(A, Bs...) = (zero(eltype(A)), _zeros_eltypes(Bs...)...)
 
 
+## iteration helpers
+
+"""
+    CSRRowIterator{Ti}(dims, row, args...)
+
+A GPU-compatible iterator for accessing the nonzero columns of a single row `row` of several
+CSR matrices `args` in one go. The size of the arguments should be identical, and provided
+as `dims`, but their structure can vary. Each iteration returns a 2-element tuple: The
+current column, and each arguments' pointer index (or 0 if that input didn't have an element
+at that column). The pointers can then be used to access the elements themselves.
+
+For convenience, this iterator can be passed non-sparse arguments as well, which will be
+ignored (with the returned `col`/`ptr` values set to 0).
+"""
+struct CSRRowIterator{Ti,N,ATs}
+    dims::NTuple{2, Ti}
+    row::Ti
+    col_ends::NTuple{N, Ti}
+    args::ATs
+end
+
+Base.size(iter::CSRRowIterator) = iter.dims
+Base.size(iter::CSRRowIterator, i) = iter.dims[i]
+
+# dims is the shape of all arguments
+# row is the row this iterator is processing
+function CSRRowIterator{Ti}(dims, row, args::Vararg{<:Any, N}) where {Ti,N}
+    # row is assumed to be in bounds
+    col_ends = ntuple(Val(N)) do i
+        arg = @inbounds args[i]
+        if arg isa CuSparseDeviceMatrixCSR
+            @inbounds(arg.rowPtr[row+1i32])
+        else
+            zero(Ti)
+        end
+    end
+    # Julia dims are often Int, but we know the actual maximal index type
+    typed_dims = map(dim->dim%Ti, dims)
+    CSRRowIterator{Ti, N, typeof(args)}(typed_dims, row, col_ends, args)
+end
+
+@inline function Base.iterate(iter::CSRRowIterator{Ti,N}, state=nothing) where {Ti,N}
+    # helper function to get the column of a sparse array at a specific pointer,
+    # or one past the maximum column if that argument does not have values anymore.
+    @inline function get_col(i, ptr)
+        arg = @inbounds iter.args[i]
+        if arg isa CuSparseDeviceMatrixCSR
+            col_end = @inbounds iter.col_ends[i]
+            if ptr < col_end
+                @inbounds arg.colVal[ptr] % Ti
+            else
+                typemax(Ti)
+            end
+        else
+            typemax(Ti)
+        end
+    end
+
+    # initialize the state
+    # - ptr: the current index into the colVal/nzVal arrays
+    # - col: the current column index (cached so that we don't have to re-read each time)
+    state = something(state,
+        ntuple(Val(N)) do i
+            arg = @inbounds iter.args[i]
+            if arg isa CuSparseDeviceMatrixCSR
+                ptr = @inbounds iter.args[i].rowPtr[iter.row] % Ti
+                col = @inbounds get_col(i, ptr)
+            else
+                ptr = typemax(Ti)
+                col = typemax(Ti)
+            end
+            (; ptr, col)
+        end
+    )
+
+    # determine the column we're currently processing
+    cols = ntuple(i -> @inbounds(state[i].col), Val(N))
+    cur_col = min(cols...)
+    if cur_col == typemax(Ti)
+        return nothing
+    end
+
+    # fetch the pointers (we don't look up the values, as the caller might want to index
+    # the sparse array directly, e.g., to mutate it). we don't return `ptrs` from the state
+    # directly, but first convert the `typemax(Ti)` to a more convenient zero value.
+    # NOTE: these values may end up unused by the caller (e.g. in the count_nnzs kernels),
+    #       but LLVM appears smart enough to filter them away.
+    ptrs = ntuple(Val(N)) do i
+        ptr, col = @inbounds state[i]
+        col == cur_col ? ptr : zero(Ti)
+    end
+
+    # advance the state
+    new_state = ntuple(Val(N)) do i
+        ptr, col = @inbounds state[i]
+        if col == cur_col
+            ptr += one(Ti)
+            col = get_col(i, ptr)
+        end
+        (; ptr, col)
+    end
+
+    return (cur_col, ptrs), new_state
+end
+
+# helpers to index a sparse or dense array
+function _getindex(arg::CuSparseDeviceMatrixCSR{Tv}, I, ptr) where Tv
+    if ptr == 0
+        zero(Tv)
+    else
+        @inbounds arg.nzVal[ptr]
+    end
+end
+_getindex(arg, I, ptr) = Broadcast._broadcast_getindex(arg, I)
+
+
 ## sparse broadcast implementation
 
+# kernel to count the number of non-zeros in a row, to determine the row offsets
+function compute_csr_row_offsets_kernel(row_offsets::AbstractVector{Ti}, cols::Integer,
+                                        args...) where Ti
+    # every thread processes an entire row
+    row = threadIdx().x + (blockIdx().x - 1i32) * blockDim().x
+    if row > length(row_offsets)-1
+        return
+    end
+
+    # count the nonzero columns of all inputs
+    iter = CSRRowIterator{Ti}((length(row_offsets)-1, cols), row, args...)
+    accum = zero(Ti)
+    for (col, vals) in iter
+        accum += one(Ti)
+    end
+
+    # the way we write the nnz counts is a bit strange, but done so that the result
+    # after accumulation can be directly used as the rowPtr array of a CSR matrix.
+    @inbounds begin
+        if row == 1
+            row_offsets[1] = 1
+        end
+        row_offsets[row+1] = accum
+    end
+
+    return
+end
+
+# broadcast kernels that iterate the elements of sparse arrays
+function sparse_to_sparse_broadcast_kernel(f, output::CuSparseDeviceMatrixCSR{Tv,Ti},
+                                           row_offsets::Union{AbstractVector,Nothing},
+                                           args...) where {Tv,Ti}
+    # every thread processes an entire row
+    row = threadIdx().x + (blockIdx().x - 1i32) * blockDim().x
+    if row > size(output, 1)
+        return
+    end
+
+    # fetch the row offset, and write it to the output
+    @inbounds begin
+        output_ptr = output.rowPtr[row] = row_offsets[row]
+        if row == size(output, 1)
+            output.rowPtr[row+1i32] = row_offsets[row+1i32]
+        end
+    end
+
+    # set the values for this row
+    iter = CSRRowIterator{Ti}(size(output), row, args...)
+    for (col, ptrs) in iter
+        I = CartesianIndex(row, col)
+        vals = ntuple(Val(length(args))) do i
+            arg = @inbounds args[i]
+            ptr = @inbounds ptrs[i]
+            _getindex(arg, I, ptr)
+        end
+
+        @inbounds output.colVal[output_ptr] = col
+        @inbounds output.nzVal[output_ptr] = f(vals...)
+        output_ptr += one(Ti)
+    end
+
+    return
+end
+function sparse_to_dense_broadcast_kernel(f, output::CuDeviceArray{Tv},
+                                          args...) where {Tv}
+    # every thread processes an entire row
+    row = threadIdx().x + (blockIdx().x - 1i32) * blockDim().x
+    if row > size(output, 1)
+        return
+    end
+
+    # set the values for this row
+    iter = CSRRowIterator{Int}(size(output), row, args...)
+    for (col, ptrs) in iter
+        I = CartesianIndex(row, col)
+        vals = ntuple(Val(length(args))) do i
+            arg = @inbounds args[i]
+            ptr = @inbounds ptrs[i]
+            _getindex(arg, I, ptr)
+        end
+
+        @inbounds output[I] = f(vals...)
+    end
+
+    return
+end
+
 function Broadcast.copy(bc::Broadcasted{<:Union{CuSparseVecStyle,CuSparseMatStyle}})
-    ElType = Broadcast.combine_eltypes(bc.f, bc.args)
-    if !Base.isconcretetype(ElType)
-        error("""GPU sparse broadcast resulted in non-concrete element type $ElType.
+    # find the sparse inputs
+    bc = Broadcast.flatten(bc)
+    sparse_args = findall(bc.args) do arg
+        arg isa AbstractCuSparseArray
+    end
+    sparse_types = unique(map(i->nameof(typeof(bc.args[i])), sparse_args))
+    if length(sparse_types) > 1
+        error("broadcast with multiple types of sparse arrays ($(join(sparse_types, ", "))) is not supported")
+    end
+    Ti = reduce(promote_type, map(i->eltype(bc.args[i].rowPtr), sparse_args))
+
+    # determine the output type
+    Tv = Broadcast.combine_eltypes(bc.f, eltype.(bc.args))
+    if !Base.isconcretetype(Tv)
+        error("""GPU sparse broadcast resulted in non-concrete element type $Tv.
                  This probably means that the function you are broadcasting contains an error or type instability.""")
     end
 
-    # we only support broadcast involving a single sparse array
-    bc = Broadcast.flatten(bc)
-    sparse_args = findall(bc.args) do arg
-        arg isa CUSPARSE.AbstractCuSparseArray
-    end
-    if length(sparse_args) != 1
-        error("broadcast with multiple sparse arguments not supported")
-    end
-    sparse_arg = sparse_args[1]
-    # XXX: can we handle multiple sparse arguments? problem is that a kernel then can't
-    # simply index one of those and use the same indices for the other sparse inputs. we
-    # could equalize the sparse inputs first, making sure they have values at the maximal
-    # set of indices, but I'm not sure how to implement that operation either.
-
-    # partially-evaluate the function, removing scalars
+    # partially-evaluate the function, removing scalars.
     parevalf, passedsrcargstup = capturescalars(bc.f, bc.args)
-    # if all we have left is sparse arrays, we can check if the partially-evaluated function
-    # preserves zeros. if so, we'll only need to apply it to the sparse input arguments.
+    # check if the partially-evaluated function preserves zeros. if so, we'll only need to
+    # apply it to the sparse input arguments, preserving the sparse structure.
     if all(arg->isa(arg, AbstractSparseArray), passedsrcargstup)
         fofzeros = parevalf(_zeros_eltypes(passedsrcargstup...)...)
         fpreszeros = _iszero(fofzeros)
     else
         fpreszeros = false
     end
-    dest = if fpreszeros
-        similar(bc.args[sparse_arg], ElType)
-    else
+
+    # allocate the output container
+    rows, cols = size(bc)
+    if !fpreszeros
         # either we have dense inputs, or the function isn't preserving zeros,
         # so use a dense output to broadcast into.
-        CuArray{ElType}(undef, size(bc.args[sparse_arg]))
-    end
+        output = CuArray{Tv}(undef, size(bc))
 
-    _copyto!(dest, bc, sparse_arg)
+        row_offsets = nothing
 
-    # TODO: if we had dense inputs, but the function was preserving zeros,
-    #       try to re-sparsify the output?
-end
-
-# TODO
-# function Base.copyto!(dest::AbstractArray, bc::Broadcasted{<:CuSparseMatStyle})
-
-# version of copyto! that deals with a single sparse argument
-function _copyto!(dest, bc, idx)
-    axes(dest) == axes(bc) || Broadcast.throwdm(axes(dest), axes(bc))
-    isempty(dest) && return dest
-
-    # the _copyto! implementations below only process elements of our sparse input array.
-    if isa(dest, AbstractSparseArray)
-        # if we're writing to a sparse output, we'll be using the exact same indices
-        # as from the input. this requires the layout of the sparse array to be identical,
-        # which is too costly to check at run time, so just compare the nnz elements.
-        nnz(dest) == nnz(bc.args[idx]) ||
-          error("Destination of sparse broadcast should have identical layout")
-    else
-        # if we're broadcasting to a dense output -- likely because the function isn't
-        # zero-preserving -- we first broadcast to fill the elements not in our sparse array
-        # by setting those to zero and re-using the dense broadcast implementation
+        # since we'll be iterating the sparse inputs, we need to pre-fill the dense output
+        # with appropriate values (while setting the sparse inputs to zero). we do this by
+        # re-using the dense broadcast implementation.
         nonsparse_args = map(bc.args) do arg
             # NOTE: this assumes the broadcst is flattened, but not yet preprocessed
-            if arg isa CUSPARSE.AbstractCuSparseArray
+            if arg isa AbstractCuSparseArray
                 zero(eltype(arg))
             else
                 arg
             end
         end
-        broadcast!(bc.f, dest, nonsparse_args...)
+        broadcast!(bc.f, output, nonsparse_args...)
+    elseif length(sparse_args) == 1
+        # we only have a single sparse input, so we can reuse its structure for the output.
+        # this avoids a kernel launch and costly synchronization.
+        sparse_arg = bc.args[first(sparse_args)]
+        row_offsets = sparse_arg.rowPtr
+
+        # NOTE: we don't use CUSPARSE's similar, because that copies the structure arrays,
+        #       while we do that in our kernel (for consistency with other code paths)
+        colVal = similar(sparse_arg.rowPtr)
+        rowPtr = similar(sparse_arg.colVal)
+        nzVal = similar(sparse_arg.nzVal)
+        output = CuSparseMatrixCSR(row_offsets, colVal, nzVal, (rows,cols))
+    else
+        # determine the number of non-zero elements per row so that we can create an
+        # appropriately-structured output container
+        row_offsets = CuArray{Ti}(undef, rows+1)
+        let
+            args = (row_offsets, cols%Ti, bc.args...)
+            kernel = @cuda launch=false compute_csr_row_offsets_kernel(args...)
+            # it's unlikely we'll be able to spawn many threads,
+            # so parallelize across blocks first
+            config = launch_configuration(kernel.fun)
+            threads = min(rows, config.threads)
+            blocks = max(cld(rows, threads), config.blocks)
+            threads = cld(rows, blocks)
+            kernel(args...; threads, blocks)
+        end
+
+        # accumulate these values so that we can use them directly as row pointer offsets
+        accumulate!(Base.add_sum, row_offsets, row_offsets)
+
+        # we need the total nnz count to allocate the other sparse array components. either we
+        # fetch that value, or we use an estimation. the former is synchronizing while the
+        # latter may greatly inflate memory usage. we'll need the exact nnz count anyway,
+        # to set the nnz field correctly (needed for other interactions with CUSPARSE).
+        #total_nnz = sum(arg->nnz(arg), args)
+        total_nnz = CUDA.@allowscalar last(row_offsets[end]) - 1
+        colVal = CuArray{Ti}(undef, total_nnz)
+        nzVal = CuArray{Tv}(undef, total_nnz)
+        output = CuSparseMatrixCSR(row_offsets, colVal, nzVal, (rows,cols))
     end
 
-    bc′ = Broadcast.preprocess(dest, bc)
-    sparse_arg = bc′.args[idx]
-    other_args = [bc′.args[begin:idx-1]..., bc′.args[idx+1:end]...]
-    _copyto!(typeof(bc.args[idx]), dest, bc′.f, sparse_arg, idx, other_args)
-end
-_copyto!(T::Type, dest, f, sparse_arg, idx, other_args) =
-    error("Broadcast with sparse array of type $T not implemented")
-
-# TODO: broadcast sparse vector with something 2d?
-
-function _copyto!(::Type{<:CuSparseVector}, dest, f, sparse_arg, idx, other_args)
-    function kernel(dest, f, arg, ::Val{idx}, other_args...) where idx
-        # every thread processes a single element
-        i = threadIdx().x + (blockIdx().x - 1i32) * blockDim().x
-        if i > nnz(arg)
-            return
-        end
-
-        # @inbounds begin
-            row = arg.iPtr[i]
-
-            # get the argument values at this index
-            val = arg.nzVal[i]
-            other_vals = Broadcast._getindex(other_args, row)
-
-            # apply the broadcast function
-            output = Broadcast._broadcast_getindex_evalf(f, other_vals[begin:idx-1]...,
-                                                         val, other_vals[idx:end]...)
-
-            # store the result
-            if dest isa AbstractSparseVector
-              dest.nzVal[i] = output
-            else
-              dest[row] = output
-            end
-        # end
-        return
+    # perform the actual broadcast
+    if output isa AbstractCuSparseArray
+        args = (bc.f, output, row_offsets, bc.args...)
+        kernel = @cuda launch=false sparse_to_sparse_broadcast_kernel(args...)
+        config = launch_configuration(kernel.fun)
+        threads = min(rows, config.threads)
+        blocks = max(cld(rows, threads), config.blocks)
+        threads = cld(rows, blocks)
+        kernel(args...; threads, blocks)
+    else
+        args = (bc.f, output, bc.args...)
+        kernel = @cuda launch=false sparse_to_dense_broadcast_kernel(args...)
+        config = launch_configuration(kernel.fun)
+        threads = min(rows, config.threads)
+        blocks = max(cld(rows, threads), config.blocks)
+        threads = cld(rows, blocks)
+        kernel(args...; threads, blocks)
     end
 
-    cols = nnz(sparse_arg)
-    kernel = @cuda launch=false kernel(dest, f, sparse_arg, Val(idx), other_args...)
-    config = launch_configuration(kernel.fun)
-    threads = min(cols, config.threads)
-    blocks = cld(cols, threads)
-    kernel(dest, f, sparse_arg, Val(idx), other_args...; threads, blocks)
-
-    return dest
-end
-
-function _copyto!(::Type{<:CuSparseMatrixCSC}, dest, f, sparse_arg, idx, other_args)
-    function kernel(dest, f, arg, ::Val{idx}, other_args...) where idx
-        # every thread processes an entire column
-        col = threadIdx().x + (blockIdx().x - 1i32) * blockDim().x
-        if col >= length(arg.colPtr)
-            return
-        end
-
-        # TODO: parallelize across these as well? uncertain, but may yield improvements
-        @inbounds for i in arg.colPtr[col]:arg.colPtr[col+1]-1
-            row = arg.rowVal[i]
-            I = CartesianIndex(row, col)
-
-            # get the argument values at this index
-            val = arg.nzVal[i]
-            other_vals = Broadcast._getindex(other_args, I)
-
-            # apply the broadcast function
-            output = Broadcast._broadcast_getindex_evalf(f, other_vals[begin:idx-1]...,
-                                                         val, other_vals[idx:end]...)
-
-            # store the result
-            if dest isa AbstractSparseMatrix
-              dest.nzVal[i] = output
-            else
-              dest[I] = output
-            end
-        end
-        return
-    end
-
-    cols = length(sparse_arg.colPtr)-1
-    kernel = @cuda launch=false kernel(dest, f, sparse_arg, Val(idx), other_args...)
-    config = launch_configuration(kernel.fun)
-    threads = min(cols, config.threads)
-    blocks = cld(cols, threads)
-    kernel(dest, f, sparse_arg, Val(idx), other_args...; threads, blocks)
-
-    return dest
-end
-
-function _copyto!(::Type{<:CuSparseMatrixCSR}, dest, f, sparse_arg, idx, other_args)
-    function kernel(dest, f, arg, ::Val{idx}, other_args...) where idx
-        # every thread processes an entire row
-        row = threadIdx().x + (blockIdx().x - 1i32) * blockDim().x
-        if row >= length(arg.rowPtr)
-            return
-        end
-
-        # TODO: parallelize across these as well? uncertain, but may yield improvements
-        @inbounds for i in arg.rowPtr[row]:arg.rowPtr[row+1]-1
-            col = arg.colVal[i]
-            I = CartesianIndex(row, col)
-
-            # get the argument values at this index
-            val = arg.nzVal[i]
-            other_vals = Broadcast._getindex(other_args, I)
-
-            # apply the broadcast function
-            output = Broadcast._broadcast_getindex_evalf(f, other_vals[begin:idx-1]...,
-                                                         val, other_vals[idx:end]...)
-
-            # store the result
-            if dest isa AbstractSparseMatrix
-              dest.nzVal[i] = output
-            else
-              dest[I] = output
-            end
-        end
-        return
-    end
-
-    rows = length(sparse_arg.rowPtr)-1
-    kernel = @cuda launch=false kernel(dest, f, sparse_arg, Val(idx), other_args...)
-    config = launch_configuration(kernel.fun)
-    threads = min(rows, config.threads)
-    blocks = cld(rows, threads)
-    kernel(dest, f, sparse_arg, Val(idx), other_args...; threads, blocks)
-
-    return dest
-end
-
-function _copyto!(::Type{<:CuSparseMatrixCOO}, dest, f, sparse_arg, idx, other_args)
-    function kernel(dest, f, arg, ::Val{idx}, other_args...) where idx
-        # every thread processes a single element
-        i = threadIdx().x + (blockIdx().x - 1i32) * blockDim().x
-        if i > nnz(arg)
-            return
-        end
-
-        @inbounds begin
-            row = arg.rowInd[i]
-            col = arg.colInd[i]
-            I = CartesianIndex(row, col)
-
-            # get the argument values at this index
-            val = arg.nzVal[i]
-            other_vals = Broadcast._getindex(other_args, I)
-
-            # apply the broadcast function
-            output = Broadcast._broadcast_getindex_evalf(f, other_vals[begin:idx-1]...,
-                                                         val, other_vals[idx:end]...)
-
-            # store the result
-            if dest isa AbstractSparseMatrix
-              dest.nzVal[i] = output
-            else
-              dest[I] = output
-            end
-        end
-        return
-    end
-
-    nels = nnz(sparse_arg)
-    kernel = @cuda launch=false kernel(dest, f, sparse_arg, Val(idx), other_args...)
-    config = launch_configuration(kernel.fun)
-    threads = min(nels, config.threads)
-    blocks = cld(nels, threads)
-    kernel(dest, f, sparse_arg, Val(idx), other_args...; threads, blocks)
-
-    return dest
+    return output
 end

--- a/lib/cusparse/broadcast.jl
+++ b/lib/cusparse/broadcast.jl
@@ -363,8 +363,8 @@ function Broadcast.copy(bc::Broadcasted{<:Union{CuSparseVecStyle,CuSparseMatStyl
 
         # NOTE: we don't use CUSPARSE's similar, because that copies the structure arrays,
         #       while we do that in our kernel (for consistency with other code paths)
-        colVal = similar(sparse_arg.rowPtr)
-        rowPtr = similar(sparse_arg.colVal)
+        rowPtr = similar(sparse_arg.rowPtr)
+        colVal = similar(sparse_arg.colVal)
         nzVal = similar(sparse_arg.nzVal)
         output = CuSparseMatrixCSR(row_offsets, colVal, nzVal, (rows,cols))
     else

--- a/lib/cusparse/broadcast.jl
+++ b/lib/cusparse/broadcast.jl
@@ -303,6 +303,8 @@ function Broadcast.copy(bc::Broadcasted{<:Union{CuSparseVecStyle,CuSparseMatStyl
     if length(sparse_types) > 1
         error("broadcast with multiple types of sparse arrays ($(join(sparse_types, ", "))) is not supported")
     end
+    bc.args[first(sparse_args)] isa CuSparseMatrixCSR ||
+        error("broadcast with sparse arrays is currently only implemented for CSR matrices")
     Ti = reduce(promote_type, map(i->eltype(bc.args[i].rowPtr), sparse_args))
 
     # determine the output type

--- a/lib/cusparse/broadcast.jl
+++ b/lib/cusparse/broadcast.jl
@@ -2,6 +2,8 @@ using Base.Broadcast: Broadcasted
 
 using CUDA: CuArrayStyle
 
+# TODO: support more types (SparseVector, SparseMatrixCSC, COO, BSR)
+
 
 ## sparse broadcast style
 

--- a/test/cusparse/broadcast.jl
+++ b/test/cusparse/broadcast.jl
@@ -4,8 +4,6 @@ m,n = 2,3
 p = 0.5
 
 for elty in [Float32]
-    # TODO: CuSparseVector
-
     @testset "$typ" for typ in [CuSparseMatrixCSR]
         x = sprand(elty, m, n, p)
         dx = typ(x)

--- a/test/cusparse/broadcast.jl
+++ b/test/cusparse/broadcast.jl
@@ -4,31 +4,9 @@ m,n = 2,3
 p = 0.5
 
 for elty in [Float32]
-    @testset "CuSparseVector" begin
-        x = sprand(elty, m*n, p)
-        dx = CuSparseVector(x)
+    # TODO: CuSparseVector
 
-        # zero-preserving
-        y = x .* 1
-        dy = dx .* 1
-        @test dy isa CuSparseVector{elty}
-        @test y == SparseVector(dy)
-
-        # not zero-preserving
-        y = x .+ 1
-        dy = dx .+ 1
-        @test dy isa CuVector{elty}
-        @test y == Array(dy)
-
-        # involving something dense
-        y = x .* ones(m*n)
-        dy = dx .* CUDA.ones(m*n)
-        @test dy isa CuVector{elty}
-        @test y == Array(dy)
-    end
-
-    # TODO: BSR
-    @testset "$typ" for typ in [CuSparseMatrixCSC, CuSparseMatrixCSR, CuSparseMatrixCOO]
+    @testset "$typ" for typ in [CuSparseMatrixCSR]
         x = sprand(elty, m, n, p)
         dx = typ(x)
 
@@ -49,5 +27,13 @@ for elty in [Float32]
         dy = dx .* CUDA.ones(m, n)
         @test dy isa CuArray{elty}
         @test y == Array(dy)
+
+        # multiple inputs
+        y = sprand(elty, m, n, p)
+        dy = typ(y)
+        z = x .* y .* 2
+        dz = dx .* dy .* 2
+        @test dz isa typ{elty}
+        @test z == SparseMatrixCSC(dz)
     end
 end


### PR DESCRIPTION
Adapts the implementation from last week, adding general purpose broadcast support (i.e. involving multiple sparse inputs, dense arrays, scalars, etc). The trick here is to have a separate kernel count the nnz values per row so that we can allocate an output container that will fit all values, and use those values as row offsets (after scanning them). The only disadvantage of that approach is that it's synchronizing, to access the total nnz count, but performance seems pretty good nonetheless:

```julia
julia> using BenchmarkTools

julia> using SparseArrays, CUDA, CUDA.CUSPARSE

julia> cx = sprand(Float32, 1024, 1024, 0.1);

julia> cy = sprand(Float32, size(cx)..., 0.1);

julia> @benchmark cx .+ cy
BenchmarkTools.Trial: 4707 samples with 1 evaluation.
 Range (min … max):  959.167 μs …   3.586 ms  ┊ GC (min … max): 0.00% … 53.32%
 Time  (median):       1.007 ms               ┊ GC (median):    0.00%
 Time  (mean ± σ):     1.060 ms ± 288.209 μs  ┊ GC (mean ± σ):  5.39% ± 11.41%

  █▆█▄▂                                                         ▁
  █████▃▁▁▃▃▁▄▅▃▁▁▁▁▁▁▁▁▁▁▁▃▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▄▄▆▆▆▆▆▆█▇▇▇▆▆▆ █
  959 μs        Histogram: log(frequency) by time       2.54 ms <

 Memory estimate: 2.40 MiB, allocs estimate: 8.

julia> x = CuSparseMatrixCSR(cx);

julia> y = CuSparseMatrixCSR(cy);

julia> @benchmark CUDA.@sync x .+ y
BenchmarkTools.Trial: 10000 samples with 1 evaluation.
 Range (min … max):  152.027 μs …  18.858 ms  ┊ GC (min … max): 0.00% … 46.43%
 Time  (median):     160.127 μs               ┊ GC (median):    0.00%
 Time  (mean ± σ):   184.608 μs ± 320.993 μs  ┊ GC (mean ± σ):  0.94% ±  0.66%

  █▅▁                                                           ▁
  █████▅▃▁▄▄▁▁▁▁▁▁▄▁▃▁▁▄▃▃▄▁▄▄▄▁▁▃▃▃▅▅▆▆▅▆▅▅▅▅▁▄▄▄▄▄▄▄▄▁▁▄▄▆▅▆▅ █
  152 μs        Histogram: log(frequency) by time        905 μs <

 Memory estimate: 16.53 KiB, allocs estimate: 293.
```

Still a WIP, I want to at least add CSC support.
cc @kshyatt @Roger-luo 