### PR TITLE
Bugfixes when using \ operator with non square matrices

### DIFF
--- a/lib/cusolver/linalg.jl
+++ b/lib/cusolver/linalg.jl
@@ -209,15 +209,24 @@ end
 LinearAlgebra.det(Q::CuQRPackedQ{<:Real}) = isodd(count(!iszero, Q.τ)) ? -1 : 1
 LinearAlgebra.det(Q::CuQRPackedQ) = prod(τ -> iszero(τ) ? one(τ) : -sign(τ)^2, Q.τ)
 
-function LinearAlgebra.ldiv!(_qr::CuQR, b::CuArray)
-    _x = UpperTriangular(_qr.R) \ (_qr.Q' * reshape(b,length(b),1))
-    b .= vec(_x)
+function LinearAlgebra.ldiv!(_qr::CuQR, b::CuVector)
+    m,n = size(_qr)
+    _x = UpperTriangular(_qr.R[1:min(m,n), 1:n]) \ ((_qr.Q' * b)[1:n])
+    b[1:n] .= _x
     unsafe_free!(_x)
-    return b
+    return b[1:n]
+end
+
+function LinearAlgebra.ldiv!(_qr::CuQR, B::CuMatrix)
+    m,n = size(_qr)
+    _x = UpperTriangular(_qr.R[1:min(m,n), 1:n]) \ ((_qr.Q' * B)[1:n, 1:size(B, 2)])
+    B[1:n, 1:size(B, 2)] .= _x
+    unsafe_free!(_x)
+    return B[1:n, 1:size(B, 2)]
 end
 
 function LinearAlgebra.ldiv!(x::CuArray,_qr::CuQR, b::CuArray)
-    _x = UpperTriangular(_qr.R) \ (_qr.Q' * reshape(b,length(b),1))
+    _x = ldiv!(_qr, b)
     x .= vec(_x)
     unsafe_free!(_x)
     return x

--- a/lib/cusolver/linalg.jl
+++ b/lib/cusolver/linalg.jl
@@ -85,15 +85,24 @@ CuArray(F::Union{QR,QRCompactWY}) = CuMatrix(F)
 CuMatrix(F::QRPivoted) = CuArray(AbstractArray(F))
 CuArray(F::QRPivoted) = CuMatrix(F)
 
-function LinearAlgebra.ldiv!(_qr::QR, b::CuArray)
-    _x = UpperTriangular(_qr.R) \ (_qr.Q' * reshape(b,length(b),1))
-    b .= vec(_x)
+function LinearAlgebra.ldiv!(_qr::QR, b::CuVector)
+    m,n = size(_qr)
+    _x = UpperTriangular(_qr.R[1:min(m,n), 1:n]) \ ((_qr.Q' * b)[1:n])
+    b[1:n] .= _x
     unsafe_free!(_x)
-    return b
+    return b[1:n]
+end
+
+function LinearAlgebra.ldiv!(_qr::QR, B::CuMatrix)
+    m,n = size(_qr)
+    _x = UpperTriangular(_qr.R[1:min(m,n), 1:n]) \ ((_qr.Q' * B)[1:n, 1:size(B, 2)])
+    B[1:n, 1:size(B, 2)] .= _x
+    unsafe_free!(_x)
+    return B[1:n, 1:size(B, 2)]
 end
 
 function LinearAlgebra.ldiv!(x::CuArray, _qr::QR, b::CuArray)
-    _x = UpperTriangular(_qr.R) \ (_qr.Q' * reshape(b,length(b),1))
+    _x = ldiv!(_qr, b)
     x .= vec(_x)
     unsafe_free!(_x)
     return x

--- a/test/cusolver/dense.jl
+++ b/test/cusolver/dense.jl
@@ -426,6 +426,27 @@ k = 1
         q, r           = qr(A)
         @test Array(h_q) ≈ Array(q)
         @test Array(h_r) ≈ Array(r)
+        A              = rand(elty, n)  # A and B are vectors
+        d_A            = CuArray(A)
+        M              = qr(A)
+        h_M            = qr(d_A)
+        B              = rand(elty, n)
+        d_B            = CuArray(B)
+        @test Array(M \ B) ≈ Array(h_M \ d_B)
+        A              = rand(elty, m, n)  # A is a matrix and B is a vector
+        d_A            = CuArray(A)
+        M              = qr(A)
+        h_M            = qr(d_A)
+        B              = rand(elty, m)
+        d_B            = CuArray(B)
+        @test Array(M \ B) ≈ Array(h_M \ d_B)
+        A              = rand(elty, m, n)  # A and B are matrices
+        d_A            = CuArray(A)
+        M              = qr(A)
+        h_M            = qr(d_A)
+        B              = rand(elty, m, n)
+        d_B            = CuArray(B)
+        @test Array(M \ B) ≈ Array(h_M \ d_B)
     end
 
     @testset "potrsBatched!" begin


### PR DESCRIPTION
Hi,
I was experiencing issues with the `\` operator and QR decomposition in CUDA. I checked the issues and saw #138, but it is quite old and outdated. Currently, here is the bug I am facing
```
julia> A = CUDA.rand(4);
julia> B = CUDA.rand(4);
julia> M = qr(A);
julia> M \ B
ERROR: DimensionMismatch("trsm!")
Stacktrace:
 [1] trsm!
   @ ~/.julia/packages/CUDA/DfvRa/lib/cublas/wrappers.jl:1375 [inlined]
 [2] ldiv!
   @ ~/.julia/packages/CUDA/DfvRa/lib/cublas/linalg.jl:359 [inlined]
 [3] \(A::UpperTriangular{Float32, CuArray{Float32, 2, CUDA.Mem.DeviceBuffer}}, B::CuArray{Float32, 2, CUDA.Mem.DeviceBuffer})
   @ LinearAlgebra /opt/julia-1.7.3/share/julia/stdlib/v1.7/LinearAlgebra/src/triangular.jl:1661
 [4] ldiv!(_qr::CUDA.CUSOLVER.CuQR{Float32, CuArray{Float32, 2, CUDA.Mem.DeviceBuffer}}, b::CuArray{Float32, 1, CUDA.Mem.DeviceBuffer})
   @ CUDA.CUSOLVER ~/.julia/packages/CUDA/DfvRa/lib/cusolver/linalg.jl:213
 [5] \(F::CUDA.CUSOLVER.CuQR{Float32, CuArray{Float32, 2, CUDA.Mem.DeviceBuffer}}, B::CuArray{Float32, 1, CUDA.Mem.DeviceBuffer})
   @ LinearAlgebra /opt/julia-1.7.3/share/julia/stdlib/v1.7/LinearAlgebra/src/factorization.jl:107
 [6] top-level scope
   @ REPL[14]:1
 [7] top-level scope
   @ ~/.julia/packages/CUDA/DfvRa/src/initialization.jl:52
```
This also fails if `A` is a rectangular matrix, or if it is a square matrix and `B` is a rectangular matrix.
I took a look at how it's done in LinearAlgebra and it seems that there are two specialized versions of `ldiv!`, one for vectors and one for matrices. These two `ldiv!` functions select only the relevant part of the input elements by using a view, and this is how it avoids dimension mismatch.

I tried to reproduce this in CUDA by breaking down `ldiv!` into two functions. With this, I can run the code above and it gives the correct result.
```
julia> A = CUDA.rand(4);
julia> B = CUDA.rand(4);
julia> M = qr(A);
julia> M \ B
4-element CuArray{Float32, 1, CUDA.Mem.DeviceBuffer}:
  0.64181817
  0.905216
 -3.1400292
  0.83969826
julia> qr(Array(A)) \ Array(B)
4-element Vector{Float32}:
  0.64181787
  0.90521634
 -3.1400278
  0.83969784
```

Fixes https://github.com/JuliaGPU/CUDA.jl/pull/1584