### PR TITLE
remove unbound type parameters

### DIFF
--- a/lib/cudadrv/execution.jl
+++ b/lib/cudadrv/execution.jl
@@ -128,7 +128,7 @@ being slightly faster.
 cudacall
 
 # FIXME: can we make this infer properly?
-cudacall(f, types::Tuple, args...; kwargs...) where {N} =
+cudacall(f, types::Tuple, args...; kwargs...) =
     cudacall(f, Base.to_tuple_type(types), args...; kwargs...)
 
 function cudacall(f, types::Type, args...; kwargs...)

--- a/lib/cudadrv/pool.jl
+++ b/lib/cudadrv/pool.jl
@@ -76,7 +76,7 @@ trim(pool::CuMemoryPool, bytes_to_keep::Integer=0) = cuMemPoolTrimTo(pool, bytes
 Returns attribute `attr` about `pool`. The type of the returned value depends on the
 attribute, and as such must be passed as the `X` parameter.
 """
-function attribute(X::Type, pool::CuMemoryPool, attr::CUmemPool_attribute) where {T}
+function attribute(X::Type, pool::CuMemoryPool, attr::CUmemPool_attribute)
     value = Ref{X}()
     cuMemPoolGetAttribute(pool, attr, value)
     return value[]
@@ -87,7 +87,7 @@ end
 
 Sets attribute` attr` on a pointer `ptr` to `val`.
 """
-function attribute!(pool::CuMemoryPool, attr::CUmemPool_attribute, value) where {T}
+function attribute!(pool::CuMemoryPool, attr::CUmemPool_attribute, value)
     cuMemPoolSetAttribute(pool, attr, Ref(value))
     return
 end

--- a/src/sorting.jl
+++ b/src/sorting.jl
@@ -833,7 +833,7 @@ of values and an index array for doing `sortperm!`. Cannot provide a stable
 `sort!` although `sortperm!` is properly stable. To reverse, set `rev=true`
 rather than `lt=!isless` (otherwise stability of sortperm breaks down).
 """
-function bitonic_sort!(c; by = identity, lt = isless, rev = false) where {T}
+function bitonic_sort!(c; by = identity, lt = isless, rev = false)
     c_len = if typeof(c) <: Tuple
         length(c[1])
     else


### PR DESCRIPTION
Unbound type parameters often cause performance issues and run time dispatch.

Issue found using https://github.com/JuliaLang/julia/pull/46608