### PR TITLE
Allow `copy(::RNG)`

### DIFF
--- a/src/random.jl
+++ b/src/random.jl
@@ -23,11 +23,14 @@ mutable struct RNG <: AbstractRNG
     function RNG(seed::Integer)
         new(seed%UInt32, 0)
     end
+    RNG(seed::UInt32, counter::UInt32) = new(seed, counter)
 end
 
 make_seed() = Base.rand(RandomDevice(), UInt32)
 
 RNG() = RNG(make_seed())
+
+Base.copy(rng::RNG) = RNG(rng.seed, rng.counter)
 
 function Random.seed!(rng::RNG, seed::Integer)
     rng.seed = seed % UInt32

--- a/src/random.jl
+++ b/src/random.jl
@@ -31,6 +31,7 @@ make_seed() = Base.rand(RandomDevice(), UInt32)
 RNG() = RNG(make_seed())
 
 Base.copy(rng::RNG) = RNG(rng.seed, rng.counter)
+Base.:(==)(r::RNG, s::RNG) = (r.seed == s.seed) && (r.counter == s.counter)
 
 function Random.seed!(rng::RNG, seed::Integer)
     rng.seed = seed % UInt32

--- a/src/random.jl
+++ b/src/random.jl
@@ -31,7 +31,8 @@ make_seed() = Base.rand(RandomDevice(), UInt32)
 RNG() = RNG(make_seed())
 
 Base.copy(rng::RNG) = RNG(rng.seed, rng.counter)
-Base.:(==)(r::RNG, s::RNG) = (r.seed == s.seed) && (r.counter == s.counter)
+Base.hash(rng::RNG, h::UInt) = hash(rng.seed, hash(rng.counter, h))
+Base.:(==)(a::RNG, b::RNG) = (a.seed == b.seed) && (a.counter == b.counter)
 
 function Random.seed!(rng::RNG, seed::Integer)
     rng.seed = seed % UInt32


### PR DESCRIPTION
The purpose of this is to allow generating the same sequence of random numbers twice:
```
julia> let r1 = copy(CUDA.default_rng()), r2 = copy(CUDA.default_rng())
               x1 = rand(r1, 10^6)
               x2 = rand(r2, 10^6)
               x1==x2
           end
true
```
Edit: relevant links here are:

https://docs.julialang.org/en/v1.10-dev/stdlib/Random/#Hooking-into-the-Random-API 

which asks for `copy`. And perhaps also this, the only other implementation of an AbstractRNG I know of:

https://github.com/JuliaRandom/StableRNGs.jl/blob/master/src/StableRNGs.jl

