### PR TITLE
Allow precompiling CUDA code.

### DIFF
--- a/lib/cudnn/src/cuDNN.jl
+++ b/lib/cudnn/src/cuDNN.jl
@@ -151,14 +151,13 @@ end
 
 function __init__()
     precompiling = ccall(:jl_generating_output, Cint, ()) != 0
-    precompiling && return
 
     CUDA.functional() || return
 
     global libcudnn
     if CUDA_Runtime == CUDA_Runtime_jll
         if !CUDNN_jll.is_available()
-            @error "cuDNN is not available for your platform ($(Base.BinaryPlatforms.triplet(CUDNN_jll.host_platform)))"
+            precompiling || @error "cuDNN is not available for your platform ($(Base.BinaryPlatforms.triplet(CUDNN_jll.host_platform)))"
             return
         end
         libcudnn = CUDNN_jll.libcudnn
@@ -166,7 +165,7 @@ function __init__()
         dirs = CUDA_Runtime.find_toolkit()
         path = CUDA_Runtime.get_library(dirs, "cudnn"; optional=true)
         if path === nothing
-            @error "cuDNN is not available on your system (looked in $(join(dirs, ", ")))"
+            precompiling || @error "cuDNN is not available on your system (looked in $(join(dirs, ", ")))"
             return
         end
         libcudnn = path

--- a/lib/custatevec/src/cuStateVec.jl
+++ b/lib/custatevec/src/cuStateVec.jl
@@ -103,14 +103,13 @@ end
 
 function __init__()
     precompiling = ccall(:jl_generating_output, Cint, ()) != 0
-    precompiling && return
 
     CUDA.functional() || return
 
     global libcustatevec
     if CUDA_Runtime == CUDA_Runtime_jll
         if !cuQuantum_jll.is_available()
-            @error "cuQuantum is not available for your platform ($(Base.BinaryPlatforms.triplet(cuQuantum_jll.host_platform)))"
+            precompiling || @error "cuQuantum is not available for your platform ($(Base.BinaryPlatforms.triplet(cuQuantum_jll.host_platform)))"
             return
         end
         libcustatevec = cuQuantum_jll.libcustatevec
@@ -118,7 +117,7 @@ function __init__()
         dirs = CUDA_Runtime.find_toolkit()
         path = CUDA_Runtime.get_library(dirs, "custatevec"; optional=true)
         if path === nothing
-            @error "cuQuantum is not available on your system (looked for custatevec in $(join(dirs, ", ")))"
+            precompiling || @error "cuQuantum is not available on your system (looked for custatevec in $(join(dirs, ", ")))"
             return
         end
         libcustatevec = path

--- a/lib/cutensor/src/cuTENSOR.jl
+++ b/lib/cutensor/src/cuTENSOR.jl
@@ -87,14 +87,13 @@ end
 
 function __init__()
     precompiling = ccall(:jl_generating_output, Cint, ()) != 0
-    precompiling && return
 
     CUDA.functional() || return
 
     global libcutensor
     if CUDA_Runtime == CUDA_Runtime_jll
         if !CUTENSOR_jll.is_available()
-            @error "cuTENSOR is not available for your platform ($(Base.BinaryPlatforms.triplet(CUTENSOR_jll.host_platform)))"
+            precompiling || @error "cuTENSOR is not available for your platform ($(Base.BinaryPlatforms.triplet(CUTENSOR_jll.host_platform)))"
             return
         end
         libcutensor = CUTENSOR_jll.libcutensor
@@ -102,7 +101,7 @@ function __init__()
         dirs = CUDA_Runtime.find_toolkit()
         path = CUDA_Runtime.get_library(dirs, "cutensor"; optional=true)
         if path === nothing
-            @error "cuTENSOR is not available on your system (looked in $(join(dirs, ", ")))"
+            precompiling || @error "cuTENSOR is not available on your system (looked in $(join(dirs, ", ")))"
             return
         end
         libcutensor = path

--- a/lib/cutensornet/src/cuTensorNet.jl
+++ b/lib/cutensornet/src/cuTensorNet.jl
@@ -104,14 +104,13 @@ end
 
 function __init__()
     precompiling = ccall(:jl_generating_output, Cint, ()) != 0
-    precompiling && return
 
     CUDA.functional() || return
 
     global libcutensornet
     if CUDA_Runtime == CUDA_Runtime_jll
         if !cuQuantum_jll.is_available()
-            @error "cuQuantum is not available for your platform ($(Base.BinaryPlatforms.triplet(cuQuantum_jll.host_platform)))"
+            precompiling || @error "cuQuantum is not available for your platform ($(Base.BinaryPlatforms.triplet(cuQuantum_jll.host_platform)))"
             return
         end
         libcutensornet = cuQuantum_jll.libcutensornet
@@ -119,7 +118,7 @@ function __init__()
         dirs = CUDA_Runtime.find_toolkit()
         path = CUDA_Runtime.get_library(dirs, "cutensornet"; optional=true)
         if path === nothing
-            @error "cuQuantum is not available on your system (looked for cutensornet in $(join(dirs, ", ")))"
+            precompiling || @error "cuQuantum is not available on your system (looked for cutensornet in $(join(dirs, ", ")))"
             return
         end
         libcutensornet = path


### PR DESCRIPTION
Disabling `__init__` during precompilation is a sane thing to do, but with SnoopPrecompile users may want to execute CUDA code at top level (even though that will break containers, package registration, and whatnot). Still, we should probably allow it, and currently it throws a pretty annoying `libcuda is not defined` error.