### PR TITLE
Add a utility to download artifacts without a functional driver.

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -146,6 +146,31 @@ steps:
   #   if: build.message !~ /\[skip tests\]/ && !build.pull_request.draft
   #   timeout_in_minutes: 120
 
+  - label: "GPU-less environment"
+    plugins:
+      - JuliaCI/julia#v1:
+          version: 1.6
+      - JuliaCI/julia-coverage#v1:
+          codecov: true
+          dirs:
+            - src
+            - lib
+            - examples
+      - JuliaCI/julia-test#v1:
+          run_tests: false
+    command: |
+      julia --project -e 'using CUDA;
+                          @assert !CUDA.functional();
+                          CUDA.download_artifacts()'
+    env:
+      CUDA_VISIBLE_DEVICES: ''
+      JULIA_CUDA_VERSION: '11.6'
+    agents:
+      queue: "juliagpu"
+      cuda: "*"
+    if: build.message !~ /\[skip tests\]/ && !build.pull_request.draft
+    timeout_in_minutes: 60
+
   - label: "NNlibCUDA.jl"
     plugins:
       - JuliaCI/julia#v1:

--- a/lib/cudadrv/error.jl
+++ b/lib/cudadrv/error.jl
@@ -63,7 +63,7 @@ function Base.showerror(io::IO, err::CuError)
         print(io, "CUDA error (code $(reinterpret(Int32, err.code)), $(err.code))")
     end
 
-    if err.meta != nothing
+    if err.meta !== nothing
         print(io, "\n")
         print(io, err.meta)
     end
@@ -82,8 +82,6 @@ Base.show(io::IO, ::MIME"text/plain", err::CuError) = print(io, "CuError($(err.c
 end
 
 # outlined functionality to avoid GC frame allocation
-@noinline throw_stub_error() =
-    error("Cannot use the CUDA stub libraries. You either don't have the NVIDIA driver installed, or it is not properly discoverable.")
 @noinline function throw_api_error(res)
     if res == ERROR_OUT_OF_MEMORY
         throw(OutOfGPUMemoryError())
@@ -95,9 +93,7 @@ end
 macro check(ex)
     quote
         res = $(esc(ex))
-        if res == 0xffffffff
-            throw_stub_error()
-        elseif res != SUCCESS
+        if res != SUCCESS
             throw_api_error(res)
         end
 


### PR DESCRIPTION
This has been commonly requested as a way to set-up a container environment without having to rely on either run-time download of artifacts, or falling back to a local CUDA installation.

Note that this is a temporary hack, over time I hope to switch to actual JLLs where Pkg will be able to download the artifacts during package installation.