### PR TITLE
Specialize cholcopy to avoid scalar indexing.

### DIFF
--- a/lib/cusolver/linalg.jl
+++ b/lib/cusolver/linalg.jl
@@ -400,4 +400,7 @@ if VERSION >= v"1.8-"
         C, info = LinearAlgebra._chol!(copy(parent(A)), A.uplo == 'U' ? UpperTriangular : LowerTriangular)
         return Cholesky(C.data, A.uplo, info)
     end
+
+    LinearAlgebra.cholcopy(A::LinearAlgebra.RealHermSymComplexHerm{<:Any,<:CuArray}) =
+        copyto!(similar(A, LinearAlgebra.choltype(A)), A)
 end


### PR DESCRIPTION
Helps on 1.9, doesn't hurt on 1.8.