### PR TITLE
[CUSPARSE] Use cusparseSpMM_preprocess

### DIFF
--- a/lib/cusparse/generic.jl
+++ b/lib/cusparse/generic.jl
@@ -225,6 +225,11 @@ function mm!(transa::SparseChar, transb::SparseChar, alpha::Number, A::Union{CuS
         return out[]
     end
     with_workspace(bufferSize) do buffer
+        if (algo == CUSPARSE_SPMM_CSR_ALG1) || (algo == CUSPARSE_SPMM_CSR_ALG3)
+            cusparseSpMM_preprocess(
+                handle(), transa, transb, Ref{T}(alpha), descA, descB, Ref{T}(beta),
+                descC, T, algo, buffer)
+        end
         cusparseSpMM(
             handle(), transa, transb, Ref{T}(alpha), descA, descB, Ref{T}(beta),
             descC, T, algo, buffer)


### PR DESCRIPTION
The function `cusparseSpMM_preprocess()` can be called before cusparseSpMM to speedup the actual computation. It is useful when cusparseSpMM is called multiple times with the same sparsity pattern (matA). The values of the matrices (matA, matB, matC) can change arbitrarily. It provides performance advantages if used with `CUSPARSE_SPMM_CSR_ALG1` or `CUSPARSE_SPMM_CSR_ALG3`. For all other formats and algorithms have no effect. 

https://docs.nvidia.com/cuda/cusparse/index.html#cusparse-generic-function-spmm