### PR TITLE
Add scoped atomic_thread_fence

### DIFF
--- a/src/device/intrinsics/atomics.jl
+++ b/src/device/intrinsics/atomics.jl
@@ -43,7 +43,7 @@ function atomic_thread_fence(order, scope::Block)
            order == Acq_Rel() ||
            order == Release()
 
-           threadfence_block()
+            threadfence_block()
         else
             assert(false)
         end

--- a/src/device/intrinsics/atomics.jl
+++ b/src/device/intrinsics/atomics.jl
@@ -32,12 +32,10 @@ function atomic_thread_fence(order, scope::Block)
                order == Acq_Rel() ||
                order == Release()
 
-           threadfence_acq_rel_block()
+            threadfence_acq_rel_block()
         else 
             assert(false)
         end
-    end
-
     else
         if order == Seq_Cst() ||
            order == Consume() ||
@@ -67,12 +65,10 @@ function atomic_thread_fence(order, scope::Device)
                order == Acq_Rel() ||
                order == Release()
 
-           threadfence_acq_rel_device()
+            threadfence_acq_rel_device()
         else 
             assert(false)
         end
-    end
-
     else
         if order == Seq_Cst() ||
            order == Consume() ||
@@ -80,7 +76,7 @@ function atomic_thread_fence(order, scope::Device)
            order == Acq_Rel() ||
            order == Release()
 
-           threadfence()
+            threadfence()
         else
             assert(false)
         end
@@ -97,12 +93,10 @@ function atomic_thread_fence(order, scope::System=System())
                order == Acq_Rel() ||
                order == Release()
 
-           threadfence_acq_rel_system()
+            threadfence_acq_rel_system()
         else 
             assert(false)
         end
-    end
-
     else
         if order == Seq_Cst() ||
            order == Consume() ||
@@ -110,7 +104,7 @@ function atomic_thread_fence(order, scope::System=System())
            order == Acq_Rel() ||
            order == Release()
 
-           threadfence_system()
+            threadfence_system()
         else
             assert(false)
         end

--- a/src/device/intrinsics/atomics.jl
+++ b/src/device/intrinsics/atomics.jl
@@ -235,6 +235,17 @@ function atomic_store!(ptr::LLVMPtr{T}, val::T, order, scope::System=System()) w
     end
 end
 
+# TODO: These have assembly representations
+# - compare_exchange
+# - exchange
+# - fetch_add/fetch_sub
+# - fetch_and
+# - fetch_max
+# - fetch_min
+# - fetch_xor
+
+# TODO: "Derived" implementations for `sizeof(T) <= 2`
+
 # TODO:
 # - scoped atomics: _system and _block versions (see CUDA programming guide, sm_60+)
 #   https://github.com/Microsoft/clang/blob/86d4513d3e0daa4d5a29b0b1de7c854ca15f9fe5/test/CodeGen/builtins-nvptx.c#L293


### PR DESCRIPTION
As noticed in EnzymeAD/Enzyme.jl#511 CUDA C++ support a wider selection of memory orders
and emits different assembly for SM_70 and above: https://godbolt.org/z/Y7Pj5G7sK

For now I just added the memory fences necessary to implement the rest. 

@tkf @maleadt over the long-term I would be in favor of moving to Atomix.jl instead of `CUDA.@atomic`
is there any shared infrastructure we can use? As you see I am defining scope and order here again.


