### PR TITLE
Fix Box-Muller transformation for complex eltypes

### DIFF
--- a/src/random.jl
+++ b/src/random.jl
@@ -88,6 +88,9 @@ function Random.randn!(rng::RNG, A::AnyCuArray{<:Union{AbstractFloat,Complex{<:A
             if i <= length(A)
                 # Box–Muller transform
                 U1 = Random.rand(device_rng, T)
+                while U1 == zero(T)
+                    U1 = Random.rand(device_rng, T)
+                end
                 U2 = Random.rand(device_rng, T)
                 Z0 = sqrt(T(-2.0)*log(U1))*cos(T(2pi)*U2)
                 Z1 = sqrt(T(-2.0)*log(U1))*sin(T(2pi)*U2)
@@ -117,6 +120,9 @@ function Random.randn!(rng::RNG, A::AnyCuArray{<:Union{AbstractFloat,Complex{<:A
             if i <= length(A)
                 # Complex Box–Muller transform
                 U1 = Random.rand(device_rng, T)
+                while U1 == zero(T)
+                    U1 = Random.rand(device_rng, T)
+                end
                 U2 = Random.rand(device_rng, T)
                 Z0 = sqrt(-log(U1))*cos(T(2pi)*U2)
                 Z1 = sqrt(-log(U1))*sin(T(2pi)*U2)

--- a/src/random.jl
+++ b/src/random.jl
@@ -71,8 +71,8 @@ function Random.rand!(rng::RNG, A::AnyCuArray)
     A
 end
 
-function Random.randn!(rng::RNG, A::AnyCuArray{<:T}) where {T<:Union{AbstractFloat,Complex{<:AbstractFloat}}}
-    function kernel(A::AbstractArray{T}, seed::UInt32, counter::UInt32)
+function Random.randn!(rng::RNG, A::AnyCuArray{<:Union{AbstractFloat,Complex{<:AbstractFloat}}})
+    function kernel(A::AbstractArray{T}, seed::UInt32, counter::UInt32) where {T<:Real}
         device_rng = Random.default_rng()
 
         # initialize the state
@@ -99,7 +99,32 @@ function Random.randn!(rng::RNG, A::AnyCuArray{<:T}) where {T<:Union{AbstractFlo
 
             offset += 2*window
         end
+        return
+    end
 
+    function kernel(A::AbstractArray{Complex{T}}, seed::UInt32, counter::UInt32) where {T<:Real}
+        device_rng = Random.default_rng()
+
+        # initialize the state
+        @inbounds Random.seed!(device_rng, seed, counter)
+
+        # grid-stride loop
+        threadId = threadIdx().x
+        window = (blockDim().x - 1i32) * gridDim().x
+        offset = (blockIdx().x - 1i32) * blockDim().x
+        while offset < length(A)
+            i = threadId + offset
+            if i <= length(A)
+                # Complex Box–Muller transform
+                U1 = Random.rand(device_rng, T)
+                U2 = Random.rand(device_rng, T)
+                Z0 = sqrt(-log(U1))*cos(T(2pi)*U2)
+                Z1 = sqrt(-log(U1))*sin(T(2pi)*U2)
+                @inbounds A[i] = complex(Z0, Z1)
+            end
+
+            offset += window
+        end
         return
     end
 

--- a/test/random.jl
+++ b/test/random.jl
@@ -123,6 +123,12 @@ end
     @test randn(rng, Float32, 1) isa CuArray
     @test randn(rng, 1) isa CuArray
 
+    # #1464: Check that the Box-Muller transform doesn't produce infinities (stemming from
+    # zeros in the radial sample). Virtually deterministic for the typical 23-24 bits of
+    # entropy; a larger sample would be needed for a higher-entropy algorithm like the one
+    # used by CURAND.
+    @test isfinite(maximum(randn(rng, Float32, 2^26)))
+
     # #1515: A quick way to check if the Box-Muller transform is correctly implemented for
     # complex numbers is to check that the real part never gets too large. The largest
     # possible value for ComplexF32 is sqrt(-log(u)) where u is the smallest nonzero Float32

--- a/test/random.jl
+++ b/test/random.jl
@@ -122,4 +122,13 @@ end
     end
     @test randn(rng, Float32, 1) isa CuArray
     @test randn(rng, 1) isa CuArray
+
+    # #1515: A quick way to check if the Box-Muller transform is correctly implemented for
+    # complex numbers is to check that the real part never gets too large. The largest
+    # possible value for ComplexF32 is sqrt(-log(u)) where u is the smallest nonzero Float32
+    # that can be produced by rand. Typically u = 2f0^(-23) or u = 2f0^(-24) giving an upper
+    # bound of around 4 or 4.1, while CURAND.rand gets down to u = 2f0^(-33) giving an upper
+    # bound of around 4.8. In contrast, incorrectly reusing the real Box-Muller transform
+    # gives typical real parts in the hundreds.
+    @test maximum(real(randn(rng, ComplexF32, 32))) <= sqrt(-log(2f0^(-33)))
 end


### PR DESCRIPTION
Fixes #1515. This touches the same code as #1513 and requires that the fix from there be duplicated, so perhaps better to squash to a single PR? Or merge one, rebase, update, and merge the other.

```julia
using CUDA, UnicodePlots

randns = randn(ComplexF32, 1000);
randns_cuda = Array(randn(CUDA.default_rng(), ComplexF32, 1000));

julia> histogram(real(randns))
                ┌                                        ┐
   [-2.5, -2.0) ┤▍ 2
   [-2.0, -1.5) ┤██▍ 18
   [-1.5, -1.0) ┤████████▏ 63
   [-1.0, -0.5) ┤████████████████████▌ 161
   [-0.5,  0.0) ┤███████████████████████████████████  274
   [ 0.0,  0.5) ┤██████████████████████████████████▋ 272
   [ 0.5,  1.0) ┤█████████████████▎ 134
   [ 1.0,  1.5) ┤███████▌ 59
   [ 1.5,  2.0) ┤█▊ 14
   [ 2.0,  2.5) ┤▍ 3
                └                                        ┘
                                 Frequency

julia> histogram(real(randns_cuda))
                ┌                                        ┐
   [-2.5, -2.0) ┤▍ 2
   [-2.0, -1.5) ┤██▍ 18
   [-1.5, -1.0) ┤███████▎ 56
   [-1.0, -0.5) ┤██████████████████████▌ 176
   [-0.5,  0.0) ┤███████████████████████████████▍ 244
   [ 0.0,  0.5) ┤███████████████████████████████████  273
   [ 0.5,  1.0) ┤███████████████████▎ 149
   [ 1.0,  1.5) ┤███████▍ 57
   [ 1.5,  2.0) ┤██▊ 22
   [ 2.0,  2.5) ┤▍ 2
   [ 2.5,  3.0) ┤▎ 1
                └                                        ┘
                                 Frequency
```