### PR TITLE
Fix handling of inline-allocated structures with unions.

### DIFF
--- a/src/device/array.jl
+++ b/src/device/array.jl
@@ -69,20 +69,20 @@ Base.unsafe_convert(::Type{LLVMPtr{T,A}}, x::CuDeviceArray{T,<:Any,A}) where {T,
 #       (cfr. shared memory and its wider-than-datatype alignment)
 
 @generated function alignment(::CuDeviceArray{T}) where {T}
-    if isbitstype(T)
-        Base.datatype_alignment(T)
-    else # isbitsunion etc
+    if Base.isbitsunion(T)
         _, sz, al = Base.uniontype_layout(T)
         al
+    else
+        Base.datatype_alignment(T)
     end
 end
 
 @device_function @inline function arrayref(A::CuDeviceArray{T}, index::Integer) where {T}
     @boundscheck checkbounds(A, index)
-    if isbitstype(T)
-        arrayref_bits(A, index)
-    else # isbitsunion etc
+    if Base.isbitsunion(T)
         arrayref_union(A, index)
+    else
+        arrayref_bits(A, index)
     end
 end
 
@@ -121,10 +121,10 @@ end
 
 @device_function @inline function arrayset(A::CuDeviceArray{T}, x::T, index::Integer) where {T}
     @boundscheck checkbounds(A, index)
-    if isbitstype(T)
-        arrayset_bits(A, x, index)
-    else # isbitsunion etc
+    if Base.isbitsunion(T)
         arrayset_union(A, x, index)
+    else
+        arrayset_bits(A, x, index)
     end
     return A
 end


### PR DESCRIPTION
These aren't isbits, but also do not require a selector array. Instead, Julia handles the selector bit automatically:

```julia
julia> struct Bar
       x::Union{Int8,UInt8}
       end

julia> a = [Bar(Int8(1)), Bar(UInt8(2)), Bar(Int8(3))]
3-element Vector{Bar}:
 Bar(1)
 Bar(0x02)
 Bar(3)

julia> hexdump(pointer(a), 6)
00000000  01 00 02 01 03 00                                 │ ...... │
00000006
julia> unsafe_load(pointer(a,1))
Bar(1)

julia> unsafe_load(pointer(a,2))
Bar(0x02)

julia> unsafe_load(pointer(a,3))
Bar(3)

julia> sizeof(Bar)
2

julia> Base.allocatedinline(Bar)
true

julia> Base.isbitstype(Bar)
false
```

Encountered using an assertions build:

```
julia: /home/tim/Julia/src/julia/src/array.c:58: ijl_array_typetagdata: Assertion `jl_array_isbitsunion(a)' failed.

[4188443] signal (6.-6): Aborted
in expression starting at /home/tim/Julia/pkg/CUDA/wip.jl:9
unknown function (ip: 0x7f47b461e64c)
gsignal at /usr/lib/libc.so.6 (unknown line)
abort at /usr/lib/libc.so.6 (unknown line)
unknown function (ip: 0x7f47b45b845b)
__assert_fail at /usr/lib/libc.so.6 (unknown line)
ijl_array_typetagdata at /home/tim/Julia/src/julia/src/array.c:58 [inlined]
ijl_array_typetagdata at /home/tim/Julia/src/julia/src/array.c:56
typetagdata at /home/tim/Julia/pkg/CUDA/wip.jl:1 [inlined]
typetagdata at /home/tim/Julia/pkg/CUDA/wip.jl:1
```