### PR TITLE
Upgrade CUSTATEVEC to v1.1

### DIFF
--- a/lib/custatevec/Project.toml
+++ b/lib/custatevec/Project.toml
@@ -9,4 +9,4 @@ CUDA = "052768ef-5323-5732-b1bb-66c8b64840ba"
 cuQuantum_jll = "b75408ef-6fdf-5d74-b65a-7df000ad18e6"
 
 [compat]
-cuQuantum_jll = "~0.1"
+cuQuantum_jll = "~22.7"

--- a/lib/custatevec/src/CUSTATEVEC.jl
+++ b/lib/custatevec/src/CUSTATEVEC.jl
@@ -80,7 +80,7 @@ end
 function version()
   ver = custatevecGetVersion()
   major, ver = divrem(ver, 1000)
-  minor, patch = divrem(ver, 10)
+  minor, patch = divrem(ver, 100)
 
   VersionNumber(major, minor, patch)
 end

--- a/lib/custatevec/src/error.jl
+++ b/lib/custatevec/src/error.jl
@@ -32,6 +32,8 @@ function description(err)
         "the workspace on the device is too small to execute."
     elseif err.code == CUSTATEVEC_STATUS_SAMPLER_NOT_PREPROCESSED
         "the sampler was called prior to preprocessing."
+    elseif err.code == CUSTATEVEC_STATUS_NO_DEVICE_ALLOCATOR
+        "the device memory pool was not set."
     else
         "no description for this error"
     end

--- a/lib/custatevec/src/libcustatevec.jl
+++ b/lib/custatevec/src/libcustatevec.jl
@@ -1,17 +1,6 @@
-
-function custatevecApplyGeneralizedPermutationMatrix(handle, sv, svDataType, nIndexBits, permutation, diagonals, diagonalsDataType, adjoint, basisBits, nBasisBits, maskBitString, maskOrdering, maskLen, extraWorkspace, extraWorkspaceSizeInBytes)
-    initialize_context()
-    ccall((:custatevecApplyGeneralizedPermutationMatrix, libcustatevec), custatevecStatus_t, (custatevecHandle_t, Ptr{Cvoid}, cudaDataType_t, UInt32, Ptr{custatevecIndex_t}, Ptr{Cvoid}, cudaDataType_t, Int32, Ptr{Int32}, UInt32, Ptr{Int32}, Ptr{Int32}, UInt32, Ptr{Cvoid}, Csize_t), handle, sv, svDataType, nIndexBits, permutation, diagonals, diagonalsDataType, adjoint, basisBits, nBasisBits, maskBitString, maskOrdering, maskLen, extraWorkspace, extraWorkspaceSizeInBytes)
-end
-
 function custatevecGetErrorName(status)
     initialize_context()
     ccall((:custatevecGetErrorName, libcustatevec), Cstring, (custatevecStatus_t,), status)
-end
-
-function custatevecAccessor_create(handle, sv, svDataType, nIndexBits, accessor, bitOrdering, bitOrderingLen, maskBitString, maskOrdering, maskLen, extraWorkspaceSizeInBytes)
-    initialize_context()
-    ccall((:custatevecAccessor_create, libcustatevec), custatevecStatus_t, (custatevecHandle_t, Ptr{Cvoid}, cudaDataType_t, UInt32, Ptr{custatevecAccessorDescriptor_t}, Ptr{Int32}, UInt32, Ptr{Int32}, Ptr{Int32}, UInt32, Ptr{Csize_t}), handle, sv, svDataType, nIndexBits, accessor, bitOrdering, bitOrderingLen, maskBitString, maskOrdering, maskLen, extraWorkspaceSizeInBytes)
 end
 
 function custatevecCreate(handle)
@@ -19,34 +8,9 @@ function custatevecCreate(handle)
     ccall((:custatevecCreate, libcustatevec), custatevecStatus_t, (Ptr{custatevecHandle_t},), handle)
 end
 
-function custatevecExpectationsOnPauliBasis(handle, sv, svDataType, nIndexBits, expectationValues, pauliOperatorsArray, basisBitsArray, nBasisBitsArray, nPauliOperatorArrays)
-    initialize_context()
-    ccall((:custatevecExpectationsOnPauliBasis, libcustatevec), custatevecStatus_t, (custatevecHandle_t, Ptr{Cvoid}, cudaDataType_t, UInt32, Ptr{Cdouble}, Ptr{Ptr{custatevecPauli_t}}, Ptr{Ptr{Int32}}, Ptr{UInt32}, UInt32), handle, sv, svDataType, nIndexBits, expectationValues, pauliOperatorsArray, basisBitsArray, nBasisBitsArray, nPauliOperatorArrays)
-end
-
-function custatevecApplyMatrix(handle, sv, svDataType, nIndexBits, matrix, matrixDataType, layout, adjoint, targets, nTargets, controls, nControls, controlBitValues, computeType, extraWorkspace, extraWorkspaceSizeInBytes)
-    initialize_context()
-    ccall((:custatevecApplyMatrix, libcustatevec), custatevecStatus_t, (custatevecHandle_t, CuPtr{Cvoid}, cudaDataType_t, UInt32, PtrOrCuPtr{Cvoid}, cudaDataType_t, custatevecMatrixLayout_t, Int32, Ptr{Int32}, UInt32, Ptr{Int32}, UInt32, Ptr{Int32}, custatevecComputeType_t, CuPtr{Cvoid}, Csize_t), handle, sv, svDataType, nIndexBits, matrix, matrixDataType, layout, adjoint, targets, nTargets, controls, nControls, controlBitValues, computeType, extraWorkspace, extraWorkspaceSizeInBytes)
-end
-
-function custatevecAccessor_setExtraWorkspace(handle, accessor, extraWorkspace, extraWorkspaceSizeInBytes)
-    initialize_context()
-    ccall((:custatevecAccessor_setExtraWorkspace, libcustatevec), custatevecStatus_t, (custatevecHandle_t, Ptr{custatevecAccessorDescriptor_t}, Ptr{Cvoid}, Csize_t), handle, accessor, extraWorkspace, extraWorkspaceSizeInBytes)
-end
-
-function custatevecSampler_create(handle, sv, svDataType, nIndexBits, sampler, nMaxShots, extraWorkspaceSizeInBytes)
-    initialize_context()
-    ccall((:custatevecSampler_create, libcustatevec), custatevecStatus_t, (custatevecHandle_t, CuPtr{Cvoid}, cudaDataType_t, UInt32, Ptr{custatevecSamplerDescriptor_t}, UInt32, Ptr{Csize_t}), handle, sv, svDataType, nIndexBits, sampler, nMaxShots, extraWorkspaceSizeInBytes)
-end
-
 function custatevecCollapseOnZBasis(handle, sv, svDataType, nIndexBits, parity, basisBits, nBasisBits, norm)
     initialize_context()
     ccall((:custatevecCollapseOnZBasis, libcustatevec), custatevecStatus_t, (custatevecHandle_t, Ptr{Cvoid}, cudaDataType_t, UInt32, Int32, Ptr{Int32}, UInt32, Cdouble), handle, sv, svDataType, nIndexBits, parity, basisBits, nBasisBits, norm)
-end
-
-function custatevecExpectation(handle, sv, svDataType, nIndexBits, expectationValue, expectationDataType, residualNorm, matrix, matrixDataType, layout, basisBits, nBasisBits, computeType, extraWorkspace, extraWorkspaceSizeInBytes)
-    initialize_context()
-    ccall((:custatevecExpectation, libcustatevec), custatevecStatus_t, (custatevecHandle_t, PtrOrCuPtr{Cvoid}, cudaDataType_t, UInt32, Ptr{Cvoid}, cudaDataType_t, Ptr{Cdouble}, Ptr{Cvoid}, cudaDataType_t, custatevecMatrixLayout_t, Ptr{Int32}, UInt32, custatevecComputeType_t, CuPtr{Cvoid}, Csize_t), handle, sv, svDataType, nIndexBits, expectationValue, expectationDataType, residualNorm, matrix, matrixDataType, layout, basisBits, nBasisBits, computeType, extraWorkspace, extraWorkspaceSizeInBytes)
 end
 
 function custatevecBatchMeasure(handle, sv, svDataType, nIndexBits, bitString, bitOrdering, bitStringLen, randnum, collapse)
@@ -54,33 +18,13 @@ function custatevecBatchMeasure(handle, sv, svDataType, nIndexBits, bitString, b
     ccall((:custatevecBatchMeasure, libcustatevec), custatevecStatus_t, (custatevecHandle_t, Ptr{Cvoid}, cudaDataType_t, UInt32, Ptr{Int32}, Ptr{Int32}, UInt32, Cdouble, custatevecCollapseOp_t), handle, sv, svDataType, nIndexBits, bitString, bitOrdering, bitStringLen, randnum, collapse)
 end
 
-function custatevecExpectation_bufferSize(handle, svDataType, nIndexBits, matrix, matrixDataType, layout, nBasisBits, computeType, extraWorkspaceSizeInBytes)
-    initialize_context()
-    ccall((:custatevecExpectation_bufferSize, libcustatevec), custatevecStatus_t, (custatevecHandle_t, cudaDataType_t, UInt32, Ptr{Cvoid}, cudaDataType_t, custatevecMatrixLayout_t, UInt32, custatevecComputeType_t, Ptr{Csize_t}), handle, svDataType, nIndexBits, matrix, matrixDataType, layout, nBasisBits, computeType, extraWorkspaceSizeInBytes)
-end
-
-function custatevecApplyMatrix_bufferSize(handle, svDataType, nIndexBits, matrix, matrixDataType, layout, adjoint, nTargets, nControls, computeType, extraWorkspaceSizeInBytes)
-    initialize_context()
-    ccall((:custatevecApplyMatrix_bufferSize, libcustatevec), custatevecStatus_t, (custatevecHandle_t, cudaDataType_t, UInt32, Ptr{Cvoid}, cudaDataType_t, custatevecMatrixLayout_t, Int32, UInt32, UInt32, custatevecComputeType_t, Ptr{Csize_t}), handle, svDataType, nIndexBits, matrix, matrixDataType, layout, adjoint, nTargets, nControls, computeType, extraWorkspaceSizeInBytes)
-end
-
 function custatevecLoggerSetMask(mask)
     ccall((:custatevecLoggerSetMask, libcustatevec), custatevecStatus_t, (Int32,), mask)
-end
-
-function custatevecAccessor_createReadOnly(handle, sv, svDataType, nIndexBits, accessor, bitOrdering, bitOrderingLen, maskBitString, maskOrdering, maskLen, extraWorkspaceSizeInBytes)
-    initialize_context()
-    ccall((:custatevecAccessor_createReadOnly, libcustatevec), custatevecStatus_t, (custatevecHandle_t, Ptr{Cvoid}, cudaDataType_t, UInt32, Ptr{custatevecAccessorDescriptor_t}, Ptr{Int32}, UInt32, Ptr{Int32}, Ptr{Int32}, UInt32, Ptr{Csize_t}), handle, sv, svDataType, nIndexBits, accessor, bitOrdering, bitOrderingLen, maskBitString, maskOrdering, maskLen, extraWorkspaceSizeInBytes)
 end
 
 function custatevecGetStream(handle, streamId)
     initialize_context()
     ccall((:custatevecGetStream, libcustatevec), custatevecStatus_t, (custatevecHandle_t, Ptr{CUstream}), handle, streamId)
-end
-
-function custatevecAccessor_get(handle, accessor, externalBuffer, _begin, _end)
-    initialize_context()
-    ccall((:custatevecAccessor_get, libcustatevec), custatevecStatus_t, (custatevecHandle_t, Ptr{custatevecAccessorDescriptor_t}, Ptr{Cvoid}, custatevecIndex_t, custatevecIndex_t), handle, accessor, externalBuffer, _begin, _end)
 end
 
 function custatevecGetVersion()
@@ -104,11 +48,6 @@ end
 function custatevecSetWorkspace(handle, workspace, workspaceSizeInBytes)
     initialize_context()
     ccall((:custatevecSetWorkspace, libcustatevec), custatevecStatus_t, (custatevecHandle_t, Ptr{Cvoid}, Csize_t), handle, workspace, workspaceSizeInBytes)
-end
-
-function custatevecApplyExp(handle, sv, svDataType, nIndexBits, theta, paulis, targets, nTargets, controls, controlBitValues, nControls)
-    initialize_context()
-    ccall((:custatevecApplyExp, libcustatevec), custatevecStatus_t, (custatevecHandle_t, Ptr{Cvoid}, cudaDataType_t, UInt32, Cdouble, Ptr{custatevecPauli_t}, Ptr{Int32}, UInt32, Ptr{Int32}, Ptr{Int32}, UInt32), handle, sv, svDataType, nIndexBits, theta, paulis, targets, nTargets, controls, controlBitValues, nControls)
 end
 
 function custatevecAbs2SumArray(handle, sv, svDataType, nIndexBits, abs2sum, bitOrdering, bitOrderingLen, maskBitString, maskOrdering, maskLen)
@@ -140,11 +79,6 @@ function custatevecLoggerSetLevel(level)
     ccall((:custatevecLoggerSetLevel, libcustatevec), custatevecStatus_t, (Int32,), level)
 end
 
-function custatevecApplyGeneralizedPermutationMatrix_bufferSize(handle, svDataType, nIndexBits, permutation, diagonals, diagonalsDataType, basisBits, nBasisBits, maskLen, extraWorkspaceSizeInBytes)
-    initialize_context()
-    ccall((:custatevecApplyGeneralizedPermutationMatrix_bufferSize, libcustatevec), custatevecStatus_t, (custatevecHandle_t, cudaDataType_t, UInt32, Ptr{custatevecIndex_t}, Ptr{Cvoid}, cudaDataType_t, Ptr{Int32}, UInt32, UInt32, Ptr{Csize_t}), handle, svDataType, nIndexBits, permutation, diagonals, diagonalsDataType, basisBits, nBasisBits, maskLen, extraWorkspaceSizeInBytes)
-end
-
 function custatevecLoggerSetFile(file)
     ccall((:custatevecLoggerSetFile, libcustatevec), custatevecStatus_t, (Ptr{Cvoid},), file)
 end
@@ -162,22 +96,147 @@ function custatevecCollapseByBitString(handle, sv, svDataType, nIndexBits, bitSt
     ccall((:custatevecCollapseByBitString, libcustatevec), custatevecStatus_t, (custatevecHandle_t, Ptr{Cvoid}, cudaDataType_t, UInt32, Ptr{Int32}, Ptr{Int32}, UInt32, Cdouble), handle, sv, svDataType, nIndexBits, bitString, bitOrdering, bitStringLen, norm)
 end
 
-function custatevecSampler_preprocess(handle, sampler, extraWorkspace, extraWorkspaceSizeInBytes)
-    initialize_context()
-    ccall((:custatevecSampler_preprocess, libcustatevec), custatevecStatus_t, (custatevecHandle_t, Ptr{custatevecSamplerDescriptor_t}, CuPtr{Cvoid}, Csize_t), handle, sampler, extraWorkspace, extraWorkspaceSizeInBytes)
-end
-
 function custatevecMeasureOnZBasis(handle, sv, svDataType, nIndexBits, parity, basisBits, nBasisBits, randnum, collapse)
     initialize_context()
     ccall((:custatevecMeasureOnZBasis, libcustatevec), custatevecStatus_t, (custatevecHandle_t, Ptr{Cvoid}, cudaDataType_t, UInt32, Ptr{Int32}, Ptr{Int32}, UInt32, Cdouble, custatevecCollapseOp_t), handle, sv, svDataType, nIndexBits, parity, basisBits, nBasisBits, randnum, collapse)
 end
 
-function custatevecSampler_sample(handle, sampler, bitStrings, bitOrdering, bitStringLen, randnums, nShots, output)
+function custatevecSamplerGetSquaredNorm(handle, sampler, norm)
     initialize_context()
-    ccall((:custatevecSampler_sample, libcustatevec), custatevecStatus_t, (custatevecHandle_t, Ptr{custatevecSamplerDescriptor_t}, Ptr{custatevecIndex_t}, Ptr{Int32}, UInt32, Ptr{Cdouble}, UInt32, custatevecSamplerOutput_t), handle, sampler, bitStrings, bitOrdering, bitStringLen, randnums, nShots, output)
+    ccall((:custatevecSamplerGetSquaredNorm, libcustatevec), custatevecStatus_t, (custatevecHandle_t, custatevecSamplerDescriptor_t, Ptr{Cdouble}), handle, sampler, norm)
 end
 
-function custatevecAccessor_set(handle, accessor, externalBuffer, _begin, _end)
+function custatevecMultiDeviceSwapIndexBits(handles, nHandles, subSVs, svDataType, nGlobalIndexBits, nLocalIndexBits, indexBitSwaps, nIndexBitSwaps, maskBitString, maskOrdering, maskLen, deviceNetworkType)
     initialize_context()
-    ccall((:custatevecAccessor_set, libcustatevec), custatevecStatus_t, (custatevecHandle_t, Ptr{custatevecAccessorDescriptor_t}, Ptr{Cvoid}, custatevecIndex_t, custatevecIndex_t), handle, accessor, externalBuffer, _begin, _end)
+    ccall((:custatevecMultiDeviceSwapIndexBits, libcustatevec), custatevecStatus_t, (Ptr{custatevecHandle_t}, UInt32, Ptr{Ptr{Cvoid}}, cudaDataType_t, UInt32, UInt32, Ptr{Tuple{Int32,Int32}}, UInt32, Ptr{Int32}, Ptr{Int32}, UInt32, custatevecDeviceNetworkType_t), handles, nHandles, subSVs, svDataType, nGlobalIndexBits, nLocalIndexBits, indexBitSwaps, nIndexBitSwaps, maskBitString, maskOrdering, maskLen, deviceNetworkType)
+end
+
+function custatevecBatchMeasureWithOffset(handle, sv, svDataType, nIndexBits, bitString, bitOrdering, bitStringLen, randnum, collapse, offset, abs2sum)
+    initialize_context()
+    ccall((:custatevecBatchMeasureWithOffset, libcustatevec), custatevecStatus_t, (custatevecHandle_t, Ptr{Cvoid}, cudaDataType_t, UInt32, Ptr{Int32}, Ptr{Int32}, UInt32, Cdouble, custatevecCollapseOp_t, Cdouble, Cdouble), handle, sv, svDataType, nIndexBits, bitString, bitOrdering, bitStringLen, randnum, collapse, offset, abs2sum)
+end
+
+function custatevecComputeExpectationGetWorkspaceSize(handle, svDataType, nIndexBits, matrix, matrixDataType, layout, nBasisBits, computeType, extraWorkspaceSizeInBytes)
+    initialize_context()
+    ccall((:custatevecComputeExpectationGetWorkspaceSize, libcustatevec), custatevecStatus_t, (custatevecHandle_t, cudaDataType_t, UInt32, PtrOrCuPtr{Cvoid}, cudaDataType_t, custatevecMatrixLayout_t, UInt32, custatevecComputeType_t, Ptr{Csize_t}), handle, svDataType, nIndexBits, matrix, matrixDataType, layout, nBasisBits, computeType, extraWorkspaceSizeInBytes)
+end
+
+function custatevecSetDeviceMemHandler(handle, handler)
+    initialize_context()
+    ccall((:custatevecSetDeviceMemHandler, libcustatevec), custatevecStatus_t, (custatevecHandle_t, Ptr{custatevecDeviceMemHandler_t}), handle, handler)
+end
+
+function custatevecAccessorSetExtraWorkspace(handle, accessor, extraWorkspace, extraWorkspaceSizeInBytes)
+    initialize_context()
+    ccall((:custatevecAccessorSetExtraWorkspace, libcustatevec), custatevecStatus_t, (custatevecHandle_t, custatevecAccessorDescriptor_t, Ptr{Cvoid}, Csize_t), handle, accessor, extraWorkspace, extraWorkspaceSizeInBytes)
+end
+
+function custatevecAccessorCreate(handle, sv, svDataType, nIndexBits, accessor, bitOrdering, bitOrderingLen, maskBitString, maskOrdering, maskLen, extraWorkspaceSizeInBytes)
+    initialize_context()
+    ccall((:custatevecAccessorCreate, libcustatevec), custatevecStatus_t, (custatevecHandle_t, Ptr{Cvoid}, cudaDataType_t, UInt32, Ptr{custatevecAccessorDescriptor_t}, Ptr{Int32}, UInt32, Ptr{Int32}, Ptr{Int32}, UInt32, Ptr{Csize_t}), handle, sv, svDataType, nIndexBits, accessor, bitOrdering, bitOrderingLen, maskBitString, maskOrdering, maskLen, extraWorkspaceSizeInBytes)
+end
+
+function custatevecAccessorDestroy(accessor)
+    initialize_context()
+    ccall((:custatevecAccessorDestroy, libcustatevec), custatevecStatus_t, (custatevecAccessorDescriptor_t,), accessor)
+end
+
+function custatevecLoggerSetCallbackData(callback, userData)
+    initialize_context()
+    ccall((:custatevecLoggerSetCallbackData, libcustatevec), custatevecStatus_t, (custatevecLoggerCallbackData_t, Ptr{Cvoid}), callback, userData)
+end
+
+function custatevecAccessorSet(handle, accessor, externalBuffer, _begin, _end)
+    initialize_context()
+    ccall((:custatevecAccessorSet, libcustatevec), custatevecStatus_t, (custatevecHandle_t, custatevecAccessorDescriptor_t, Ptr{Cvoid}, custatevecIndex_t, custatevecIndex_t), handle, accessor, externalBuffer, _begin, _end)
+end
+
+function custatevecSamplerSample(handle, sampler, bitStrings, bitOrdering, bitStringLen, randnums, nShots, output)
+    initialize_context()
+    ccall((:custatevecSamplerSample, libcustatevec), custatevecStatus_t, (custatevecHandle_t, custatevecSamplerDescriptor_t, Ptr{custatevecIndex_t}, Ptr{Int32}, UInt32, Ptr{Cdouble}, UInt32, custatevecSamplerOutput_t), handle, sampler, bitStrings, bitOrdering, bitStringLen, randnums, nShots, output)
+end
+
+function custatevecSwapIndexBits(handle, sv, svDataType, nIndexBits, bitSwaps, nBitSwaps, maskBitString, maskOrdering, maskLen)
+    initialize_context()
+    ccall((:custatevecSwapIndexBits, libcustatevec), custatevecStatus_t, (custatevecHandle_t, Ptr{Cvoid}, cudaDataType_t, UInt32, Ptr{Tuple{Int32,Int32}}, UInt32, Ptr{Int32}, Ptr{Int32}, UInt32), handle, sv, svDataType, nIndexBits, bitSwaps, nBitSwaps, maskBitString, maskOrdering, maskLen)
+end
+
+function custatevecSamplerDestroy(sampler)
+    initialize_context()
+    ccall((:custatevecSamplerDestroy, libcustatevec), custatevecStatus_t, (custatevecSamplerDescriptor_t,), sampler)
+end
+
+function custatevecApplyMatrixGetWorkspaceSize(handle, svDataType, nIndexBits, matrix, matrixDataType, layout, adjoint, nTargets, nControls, computeType, extraWorkspaceSizeInBytes)
+    initialize_context()
+    ccall((:custatevecApplyMatrixGetWorkspaceSize, libcustatevec), custatevecStatus_t, (custatevecHandle_t, cudaDataType_t, UInt32, Ptr{Cvoid}, cudaDataType_t, custatevecMatrixLayout_t, Int32, UInt32, UInt32, custatevecComputeType_t, Ptr{Csize_t}), handle, svDataType, nIndexBits, matrix, matrixDataType, layout, adjoint, nTargets, nControls, computeType, extraWorkspaceSizeInBytes)
+end
+
+function custatevecTestMatrixTypeGetWorkspaceSize(handle, matrixType, matrix, matrixDataType, layout, nTargets, adjoint, computeType, extraWorkspaceSizeInBytes)
+    initialize_context()
+    ccall((:custatevecTestMatrixTypeGetWorkspaceSize, libcustatevec), custatevecStatus_t, (custatevecHandle_t, custatevecMatrixType_t, Ptr{Cvoid}, cudaDataType_t, custatevecMatrixLayout_t, UInt32, Int32, custatevecComputeType_t, Ptr{Csize_t}), handle, matrixType, matrix, matrixDataType, layout, nTargets, adjoint, computeType, extraWorkspaceSizeInBytes)
+end
+
+function custatevecTestMatrixType(handle, residualNorm, matrixType, matrix, matrixDataType, layout, nTargets, adjoint, computeType, extraWorkspace, extraWorkspaceSizeInBytes)
+    initialize_context()
+    ccall((:custatevecTestMatrixType, libcustatevec), custatevecStatus_t, (custatevecHandle_t, Ptr{Cdouble}, custatevecMatrixType_t, Ptr{Cvoid}, cudaDataType_t, custatevecMatrixLayout_t, UInt32, Int32, custatevecComputeType_t, Ptr{Cvoid}, Csize_t), handle, residualNorm, matrixType, matrix, matrixDataType, layout, nTargets, adjoint, computeType, extraWorkspace, extraWorkspaceSizeInBytes)
+end
+
+function custatevecAccessorGet(handle, accessor, externalBuffer, _begin, _end)
+    initialize_context()
+    ccall((:custatevecAccessorGet, libcustatevec), custatevecStatus_t, (custatevecHandle_t, custatevecAccessorDescriptor_t, Ptr{Cvoid}, custatevecIndex_t, custatevecIndex_t), handle, accessor, externalBuffer, _begin, _end)
+end
+
+function custatevecSamplerPreprocess(handle, sampler, extraWorkspace, extraWorkspaceSizeInBytes)
+    initialize_context()
+    ccall((:custatevecSamplerPreprocess, libcustatevec), custatevecStatus_t, (custatevecHandle_t, custatevecSamplerDescriptor_t, CuPtr{Cvoid}, Csize_t), handle, sampler, extraWorkspace, extraWorkspaceSizeInBytes)
+end
+
+function custatevecComputeExpectation(handle, sv, svDataType, nIndexBits, expectationValue, expectationDataType, residualNorm, matrix, matrixDataType, layout, basisBits, nBasisBits, computeType, extraWorkspace, extraWorkspaceSizeInBytes)
+    initialize_context()
+    ccall((:custatevecComputeExpectation, libcustatevec), custatevecStatus_t, (custatevecHandle_t, CuPtr{Cvoid}, cudaDataType_t, UInt32, Ptr{Cvoid}, cudaDataType_t, Ptr{Cdouble}, PtrOrCuPtr{Cvoid}, cudaDataType_t, custatevecMatrixLayout_t, Ptr{Int32}, UInt32, custatevecComputeType_t, CuPtr{Cvoid}, Csize_t), handle, sv, svDataType, nIndexBits, expectationValue, expectationDataType, residualNorm, matrix, matrixDataType, layout, basisBits, nBasisBits, computeType, extraWorkspace, extraWorkspaceSizeInBytes)
+end
+
+function custatevecSamplerCreate(handle, sv, svDataType, nIndexBits, sampler, nMaxShots, extraWorkspaceSizeInBytes)
+    initialize_context()
+    ccall((:custatevecSamplerCreate, libcustatevec), custatevecStatus_t, (custatevecHandle_t, CuPtr{Cvoid}, cudaDataType_t, UInt32, Ptr{custatevecSamplerDescriptor_t}, UInt32, Ptr{Csize_t}), handle, sv, svDataType, nIndexBits, sampler, nMaxShots, extraWorkspaceSizeInBytes)
+end
+
+function custatevecApplyPauliRotation(handle, sv, svDataType, nIndexBits, theta, paulis, targets, nTargets, controls, controlBitValues, nControls)
+    initialize_context()
+    ccall((:custatevecApplyPauliRotation, libcustatevec), custatevecStatus_t, (custatevecHandle_t, Ptr{Cvoid}, cudaDataType_t, UInt32, Cdouble, Ptr{custatevecPauli_t}, Ptr{Int32}, UInt32, Ptr{Int32}, Ptr{Int32}, UInt32), handle, sv, svDataType, nIndexBits, theta, paulis, targets, nTargets, controls, controlBitValues, nControls)
+end
+
+function custatevecGetDeviceMemHandler(handle, handler)
+    initialize_context()
+    ccall((:custatevecGetDeviceMemHandler, libcustatevec), custatevecStatus_t, (custatevecHandle_t, Ptr{custatevecDeviceMemHandler_t}), handle, handler)
+end
+
+function custatevecSamplerApplySubSVOffset(handle, sampler, subSVOrd, nSubSVs, offset, norm)
+    initialize_context()
+    ccall((:custatevecSamplerApplySubSVOffset, libcustatevec), custatevecStatus_t, (custatevecHandle_t, custatevecSamplerDescriptor_t, Int32, UInt32, Cdouble, Cdouble), handle, sampler, subSVOrd, nSubSVs, offset, norm)
+end
+
+function custatevecAccessorCreateView(handle, sv, svDataType, nIndexBits, accessor, bitOrdering, bitOrderingLen, maskBitString, maskOrdering, maskLen, extraWorkspaceSizeInBytes)
+    initialize_context()
+    ccall((:custatevecAccessorCreateView, libcustatevec), custatevecStatus_t, (custatevecHandle_t, Ptr{Cvoid}, cudaDataType_t, UInt32, Ptr{custatevecAccessorDescriptor_t}, Ptr{Int32}, UInt32, Ptr{Int32}, Ptr{Int32}, UInt32, Ptr{Csize_t}), handle, sv, svDataType, nIndexBits, accessor, bitOrdering, bitOrderingLen, maskBitString, maskOrdering, maskLen, extraWorkspaceSizeInBytes)
+end
+
+function custatevecComputeExpectationsOnPauliBasis(handle, sv, svDataType, nIndexBits, expectationValues, pauliOperatorsArray, nPauliOperatorArrays, basisBitsArray, nBasisBitsArray)
+    initialize_context()
+    ccall((:custatevecComputeExpectationsOnPauliBasis, libcustatevec), custatevecStatus_t, (custatevecHandle_t, Ptr{Cvoid}, cudaDataType_t, UInt32, Ptr{Cdouble}, Ptr{Ptr{custatevecPauli_t}}, UInt32, Ptr{Ptr{Int32}}, Ptr{UInt32}), handle, sv, svDataType, nIndexBits, expectationValues, pauliOperatorsArray, nPauliOperatorArrays, basisBitsArray, nBasisBitsArray)
+end
+
+function custatevecApplyGeneralizedPermutationMatrixGetWorkspaceSize(handle, svDataType, nIndexBits, permutation, diagonals, diagonalsDataType, targets, nTargets, nControls, extraWorkspaceSizeInBytes)
+    initialize_context()
+    ccall((:custatevecApplyGeneralizedPermutationMatrixGetWorkspaceSize, libcustatevec), custatevecStatus_t, (custatevecHandle_t, cudaDataType_t, UInt32, Ptr{custatevecIndex_t}, Ptr{Cvoid}, cudaDataType_t, Ptr{Int32}, UInt32, UInt32, Ptr{Csize_t}), handle, svDataType, nIndexBits, permutation, diagonals, diagonalsDataType, targets, nTargets, nControls, extraWorkspaceSizeInBytes)
+end
+
+function custatevecApplyMatrix(handle, sv, svDataType, nIndexBits, matrix, matrixDataType, layout, adjoint, targets, nTargets, controls, controlBitValues, nControls, computeType, extraWorkspace, extraWorkspaceSizeInBytes)
+    initialize_context()
+    ccall((:custatevecApplyMatrix, libcustatevec), custatevecStatus_t, (custatevecHandle_t, CuPtr{Cvoid}, cudaDataType_t, UInt32, PtrOrCuPtr{Cvoid}, cudaDataType_t, custatevecMatrixLayout_t, Int32, Ptr{Int32}, UInt32, Ptr{Int32}, Ptr{Int32}, UInt32, custatevecComputeType_t, CuPtr{Cvoid}, Csize_t), handle, sv, svDataType, nIndexBits, matrix, matrixDataType, layout, adjoint, targets, nTargets, controls, controlBitValues, nControls, computeType, extraWorkspace, extraWorkspaceSizeInBytes)
+end
+
+function custatevecApplyGeneralizedPermutationMatrix(handle, sv, svDataType, nIndexBits, permutation, diagonals, diagonalsDataType, adjoint, targets, nTargets, controls, controlBitValues, nControls, extraWorkspace, extraWorkspaceSizeInBytes)
+    initialize_context()
+    ccall((:custatevecApplyGeneralizedPermutationMatrix, libcustatevec), custatevecStatus_t, (custatevecHandle_t, Ptr{Cvoid}, cudaDataType_t, UInt32, Ptr{custatevecIndex_t}, Ptr{Cvoid}, cudaDataType_t, Int32, Ptr{Int32}, UInt32, Ptr{Int32}, Ptr{Int32}, UInt32, Ptr{Cvoid}, Csize_t), handle, sv, svDataType, nIndexBits, permutation, diagonals, diagonalsDataType, adjoint, targets, nTargets, controls, controlBitValues, nControls, extraWorkspace, extraWorkspaceSizeInBytes)
 end

--- a/lib/custatevec/src/libcustatevec_common.jl
+++ b/lib/custatevec/src/libcustatevec_common.jl
@@ -1,25 +1,26 @@
 # Automatically generated using Clang.jl
 
-const CUSTATEVEC_VER_MAJOR = 0
+const CUSTATEVEC_VER_MAJOR = 1
 const CUSTATEVEC_VER_MINOR = 1
 const CUSTATEVEC_VER_PATCH = 0
-const CUSTATEVEC_VERSION = CUSTATEVEC_VER_MAJOR * 1000 + CUSTATEVEC_VER_MINOR * 100 + CUSTATEVEC_VER_PATCH
+const CUSTATEVEC_VERSION = 1100
+const CUSTATEVEC_ALLOCATOR_NAME_LEN = 64
 const custatevecIndex_t = Int64
 const custatevecContext = Cvoid
 const custatevecHandle_t = Ptr{custatevecContext}
-
-struct custatevecSamplerDescriptor
-    data::NTuple{256, UInt8}
-end
-
-const custatevecSamplerDescriptor_t = custatevecSamplerDescriptor
-
-struct custatevecAccessorDescriptor
-    data::NTuple{1024, UInt8}
-end
-
-const custatevecAccessorDescriptor_t = custatevecAccessorDescriptor
+const custatevecSamplerDescriptor = Cvoid
+const custatevecSamplerDescriptor_t = Ptr{custatevecSamplerDescriptor}
+const custatevecAccessorDescriptor = Cvoid
+const custatevecAccessorDescriptor_t = Ptr{custatevecAccessorDescriptor}
 const custatevecLoggerCallback_t = Ptr{Cvoid}
+const custatevecLoggerCallbackData_t = Ptr{Cvoid}
+
+struct custatevecDeviceMemHandler_t
+    ctx::Ptr{Cvoid}
+    device_alloc::Ptr{Cvoid}
+    device_free::Ptr{Cvoid}
+    name::NTuple{64, UInt8}
+end
 
 @cenum custatevecStatus_t::UInt32 begin
     CUSTATEVEC_STATUS_SUCCESS = 0
@@ -32,6 +33,8 @@ const custatevecLoggerCallback_t = Ptr{Cvoid}
     CUSTATEVEC_STATUS_NOT_SUPPORTED = 7
     CUSTATEVEC_STATUS_INSUFFICIENT_WORKSPACE = 8
     CUSTATEVEC_STATUS_SAMPLER_NOT_PREPROCESSED = 9
+    CUSTATEVEC_STATUS_NO_DEVICE_ALLOCATOR = 10
+    CUSTATEVEC_STATUS_MAX_VALUE = 11
 end
 
 @cenum custatevecPauli_t::UInt32 begin
@@ -67,5 +70,10 @@ end
 @cenum custatevecSamplerOutput_t::UInt32 begin
     CUSTATEVEC_SAMPLER_OUTPUT_RANDNUM_ORDER = 0
     CUSTATEVEC_SAMPLER_OUTPUT_ASCENDING_ORDER = 1
+end
+
+@cenum custatevecDeviceNetworkType_t::UInt32 begin
+    CUSTATEVEC_DEVICE_NETWORK_TYPE_SWITCH = 1
+    CUSTATEVEC_DEVICE_NETWORK_TYPE_FULLMESH = 2
 end
 

--- a/lib/custatevec/src/statevec.jl
+++ b/lib/custatevec/src/statevec.jl
@@ -34,8 +34,8 @@ function sample(sv::CuStateVec, sampled_bits::Vector{Int32}, shot_count)
     sampler = CuStateVecSampler(sv, UInt32(shot_count))
     bitstrings = Vector{custatevecIndex_t}(undef, shot_count)
     with_workspace(sampler.ws_size) do buffer
-        custatevecSamplerPreprocess(handle(), Ref(sampler.handle), buffer, length(buffer))
-        custatevecSamplerSample(handle(), Ref(sampler.handle), bitstrings, sampled_bits, length(sampled_bits), rand(shot_count), shot_count, CUSTATEVEC_SAMPLER_OUTPUT_RANDNUM_ORDER)
+        custatevecSamplerPreprocess(handle(), sampler.handle, buffer, length(buffer))
+        custatevecSamplerSample(handle(), sampler.handle, bitstrings, sampled_bits, length(sampled_bits), rand(shot_count), shot_count, CUSTATEVEC_SAMPLER_OUTPUT_RANDNUM_ORDER)
     end
     return bitstrings
 end

--- a/lib/custatevec/src/statevec.jl
+++ b/lib/custatevec/src/statevec.jl
@@ -1,17 +1,17 @@
 function applyPauliExp!(sv::CuStateVec, theta::Float64, paulis::Vector{<:Pauli}, targets::Vector{Int32}, controls::Vector{Int32}, controlValues::Vector{Int32}=fill(one(Int32), length(controls)))
     cupaulis = CuStateVecPauli.(paulis)
-    custatevecApplyExp(handle(), pointer(sv.data), sv.nbits, theta, cupaulis, targets, length(targets), controls, controlVals, length(controls))
+    custatevecApplyPauliRotation(handle(), sv.data, sv.nbits, theta, cupaulis, targets, length(targets), controls, controlVals, length(controls))
     sv
 end
 
 function applyMatrix!(sv::CuStateVec, matrix::Union{Matrix, CuMatrix}, adjoint::Bool, targets::Vector{Int32}, controls::Vector{Int32}, controlValues::Vector{Int32}=fill(one(Int32), length(controls)))
     function bufferSize()
         out = Ref{Csize_t}()
-        custatevecApplyMatrix_bufferSize(handle(), eltype(sv), sv.nbits, pointer(matrix), eltype(matrix), CUSTATEVEC_MATRIX_LAYOUT_COL, Int32(adjoint), length(targets), length(controls), compute_type(eltype(sv), eltype(matrix)), out)
+        custatevecApplyMatrixGetWorkspaceSize(handle(), eltype(sv), sv.nbits, matrix, eltype(matrix), CUSTATEVEC_MATRIX_LAYOUT_COL, Int32(adjoint), length(targets), length(controls), compute_type(eltype(sv), eltype(matrix)), out)
         out[]
     end
     with_workspace(bufferSize) do buffer
-        custatevecApplyMatrix(handle(), pointer(sv.data), eltype(sv), sv.nbits, pointer(matrix), eltype(matrix), CUSTATEVEC_MATRIX_LAYOUT_COL, Int32(adjoint), targets, length(targets), controls, length(controls), controlValues, compute_type(eltype(sv), eltype(matrix)), pointer(buffer), length(buffer))
+        custatevecApplyMatrix(handle(), sv.data, eltype(sv), sv.nbits, matrix, eltype(matrix), CUSTATEVEC_MATRIX_LAYOUT_COL, Int32(adjoint), targets, length(targets), controls, controlValues, length(controls), compute_type(eltype(sv), eltype(matrix)), buffer, length(buffer))
     end
     sv
 end
@@ -19,13 +19,13 @@ end
 function expectation(sv::CuStateVec, matrix::Union{Matrix, CuMatrix}, basis_bits::Vector{Int32})
     function bufferSize()
         out = Ref{Csize_t}()
-        custatevecExpectation_bufferSize(handle(), eltype(sv), sv.nbits, pointer(matrix), eltype(matrix), CUSTATEVEC_MATRIX_LAYOUT_COL, length(basis_bits), compute_type(eltype(sv), eltype(matrix)), out)
+        custatevecComputeExpectationGetWorkspaceSize(handle(), eltype(sv), sv.nbits, matrix, eltype(matrix), CUSTATEVEC_MATRIX_LAYOUT_COL, length(basis_bits), compute_type(eltype(sv), eltype(matrix)), out)
         out[]
     end
     expVal = Ref{Float64}()
     residualNorm = Ref{Float64}()
     with_workspace(bufferSize) do buffer
-        custatevecExpectation(handle(), pointer(sv.data), eltype(sv), sv.nbits, expVal, Float64, residualNorm, pointer(matrix), eltype(matrix), CUSTATEVEC_MATRIX_LAYOUT_COL, basis_bits, length(basis_bits), compute_type(eltype(sv), eltype(matrix)), buffer, length(buffer))
+        custatevecComputeExpectation(handle(), sv.data, eltype(sv), sv.nbits, expVal, Float64, residualNorm, matrix, eltype(matrix), CUSTATEVEC_MATRIX_LAYOUT_COL, basis_bits, length(basis_bits), compute_type(eltype(sv), eltype(matrix)), buffer, length(buffer))
     end
     return expVal[], residualNorm[]
 end
@@ -34,8 +34,8 @@ function sample(sv::CuStateVec, sampled_bits::Vector{Int32}, shot_count)
     sampler = CuStateVecSampler(sv, UInt32(shot_count))
     bitstrings = Vector{custatevecIndex_t}(undef, shot_count)
     with_workspace(sampler.ws_size) do buffer
-        custatevecSampler_preprocess(handle(), Ref(sampler.handle), buffer, length(buffer))
-        custatevecSampler_sample(handle(), Ref(sampler.handle), bitstrings, sampled_bits, length(sampled_bits), rand(shot_count), shot_count, CUSTATEVEC_SAMPLER_OUTPUT_RANDNUM_ORDER)
+        custatevecSamplerPreprocess(handle(), Ref(sampler.handle), buffer, length(buffer))
+        custatevecSamplerSample(handle(), Ref(sampler.handle), bitstrings, sampled_bits, length(sampled_bits), rand(shot_count), shot_count, CUSTATEVEC_SAMPLER_OUTPUT_RANDNUM_ORDER)
     end
     return bitstrings
 end

--- a/lib/custatevec/src/types.jl
+++ b/lib/custatevec/src/types.jl
@@ -83,10 +83,10 @@ mutable struct CuStateVecSampler
     ws_size::Csize_t
     function CuStateVecSampler(sv::CuStateVec, shot_count::UInt32)
         desc_ref   = Ref{custatevecSamplerDescriptor_t}()
-        extra_size = Ref{Csize_t}()
+        extra_size = Ref{Csize_t}(0)
         custatevecSamplerCreate(handle(), pointer(sv.data), eltype(sv), sv.nbits, desc_ref, shot_count, extra_size)
         obj = new(desc_ref[], extra_size[])
-        #finalizer(custatevecSampler_destroy, obj) # apparently there is no such method?
+        finalizer(custatevecSamplerDestroy, obj)
         obj
     end
 end

--- a/lib/custatevec/src/types.jl
+++ b/lib/custatevec/src/types.jl
@@ -5,17 +5,17 @@
 function Base.convert(::Type{custatevecComputeType_t}, T::DataType)
     if T == Float16
         return CUSTATEVEC_COMPUTE_16F
-    elseif T == Float32 
+    elseif T == Float32
         return CUSTATEVEC_COMPUTE_32F
     elseif T == Float64
         return CUSTATEVEC_COMPUTE_64F
-    elseif T == UInt8 
+    elseif T == UInt8
         return CUSTATEVEC_COMPUTE_8U
-    elseif T == Int8 
+    elseif T == Int8
         return CUSTATEVEC_COMPUTE_8I
-    elseif T == UInt32 
+    elseif T == UInt32
         return CUSTATEVEC_COMPUTE_32U
-    elseif T == Int32 
+    elseif T == Int32
         return CUSTATEVEC_COMPUTE_32I
     else
         throw(ArgumentError("CUSTATEVEC type equivalent for compute type $T does not exist!"))
@@ -24,17 +24,17 @@ end
 
 function Base.convert(::Type{Type}, T::custatevecComputeType_t)
     if T == CUSTATEVEC_COMPUTE_16F
-        return Float16 
+        return Float16
     elseif T == CUSTATEVEC_COMPUTE_32F
         return Float32
     elseif T == CUSTATEVEC_COMPUTE_64F
         return Float64
     elseif T == CUSTATEVEC_COMPUTE_8U
-        return UInt8 
+        return UInt8
     elseif T == CUSTATEVEC_COMPUTE_32U
         return UInt32
     elseif T == CUSTATEVEC_COMPUTE_8I
-        return Int8 
+        return Int8
     elseif T == CUSTATEVEC_COMPUTE_32I
         return Int32
     else
@@ -49,7 +49,7 @@ function compute_type(sv_type::DataType, mat_type::DataType)
         return Float32
     elseif sv_type == ComplexF32 && mat_type == ComplexF32
         return Float32
-    end 
+    end
 end
 
 abstract type Pauli end
@@ -70,7 +70,7 @@ end
 function CuStateVec(T, n_qubits::Int)
     data = CUDA.zeros(T, 2^n_qubits)
     # in most cases, taking the hit here for setting one element
-    # is cheaper than building the entire thing on the CPU and 
+    # is cheaper than building the entire thing on the CPU and
     # copying it over
     CUDA.@allowscalar data[1] = one(T)
     CuStateVec{T}(data, n_qubits)
@@ -84,7 +84,7 @@ mutable struct CuStateVecSampler
     function CuStateVecSampler(sv::CuStateVec, shot_count::UInt32)
         desc_ref   = Ref{custatevecSamplerDescriptor_t}()
         extra_size = Ref{Csize_t}()
-        custatevecSampler_create(handle(), pointer(sv.data), eltype(sv), sv.nbits, desc_ref, shot_count, extra_size)
+        custatevecSamplerCreate(handle(), pointer(sv.data), eltype(sv), sv.nbits, desc_ref, shot_count, extra_size)
         obj = new(desc_ref[], extra_size[])
         #finalizer(custatevecSampler_destroy, obj) # apparently there is no such method?
         obj


### PR DESCRIPTION
Taken from https://github.com/JuliaGPU/CUDA.jl/pull/1623; with the JLL refactor we can now upgrade sublibraries separately.

@kshyatt although on this PR all tests work, I also added support for the new logging capabilities, and enabling them (by running tests under `JULIA_DEBUG=CUSTATEVEC`) I'm noticing several errors:

```
┌ Error: custatevecSamplerPreprocess: Invalid sampler is passed to custatevecSamplerPreprocess.
└ @ CUSTATEVEC ~/Julia/pkg/CUDA/lib/custatevec/src/CUSTATEVEC.jl:100

┌ Error: custatevecSamplerSample: sampler is not initialized in custatevecSamplerSample.
└ @ CUSTATEVEC ~/Julia/pkg/CUDA/lib/custatevec/src/CUSTATEVEC.jl:100
```

Could you take a look at those?