### PR TITLE
Upgrade CUTENSORNET to v1.1

### DIFF
--- a/lib/cutensornet/Project.toml
+++ b/lib/cutensornet/Project.toml
@@ -9,4 +9,4 @@ CUDA = "052768ef-5323-5732-b1bb-66c8b64840ba"
 cuQuantum_jll = "b75408ef-6fdf-5d74-b65a-7df000ad18e6"
 
 [compat]
-cuQuantum_jll = "~0.1"
+cuQuantum_jll = "~22.7"

--- a/lib/cutensornet/src/CUTENSORNET.jl
+++ b/lib/cutensornet/src/CUTENSORNET.jl
@@ -69,8 +69,8 @@ end
 
 function version()
   ver = cutensornetGetVersion()
-  major, ver = divrem(ver, 1000)
-  minor, patch = divrem(ver, 10)
+  major, ver = divrem(ver, 10000)
+  minor, patch = divrem(ver, 100)
 
   VersionNumber(major, minor, patch)
 end

--- a/lib/cutensornet/src/error.jl
+++ b/lib/cutensornet/src/error.jl
@@ -40,8 +40,12 @@ function description(err::CUTENSORNETError)
         "the driver version is insufficient."
     elseif err.code == CUTENSORNET_STATUS_IO_ERROR
         "an error occurred related to file IO."
-    elseif err.code == CUTENSORNET_STATUS_VERSION_MISMATCH
+    elseif err.code == CUTENSORNET_STATUS_CUTENSOR_VERSION_MISMATCH
         "the dynamically linked cuTENSOR library is incompatible."
+    elseif err.code == CUTENSORNET_STATUS_NO_DEVICE_ALLOCATOR
+        "drawing device memory from a mempool is requested, but the mempool is not set."
+    elseif err.code == CUTENSORNET_STATUS_ALL_HYPER_SAMPLES_FAILED
+        "all hyper samples failed for one or more errors (enable LOGs via export CUTENSORNET_LOG_LEVEL= > 1 for details)."
     else
         "no description for this error"
     end

--- a/lib/cutensornet/src/error.jl
+++ b/lib/cutensornet/src/error.jl
@@ -45,7 +45,7 @@ function description(err::CUTENSORNETError)
     elseif err.code == CUTENSORNET_STATUS_NO_DEVICE_ALLOCATOR
         "drawing device memory from a mempool is requested, but the mempool is not set."
     elseif err.code == CUTENSORNET_STATUS_ALL_HYPER_SAMPLES_FAILED
-        "all hyper samples failed for one or more errors (enable LOGs via export CUTENSORNET_LOG_LEVEL= > 1 for details)."
+        "all hyper samples failed for one or more errors."
     else
         "no description for this error"
     end

--- a/lib/cutensornet/src/libcutensornet.jl
+++ b/lib/cutensornet/src/libcutensornet.jl
@@ -3,11 +3,6 @@ function cutensornetGetCudartVersion()
     ccall((:cutensornetGetCudartVersion, libcutensornet), Csize_t, ())
 end
 
-@checked function cutensornetContraction(handle, plan, rawDataIn, rawDataOut, workspace, workspaceSize, sliceId, stream)
-    initialize_context()
-    ccall((:cutensornetContraction, libcutensornet), cutensornetStatus_t, (cutensornetHandle_t, cutensornetContractionPlan_t, Ptr{CuPtr{Cvoid}}, CuPtr{Cvoid}, CuPtr{Cvoid}, UInt64, Int64, CUstream), handle, plan, rawDataIn, rawDataOut, workspace, workspaceSize, sliceId, stream)
-end
-
 @checked function cutensornetCreateContractionOptimizerConfig(handle, optimizerConfig)
     initialize_context()
     ccall((:cutensornetCreateContractionOptimizerConfig, libcutensornet), cutensornetStatus_t, (cutensornetHandle_t, Ptr{cutensornetContractionOptimizerConfig_t}), handle, optimizerConfig)
@@ -18,11 +13,6 @@ end
     ccall((:cutensornetCreate, libcutensornet), cutensornetStatus_t, (Ptr{cutensornetHandle_t},), handle)
 end
 
-@checked function cutensornetContractionGetWorkspaceSize(handle, descNet, optimizerInfo, workspaceSize)
-    initialize_context()
-    ccall((:cutensornetContractionGetWorkspaceSize, libcutensornet), cutensornetStatus_t, (cutensornetHandle_t, cutensornetNetworkDescriptor_t, cutensornetContractionOptimizerInfo_t, Ptr{UInt64}), handle, descNet, optimizerInfo, workspaceSize)
-end
-
 @checked function cutensornetDestroyContractionOptimizerInfo(optimizerInfo)
     initialize_context()
     ccall((:cutensornetDestroyContractionOptimizerInfo, libcutensornet), cutensornetStatus_t, (cutensornetContractionOptimizerInfo_t,), optimizerInfo)
@@ -30,11 +20,6 @@ end
 
 @checked function cutensornetLoggerOpenFile(logFile)
     ccall((:cutensornetLoggerOpenFile, libcutensornet), cutensornetStatus_t, (Cstring,), logFile)
-end
-
-@checked function cutensornetContractionAutotunePreferenceSetAttribute(handle, autotunePreference, attr, buf, sizeInBytes)
-    initialize_context()
-    ccall((:cutensornetContractionAutotunePreferenceSetAttribute, libcutensornet), cutensornetStatus_t, (cutensornetHandle_t, cutensornetContractionAutotunePreference_t, cutensornetContractionAutotunePreferenceAttributes_t, Ptr{Cvoid}, Csize_t), handle, autotunePreference, attr, buf, sizeInBytes)
 end
 
 @checked function cutensornetLoggerSetCallback(callback)
@@ -99,11 +84,6 @@ end
     ccall((:cutensornetDestroyNetworkDescriptor, libcutensornet), cutensornetStatus_t, (cutensornetNetworkDescriptor_t,), desc)
 end
 
-@checked function cutensornetContractionAutotune(handle, plan, rawDataIn, rawDataOut, workspace, workspaceSize, pref, stream)
-    initialize_context()
-    ccall((:cutensornetContractionAutotune, libcutensornet), cutensornetStatus_t, (cutensornetHandle_t, cutensornetContractionPlan_t, Ptr{CuPtr{Cvoid}}, CuPtr{Cvoid}, CuPtr{Cvoid}, UInt64, cutensornetContractionAutotunePreference_t, CUstream), handle, plan, rawDataIn, rawDataOut, workspace, workspaceSize, pref, stream)
-end
-
 @checked function cutensornetDestroyContractionAutotunePreference(autotunePreference)
     initialize_context()
     ccall((:cutensornetDestroyContractionAutotunePreference, libcutensornet), cutensornetStatus_t, (cutensornetContractionAutotunePreference_t,), autotunePreference)
@@ -141,7 +121,111 @@ end
     ccall((:cutensornetContractionAutotunePreferenceGetAttribute, libcutensornet), cutensornetStatus_t, (cutensornetHandle_t, cutensornetContractionAutotunePreference_t, cutensornetContractionAutotunePreferenceAttributes_t, Ptr{Cvoid}, Csize_t), handle, autotunePreference, attr, buf, sizeInBytes)
 end
 
-@checked function cutensornetCreateContractionPlan(handle, descNet, optimizerInfo, workspaceSize, plan)
+@checked function cutensornetContractionOptimizerInfoPackData(handle, optimizerInfo, buffer, sizeInBytes)
     initialize_context()
-    ccall((:cutensornetCreateContractionPlan, libcutensornet), cutensornetStatus_t, (cutensornetHandle_t, cutensornetNetworkDescriptor_t, cutensornetContractionOptimizerInfo_t, UInt64, Ptr{cutensornetContractionPlan_t}), handle, descNet, optimizerInfo, workspaceSize, plan)
+    ccall((:cutensornetContractionOptimizerInfoPackData, libcutensornet), cutensornetStatus_t, (cutensornetHandle_t, cutensornetContractionOptimizerInfo_t, Ptr{Cvoid}, Csize_t), handle, optimizerInfo, buffer, sizeInBytes)
+end
+
+@checked function cutensornetWorkspaceComputeSizes(handle, descNet, optimizerInfo, workDesc)
+    initialize_context()
+    ccall((:cutensornetWorkspaceComputeSizes, libcutensornet), cutensornetStatus_t, (cutensornetHandle_t, cutensornetNetworkDescriptor_t, cutensornetContractionOptimizerInfo_t, cutensornetWorkspaceDescriptor_t), handle, descNet, optimizerInfo, workDesc)
+end
+
+@checked function cutensornetDestroyWorkspaceDescriptor(desc)
+    initialize_context()
+    ccall((:cutensornetDestroyWorkspaceDescriptor, libcutensornet), cutensornetStatus_t, (cutensornetWorkspaceDescriptor_t,), desc)
+end
+
+@checked function cutensornetWorkspaceSet(handle, workDesc, memSpace, workspacePtr, workspaceSize)
+    initialize_context()
+    ccall((:cutensornetWorkspaceSet, libcutensornet), cutensornetStatus_t, (cutensornetHandle_t, cutensornetWorkspaceDescriptor_t, cutensornetMemspace_t, Ptr{Cvoid}, UInt64), handle, workDesc, memSpace, workspacePtr, workspaceSize)
+end
+
+@checked function cutensornetDestroySliceGroup(sliceGroup)
+    initialize_context()
+    ccall((:cutensornetDestroySliceGroup, libcutensornet), cutensornetStatus_t, (cutensornetSliceGroup_t,), sliceGroup)
+end
+
+@checked function cutensornetContractionOptimizerInfoGetPackedSize(handle, optimizerInfo, sizeInBytes)
+    initialize_context()
+    ccall((:cutensornetContractionOptimizerInfoGetPackedSize, libcutensornet), cutensornetStatus_t, (cutensornetHandle_t, cutensornetContractionOptimizerInfo_t, Ptr{Csize_t}), handle, optimizerInfo, sizeInBytes)
+end
+
+@checked function cutensornetCreateSliceGroupFromIDRange(handle, sliceIdStart, sliceIdStop, sliceIdStep, sliceGroup)
+    initialize_context()
+    ccall((:cutensornetCreateSliceGroupFromIDRange, libcutensornet), cutensornetStatus_t, (cutensornetHandle_t, Int64, Int64, Int64, Ptr{cutensornetSliceGroup_t}), handle, sliceIdStart, sliceIdStop, sliceIdStep, sliceGroup)
+end
+
+@checked function cutensornetWorkspaceGet(handle, workDesc, memSpace, workspacePtr, workspaceSize)
+    initialize_context()
+    ccall((:cutensornetWorkspaceGet, libcutensornet), cutensornetStatus_t, (cutensornetHandle_t, cutensornetWorkspaceDescriptor_t, cutensornetMemspace_t, Ptr{Ptr{Cvoid}}, Ptr{UInt64}), handle, workDesc, memSpace, workspacePtr, workspaceSize)
+end
+
+@checked function cutensornetUpdateContractionOptimizerInfoFromPackedData(handle, buffer, sizeInBytes, optimizerInfo)
+    initialize_context()
+    ccall((:cutensornetUpdateContractionOptimizerInfoFromPackedData, libcutensornet), cutensornetStatus_t, (cutensornetHandle_t, Ptr{Cvoid}, Csize_t, cutensornetContractionOptimizerInfo_t), handle, buffer, sizeInBytes, optimizerInfo)
+end
+
+@checked function cutensornetLoggerSetCallbackData(callback, userData)
+    initialize_context()
+    ccall((:cutensornetLoggerSetCallbackData, libcutensornet), cutensornetStatus_t, (cutensornetLoggerCallbackData_t, Ptr{Cvoid}), callback, userData)
+end
+
+@checked function cutensornetGetDeviceMemHandler(handle, devMemHandler)
+    initialize_context()
+    ccall((:cutensornetGetDeviceMemHandler, libcutensornet), cutensornetStatus_t, (cutensornetHandle_t, Ptr{cutensornetDeviceMemHandler_t}), handle, devMemHandler)
+end
+
+@checked function cutensornetCreateWorkspaceDescriptor(handle, workDesc)
+    initialize_context()
+    ccall((:cutensornetCreateWorkspaceDescriptor, libcutensornet), cutensornetStatus_t, (cutensornetHandle_t, Ptr{cutensornetWorkspaceDescriptor_t}), handle, workDesc)
+end
+
+@checked function cutensornetGetOutputTensorDetails(handle, descNet, numModesOut, dataSizeOut, modeLabelsOut, extentsOut, stridesOut)
+    initialize_context()
+    ccall((:cutensornetGetOutputTensorDetails, libcutensornet), cutensornetStatus_t, (cutensornetHandle_t, cutensornetNetworkDescriptor_t, Ptr{Int32}, Ptr{Csize_t}, Ptr{Int32}, Ptr{Int64}, Ptr{Int64}), handle, descNet, numModesOut, dataSizeOut, modeLabelsOut, extentsOut, stridesOut)
+end
+
+@checked function cutensornetContractSlices(handle, plan, rawDataIn, rawDataOut, accumulateOutput, workDesc, sliceGroup, stream)
+    initialize_context()
+    ccall((:cutensornetContractSlices, libcutensornet), cutensornetStatus_t, (cutensornetHandle_t, cutensornetContractionPlan_t, Ptr{Ptr{Cvoid}}, Ptr{Cvoid}, Int32, cutensornetWorkspaceDescriptor_t, cutensornetSliceGroup_t, CUstream), handle, plan, rawDataIn, rawDataOut, accumulateOutput, workDesc, sliceGroup, stream)
+end
+
+@checked function cutensornetWorkspaceGetSize(handle, workDesc, workPref, memSpace, workspaceSize)
+    initialize_context()
+    ccall((:cutensornetWorkspaceGetSize, libcutensornet), cutensornetStatus_t, (cutensornetHandle_t, cutensornetWorkspaceDescriptor_t, cutensornetWorksizePref_t, cutensornetMemspace_t, Ptr{UInt64}), handle, workDesc, workPref, memSpace, workspaceSize)
+end
+
+@checked function cutensornetCreateSliceGroupFromIDs(handle, beginIDSequence, endIDSequence, sliceGroup)
+    initialize_context()
+    ccall((:cutensornetCreateSliceGroupFromIDs, libcutensornet), cutensornetStatus_t, (cutensornetHandle_t, Ptr{Int64}, Ptr{Int64}, Ptr{cutensornetSliceGroup_t}), handle, beginIDSequence, endIDSequence, sliceGroup)
+end
+
+@checked function cutensornetSetDeviceMemHandler(handle, devMemHandler)
+    initialize_context()
+    ccall((:cutensornetSetDeviceMemHandler, libcutensornet), cutensornetStatus_t, (cutensornetHandle_t, Ptr{cutensornetDeviceMemHandler_t}), handle, devMemHandler)
+end
+
+@checked function cutensornetCreateContractionOptimizerInfoFromPackedData(handle, descNet, buffer, sizeInBytes, optimizerInfo)
+    initialize_context()
+    ccall((:cutensornetCreateContractionOptimizerInfoFromPackedData, libcutensornet), cutensornetStatus_t, (cutensornetHandle_t, cutensornetNetworkDescriptor_t, Ptr{Cvoid}, Csize_t, Ptr{cutensornetContractionOptimizerInfo_t}), handle, descNet, buffer, sizeInBytes, optimizerInfo)
+end
+
+@checked function cutensornetContractionAutotunePreferenceSetAttribute(handle, autotunePreference, attr, buf, sizeInBytes)
+    initialize_context()
+    ccall((:cutensornetContractionAutotunePreferenceSetAttribute, libcutensornet), cutensornetStatus_t, (cutensornetHandle_t, cutensornetContractionAutotunePreference_t, cutensornetContractionAutotunePreferenceAttributes_t, Ptr{Cvoid}, Csize_t), handle, autotunePreference, attr, buf, sizeInBytes)
+end
+
+@checked function cutensornetContractionAutotune(handle, plan, rawDataIn, rawDataOut, workDesc, pref, stream)
+    initialize_context()
+    ccall((:cutensornetContractionAutotune, libcutensornet), cutensornetStatus_t, (cutensornetHandle_t, cutensornetContractionPlan_t, Ptr{Ptr{Cvoid}}, Ptr{Cvoid}, cutensornetWorkspaceDescriptor_t, cutensornetContractionAutotunePreference_t, CUstream), handle, plan, rawDataIn, rawDataOut, workDesc, pref, stream)
+end
+
+@checked function cutensornetCreateContractionPlan(handle, descNet, optimizerInfo, workDesc, plan)
+    initialize_context()
+    ccall((:cutensornetCreateContractionPlan, libcutensornet), cutensornetStatus_t, (cutensornetHandle_t, cutensornetNetworkDescriptor_t, cutensornetContractionOptimizerInfo_t, cutensornetWorkspaceDescriptor_t, Ptr{cutensornetContractionPlan_t}), handle, descNet, optimizerInfo, workDesc, plan)
+end
+@checked function cutensornetContraction(handle, plan, rawDataIn, rawDataOut, workDesc, sliceId, stream)
+    initialize_context()
+    ccall((:cutensornetContraction, libcutensornet), cutensornetStatus_t, (cutensornetHandle_t, cutensornetContractionPlan_t, Ptr{Ptr{Cvoid}}, Ptr{Cvoid}, cutensornetWorkspaceDescriptor_t, Int64, CUstream), handle, plan, rawDataIn, rawDataOut, workDesc, sliceId, stream)
 end

--- a/lib/cutensornet/src/libcutensornet.jl
+++ b/lib/cutensornet/src/libcutensornet.jl
@@ -138,7 +138,7 @@ end
 
 @checked function cutensornetWorkspaceSet(handle, workDesc, memSpace, workspacePtr, workspaceSize)
     initialize_context()
-    ccall((:cutensornetWorkspaceSet, libcutensornet), cutensornetStatus_t, (cutensornetHandle_t, cutensornetWorkspaceDescriptor_t, cutensornetMemspace_t, Ptr{Cvoid}, UInt64), handle, workDesc, memSpace, workspacePtr, workspaceSize)
+    ccall((:cutensornetWorkspaceSet, libcutensornet), cutensornetStatus_t, (cutensornetHandle_t, cutensornetWorkspaceDescriptor_t, cutensornetMemspace_t, PtrOrCuPtr{Cvoid}, UInt64), handle, workDesc, memSpace, workspacePtr, workspaceSize)
 end
 
 @checked function cutensornetDestroySliceGroup(sliceGroup)
@@ -218,7 +218,7 @@ end
 
 @checked function cutensornetContractionAutotune(handle, plan, rawDataIn, rawDataOut, workDesc, pref, stream)
     initialize_context()
-    ccall((:cutensornetContractionAutotune, libcutensornet), cutensornetStatus_t, (cutensornetHandle_t, cutensornetContractionPlan_t, Ptr{Ptr{Cvoid}}, Ptr{Cvoid}, cutensornetWorkspaceDescriptor_t, cutensornetContractionAutotunePreference_t, CUstream), handle, plan, rawDataIn, rawDataOut, workDesc, pref, stream)
+    ccall((:cutensornetContractionAutotune, libcutensornet), cutensornetStatus_t, (cutensornetHandle_t, cutensornetContractionPlan_t, Ptr{CuPtr{Cvoid}}, CuPtr{Cvoid}, cutensornetWorkspaceDescriptor_t, cutensornetContractionAutotunePreference_t, CUstream), handle, plan, rawDataIn, rawDataOut, workDesc, pref, stream)
 end
 
 @checked function cutensornetCreateContractionPlan(handle, descNet, optimizerInfo, workDesc, plan)
@@ -227,5 +227,5 @@ end
 end
 @checked function cutensornetContraction(handle, plan, rawDataIn, rawDataOut, workDesc, sliceId, stream)
     initialize_context()
-    ccall((:cutensornetContraction, libcutensornet), cutensornetStatus_t, (cutensornetHandle_t, cutensornetContractionPlan_t, Ptr{Ptr{Cvoid}}, Ptr{Cvoid}, cutensornetWorkspaceDescriptor_t, Int64, CUstream), handle, plan, rawDataIn, rawDataOut, workDesc, sliceId, stream)
+    ccall((:cutensornetContraction, libcutensornet), cutensornetStatus_t, (cutensornetHandle_t, cutensornetContractionPlan_t, Ptr{CuPtr{Cvoid}}, CuPtr{Cvoid}, cutensornetWorkspaceDescriptor_t, Int64, CUstream), handle, plan, rawDataIn, rawDataOut, workDesc, sliceId, stream)
 end

--- a/lib/cutensornet/src/libcutensornet_common.jl
+++ b/lib/cutensornet/src/libcutensornet_common.jl
@@ -1,9 +1,12 @@
 # Automatically generated using Clang.jl
 
-const CUTENSORNET_MAJOR = 0
-const CUTENSORNET_MINOR = 0
+const CUTENSORNET_MAJOR = 1
+const CUTENSORNET_MINOR = 1
 const CUTENSORNET_PATCH = 1
 const CUTENSORNET_VERSION = CUTENSORNET_MAJOR * 10000 + CUTENSORNET_MINOR * 100 + CUTENSORNET_PATCH
+const CUTENSORNET_ALLOCATOR_NAME_LEN = 64
+
+# Skipping MacroDefinition: CUTENSORNET_DEPRECATED ( new_func ) __attribute__ ( ( deprecated ( "please use " # new_func " instead" ) ) )
 
 @cenum cutensornetStatus_t::UInt32 begin
     CUTENSORNET_STATUS_SUCCESS = 0
@@ -22,6 +25,8 @@ const CUTENSORNET_VERSION = CUTENSORNET_MAJOR * 10000 + CUTENSORNET_MINOR * 100 
     CUTENSORNET_STATUS_INSUFFICIENT_DRIVER = 20
     CUTENSORNET_STATUS_IO_ERROR = 21
     CUTENSORNET_STATUS_CUTENSOR_VERSION_MISMATCH = 22
+    CUTENSORNET_STATUS_NO_DEVICE_ALLOCATOR = 23
+    CUTENSORNET_STATUS_ALL_HYPER_SAMPLES_FAILED = 24
 end
 
 @cenum cutensornetComputeType_t::UInt32 begin
@@ -37,13 +42,19 @@ end
 end
 
 @cenum cutensornetGraphAlgo_t::UInt32 begin
-    CUTENSORNET_CONTRACTION_OPTIMIZER_CONFIG_GRAPH_ALGORITHM_RB = 0
-    CUTENSORNET_CONTRACTION_OPTIMIZER_CONFIG_GRAPH_ALGORITHM_KWAY = 1
+    CUTENSORNET_GRAPH_ALGO_RB = 0
+    CUTENSORNET_GRAPH_ALGO_KWAY = 1
 end
 
 @cenum cutensornetMemoryModel_t::UInt32 begin
-    CUTENSORNET_CONTRACTION_OPTIMIZER_CONFIG_SLICER_MEMORY_MODEL_HEURISTIC = 0
-    CUTENSORNET_CONTRACTION_OPTIMIZER_CONFIG_SLICER_MEMORY_MODEL_CUTENSOR = 1
+    CUTENSORNET_MEMORY_MODEL_HEURISTIC = 0
+    CUTENSORNET_MEMORY_MODEL_CUTENSOR = 1
+end
+
+@cenum cutensornetOptimizerCost_t::UInt32 begin
+    CUTENSORNET_OPTIMIZER_COST_FLOPS = 0
+    CUTENSORNET_OPTIMIZER_COST_TIME = 1
+    CUTENSORNET_OPTIMIZER_COST_TIME_TUNED = 2
 end
 
 @cenum cutensornetContractionOptimizerConfigAttributes_t::UInt32 begin
@@ -61,8 +72,10 @@ end
     CUTENSORNET_CONTRACTION_OPTIMIZER_CONFIG_SLICER_MIN_SLICES = 11
     CUTENSORNET_CONTRACTION_OPTIMIZER_CONFIG_SLICER_SLICE_FACTOR = 12
     CUTENSORNET_CONTRACTION_OPTIMIZER_CONFIG_HYPER_NUM_SAMPLES = 13
+    CUTENSORNET_CONTRACTION_OPTIMIZER_CONFIG_HYPER_NUM_THREADS = 16
     CUTENSORNET_CONTRACTION_OPTIMIZER_CONFIG_SIMPLIFICATION_DISABLE_DR = 14
     CUTENSORNET_CONTRACTION_OPTIMIZER_CONFIG_SEED = 15
+    CUTENSORNET_CONTRACTION_OPTIMIZER_CONFIG_COST_FUNCTION_OBJECTIVE = 18
 end
 
 @cenum cutensornetContractionOptimizerInfoAttributes_t::UInt32 begin
@@ -75,25 +88,48 @@ end
     CUTENSORNET_CONTRACTION_OPTIMIZER_INFO_FLOP_COUNT = 6
     CUTENSORNET_CONTRACTION_OPTIMIZER_INFO_LARGEST_TENSOR = 7
     CUTENSORNET_CONTRACTION_OPTIMIZER_INFO_SLICING_OVERHEAD = 8
+    CUTENSORNET_CONTRACTION_OPTIMIZER_INFO_INTERMEDIATE_MODES = 9
+    CUTENSORNET_CONTRACTION_OPTIMIZER_INFO_NUM_INTERMEDIATE_MODES = 10
+    CUTENSORNET_CONTRACTION_OPTIMIZER_INFO_EFFECTIVE_FLOPS_EST = 11
+    CUTENSORNET_CONTRACTION_OPTIMIZER_INFO_RUNTIME_EST = 12
 end
 
 @cenum cutensornetContractionAutotunePreferenceAttributes_t::UInt32 begin
     CUTENSORNET_CONTRACTION_AUTOTUNE_MAX_ITERATIONS = 0
+    CUTENSORNET_CONTRACTION_AUTOTUNE_INTERMEDIATE_MODES = 1
 end
 
 const cutensornetNetworkDescriptor_t = Ptr{Cvoid}
 const cutensornetContractionPlan_t = Ptr{Cvoid}
 const cutensornetHandle_t = Ptr{Cvoid}
-const cutensornetNodePair = Ptr{Cvoid}
-const cutensornetNodePair_t = cutensornetNodePair
+const cutensornetWorkspaceDescriptor_t = Ptr{Cvoid}
 
-struct cutensornetContractionPath
-    numContractions::Int32
-    data::Ptr{cutensornetNodePair_t}
+@cenum cutensornetWorksizePref_t::UInt32 begin
+    CUTENSORNET_WORKSIZE_PREF_MIN = 0
+    CUTENSORNET_WORKSIZE_PREF_RECOMMENDED = 1
+    CUTENSORNET_WORKSIZE_PREF_MAX = 2
 end
 
-const cutensornetContractionPath_t = cutensornetContractionPath
+@cenum cutensornetMemspace_t::UInt32 begin
+    CUTENSORNET_MEMSPACE_DEVICE = 0
+end
+
+struct cutensornetContractionPath_t
+    numContractions::Int32
+    data::Ptr{Tuple{Int32,Int32}}
+end
+
 const cutensornetContractionOptimizerConfig_t = Ptr{Cvoid}
 const cutensornetContractionOptimizerInfo_t = Ptr{Cvoid}
 const cutensornetContractionAutotunePreference_t = Ptr{Cvoid}
+const cutensornetSliceGroup_t = Ptr{Cvoid}
+
+struct cutensornetDeviceMemHandler_t
+    ctx::Ptr{Cvoid}
+    device_alloc::Ptr{Cvoid}
+    device_free::Ptr{Cvoid}
+    name::NTuple{64, UInt8}
+end
+
 const cutensornetLoggerCallback_t = Ptr{Cvoid}
+const cutensornetLoggerCallbackData_t = Ptr{Cvoid}

--- a/lib/cutensornet/src/types.jl
+++ b/lib/cutensornet/src/types.jl
@@ -5,17 +5,17 @@
 function Base.convert(::Type{cutensornetComputeType_t}, T::DataType)
     if T == Float16
         return CUTENSORNET_COMPUTE_16F
-    elseif T == Float32 
+    elseif T == Float32
         return CUTENSORNET_COMPUTE_32F
     elseif T == Float64
         return CUTENSORNET_COMPUTE_64F
-    elseif T == UInt8 
+    elseif T == UInt8
         return CUTENSORNET_COMPUTE_8U
-    elseif T == Int8 
+    elseif T == Int8
         return CUTENSORNET_COMPUTE_8I
-    elseif T == UInt32 
+    elseif T == UInt32
         return CUTENSORNET_COMPUTE_32U
-    elseif T == Int32 
+    elseif T == Int32
         return CUTENSORNET_COMPUTE_32I
     else
         throw(ArgumentError("CUTENSORNET type equivalent for compute type $T does not exist!"))
@@ -24,17 +24,17 @@ end
 
 function Base.convert(::Type{Type}, T::cutensornetComputeType_t)
     if T == CUTENSORNET_COMPUTE_16F
-        return Float16 
+        return Float16
     elseif T == CUTENSORNET_COMPUTE_32F
         return Float32
     elseif T == CUTENSORNET_COMPUTE_64F
         return Float64
     elseif T == CUTENSORNET_COMPUTE_8U
-        return UInt8 
+        return UInt8
     elseif T == CUTENSORNET_COMPUTE_32U
         return UInt32
     elseif T == CUTENSORNET_COMPUTE_8I
-        return Int8 
+        return Int8
     elseif T == CUTENSORNET_COMPUTE_32I
         return Int32
     else
@@ -65,7 +65,7 @@ function compute_type(T::DataType)
         return Float16
     elseif T == Float64
         return Float64
-    end 
+    end
 end
 
 mutable struct CuTensorNetwork{T}
@@ -83,7 +83,7 @@ mutable struct CuTensorNetwork{T}
 end
 function CuTensorNetwork(T::DataType, input_modes, input_extents, input_strides, input_alignment_reqs, output_modes, output_extents, output_strides, output_alignment_reqs)
     desc = CuTensorNetworkDescriptor(Int32(length(input_modes)), Int32.(length.(input_modes)), input_extents, input_strides, input_modes, input_alignment_reqs, Int32(length(output_modes)), output_extents, output_strides, output_modes, output_alignment_reqs, T, compute_type(real(T)))
-    
+
     return CuTensorNetwork{T}(desc, input_modes, input_extents, input_strides, input_alignment_reqs, Vector{CuArray{T}}(undef, 0), output_modes, output_extents, output_strides, output_alignment_reqs, CUDA.zeros(T, 0))
 end
 
@@ -120,14 +120,14 @@ struct AutoTune   <: UseAutotuning end
 Base.@kwdef struct OptimizerConfig
     num_graph_partitions::Int32=8
     graph_cutoff_size::Int32=8
-    graph_algorithm::cutensornetGraphAlgo_t=CUTENSORNET_CONTRACTION_OPTIMIZER_CONFIG_GRAPH_ALGORITHM_KWAY
+    graph_algorithm::cutensornetGraphAlgo_t=CUTENSORNET_GRAPH_ALGO_KWAY
     graph_imbalance_factor::Int32=200
     graph_num_iterations::Int32=60
     graph_num_cuts::Int32=10
     reconfig_num_iterations::Int32=500
     reconfig_num_leaves::Int32=500
     slicer_disable_slicing::Int32=0
-    slicer_memory_model::cutensornetMemoryModel_t=CUTENSORNET_CONTRACTION_OPTIMIZER_CONFIG_SLICER_MEMORY_MODEL_CUTENSOR
+    slicer_memory_model::cutensornetMemoryModel_t=CUTENSORNET_MEMORY_MODEL_CUTENSOR
     slicer_memory_factor::Int32=2
     slicer_min_slices::Int32=1
     slicer_slice_factor::Int32=2
@@ -171,7 +171,7 @@ end
 
 Base.unsafe_convert(::Type{cutensornetContractionOptimizerConfig_t}, desc::CuTensorNetworkContractionOptimizerConfig) = desc.handle
 
-Base.@kwdef struct AutotunePreferences 
+Base.@kwdef struct AutotunePreferences
     max_iterations::Int32=3
 end
 

--- a/lib/cutensornet/src/types.jl
+++ b/lib/cutensornet/src/types.jl
@@ -45,12 +45,13 @@ end
 mutable struct CuTensorNetworkDescriptor
     handle::cutensornetNetworkDescriptor_t
     function CuTensorNetworkDescriptor(numInputs::Int32, numModesIn::Vector{Int32}, extentsIn::Vector{Vector{Int64}},
-                                       stridesIn::Vector{Vector{Int64}}, modesIn::Vector{Vector{Int32}},
-                                       alignmentRequirementsIn::Vector{Int32}, numModesOut::Int32,
-                                       extentsOut::Vector{Int64}, stridesOut::Vector{Int64}, modesOut::Vector{Int32},
-                                       alignmentRequirementsOut::Int32, dataType::Type, computeType::Type)
+                                       stridesIn, modesIn::Vector{Vector{Int32}},
+                                       alignmentRequirementsIn::Vector{UInt32}, numModesOut::Int32,
+                                       extentsOut::Vector{Int64}, stridesOut::Union{Ptr{Nothing}, Vector{Int64}}, modesOut::Vector{Int32},
+                                       alignmentRequirementsOut::UInt32, dataType::Type, computeType::Type)
         desc_ref = Ref{cutensornetNetworkDescriptor_t}()
-        cutensornetCreateNetworkDescriptor(handle(), numInputs, numModesIn, extentsIn, stridesIn, modesIn, alignmentRequirementsIn, numModesOut, extentsOut, stridesOut, modesOut, alignmentRequirementsOut, dataType, computeType, desc_ref)
+        cutensornetCreateNetworkDescriptor(handle(), numInputs, numModesIn, extentsIn, stridesIn, modesIn, alignmentRequirementsIn, numModesOut,
+                                           extentsOut, stridesOut, modesOut, alignmentRequirementsOut, dataType, computeType, desc_ref)
         obj = new(desc_ref[])
         finalizer(cutensornetDestroyNetworkDescriptor, obj)
         obj
@@ -72,19 +73,21 @@ mutable struct CuTensorNetwork{T}
     desc::CuTensorNetworkDescriptor
     input_modes::Vector{Vector{Int32}}
     input_extents::Vector{Vector{Int32}}
-    input_strides::Vector{Vector{Int32}}
+    input_strides::Vector{<:Union{Ptr{Nothing}, Vector{Int32}}}
     input_alignment_reqs::Vector{Int32}
     input_arrs::Vector{CuArray{T}}
     output_modes::Vector{Int32}
     output_extents::Vector{Int32}
-    output_strides::Vector{Int32}
+    output_strides::Union{Ptr{Nothing}, Vector{Int32}}
     output_alignment_reqs::Int32
     output_arr::CuArray{T}
 end
 function CuTensorNetwork(T::DataType, input_modes, input_extents, input_strides, input_alignment_reqs, output_modes, output_extents, output_strides, output_alignment_reqs)
-    desc = CuTensorNetworkDescriptor(Int32(length(input_modes)), Int32.(length.(input_modes)), input_extents, input_strides, input_modes, input_alignment_reqs, Int32(length(output_modes)), output_extents, output_strides, output_modes, output_alignment_reqs, T, compute_type(real(T)))
+    desc = CuTensorNetworkDescriptor(Int32(length(input_modes)), Int32.(length.(input_modes)), input_extents, input_strides, input_modes, input_alignment_reqs,
+                                     Int32(length(output_modes)), output_extents, output_strides, output_modes, output_alignment_reqs, T, compute_type(real(T)))
 
-    return CuTensorNetwork{T}(desc, input_modes, input_extents, input_strides, input_alignment_reqs, Vector{CuArray{T}}(undef, 0), output_modes, output_extents, output_strides, output_alignment_reqs, CUDA.zeros(T, 0))
+    return CuTensorNetwork{T}(desc, input_modes, input_extents, input_strides, input_alignment_reqs, Vector{CuArray{T}}(undef, 0),
+                              output_modes, output_extents, output_strides, output_alignment_reqs, CUDA.zeros(T, 0))
 end
 
 mutable struct CuTensorNetworkContractionOptimizerInfo
@@ -100,11 +103,24 @@ end
 
 Base.unsafe_convert(::Type{cutensornetContractionOptimizerInfo_t}, desc::CuTensorNetworkContractionOptimizerInfo) = desc.handle
 
+mutable struct CuTensorNetworkWorkspaceDescriptor
+    handle::cutensornetWorkspaceDescriptor_t
+    function CuTensorNetworkWorkspaceDescriptor()
+        desc_ref = Ref{cutensornetWorkspaceDescriptor_t}()
+        cutensornetCreateWorkspaceDescriptor(handle(), desc_ref)
+        obj = new(desc_ref[])
+        finalizer(cutensornetDestroyWorkspaceDescriptor, obj)
+        obj
+    end
+end
+
+Base.unsafe_convert(::Type{cutensornetWorkspaceDescriptor_t}, desc::CuTensorNetworkWorkspaceDescriptor) = desc.handle
+
 mutable struct CuTensorNetworkContractionPlan
     handle::cutensornetContractionPlan_t
-    function CuTensorNetworkContractionPlan(net_desc::CuTensorNetworkDescriptor, info::CuTensorNetworkContractionOptimizerInfo, ws_size)
+    function CuTensorNetworkContractionPlan(net_desc::CuTensorNetworkDescriptor, info::CuTensorNetworkContractionOptimizerInfo, ws_desc::CuTensorNetworkWorkspaceDescriptor)
         desc_ref = Ref{cutensornetContractionPlan_t}()
-        cutensornetCreateContractionPlan(handle(), net_desc, info, ws_size, desc_ref)
+        cutensornetCreateContractionPlan(handle(), net_desc, info, ws_desc, desc_ref)
         obj = new(desc_ref[])
         finalizer(cutensornetDestroyContractionPlan, obj)
         obj
@@ -125,15 +141,17 @@ Base.@kwdef struct OptimizerConfig
     graph_num_iterations::Int32=60
     graph_num_cuts::Int32=10
     reconfig_num_iterations::Int32=500
-    reconfig_num_leaves::Int32=500
+    reconfig_num_leaves::Int32=8
     slicer_disable_slicing::Int32=0
     slicer_memory_model::cutensornetMemoryModel_t=CUTENSORNET_MEMORY_MODEL_CUTENSOR
-    slicer_memory_factor::Int32=2
+    slicer_memory_factor::Int32=80
     slicer_min_slices::Int32=1
     slicer_slice_factor::Int32=2
     hyper_num_samples::Int32=0
     simplification_disable_dr::Int32=0
+    hyper_num_threads::Int32=Threads.nthreads()
     seed::Int32=0
+    cost_function_objective::cutensornetOptimizerCost_t=CUTENSORNET_OPTIMIZER_COST_FLOPS
 end
 
 mutable struct CuTensorNetworkContractionOptimizerConfig
@@ -160,7 +178,9 @@ mutable struct CuTensorNetworkContractionOptimizerConfig
                         :slicer_slice_factor=>CUTENSORNET_CONTRACTION_OPTIMIZER_CONFIG_SLICER_SLICE_FACTOR,
                         :hyper_num_samples=>CUTENSORNET_CONTRACTION_OPTIMIZER_CONFIG_HYPER_NUM_SAMPLES,
                         :simplification_disable_dr=>CUTENSORNET_CONTRACTION_OPTIMIZER_CONFIG_SIMPLIFICATION_DISABLE_DR,
+                        :hyper_num_threads=>CUTENSORNET_CONTRACTION_OPTIMIZER_CONFIG_HYPER_NUM_THREADS,
                         :seed=>CUTENSORNET_CONTRACTION_OPTIMIZER_CONFIG_SEED,
+                        :cost_function_objective=>CUTENSORNET_CONTRACTION_OPTIMIZER_CONFIG_COST_FUNCTION_OBJECTIVE,
                     )
             attr_buf = Ref(Base.getproperty(prefs, attr[1]))
             cutensornetContractionOptimizerConfigSetAttribute(handle(), desc_ref[], attr[2], attr_buf, sizeof(attr_buf))

--- a/lib/cutensornet/test/Project.toml
+++ b/lib/cutensornet/test/Project.toml
@@ -2,4 +2,5 @@
 CEnum = "fa961155-64e5-5f13-b03f-caf6b980ea82"
 CUDA = "052768ef-5323-5732-b1bb-66c8b64840ba"
 CUDA_Runtime_jll = "76a88914-d11a-5bdc-97e0-2f5a05c973a2"
+TensorOperations = "6aa20fa7-93e2-5fca-9bc0-fbd0db3c71a2"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"

--- a/lib/cutensornet/test/runtests.jl
+++ b/lib/cutensornet/test/runtests.jl
@@ -19,38 +19,56 @@ using CUTENSORNET
 
 import CUTENSORNET: CuTensorNetwork, rehearse_contraction, perform_contraction!, AutoTune, NoAutoTune
 
+using TensorOperations
+
 @testset "CUTENSORNET" begin
     n = 8
     m = 16
     k = 32
-    #@testset for elty in [Float16, Float32, Float64, ComplexF16, ComplexF32, ComplexF64, Int8, Int32, UInt8, UInt32]
-    @testset for elty in [Float16, Float32]
-        # make the simplest TN: two matrices
-        A = rand(elty, n, k)
-        B = rand(elty, k, m)
-        A_modes = Int32[1, 2]
-        B_modes = Int32[2, 3]
-        A_extents = collect(size(A))
-        B_extents = collect(size(B))
-        A_strides = collect(strides(A))
-        B_strides = collect(strides(B))
-        A_aligns  = Int32(256)
-        B_aligns  = Int32(256)
-        
-        C = zeros(elty, n, m)
-        C_modes = Int32[1, 3]
-        C_extents = collect(size(C))
-        C_strides = collect(strides(C))
-        C_aligns  = Int32(256)
-        @testset for max_ws_size in [2^10, 2^20] # test that slicing works
-            @testset for tuning in [AutoTune(), NoAutoTune()]
-                ctn = CuTensorNetwork(elty, [A_modes, B_modes], [A_extents, B_extents], [A_strides, B_strides], [A_aligns, B_aligns], C_modes, C_extents, C_strides, C_aligns)
-                info, plan = rehearse_contraction(ctn, max_ws_size)
-                ctn.input_arrs = CuArray.([A, B])
-                ctn.output_arr = CuArray(C)
-                ctn = perform_contraction!(ctn, info, plan, max_ws_size, tuning)
-                dC = ctn.output_arr
-                @test collect(dC) ≈ A*B 
+    @testset for elty in [Float32, Float64, ComplexF32, ComplexF64]
+        @testset "Simple serial" begin
+            modesA = ['m', 'h', 'k', 'n']
+            modesB = ['u', 'k', 'h']
+            modesC = ['x', 'u', 'y']
+            modesD = ['m', 'x', 'n', 'y']
+            extent = Dict{Char, Int}()
+            extent['m'] = 96;
+            extent['n'] = 96;
+            extent['u'] = 96;
+            extent['h'] = 64;
+            extent['k'] = 64;
+            extent['x'] = 64;
+            extent['y'] = 64;
+            extentsA = [extent[mode] for mode in modesA]
+            extentsB = [extent[mode] for mode in modesB]
+            extentsC = [extent[mode] for mode in modesC]
+            extentsD = [extent[mode] for mode in modesD]
+            A = CUDA.rand(elty, extentsA...)
+            B = CUDA.rand(elty, extentsB...)
+            C = CUDA.rand(elty, extentsC...)
+            raw_data_in = [A, B, C]
+            modes_in = [Int32.(modesA), Int32.(modesB), Int32.(modesC)]
+            extents_in = [extentsA, extentsB, extentsC]
+            aligns_in = UInt32.([256, 256, 256])
+            aligns_out = UInt32(256)
+            ctn = CuTensorNetwork(elty, modes_in, extents_in, [C_NULL, C_NULL, C_NULL], aligns_in, Int32.(modesD), extentsD, C_NULL, aligns_out)
+            @testset for max_ws_size in [2^28, 2^32]
+                @testset for tuning in [NoAutoTune(), AutoTune()]
+                    ctn.input_arrs = raw_data_in
+                    info = rehearse_contraction(ctn, max_ws_size)
+                    ctn.output_arr = CUDA.zeros(elty, extentsD...)
+                    ctn = perform_contraction!(ctn, info, tuning)
+                    @test size(ctn.output_arr) == tuple(extentsD...)
+                    hA = collect(A)
+                    hB = collect(B)
+                    hC = collect(C)
+                    hD = zeros(elty, extentsD...)
+                    @tensor begin
+                        hD[m, x, n, y] := hA[m, h, k, n] * hB[u, k, h] * hC[x, u, y]
+                    end
+                    D = collect(ctn.output_arr)
+                    @test D ≈ hD
+                end
             end
         end
     end


### PR DESCRIPTION
This is the part from https://github.com/JuliaGPU/CUDA.jl/pull/1623 that fails CI, rebased on top of all recent changes (submodule split, JLL conversion), so should be easier for @kshyatt to take a look at :-)

This also adds logging, so run with `JULIA_DEBUG=CUTENSORNET` for more information.