### PR TITLE
Avoid unneeded macros to cut down on generated code

### DIFF
--- a/lib/cublas/CUBLAS.jl
+++ b/lib/cublas/CUBLAS.jl
@@ -4,7 +4,7 @@ using ..APIUtils
 
 using ..CUDA
 using ..CUDA: CUstream, cuComplex, cuDoubleComplex, libraryPropertyType, cudaDataType, i32
-using ..CUDA: unsafe_free!, @retry_reclaim, isdebug, @sync, initialize_context
+using ..CUDA: unsafe_free!, retry_reclaim, isdebug, @sync, initialize_context
 
 using ..CUDA: CUDA_Runtime
 using ..CUDA_Runtime

--- a/lib/cublas/libcublas.jl
+++ b/lib/cublas/libcublas.jl
@@ -19,7 +19,9 @@ macro check(ex, errs...)
     end
 
     quote
-        res = @retry_reclaim err -> $check $(esc(ex))
+        res = retry_reclaim(err -> $check) do
+            $(esc(ex))
+        end
         if res != CUBLAS_STATUS_SUCCESS
             throw_api_error(res)
         end

--- a/lib/cudnn/src/cuDNN.jl
+++ b/lib/cudnn/src/cuDNN.jl
@@ -10,7 +10,7 @@ module cuDNN
 using CUDA
 using CUDA.APIUtils
 using CUDA: CUstream, libraryPropertyType
-using CUDA: @retry_reclaim, isdebug, initialize_context
+using CUDA: retry_reclaim, isdebug, initialize_context
 using CUDA: CUDA_Runtime, CUDA_Runtime_jll
 
 using CEnum: @cenum

--- a/lib/cudnn/src/libcudnn.jl
+++ b/lib/cudnn/src/libcudnn.jl
@@ -19,7 +19,9 @@ macro check(ex, errs...)
     end
 
     quote
-        res = @retry_reclaim err -> $check $(esc(ex))
+        res = retry_reclaim(err -> $check) do
+            $(esc(ex))
+        end
         if res != CUDNN_STATUS_SUCCESS
             throw_api_error(res)
         end

--- a/lib/cudnn/test/tensor.jl
+++ b/lib/cudnn/test/tensor.jl
@@ -6,8 +6,7 @@ using cuDNN:
     cudnnDataType,
     cudnnDataType_t,
     CUDNN_TENSOR_NCHW,
-    CUDNN_STATUS_SUCCESS,
-    @retry_reclaim
+    CUDNN_STATUS_SUCCESS
 
 x = CUDA.rand(1,1,1,2)
 
@@ -29,4 +28,6 @@ fd = FD(x)
 
 @test DT(Float32) isa cudnnDataType_t
 
-@test (@retry_reclaim(x->(x!==CUDNN_STATUS_SUCCESS),cudnnCreateTensorDescriptor(Ref{cudnnTensorDescriptor_t}(C_NULL)))) isa Nothing
+@test (CUDA.retry_reclaim(x->(x!==CUDNN_STATUS_SUCCESS)) do
+        cudnnCreateTensorDescriptor(Ref{cudnnTensorDescriptor_t}(C_NULL))
+    end) isa Nothing

--- a/lib/cufft/CUFFT.jl
+++ b/lib/cufft/CUFFT.jl
@@ -6,7 +6,7 @@ using ..CUDA_Runtime
 
 using ..CUDA
 using ..CUDA: CUstream, cuComplex, cuDoubleComplex, libraryPropertyType
-using ..CUDA: unsafe_free!, @retry_reclaim, initialize_context
+using ..CUDA: unsafe_free!, retry_reclaim, initialize_context
 
 using CEnum: @cenum
 

--- a/lib/cufft/libcufft.jl
+++ b/lib/cufft/libcufft.jl
@@ -19,7 +19,9 @@ macro check(ex, errs...)
     end
 
     quote
-        res = @retry_reclaim err -> $check $(esc(ex))
+        res = retry_reclaim(err -> $check) do
+            $(esc(ex))
+        end
         if res != CUFFT_SUCCESS
             throw_api_error(res)
         end

--- a/lib/cupti/CUPTI.jl
+++ b/lib/cupti/CUPTI.jl
@@ -5,7 +5,7 @@ using ..APIUtils
 using ..CUDA_Runtime
 
 using ..CUDA
-using ..CUDA: @retry_reclaim, initialize_context
+using ..CUDA: retry_reclaim, initialize_context
 using ..CUDA: CUuuid, CUcontext, CUstream, CUdevice, CUdevice_attribute,
               CUgraph, CUgraphNode, CUgraphNodeType, CUgraphExec, CUaccessPolicyWindow
 

--- a/lib/cupti/libcupti.jl
+++ b/lib/cupti/libcupti.jl
@@ -19,7 +19,9 @@ macro check(ex, errs...)
     end
 
     quote
-        res = @retry_reclaim err -> $check $(esc(ex))
+        res = retry_reclaim(err -> $check) do
+            $(esc(ex))
+        end
         if res != CUPTI_SUCCESS
             throw_api_error(res)
         end

--- a/lib/curand/CURAND.jl
+++ b/lib/curand/CURAND.jl
@@ -6,7 +6,7 @@ using ..CUDA_Runtime
 
 using ..CUDA
 using ..CUDA: CUstream, libraryPropertyType, DEVICE_ATTRIBUTE_MAX_THREADS_PER_BLOCK
-using ..CUDA: @retry_reclaim, initialize_context
+using ..CUDA: retry_reclaim, initialize_context
 
 using CEnum: @cenum
 

--- a/lib/curand/libcurand.jl
+++ b/lib/curand/libcurand.jl
@@ -19,7 +19,9 @@ macro check(ex, errs...)
     end
 
     quote
-        res = @retry_reclaim err -> $check $(esc(ex))
+        res = retry_reclaim(err -> $check) do
+            $(esc(ex))
+        end
         if res != CURAND_STATUS_SUCCESS
             throw_api_error(res)
         end

--- a/lib/cusolver/CUSOLVER.jl
+++ b/lib/cusolver/CUSOLVER.jl
@@ -6,7 +6,7 @@ using ..CUDA_Runtime
 
 using ..CUDA
 using ..CUDA: CUstream, cuComplex, cuDoubleComplex, libraryPropertyType, cudaDataType
-using ..CUDA: @allowscalar, assertscalar, unsafe_free!, @retry_reclaim, initialize_context
+using ..CUDA: @allowscalar, assertscalar, unsafe_free!, retry_reclaim, initialize_context
 
 using ..CUBLAS: cublasFillMode_t, cublasOperation_t, cublasSideMode_t, cublasDiagType_t
 using ..CUSPARSE: cusparseMatDescr_t

--- a/lib/cusolver/libcusolver.jl
+++ b/lib/cusolver/libcusolver.jl
@@ -19,7 +19,9 @@ macro check(ex, errs...)
     end
 
     quote
-        res = @retry_reclaim err -> $check $(esc(ex))
+        res = retry_reclaim(err -> $check) do
+            $(esc(ex))
+        end
         if res != CUSOLVER_STATUS_SUCCESS
             throw_api_error(res)
         end

--- a/lib/cusolver/sparse.jl
+++ b/lib/cusolver/sparse.jl
@@ -12,8 +12,8 @@ end
 
 function cusolverMgCreate()
   handle_ref = Ref{cusolverMgHandle_t}()
-  res = @retry_reclaim err->isequal(err, CUSOLVER_STATUS_ALLOC_FAILED) ||
-                            isequal(err, CUSOLVER_STATUS_NOT_INITIALIZED) begin
+  res = retry_reclaim(err->isequal(err, CUSOLVER_STATUS_ALLOC_FAILED) ||
+                           isequal(err, CUSOLVER_STATUS_NOT_INITIALIZED)) do
     unsafe_cusolverMgCreate(handle_ref)
   end
   if res != CUSOLVER_STATUS_SUCCESS

--- a/lib/cusparse/CUSPARSE.jl
+++ b/lib/cusparse/CUSPARSE.jl
@@ -6,7 +6,7 @@ using ..CUDA_Runtime
 
 using ..CUDA
 using ..CUDA: CUstream, cuComplex, cuDoubleComplex, libraryPropertyType, cudaDataType
-using ..CUDA: unsafe_free!, @retry_reclaim, initialize_context, i32, @allowscalar
+using ..CUDA: unsafe_free!, retry_reclaim, initialize_context, i32, @allowscalar
 
 using CEnum: @cenum
 

--- a/lib/cusparse/libcusparse.jl
+++ b/lib/cusparse/libcusparse.jl
@@ -19,7 +19,9 @@ macro check(ex, errs...)
     end
 
     quote
-        res = @retry_reclaim err -> $check $(esc(ex))
+        res = retry_reclaim(err -> $check) do
+            $(esc(ex))
+        end
         if res != CUSPARSE_STATUS_SUCCESS
             throw_api_error(res)
         end

--- a/lib/custatevec/src/cuStateVec.jl
+++ b/lib/custatevec/src/cuStateVec.jl
@@ -2,7 +2,7 @@ module cuStateVec
 
 using CUDA
 using CUDA: CUstream, cudaDataType, @checked, HandleCache, with_workspace, libraryPropertyType
-using CUDA: unsafe_free!, @retry_reclaim, initialize_context, isdebug
+using CUDA: unsafe_free!, retry_reclaim, initialize_context, isdebug
 using CUDA: CUDA_Runtime, CUDA_Runtime_jll
 
 using CEnum: @cenum

--- a/lib/custatevec/src/libcustatevec.jl
+++ b/lib/custatevec/src/libcustatevec.jl
@@ -22,7 +22,9 @@ macro check(ex, errs...)
     end
 
     quote
-        res = @retry_reclaim err -> $check $(esc(ex))
+        res = retry_reclaim(err -> $check) do
+            $(esc(ex))
+        end
         if res != CUSTATEVEC_STATUS_SUCCESS
             throw_api_error(res)
         end

--- a/lib/cutensor/src/cuTENSOR.jl
+++ b/lib/cutensor/src/cuTENSOR.jl
@@ -3,7 +3,7 @@ module cuTENSOR
 using CUDA
 using CUDA.APIUtils
 using CUDA: CUstream, cudaDataType
-using CUDA: @retry_reclaim, initialize_context, isdebug
+using CUDA: retry_reclaim, initialize_context, isdebug
 using CUDA: CUDA_Runtime, CUDA_Runtime_jll
 
 using CEnum: @cenum

--- a/lib/cutensor/src/libcutensor.jl
+++ b/lib/cutensor/src/libcutensor.jl
@@ -19,7 +19,9 @@ macro check(ex, errs...)
     end
 
     quote
-        res = @retry_reclaim err -> $check $(esc(ex))
+        res = retry_reclaim(err -> $check) do
+            $(esc(ex))
+        end
         if res != CUTENSOR_STATUS_SUCCESS
             throw_api_error(res)
         end

--- a/lib/cutensornet/src/cuTensorNet.jl
+++ b/lib/cutensornet/src/cuTensorNet.jl
@@ -3,7 +3,7 @@ module cuTensorNet
 using LinearAlgebra
 using CUDA
 using CUDA: CUstream, cudaDataType, @checked, HandleCache, with_workspace
-using CUDA: @retry_reclaim, initialize_context, isdebug
+using CUDA: retry_reclaim, initialize_context, isdebug
 using CUDA: CUDA_Runtime, CUDA_Runtime_jll
 
 using cuTENSOR

--- a/lib/cutensornet/src/libcutensornet.jl
+++ b/lib/cutensornet/src/libcutensornet.jl
@@ -19,7 +19,9 @@ macro check(ex, errs...)
     end
 
     quote
-        res = @retry_reclaim err -> $check $(esc(ex))
+        res = retry_reclaim(err -> $check) do
+            $(esc(ex))
+        end
         if res != CUTENSORNET_STATUS_SUCCESS
             throw_api_error(res)
         end

--- a/res/wrap/libcublas_prologue.jl
+++ b/res/wrap/libcublas_prologue.jl
@@ -17,7 +17,9 @@ macro check(ex, errs...)
     end
 
     quote
-        res = @retry_reclaim err->$check $(esc(ex))
+        res = retry_reclaim(err -> $check) do
+            $(esc(ex))
+        end
         if res != CUBLAS_STATUS_SUCCESS
             throw_api_error(res)
         end

--- a/res/wrap/libcudnn_prologue.jl
+++ b/res/wrap/libcudnn_prologue.jl
@@ -17,7 +17,9 @@ macro check(ex, errs...)
     end
 
     quote
-        res = @retry_reclaim err->$check $(esc(ex))
+        res = retry_reclaim(err -> $check) do
+            $(esc(ex))
+        end
         if res != CUDNN_STATUS_SUCCESS
             throw_api_error(res)
         end

--- a/res/wrap/libcufft_prologue.jl
+++ b/res/wrap/libcufft_prologue.jl
@@ -17,7 +17,9 @@ macro check(ex, errs...)
     end
 
     quote
-        res = @retry_reclaim err->$check $(esc(ex))
+        res = retry_reclaim(err -> $check) do
+            $(esc(ex))
+        end
         if res != CUFFT_SUCCESS
             throw_api_error(res)
         end

--- a/res/wrap/libcupti_prologue.jl
+++ b/res/wrap/libcupti_prologue.jl
@@ -17,7 +17,9 @@ macro check(ex, errs...)
     end
 
     quote
-        res = @retry_reclaim err->$check $(esc(ex))
+        res = retry_reclaim(err -> $check) do
+            $(esc(ex))
+        end
         if res != CUPTI_SUCCESS
             throw_api_error(res)
         end

--- a/res/wrap/libcurand_prologue.jl
+++ b/res/wrap/libcurand_prologue.jl
@@ -17,7 +17,9 @@ macro check(ex, errs...)
     end
 
     quote
-        res = @retry_reclaim err->$check $(esc(ex))
+        res = retry_reclaim(err -> $check) do
+            $(esc(ex))
+        end
         if res != CURAND_STATUS_SUCCESS
             throw_api_error(res)
         end

--- a/res/wrap/libcusolver_prologue.jl
+++ b/res/wrap/libcusolver_prologue.jl
@@ -17,7 +17,9 @@ macro check(ex, errs...)
     end
 
     quote
-        res = @retry_reclaim err->$check $(esc(ex))
+        res = retry_reclaim(err -> $check) do
+            $(esc(ex))
+        end
         if res != CUSOLVER_STATUS_SUCCESS
             throw_api_error(res)
         end

--- a/res/wrap/libcusparse_prologue.jl
+++ b/res/wrap/libcusparse_prologue.jl
@@ -17,7 +17,9 @@ macro check(ex, errs...)
     end
 
     quote
-        res = @retry_reclaim err->$check $(esc(ex))
+        res = retry_reclaim(err -> $check) do
+            $(esc(ex))
+        end
         if res != CUSPARSE_STATUS_SUCCESS
             throw_api_error(res)
         end

--- a/res/wrap/libcustatevec_prologue.jl
+++ b/res/wrap/libcustatevec_prologue.jl
@@ -20,7 +20,9 @@ macro check(ex, errs...)
     end
 
     quote
-        res = @retry_reclaim err->$check $(esc(ex))
+        res = retry_reclaim(err -> $check) do
+            $(esc(ex))
+        end
         if res != CUSTATEVEC_STATUS_SUCCESS
             throw_api_error(res)
         end

--- a/res/wrap/libcutensor_prologue.jl
+++ b/res/wrap/libcutensor_prologue.jl
@@ -17,7 +17,9 @@ macro check(ex, errs...)
     end
 
     quote
-        res = @retry_reclaim err->$check $(esc(ex))
+        res = retry_reclaim(err -> $check) do
+            $(esc(ex))
+        end
         if res != CUTENSOR_STATUS_SUCCESS
             throw_api_error(res)
         end

--- a/res/wrap/libcutensornet_prologue.jl
+++ b/res/wrap/libcutensornet_prologue.jl
@@ -17,7 +17,9 @@ macro check(ex, errs...)
     end
 
     quote
-        res = @retry_reclaim err->$check $(esc(ex))
+        res = retry_reclaim(err -> $check) do
+            $(esc(ex))
+        end
         if res != CUTENSORNET_STATUS_SUCCESS
             throw_api_error(res)
         end

--- a/test/pool.jl
+++ b/test/pool.jl
@@ -27,8 +27,12 @@ end
     CUDA.reclaim(1024)
     CUDA.reclaim()
 
-    @test CUDA.@retry_reclaim(isequal(42), 42) == 42
-    @test CUDA.@retry_reclaim(isequal(42), 41) == 41
+    @test CUDA.retry_reclaim(isequal(42)) do
+            42
+        end == 42
+    @test CUDA.retry_reclaim(isequal(42)) do
+            41
+        end == 41
 end
 
 @testset "memory_status" begin


### PR DESCRIPTION
Apparently lowering is pretty slow, so expanding the many `@retry_reclaim` macros took significant time (around 6ms each). Replacing it with a regular function cuts down the time to around 1.5ms, significantly improving the time to compile the package.

Before:

```
julia> @time Base.compilecache(pkg)
 28.516434 seconds (4.16 k allocations: 379.914 KiB)

BenchmarkTools.Trial: 10000 samples with 998 evaluations.
 Range (min … max):  14.018 ns … 260.649 ns  ┊ GC (min … max): 0.00% … 87.61%
 Time  (median):     14.689 ns               ┊ GC (median):    0.00%
 Time  (mean ± σ):   15.337 ns ±   4.029 ns  ┊ GC (mean ± σ):  0.40% ±  1.54%

      ▆█
  ▂▂▂▄██▇▃▃▂▂▂▃▆▅▄▄▃▄▄▃▃▄▃▃▃▃▃▃▃▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▁▂▁▁▂▁▁▁▁▁▁▁▁▁▂ ▃
  14 ns           Histogram: frequency by time         19.6 ns <

 Memory estimate: 16 bytes, allocs estimate: 1.
```

After:
```
julia> @time Base.compilecache(pkg)
 22.752074 seconds (4.16 k allocations: 379.914 KiB)

❯ jl +dev --project -e 'using CUDA, BenchmarkTools; display(@benchmark CUBLAS.cublasGetProperty(CUDA.MAJOR_VERSION))'
BenchmarkTools.Trial: 10000 samples with 998 evaluations.
 Range (min … max):  14.198 ns … 253.505 ns  ┊ GC (min … max): 0.00% … 88.39%
 Time  (median):     14.754 ns               ┊ GC (median):    0.00%
 Time  (mean ± σ):   15.411 ns ±   4.154 ns  ┊ GC (mean ± σ):  0.42% ±  1.53%

      ▅█▂
  ▂▂▂▂███▄▃▂▂▂▂▂▃▅▆▅▃▄▄▃▃▃▃▃▃▃▃▃▃▃▃▃▃▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▁▁▁▁▁▂ ▃
  14.2 ns         Histogram: frequency by time         18.8 ns <

 Memory estimate: 16 bytes, allocs estimate: 1.
```

There's still about 12s of that spent in lowering, much of which spent expanding `@cuda`. But that is a separate issue.

Helps with https://github.com/JuliaGPU/CUDA.jl/issues/1684