### PR TITLE
Preserve buffer type when adapting to CuArray.

### DIFF
--- a/src/array.jl
+++ b/src/array.jl
@@ -567,9 +567,13 @@ end
 Adapt.adapt_storage(::Type{CuArray}, xs::AT) where {AT<:AbstractArray} =
   isbitstype(AT) ? xs : convert(CuArray, xs)
 
-# if an element type is specified, convert to it
+# if specific type parameters are specified, preserve those
 Adapt.adapt_storage(::Type{<:CuArray{T}}, xs::AT) where {T, AT<:AbstractArray} =
   isbitstype(AT) ? xs : convert(CuArray{T}, xs)
+Adapt.adapt_storage(::Type{<:CuArray{T, N}}, xs::AT) where {T, N, AT<:AbstractArray} =
+  isbitstype(AT) ? xs : convert(CuArray{T,N}, xs)
+Adapt.adapt_storage(::Type{<:CuArray{T, N, B}}, xs::AT) where {T, N, B, AT<:AbstractArray} =
+  isbitstype(AT) ? xs : convert(CuArray{T,N,B}, xs)
 
 
 ## opinionated gpu array adaptor

--- a/test/array.jl
+++ b/test/array.jl
@@ -14,12 +14,12 @@ import Adapt
   @test CuArray{Int, 2}(xs) === xs
 
   # test aggressive conversion to Float32, but only for floats, and only with `cu`
-  @test cu([1]) isa AbstractArray{Int}
-  @test cu(Float64[1]) isa AbstractArray{Float32}
-  @test cu(ComplexF64[1+1im]) isa AbstractArray{ComplexF32}
-  @test Adapt.adapt(CuArray, Float64[1]) isa AbstractArray{Float64}
-  @test Adapt.adapt(CuArray, ComplexF64[1]) isa AbstractArray{ComplexF64}
-  @test Adapt.adapt(CuArray{Float16}, Float64[1]) isa AbstractArray{Float16}
+  @test cu([1]) isa CuArray{Int}
+  @test cu(Float64[1]) isa CuArray{Float32}
+  @test cu(ComplexF64[1+1im]) isa CuArray{ComplexF32}
+  @test Adapt.adapt(CuArray, Float64[1]) isa CuArray{Float64}
+  @test Adapt.adapt(CuArray, ComplexF64[1]) isa CuArray{ComplexF64}
+  @test Adapt.adapt(CuArray{Float16}, Float64[1]) isa CuArray{Float16}
 
   @test_throws ArgumentError Base.unsafe_convert(Ptr{Int}, xs)
   @test_throws ArgumentError Base.unsafe_convert(Ptr{Float32}, xs)
@@ -94,6 +94,10 @@ end
   @test Adapt.adapt(Array, dA) == A
   @test Adapt.adapt(CuArray, A) isa CuArray
   @test Array(Adapt.adapt(CuArray, A)) == A
+
+  @test Adapt.adapt(CuArray{Float64}, A) isa CuArray{Float64}
+  @test Adapt.adapt(CuArray{Float64,2}, A) isa CuArray{Float64,2}
+  @test Adapt.adapt(CuArray{Float64,2, Mem.UnifiedBuffer}, A) isa CuArray{Float64,2, Mem.UnifiedBuffer}
 end
 
 @testset "view" begin


### PR DESCRIPTION
```julia
julia> adapt(CuArray{Float32,1,Mem.UnifiedBuffer}, [1])
1-element CuArray{Float32, 1, CUDA.Mem.UnifiedBuffer}:
 1.0
```

cc @Jutho 