### PR TITLE
Introduce cuFFT plan cache; switch to auto-managed memory.

### DIFF
--- a/lib/cufft/fft.jl
+++ b/lib/cufft/fft.jl
@@ -24,19 +24,12 @@ abstract type CuFFTPlan{T<:cufftNumber, K, inplace} <: Plan{T} end
 # for some reason, cufftHandle is an integer and not a pointer...
 Base.convert(::Type{cufftHandle}, p::CuFFTPlan) = p.handle
 
-function CUDA.unsafe_free!(plan::CuFFTPlan, stream::CuStream=stream())
-    # verify that the caller has switched contexts
-    if plan.ctx != context()
-      error("Trying to free $plan from an unrelated context")
-    end
-
-    cufftDestroy(plan)
-    unsafe_free!(plan.workarea, stream)
-end
-
-function unsafe_finalize!(plan::CuFFTPlan)
-    context!(plan.ctx; skip_destroyed=true) do
-        unsafe_free!(plan, default_stream())
+function CUDA.unsafe_free!(plan::CuFFTPlan)
+    if plan.handle != C_NULL
+        context!(plan.ctx; skip_destroyed=true) do
+            cufftReleasePlan(plan.handle)
+        end
+        plan.handle = C_NULL
     end
 end
 
@@ -44,19 +37,18 @@ mutable struct cCuFFTPlan{T<:cufftNumber,K,inplace,N} <: CuFFTPlan{T,K,inplace}
     handle::cufftHandle
     ctx::CuContext
     stream::CuStream
-    workarea::CuVector{Int8}
     sz::NTuple{N,Int} # Julia size of input array
     osz::NTuple{N,Int} # Julia size of output array
     xtype::cufftType
     region::Any
     pinv::ScaledPlan # required by AbstractFFT API
 
-    function cCuFFTPlan{T,K,inplace,N}(handle::cufftHandle, workarea::CuVector{Int8},
-                                       X::DenseCuArray{T,N}, sizey::Tuple, region, xtype;
-                                       stream::CuStream=stream()) where {T<:cufftNumber,K,inplace,N}
-        # maybe enforce consistency of sizey
-        p = new(handle, context(), stream, workarea, size(X), sizey, xtype, region)
-        finalizer(unsafe_finalize!, p)
+    function cCuFFTPlan{T,K,inplace,N}(handle::cufftHandle, X::DenseCuArray{T,N},
+                                       sizey::Tuple, region, xtype
+                                      ) where {T<:cufftNumber,K,inplace,N}
+        # TODO: enforce consistency of sizey
+        p = new(handle, context(), stream(), size(X), sizey, xtype, region)
+        finalizer(unsafe_free!, p)
         p
     end
 end
@@ -65,19 +57,18 @@ mutable struct rCuFFTPlan{T<:cufftNumber,K,inplace,N} <: CuFFTPlan{T,K,inplace}
     handle::cufftHandle
     ctx::CuContext
     stream::CuStream
-    workarea::CuVector{Int8}
     sz::NTuple{N,Int} # Julia size of input array
     osz::NTuple{N,Int} # Julia size of output array
     xtype::cufftType
     region::Any
     pinv::ScaledPlan # required by AbstractFFT API
 
-    function rCuFFTPlan{T,K,inplace,N}(handle::cufftHandle, workarea::CuVector{Int8},
-                                       X::DenseCuArray{T,N}, sizey::Tuple, region, xtype;
-                                       stream::CuStream=stream()) where {T<:cufftNumber,K,inplace,N}
-        # maybe enforce consistency of sizey
-        p = new(handle, context(), stream, workarea, size(X), sizey, xtype, region)
-        finalizer(unsafe_finalize!, p)
+    function rCuFFTPlan{T,K,inplace,N}(handle::cufftHandle, X::DenseCuArray{T,N},
+                                       sizey::Tuple, region, xtype
+                                      ) where {T<:cufftNumber,K,inplace,N}
+        # TODO: enforce consistency of sizey
+        p = new(handle, context(), stream(), size(X), sizey, xtype, region)
+        finalizer(unsafe_free!, p)
         p
     end
 end
@@ -118,152 +109,12 @@ Base.size(p::CuFFTPlan) = p.sz
     if plan.stream != new_stream
         plan.stream = new_stream
         cufftSetStream(plan, new_stream)
-
-        # replace the workarea by one (asynchronously) allocated on the current stream
-        new_workarea = similar(plan.workarea)
-        cufftSetWorkArea(plan, new_workarea)
-        CUDA.unsafe_free!(plan.workarea)
-        plan.workarea = new_workarea
     end
     return
 end
 
 
 ## plan methods
-
-# Note: we don't implement padded storage dimensions
-function create_plan(xtype, xdims, region)
-    nrank = length(region)
-    sz = [xdims[i] for i in region]
-    csz = copy(sz)
-    csz[1] = div(sz[1],2) + 1
-    batch = prod(xdims) ÷ prod(sz)
-
-    # initialize the plan handle
-    handle_ref = Ref{cufftHandle}()
-    cufftCreate(handle_ref)
-    handle = handle_ref[]
-
-    # take control over the workarea
-    cufftSetAutoAllocation(handle, 0)
-    cufftSetStream(handle, stream())
-
-    # make the plan
-    worksize_ref = Ref{Csize_t}()
-    if (nrank == 1) && (batch == 1)
-        cufftMakePlan1d(handle, sz[1], xtype, 1, worksize_ref)
-    elseif (nrank == 2) && (batch == 1)
-        cufftMakePlan2d(handle, sz[2], sz[1], xtype, worksize_ref)
-    elseif (nrank == 3) && (batch == 1)
-        cufftMakePlan3d(handle, sz[3], sz[2], sz[1], xtype, worksize_ref)
-    else
-        rsz = (length(sz) > 1) ? rsz = reverse(sz) : sz
-        if ((region...,) == ((1:nrank)...,))
-            # handle simple case ... simply! (for robustness)
-           cufftMakePlanMany(handle, nrank, Cint[rsz...], C_NULL, 1, 1, C_NULL, 1, 1,
-                             xtype, batch, worksize_ref)
-        else
-            if nrank==1 || all(diff(collect(region)) .== 1)
-                # _stride: successive elements in innermost dimension
-                # _dist: distance between first elements of batches
-                if region[1] == 1
-                    istride = 1
-                    idist = prod(sz)
-                    cdist = prod(csz)
-                else
-                    if region[end] != length(xdims)
-                        throw(ArgumentError("batching dims must be sequential"))
-                    end
-                    istride = prod(xdims[1:region[1]-1])
-                    idist = 1
-                    cdist = 1
-                end
-                inembed = Cint[rsz...]
-                cnembed = (length(csz) > 1) ? Cint[reverse(csz)...] : Cint[csz[1]]
-                ostride = istride
-                if xtype == CUFFT_R2C || xtype == CUFFT_D2Z
-                    odist = cdist
-                    onembed = cnembed
-                else
-                    odist = idist
-                    onembed = inembed
-                end
-                if xtype == CUFFT_C2R || xtype == CUFFT_Z2D
-                    idist = cdist
-                    inembed = cnembed
-                end
-            else
-                if any(diff(collect(region)) .< 1)
-                    throw(ArgumentError("region must be an increasing sequence"))
-                end
-                cdims = collect(xdims)
-                cdims[region[1]] = div(cdims[region[1]],2)+1
-
-                if region[1] == 1
-                    istride = 1
-                    ii=1
-                    while (ii < nrank) && (region[ii] == region[ii+1]-1)
-                        ii += 1
-                    end
-                    idist = prod(xdims[1:ii])
-                    cdist = prod(cdims[1:ii])
-                    ngaps = 0
-                else
-                    istride = prod(xdims[1:region[1]-1])
-                    idist = 1
-                    cdist = 1
-                    ngaps = 1
-                end
-                nem = ones(Int,nrank)
-                cem = ones(Int,nrank)
-                id = 1
-                for ii=1:nrank-1
-                    if region[ii+1] > region[ii]+1
-                        ngaps += 1
-                    end
-                    while id < region[ii+1]
-                        nem[ii] *= xdims[id]
-                        cem[ii] *= cdims[id]
-                        id += 1
-                    end
-                    @assert nem[ii] >= sz[ii]
-                end
-                if region[end] < length(xdims)
-                    ngaps += 1
-                end
-                # CUFFT represents batches by a single stride (_dist)
-                # so we must verify that region is consistent with this:
-                if ngaps > 1
-                    throw(ArgumentError("batch regions must be sequential"))
-                end
-
-                inembed = Cint[reverse(nem)...]
-                cnembed = Cint[reverse(cem)...]
-                ostride = istride
-                if xtype == CUFFT_R2C || xtype == CUFFT_D2Z
-                    odist = cdist
-                    onembed = cnembed
-                else
-                    odist = idist
-                    onembed = inembed
-                end
-                if xtype == CUFFT_C2R || xtype == CUFFT_Z2D
-                    idist = cdist
-                    inembed = cnembed
-                end
-            end
-            cufftMakePlanMany(handle, nrank, Cint[rsz...],
-                              inembed, istride, idist, onembed, ostride, odist,
-                              xtype, batch, worksize_ref)
-        end
-    end
-
-    # assign the workarea
-    workarea = CuArray{Int8}(undef, worksize_ref[])
-    cufftSetWorkArea(handle, workarea)
-
-    handle, workarea
-end
 
 # promote to a complex floating-point type (out-of-place only),
 # so implementations only need Complex{Float} methods
@@ -288,9 +139,9 @@ function plan_fft!(X::DenseCuArray{T,N}, region) where {T<:cufftComplexes,N}
     inplace = true
     xtype = (T == cufftComplex) ? CUFFT_C2C : CUFFT_Z2Z
 
-    handle, workarea = create_plan(xtype, size(X), region)
+    handle = cufftGetPlan(xtype, size(X), region)
 
-    cCuFFTPlan{T,K,inplace,N}(handle, workarea, X, size(X), region, xtype)
+    cCuFFTPlan{T,K,inplace,N}(handle, X, size(X), region, xtype)
 end
 
 function plan_bfft!(X::DenseCuArray{T,N}, region) where {T<:cufftComplexes,N}
@@ -298,9 +149,9 @@ function plan_bfft!(X::DenseCuArray{T,N}, region) where {T<:cufftComplexes,N}
     inplace = true
     xtype =  (T == cufftComplex) ? CUFFT_C2C : CUFFT_Z2Z
 
-    handle, workarea = create_plan(xtype, size(X), region)
+    handle = cufftGetPlan(xtype, size(X), region)
 
-    cCuFFTPlan{T,K,inplace,N}(handle, workarea, X, size(X), region, xtype)
+    cCuFFTPlan{T,K,inplace,N}(handle, X, size(X), region, xtype)
 end
 
 # out-of-place complex
@@ -309,9 +160,9 @@ function plan_fft(X::DenseCuArray{T,N}, region) where {T<:cufftComplexes,N}
     xtype =  (T == cufftComplex) ? CUFFT_C2C : CUFFT_Z2Z
     inplace = false
 
-    handle, workarea = create_plan(xtype, size(X), region)
+    handle = cufftGetPlan(xtype, size(X), region)
 
-    cCuFFTPlan{T,K,inplace,N}(handle, workarea, X, size(X), region, xtype)
+    cCuFFTPlan{T,K,inplace,N}(handle, X, size(X), region, xtype)
 end
 
 function plan_bfft(X::DenseCuArray{T,N}, region) where {T<:cufftComplexes,N}
@@ -319,9 +170,9 @@ function plan_bfft(X::DenseCuArray{T,N}, region) where {T<:cufftComplexes,N}
     inplace = false
     xtype =  (T == cufftComplex) ? CUFFT_C2C : CUFFT_Z2Z
 
-    handle, workarea = create_plan(xtype, size(X), region)
+    handle = cufftGetPlan(xtype, size(X), region)
 
-    cCuFFTPlan{T,K,inplace,N}(handle, workarea, X, size(X), region, xtype)
+    cCuFFTPlan{T,K,inplace,N}(handle, X, size(X), region, xtype)
 end
 
 # out-of-place real-to-complex
@@ -330,12 +181,12 @@ function plan_rfft(X::DenseCuArray{T,N}, region) where {T<:cufftReals,N}
     inplace = false
     xtype =  (T == cufftReal) ? CUFFT_R2C : CUFFT_D2Z
 
-    handle, workarea = create_plan(xtype, size(X), region)
+    handle = cufftGetPlan(xtype, size(X), region)
 
     ydims = collect(size(X))
     ydims[region[1]] = div(ydims[region[1]],2)+1
 
-    rCuFFTPlan{T,K,inplace,N}(handle, workarea, X, (ydims...,), region, xtype)
+    rCuFFTPlan{T,K,inplace,N}(handle, X, (ydims...,), region, xtype)
 end
 
 function plan_brfft(X::DenseCuArray{T,N}, d::Integer, region::Any) where {T<:cufftComplexes,N}
@@ -345,9 +196,9 @@ function plan_brfft(X::DenseCuArray{T,N}, d::Integer, region::Any) where {T<:cuf
     ydims = collect(size(X))
     ydims[region[1]] = d
 
-    handle, workarea = create_plan(xtype, (ydims...,), region)
+    handle = cufftGetPlan(xtype, (ydims...,), region)
 
-    rCuFFTPlan{T,K,inplace,N}(handle, workarea, X, (ydims...,), region, xtype)
+    rCuFFTPlan{T,K,inplace,N}(handle, X, (ydims...,), region, xtype)
 end
 
 # FIXME: plan_inv methods allocate needlessly (to provide type parameters)
@@ -355,16 +206,16 @@ end
 
 function plan_inv(p::cCuFFTPlan{T,CUFFT_FORWARD,inplace,N}) where {T,N,inplace}
     X = CuArray{T}(undef, p.sz)
-    handle, workarea = create_plan(p.xtype, p.sz, p.region)
-    ScaledPlan(cCuFFTPlan{T,CUFFT_INVERSE,inplace,N}(handle, workarea, X, p.sz, p.region,
+    handle = cufftGetPlan(p.xtype, p.sz, p.region)
+    ScaledPlan(cCuFFTPlan{T,CUFFT_INVERSE,inplace,N}(handle, X, p.sz, p.region,
                                                      p.xtype),
                normalization(X, p.region))
 end
 
 function plan_inv(p::cCuFFTPlan{T,CUFFT_INVERSE,inplace,N}) where {T,N,inplace}
     X = CuArray{T}(undef, p.sz)
-    handle, workarea = create_plan(p.xtype, p.sz, p.region)
-    ScaledPlan(cCuFFTPlan{T,CUFFT_FORWARD,inplace,N}(handle, workarea, X, p.sz, p.region,
+    handle = cufftGetPlan(p.xtype, p.sz, p.region)
+    ScaledPlan(cCuFFTPlan{T,CUFFT_FORWARD,inplace,N}(handle, X, p.sz, p.region,
                                                      p.xtype),
                normalization(X, p.region))
 end
@@ -374,8 +225,8 @@ function plan_inv(p::rCuFFTPlan{T,CUFFT_INVERSE,inplace,N}
     X = CuArray{real(T)}(undef, p.osz)
     Y = CuArray{T}(undef, p.sz)
     xtype = p.xtype == CUFFT_C2R ? CUFFT_R2C : CUFFT_D2Z
-    handle, workarea = create_plan(xtype, p.osz, p.region)
-    ScaledPlan(rCuFFTPlan{real(T),CUFFT_FORWARD,inplace,N}(handle, workarea, X, p.sz, p.region, xtype),
+    handle = cufftGetPlan(xtype, p.osz, p.region)
+    ScaledPlan(rCuFFTPlan{real(T),CUFFT_FORWARD,inplace,N}(handle, X, p.sz, p.region, xtype),
                normalization(X, p.region))
 end
 
@@ -384,8 +235,8 @@ function plan_inv(p::rCuFFTPlan{T,CUFFT_FORWARD,inplace,N}
     X = CuArray{complex(T)}(undef, p.osz)
     Y = CuArray{T}(undef, p.sz)
     xtype = p.xtype == CUFFT_R2C ? CUFFT_C2R : CUFFT_Z2D
-    handle, workarea = create_plan(xtype, p.sz, p.region)
-    ScaledPlan(rCuFFTPlan{complex(T),CUFFT_INVERSE,inplace,N}(handle, workarea, X, p.sz,
+    handle = cufftGetPlan(xtype, p.sz, p.region)
+    ScaledPlan(rCuFFTPlan{complex(T),CUFFT_INVERSE,inplace,N}(handle, X, p.sz,
                                                               p.region, xtype),
                normalization(Y, p.region))
 end

--- a/lib/cufft/wrappers.jl
+++ b/lib/cufft/wrappers.jl
@@ -9,3 +9,154 @@ end
 version() = VersionNumber(cufftGetProperty(CUDA.MAJOR_VERSION),
                           cufftGetProperty(CUDA.MINOR_VERSION),
                           cufftGetProperty(CUDA.PATCH_LEVEL))
+
+function cufftMakePlan(xtype::cufftType_t, xdims::Dims, region)
+    nrank = length(region)
+    sz = [xdims[i] for i in region]
+    csz = copy(sz)
+    csz[1] = div(sz[1],2) + 1
+    batch = prod(xdims) ÷ prod(sz)
+
+    # initialize the plan handle
+    handle_ref = Ref{cufftHandle}()
+    cufftCreate(handle_ref)
+    handle = handle_ref[]
+
+    # make the plan
+    worksize_ref = Ref{Csize_t}()
+    if (nrank == 1) && (batch == 1)
+        cufftMakePlan1d(handle, sz[1], xtype, 1, worksize_ref)
+    elseif (nrank == 2) && (batch == 1)
+        cufftMakePlan2d(handle, sz[2], sz[1], xtype, worksize_ref)
+    elseif (nrank == 3) && (batch == 1)
+        cufftMakePlan3d(handle, sz[3], sz[2], sz[1], xtype, worksize_ref)
+    else
+        rsz = (length(sz) > 1) ? rsz = reverse(sz) : sz
+        if ((region...,) == ((1:nrank)...,))
+            # handle simple case ... simply! (for robustness)
+           cufftMakePlanMany(handle, nrank, Cint[rsz...], C_NULL, 1, 1, C_NULL, 1, 1,
+                             xtype, batch, worksize_ref)
+        else
+            if nrank==1 || all(diff(collect(region)) .== 1)
+                # _stride: successive elements in innermost dimension
+                # _dist: distance between first elements of batches
+                if region[1] == 1
+                    istride = 1
+                    idist = prod(sz)
+                    cdist = prod(csz)
+                else
+                    if region[end] != length(xdims)
+                        throw(ArgumentError("batching dims must be sequential"))
+                    end
+                    istride = prod(xdims[1:region[1]-1])
+                    idist = 1
+                    cdist = 1
+                end
+                inembed = Cint[rsz...]
+                cnembed = (length(csz) > 1) ? Cint[reverse(csz)...] : Cint[csz[1]]
+                ostride = istride
+                if xtype == CUFFT_R2C || xtype == CUFFT_D2Z
+                    odist = cdist
+                    onembed = cnembed
+                else
+                    odist = idist
+                    onembed = inembed
+                end
+                if xtype == CUFFT_C2R || xtype == CUFFT_Z2D
+                    idist = cdist
+                    inembed = cnembed
+                end
+            else
+                if any(diff(collect(region)) .< 1)
+                    throw(ArgumentError("region must be an increasing sequence"))
+                end
+                cdims = collect(xdims)
+                cdims[region[1]] = div(cdims[region[1]],2)+1
+
+                if region[1] == 1
+                    istride = 1
+                    ii=1
+                    while (ii < nrank) && (region[ii] == region[ii+1]-1)
+                        ii += 1
+                    end
+                    idist = prod(xdims[1:ii])
+                    cdist = prod(cdims[1:ii])
+                    ngaps = 0
+                else
+                    istride = prod(xdims[1:region[1]-1])
+                    idist = 1
+                    cdist = 1
+                    ngaps = 1
+                end
+                nem = ones(Int,nrank)
+                cem = ones(Int,nrank)
+                id = 1
+                for ii=1:nrank-1
+                    if region[ii+1] > region[ii]+1
+                        ngaps += 1
+                    end
+                    while id < region[ii+1]
+                        nem[ii] *= xdims[id]
+                        cem[ii] *= cdims[id]
+                        id += 1
+                    end
+                    @assert nem[ii] >= sz[ii]
+                end
+                if region[end] < length(xdims)
+                    ngaps += 1
+                end
+                # CUFFT represents batches by a single stride (_dist)
+                # so we must verify that region is consistent with this:
+                if ngaps > 1
+                    throw(ArgumentError("batch regions must be sequential"))
+                end
+
+                inembed = Cint[reverse(nem)...]
+                cnembed = Cint[reverse(cem)...]
+                ostride = istride
+                if xtype == CUFFT_R2C || xtype == CUFFT_D2Z
+                    odist = cdist
+                    onembed = cnembed
+                else
+                    odist = idist
+                    onembed = inembed
+                end
+                if xtype == CUFFT_C2R || xtype == CUFFT_Z2D
+                    idist = cdist
+                    inembed = cnembed
+                end
+            end
+            cufftMakePlanMany(handle, nrank, Cint[rsz...],
+                              inembed, istride, idist, onembed, ostride, odist,
+                              xtype, batch, worksize_ref)
+        end
+    end
+
+    handle, worksize_ref[]
+end
+
+# plan cache
+const cufftHandleCacheKey = Tuple{CuContext, cufftType_t, Dims, Any}
+const idle_handles = HandleCache{cufftHandleCacheKey, cufftHandle}()
+function cufftGetPlan(args...)
+    ctx = context()
+    handle = pop!(idle_handles, (ctx, args...)) do
+        # make the plan
+        handle, worksize = cufftMakePlan(args...)
+
+        # NOTE: we currently do not use the worksize to allocate our own workarea,
+        #       instead relying on the automatic allocation strategy.
+        handle
+    end
+
+    # assign to the current stream
+    cufftSetStream(handle, stream())
+
+    return handle
+end
+function cufftReleasePlan(plan)
+    push!(idle_handles, plan) do
+        cufftDestroy(plan)
+    end
+
+end


### PR DESCRIPTION
This PR introduces a cache for CUFFT handles, much like how cupy recently did.

Before:

```
julia> @benchmark fft($A)
BenchmarkTools.Trial: 1166 samples with 1 evaluation.
 Range (min … max):  2.479 ms … 281.481 ms  ┊ GC (min … max): 0.00% … 0.00%
 Time  (median):     3.999 ms               ┊ GC (median):    0.00%
 Time  (mean ± σ):   4.274 ms ±   8.145 ms  ┊ GC (mean ± σ):  0.00% ± 0.00%

                    ▃ ▁  ▁ ▂▄█▇▃▃▅▂▄▃▃ ▁ ▁▂▃▂▅ ▁  ▁
  ▃▁▁▁▂▁▂▃▁▃▄▃▆▇▇████▇██▆███████████████▇███████▇██▇▇▇▄▅▄▃▃▃▃ ▅
  2.48 ms         Histogram: frequency by time        5.26 ms <

 Memory estimate: 2.81 KiB, allocs estimate: 64.
```

After:

```
julia> @benchmark fft($A)
BenchmarkTools.Trial: 10000 samples with 1 evaluation.
 Range (min … max):   84.129 μs … 805.442 μs  ┊ GC (min … max):  0.00% … 91.37%
 Time  (median):     275.457 μs               ┊ GC (median):    87.83%
 Time  (mean ± σ):   276.244 μs ±   9.010 μs  ┊ GC (mean ± σ):  87.78% ±  0.98%

                                                           █▂
  ▂▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▂██▄▂ ▂
  84.1 μs          Histogram: frequency by time          286 μs <
```

Reference:

```
❯ python wip.py
fft_func            :    CPU:   94.263 us   +/-16.328 (min:   68.750 / max:  421.615) us     GPU-0:  110.159 us   +/-31.509 (min:   42.400 / max: 2295.744) us
```

Closes https://github.com/JuliaGPU/CUDA.jl/issues/1682.