### PR TITLE
Add right division operator for Diagonal matrices

### DIFF
--- a/Manifest.toml
+++ b/Manifest.toml
@@ -93,7 +93,9 @@ version = "0.1.8"
 
 [[GPUArrays]]
 deps = ["Adapt", "GPUArraysCore", "LLVM", "LinearAlgebra", "Printf", "Random", "Reexport", "Serialization", "Statistics"]
-git-tree-sha1 = "45d7deaf05cbb44116ba785d147c518ab46352d7"
+git-tree-sha1 = "b16faf84c4e513a7b7b61884cd27f771349e9923"
+repo-rev = "a3bcdba"
+repo-url = "https://github.com/JuliaGPU/GPUArrays.jl.git"
 uuid = "0c68f7d7-f131-5f86-a1c3-88cf8149b2d7"
 version = "8.5.0"
 

--- a/test/cublas.jl
+++ b/test/cublas.jl
@@ -1019,6 +1019,18 @@ end
             end
         end
 
+        @testset "Diagonal rdiv!" begin
+            A = rand(elty, m,m)
+            B = Diagonal(rand(elty, m))
+
+            dA = CuArray(A)
+            dB = CuArray(B)
+
+            C = A / B
+            rdiv!(dA, dB)
+            @test C ≈ Array(dA)
+        end
+
         @testset "triangular-dense mul!" begin
             A = triu(rand(elty, m, m))
             B = rand(elty,m,n)


### PR DESCRIPTION
This PR aims to implement the right division operator for `Diagonal` matrices. I noticed there are quite a few things in LinearAlgebra which are hardcoded to iterate through the diagonal of those matrices (such as [`rdiv!`](https://github.com/JuliaLang/julia/blob/ee54dd528ea12ff0007c3cd85fff3483449ff45e/stdlib/LinearAlgebra/src/diagonal.jl#L411-L428)), and so using them with CuArrays will raise a scalar indexing warning (and is quite bad for performance).

I also added a conversion which I think makes sense, but is still open for debate: I think converting a `Diagonal` matrix living on the CPU should also yield a `Diagonal` matrix on the GPU (and not a plain array), and vice versa. This convention also fixes a problem which we currently have, which is that converting a GPU `Diagonal` matrix to a CPU Array raises the scalar indexing warning (which will turn into an error if scalar indexing is not allowed): this is because the conversion is done simply by [iterating through the array underneath the `Diagonal` matrix](https://github.com/JuliaLang/julia/blob/ee54dd528ea12ff0007c3cd85fff3483449ff45e/stdlib/LinearAlgebra/src/diagonal.jl#L107-L114) which in our case lives on the device, and copying one by one its elements to the matrix living on the host.

I also added some tests.