### PR TITLE
Add `sind`/`cosd`

### DIFF
--- a/src/device/intrinsics/math.jl
+++ b/src/device/intrinsics/math.jl
@@ -28,11 +28,8 @@ within(lower, upper) = (val) -> lower <= val <= upper
 @device_override Base.tan(x::Float32) = ccall("extern __nv_tanf", llvmcall, Cfloat, (Cfloat,), x)
 @device_override FastMath.tan_fast(x::Float32) = ccall("extern __nv_fast_tanf", llvmcall, Cfloat, (Cfloat,), x)
 
-@device_override Base.cosd(x::Float64) = ccall("extern __nv_cosd", llvmcall, Cdouble, (Cdouble,), x)
-@device_override Base.cosd(x::Float32) = ccall("extern __nv_cosdf", llvmcall, Cfloat, (Cfloat,), x)
-
-@device_override Base.sind(x::Float64) = ccall("extern __nv_sind", llvmcall, Cdouble, (Cdouble,), x)
-@device_override Base.sind(x::Float32) = ccall("extern __nv_sindf", llvmcall, Cfloat, (Cfloat,), x)
+@device_override Base.sind(φ::Union{Float32, Float64}) = sin(π * φ / 180)
+@device_override Base.cosd(φ::Union{Float32, Float64}) = cos(π * φ / 180)
 
 @device_override function Base.sincos(x::Float64)
     s = Ref{Cdouble}()

--- a/src/device/intrinsics/math.jl
+++ b/src/device/intrinsics/math.jl
@@ -28,6 +28,12 @@ within(lower, upper) = (val) -> lower <= val <= upper
 @device_override Base.tan(x::Float32) = ccall("extern __nv_tanf", llvmcall, Cfloat, (Cfloat,), x)
 @device_override FastMath.tan_fast(x::Float32) = ccall("extern __nv_fast_tanf", llvmcall, Cfloat, (Cfloat,), x)
 
+@device_override Base.cosd(x::Float64) = ccall("extern __nv_cosd", llvmcall, Cdouble, (Cdouble,), x)
+@device_override Base.cosd(x::Float32) = ccall("extern __nv_cosdf", llvmcall, Cfloat, (Cfloat,), x)
+
+@device_override Base.sind(x::Float64) = ccall("extern __nv_sind", llvmcall, Cdouble, (Cdouble,), x)
+@device_override Base.sind(x::Float32) = ccall("extern __nv_sindf", llvmcall, Cfloat, (Cfloat,), x)
+
 @device_override function Base.sincos(x::Float64)
     s = Ref{Cdouble}()
     c = Ref{Cdouble}()

--- a/src/device/intrinsics/math.jl
+++ b/src/device/intrinsics/math.jl
@@ -28,8 +28,8 @@ within(lower, upper) = (val) -> lower <= val <= upper
 @device_override Base.tan(x::Float32) = ccall("extern __nv_tanf", llvmcall, Cfloat, (Cfloat,), x)
 @device_override FastMath.tan_fast(x::Float32) = ccall("extern __nv_fast_tanf", llvmcall, Cfloat, (Cfloat,), x)
 
-@device_override Base.sind(φ::Union{Float32, Float64}) = sin(π * φ / 180)
-@device_override Base.cosd(φ::Union{Float32, Float64}) = cos(π * φ / 180)
+@device_override Base.sind(x::Union{Float32, Float64}) = sin(π * x / 180)
+@device_override Base.cosd(x::Union{Float32, Float64}) = cos(π * x / 180)
 
 @device_override function Base.sincos(x::Float64)
     s = Ref{Cdouble}()

--- a/test/device/intrinsics/math.jl
+++ b/test/device/intrinsics/math.jl
@@ -96,6 +96,8 @@ using SpecialFunctions
     end
 
     @testset "sind/cosd" begin
+        @test testf(a->sind.(a), 0.4)
+        @test testf(a->cosd.(a), 0.4)
         @test testf(a->sind.(a), Float32[0.4])
         @test testf(a->cosd.(a), Float32[0.4])
     end

--- a/test/device/intrinsics/math.jl
+++ b/test/device/intrinsics/math.jl
@@ -95,6 +95,11 @@ using SpecialFunctions
         @test testf(x->exp.(x), [1e7im])
     end
 
+    @testset "sind/cosd" begin
+        @test testf(a->sind.(a), Float32[0.4])
+        @test testf(a->cosd.(a), Float32[0.4])
+    end
+
     @testset "fastmath" begin
         # libdevice provides some fast math functions
         a(x) = cos(x)


### PR DESCRIPTION
This PR adds CUDA-aware implementation for `sind` and `cosd` (`sin`/`cos` when argument is in degrees).