### PR TITLE
Simplify CuError rendering before library initialization (master branch version)

### DIFF
--- a/lib/cudadrv/error.jl
+++ b/lib/cudadrv/error.jl
@@ -56,11 +56,11 @@ function description(err::CuError)
 end
 
 function Base.showerror(io::IO, err::CuError)
-    try
-        print(io, "CUDA error: $(description(err)) (code $(reinterpret(Int32, err.code)), $(name(err)))")
-    catch
+    if !functional()
         # we might throw before the library is initialized
         print(io, "CUDA error (code $(reinterpret(Int32, err.code)), $(err.code))")
+    else
+        print(io, "CUDA error: $(description(err)) (code $(reinterpret(Int32, err.code)), $(name(err)))")
     end
 
     if err.meta !== nothing


### PR DESCRIPTION
Same as https://github.com/JuliaGPU/CUDA.jl/pull/1723. Although I couldn't reproduce this on master, it's good to deal with the error in the same way.