### PR TITLE
fix unsafe_wrap docstring and widen signature

### DIFF
--- a/src/array.jl
+++ b/src/array.jl
@@ -178,7 +178,7 @@ end
 
 
 """
-  unsafe_wrap(::CuArray, ptr::CuPtr{T}, dims; own=false, ctx=context())
+  unsafe_wrap(CuArray, ptr::CuPtr{T}, dims; own=false, ctx=context())
 
 Wrap a `CuArray` object around the data at the address given by `ptr`. The pointer
 element type `T` determines the array element type. `dims` is either an integer (for a 1d
@@ -186,9 +186,9 @@ array) or a tuple of the array dimensions. `own` optionally specified whether Ju
 take ownership of the memory, calling `cudaFree` when the array is no longer referenced. The
 `ctx` argument determines the CUDA context where the data is allocated in.
 """
-function Base.unsafe_wrap(::Union{Type{CuArray},Type{CuArray{T}},Type{CuArray{T,N}}},
+function Base.unsafe_wrap(::Union{Type{CuArray},Type{CuArray{T}},Type{CuArray{T,N}},Type{CuArray{T,N,B}}},
                           ptr::CuPtr{T}, dims::NTuple{N,Int};
-                          own::Bool=false, ctx::CuContext=context()) where {T,N}
+                          own::Bool=false, ctx::CuContext=context()) where {T,N,B}
   Base.isbitstype(T) || error("Can only unsafe_wrap a pointer to a bits type")
   sz = prod(dims) * sizeof(T)
 
@@ -209,13 +209,17 @@ function Base.unsafe_wrap(::Union{Type{CuArray},Type{CuArray{T}},Type{CuArray{T,
       error("Could not identify the buffer type; are you passing a valid CUDA pointer to unsafe_wrap?")
   end
 
+  if @isdefined(B) && typeof(buf) !== B
+    error("Declared buffer type does not match inferred buffer type.")
+  end
+
   storage = ArrayStorage(buf, own ? 1 : -1)
   CuArray{T, length(dims)}(storage, dims)
 end
 
-function Base.unsafe_wrap(Atype::Union{Type{CuArray},Type{CuArray{T}},Type{CuArray{T,1}}},
+function Base.unsafe_wrap(Atype::Union{Type{CuArray},Type{CuArray{T}},Type{CuArray{T,1}},Type{CuArray{T,1,B}}},
                           p::CuPtr{T}, dim::Integer;
-                          own::Bool=false, ctx::CuContext=context()) where {T}
+                          own::Bool=false, ctx::CuContext=context()) where {T,B}
   unsafe_wrap(Atype, p, (dim,); own, ctx)
 end
 

--- a/test/array.jl
+++ b/test/array.jl
@@ -28,6 +28,7 @@ import Adapt
   let
     data = CuArray{Int}(undef, 2)
     ptr = pointer(data)
+    B = Mem.DeviceBuffer
 
     @test unsafe_wrap(CuArray, ptr, 1; own=false).storage.refcount[] == -1
 
@@ -42,12 +43,17 @@ import Adapt
       @test a.dims == b.dims
     end
 
-    test_eq(unsafe_wrap(CuArray, ptr, 2),              CuArray{Int,1}(data.storage, (2,)))
-    test_eq(unsafe_wrap(CuArray{Int}, ptr, 2),         CuArray{Int,1}(data.storage, (2,)))
-    test_eq(unsafe_wrap(CuArray{Int,1}, ptr, 2),       CuArray{Int,1}(data.storage, (2,)))
-    test_eq(unsafe_wrap(CuArray, ptr, (1,2)),          CuArray{Int,2}(data.storage, (1,2)))
-    test_eq(unsafe_wrap(CuArray{Int}, ptr, (1,2)),     CuArray{Int,2}(data.storage, (1,2)))
-    test_eq(unsafe_wrap(CuArray{Int,2}, ptr, (1,2)),   CuArray{Int,2}(data.storage, (1,2)))
+    test_eq(unsafe_wrap(CuArray, ptr, 2),                CuArray{Int,1}(data.storage, (2,)))
+    test_eq(unsafe_wrap(CuArray{Int}, ptr, 2),           CuArray{Int,1}(data.storage, (2,)))
+    test_eq(unsafe_wrap(CuArray{Int,1}, ptr, 2),         CuArray{Int,1}(data.storage, (2,)))
+    test_eq(unsafe_wrap(CuArray{Int,1,B}, ptr, 2),       CuArray{Int,1}(data.storage, (2,)))
+    test_eq(unsafe_wrap(CuArray, ptr, (1,2)),            CuArray{Int,2}(data.storage, (1,2)))
+    test_eq(unsafe_wrap(CuArray{Int}, ptr, (1,2)),       CuArray{Int,2}(data.storage, (1,2)))
+    test_eq(unsafe_wrap(CuArray{Int,2}, ptr, (1,2)),     CuArray{Int,2}(data.storage, (1,2)))
+    test_eq(unsafe_wrap(CuArray{Int,2,B}, ptr, (1,2)),   CuArray{Int,2}(data.storage, (1,2)))
+
+    @test_throws ErrorException unsafe_wrap(CuArray{Int,1,Mem.HostBuffer}, ptr, 2)
+    @test_throws ErrorException unsafe_wrap(CuArray{Int,2,Mem.HostBuffer}, ptr, (1,2))
   end
   let buf = Mem.alloc(Mem.Host, sizeof(Int), Mem.HOSTALLOC_DEVICEMAP)
     gpu_ptr = convert(CuPtr{Int}, buf)


### PR DESCRIPTION
As discussed on slack, this widens the signature of `unsafe_wrap` for `CuArrays`, so that one can also pass a concrete type as first argument, and e.g. `unsafe_wrap(typeof(s), pointer(s), size(s))` works with `s::CuArray`.

I've also edited the signature on the docstring, as it seemed incorrect. The current docstring (on master) implies that one should pass an instance of `CuArray`, instead of the type `CuArray`, as first argument to `unsafe_wrap`.