### PR TITLE
Don't collect `AbstractQ` objects in tests

### DIFF
--- a/lib/cusolver/linalg.jl
+++ b/lib/cusolver/linalg.jl
@@ -178,6 +178,7 @@ CuMatrix{T}(Q::QRCompactWYQ) where {T} = error("QRCompactWY format is not suppor
 Matrix{T}(Q::QRPackedQ{S,<:CuArray,<:CuArray}) where {T,S} = Array(CuMatrix{T}(Q))
 Matrix{T}(Q::QRCompactWYQ{S,<:CuArray,<:CuArray}) where {T,S} = Array(CuMatrix{T}(Q))
 
+if VERSION < v"1.10-"
 # extracting the full matrix can be done with `collect` (which defaults to `Array`)
 function Base.collect(src::Union{QRPackedQ{<:Any,<:CuArray,<:CuArray},
                                  QRCompactWYQ{<:Any,<:CuArray,<:CuArray}})
@@ -197,6 +198,7 @@ function Base.getindex(Q::QRPackedQ{<:Any, <:CuArray}, ::Colon, j::Int)
     y = CUDA.zeros(eltype(Q), size(Q, 2))
     y[j] = 1
     lmul!(Q, y)
+end
 end
 
 # multiplication by Q

--- a/lib/cusolver/linalg.jl
+++ b/lib/cusolver/linalg.jl
@@ -194,11 +194,12 @@ Base.similar(Q::Union{QRPackedQ{<:Any,<:CuArray,<:CuArray},
              ::Type{T}, dims::Dims{N}) where {T,N} =
     CuArray{T,N}(undef, dims)
 
+end
+
 function Base.getindex(Q::QRPackedQ{<:Any, <:CuArray}, ::Colon, j::Int)
     y = CUDA.zeros(eltype(Q), size(Q, 2))
     y[j] = 1
     lmul!(Q, y)
-end
 end
 
 # multiplication by Q

--- a/test/cusolver/dense.jl
+++ b/test/cusolver/dense.jl
@@ -360,8 +360,10 @@ k = 1
         d_I = CuMatrix{elty}(I, size(d_F.Q))
         @test det(d_F.Q) ≈ det(collect(d_F.Q * CuMatrix{elty}(I, size(d_F.Q)))) atol=tol*norm(A)
         if VERSION >= v"1.10-"
-            @test collect(d_F.Q * d_I) ≈ d_F.Q[1:m,1:m]
-            @test collect(d_I * d_F.Q) ≈ d_F.Q[1:m,1:m]
+            @test collect((d_F.Q'd_I) * d_F.Q) ≈ d_I
+            @test collect(d_F.Q * (d_I * d_F.Q')) ≈ d_I
+            @test collect(d_F.Q'd_F.Q) ≈ d_I
+            @test collect(d_F.Q * d_F.Q') ≈ d_I
         else
             @test collect(d_F.Q * d_I) ≈ collect(d_F.Q)
             @test collect(d_I * d_F.Q) ≈ collect(d_F.Q)

--- a/test/cusolver/dense.jl
+++ b/test/cusolver/dense.jl
@@ -359,8 +359,13 @@ k = 1
 
         d_I = CuMatrix{elty}(I, size(d_F.Q))
         @test det(d_F.Q) ≈ det(collect(d_F.Q * CuMatrix{elty}(I, size(d_F.Q)))) atol=tol*norm(A)
-        @test collect(d_F.Q * d_I) ≈ d_F.Q[1:m,1:m]
-        @test collect(d_I * d_F.Q) ≈ d_F.Q[1:m,1:m]
+        if VERSION >= v"1.10-"
+            @test collect(d_F.Q * d_I) ≈ d_F.Q[1:m,1:m]
+            @test collect(d_I * d_F.Q) ≈ d_F.Q[1:m,1:m]
+        else
+            @test collect(d_F.Q * d_I) ≈ collect(d_F.Q)
+            @test collect(d_I * d_F.Q) ≈ collect(d_F.Q)
+        end
 
         d_I = CuMatrix{elty}(I, size(d_F.R))
         @test collect(d_F.R * d_I) ≈ collect(d_F.R)

--- a/test/cusolver/dense.jl
+++ b/test/cusolver/dense.jl
@@ -362,8 +362,6 @@ k = 1
         if VERSION >= v"1.10-"
             @test collect((d_F.Q'd_I) * d_F.Q) ≈ collect(d_I)
             @test collect(d_F.Q * (d_I * d_F.Q')) ≈ collect(d_I)
-            @test collect(d_F.Q'd_F.Q) ≈ collect(d_I)
-            @test collect(d_F.Q * d_F.Q') ≈ collect(d_I)
         else
             @test collect(d_F.Q * d_I) ≈ collect(d_F.Q)
             @test collect(d_I * d_F.Q) ≈ collect(d_F.Q)

--- a/test/cusolver/dense.jl
+++ b/test/cusolver/dense.jl
@@ -359,8 +359,8 @@ k = 1
 
         d_I = CuMatrix{elty}(I, size(d_F.Q))
         @test det(d_F.Q) ≈ det(collect(d_F.Q * CuMatrix{elty}(I, size(d_F.Q)))) atol=tol*norm(A)
-        @test collect(d_F.Q * d_I) ≈ collect(d_F.Q)
-        @test collect(d_I * d_F.Q) ≈ collect(d_F.Q)
+        @test collect(d_F.Q * d_I) ≈ Matrix(d_F.Q)
+        @test collect(d_I * d_F.Q) ≈ Matrix(d_F.Q)
 
         d_I = CuMatrix{elty}(I, size(d_F.R))
         @test collect(d_F.R * d_I) ≈ collect(d_F.R)

--- a/test/cusolver/dense.jl
+++ b/test/cusolver/dense.jl
@@ -359,8 +359,8 @@ k = 1
 
         d_I = CuMatrix{elty}(I, size(d_F.Q))
         @test det(d_F.Q) ≈ det(collect(d_F.Q * CuMatrix{elty}(I, size(d_F.Q)))) atol=tol*norm(A)
-        @test collect(d_F.Q * d_I) ≈ Matrix(d_F.Q)
-        @test collect(d_I * d_F.Q) ≈ Matrix(d_F.Q)
+        @test collect(d_F.Q * d_I) ≈ d_F.Q[1:m,1:m]
+        @test collect(d_I * d_F.Q) ≈ d_F.Q[1:m,1:m]
 
         d_I = CuMatrix{elty}(I, size(d_F.R))
         @test collect(d_F.R * d_I) ≈ collect(d_F.R)

--- a/test/cusolver/dense.jl
+++ b/test/cusolver/dense.jl
@@ -360,10 +360,10 @@ k = 1
         d_I = CuMatrix{elty}(I, size(d_F.Q))
         @test det(d_F.Q) ≈ det(collect(d_F.Q * CuMatrix{elty}(I, size(d_F.Q)))) atol=tol*norm(A)
         if VERSION >= v"1.10-"
-            @test collect((d_F.Q'd_I) * d_F.Q) ≈ d_I
-            @test collect(d_F.Q * (d_I * d_F.Q')) ≈ d_I
-            @test collect(d_F.Q'd_F.Q) ≈ d_I
-            @test collect(d_F.Q * d_F.Q') ≈ d_I
+            @test collect((d_F.Q'd_I) * d_F.Q) ≈ collect(d_I)
+            @test collect(d_F.Q * (d_I * d_F.Q')) ≈ collect(d_I)
+            @test collect(d_F.Q'd_F.Q) ≈ collect(d_I)
+            @test collect(d_F.Q * d_F.Q') ≈ collect(d_I)
         else
             @test collect(d_F.Q * d_I) ≈ collect(d_F.Q)
             @test collect(d_I * d_F.Q) ≈ collect(d_F.Q)


### PR DESCRIPTION
This PR collects fixes to make CUDA.jl work properly with the new `AbstractQ` API.