### PR TITLE
`ldiv!` for LU Decomposition

### DIFF
--- a/lib/cusolver/linalg.jl
+++ b/lib/cusolver/linalg.jl
@@ -336,20 +336,19 @@ end
 LinearAlgebra.ipiv2perm(v::CuVector{T}, maxi::Integer) where T =
     LinearAlgebra.ipiv2perm(Array(v), maxi)
 
-function LinearAlgebra.LAPACK.getrs!(trans::AbstractChar, A::StridedCuMatrix{T}, ipiv::CuVector{<:Integer}, B::CuVecOrMat{T}) where {T} 
-    LinearAlgebra.LAPACK.require_one_based_indexing(A, ipiv, B)
-    LinearAlgebra.LAPACK.chktrans(trans)
-    LinearAlgebra.LAPACK.chkstride1(A, B, ipiv)
-    n = LinearAlgebra.LAPACK.checksquare(A)
-    if n != size(B, 1)
-        throw(DimensionMismatch("B has leading dimension $(size(B,1)), but needs $n"))
-    end
-    getrs!(trans, A, ipiv, B)
-    return B
 end
 
+function LinearAlgebra.ldiv!(F::LU{T,<:StridedCuMatrix{T}}, B::CuVecOrMat{T}) where {T}
+    return CUSOLVER.getrs!('N', F.factors, F.ipiv, B)
 end
 
+# LinearAlgebra.jl defines a comparable method with these restrictions on T, so we need
+#   to define with the same type parameters to resolve method ambiguity for these cases
+function LinearAlgebra.ldiv!(
+    F::LU{T,<:StridedCuMatrix{T}}, B::CuVecOrMat{T}
+    ) where {T <: Union{Float32, Float64, ComplexF32, ComplexF64}}
+    return CUSOLVER.getrs!('N', F.factors, F.ipiv, B)
+end
 
 ## cholesky
 

--- a/lib/cusolver/linalg.jl
+++ b/lib/cusolver/linalg.jl
@@ -339,15 +339,13 @@ LinearAlgebra.ipiv2perm(v::CuVector{T}, maxi::Integer) where T =
 end
 
 function LinearAlgebra.ldiv!(F::LU{T,<:StridedCuMatrix{T}}, B::CuVecOrMat{T}) where {T}
-    return CUSOLVER.getrs!('N', F.factors, F.ipiv, B)
+    return getrs!('N', F.factors, F.ipiv, B)
 end
 
 # LinearAlgebra.jl defines a comparable method with these restrictions on T, so we need
 #   to define with the same type parameters to resolve method ambiguity for these cases
-function LinearAlgebra.ldiv!(
-    F::LU{T,<:StridedCuMatrix{T}}, B::CuVecOrMat{T}
-    ) where {T <: Union{Float32, Float64, ComplexF32, ComplexF64}}
-    return CUSOLVER.getrs!('N', F.factors, F.ipiv, B)
+function LinearAlgebra.ldiv!(F::LU{T,<:StridedCuMatrix{T}}, B::CuVecOrMat{T}) where {T <: Union{Float32, Float64, ComplexF32, ComplexF64}}
+    return getrs!('N', F.factors, F.ipiv, B)
 end
 
 ## cholesky

--- a/lib/cusolver/linalg.jl
+++ b/lib/cusolver/linalg.jl
@@ -338,6 +338,18 @@ LinearAlgebra.ipiv2perm(v::CuVector{T}, maxi::Integer) where T =
 
 end
 
+function LinearAlgebra.ldiv!(F::LU{T,<:StridedCuMatrix{T}}, B::CuVecOrMat{T}) where {T}
+    return CUSOLVER.getrs!('N', F.factors, F.ipiv, B)
+end
+
+# LinearAlgebra.jl defines a comparable method with these restrictions on T, so we need
+#   to define with the same type parameters to resolve method ambiguity for these cases
+function LinearAlgebra.ldiv!(
+    F::LU{T,<:StridedCuMatrix{T}}, B::CuVecOrMat{T}
+    ) where {T <: Union{Float32, Float64, ComplexF32, ComplexF64}}
+    return CUSOLVER.getrs!('N', F.factors, F.ipiv, B)
+end
+
 ## cholesky
 
 if VERSION >= v"1.8-"

--- a/lib/cusolver/linalg.jl
+++ b/lib/cusolver/linalg.jl
@@ -336,19 +336,20 @@ end
 LinearAlgebra.ipiv2perm(v::CuVector{T}, maxi::Integer) where T =
     LinearAlgebra.ipiv2perm(Array(v), maxi)
 
+function LinearAlgebra.LAPACK.getrs!(trans::AbstractChar, A::StridedCuMatrix{T}, ipiv::CuVector{<:Integer}, B::CuVecOrMat{T}) where {T} 
+    LinearAlgebra.LAPACK.require_one_based_indexing(A, ipiv, B)
+    LinearAlgebra.LAPACK.chktrans(trans)
+    LinearAlgebra.LAPACK.chkstride1(A, B, ipiv)
+    n = LinearAlgebra.LAPACK.checksquare(A)
+    if n != size(B, 1)
+        throw(DimensionMismatch("B has leading dimension $(size(B,1)), but needs $n"))
+    end
+    getrs!(trans, A, ipiv, B)
+    return B
 end
 
-function LinearAlgebra.ldiv!(F::LU{T,<:StridedCuMatrix{T}}, B::CuVecOrMat{T}) where {T}
-    return CUSOLVER.getrs!('N', F.factors, F.ipiv, B)
 end
 
-# LinearAlgebra.jl defines a comparable method with these restrictions on T, so we need
-#   to define with the same type parameters to resolve method ambiguity for these cases
-function LinearAlgebra.ldiv!(
-    F::LU{T,<:StridedCuMatrix{T}}, B::CuVecOrMat{T}
-    ) where {T <: Union{Float32, Float64, ComplexF32, ComplexF64}}
-    return CUSOLVER.getrs!('N', F.factors, F.ipiv, B)
-end
 
 ## cholesky
 

--- a/test/cusolver/dense.jl
+++ b/test/cusolver/dense.jl
@@ -579,6 +579,17 @@ k = 1
 
             @test_throws LinearAlgebra.SingularException lu(CUDA.zeros(elty,n,n))
         end
+        @testset "lu ldiv! elty = $elty" for elty in [Float32, Float64, ComplexF32, ComplexF64]
+            A = rand(elty, m, m)
+            B = rand(elty, m, m)
+            A_d = CuArray(A)
+            B_d = CuArray(B)
+
+            lu_cpu = lu(A)
+            lu_gpu = lu(A_d)
+            @test ldiv!(lu_cpu, B) ≈ collect(ldiv!(lu_gpu, B_d))
+
+        end
     end
 end
 

--- a/test/cusolver/dense.jl
+++ b/test/cusolver/dense.jl
@@ -584,11 +584,9 @@ k = 1
             B = rand(elty, m, m)
             A_d = CuArray(A)
             B_d = CuArray(B)
-
             lu_cpu = lu(A)
             lu_gpu = lu(A_d)
             @test ldiv!(lu_cpu, B) ≈ collect(ldiv!(lu_gpu, B_d))
-
         end
     end
 end


### PR DESCRIPTION
Implements `ldiv!(::LU, ::CuVecOrMat)`, addressing Chris's comment at the end of the OP for #1193 

There are some extra type parameters on one of the two `ldiv!` methods because there's a method ambiguity with a similar method in `LinearAlgebra.jl`. If there's a better way to resolve the ambiguity with one method, I'll happy make the change