### PR TITLE
Docs, remove global variables in intro benchmark

### DIFF
--- a/docs/src/tutorials/introduction.jl
+++ b/docs/src/tutorials/introduction.jl
@@ -391,7 +391,7 @@ kernel(y_d, x_d; threads, blocks)
 # Now let's benchmark this:
 
 function bench_gpu4!(y, x)
-    kernel = @cuda launch=false gpu_add3!(y_d, x_d)
+    kernel = @cuda launch=false gpu_add3!(y, x)
     config = launch_configuration(kernel.fun)
     threads = min(length(y), config.threads)
     blocks = cld(length(y), threads)


### PR DESCRIPTION
Probably just a small typo: The benchmark `bench_gpu4!` references to global variables `x_d` and `y_d`.

That makes (at least on my machine) the gap to `bench_gpu3!` larger, causes more (CPU side) 
allocations than needed and would be wrong for inputs with other lengths.

I only have a laptop GPU (GeForce GTX 1650), so I didn't touch the reported benchmark timings to keep it consistent.