### PR TITLE
Use `adapt` symmetrically in `CuIterator`

### DIFF
--- a/src/array.jl
+++ b/src/array.jl
@@ -649,6 +649,15 @@ julia> CuArray(1:3)
 
 Base.getindex(::typeof(cu), xs...) = CuArray([xs...])
 
+## unsafe_free!
+# This allows adapt(unsafe_free!, obj) to go whereever adapt(CuArray, obj) went,
+# so that for example CuIterator can free arrays within Adjoint.
+
+function Adapt.adapt_storage(::typeof(unsafe_free!), x::CuArray)
+  unsafe_free!(x)
+  return x
+end
+
 
 ## utilities
 

--- a/src/array.jl
+++ b/src/array.jl
@@ -649,15 +649,6 @@ julia> CuArray(1:3)
 
 Base.getindex(::typeof(cu), xs...) = CuArray([xs...])
 
-## unsafe_free!
-# This allows adapt(unsafe_free!, obj) to go whereever adapt(CuArray, obj) went,
-# so that for example CuIterator can free arrays within Adjoint.
-
-function Adapt.adapt_storage(::typeof(unsafe_free!), x::CuArray)
-  unsafe_free!(x)
-  return x
-end
-
 
 ## utilities
 

--- a/src/iterator.jl
+++ b/src/iterator.jl
@@ -5,8 +5,10 @@ export CuIterator
 
 Return a `CuIterator` that can iterate through the provided `batches` via `Base.iterate`.
 
-Upon each iteration, the current `batch` is adapted to the GPU (via `map(x -> adapt(CuArray, x), batch)`)
+Upon each iteration, the current `batch` is copied to the GPU,
 and the previous iteration is marked as freeable from GPU memory (via `unsafe_free!`).
+Both of these use `adapt`, so that each `batch` can be an array, an array of arrays,
+or a more complex object such as a nested set of NamedTuples, which is explored recursively.
 
 This abstraction is useful for batching data into GPU memory in a manner that
 allows old iterations to potentially be freed (or marked as reusable) earlier

--- a/src/iterator.jl
+++ b/src/iterator.jl
@@ -20,10 +20,10 @@ end
 
 function Base.iterate(c::CuIterator, state...)
     item = iterate(c.batches, state...)
-    isdefined(c, :previous) && foreach(unsafe_free!, c.previous)
+    isdefined(c, :previous) && adapt(unsafe_free!, c.previous)
     item === nothing && return nothing
     batch, next_state = item
-    cubatch = map(x -> adapt(CuArray, x), batch)
+    cubatch = adapt(CuArray, batch)
     c.previous = cubatch
     return cubatch, next_state
 end

--- a/test/iterator.jl
+++ b/test/iterator.jl
@@ -37,5 +37,6 @@ batch2, _ = iterate(it_nt, state)
 it_vec = CuIterator([[i,i/2], [i/3, i/4]] for i in 1:4)
 @test first(it_vec)[1] isa CuArray{Float64}
 
+using StaticArrays: SVector, SA
 it_static = CuIterator([SA[i,i/2], SA[i/3, i/4]] for i in 1:4)
 @test first(it_static) isa CuArray{<:SVector}

--- a/test/iterator.jl
+++ b/test/iterator.jl
@@ -25,3 +25,17 @@ end
 @test eltype(cubatches) == eltype(batch for batch in batches) == Any
 @test Base.IteratorEltype(typeof(CuIterator(batches))) isa Base.HasEltype
 @test eltype(CuIterator(batches)) == eltype(batches)  # Vector
+
+it_nt = CuIterator((x=Float32[i,i/2], y=i) for i in 1:4)
+@test first(it_nt).x isa CuArray{Float32}
+batch1, state = iterate(it_nt)
+@test batch1.x == cu([1,1/2])
+batch2, _ = iterate(it_nt, state)
+@test batch2.x == cu([2,2/2])
+@test batch1.x.storage === nothing  # unsafe_free! has worked inside
+
+it_vec = CuIterator([[i,i/2], [i/3, i/4]] for i in 1:4)
+@test first(it_vec)[1] isa CuArray{Float64}
+
+it_static = CuIterator([SA[i,i/2], SA[i/3, i/4]] for i in 1:4)
+@test first(it_static) isa CuArray{<:SVector}


### PR DESCRIPTION
Closes #1768

The examples there become:
```julia
julia> sumone(CuIterator((Array(x),) for x in eachcol(ones(3,4))))  # fine
summary(x) = "Tuple{CuArray{Float64, 1, CUDA.Mem.DeviceBuffer}}"
12.0

julia> sumone(CuIterator(Array(x) for x in eachcol(ones(3,4))))  # 2, no CuArrays
summary(x) = "3-element CuArray{Float64, 1, CUDA.Mem.DeviceBuffer}"
4.0

julia> sumone(CuIterator((Array(x)',) for x in eachcol(ones(3,4))))  # 3, makes but can't free
summary(x) = "Tuple{LinearAlgebra.Adjoint{Float64, CuArray{Float64, 1, CUDA.Mem.DeviceBuffer}}}"
12.0

julia> sumone(CuIterator((x,) for x in eachcol(ones(3,4))))  # 4, here adapt acts on whole array
summary(x) = "Tuple{SubArray{Float64, 1, CuArray{Float64, 2, CUDA.Mem.DeviceBuffer}, Tuple{Base.Slice{Base.OneTo{Int64}}, Int64}, true}}"
12.0

julia> sumone(CuIterator((i, Array(x)) for (i,x) in enumerate(eachcol(ones(3,4)))))  # 5, finalize?
summary(x) = "Tuple{Int64, CuArray{Float64, 1, CUDA.Mem.DeviceBuffer}}"
30.0
```
Needs tests (and doc update) hence draft. But does this seem like a good idea?