### PR TITLE
adding defaults for accumulate(op, a) with modified code from Base.accumulate

### DIFF
--- a/test/array.jl
+++ b/test/array.jl
@@ -326,6 +326,7 @@ end
                         (3,4,5) => 2,
                         (1, 70, 50, 20) => 3)
     @test testf(x->accumulate(+, x; dims=dims), rand(Int, sizes))
+    @test testf(x->accumulate(+, x), rand(Int, sizes))
   end
 
   # using initializer
@@ -333,6 +334,7 @@ end
                         (3,4,5) => 2,
                         (1, 70, 50, 20) => 3)
     @test testf((x,y)->accumulate(+, x; dims=dims, init=y), rand(Int, sizes), rand(Int))
+    @test testf((x,y)->accumulate(+, x; init=y), rand(Int, sizes), rand(Int))
   end
 
   # in place


### PR DESCRIPTION
This (in principle) fixes #1680 

Note that I wasn't able to get something simple like `accumulate(op, a::AnyCuArray) = accumulate(op, a; dims = length(a.dims))`, so I ended up just porting the function from base with `return collect(Iterators.accumulate(op, A; kw...))` replaced with `reshape(accumulate(op, A[:]; kw...), size(A))`.

There might be a more elegant approach, but I think this works fine.