### PR TITLE
[CUSPARSE] Add CuSparseMatrixCSC * CuSparseMatrixCSC

### DIFF
--- a/lib/cusparse/generic.jl
+++ b/lib/cusparse/generic.jl
@@ -373,7 +373,7 @@ function gemm!(transa::SparseChar, transb::SparseChar, alpha::Number, A::CuSpars
     Cᵀ = CuSparseMatrixCSR(C.colPtr, C.rowVal, C.nzVal, reverse(size(C)))
     gemm!(transb, transa, alpha, Bᵀ, Aᵀ, beta, Cᵀ, index, algo)
     # If BᵀAᵀ and Cᵀ have the same sparsity pattern, C is already updated after the gemm! call.
-    # If BᵀAᵀ and Cᵀ doesn't the same sparsity pattern, Cᵀ was reallocated and C must be updated.
+    # If BᵀAᵀ and Cᵀ don't have the same sparsity pattern, Cᵀ is reallocated and C must be updated.
     C = CuSparseMatrixCSC(Cᵀ.rowPtr, Cᵀ.colVal, Cᵀ.nzVal, size(C))
     return C
 end

--- a/lib/cusparse/interfaces.jl
+++ b/lib/cusparse/interfaces.jl
@@ -110,6 +110,12 @@ for (taga, untaga) in tag_wrappers, (wrapa, transa, unwrapa) in op_wrappers
     end
 end
 
+for SparseMatrixType in (:CuSparseMatrixCSC, :CuSparseMatrixCSR)
+    @eval begin
+        Base.:(*)(A::$SparseMatrixType{T}, B::$SparseMatrixType{T}) where {T <: BlasFloat} = gemm('N', 'N', one(T), A, B, 'O')
+    end
+end
+
 for op in (:(+), :(-))
     @eval begin
         Base.$op(A::CuSparseVector{T}, B::CuSparseVector{T}) where {T <: BlasFloat} = axpby(one(T), A, $(op)(one(T)), B, 'O')

--- a/lib/cusparse/interfaces.jl
+++ b/lib/cusparse/interfaces.jl
@@ -112,7 +112,10 @@ end
 
 for SparseMatrixType in (:CuSparseMatrixCSC, :CuSparseMatrixCSR)
     @eval begin
-        Base.:(*)(A::$SparseMatrixType{T}, B::$SparseMatrixType{T}) where {T <: BlasFloat} = gemm('N', 'N', one(T), A, B, 'O')
+        function Base.:(*)(A::$SparseMatrixType{T}, B::$SparseMatrixType{T}) where {T <: BlasFloat}
+            CUSPARSE.version() < v"11.1.1" && throw(ErrorException("This operation is not supported by the current CUDA version."))
+            gemm('N', 'N', one(T), A, B, 'O')
+        end
     end
 end
 

--- a/test/cusparse/generic.jl
+++ b/test/cusparse/generic.jl
@@ -308,9 +308,12 @@ end # CUSPARSE.version >= 11.3.0
 
 if CUSPARSE.version() >= v"11.1.1"
 
-    SPGEMM_ALGOS = Dict(CuSparseMatrixCSR => [CUSPARSE.CUSPARSE_SPGEMM_DEFAULT])
+    SPGEMM_ALGOS = Dict(CuSparseMatrixCSR => [CUSPARSE.CUSPARSE_SPGEMM_DEFAULT],
+                        CuSparseMatrixCSC => [CUSPARSE.CUSPARSE_SPGEMM_DEFAULT])
     if CUSPARSE.version() >= v"11.6.0"
         push!(SPGEMM_ALGOS[CuSparseMatrixCSR], CUSPARSE.CUSPARSE_SPGEMM_CSR_ALG_DETERMINITIC,
+                                               CUSPARSE.CUSPARSE_SPGEMM_CSR_ALG_NONDETERMINITIC)
+        push!(SPGEMM_ALGOS[CuSparseMatrixCSC], CUSPARSE.CUSPARSE_SPGEMM_CSR_ALG_DETERMINITIC,
                                                CUSPARSE.CUSPARSE_SPGEMM_CSR_ALG_NONDETERMINITIC)
     end
 

--- a/test/cusparse/interfaces.jl
+++ b/test/cusparse/interfaces.jl
@@ -52,20 +52,22 @@ using LinearAlgebra, SparseArrays
         end
     end
 
-    for SparseMatrixType in (CuSparseMatrixCSC, CuSparseMatrixCSR)
-        @testset "$SparseMatrixType -- A * B $elty" for elty in [Float32, Float64, ComplexF32, ComplexF64]
-            n = 10
-            k = 15
-            m = 20
-            A = sprand(elty, m, k, 0.2)
-            B = sprand(elty, k, n, 0.5)
+    if CUSPARSE.version() >= v"11.1.1"
+        for SparseMatrixType in (CuSparseMatrixCSC, CuSparseMatrixCSR)
+            @testset "$SparseMatrixType -- A * B $elty" for elty in [Float32, Float64, ComplexF32, ComplexF64]
+                n = 10
+                k = 15
+                m = 20
+                A = sprand(elty, m, k, 0.2)
+                B = sprand(elty, k, n, 0.5)
 
-            dA = SparseMatrixType(A)
-            dB = SparseMatrixType(B)
+                dA = SparseMatrixType(A)
+                dB = SparseMatrixType(B)
 
-            C = A * B
-            dC = dA * dB
-            @test C ≈ collect(dC)
+                C = A * B
+                dC = dA * dB
+                @test C ≈ collect(dC)
+            end
         end
     end
 

--- a/test/cusparse/interfaces.jl
+++ b/test/cusparse/interfaces.jl
@@ -52,6 +52,23 @@ using LinearAlgebra, SparseArrays
         end
     end
 
+    for SparseMatrixType in (CuSparseMatrixCSC, CuSparseMatrixCSR)
+        @testset "$SparseMatrixType -- A * B $elty" for elty in [Float32, Float64, ComplexF32, ComplexF64]
+            n = 10
+            k = 15
+            m = 20
+            A = sprand(elty, m, k, 0.2)
+            B = sprand(elty, k, n, 0.5)
+
+            dA = SparseMatrixType(A)
+            dB = SparseMatrixType(B)
+
+            C = A * B
+            dC = dA * dB
+            @test C ≈ collect(dC)
+        end
+    end
+
     @testset "$f(A)±$h(B) $elty" for elty in [Float32, Float64, ComplexF32, ComplexF64],
                                      f in (identity, transpose), #adjoint),
                                      h in (identity, transpose)#, adjoint)

--- a/test/cusparse/interfaces.jl
+++ b/test/cusparse/interfaces.jl
@@ -52,6 +52,7 @@ using LinearAlgebra, SparseArrays
         end
     end
 
+    # SpGEMM was added in CUSPARSE v"11.1.1"
     if CUSPARSE.version() >= v"11.1.1"
         for SparseMatrixType in (CuSparseMatrixCSC, CuSparseMatrixCSR)
             @testset "$SparseMatrixType -- A * B $elty" for elty in [Float32, Float64, ComplexF32, ComplexF64]


### PR DESCRIPTION
I found today that we could use the relation `C = AB <---> Cᵀ = BᵀAᵀ` to support sparse CSC * sparse CSC products.