### PR TITLE
Always inspect the task-local context when verifying before freeing.

### DIFF
--- a/lib/cufft/fft.jl
+++ b/lib/cufft/fft.jl
@@ -25,6 +25,11 @@ abstract type CuFFTPlan{T<:cufftNumber, K, inplace} <: Plan{T} end
 Base.convert(::Type{cufftHandle}, p::CuFFTPlan) = p.handle
 
 function CUDA.unsafe_free!(plan::CuFFTPlan, stream::CuStream=stream())
+    # verify that the caller has switched contexts
+    if plan.ctx != context()
+      error("Trying to free $plan from an unrelated context")
+    end
+
     cufftDestroy(plan)
     unsafe_free!(plan.workarea, stream)
 end


### PR DESCRIPTION
For some reason, the thread-bound context can become desynchronized
from the task-local one. Generally we don't notice this, because we
prefix every API call with a call that synchronizes both. Here, however,
we explicitly didn't to avoid initializing the state as that was thought
to cause the kind of initialization that may have to yield (which is
unsupported when done so from a finalizer).

However, just creating the task local state shouldn't result in yield,
only creating a stream does, like querying `active_state` as was done
before #1383.

Fixes https://github.com/JuliaGPU/CUDA.jl/issues/1454.
@DhairyaLGandhi Could you verify this doesn't re-introduce the errors when finalizing arrays?
Ultimately though this needs https://github.com/JuliaLang/julia/issues/35689.