### PR TITLE
tighten `unsafe_wrap` signature on scalar length

### DIFF
--- a/src/array.jl
+++ b/src/array.jl
@@ -218,7 +218,7 @@ function Base.unsafe_wrap(::Union{Type{CuArray},Type{CuArray{T}},Type{CuArray{T,
 end
 
 function Base.unsafe_wrap(Atype::Union{Type{CuArray},Type{CuArray{T}},Type{CuArray{T,1}},Type{CuArray{T,1,B}}},
-                          p::CuPtr{T}, dim::Integer;
+                          p::CuPtr{T}, dim::Int;
                           own::Bool=false, ctx::CuContext=context()) where {T,B}
   unsafe_wrap(Atype, p, (dim,); own, ctx)
 end


### PR DESCRIPTION
`Integer` is allowed here, but the underlying calls require `Int`, yielding confusing
MethodErrors.

Before:
```
ERROR: LoadError: MethodError: no method matching unsafe_wrap(::Type{CuArray{Complex{Int16}, 1}}, ::CuPtr{Complex{Int16}}, ::Tuple{Int16}; own=false, ctx=CuContext(0x0000000001f2ffc0, instance 3917365de40cc534))
Closest candidates are:
  unsafe_wrap(::Type, ::Ptr, ::Tuple{Vararg{var"#s76", N}} where var"#s76"<:Integer; own) where N at ~/.julia/juliaup/julia-1.7.3+0~x64/share/julia/base/pointer.jl:92 got unsupported keyword argument "ctx"
  unsafe_wrap(::Union{Type{CuArray}, Type{CuArray{T}}, Type{CuArray{T, 1}}, Type{CuArray{T, 1, B}}}, ::CuPtr{T}, ::Integer; own, ctx) where {T, B} at ~/.julia/packages/CUDA/tTK8Y/src/array.jl:220
  unsafe_wrap(::Union{Type{CuArray}, Type{CuArray{T}}, Type{CuArray{T, N}}, Type{CuArray{T, N, B}}}, ::CuPtr{T}, ::Tuple{Vararg{Int64, N}}; own, ctx) where {T, N, B} at ~/.julia/packages/CUDA/tTK8Y/src/array.jl:189
```

After:
```
ERROR: LoadError: MethodError: no method matching unsafe_wrap(::Type{CuArray{Complex{Int16}, 1}}, ::CuPtr{Complex{Int16}}, ::Int16)
Closest candidates are:
  unsafe_wrap(::Union{Type{CuArray}, Type{CuArray{T}}, Type{CuArray{T, 1}}, Type{CuArray{T, 1, B}}}, ::CuPtr{T}, ::Int64; own, ctx) where {T, B} at ~/.julia/dev/CUDA/src/array.jl:220
  unsafe_wrap(::Union{Type{CuArray}, Type{CuArray{T}}, Type{CuArray{T, N}}, Type{CuArray{T, N, B}}}, ::CuPtr{T}, ::Tuple{Vararg{Int64, N}}; own, ctx) where {T, N, B} at ~/.julia/dev/CUDA/src/array.jl:189
  unsafe_wrap(::Union{Type{Array}, Type{Array{T}}, Type{Vector{T}}}, ::Ptr{T}, ::Integer; own) where T at ~/.julia/juliaup/julia-1.7.3+0~x64/share/julia/base/pointer.jl:87
```