### PR TITLE
Extend conversion of QRPackedQ object to CuArray

### DIFF
--- a/lib/cusolver/linalg.jl
+++ b/lib/cusolver/linalg.jl
@@ -114,6 +114,7 @@ CuArray{T}(Q::AbstractQ) where {T} = CuMatrix{T}(Q)
 CuMatrix(Q::AbstractQ{T}) where {T} = CuMatrix{T}(Q)
 CuMatrix{T}(Q::QRPackedQ{S}) where {T,S} =
     CuMatrix{T}(lmul!(Q, CuMatrix{S}(I, size(Q, 1), min(size(Q.factors)...))))
+CuMatrix{T, B}(Q::QRPackedQ{S}) where {T, B, S} = CuMatrix{T}(Q)
 CuMatrix{T}(Q::QRCompactWYQ) where {T} = error("QRCompactWY format is not supported")
 # avoid the CPU array in the above mul!
 Matrix{T}(Q::QRPackedQ{S,<:CuArray,<:CuArray}) where {T,S} = Array(CuMatrix{T}(Q))

--- a/lib/cusolver/linalg.jl
+++ b/lib/cusolver/linalg.jl
@@ -162,7 +162,8 @@ CuQRPackedQ(factors::AbstractMatrix{T}, τ::CuVector{T}) where {T} =
 # AbstractQ's `size` is the size of the full matrix,
 # while `Matrix(Q)` only gives the compact Q.
 # See JuliaLang/julia#26591 and JuliaGPU/CUDA.jl#969.
-CuMatrix{T}(Q::AbstractQ{S}) where {T,S} = convert(CuArray, Matrix{T}(Q))
+CuMatrix{T}(Q::AbstractQ{S}) where {T,S} = convert(CuArray{T}, Matrix(Q))
+CuMatrix{T, B}(Q::AbstractQ{S}) where {T, B, S} = CuMatrix{T}(Q)
 CuMatrix(Q::AbstractQ{T}) where {T} = CuMatrix{T}(Q)
 CuArray{T}(Q::AbstractQ) where {T} = CuMatrix{T}(Q)
 CuArray(Q::AbstractQ) = CuMatrix(Q)

--- a/test/cusolver/dense.jl
+++ b/test/cusolver/dense.jl
@@ -421,6 +421,7 @@ k = 1
         @test Array(h_q) ≈ Array(q)
         @test collect(CuArray(h_q)) ≈ Array(q)
         @test Array(h_r) ≈ Array(r)
+        @test CuArray(h_q) ≈ convert(typeof(d_A), h_q)
         A              = rand(elty, n, m)
         d_A            = CuArray(A)
         h_q, h_r       = qr(d_A) # FixMe! Use iteration protocol when implemented

--- a/test/cusolver/dense.jl
+++ b/test/cusolver/dense.jl
@@ -421,7 +421,9 @@ k = 1
         @test Array(h_q) ≈ Array(q)
         @test collect(CuArray(h_q)) ≈ Array(q)
         @test Array(h_r) ≈ Array(r)
-        @test CuArray(h_q) ≈ convert(typeof(d_A), h_q)
+        if VERSION >= v"1.8-"
+            @test CuArray(h_q) ≈ convert(typeof(d_A), h_q)
+        end
         A              = rand(elty, n, m)
         d_A            = CuArray(A)
         h_q, h_r       = qr(d_A) # FixMe! Use iteration protocol when implemented

--- a/test/cusolver/dense.jl
+++ b/test/cusolver/dense.jl
@@ -421,9 +421,7 @@ k = 1
         @test Array(h_q) ≈ Array(q)
         @test collect(CuArray(h_q)) ≈ Array(q)
         @test Array(h_r) ≈ Array(r)
-        if VERSION >= v"1.8-"
-            @test CuArray(h_q) ≈ convert(typeof(d_A), h_q)
-        end
+        @test CuArray(h_q) ≈ convert(typeof(d_A), h_q)
         A              = rand(elty, n, m)
         d_A            = CuArray(A)
         h_q, h_r       = qr(d_A) # FixMe! Use iteration protocol when implemented


### PR DESCRIPTION
Hi!
While working with the qr decomposition, I ran into some strange behaviour.
```
julia> A = rand(10,4);
julia> Q = qr(A).Q;
julia> convert(typeof(A), Q)
10×4 Matrix{Float64}:
 -0.166542    -0.326957     0.261138   -0.348459
 -0.00210216  -0.684159    -0.284112    0.312029
 -0.43897     -0.00298528  -0.0528599   0.340616
 -0.361066     0.176113    -0.366158   -0.0536265
 -0.418086     0.163061     0.393701   -0.0271839
 -0.209439    -0.552428     0.122154   -0.00112986
 -0.448487    -0.0430719    0.402708    0.0745772
 -0.0727113   -0.179783    -0.343167   -0.546533
 -0.310461     0.0545133   -0.21268    -0.518731
 -0.357382     0.158385    -0.468113    0.297048
```
Using `convert(typeof(A), Q)` when A is a CPU Array works fine: instead of getting the entire matrix (here, a 10 by 10 matrix) we get the reduced matrix, which is the interesting part (here a 10 by 4 matrix).

However,
```
julia> A = CUDA.rand(10,4);
julia> Q = qr(A).Q;
julia> convert(typeof(A), Q)
10×10 CuArray{Float32, 2, CUDA.Mem.DeviceBuffer}:
 -0.356086    0.181286     0.235457   0.0572469  0.0  0.0  0.0  0.0  0.0  0.0
 -0.391762   -0.280434     0.132725   0.111423   0.0  0.0  0.0  0.0  0.0  0.0
 -0.105766    0.484414    -0.410957  -0.0605049  0.0  0.0  0.0  0.0  0.0  0.0
 -0.350789   -0.297095     0.141403  -0.436914   0.0  0.0  0.0  0.0  0.0  0.0
 -0.373371    0.154585     0.583984  -0.0370565  0.0  0.0  0.0  0.0  0.0  0.0
 -0.402874   -0.155923    -0.398878   0.291257   0.0  0.0  0.0  0.0  0.0  0.0
 -0.395279   -0.00280553  -0.277097  -0.137762   0.0  0.0  0.0  0.0  0.0  0.0
 -0.0386753   0.684874     0.209676  -0.0835096  0.0  0.0  0.0  0.0  0.0  0.0
 -0.207833    0.131158    -0.325856  -0.575457   0.0  0.0  0.0  0.0  0.0  0.0
 -0.287814    0.176348    -0.104851   0.588597   0.0  0.0  0.0  0.0  0.0  0.0
```
This actually doesn't return the reduced matrix, but the whole matrix. This is because `size(Q) != size(Matrix(Q))` (see https://github.com/JuliaLang/LinearAlgebra.jl/issues/513). Therefore, when doing the conversion (which is happening [here](https://github.com/JuliaGPU/CUDA.jl/blob/00624597dbb1e0719cdb3992be75a39cbe612e38/src/array.jl#L333-L337)), we first build a CuArray which is too big for the result, hence the additional zeros.
A number of functions doing this conversion exist, but I think one is missing: in the example above, `typeof(A)` is `CuArray{Float32, 2, CUDA.Mem.DeviceBuffer}` but no conversion function exists for when the three parametric types are given (hence the default fallback).

This PR aims to fix this by adding the specialized function `CuMatrix{T, B}(Q::QRPackedQ)`.