### PR TITLE
Add method for LinearAlgebra.opnorm2

### DIFF
--- a/lib/cusolver/linalg.jl
+++ b/lib/cusolver/linalg.jl
@@ -296,6 +296,14 @@ _svdvals!(A::CuMatrix{T}, alg::SVDAlgorithm) where T =
 _svdvals!(A::CuMatrix{T}, alg::QRAlgorithm) where T = gesvd!('N', 'N', A::CuMatrix{T})[2]
 _svdvals!(A::CuMatrix{T}, alg::JacobiAlgorithm) where T = gesvdj!('N', 1, A::CuMatrix{T})[2]
 
+### opnorm2, enabled by svdvals
+
+function LinearAlgebra.opnorm2(A::CuMatrix{T}) where {T}
+    # The implementation in Base.LinearAlgebra can be reused verbatim, but it uses a scalar
+    # index to access the larges singular value, so must be wrapped in @allowscalar
+    return @allowscalar invoke(LinearAlgebra.opnorm2, Tuple{AbstractMatrix{T}}, A)
+end
+
 ## LU
 
 if VERSION >= v"1.8-"

--- a/test/cusolver/dense.jl
+++ b/test/cusolver/dense.jl
@@ -385,6 +385,12 @@ k = 1
     _svd(A) = svd(A; alg=CUSOLVER.QRAlgorithm())
     @inferred _svd(CUDA.rand(Float32, 4, 4))
 
+    @testset "2-opnorm($sz x $elty)" for sz in [(2, 0), (2, 3)]
+        A = rand(elty, sz)
+        d_A = CuArray(A)
+        @test opnorm(A, 2) ≈ opnorm(d_A, 2)
+    end
+
 
     @testset "qr" begin
         tol = min(m, n)*eps(real(elty))*(1 + (elty <: Complex))


### PR DESCRIPTION
`opnorm2` relies on `svdvals`, so it belongs here, not in GPUArrays, ref. JuliaGPU/GPUArrays.jl#403

Closes https://github.com/JuliaGPU/GPUArrays.jl/issues/396, replaces https://github.com/JuliaGPU/GPUArrays.jl/pull/403.