### PR TITLE
Don't use isbitsunion to support structs of union types.

### DIFF
--- a/src/device/array.jl
+++ b/src/device/array.jl
@@ -97,11 +97,11 @@ Base.unsafe_convert(::Type{LLVMPtr{T,A}}, x::CuDeviceArray{T,<:Any,A}) where {T,
 #       (cfr. shared memory and its wider-than-datatype alignment)
 
 @generated function alignment(::CuDeviceArray{T}) where {T}
-    if Base.isbitsunion(T)
+    if isbitstype(T)
+        Base.datatype_alignment(T)
+    else # isbitsunion etc
         _, sz, al = Base.uniontype_layout(T)
         al
-    else
-        Base.datatype_alignment(T)
     end
 end
 
@@ -109,7 +109,7 @@ end
     @boundscheck checkbounds(A, index)
     if isbitstype(T)
         arrayref_bits(A, index)
-    else #if isbitsunion(T)
+    else # isbitsunion etc
         arrayref_union(A, index)
     end
 end
@@ -151,7 +151,7 @@ end
     @boundscheck checkbounds(A, index)
     if isbitstype(T)
         arrayset_bits(A, x, index)
-    else #if isbitsunion(T)
+    else # isbitsunion etc
         arrayset_union(A, x, index)
     end
     return A

--- a/src/device/intrinsics/memory_shared.jl
+++ b/src/device/intrinsics/memory_shared.jl
@@ -42,7 +42,7 @@ shared memory; in the case of a homogeneous multi-part buffer it is preferred to
     @boundscheck begin
         len = prod(dims)
         sz = len*sizeof(T)
-        if Base.isbitsunion(T)
+        if !isbitstype(T)
             sz += len
         end
         if offset+sz > dynamic_smem_size()
@@ -76,9 +76,9 @@ dynamic_smem_size() =
         llvm_f, _ = create_function(T_ptr)
 
         # determine the array size
-        # TODO: assert that T isbitstype || isbitsunion (or it won't have a layout)
+        # TODO: assert that allocatedinline(T) (or it won't have a layout)
         sz = len*sizeof(T)
-        if Base.isbitsunion(T)
+        if !isbitstype(T)
             sz += len
         end
 
@@ -106,7 +106,7 @@ dynamic_smem_size() =
         align = 32
         if isbitstype(T)
             align = max(align, Base.datatype_alignment(T))
-        else # if isbitsunion(T)
+        else # isbitsunion etc
             for typ in Base.uniontypes(T)
                 if typ.layout != C_NULL
                     align = max(align, Base.datatype_alignment(typ))


### PR DESCRIPTION
`compute-sanitizer` correctly complained about an OOB read (from the selector array) after introducing a test in https://github.com/JuliaGPU/CUDA.jl/pull/1596. Turns out we were incorrectly dealing with structs of unions (which are `allocatedinline` but not `isbitsunion`), so I can't imagine this working properly at all.

cc @cdsousa 