### PR TITLE
Fix eigen when using Hermitian or Symmetric matrices

### DIFF
--- a/lib/cusolver/linalg.jl
+++ b/lib/cusolver/linalg.jl
@@ -72,13 +72,17 @@ end
 # eigenvalues
 
 function LinearAlgebra.eigen(A::Symmetric{T,<:CuMatrix}) where {T<:BlasReal}
-    A2 = copy(A)
+    A2 = copy(A.data)
     Eigen(syevd!('V', 'U', A2)...)
 end
-function LinearAlgebra.eigen(A::Hermitian{T,<:CuMatrix}) where {T<:BlasFloat}
-    A2 = copy(A)
+function LinearAlgebra.eigen(A::Hermitian{T,<:CuMatrix}) where {T<:BlasComplex}
+    A2 = copy(A.data)
     Eigen(heevd!('V', 'U', A2)...)
 end
+function LinearAlgebra.eigen(A::Hermitian{T,<:CuMatrix}) where {T<:BlasReal}
+    eigen(Symmetric(A))
+end
+
 function LinearAlgebra.eigen(A::CuMatrix{T}) where {T<:BlasReal}
     A2 = copy(A)
     issymmetric(A) ? Eigen(syevd!('V', 'U', A2)...) : error("GPU eigensolver supports only Hermitian or Symmetric matrices.")

--- a/test/cusolver/dense.jl
+++ b/test/cusolver/dense.jl
@@ -222,6 +222,23 @@ k = 1
         end
         h_W            = collect(d_W)
         @test Eig.values ≈ h_W
+
+        A              = rand(elty,m,m)
+        A             += A'
+        d_A            = CuArray(A)
+        Eig            = eigen(LinearAlgebra.Hermitian(A))
+        d_eig          = eigen(LinearAlgebra.Hermitian(d_A))
+        @test Eig.values ≈ collect(d_eig.values)
+        h_V            = collect(d_eig.vectors)
+        @test abs.(Eig.vectors'*h_V) ≈ I
+        if elty <: Real
+            Eig            = eigen(LinearAlgebra.Symmetric(A))
+            d_eig          = eigen(LinearAlgebra.Symmetric(d_A))
+            @test Eig.values ≈ collect(d_eig.values)
+            h_V            = collect(d_eig.vectors)
+            @test abs.(Eig.vectors'*h_V) ≈ I
+        end
+
     end
 
     @testset "sygvd!" begin


### PR DESCRIPTION
Hi!
I tried to use the implementation of `eigen` from #1603 but ran into some issues.
First, trying to use `eigen` with a `Hermitian` or `Symmetrix` matrix fails with the following error:
`MethodError: no method matching syevd!(::Char, ::Char, ::Symmetric{Float32, CuArray{Float32, 2, CUDA.Mem.DeviceBuffer}}).`
This is because calling `copy(A)` if `A` is `Hermitian` or `Symmetric` will also copy the wrapper around it, resulting in the creation of a new `Hermitian` or `Symmetric` array and not a plain array.
Second, those wrappers don't actually check if the given matrix really is hermitian/symmetric, so that running the following code will not bug:
```
julia> A = rand(10,10); # A is a matrix of Float64, and probably not symmetric
julia> B = Hermitian(A);
```
However, CUDA's `heevd` and `syevd` routines are specialised (for complex and real numbers respectively), so we can't simply call `heevd` if we are dealing with a `Hermitian` matrix, and `syevd` if we are dealing with `Symmetric` matrices.

This PR aims to fix this by copying the array hidden behind those structures, and by creating a fallback if `eigen` has to deal with a real matrix wrapped in `Hermitian`. 

I also added a few tests.