### PR TITLE
Add compatibility entry for Lovelace

### DIFF
--- a/src/compatibility.jl
+++ b/src/compatibility.jl
@@ -51,6 +51,7 @@ const cuda_cap_db = Dict(
     v"8.0" => v"11.0":highest,
     v"8.6" => v"11.1":highest,
     v"8.7" => v"11.5":highest,
+    v"8.9" => v"11.8":highest,
     v"9.0" => v"11.8":highest,
 )
 


### PR DESCRIPTION
## What this fixes
Currently if I try to run CUDA.jl on a Lovelace gpu, I get the following error:
```
     Testing Running tests...
┌ Info: System information:
│ CUDA runtime 12.1, artifact installation
│ CUDA driver 12.1
│ NVIDIA driver 531.61.0
│
│ Libraries:
│ - CUBLAS: 12.1.0
│ - CURAND: 10.3.2
│ - CUFFT: 11.0.2
│ - CUSOLVER: 11.4.4
│ - CUSPARSE: 12.0.2
│ - CUPTI: 18.0.0
│ - NVML: 12.0.0+531.61
│
│ Toolchain:
│ - Julia: 1.8.5
│ - LLVM: 13.0.1
│ - PTX ISA support: 3.2, 4.0, 4.1, 4.2, 4.3, 5.0, 6.0, 6.1, 6.3, 6.4, 6.5, 7.0, 7.1, 7.2
│ - Device capability support: sm_37, sm_50, sm_52, sm_53, sm_60, sm_61, sm_62, sm_70, sm_72, sm_75, sm_80, sm_86
│
│ 1 device:
└   0: NVIDIA GeForce RTX 4090 (sm_89, 22.299 GiB / 23.988 GiB available)
ERROR: LoadError: Could not find any suitable device for this configuration
```

## The fix
The toolchain requirements are the same as for Hopper, which is supported, so I copied that line in compatibility.jl.


### Testing
I ran the full test suite, and had complete success except for sorting.jl
