### PR TITLE
specialize +/- op for sparse diag

### DIFF
--- a/lib/cusparse/interfaces.jl
+++ b/lib/cusparse/interfaces.jl
@@ -210,3 +210,15 @@ Base.:(+)(A::Union{CuSparseMatrixCSR,CuSparseMatrixCSC}, J::UniformScaling) =
 
 Base.:(-)(J::UniformScaling, A::Union{CuSparseMatrixCSR,CuSparseMatrixCSC}) =
     _sparse_identity(typeof(A), J, size(A)) .- A
+
+
+for SparseMatrixType in [:CuSparseMatrixCSC, :CuSparseMatrixCSR], op in [:(+), :(-)]
+    @eval begin
+        function Base.$op(lhs::Diagonal{T,<:CuArray}, rhs::$SparseMatrixType{T}) where {T}
+            return $op($SparseMatrixType(lhs), rhs)
+        end
+        function Base.$op(lhs::$SparseMatrixType{T}, rhs::Diagonal{T,<:CuArray}) where {T}
+            return $op(lhs, $SparseMatrixType(rhs))
+        end
+    end
+end

--- a/lib/cusparse/interfaces.jl
+++ b/lib/cusparse/interfaces.jl
@@ -211,7 +211,7 @@ Base.:(+)(A::Union{CuSparseMatrixCSR,CuSparseMatrixCSC}, J::UniformScaling) =
 Base.:(-)(J::UniformScaling, A::Union{CuSparseMatrixCSR,CuSparseMatrixCSC}) =
     _sparse_identity(typeof(A), J, size(A)) .- A
 
-
+# TODO: let Broadcast handle this automatically (a la SparseArrays.PromoteToSparse)
 for SparseMatrixType in [:CuSparseMatrixCSC, :CuSparseMatrixCSR], op in [:(+), :(-)]
     @eval begin
         function Base.$op(lhs::Diagonal{T,<:CuArray}, rhs::$SparseMatrixType{T}) where {T}

--- a/test/cusparse/interfaces.jl
+++ b/test/cusparse/interfaces.jl
@@ -1,3 +1,4 @@
+using Adapt
 using CUDA.CUSPARSE
 using LinearAlgebra, SparseArrays
 
@@ -197,5 +198,24 @@ using LinearAlgebra, SparseArrays
         @test Array(dA - I) == S - I
         @test Array(I - dA) == I - S
     end
-end
 
+    @testset "Diagonal with $typ(10, 10)" for
+        typ in [CuSparseMatrixCSR, CuSparseMatrixCSC]
+        
+        S = sprand(Float32, 10, 10, 0.8)
+        D = Diagonal(rand(Float32, 10))
+        dA = typ(S)
+        dD = adapt(CuArray, D)
+
+        @test Array(dA + dD) == S + D
+        @test Array(dD + dA) == D + S
+
+        @test Array(dA - dD) == S - D
+        @test Array(dD - dA) == D - S
+
+        @test dA + dD isa typ
+        @test dD + dA isa typ
+        @test dA - dD isa typ
+        @test dD - dA isa typ
+    end
+end


### PR DESCRIPTION
I just move the patch we had for [Bloqade](https://github.com/QuEraComputing/Bloqade.jl/blob/master/lib/BloqadeCUDA/src/patch.jl) to this PR to fix #1469 

It's not really a fix but more a workaround tho, since we don't actually have the general mechanism