### PR TITLE
Re-introduce memory limits.

### DIFF
--- a/docs/src/usage/memory.md
+++ b/docs/src/usage/memory.md
@@ -119,6 +119,25 @@ Memory pool usage: 0 bytes (0 bytes reserved)
     importing CUDA.jl.
 
 
+### Memory limits
+
+If you're sharing a GPU with other users or applications, you might want to limit how much
+memory is used. By default, CUDA.jl will configure the memory pool to use all available
+device memory. You can change this using two environment variables:
+
+* `JULIA_CUDA_SOFT_MEMORY_LIMIT`: This is an advisory limit, used to configure the memory
+  pool. If you set this to a nonzero value, the memory pool will attempt to release cached
+  memory until memory use falls below this limit. Note that this only happens at specific
+  synchronization points, so memory use may temporarily exceed this limit. In addition,
+  this limit is incompatible with `JULIA_CUDA_MEMORY_POOL=none`.
+* `JULIA_CUDA_HARD_MEMORY_LIMIT`: This is a hard limit, checked before every allocation.
+  This incurs a certain cost, so it is recommended to first try to use the soft limit.
+
+The value of these variables can be formatted as a numer of bytes, optionally followed by
+a unit, or as a percentage of the total device memory. Examples: `100M`, `50%`, `1.5GiB`,
+`10000`.
+
+
 ### Avoiding GC pressure
 
 When your application performs a lot of memory operations, the time spent during GC might

--- a/src/pool.jl
+++ b/src/pool.jl
@@ -34,6 +34,8 @@ AllocStats(b::AllocStats, a::AllocStats) =
 
 function actual_alloc(bytes::Integer; async::Bool=false,
                       stream::Union{CuStream,Nothing}=nothing)
+  memory_limit_exceeded(bytes) && return nothing
+
   # try the actual allocation
   buf = try
     Mem.alloc(Mem.Device, bytes; async, stream)
@@ -51,6 +53,77 @@ function actual_free(buf::Mem.DeviceBuffer;
   Mem.free(buf; stream)
 
   return
+end
+
+
+## memory limits
+
+# to enforce a hard memory limit, we need to keep track of the amount currently allocated.
+const memory_use = Threads.Atomic{Int}(0)
+
+# parse a memory limit, e.g. "1.5GiB" or "50%, to the number of bytes
+function parse_limit(str::AbstractString)
+    if endswith(str, "%")
+        str = str[1:end-1]
+        return round(UInt, parse(Float64, str) / 100 * total_memory())
+    end
+
+    si_units = [("k", "kB", "K", "KB"), ("M", "MB"), ("G", "GB")]
+    for (i, units) in enumerate(si_units), unit in units
+        if endswith(str, unit)
+            multiplier = 1000^i
+            str = str[1:end-length(unit)]
+            return round(UInt, parse(Float64, str) * multiplier)
+        end
+    end
+
+    iec_units = ["KiB", "MiB", "GiB"]
+    for (i, unit) in enumerate(iec_units)
+        if endswith(str, unit)
+            multiplier = 1024^i
+            str = str[1:end-length(unit)]
+            return round(UInt, parse(Float64, str) * multiplier)
+        end
+    end
+
+    return parse(UInt, str)
+end
+
+function memory_limits()
+  @memoize begin
+    soft = if haskey(ENV, "JULIA_CUDA_SOFT_MEMORY_LIMIT")
+      parse_limit(ENV["JULIA_CUDA_SOFT_MEMORY_LIMIT"])
+    else
+      UInt(0)
+    end
+
+    hard = if haskey(ENV, "JULIA_CUDA_HARD_MEMORY_LIMIT")
+      parse_limit(ENV["JULIA_CUDA_HARD_MEMORY_LIMIT"])
+    else
+      UInt(0)
+    end
+
+    (; soft, hard)
+  end::NamedTuple{(:soft, :hard), Tuple{UInt,UInt}}
+end
+
+function memory_limit_exceeded(bytes::Integer)
+  limit = memory_limits()
+  limit.hard > 0 || return false
+
+  dev = device()
+  used_bytes = if stream_ordered(dev) && driver_version() >= v"11.3"
+    # XXX: this should be done by the allocator itself (NVIDIA bug #3503815).
+    pool = memory_pool(dev)
+    Int(attribute(UInt64, pool, MEMPOOL_ATTR_RESERVED_MEM_CURRENT))
+  else
+    # NOTE: cannot use `Mem.info()`, because it only reports total & free memory, not used.
+    #       computing `total - free` would include memory allocated by other processes.
+    #       NVML does report used memory, but is slow, and not available on all platforms.
+    memory_use[]
+  end
+
+  return used_bytes + bytes > limit.hard
 end
 
 
@@ -75,7 +148,9 @@ function pool_mark(dev::CuDevice)
   status = pool_status(dev)
   if status[] === nothing
       # allow the pool to use up all memory of this device
-      attribute!(memory_pool(dev), MEMPOOL_ATTR_RELEASE_THRESHOLD, typemax(UInt64))
+      limits = memory_limits()
+      attribute!(memory_pool(dev), MEMPOOL_ATTR_RELEASE_THRESHOLD,
+                 limits.soft == 0 ? typemax(UInt64) : limits.soft)
 
       # launch a task to periodically trim the pool
       if isinteractive() && !isassigned(__pool_cleanup)
@@ -181,6 +256,21 @@ function memory_status(io::IO=stdout, info::MemoryInfo=MemoryInfo())
                 Base.format_bytes(info.pool_used_bytes),
                 Base.format_bytes(info.pool_reserved_bytes))
 
+  end
+
+  limits = memory_limits()
+  if limits.soft > 0 || limits.hard > 0
+    print(io, "Memory limit: ")
+    if limits.soft > 0
+      print(io, "soft = $(Base.format_bytes(limits.soft))")
+    end
+    if limits.hard > 0
+      if limits.soft > 0
+        print(io, ", ")
+      end
+      print(io, "hard = $(Base.format_bytes(limits.hard))")
+    end
+    println(io)
   end
 end
 
@@ -288,6 +378,7 @@ an [`OutOfGPUMemoryError`](@ref) if the allocation request cannot be satisfied.
   # (and using Base.@timed/gc_num to exclude that time is too expensive)
   buf, time = _alloc(B, sz; stream)
 
+  memory_use[] += sz
   alloc_stats.alloc_count += 1
   alloc_stats.alloc_bytes += sz
   alloc_stats.total_time += time
@@ -329,7 +420,8 @@ Releases a buffer `buf` to the memory pool.
   # XXX: have @timeit use the root timer, since we may be called from a finalizer
 
   # 0-byte allocations shouldn't hit the pool
-  sizeof(buf) == 0 && return
+  sz = sizeof(buf)
+  sz == 0 && return
 
   # this function is typically called from a finalizer, where we can't switch tasks,
   # so perform our own error handling.
@@ -338,8 +430,9 @@ Releases a buffer `buf` to the memory pool.
       _free(buf; stream)
     end
 
+    memory_use[] -= sz
     alloc_stats.free_count += 1
-    alloc_stats.free_bytes += sizeof(buf)
+    alloc_stats.free_bytes += sz
     alloc_stats.total_time += time
   catch ex
     Base.showerror_nostdio(ex, "WARNING: Error while freeing $buf")


### PR DESCRIPTION
This PR introduces two environment variables that replace the old JULIA_CUDA_MEMORY_LIMIT: JULIA_CUDA_SOFT_MEMORY_LIMIT, and a HARD limit. The former is used to configure the pool, which should be sufficient for most users (assuming there's enough synchronization points in the application). The latter is checked before every allocation, which may be costly. Future improvements to the NVIDIA driver should make the hard limit cheaper.

Closes https://github.com/JuliaGPU/CUDA.jl/issues/1670.