### PR TITLE
[CUSPARSE] Fix conversions between CuSparseMatrixCOO and CuSparseMatrixCSC

### DIFF
--- a/lib/cusparse/conversions.jl
+++ b/lib/cusparse/conversions.jl
@@ -692,9 +692,19 @@ function CuSparseMatrixBSR(A::CuMatrix, blockDim::Integer=gcd(size(A)...); ind::
 end
 
 function CUDA.CuMatrix{T}(coo::CuSparseMatrixCOO{T}; ind::SparseChar='O') where {T}
-    sparsetodense(coo, ind)
+    if version() >= v"11.3"
+        sparsetodense(coo, ind)
+    else
+        csr = CuSparseMatrixCSR(coo, ind)
+        CuMatrix{T}(csr, ind=ind)
+    end
 end
 
 function CuSparseMatrixCOO(A::CuMatrix; ind::SparseChar='O')
-    densetosparse(A, :coo, ind)
+    if version() >= v"11.3"
+        densetosparse(A, :coo, ind)
+    else
+        csr = CuSparseMatrixCSR(A, ind=ind)
+        CuSparseMatrixCOO(csr, ind)
+    end
 end

--- a/lib/cusparse/conversions.jl
+++ b/lib/cusparse/conversions.jl
@@ -38,7 +38,8 @@ function SparseArrays.sparse(I::CuVector{Cint}, J::CuVector{Cint}, V::CuVector{T
     elseif fmt == :csr
         return CuSparseMatrixCSR(coo)
     elseif fmt == :coo
-        return coo
+        # The COO format is assumed to be sorted by row.
+        return sort_coo(coo, 'R')
     else
         error("Format :$fmt not available, use :csc, :csr, or :coo.")
     end

--- a/test/cusparse/conversions.jl
+++ b/test/cusparse/conversions.jl
@@ -1,5 +1,7 @@
 using LinearAlgebra
-using CUDA.CUSPARSE, SparseArrays
+using Adapt
+using CUDA.CUSPARSE
+using SparseArrays
 using CUDA
 
 @testset "sparse" begin
@@ -19,17 +21,17 @@ using CUDA
                       (:csr, CuSparseMatrixCSR),
                       (:bsr, CuSparseMatrixBSR)
                      ]
-        if fmt != :bsr # bsr not supported
-            x = sparse(I, J, V; fmt=fmt)
-            @test x isa T{Float32}
-            @test size(x) == (3, 4)
+        @testset "sparse $T" begin
+            if fmt != :bsr # bsr not supported
+                x = sparse(I, J, V; fmt=fmt)
+                @test x isa T{Float32}
+                @test size(x) == (3, 4)
 
-            x = sparse(I, J, V, m, n; fmt=fmt)
-            @test x isa T{Float32}
-            @test  size(x) == (4, 4)
-        end
+                x = sparse(I, J, V, m, n; fmt=fmt)
+                @test x isa T{Float32}
+                @test  size(x) == (4, 4)
+            end
 
-        if fmt != :coo # dense to COO not implemented
             x = sparse(dense; fmt=fmt)
             @test x isa T{Float32}
             @test collect(x) == collect(dense)
@@ -41,12 +43,13 @@ end
     I = [1, 1, 2, 3, 3, 4, 5, 4, 6, 4, 5, 6, 6, 6]
     J = [4, 6, 4, 5, 6, 6, 6, 1, 1, 2, 3, 3, 4, 5]
 
-    # ensure we cover both the CUSPARSE-based and native COO row sort
     for typ in (Float16, Float32)
         V = rand(typ, length(I))
         A = sparse(I, J, V, 6, 6)
-        Agpu = sparse(I |> cu, J |> cu, V |> cu, 6, 6)
-        @test Array(Agpu) == A
+        for format ∈ (:coo, :csr, :csc)
+            Agpu = sparse(I |> cu, J |> cu, V |> cu, 6, 6, fmt=format)
+            @test Array(Agpu) == A
+        end
     end
 end
 
@@ -68,5 +71,75 @@ end
             dC = CUSPARSE.prune(dA, threshold, 'O')
             @test droptol!(A, threshold) ≈ collect(dC)
         end
+    end
+end
+
+@testset "conversions" begin
+    A = sprand(100, 100, 0.02)
+    blockdim = 5
+    for CuSparseMatrixType1 in (CuSparseMatrixCSC, CuSparseMatrixCSR, CuSparseMatrixCOO, CuSparseMatrixBSR)
+        if CuSparseMatrixType1 == CuSparseMatrixBSR
+            dA1 = CuSparseMatrixType1(A, blockdim)
+        else
+            dA1 = CuSparseMatrixType1(A)
+        end
+        @testset "conversion SparseMatrixCSC -- $CuSparseMatrixType1" begin
+            @test collect(dA1) ≈ A
+        end
+        for CuSparseMatrixType2 in (CuSparseMatrixCSC, CuSparseMatrixCSR, CuSparseMatrixCOO, CuSparseMatrixBSR)
+            CuSparseMatrixType1 == CuSparseMatrixType2 && continue
+            @testset "conversion $CuSparseMatrixType1 -- $CuSparseMatrixType2" begin
+                if CuSparseMatrixType2 == CuSparseMatrixBSR
+                    dA2 = CuSparseMatrixType2(dA1, blockdim)
+                else
+                    dA2 = CuSparseMatrixType2(dA1)
+                end
+                @test collect(dA1) ≈ collect(dA2)
+            end
+        end
+    end
+end
+
+@testset "sort CuSparseMatrix" begin
+    #     [5 7 0]
+    # A = [8 0 6]
+    #     [0 4 9]
+    @testset "sort_coo" begin
+        rows = [3, 1, 2, 3, 2, 1] |> cu
+        cols = [3, 2, 1, 2, 3, 1] |> cu
+        vals = [9, 7, 8, 4, 6, 5] |> cu
+        coo = CuSparseMatrixCOO(rows, cols, vals, (3,3))
+
+        sorted_coo_R = sort_coo(coo, 'R')
+        @test collect(sorted_coo_R.rowInd) ≈ [1, 1, 2, 2, 3, 3]
+        @test collect(sorted_coo_R.colInd) ≈ [1, 2, 1, 3, 2, 3]
+        @test collect(sorted_coo_R.nzVal)  ≈ [5, 7, 8, 6, 4, 9]
+
+        sorted_coo_C = sort_coo(coo, 'C')
+        @test collect(sorted_coo_C.rowInd) ≈ [1, 2, 1, 3, 2, 3]
+        @test collect(sorted_coo_C.colInd) ≈ [1, 1, 2, 2, 3, 3]
+        @test collect(sorted_coo_C.nzVal)  ≈ [5, 8, 7, 4, 6, 9]
+    end
+    @testset "sort_csc" begin
+        rows = [2, 1, 3, 1, 2, 3] |> cu
+        ccols = [1, 3, 5, 7] |> cu
+        vals = [8, 5, 4, 7, 6, 9] |> cu
+        csc = CuSparseMatrixCSC(ccols, rows, vals, (3,3))
+
+        sorted_csc = sort_csc(csc)
+        @test collect(sorted_csc.colPtr) ≈ [1, 3, 5, 7]
+        @test collect(sorted_csc.rowVal) ≈ [1, 2, 1, 3, 2, 3]
+        @test collect(sorted_csc.nzVal)  ≈ [5, 8, 7, 4, 6, 9]
+    end
+    @testset "sort_csr" begin
+        crows = [1, 3, 5, 7] |> cu
+        cols = [2, 1, 1, 2, 3, 2] |> cu
+        vals = [7, 5, 8, 6, 9, 4] |> cu
+        csr = CuSparseMatrixCSR(crows, cols, vals, (3,3))
+
+        sorted_csr = sort_csr(csr)
+        @test collect(sorted_csr.rowPtr) ≈ [1, 3, 5, 7]
+        @test collect(sorted_csr.colVal) ≈ [1, 2, 1, 2, 2, 3]
+        @test collect(sorted_csr.nzVal)  ≈ [5, 7, 8, 6, 4, 9]
     end
 end

--- a/test/cusparse/conversions.jl
+++ b/test/cusparse/conversions.jl
@@ -32,11 +32,9 @@ using CUDA
                 @test  size(x) == (4, 4)
             end
 
-            if fmt != :coo || CUSPARSE.version() >= v"11.3"
-                x = sparse(dense; fmt=fmt)
-                @test x isa T{Float32}
-                @test collect(x) == collect(dense)
-            end
+            x = sparse(dense; fmt=fmt)
+            @test x isa T{Float32}
+            @test collect(x) == collect(dense)
         end
     end
 end
@@ -49,9 +47,8 @@ end
         V = rand(typ, length(I))
         A = sparse(I, J, V, 6, 6)
         for format ∈ (:coo, :csr, :csc)
-            format == :coo && CUSPARSE.version() < v"11.3" && continue
             Agpu = sparse(I |> cu, J |> cu, V |> cu, 6, 6, fmt=format)
-            @test collect(Agpu) == A
+            @test Array(Agpu) == A
         end
     end
 end
@@ -77,29 +74,27 @@ end
     end
 end
 
-if CUSPARSE.version() >= v"11.3"
-    @testset "conversions" begin
-        A = sprand(100, 100, 0.02)
-        blockdim = 5
-        for CuSparseMatrixType1 in (CuSparseMatrixCSC, CuSparseMatrixCSR, CuSparseMatrixCOO, CuSparseMatrixBSR)
-            if CuSparseMatrixType1 == CuSparseMatrixBSR
-                dA1 = CuSparseMatrixType1(A, blockdim)
-            else
-                dA1 = CuSparseMatrixType1(A)
-            end
-            @testset "conversion SparseMatrixCSC -- $CuSparseMatrixType1" begin
-                @test collect(dA1) ≈ A
-            end
-            for CuSparseMatrixType2 in (CuSparseMatrixCSC, CuSparseMatrixCSR, CuSparseMatrixCOO, CuSparseMatrixBSR)
-                CuSparseMatrixType1 == CuSparseMatrixType2 && continue
-                @testset "conversion $CuSparseMatrixType1 -- $CuSparseMatrixType2" begin
-                    if CuSparseMatrixType2 == CuSparseMatrixBSR
-                        dA2 = CuSparseMatrixType2(dA1, blockdim)
-                    else
-                        dA2 = CuSparseMatrixType2(dA1)
-                    end
-                    @test collect(dA1) ≈ collect(dA2)
+@testset "conversions between CuSparseMatrices" begin
+    A = sprand(100, 100, 0.02)
+    blockdim = 5
+    for CuSparseMatrixType1 in (CuSparseMatrixCSC, CuSparseMatrixCSR, CuSparseMatrixCOO, CuSparseMatrixBSR)
+        if CuSparseMatrixType1 == CuSparseMatrixBSR
+            dA1 = CuSparseMatrixType1(A, blockdim)
+        else
+            dA1 = CuSparseMatrixType1(A)
+        end
+        @testset "conversion SparseMatrixCSC --> $CuSparseMatrixType1" begin
+            @test collect(dA1) ≈ A
+        end
+        for CuSparseMatrixType2 in (CuSparseMatrixCSC, CuSparseMatrixCSR, CuSparseMatrixCOO, CuSparseMatrixBSR)
+            CuSparseMatrixType1 == CuSparseMatrixType2 && continue
+            @testset "conversion $CuSparseMatrixType1 --> $CuSparseMatrixType2" begin
+                if CuSparseMatrixType2 == CuSparseMatrixBSR
+                    dA2 = CuSparseMatrixType2(dA1, blockdim)
+                else
+                    dA2 = CuSparseMatrixType2(dA1)
                 end
+                @test collect(dA1) ≈ collect(dA2)
             end
         end
     end


### PR DESCRIPTION
- Fix CuSparseMatrixCOO(csc);
- Add BSR <-> CSC conversions;
- Add tests for conversions between sparse matrices;
- Test sort routines added in # 1637  (`sort_csc`, `sort_csr` and `sort_coo`).