### PR TITLE
[CUSPARSE] Update preconditioners.jl

### DIFF
--- a/lib/cusparse/preconditioners.jl
+++ b/lib/cusparse/preconditioners.jl
@@ -14,8 +14,7 @@ for (bname,aname,sname,elty) in ((:cusparseScsric02_bufferSize, :cusparseScsric0
                                  (:cusparseCcsric02_bufferSize, :cusparseCcsric02_analysis, :cusparseCcsric02, :ComplexF32),
                                  (:cusparseZcsric02_bufferSize, :cusparseZcsric02_analysis, :cusparseZcsric02, :ComplexF64))
     @eval begin
-        function ic02!(A::CuSparseMatrixCSR{$elty},
-                       index::SparseChar)
+        function ic02!(A::CuSparseMatrixCSR{$elty}, index::SparseChar='O')
             desc = CuMatrixDescriptor('G', 'L', 'N', index)
             m,n = size(A)
             if m != n
@@ -55,8 +54,7 @@ for (bname,aname,sname,elty) in ((:cusparseScsric02_bufferSize, :cusparseScsric0
                                  (:cusparseCcsric02_bufferSize, :cusparseCcsric02_analysis, :cusparseCcsric02, :ComplexF32),
                                  (:cusparseZcsric02_bufferSize, :cusparseZcsric02_analysis, :cusparseZcsric02, :ComplexF64))
     @eval begin
-        function ic02!(A::CuSparseMatrixCSC{$elty},
-                       index::SparseChar)
+        function ic02!(A::CuSparseMatrixCSC{$elty}, index::SparseChar='O')
             desc = CuMatrixDescriptor('G', 'L', 'N', index)
             m,n = size(A)
             if m != n
@@ -102,8 +100,7 @@ for (bname,aname,sname,elty) in ((:cusparseScsrilu02_bufferSize, :cusparseScsril
                                  (:cusparseCcsrilu02_bufferSize, :cusparseCcsrilu02_analysis, :cusparseCcsrilu02, :ComplexF32),
                                  (:cusparseZcsrilu02_bufferSize, :cusparseZcsrilu02_analysis, :cusparseZcsrilu02, :ComplexF64))
     @eval begin
-        function ilu02!(A::CuSparseMatrixCSR{$elty},
-                        index::SparseChar)
+        function ilu02!(A::CuSparseMatrixCSR{$elty}, index::SparseChar='O')
             desc = CuMatrixDescriptor('G', 'L', 'N', index)
             m,n = size(A)
             if m != n
@@ -144,8 +141,7 @@ for (bname,aname,sname,elty) in ((:cusparseScsrilu02_bufferSize, :cusparseScsril
                                  (:cusparseCcsrilu02_bufferSize, :cusparseCcsrilu02_analysis, :cusparseCcsrilu02, :ComplexF32),
                                  (:cusparseZcsrilu02_bufferSize, :cusparseZcsrilu02_analysis, :cusparseZcsrilu02, :ComplexF64))
     @eval begin
-        function ilu02!(A::CuSparseMatrixCSC{$elty},
-                        index::SparseChar)
+        function ilu02!(A::CuSparseMatrixCSC{$elty}, index::SparseChar='O')
             desc = CuMatrixDescriptor('G', 'L', 'N', index)
             m,n = size(A)
             if m != n
@@ -186,8 +182,7 @@ for (bname,aname,sname,elty) in ((:cusparseSbsric02_bufferSize, :cusparseSbsric0
                                  (:cusparseCbsric02_bufferSize, :cusparseCbsric02_analysis, :cusparseCbsric02, :ComplexF32),
                                  (:cusparseZbsric02_bufferSize, :cusparseZbsric02_analysis, :cusparseZbsric02, :ComplexF64))
     @eval begin
-        function ic02!(A::CuSparseMatrixBSR{$elty},
-                       index::SparseChar)
+        function ic02!(A::CuSparseMatrixBSR{$elty}, index::SparseChar='O')
             desc = CuMatrixDescriptor('G', 'U', 'N', index)
             m,n = size(A)
             if m != n
@@ -229,8 +224,7 @@ for (bname,aname,sname,elty) in ((:cusparseSbsrilu02_bufferSize, :cusparseSbsril
                                  (:cusparseCbsrilu02_bufferSize, :cusparseCbsrilu02_analysis, :cusparseCbsrilu02, :ComplexF32),
                                  (:cusparseZbsrilu02_bufferSize, :cusparseZbsrilu02_analysis, :cusparseZbsrilu02, :ComplexF64))
     @eval begin
-        function ilu02!(A::CuSparseMatrixBSR{$elty},
-                        index::SparseChar)
+        function ilu02!(A::CuSparseMatrixBSR{$elty}, index::SparseChar='O')
             desc = CuMatrixDescriptor('G', 'U', 'N', index)
             m,n = size(A)
             if m != n
@@ -268,20 +262,20 @@ end
 
 for elty in (:Float32, :Float64, :ComplexF32, :ComplexF64)
     @eval begin
-        function ilu02(A::CuSparseMatrix{$elty},
-                       index::SparseChar)
+        function ilu02(A::CuSparseMatrix{$elty}, index::SparseChar='O')
+            isa(A, CuSparseMatrixCOO) && throw(ErrorException("ILU(0) decomposition of CuSparseMatrixCOO is not supported by the current CUDA version."))
             ilu02!(copy(A),index)
         end
-        function ic02(A::CuSparseMatrix{$elty},
-                      index::SparseChar)
+        function ic02(A::CuSparseMatrix{$elty}, index::SparseChar='O')
+            isa(A, CuSparseMatrixCOO) && throw(ErrorException("IC(0) decomposition of CuSparseMatrixCOO is not supported by the current CUDA version."))
             ic02!(copy(A),index)
         end
-        function ilu02(A::HermOrSym{$elty,CuSparseMatrix{$elty}},
-                       index::SparseChar)
+        function ilu02(A::HermOrSym{$elty,CuSparseMatrix{$elty}}, index::SparseChar='O')
+            isa(A, CuSparseMatrixCOO) && throw(ErrorException("ILU(0) decomposition of CuSparseMatrixCOO is not supported by the current CUDA version."))
             ilu02!(copy(A.data),index)
         end
-        function ic02(A::HermOrSym{$elty,CuSparseMatrix{$elty}},
-                      index::SparseChar)
+        function ic02(A::HermOrSym{$elty,CuSparseMatrix{$elty}}, index::SparseChar='O')
+            isa(A, CuSparseMatrixCOO) && throw(ErrorException("IC(0) decomposition of CuSparseMatrixCOO is not supported by the current CUDA version."))
             ic02!(copy(A.data),index)
         end
     end

--- a/test/cusparse.jl
+++ b/test/cusparse.jl
@@ -317,7 +317,7 @@ end
         @testset "bsric02!" begin
             d_A = CuSparseMatrixCSR(sparse(tril(A)))
             d_A = CuSparseMatrixBSR(d_A, blockdim)
-            d_A = CUSPARSE.ic02!(d_A,'O')
+            d_A = CUSPARSE.ic02!(d_A)
             h_A = SparseMatrixCSC(CuSparseMatrixCSR(d_A))
             Ac = sparse(Array(cholesky(Hermitian(A))))
             h_A = transpose(h_A) * h_A
@@ -325,13 +325,13 @@ end
             @test reduce(&, isfinite.(nonzeros(h_A)))
             d_A = CuSparseMatrixCSR(sparse(tril(rand(elty,m,n))))
             d_A = CuSparseMatrixBSR(d_A, blockdim)
-            @test_throws DimensionMismatch CUSPARSE.ic02!(d_A,'O')
+            @test_throws DimensionMismatch CUSPARSE.ic02!(d_A)
         end
 
         @testset "bsric02" begin
             d_A = CuSparseMatrixCSR(sparse(tril(A)))
             d_A = CuSparseMatrixBSR(d_A, blockdim)
-            d_B = CUSPARSE.ic02(d_A,'O')
+            d_B = CUSPARSE.ic02(d_A)
             h_A = SparseMatrixCSC(CuSparseMatrixCSR(d_B))
             Ac = sparse(Array(cholesky(Hermitian(A))))
             h_A = transpose(h_A) * h_A
@@ -349,7 +349,7 @@ end
         @testset "bsrilu02!" begin
             d_A = CuSparseMatrixCSR(sparse(A))
             d_A = CuSparseMatrixBSR(d_A, blockdim)
-            d_A = CUSPARSE.ilu02!(d_A,'O')
+            d_A = CUSPARSE.ilu02!(d_A)
             h_A = SparseMatrixCSC(CuSparseMatrixCSR(d_A))
             pivot = VERSION >= v"1.7" ? NoPivot() : Val(false)
             Alu = lu(Array(A), pivot)
@@ -359,13 +359,13 @@ end
             @test reduce(&, isfinite.(nonzeros(h_A)))
             d_A = CuSparseMatrixCSR(sparse(rand(elty,m,n)))
             d_A = CuSparseMatrixBSR(d_A, blockdim)
-            @test_throws DimensionMismatch CUSPARSE.ilu02!(d_A,'O')
+            @test_throws DimensionMismatch CUSPARSE.ilu02!(d_A)
         end
 
         @testset "bsrilu02" begin
             d_A = CuSparseMatrixCSR(sparse(A))
             d_A = CuSparseMatrixBSR(d_A, blockdim)
-            d_B = CUSPARSE.ilu02(d_A,'O')
+            d_B = CUSPARSE.ilu02(d_A)
             h_A = SparseMatrixCSC(CuSparseMatrixCSR(d_B))
             pivot = VERSION >= v"1.7" ? NoPivot() : Val(false)
             Alu = lu(Array(A),pivot)
@@ -534,7 +534,7 @@ end
             A += transpose(A)
             A += m * Diagonal{elty}(I, m)
             d_A = CuSparseMatrixCSR(sparse(A))
-            d_B = CUSPARSE.ilu02(d_A,'O')
+            d_B = CUSPARSE.ilu02(d_A)
             h_A = SparseMatrixCSC(d_B)
             pivot = VERSION >= v"1.7" ? NoPivot() : Val(false)
             Alu = lu(Array(A),pivot)
@@ -548,7 +548,7 @@ end
             A += transpose(A)
             A += m * Diagonal{elty}(I, m)
             d_A = CuSparseMatrixCSC(sparse(A))
-            d_B = CUSPARSE.ilu02(d_A,'O')
+            d_B = CUSPARSE.ilu02(d_A)
             h_A = SparseMatrixCSC(d_B)
             pivot = VERSION >= v"1.7" ? NoPivot() : Val(false)
             Alu = lu(Array(A),pivot)
@@ -567,7 +567,7 @@ end
             A  += adjoint(A)
             A  += m * Diagonal{elty}(I, m)
             d_A = CuSparseMatrixCSR(sparse(tril(A)))
-            d_B = CUSPARSE.ic02(d_A, 'O')
+            d_B = CUSPARSE.ic02(d_A)
             h_A = SparseMatrixCSC(d_B)
             Ac  = sparse(Array(cholesky(Hermitian(A))))
             h_A = transpose(h_A) * h_A
@@ -575,14 +575,14 @@ end
             @test reduce(&, isfinite.(nonzeros(h_A)))
             A   = rand(elty,m,n)
             d_A = CuSparseMatrixCSR(sparse(tril(A)))
-            @test_throws DimensionMismatch CUSPARSE.ic02(d_A, 'O')
+            @test_throws DimensionMismatch CUSPARSE.ic02(d_A)
         end
         @testset "csc" begin
             A   = rand(elty, m, m)
             A  += adjoint(A)
             A  += m * Diagonal{elty}(I, m)
             d_A = CuSparseMatrixCSC(sparse(tril(A)))
-            d_B = CUSPARSE.ic02(d_A, 'O')
+            d_B = CUSPARSE.ic02(d_A)
             h_A = SparseMatrixCSC(d_B)
             Ac  = sparse(Array(cholesky(Hermitian(A))))
             h_A = transpose(h_A) * h_A
@@ -590,7 +590,7 @@ end
             @test reduce(&, isfinite.(nonzeros(h_A)))
             A   = rand(elty,m,n)
             d_A = CuSparseMatrixCSC(sparse(tril(A)))
-            @test_throws DimensionMismatch CUSPARSE.ic02(d_A, 'O')
+            @test_throws DimensionMismatch CUSPARSE.ic02(d_A)
         end
     end
 end


### PR DESCRIPTION
- `index` is now an optional argument in `preconditioners.jl`;
- return an error if we want to perform an IC(0) or an ILU(0) decomposition with a CuSparseMatrixCOO.