### PR TITLE
Make sure instantiating RNGs doesn't affect the global CPU RNG.

### DIFF
--- a/lib/curand/random.jl
+++ b/lib/curand/random.jl
@@ -43,7 +43,9 @@ end
 
 ## seeding
 
-function Random.seed!(rng::RNG, seed=Base.rand(UInt64), offset=0)
+make_seed() = Base.rand(RandomDevice(), UInt64)
+
+function Random.seed!(rng::RNG, seed=make_seed(), offset=0)
     update_stream(rng)
     curandSetPseudoRandomGeneratorSeed(rng, seed)
     curandSetGeneratorOffset(rng, offset)

--- a/src/random.jl
+++ b/src/random.jl
@@ -25,14 +25,16 @@ mutable struct RNG <: AbstractRNG
     end
 end
 
-RNG() = RNG(Random.rand(UInt32))
+make_seed() = Base.rand(RandomDevice(), UInt32)
+
+RNG() = RNG(make_seed())
 
 function Random.seed!(rng::RNG, seed::Integer)
     rng.seed = seed % UInt32
     rng.counter = 0
 end
 
-Random.seed!(rng::RNG) = Random.seed!(rng, Random.rand(UInt32))
+Random.seed!(rng::RNG) = Random.seed!(rng, make_seed())
 
 function Random.rand!(rng::RNG, A::AnyCuArray)
     function kernel(A::AbstractArray{T}, seed::UInt32, counter::UInt32) where {T}

--- a/test/random.jl
+++ b/test/random.jl
@@ -138,3 +138,18 @@ end
     # gives typical real parts in the hundreds.
     @test maximum(real(randn(rng, ComplexF32, 32))) <= sqrt(-log(2f0^(-33)))
 end
+
+@testset "seeding idempotency" begin
+    t = @async begin
+        Random.seed!(1)
+        CUDA.seed!(1)
+        x = rand()
+
+        Random.seed!(1)
+        CUDA.seed!(1)
+        y = rand()
+
+        x == y
+    end
+    @test fetch(t)
+end


### PR DESCRIPTION
Fixes #1526 