### PR TITLE
CUSPARSE BSR improvements

### DIFF
--- a/lib/cusparse/conversions.jl
+++ b/lib/cusparse/conversions.jl
@@ -244,12 +244,11 @@ for (fname,elty) in ((:cusparseSbsr2csr, :Float32),
             m,n = size(bsr)
             mb = div(m,bsr.blockDim)
             nb = div(n,bsr.blockDim)
-            nnzVal = nnz(bsr) * bsr.blockDim * bsr.blockDim
             cudesca = CuMatrixDescriptor('G', 'L', 'N', inda)
             cudescc = CuMatrixDescriptor('G', 'L', 'N', indc)
             csrRowPtr = CUDA.zeros(Cint, m + 1)
-            csrColInd = CUDA.zeros(Cint, nnzVal)
-            csrNzVal  = CUDA.zeros($elty, nnzVal)
+            csrColInd = CUDA.zeros(Cint, nnz(bsr))
+            csrNzVal  = CUDA.zeros($elty, nnz(bsr))
             $fname(handle(), bsr.dir, mb, nb,
                    cudesca, nonzeros(bsr), bsr.rowPtr, bsr.colVal,
                    bsr.blockDim, cudescc, csrNzVal, csrRowPtr,

--- a/lib/cusparse/level2.jl
+++ b/lib/cusparse/level2.jl
@@ -80,13 +80,13 @@ for (bname,aname,sname,elty) in ((:cusparseSbsrsv2_bufferSize, :cusparseSbsrsv2_
 
             function bufferSize()
                 out = Ref{Cint}(1)
-                $bname(handle(), A.dir, transa, mb, nnz(A),
+                $bname(handle(), A.dir, transa, mb, A.nnzb,
                        desc, nonzeros(A), A.rowPtr, A.colVal, A.blockDim,
                        info[1], out)
                 return out[]
             end
             with_workspace(bufferSize) do buffer
-                $aname(handle(), A.dir, transa, mb, nnz(A),
+                $aname(handle(), A.dir, transa, mb, A.nnzb,
                         desc, nonzeros(A), A.rowPtr, A.colVal, A.blockDim,
                         info[1], CUSPARSE_SOLVE_POLICY_USE_LEVEL, buffer)
                 posit = Ref{Cint}(1)
@@ -94,7 +94,7 @@ for (bname,aname,sname,elty) in ((:cusparseSbsrsv2_bufferSize, :cusparseSbsrsv2_
                 if posit[] >= 0
                     error("Structural/numerical zero in A at ($(posit[]),$(posit[])))")
                 end
-                $sname(handle(), A.dir, transa, mb, nnz(A),
+                $sname(handle(), A.dir, transa, mb, A.nnzb,
                         alpha, desc, nonzeros(A), A.rowPtr, A.colVal,
                         A.blockDim, info[1], X, X,
                         CUSPARSE_SOLVE_POLICY_USE_LEVEL, buffer)

--- a/lib/cusparse/level2.jl
+++ b/lib/cusparse/level2.jl
@@ -70,7 +70,7 @@ for (bname,aname,sname,elty) in ((:cusparseSbsrsv2_bufferSize, :cusparseSbsrsv2_
             if m != n
                 throw(DimensionMismatch("A must be square, but has dimensions ($m,$n)!"))
             end
-            mb = div(m,A.blockDim)
+            mb = cld(m, A.blockDim)
             mX = length(X)
             if mX != m
                 throw(DimensionMismatch("X must have length $m, but has length $mX"))

--- a/lib/cusparse/level3.jl
+++ b/lib/cusparse/level3.jl
@@ -28,8 +28,8 @@ for (fname,elty) in ((:cusparseSbsrmm, :Float32),
                      index::SparseChar)
             desc = CuMatrixDescriptor('G', 'L', 'N', index)
             m,k = size(A)
-            mb = div(m,A.blockDim)
-            kb = div(k,A.blockDim)
+            mb = cld(m, A.blockDim)
+            kb = cld(k, A.blockDim)
             n = size(C)[2]
             if transa == 'N' && transb == 'N'
                 chkmmdims(B,C,k,n,m,n)
@@ -156,7 +156,7 @@ for (bname,aname,sname,elty) in ((:cusparseSbsrsm2_bufferSize, :cusparseSbsrsm2_
             if m != n
                  throw(DimensionMismatch("A must be square, but has dimensions ($m,$n)!"))
             end
-            mb = div(m,A.blockDim)
+            mb = cld(m, A.blockDim)
             mX,nX = size(X)
             if transxy == 'N' && (mX != m)
                 throw(DimensionMismatch(""))

--- a/lib/cusparse/level3.jl
+++ b/lib/cusparse/level3.jl
@@ -43,7 +43,7 @@ for (fname,elty) in ((:cusparseSbsrmm, :Float32),
             ldb = max(1,stride(B,2))
             ldc = max(1,stride(C,2))
             $fname(handle(), A.dir,
-                   transa, transb, mb, n, kb, nnz(A),
+                   transa, transb, mb, n, kb, A.nnzb,
                    alpha, desc, nonzeros(A),A.rowPtr, A.colVal,
                    A.blockDim, B, ldb, beta, C, ldc)
             C
@@ -171,14 +171,14 @@ for (bname,aname,sname,elty) in ((:cusparseSbsrsm2_bufferSize, :cusparseSbsrsm2_
             function bufferSize()
                 out = Ref{Cint}(1)
                 $bname(handle(), A.dir, transa, transxy,
-                       mb, nX, nnz(A), desc, nonzeros(A), A.rowPtr,
+                       mb, nX, A.nnzb, desc, nonzeros(A), A.rowPtr,
                        A.colVal, A.blockDim, info[],
                        out)
                 return out[]
             end
             with_workspace(bufferSize) do buffer
                 $aname(handle(), A.dir, transa, transxy,
-                        mb, nX, nnz(A), desc, nonzeros(A), A.rowPtr,
+                        mb, nX, A.nnzb, desc, nonzeros(A), A.rowPtr,
                         A.colVal, A.blockDim, info[],
                         CUSPARSE_SOLVE_POLICY_USE_LEVEL, buffer)
                 posit = Ref{Cint}(1)
@@ -187,7 +187,7 @@ for (bname,aname,sname,elty) in ((:cusparseSbsrsm2_bufferSize, :cusparseSbsrsm2_
                     error("Structural/numerical zero in A at ($(posit[]),$(posit[])))")
                 end
                 $sname(handle(), A.dir, transa, transxy, mb,
-                        nX, nnz(A), alpha, desc, nonzeros(A), A.rowPtr,
+                        nX, A.nnzb, alpha, desc, nonzeros(A), A.rowPtr,
                         A.colVal, A.blockDim, info[], X, ldx, X, ldx,
                         CUSPARSE_SOLVE_POLICY_USE_LEVEL, buffer)
             end

--- a/test/cusparse/device.jl
+++ b/test/cusparse/device.jl
@@ -24,7 +24,6 @@ using CUDA.CUSPARSE: CuSparseDeviceVector, CuSparseDeviceMatrixCSC, CuSparseDevi
     cuA = CuSparseMatrixCOO(A)
     @test cudaconvert(cuA) isa CuSparseDeviceMatrixCOO{Float64, Cint, 1}
 
-    # Roger-Luo: I'm not sure how to create a BSR matrix
-    # cuA = CuSparseMatrixBSR(A)
-    # @test cudaconvert(cuA) isa CuSparseDeviceMatrixBSR
+    cuA = CuSparseMatrixBSR(A, 2)
+    @test cudaconvert(cuA) isa CuSparseDeviceMatrixBSR
 end


### PR DESCRIPTION
- make `nnz` return the number of nonzero elements, and not the number of nonzero blocks.
- add indexing support
- fix BSR to CSR conversion