### PR TITLE
Add a new cache for HostKernel objects.

### DIFF
--- a/lib/cudadrv/module/function.jl
+++ b/lib/cudadrv/module/function.jl
@@ -24,4 +24,4 @@ end
 Base.unsafe_convert(::Type{CUfunction}, fun::CuFunction) = fun.handle
 
 Base.:(==)(a::CuFunction, b::CuFunction) = a.handle == b.handle
-Base.hash(fun::CuFunction, h::UInt) = hash(mod.handle, h)
+Base.hash(fun::CuFunction, h::UInt) = hash(fun.handle, h)

--- a/src/compiler/execution.jl
+++ b/src/compiler/execution.jl
@@ -214,8 +214,6 @@ end
 
 struct HostKernel{F,TT} <: AbstractKernel{F,TT}
     f::F
-    ctx::CuContext
-    mod::CuModule
     fun::CuFunction
     state::KernelState
 end
@@ -298,17 +296,36 @@ when function changes, or when different types or keyword arguments are provided
     target = CUDACompilerTarget(cuda.device; kwargs...)
     params = CUDACompilerParams()
     job = CompilerJob(target, source, params)
-    res = GPUCompiler.cached_compilation(cache, job,
+    fun = GPUCompiler.cached_compilation(cache, job,
                                          cufunction_compile,
                                          cufunction_link)
-    HostKernel{F,tt}(f, cuda.context, res.mod, res.fun, res.state)
+    # compilation is cached on the function type, so we can only create a kernel object here
+    # (as it captures the function _instance_). this allocates, so use another cache level.
+    h = hash(fun, hash(f, hash(tt)))
+    kernel = get(_cufunction_kernel_cache, h, nothing)
+    if kernel === nothing
+        # create the kernel state object
+        exception_ptr = create_exceptions!(fun.mod)
+        state = KernelState(exception_ptr)
+
+        kernel = HostKernel{F,tt}(f, fun, state)
+        _cufunction_kernel_cache[h] = kernel
+    end
+    return kernel::HostKernel{F,tt}
 end
 
 # XXX: does this need a lock? we'll only write to it when we have the typeinf lock.
 const _cufunction_cache = Dict{CuContext, Dict{UInt, Any}}();
-cufunction_cache(ctx::CuContext) = get!(_cufunction_cache, ctx) do
-    Dict{UInt, Any}()
+function cufunction_cache(ctx::CuContext)
+    subcache = get(_cufunction_cache, ctx, nothing)
+    if subcache === nothing
+        subcache = Dict{UInt, Any}()
+        _cufunction_cache[ctx] = subcache
+    end
+    return subcache
 end
+
+const _cufunction_kernel_cache = Dict{UInt, Any}();
 
 # helper to run a binary and collect all relevant output
 function run_and_collect(cmd)
@@ -460,13 +477,7 @@ end
     # load as an executable kernel object
     ctx = context()
     mod = @timeit_ci "CuModule" CuModule(compiled.image)
-    fun = CuFunction(mod, compiled.entry)
-
-    # create the kernel state object
-    exception_ptr = create_exceptions!(mod)
-    state = KernelState(exception_ptr)
-
-    return (; mod, fun, state)
+    CuFunction(mod, compiled.entry)
 end
 
 function (kernel::HostKernel)(args...; threads::CuDim=1, blocks::CuDim=1, kwargs...)


### PR DESCRIPTION
Now that GPUCompiler's compilation (and compilation cache) is using the function type,
we need to allocate HostKernel objects in CUDA.jl where we still have access to
the function instance. Doing so is relatively slow, so introduce another cache.

cc @jpsamaroo AMDGPU.jl probably needs something similar.