### PR TITLE
Fix return type of nrm2 for ComplexF16

### DIFF
--- a/Manifest.toml
+++ b/Manifest.toml
@@ -83,7 +83,9 @@ version = "0.1.8"
 
 [[GPUArrays]]
 deps = ["Adapt", "LLVM", "LinearAlgebra", "Printf", "Random", "Serialization", "Statistics"]
-git-tree-sha1 = "9010083c218098a3695653773695a9949e7e8f0d"
+git-tree-sha1 = "1c99d4a4b5ae3d81cb95548153b453890cb1f460"
+repo-rev = "f0ed91d"
+repo-url = "https://github.com/JuliaGPU/GPUArrays.jl.git"
 uuid = "0c68f7d7-f131-5f86-a1c3-88cf8149b2d7"
 version = "8.3.1"
 

--- a/lib/cublas/wrappers.jl
+++ b/lib/cublas/wrappers.jl
@@ -180,7 +180,7 @@ end
 function nrm2(n::Integer, x::StridedCuArray{ComplexF16})
     wide_x = widen.(x)
     nrm    = nrm2(n, wide_x)
-    return convert(ComplexF16, nrm)
+    return convert(Float16, nrm)
 end
 
 ## asum


### PR DESCRIPTION
The currently broken test that should have caught this lives in GPUArrays.jl. PR coming over there shortly.

Curious: Is there a reason CUBLAS wrappers like this aren't added as methods on the corresponding functions in LinearAlgebra.BLAS and conform to their interface? Seems like CUBLAS itself is designed to match BLAS closely, and there are lots of CUSOLVER wrappers that add methods to LinearAlgebra.LAPACK functions.