### PR TITLE
Warn when using old devices

### DIFF
--- a/src/compiler/reflection.jl
+++ b/src/compiler/reflection.jl
@@ -59,6 +59,13 @@ function code_sass(io::IO, job::CUDACompilerJob; verbose::Bool=false)
         error("Can only generate SASS code for kernel functions")
     end
 
+    # NVIDIA bug #3964667: CUPTI in CUDA 11.7+ broken for sm_35 devices
+    if runtime_version() >= v"11.7" && capability(device()) <= v"3.7"
+        @error """SASS code generation is not supported on this device.
+                  Please downgrade to CUDA 11.6 or lower, or use a more recent device."""
+        return
+    end
+
     compiled = cufunction_compile(job)
 
     cubin = Ref{Any}()

--- a/test/codegen.jl
+++ b/test/codegen.jl
@@ -167,8 +167,10 @@ end
     valid_kernel() = return
     invalid_kernel() = 1
 
-    @not_if_sanitize @test CUDA.code_sass(devnull, valid_kernel, Tuple{}) == nothing
-    @not_if_sanitize @test_throws CUDA.KernelError CUDA.code_sass(devnull, invalid_kernel, Tuple{})
+    if can_use_cupti()
+        @test CUDA.code_sass(devnull, valid_kernel, Tuple{}) == nothing
+        @test_throws CUDA.KernelError CUDA.code_sass(devnull, invalid_kernel, Tuple{})
+    end
 end
 
 @testset "function name mangling" begin
@@ -176,13 +178,17 @@ end
 
     @eval kernel_341(ptr) = (@inbounds unsafe_store!(ptr, $(Symbol("dummy_^"))(unsafe_load(ptr))); nothing)
 
-    @not_if_sanitize CUDA.code_sass(devnull, kernel_341, Tuple{Ptr{Int}})
+    if can_use_cupti()
+        CUDA.code_sass(devnull, kernel_341, Tuple{Ptr{Int}})
+    end
 end
 
 @testset "device runtime" begin
     kernel() = (CUDA.cudaGetLastError(); return)
 
-    @not_if_sanitize CUDA.code_sass(devnull, kernel, Tuple{})
+    if can_use_cupti()
+        CUDA.code_sass(devnull, kernel, Tuple{})
+    end
 end
 
 end

--- a/test/setup.jl
+++ b/test/setup.jl
@@ -244,17 +244,6 @@ function julia_exec(args::Cmd, env...)
     proc, read(out, String), read(err, String)
 end
 
-# tests that are conditionall broken
-macro test_broken_if(cond, ex...)
-    quote
-        if $(esc(cond))
-            @test_broken $(map(esc, ex)...)
-        else
-            @test $(map(esc, ex)...)
-        end
-    end
-end
-
 # some tests are mysteriously broken with certain hardware/software.
 # use a horrible macro to mark those tests as "potentially broken"
 @eval Test begin

--- a/test/setup.jl
+++ b/test/setup.jl
@@ -21,6 +21,13 @@ macro not_if_sanitize(ex)
     end
 end
 
+# in addition, CUPTI is not available on older GPUs with recent CUDA toolkits
+function can_use_cupti()
+    sanitize && return false
+    # NVIDIA bug #3964667: CUPTI in CUDA 11.7+ broken for sm_35 devices
+    capability(device()) > v"3.7" || CUDA.runtime_version() < v"11.7"
+end
+
 # precompile the runtime library
 CUDA.precompile_runtime()
 


### PR DESCRIPTION
Fixes https://github.com/JuliaGPU/CUDA.jl/issues/1751 (well, works around it by presenting a nicer error and disabling tests).

I've filed an issue with NVIDIA about https://github.com/JuliaGPU/CUDA.jl/issues/1751, but it's unlikely that it will get fixed.