### PR TITLE
Lower dmax for contraction tests

### DIFF
--- a/test/cutensor/contractions.jl
+++ b/test/cutensor/contractions.jl
@@ -15,7 +15,7 @@ eltypes = ( (Float32, Float32, Float32, Float32),
 # using host memory with CUTENSOR doesn't work on Windows
 can_pin = !Sys.iswindows()
 
-@testset for NoA=1:3, NoB=1:3, Nc=1:3
+@testset for NoA=1:2, NoB=1:2, Nc=1:2
     @testset for (eltyA, eltyB, eltyC, eltyCompute) in eltypes
         # setup
         dmax = 2^div(12, max(NoA+Nc, NoB+Nc, NoA+NoB))
@@ -44,33 +44,13 @@ can_pin = !Sys.iswindows()
         indsC = [indsoA; indsoB][pC]
 
         A = rand(eltyA, (dimsA...,))
-        can_pin && Mem.pin(A)
-        dA = CuArray(A)
         mA = reshape(permutedims(A, ipA), (loA, lc))
         B = rand(eltyB, (dimsB...,))
-        can_pin && Mem.pin(B)
-        dB = CuArray(B)
         mB = reshape(permutedims(B, ipB), (lc, loB))
         C = zeros(eltyC, (dimsC...,))
+        dA = CuArray(A)
+        dB = CuArray(B)
         dC = CuArray(C)
-
-        # simple case host side
-        if can_pin
-            Cpin = zeros(eltyC, (dimsC...,))
-            Mem.pin(Cpin)
-            @test !any(isnan.(Cpin))
-            opA = CUTENSOR.CUTENSOR_OP_IDENTITY
-            opB = CUTENSOR.CUTENSOR_OP_IDENTITY
-            opC = CUTENSOR.CUTENSOR_OP_IDENTITY
-            opOut = CUTENSOR.CUTENSOR_OP_IDENTITY
-            Cpin  = CUDA.@sync CUTENSOR.contraction!(1, A, indsA, opA, B, indsB, opB, 0, Cpin, indsC, opC, opOut)
-            mCpin = reshape(permutedims(Cpin, ipC), (loA, loB))
-            @test !any(isnan.(A))
-            @test !any(isnan.(B))
-            @test !any(isnan.(mCpin))
-            @test mCpin ≈ mA * mB rtol=compute_rtol
-        end
-
         # simple case
         opA = CUTENSOR.CUTENSOR_OP_IDENTITY
         opB = CUTENSOR.CUTENSOR_OP_IDENTITY
@@ -80,7 +60,7 @@ can_pin = !Sys.iswindows()
         C = collect(dC)
         mC = reshape(permutedims(C, ipC), (loA, loB))
         @test mC ≈ mA * mB rtol=compute_rtol
-
+        
         # simple case with plan storage
         opA = CUTENSOR.CUTENSOR_OP_IDENTITY
         opB = CUTENSOR.CUTENSOR_OP_IDENTITY
@@ -91,19 +71,6 @@ can_pin = !Sys.iswindows()
         C = collect(dC)
         mC = reshape(permutedims(C, ipC), (loA, loB))
         @test mC ≈ mA * mB
-
-        # simple case with plan storage host-side
-        if can_pin
-            opA = CUTENSOR.CUTENSOR_OP_IDENTITY
-            opB = CUTENSOR.CUTENSOR_OP_IDENTITY
-            opC = CUTENSOR.CUTENSOR_OP_IDENTITY
-            opOut = CUTENSOR.CUTENSOR_OP_IDENTITY
-            plan  = CUTENSOR.plan_contraction(A, indsA, opA, B, indsB, opB, C, indsC, opC, opOut)
-            Cpin = CUDA.@sync CUTENSOR.contraction!(1, A, indsA, opA, B, indsB, opB, 0, Cpin, indsC, opC, opOut, plan=plan)
-            mC = reshape(permutedims(Cpin, ipC), (loA, loB))
-            @test !any(isnan.(mC))
-            @test mC ≈ mA * mB
-        end
 
         # simple case with plan storage and compute type
         opA = CUTENSOR.CUTENSOR_OP_IDENTITY
@@ -123,17 +90,6 @@ can_pin = !Sys.iswindows()
         C = collect(dC)
         mC = reshape(permutedims(C, ipC), (loA, loB))
         @test mC ≈ α * mA * mB rtol=compute_rtol
-
-        if can_pin
-            α = rand(eltyCompute)
-            Calpha = zeros(eltyC, (dimsC...,))
-            Mem.pin(Calpha)
-            @test !any(isnan.(Calpha))
-            Calpha = CUDA.@sync CUTENSOR.contraction!(α, A, indsA, opA, B, indsB, opB, 0, Calpha, indsC, opC, opOut)
-            mCalpha = reshape(permutedims(collect(Calpha), ipC), (loA, loB))
-            @test !any(isnan.(mCalpha))
-            @test mCalpha ≈ α * mA * mB rtol=compute_rtol
-        end
 
         # with non-trivial β
         C = rand(eltyC, (dimsC...,))
@@ -161,6 +117,7 @@ can_pin = !Sys.iswindows()
             mC = reshape(permutedims(C2, invperm(pC2)), (loA, loB))
             @test mC ≈ mA * mB
         end
+        
         # with conjugation flag for complex arguments
         if !((NoA, NoB, Nc) in ((1,1,3), (1,2,3), (3,1,2)))
         # not supported for these specific cases for unknown reason
@@ -194,6 +151,43 @@ can_pin = !Sys.iswindows()
                 mC = reshape(permutedims(C, ipC), (loA, loB))
                 @test mC ≈ conj(mA)*conj(mB) rtol=compute_rtol
             end
+        end
+        if can_pin
+            Mem.pin(A)
+            Mem.pin(B)
+            # simple case host side
+            Mem.pin(C)
+            @test !any(isnan.(C))
+            opA = CUTENSOR.CUTENSOR_OP_IDENTITY
+            opB = CUTENSOR.CUTENSOR_OP_IDENTITY
+            opC = CUTENSOR.CUTENSOR_OP_IDENTITY
+            opOut = CUTENSOR.CUTENSOR_OP_IDENTITY
+            C  = CUDA.@sync CUTENSOR.contraction!(1, A, indsA, opA, B, indsB, opB, 0, C, indsC, opC, opOut)
+            mC = reshape(permutedims(C, ipC), (loA, loB))
+            @test !any(isnan.(A))
+            @test !any(isnan.(B))
+            @test !any(isnan.(mC))
+            @test mC ≈ mA * mB rtol=compute_rtol
+            
+            # simple case with non-zero α host side
+            α = rand(eltyCompute)
+            C .= zero(eltyC)
+            @test !any(isnan.(C))
+            C = CUDA.@sync CUTENSOR.contraction!(α, A, indsA, opA, B, indsB, opB, 0, C, indsC, opC, opOut)
+            mC = reshape(permutedims(collect(C), ipC), (loA, loB))
+            @test !any(isnan.(mC))
+            @test mC ≈ α * mA * mB rtol=compute_rtol
+            
+            # simple case with plan storage host-side
+            opA = CUTENSOR.CUTENSOR_OP_IDENTITY
+            opB = CUTENSOR.CUTENSOR_OP_IDENTITY
+            opC = CUTENSOR.CUTENSOR_OP_IDENTITY
+            opOut = CUTENSOR.CUTENSOR_OP_IDENTITY
+            plan  = CUTENSOR.plan_contraction(A, indsA, opA, B, indsB, opB, C, indsC, opC, opOut)
+            C = CUDA.@sync CUTENSOR.contraction!(1, A, indsA, opA, B, indsB, opB, 0, C, indsC, opC, opOut, plan=plan)
+            mC = reshape(permutedims(C, ipC), (loA, loB))
+            @test !any(isnan.(mC))
+            @test mC ≈ mA * mB
         end
     end
 end

--- a/test/cutensor/contractions.jl
+++ b/test/cutensor/contractions.jl
@@ -18,7 +18,7 @@ can_pin = !Sys.iswindows()
 @testset for NoA=1:3, NoB=1:3, Nc=1:3
     @testset for (eltyA, eltyB, eltyC, eltyCompute) in eltypes
         # setup
-        dmax = 2^div(18, max(NoA+Nc, NoB+Nc, NoA+NoB))
+        dmax = 2^div(12, max(NoA+Nc, NoB+Nc, NoA+NoB))
         dimsoA = rand(2:dmax, NoA)
         loA = prod(dimsoA)
         dimsoB = rand(2:dmax, NoB)


### PR DESCRIPTION
This lowers the maximum dimension for tensors in the contraction tests by `2^6`, should help with the memory consumption issues.