### PR TITLE
Added support for more transform directions

### DIFF
--- a/lib/cufft/fft.jl
+++ b/lib/cufft/fft.jl
@@ -33,16 +33,6 @@ function CUDA.unsafe_free!(plan::CuFFTPlan)
     end
 end
 
-# stores multiple plans which are to be executed in succession
-# mutable struct mCuFFTPlan{T<:cufftNumber,K,inplace,M} <: CuFFTPlan{T,K,inplace}
-#     plans::CuFFTPlan[]
-#     permutes::NTuple{M,Int}[]
-#     pinv::ScaledPlan # required by AbstractFFT API
-#     function mCuFFTPlan{T,K,inplace,M}(p::CuFFTPlan{T,K,inplace}[], perm::NTuple{M,Int}[], X::DenseCuArray{T,N})  where {T<:cufftNumber,K,inplace,M}
-#         return new(p, perm)
-#     end
-# end
-
 mutable struct cCuFFTPlan{T<:cufftNumber,K,inplace,N} <: CuFFTPlan{T,K,inplace}
     handle::cufftHandle
     ctx::CuContext

--- a/lib/cufft/fft.jl
+++ b/lib/cufft/fft.jl
@@ -148,7 +148,11 @@ end
 # yields the maximal dimensions of the plan, for plans starting at dim 1 or ending at the size vector, 
 # this is always the full input size
 function plan_max_dims(region, sz) 
-    ifelse(region[1] == 1 && (length(region) <=1 || all(diff(collect(region)) .== 1)), length(sz), region[end])
+    if (region[1] == 1 && (length(region) <=1 || all(diff(collect(region)) .== 1)))
+        return length(sz)
+    else
+        return region[end]
+    end
 end
 
 # retrieves the size to allocate even if the trailing dimensions do no transform

--- a/lib/cufft/fft.jl
+++ b/lib/cufft/fft.jl
@@ -316,7 +316,7 @@ end
 function assert_applicable(p::CuFFTPlan{T,K,inplace}, X::DenseCuArray{T},
                            Y::DenseCuArray) where {T,K,inplace}
     assert_applicable(p, X)
-    if size(Y) != p.osz
+    if size(Y)[1:length(p.osz)] != p.osz
         throw(ArgumentError("CuFFT plan applied to wrong-size output"))
     elseif inplace != (pointer(X) == pointer(Y))
         throw(ArgumentError(string("CuFFT ",

--- a/lib/cufft/fft.jl
+++ b/lib/cufft/fft.jl
@@ -139,10 +139,16 @@ for f in (:fft, :bfft, :ifft)
 end
 rfft(x::DenseCuArray{<:Union{Integer,Rational}}, region=1:ndims(x)) = rfft(realfloat(x), region)
 plan_rfft(x::DenseCuArray{<:Real}, region) = plan_rfft(realfloat(x), region)
-irfft(x::DenseCuArray{<:Union{Real,Integer,Rational}}, d::Integer, region=1:ndims(x)) = irfft(complexfloat(x), d, region)
 
-# yields the maximal dimensions of the plan, for plans starting at dim 1 or ending at the size vector, this is always the full input size
-plan_max_dims(region, sz) = ifelse(region[1] == 1 && (length(region) <=1 || all(diff(collect(region)) .== 1)), length(sz), region[end])
+function irfft(x::DenseCuArray{<:Union{Real,Integer,Rational}}, d::Integer, region=1:ndims(x))
+    irfft(complexfloat(x), d, region)
+end
+
+# yields the maximal dimensions of the plan, for plans starting at dim 1 or ending at the size vector, 
+# this is always the full input size
+function plan_max_dims(region, sz) 
+    ifelse(region[1] == 1 && (length(region) <=1 || all(diff(collect(region)) .== 1)), length(sz), region[end])
+end
 
 # retrieves the size to allocate even if the trailing dimensions do no transform
 get_osz(osz, x) = ntuple((d)->(d>length(osz) ? size(x, d) : osz[d]), ndims(x))

--- a/src/indexing.jl
+++ b/src/indexing.jl
@@ -11,9 +11,9 @@ using Base.Cartesian
 # we cannot use Base.LogicalIndex, which does not support indexing but requires iteration.
 # TODO: it should still be possible to use the same technique;
 #       Base.LogicalIndex basically contains the same as our `findall` here does.
-Base.to_index(::AbstractGPUArray, I::AbstractArray{Bool}) = findall(I)
+Base.to_index(::CuArray, I::AbstractArray{Bool}) = findall(I)
 ## same for the trailing Array{Bool} optimization (see `_maybe_linear_logical_index` in Base)
-Base.to_indices(A::AbstractGPUArray, inds,
+Base.to_indices(A::CuArray, inds,
                 I::Tuple{Union{Array{Bool,N}, BitArray{N}}}) where {N} =
     (Base.to_index(A, I[1]),)
 

--- a/test/libraries/cufft.jl
+++ b/test/libraries/cufft.jl
@@ -39,6 +39,7 @@ function out_of_place(X::AbstractArray{T,N}) where {T <: Complex,N}
     d_Z = pinv2 * d_Y
     Z = collect(d_Z)
     @test isapprox(Z, X, rtol = MYRTOL, atol = MYATOL)
+
 end
 
 function in_place(X::AbstractArray{T,N}) where {T <: Complex,N}
@@ -62,6 +63,10 @@ function batched(X::AbstractArray{T,N},region) where {T <: Complex,N}
     d_Y = p * d_X
     Y = collect(d_Y)
     @test isapprox(Y, fftw_X, rtol = MYRTOL, atol = MYATOL)
+
+    ldiv!(d_Z, p, d_Y)
+    Z = collect(d_Z)
+    @test isapprox(Z, X, rtol = MYRTOL, atol = MYATOL)
 
     pinv = plan_ifft(d_Y,region)
     d_Z = pinv * d_Y

--- a/test/libraries/cufft.jl
+++ b/test/libraries/cufft.jl
@@ -61,6 +61,9 @@ function batched(X::AbstractArray{T,N},region) where {T <: Complex,N}
     d_X = CuArray(X)
     p = plan_fft(d_X,region)
     d_Y = p * d_X
+    d_X2 = reshape(d_X, (size(d_X)..., 1))
+    @test_throws ArgumentError p * d_X2
+
     Y = collect(d_Y)
     @test isapprox(Y, fftw_X, rtol = MYRTOL, atol = MYATOL)
 

--- a/test/libraries/cufft.jl
+++ b/test/libraries/cufft.jl
@@ -143,11 +143,11 @@ end
 
 @testset "Batch 2D (in 4D)" begin
     dims = (N1,N2,N3,N4)
-    for region in [(1,2),(1,4),(3,4)]
+    for region in [(1,2),(1,4),(3,4),(1,3),(2,3),(2,),(3,)]
         X = rand(T, dims)
         batched(X,region)
     end
-    for region in [(1,3),(2,3),(2,4)]
+    for region in [(2,4)]
         X = rand(T, dims)
         @test_throws ArgumentError batched(X,region)
     end
@@ -236,11 +236,11 @@ end
 
 @testset "Batch 2D (in 4D)" begin
     dims = (N1,N2,N3,N4)
-    for region in [(1,2),(1,4),(3,4)]
+    for region in [(1,2),(1,4),(3,4),(1,3),(2,3)]
         X = rand(T, dims)
         batched(X,region)
     end
-    for region in [(1,3),(2,3),(2,4)]
+    for region in [(2,4)]
         X = rand(T, dims)
         @test_throws ArgumentError batched(X,region)
     end

--- a/test/libraries/cufft.jl
+++ b/test/libraries/cufft.jl
@@ -64,12 +64,12 @@ function batched(X::AbstractArray{T,N},region) where {T <: Complex,N}
     Y = collect(d_Y)
     @test isapprox(Y, fftw_X, rtol = MYRTOL, atol = MYATOL)
 
-    ldiv!(d_Z, p, d_Y)
+    pinv = plan_ifft(d_Y,region)
+    d_Z = pinv * d_Y
     Z = collect(d_Z)
     @test isapprox(Z, X, rtol = MYRTOL, atol = MYATOL)
 
-    pinv = plan_ifft(d_Y,region)
-    d_Z = pinv * d_Y
+    ldiv!(d_Z, p, d_Y)
     Z = collect(d_Z)
     @test isapprox(Z, X, rtol = MYRTOL, atol = MYATOL)
 end


### PR DESCRIPTION
This is achieved by allowing fft-plans to have fewer dimensions than the data they are applied to. The trailing dimensions are treated as non-transform directions and transforms are executed sequentially. (maybe @inbounds should be added?).
This should allow for most use-cases to now work. Especially note, that single dimensions are now supported, which add flexibility.
Only rare cases such as (2,4) out of a 4-dimensional array are currently still not supported but the user would be able to execute these transforms sequentially.