### PR TITLE
Restore functionality of FastMath.sincos.

### DIFF
--- a/src/device/intrinsics/math.jl
+++ b/src/device/intrinsics/math.jl
@@ -40,6 +40,9 @@ end
     ccall("extern __nv_sincosf", llvmcall, Cvoid, (Cfloat, Ptr{Cfloat}, Ptr{Cfloat}), x, s, c)
     return (s[], c[])
 end
+# Base has sincos_fast fall back to the native implementation which is presumed faster,
+# but that is not the case compared to CUDA's intrinsics
+@device_override FastMath.sincos_fast(x::Union{Float64,Float32}) = (FastMath.sin_fast(x), FastMath.cos_fast(x))
 
 @device_override function Base.sincospi(x::Float64)
     s = Ref{Cdouble}()


### PR DESCRIPTION
Base decided in JuliaLang/julia#24031 that FastMath.sincos should fall back to the native implementation in Julia, because it is faster than the intrinsics (for the CPU at least). That does not hold for CUDA GPUs, so have it again call sin_fast/cos_fast.

Fixes https://github.com/JuliaGPU/CUDA.jl/issues/1606