### PR TITLE
[CUSPARSE] Interface generic routines

### DIFF
--- a/lib/cusparse/conversions.jl
+++ b/lib/cusparse/conversions.jl
@@ -67,7 +67,7 @@ function sort_rows(coo::CuSparseMatrixCOO{Tv,Ti}) where {Tv <: BlasFloat,Ti}
 
     sorted_nzVal = similar(coo.nzVal)
     let spvec = CuSparseVector(perm, sorted_nzVal, nnz(coo))
-        if version() >= v"11.1.1"
+        if version() >= v"11.3"
             gather!(spvec, nonzeros(coo), 'Z')
         else
             gthr!(spvec, nonzeros(coo), 'Z')
@@ -426,7 +426,7 @@ for (cname,rname,elty) in ((:cusparseScsc2dense, :cusparseScsr2dense, :Float32),
                            (:cusparseZcsc2dense, :cusparseZcsr2dense, :ComplexF64))
     @eval begin
         function CUDA.CuMatrix{$elty}(csr::CuSparseMatrixCSR{$elty}; ind::SparseChar='O')
-            if version() >= v"11.1.1" # CUSPARSE version from CUDA release notes
+            if version() >= v"11.3" # CUSPARSE version from CUDA release notes
                 denseA = sparsetodense(csr, ind)
             else
                 m,n = size(csr)
@@ -440,7 +440,7 @@ for (cname,rname,elty) in ((:cusparseScsc2dense, :cusparseScsr2dense, :Float32),
             return denseA
         end
         function CUDA.CuMatrix{$elty}(csc::CuSparseMatrixCSC{$elty}; ind::SparseChar='O')
-            if version() >= v"11.1.1" # CUSPARSE version from CUDA release notes
+            if version() >= v"11.3" # CUSPARSE version from CUDA release notes
                 denseA = sparsetodense(csc, ind)
             else
                 m,n = size(csc)
@@ -459,7 +459,7 @@ for (elty, welty) in ((:Float16, :Float32),
                       (:ComplexF16, :ComplexF32))
     @eval begin
         function CUDA.CuMatrix{$elty}(csr::CuSparseMatrixCSR{$elty}; ind::SparseChar='O')
-            if version() >= v"11.1.1" # CUSPARSE version from CUDA release notes
+            if version() >= v"11.3" # CUSPARSE version from CUDA release notes
                 denseA = sparsetodense(csr, ind)
             else
                 m,n = size(csr)
@@ -471,7 +471,7 @@ for (elty, welty) in ((:Float16, :Float32),
             return denseA
         end
         function CUDA.CuMatrix{$elty}(csc::CuSparseMatrixCSC{$elty}; ind::SparseChar='O')
-            if version() >= v"11.1.1" # CUSPARSE version from CUDA release notes
+            if version() >= v"11.3" # CUSPARSE version from CUDA release notes
                 denseA = sparsetodense(csc, ind)
             else
                 m,n = size(csc)
@@ -493,7 +493,7 @@ for (nname,cname,rname,elty) in ((:cusparseSnnz, :cusparseSdense2csc, :cusparseS
                                  (:cusparseZnnz, :cusparseZdense2csc, :cusparseZdense2csr, :ComplexF64))
     @eval begin
         function CuSparseMatrixCSR(A::CuMatrix{$elty}; ind::SparseChar='O', sorted::Bool=false)
-            if !sorted && version() >= v"11.1.1" # CUSPARSE version from CUDA release notes
+            if !sorted && version() >= v"11.3" # CUSPARSE version from CUDA release notes
                 return densetosparse(A, :csr, ind)
             else
                 m,n = size(A)
@@ -517,7 +517,7 @@ for (nname,cname,rname,elty) in ((:cusparseSnnz, :cusparseSdense2csc, :cusparseS
         end
 
         function CuSparseMatrixCSC(A::CuMatrix{$elty}; ind::SparseChar='O', sorted::Bool=false)
-            if !sorted && version() >= v"11.1.1" # CUSPARSE version from CUDA release notes
+            if !sorted && version() >= v"11.3" # CUSPARSE version from CUDA release notes
                 return densetosparse(A, :csc, ind)
             else
                 m,n = size(A)
@@ -546,7 +546,7 @@ for (elty, welty) in ((:Float16, :Float32),
                       (:ComplexF16, :ComplexF32))
     @eval begin
         function CuSparseMatrixCSR(A::CuMatrix{$elty}; ind::SparseChar='O', sorted::Bool=false)
-            if !sorted && version() >= v"11.1.1" # CUSPARSE version from CUDA release notes
+            if !sorted && version() >= v"11.3" # CUSPARSE version from CUDA release notes
                 return densetosparse(A, :csr, ind)
             else
                 wide_csr = CuSparseMatrixCSR(convert(CuMatrix{$welty}, A))
@@ -554,7 +554,7 @@ for (elty, welty) in ((:Float16, :Float32),
             end
         end
         function CuSparseMatrixCSC(A::CuMatrix{$elty}; ind::SparseChar='O', sorted::Bool=false)
-            if !sorted && version() >= v"11.1.1" # CUSPARSE version from CUDA release notes
+            if !sorted && version() >= v"11.3" # CUSPARSE version from CUDA release notes
                 return densetosparse(A, :csc, ind)
             else
                 wide_csc = CuSparseMatrixCSC(convert(CuMatrix{$welty}, A))

--- a/lib/cusparse/conversions.jl
+++ b/lib/cusparse/conversions.jl
@@ -440,7 +440,7 @@ for (cname,rname,elty) in ((:cusparseScsc2dense, :cusparseScsr2dense, :Float32),
         end
         function CUDA.CuMatrix{$elty}(csc::CuSparseMatrixCSC{$elty}; ind::SparseChar='O')
             if version() >= v"11.3.0" # CUSPARSE version from CUDA release notes
-                denseA = sparsetodense(csr, ind)
+                denseA = sparsetodense(csc, ind)
             else
                 m,n = size(csc)
                 denseA = CUDA.zeros($elty,m,n)

--- a/lib/cusparse/generic.jl
+++ b/lib/cusparse/generic.jl
@@ -6,7 +6,7 @@ export vv!, sv!, sm!
 
 function sparsetodense(A::Union{CuSparseMatrixCSC{T},CuSparseMatrixCSR{T},CuSparseMatrixCOO{T}}, index::SparseChar, algo::cusparseSparseToDenseAlg_t=CUSPARSE_SPARSETODENSE_ALG_DEFAULT) where {T}
     m,n = size(A)
-    B = CUDA.zeros(T,m,n)
+    B = CuMatrix{T}(undef, m, n)
     desc_sparse = CuSparseMatrixDescriptor(A, index)
     desc_dense = CuDenseMatrixDescriptor(B)
 

--- a/lib/cusparse/generic.jl
+++ b/lib/cusparse/generic.jl
@@ -23,7 +23,7 @@ end
 
 function densetosparse(A::CuMatrix{T}, fmt::Symbol, index::SparseChar, algo::cusparseDenseToSparseAlg_t=CUSPARSE_DENSETOSPARSE_ALG_DEFAULT) where {T}
     m,n = size(A)
-    # local rowPtr, colPtr, B
+    local rowPtr, colPtr, desc_sparse, B
     if fmt == :coo
         desc_sparse = CuSparseMatrixDescriptor(CuSparseMatrixCOO, T, Cint, m, n, index)
     elseif fmt == :csr

--- a/lib/cusparse/generic.jl
+++ b/lib/cusparse/generic.jl
@@ -23,7 +23,7 @@ end
 
 function densetosparse(A::CuMatrix{T}, fmt::Symbol, index::SparseChar, algo::cusparseDenseToSparseAlg_t=CUSPARSE_DENSETOSPARSE_ALG_DEFAULT) where {T}
     m,n = size(A)
-    local rowPtr, colPtr, B
+    # local rowPtr, colPtr, B
     if fmt == :coo
         desc_sparse = CuSparseMatrixDescriptor(CuSparseMatrixCOO, T, Cint, m, n, index)
     elseif fmt == :csr
@@ -220,6 +220,7 @@ function mm!(transa::SparseChar, transb::SparseChar, alpha::Number, A::Union{CuS
             handle(), transa, transb, Ref{T}(alpha), descA, descB, Ref{T}(beta),
             descC, T, algo, buffer)
     end
+
     return C
 end
 

--- a/lib/cusparse/helpers.jl
+++ b/lib/cusparse/helpers.jl
@@ -30,6 +30,141 @@ function CuMatrixDescriptor(MatrixType::Char, FillMode::Char, DiagType::Char, In
     return desc
 end
 
+
+## dense vector descriptor
+
+mutable struct CuDenseVectorDescriptor
+    handle::cusparseDnVecDescr_t
+
+    function CuDenseVectorDescriptor(x::DenseCuVector)
+        desc_ref = Ref{cusparseDnVecDescr_t}()
+        cusparseCreateDnVec(desc_ref, length(x), x, eltype(x))
+        obj = new(desc_ref[])
+        finalizer(cusparseDestroyDnVec, obj)
+        obj
+    end
+end
+
+Base.unsafe_convert(::Type{cusparseDnVecDescr_t}, desc::CuDenseVectorDescriptor) = desc.handle
+
+
+## sparse vector descriptor
+
+mutable struct CuSparseVectorDescriptor
+    handle::cusparseSpVecDescr_t
+
+    function CuSparseVectorDescriptor(x::CuSparseVector, IndexBase::Char)
+        desc_ref = Ref{cusparseSpVecDescr_t}()
+        cusparseCreateSpVec(desc_ref, length(x), nnz(x), nonzeroinds(x), nonzeros(x),
+                            eltype(nonzeroinds(x)), IndexBase, eltype(x))
+        obj = new(desc_ref[])
+        finalizer(cusparseDestroySpVec, obj)
+        obj
+    end
+end
+
+Base.unsafe_convert(::Type{cusparseSpVecDescr_t}, desc::CuSparseVectorDescriptor) = desc.handle
+
+
+## dense matrix descriptor
+
+mutable struct CuDenseMatrixDescriptor
+    handle::cusparseDnMatDescr_t
+
+    function CuDenseMatrixDescriptor(x::DenseCuMatrix)
+        desc_ref = Ref{cusparseDnMatDescr_t}()
+        cusparseCreateDnMat(desc_ref, size(x)..., stride(x,2), x, eltype(x), CUSPARSE_ORDER_COL)
+        obj = new(desc_ref[])
+        finalizer(cusparseDestroyDnMat, obj)
+        obj
+    end
+end
+
+Base.unsafe_convert(::Type{cusparseDnMatDescr_t}, desc::CuDenseMatrixDescriptor) = desc.handle
+
+
+## sparse matrix descriptor
+
+mutable struct CuSparseMatrixDescriptor
+    handle::cusparseSpMatDescr_t
+
+    function CuSparseMatrixDescriptor(A::CuSparseMatrixCOO, IndexBase::Char)
+        desc_ref = Ref{cusparseSpMatDescr_t}()
+        cusparseCreateCoo(
+            desc_ref,
+            size(A)..., nnz(A),
+            A.rowInd, A.colInd, nonzeros(A),
+            eltype(A.rowInd), IndexBase, eltype(nonzeros(A))
+        )
+        obj = new(desc_ref[])
+        finalizer(cusparseDestroySpMat, obj)
+        return obj
+    end
+
+    function CuSparseMatrixDescriptor(::Type{CuSparseMatrixCOO}, Tv::DataType, Ti::DataType, m::Integer, n::Integer, IndexBase::Char)
+        desc_ref = Ref{cusparseSpMatDescr_t}()
+        cusparseCreateCoo(desc_ref, m, n, Ti(0), CU_NULL, CU_NULL, CU_NULL, Ti, IndexBase, Tv)
+        obj = new(desc_ref[])
+        finalizer(cusparseDestroySpMat, obj)
+        return obj
+    end
+
+    function CuSparseMatrixDescriptor(A::CuSparseMatrixCSR, IndexBase::Char)
+        desc_ref = Ref{cusparseSpMatDescr_t}()
+        cusparseCreateCsr(
+            desc_ref,
+            size(A)..., nnz(A),
+            A.rowPtr, A.colVal, nonzeros(A),
+            eltype(A.rowPtr), eltype(A.colVal), IndexBase, eltype(nonzeros(A))
+        )
+        obj = new(desc_ref[])
+        finalizer(cusparseDestroySpMat, obj)
+        return obj
+    end
+
+    function CuSparseMatrixDescriptor(::Type{CuSparseMatrixCSR}, rowPtr::CuVector, Tv::DataType, Ti::DataType, m::Integer, n::Integer, IndexBase::Char)
+        desc_ref = Ref{cusparseSpMatDescr_t}()
+        cusparseCreateCsr(desc_ref, m, n, Ti(0), rowPtr, CU_NULL, CU_NULL, Ti, Ti, IndexBase, Tv)
+        obj = new(desc_ref[])
+        finalizer(cusparseDestroySpMat, obj)
+        return obj
+    end
+
+    function CuSparseMatrixDescriptor(A::CuSparseMatrixCSC, IndexBase::Char; convert=false)
+        desc_ref = Ref{cusparseSpMatDescr_t}()
+        if convert
+            # many algorithms, e.g. mv! and mm!, do not support CSC sparse format
+            # so we eagerly convert this to a CSR matrix.
+            cusparseCreateCsr(
+                desc_ref,
+                reverse(size(A))..., nnz(A),
+                A.colPtr, rowvals(A), nonzeros(A),
+                eltype(A.colPtr), eltype(rowvals(A)), IndexBase, eltype(nonzeros(A))
+            )
+        else
+            cusparseCreateCsc(
+                desc_ref,
+                size(A)..., nnz(A),
+                A.colPtr, rowvals(A), nonzeros(A),
+                eltype(A.colPtr), eltype(rowvals(A)), IndexBase, eltype(nonzeros(A))
+            )
+        end
+        obj = new(desc_ref[])
+        finalizer(cusparseDestroySpMat, obj)
+        return obj
+    end
+
+    function CuSparseMatrixDescriptor(::Type{CuSparseMatrixCSC}, colPtr::CuVector, Tv::DataType, Ti::DataType, m::Integer, n::Integer, IndexBase::Char)
+        desc_ref = Ref{cusparseSpMatDescr_t}()
+        cusparseCreateCsc(desc_ref, m, n, Ti(0), colPtr, CU_NULL, CU_NULL, Ti, Ti, IndexBase, Tv)
+        obj = new(desc_ref[])
+        finalizer(cusparseDestroySpMat, obj)
+        return obj
+    end
+end
+
+Base.unsafe_convert(::Type{cusparseSpMatDescr_t}, desc::CuSparseMatrixDescriptor) = desc.handle
+
 mutable struct CuSpGEMMDescriptor
     handle::cusparseSpGEMMDescr_t
 

--- a/lib/cusparse/libcusparse.jl
+++ b/lib/cusparse/libcusparse.jl
@@ -5232,7 +5232,7 @@ end
 
 @checked function cusparseCscSetPointers(spMatDescr, cscColOffsets, cscRowInd, cscValues)
     initialize_context()
-    ccall((:cusparseCscSetPointers, libcusparse()), cusparseStatus_t, (cusparseSpMatDescr_t, Ptr{Cvoid}, Ptr{Cvoid}, Ptr{Cvoid}), spMatDescr, cscColOffsets, cscRowInd, cscValues)
+    ccall((:cusparseCscSetPointers, libcusparse()), cusparseStatus_t, (cusparseSpMatDescr_t, CuPtr{Cvoid}, CuPtr{Cvoid}, CuPtr{Cvoid}), spMatDescr, cscColOffsets, cscRowInd, cscValues)
 end
 
 @checked function cusparseCreateCsc(spMatDescr, rows, cols, nnz, csrColOffsets, csrRowInd, csrValues, csrColOffsetsType, csrRowIndType, idxBase, valueType)
@@ -5247,7 +5247,7 @@ end
 
 @checked function cusparseDenseToSparse_convert(handle, matA, matB, alg, buffer)
     initialize_context()
-    ccall((:cusparseDenseToSparse_convert, libcusparse()), cusparseStatus_t, (cusparseHandle_t, cusparseDnMatDescr_t, cusparseSpMatDescr_t, cusparseDenseToSparseAlg_t, Ptr{Cvoid}), handle, matA, matB, alg, buffer)
+    ccall((:cusparseDenseToSparse_convert, libcusparse()), cusparseStatus_t, (cusparseHandle_t, cusparseDnMatDescr_t, cusparseSpMatDescr_t, cusparseDenseToSparseAlg_t, CuPtr{Cvoid}), handle, matA, matB, alg, buffer)
 end
 
 @checked function cusparseSparseToDense_bufferSize(handle, matA, matB, alg, bufferSize)
@@ -5257,12 +5257,12 @@ end
 
 @checked function cusparseDenseToSparse_analysis(handle, matA, matB, alg, buffer)
     initialize_context()
-    ccall((:cusparseDenseToSparse_analysis, libcusparse()), cusparseStatus_t, (cusparseHandle_t, cusparseDnMatDescr_t, cusparseSpMatDescr_t, cusparseDenseToSparseAlg_t, Ptr{Cvoid}), handle, matA, matB, alg, buffer)
+    ccall((:cusparseDenseToSparse_analysis, libcusparse()), cusparseStatus_t, (cusparseHandle_t, cusparseDnMatDescr_t, cusparseSpMatDescr_t, cusparseDenseToSparseAlg_t, CuPtr{Cvoid}), handle, matA, matB, alg, buffer)
 end
 
 @checked function cusparseCooSetPointers(spMatDescr, cooRows, cooColumns, cooValues)
     initialize_context()
-    ccall((:cusparseCooSetPointers, libcusparse()), cusparseStatus_t, (cusparseSpMatDescr_t, Ptr{Cvoid}, Ptr{Cvoid}, Ptr{Cvoid}), spMatDescr, cooRows, cooColumns, cooValues)
+    ccall((:cusparseCooSetPointers, libcusparse()), cusparseStatus_t, (cusparseSpMatDescr_t, CuPtr{Cvoid}, CuPtr{Cvoid}, CuPtr{Cvoid}), spMatDescr, cooRows, cooColumns, cooValues)
 end
 
 ## Added in CUDA 11.2

--- a/test/cusparse.jl
+++ b/test/cusparse.jl
@@ -196,7 +196,7 @@ end
         @testset "BSR(::Dense)" begin
             x = rand(elty,m,n)
             d_x = CuArray(x)
-            d_x = CuSparseMatrixBSR(d_x)
+            d_x = CuSparseMatrixBSR(d_x, blockdim)
             @test collect(d_x) ≈ x
         end
 

--- a/test/cusparse/generic.jl
+++ b/test/cusparse/generic.jl
@@ -165,7 +165,7 @@ if CUSPARSE.version() >= v"11.7.0"
     end
 end # CUSPARSE.version >= 11.7.0
 
-if CUSPARSE.version() >= v"11.3.0"
+if CUSPARSE.version() >= v"11.1.1" # lower CUDA version doesn't support these algorithms
 
     fmt = Dict(CuSparseMatrixCSC => :csc,
                CuSparseMatrixCSR => :csr,
@@ -191,7 +191,9 @@ if CUSPARSE.version() >= v"11.3.0"
             end
         end
     end
+end # CUSPARSE.version >= 11.1.1
 
+if CUSPARSE.version() >= v"11.0" # lower CUDA version doesn't support these algorithms
     @testset "vv! $T" for T in [Float32, Float64, ComplexF32, ComplexF64]
         for (transx, opx) in [('N', identity), ('C', conj)]
             T <: Real && transx == 'C' && continue
@@ -258,4 +260,4 @@ if CUSPARSE.version() >= v"11.3.0"
         @test W ≈ collect(dX)
         @test Z ≈ collect(dY)
     end
-end # CUSPARSE.version >= 11.3.0
+end # CUSPARSE.version >= 11.0

--- a/test/cusparse/generic.jl
+++ b/test/cusparse/generic.jl
@@ -178,7 +178,7 @@ if CUSPARSE.version() >= v"11.3.0"
                 A_dense = Matrix{T}(A_sparse)
                 dA_dense = CuMatrix{T}(A_dense)
                 dA_sparse = CUSPARSE.densetosparse(dA_dense, fmt[SparseMatrixType], 'O', algo)
-                @test A_sparse ≈ collect(dA_dense)
+                @test A_sparse ≈ collect(dA_sparse)
             end
         end
         @testset "$SparseMatrixType -- sparsetodense algo=$algo" for algo in [CUSPARSE.CUSPARSE_SPARSETODENSE_ALG_DEFAULT]

--- a/test/cusparse/generic.jl
+++ b/test/cusparse/generic.jl
@@ -165,7 +165,7 @@ if CUSPARSE.version() >= v"11.7.0"
     end
 end # CUSPARSE.version >= 11.7.0
 
-if CUSPARSE.version() >= v"11.1.1" # lower CUDA version doesn't support these algorithms
+if CUSPARSE.version() >= v"11.3.0" # lower CUDA version doesn't support these algorithms
 
     fmt = Dict(CuSparseMatrixCSC => :csc,
                CuSparseMatrixCSR => :csr,
@@ -191,9 +191,7 @@ if CUSPARSE.version() >= v"11.1.1" # lower CUDA version doesn't support these al
             end
         end
     end
-end # CUSPARSE.version >= 11.1.1
 
-if CUSPARSE.version() >= v"11.0" # lower CUDA version doesn't support these algorithms
     @testset "vv! $T" for T in [Float32, Float64, ComplexF32, ComplexF64]
         for (transx, opx) in [('N', identity), ('C', conj)]
             T <: Real && transx == 'C' && continue
@@ -260,4 +258,4 @@ if CUSPARSE.version() >= v"11.0" # lower CUDA version doesn't support these algo
         @test W ≈ collect(dX)
         @test Z ≈ collect(dY)
     end
-end # CUSPARSE.version >= 11.0
+end # CUSPARSE.version >= 11.3.0


### PR DESCRIPTION
* Add a Julia function and tests for the following CUSPARSE routines:
-  sparsetodense
- densetosparse
- vv!
- gather! (tests only)
- scatter!
- sparse axpby!
- sparse rot!

* Move the `Descriptor` structures of the file `cusparse/generic.jl` in `cusparse/helpers.jl`.

* Add the following conversions:
```julia
function CUDA.CuMatrix{T}(coo::CuSparseMatrixCOO{T}; ind::SparseChar='O') where {T}
    sparsetodense(coo, ind)
end

function CuSparseMatrixCOO(A::CuMatrix; ind::SparseChar='O')
    densetosparse(A, :coo, ind)
end
```

* Add three news constructors for `CuSparseMatrixDescriptor`.
They help to just allocate the required vectors for the `densetosparse` function.
```julia
function CuSparseMatrixDescriptor(::Type{CuSparseMatrixCOO}, Tv::DataType, Ti::DataType, m::Integer, n::Integer, IndexBase::Char)
        desc_ref = Ref{cusparseSpMatDescr_t}()
        cusparseCreateCoo(desc_ref, m, n, Ti(0), CU_NULL, CU_NULL, CU_NULL, Ti, IndexBase, Tv)
        obj = new(desc_ref[])
        finalizer(cusparseDestroySpMat, obj)
        return obj
    end

    function CuSparseMatrixDescriptor(::Type{CuSparseMatrixCSR}, rowPtr::CuVector, Tv::DataType, Ti::DataType, m::Integer, n::Integer, IndexBase::Char)
        desc_ref = Ref{cusparseSpMatDescr_t}()
        cusparseCreateCsr(desc_ref, m, n, Ti(0), rowPtr, CU_NULL, CU_NULL, Ti, Ti, IndexBase, Tv)
        obj = new(desc_ref[])
        finalizer(cusparseDestroySpMat, obj)
        return obj
    end

    function CuSparseMatrixDescriptor(::Type{CuSparseMatrixCSC}, colPtr::CuVector, Tv::DataType, Ti::DataType, m::Integer, n::Integer, IndexBase::Char)
        desc_ref = Ref{cusparseSpMatDescr_t}()
        cusparseCreateCsc(desc_ref, m, n, Ti(0), colPtr, CU_NULL, CU_NULL, Ti, Ti, IndexBase, Tv)
        obj = new(desc_ref[])
        finalizer(cusparseDestroySpMat, obj)
        return obj
    end
```