### PR TITLE
Implement sparse operations with UniformScaling using broadcast.

### DIFF
--- a/lib/cusparse/broadcast.jl
+++ b/lib/cusparse/broadcast.jl
@@ -294,6 +294,9 @@ function sparse_to_dense_broadcast_kernel(f, output::CuDeviceArray, args...)
 end
 
 function Broadcast.copy(bc::Broadcasted{<:Union{CuSparseVecStyle,CuSparseMatStyle}})
+    # on 1.6, ntuple closures often fail to infer
+    VERSION < v"1.7" && @warn "Sparse broadcast is only supported on Julia 1.7 or higher" maxlog=1
+
     # find the sparse inputs
     bc = Broadcast.flatten(bc)
     sparse_args = findall(bc.args) do arg

--- a/test/cusparse/interfaces.jl
+++ b/test/cusparse/interfaces.jl
@@ -154,7 +154,7 @@ using LinearAlgebra, SparseArrays
         @test SparseMatrixCSC(CuSparseMatrixCSR(T)) ≈ f(S)
     end
 
-    @testset "UniformScaling with CSR($dims)" for dims in [(10, 10), (5, 10), (10, 5)]
+    VERSION >= v"1.7" && @testset "UniformScaling with CSR($dims)" for dims in [(10, 10), (5, 10), (10, 5)]
         S = sprand(Float32, dims..., 0.1)
         dA = CuSparseMatrixCSR(S)
 

--- a/test/cusparse/interfaces.jl
+++ b/test/cusparse/interfaces.jl
@@ -153,5 +153,16 @@ using LinearAlgebra, SparseArrays
         T = f(CuSparseMatrixCSC(S))
         @test SparseMatrixCSC(CuSparseMatrixCSR(T)) ≈ f(S)
     end
+
+    @testset "UniformScaling with CSR($dims)" for dims in [(10, 10), (5, 10), (10, 5)]
+        S = sprand(Float32, dims..., 0.1)
+        dA = CuSparseMatrixCSR(S)
+
+        @test Array(dA + I) == S + I
+        @test Array(I + dA) == I + S
+
+        @test Array(dA - I) == S - I
+        @test Array(I - dA) == I - S
+    end
 end
 


### PR DESCRIPTION
```julia
julia> S = CuSparseMatrixCSR(sprand(2,2,0.5))
2×2 CuSparseMatrixCSR{Float64, Int32} with 2 stored entries:
 0.9425289370752049   ⋅ 
 0.9999923955293779   ⋅ 

julia> I - 3 * S
2×2 CuSparseMatrixCSR{Float64, Int32} with 3 stored entries:
 -1.8275868112256148   ⋅ 
 -2.9999771865881337  1.0
```

cc @ChrisRackauckas 