### PR TITLE
Silence EOFError in pool_cleanup

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "CUDA"
 uuid = "052768ef-5323-5732-b1bb-66c8b64840ba"
-version = "3.9.1"
+version = "3.9.2"
 
 [deps]
 AbstractFFTs = "621f4979-c628-5d54-868e-fcf4e3e8185c"

--- a/src/pool.jl
+++ b/src/pool.jl
@@ -126,7 +126,16 @@ function pool_cleanup()
       end
     end
 
-    sleep(60)
+    try
+      sleep(60)
+    catch ex
+      if ex isa EOFError
+        # If we get EOF here, it's because Julia is shutting down, so we should just exit the loop
+        break
+      else
+        rethrow()
+      end
+    end
   end
 end
 


### PR DESCRIPTION
This PR silences the `EOFError` thrown by `pool_cleanup()` when the REPL exits.

Closes #1495.
