### PR TITLE
CUSPARSE: Better error msg for unsupported sparse mm

### DIFF
--- a/test/cusparse/interfaces.jl
+++ b/test/cusparse/interfaces.jl
@@ -1,3 +1,4 @@
+using CUDA
 using CUDA.CUSPARSE
 using LinearAlgebra, SparseArrays
 
@@ -165,6 +166,20 @@ using LinearAlgebra, SparseArrays
 
         @test Array(dA - I) == S - I
         @test Array(I - dA) == I - S
+    end
+
+    @testset "error on unsupported operation" begin
+        A = cu(sprand(Float32, 10, 10, 0.1))
+        x = CUDA.rand(Float64, 10)
+        y = CUDA.zeros(Float64, 10)
+        X = CUDA.rand(Float64, 10, 10)
+        Y = CUDA.zeros(Float64, 10, 10)
+
+        @test_throws ErrorException mul!(y, A, x, 1.0, 1.0)
+        @test_throws ErrorException mul!(y, A', x, 1.0, 1.0)
+
+        @test_throws ErrorException mul!(Y, A, X, 1.0, 1.0)
+        @test_throws ErrorException mul!(Y, A', X, 1.0, 1.0)
     end
 end
 


### PR DESCRIPTION
currently when the element-type happens to be mix of `Float32` and `Float64` (which happens quite often for users when they use `cu` for the conversion) `mul!` will just call the generic fallback and if `CUDA.allowscalar` is not set, this would just throw a warning a while later.

This PR let this dispatch path just error since it's not supported for now anyways.