### PR TITLE
Diagonal for lower triangular of LU decomposition set incorrectly

### DIFF
--- a/lib/cusolver/linalg.jl
+++ b/lib/cusolver/linalg.jl
@@ -455,7 +455,7 @@ function Base.getproperty(F::LU{T,<:StridedCuMatrix}, d::Symbol) where T
     m, n = size(F)
     if d === :L
         L = tril!(getfield(F, :factors)[1:m, 1:min(m,n)])
-        L[1:min(m,n)+1:end] .= one(T)   # set the diagonal (linear indexing trick)
+        L[1:m+1:end] .= one(T)   # set the diagonal (linear indexing trick)
         return L
     elseif VERSION >= v"1.9.0-DEV.1775"
         invoke(getproperty, Tuple{LU{T}, Symbol}, F, d)

--- a/test/cusolver/dense.jl
+++ b/test/cusolver/dense.jl
@@ -602,6 +602,18 @@ k = 1
             lu_gpu = lu(A_d)
             @test ldiv!(lu_cpu, B) ≈ collect(ldiv!(lu_gpu, B_d))
         end
+        
+        A = CuMatrix(rand(1024, 1024))
+        lua = lu(A)
+        @test Matrix(lua.L) * Matrix(lua.U) ≈ Matrix(lua.P) * Matrix(A)
+
+        A = CuMatrix(rand(1024, 512))
+        lua = lu(A)
+        @test Matrix(lua.L) * Matrix(lua.U) ≈ Matrix(lua.P) * Matrix(A)
+    
+        A = CuMatrix(rand(512, 1024))
+        lua = lu(A)
+        @test Matrix(lua.L) * Matrix(lua.U) ≈ Matrix(lua.P) * Matrix(A)
     end
 end
 
@@ -679,28 +691,5 @@ end
         @test Array(d_A \ d_b) ≈ (Af \ bf)
         @inferred d_A \ d_B
         @inferred d_A \ d_b
-    end
-
-    @testset "decompositions" begin
-        A = CuMatrix(rand(1024, 1024))
-        lua = lu(A)
-        @test Matrix(lua.L) * Matrix(lua.U) ≈ Matrix(lua.P) * Matrix(A)
-
-        A = CuMatrix(rand(1024, 512))
-        lua = lu(A)
-        @test Matrix(lua.L) * Matrix(lua.U) ≈ Matrix(lua.P) * Matrix(A)
-    
-        A = CuMatrix(rand(512, 1024))
-        lua = lu(A)
-        @test Matrix(lua.L) * Matrix(lua.U) ≈ Matrix(lua.P) * Matrix(A)
-
-        a = rand(1024, 1024)
-        A = CuMatrix(a)
-        B = CuMatrix(a)
-        lua = lu!(A)
-        @test Matrix(lua.L) * Matrix(lua.U) ≈ Matrix(lua.P) * Matrix(B)
-
-        A = CuMatrix{Float32}([1 2; 0 0])
-        @test_throws SingularException lu(A)
     end
 end

--- a/test/cusolver/dense.jl
+++ b/test/cusolver/dense.jl
@@ -680,4 +680,27 @@ end
         @inferred d_A \ d_B
         @inferred d_A \ d_b
     end
+
+    @testset "decompositions" begin
+        A = CuMatrix(rand(1024, 1024))
+        lua = lu(A)
+        @test Matrix(lua.L) * Matrix(lua.U) ≈ Matrix(lua.P) * Matrix(A)
+
+        A = CuMatrix(rand(1024, 512))
+        lua = lu(A)
+        @test Matrix(lua.L) * Matrix(lua.U) ≈ Matrix(lua.P) * Matrix(A)
+    
+        A = CuMatrix(rand(512, 1024))
+        lua = lu(A)
+        @test Matrix(lua.L) * Matrix(lua.U) ≈ Matrix(lua.P) * Matrix(A)
+
+        a = rand(1024, 1024)
+        A = CuMatrix(a)
+        B = CuMatrix(a)
+        lua = lu!(A)
+        @test Matrix(lua.L) * Matrix(lua.U) ≈ Matrix(lua.P) * Matrix(B)
+
+        A = CuMatrix{Float32}([1 2; 0 0])
+        @test_throws SingularException lu(A)
+    end
 end


### PR DESCRIPTION
The diagonal for the lower triangular (`LU.L`) is set incorrectly for non square matrices.