### PR TITLE
Box-Muller: resample zeros.

### DIFF
--- a/src/random.jl
+++ b/src/random.jl
@@ -88,6 +88,9 @@ function Random.randn!(rng::RNG, A::AnyCuArray{<:T}) where {T<:Union{AbstractFlo
             if i <= length(A)
                 # Box–Muller transform
                 U1 = Random.rand(device_rng, T)
+                while U1 == zero(T)
+                    U1 = Random.rand(device_rng, T)
+                end
                 U2 = Random.rand(device_rng, T)
                 Z0 = sqrt(T(-2.0)*log(U1))*cos(T(2pi)*U2)
                 Z1 = sqrt(T(-2.0)*log(U1))*sin(T(2pi)*U2)

--- a/test/random.jl
+++ b/test/random.jl
@@ -122,4 +122,5 @@ end
     end
     @test randn(rng, Float32, 1) isa CuArray
     @test randn(rng, 1) isa CuArray
+    @test maximum(randn(rng, Float32, 2^26)) != Inf
 end


### PR DESCRIPTION
Fixes https://github.com/JuliaGPU/CUDA.jl/issues/1464

@danielwe: Given your explanation in https://github.com/JuliaGPU/CUDA.jl/issues/1464#issuecomment-1090893798, I just check for `zero` instead of `eps`. It also helps for complex numbers, where we don't have an `eps` defined.