### PR TITLE
Use symbols instead of values when emitting code, when possible.

### DIFF
--- a/lib/cublas/linalg.jl
+++ b/lib/cublas/linalg.jl
@@ -182,7 +182,7 @@ function gemv_dispatch!(Y::CuVector, A, B, alpha::Number=true, beta::Number=fals
     end
 end
 
-for NT in (Number, Real)
+for NT in (:Number, :Real)
     # NOTE: alpha/beta also ::Real to avoid ambiguities with certain Base methods
     @eval begin
         LinearAlgebra.mul!(Y::CuVector, A::StridedCuMatrix, B::StridedCuVector, a::$NT, b::$NT) =
@@ -303,7 +303,7 @@ function gemm_dispatch!(C::CuVecOrMat, A, B, alpha::Number=true, beta::Number=fa
     end
 end
 
-for NT in (Number, Real)
+for NT in (:Number, :Real)
     # NOTE: alpha/beta also ::Real to avoid ambiguities with certain Base methods
     @eval begin
         LinearAlgebra.mul!(C::CuMatrix, A::StridedCuVecOrMat, B::StridedCuVecOrMat, a::$NT, b::$NT) =

--- a/lib/cudadrv/memory.jl
+++ b/lib/cudadrv/memory.jl
@@ -388,8 +388,8 @@ end
 
 ## copy operations
 
-for (fn, srcPtrTy, dstPtrTy) in (("cuMemcpyDtoHAsync_v2", CuPtr, Ptr),
-                                 ("cuMemcpyHtoDAsync_v2", Ptr,   CuPtr),
+for (fn, srcPtrTy, dstPtrTy) in (("cuMemcpyDtoHAsync_v2", :CuPtr, :Ptr),
+                                 ("cuMemcpyHtoDAsync_v2", :Ptr,   :CuPtr),
                                  )
     @eval function Base.unsafe_copyto!(dst::$dstPtrTy{T}, src::$srcPtrTy{T}, N::Integer;
                                        stream::CuStream=stream(),

--- a/lib/cusparse/array.jl
+++ b/lib/cusparse/array.jl
@@ -510,7 +510,7 @@ Base.copy(Mat::CuSparseMatrixCOO) = copyto!(similar(Mat), Mat)
 
 # input/output
 
-for (gpu, cpu) in [CuSparseVector => SparseVector]
+for (gpu, cpu) in [:CuSparseVector => :SparseVector]
     @eval function Base.show(io::IO, ::MIME"text/plain", x::$gpu)
         xnnz = length(nonzeros(x))
         print(io, length(x), "-element ", typeof(x), " with ", xnnz,
@@ -522,10 +522,10 @@ for (gpu, cpu) in [CuSparseVector => SparseVector]
     end
 end
 
-for (gpu, cpu) in [CuSparseMatrixCSC => SparseMatrixCSC,
-                   CuSparseMatrixCSR => SparseMatrixCSC,
-                   CuSparseMatrixBSR => SparseMatrixCSC,
-                   CuSparseMatrixCOO => SparseMatrixCSC]
+for (gpu, cpu) in [:CuSparseMatrixCSC => :SparseMatrixCSC,
+                   :CuSparseMatrixCSR => :SparseMatrixCSC,
+                   :CuSparseMatrixBSR => :SparseMatrixCSC,
+                   :CuSparseMatrixCOO => :SparseMatrixCSC]
     @eval Base.show(io::IOContext, x::$gpu) =
         show(io, $cpu(x))
 

--- a/lib/cusparse/conversions.jl
+++ b/lib/cusparse/conversions.jl
@@ -227,7 +227,7 @@ for SparseMatrixType in [:CuSparseMatrixCSC, :CuSparseMatrixCSR]
 end
 
 # by flipping rows and columns, we can use that to get CSC to CSR too
-for elty in (Float32, Float64, ComplexF32, ComplexF64)
+for elty in (:Float32, :Float64, :ComplexF32, :ComplexF64)
     @eval begin
         function CuSparseMatrixCSC{$elty}(csr::CuSparseMatrixCSR{$elty}; index::SparseChar='O', action::cusparseAction_t=CUSPARSE_ACTION_NUMERIC, algo::cusparseCsr2CscAlg_t=CUSPARSE_CSR2CSC_ALG1)
             m,n = size(csr)

--- a/perf/volumerhs.jl
+++ b/perf/volumerhs.jl
@@ -20,7 +20,7 @@ end
 
 # HACK: module-local versions of core arithmetic; needed to get FMA
 for (jlf, f) in zip((:+, :*, :-), (:add, :mul, :sub))
-    for (T, llvmT) in ((Float32, "float"), (Float64, "double"))
+    for (T, llvmT) in ((:Float32, "float"), (:Float64, "double"))
         ir = """
             %x = f$f contract nsz $llvmT %0, %1
             ret $llvmT %x
@@ -38,7 +38,7 @@ for (jlf, f) in zip((:+, :*, :-), (:add, :mul, :sub))
 end
 
 let (jlf, f) = (:div_arcp, :div)
-    for (T, llvmT) in ((Float32, "float"), (Float64, "double"))
+    for (T, llvmT) in ((:Float32, "float"), (:Float64, "double"))
         ir = """
             %x = f$f fast $llvmT %0, %1
             ret $llvmT %x

--- a/src/device/intrinsics/atomics.jl
+++ b/src/device/intrinsics/atomics.jl
@@ -85,7 +85,7 @@ for T in (Int32, Int64, UInt32, UInt64)
     end
 end
 
-for T in (Float32, Float64)
+for T in (:Float32, :Float64)
     ops = [:add]
 
     for op in ops
@@ -135,13 +135,13 @@ end
     end
 end
 
-for T in (Int32, Int64, UInt32, UInt64)
+for T in (:Int32, :Int64, :UInt32, :UInt64)
     @eval @inline atomic_cas!(ptr::LLVMPtr{$T}, cmp::$T, val::$T) =
         llvm_atomic_cas(ptr, cmp, val)
 end
 
 # NVPTX doesn't support cmpxchg with i16 yet
-for A in (AS.Generic, AS.Global, AS.Shared), T in (Int16, UInt16)
+for A in (AS.Generic, AS.Global, AS.Shared), T in (:Int16, :UInt16)
     if A == AS.Global
         scope = ".global"
     elseif A == AS.Shared
@@ -182,7 +182,7 @@ end
 
 # half-precision atomics using PTX instruction
 
-for A in (AS.Generic, AS.Global, AS.Shared), T in (Float16,)
+for A in (AS.Generic, AS.Global, AS.Shared), T in (:Float16,)
     if A == AS.Global
         scope = ".global"
     elseif A == AS.Shared
@@ -207,7 +207,7 @@ inttype(::Type{Float32}) = Int32
 inttype(::Type{Float64}) = Int64
 inttype(::Type{BFloat16}) = Int16
 
-for T in [Float16, Float32, Float64, BFloat16]
+for T in [:Float16, :Float32, :Float64, :BFloat16]
     @eval @inline function atomic_cas!(ptr::LLVMPtr{$T,A}, cmp::$T, new::$T) where {A}
         IT = inttype($T)
         cmp_i = reinterpret(IT, cmp)
@@ -445,13 +445,13 @@ end
     atomic_arrayset(A, Base._to_linear_index(A, Is...), op, convert(T, val))
 
 # native atomics
-for (op,impl,typ) in [(+,   atomic_add!, [UInt32,Int32,UInt64,Int64,Float32]),
-                      (-,   atomic_sub!, [UInt32,Int32,UInt64,Int64,Float32]),
-                      (&,   atomic_and!, [UInt32,Int32,UInt64,Int64]),
-                      (|,   atomic_or!,  [UInt32,Int32,UInt64,Int64]),
-                      (⊻,   atomic_xor!, [UInt32,Int32,UInt64,Int64]),
-                      (max, atomic_max!, [UInt32,Int32,UInt64,Int64]),
-                      (min, atomic_min!, [UInt32,Int32,UInt64,Int64])]
+for (op,impl,typ) in [(:(+), :(atomic_add!), [:UInt32,:Int32,:UInt64,:Int64,:Float32]),
+                      (:(-), :(atomic_sub!), [:UInt32,:Int32,:UInt64,:Int64,:Float32]),
+                      (:(&), :(atomic_and!), [:UInt32,:Int32,:UInt64,:Int64]),
+                      (:(|), :(atomic_or!),  [:UInt32,:Int32,:UInt64,:Int64]),
+                      (:(⊻), :(atomic_xor!), [:UInt32,:Int32,:UInt64,:Int64]),
+                      (:max, :(atomic_max!), [:UInt32,:Int32,:UInt64,:Int64]),
+                      (:min, :(atomic_min!), [:UInt32,:Int32,:UInt64,:Int64])]
     @eval @inline atomic_arrayset(A::AbstractArray{T}, I::Integer, ::typeof($op),
                                   val::T) where {T<:Union{$(typ...)}} =
         $impl(pointer(A, I), val)

--- a/src/device/intrinsics/wmma.jl
+++ b/src/device/intrinsics/wmma.jl
@@ -193,7 +193,7 @@ for ops in all_ldst_ops,
 
     ccall_name = "$llvm_intr"
 
-    ptr_ty = LLVMPtr{arr_ty, addr_space_int}
+    ptr_ty = :(LLVMPtr{$arr_ty, $addr_space_int})
 
     if sz == 1
         @eval $func_name(src_addr, stride) = tuple(ccall($ccall_name, llvmcall, $frag_ty, ($ptr_ty, Int32), src_addr, stride))
@@ -261,7 +261,7 @@ export llvm_wmma_store
     frag_types = ntuple(i -> frag_ty, sz)
     frag_vars = ntuple(i -> :(data[$i]), sz)
 
-    ptr_ty = LLVMPtr{arr_ty, addr_space_int}
+    ptr_ty = :(LLVMPtr{$arr_ty, $addr_space_int})
 
     @eval $func_name(dst_addr, data, stride) = ccall($ccall_name, llvmcall, Nothing, ($ptr_ty, $(frag_types...), Int32), dst_addr, $(frag_vars...), stride)
     @eval export $func_name

--- a/src/device/texture.jl
+++ b/src/device/texture.jl
@@ -56,11 +56,11 @@ end
 Base.Tuple(x::Vec4) = tuple(x.a, x.b, x.c, x.d)
 
 for (dispatch_rettyp, julia_rettyp, llvm_rettyp) in
-        ((Signed,        Vec4{UInt32},  :v4u32),
-         (Unsigned,      Vec4{Int32},   :v4s32),
-         (AbstractFloat, Vec4{Float32}, :v4f32))
+        ((:Signed,        :(Vec4{UInt32}),  :v4u32),
+         (:Unsigned,      :(Vec4{Int32}),   :v4s32),
+         (:AbstractFloat, :(Vec4{Float32}), :v4f32))
 
-    eltyp = Union{dispatch_rettyp, NTuple{<:Any,dispatch_rettyp}}
+    eltyp = :(Union{$dispatch_rettyp, NTuple{<:Any,$dispatch_rettyp}})
 
     # tex1D only supports array memory
     @eval tex(texObject::CuDeviceTexture{<:$eltyp,1,ArrayMemory}, x::Number) =


### PR DESCRIPTION
@vtjnash noted that this is preferable.

Some uses of types remain because we do things like inspecting the size or supertype when metaprogramming.