### PR TITLE
Follow `Array`'s behavior when initializing

### DIFF
--- a/src/array.jl
+++ b/src/array.jl
@@ -355,9 +355,9 @@ CuArray{T}(xs::AbstractArray{S,N}) where {T,N,S} = CuArray{T,N}(xs)
 (::Type{CuArray{T,N} where T})(x::AbstractArray{S,N}) where {S,N} = CuArray{S,N}(x)
 CuArray(A::AbstractArray{T,N}) where {T,N} = CuArray{T,N}(A)
 
-# idempotency
-CuArray{T,N,B}(xs::CuArray{T,N,B}) where {T,N,B} = xs
-CuArray{T,N}(xs::CuArray{T,N,B}) where {T,N,B} = xs
+# copy xs to match Array behavior
+CuArray{T,N,B}(xs::CuArray{T,N,B}) where {T,N,B} = copy(xs)
+CuArray{T,N}(xs::CuArray{T,N,B}) where {T,N,B} = copy(xs)
 
 
 ## conversions

--- a/test/array.jl
+++ b/test/array.jl
@@ -11,7 +11,7 @@ import Adapt
   @test testf(vec, rand(5,3))
   @test cu(1:3) === 1:3
   @test Base.elsize(xs) == sizeof(Int)
-  @test CuArray{Int, 2}(xs) === xs
+  @test pointer(CuArray{Int, 2}(xs)) != pointer(xs)
 
   # test aggressive conversion to Float32, but only for floats, and only with `cu`
   @test cu([1]) isa CuArray{Int}


### PR DESCRIPTION
Initializing an `Array` with an `Array` creates a copy of the array. This change implements the same behavior for `CuArray`.