### PR TITLE
Avoid unneeded macros to cut down on generated code

### DIFF
--- a/lib/cublas/CUBLAS.jl
+++ b/lib/cublas/CUBLAS.jl
@@ -4,7 +4,7 @@ using ..APIUtils
 
 using ..CUDA
 using ..CUDA: CUstream, cuComplex, cuDoubleComplex, libraryPropertyType, cudaDataType, i32
-using ..CUDA: unsafe_free!, @retry_reclaim, isdebug, @sync, initialize_context
+using ..CUDA: unsafe_free!, retry_reclaim, isdebug, @sync, initialize_context
 
 using ..CUDA: CUDA_Runtime
 using ..CUDA_Runtime

--- a/lib/cublas/libcublas.jl
+++ b/lib/cublas/libcublas.jl
@@ -19,7 +19,9 @@ macro check(ex, errs...)
     end
 
     quote
-        res = @retry_reclaim err -> $check $(esc(ex))
+        res = retry_reclaim(err -> $check) do
+            $(esc(ex))
+        end
         if res != CUBLAS_STATUS_SUCCESS
             throw_api_error(res)
         end

--- a/lib/cublas/libcublas.jl
+++ b/lib/cublas/libcublas.jl
@@ -12,22 +12,16 @@ const cudaStream_t = CUstream
     end
 end
 
-macro check(ex, errs...)
-    check = :(isequal(err, CUBLAS_STATUS_ALLOC_FAILED))
-    for err in errs
-        check = :($check || isequal(err, $(esc(err))))
+function check(f, errs...)
+    res = retry_reclaim(in((CUBLAS_STATUS_ALLOC_FAILED, errs...))) do
+        f()
     end
 
-    quote
-        res = retry_reclaim(err -> $check) do
-            $(esc(ex))
-        end
-        if res != CUBLAS_STATUS_SUCCESS
-            throw_api_error(res)
-        end
-
-        nothing
+    if res != CUBLAS_STATUS_SUCCESS
+        throw_api_error(res)
     end
+
+    return
 end
 
 mutable struct cublasContext end

--- a/lib/cublas/wrappers.jl
+++ b/lib/cublas/wrappers.jl
@@ -5,13 +5,17 @@
 
 function cublasCreate()
   handle_ref = Ref{cublasHandle_t}()
-  @check unsafe_cublasCreate_v2(handle_ref) CUBLAS_STATUS_NOT_INITIALIZED
+  check(CUBLAS_STATUS_NOT_INITIALIZED) do
+    unsafe_cublasCreate_v2(handle_ref)
+  end
   handle_ref[]
 end
 
 function cublasXtCreate()
   handle_ref = Ref{cublasXtHandle_t}()
-  @check unsafe_cublasXtCreate(handle_ref) CUBLAS_STATUS_NOT_INITIALIZED
+  check(CUBLAS_STATUS_NOT_INITIALIZED) do
+    unsafe_cublasXtCreate(handle_ref)
+  end
   handle_ref[]
 end
 

--- a/lib/cudadrv/libcuda.jl
+++ b/lib/cudadrv/libcuda.jl
@@ -28,15 +28,13 @@ end
     end
 end
 
-macro check(ex)
-    quote
-        res = $(esc(ex))
-        if res != SUCCESS
-            throw_api_error(res)
-        end
-
-        nothing
+function check(f)
+    res = f()
+    if res != SUCCESS
+        throw_api_error(res)
     end
+
+    return
 end
 
 const CUdevice_v1 = Cint

--- a/lib/cudadrv/version.jl
+++ b/lib/cudadrv/version.jl
@@ -36,7 +36,9 @@ Returns the CUDA Runtime version.
 """
 function runtime_version()
     version_ref = Ref{Cint}()
-    @check @ccall libcudart.cudaRuntimeGetVersion(version_ref::Ptr{Cint})::CUresult
+    check() do
+        @ccall libcudart.cudaRuntimeGetVersion(version_ref::Ptr{Cint})::CUresult
+    end
     major, ver = divrem(version_ref[], 1000)
     minor, patch = divrem(ver, 10)
     return VersionNumber(major, minor, patch)

--- a/lib/cudnn/src/base.jl
+++ b/lib/cudnn/src/base.jl
@@ -1,6 +1,8 @@
 function cudnnCreate()
     handle_ref = Ref{cudnnHandle_t}()
-    @check unsafe_cudnnCreate(handle_ref) CUDNN_STATUS_NOT_INITIALIZED CUDNN_STATUS_INTERNAL_ERROR
+    check(CUDNN_STATUS_NOT_INITIALIZED,CUDNN_STATUS_INTERNAL_ERROR) do
+      unsafe_cudnnCreate(handle_ref)
+    end
     return handle_ref[]
 end
 

--- a/lib/cudnn/src/cuDNN.jl
+++ b/lib/cudnn/src/cuDNN.jl
@@ -10,7 +10,7 @@ module cuDNN
 using CUDA
 using CUDA.APIUtils
 using CUDA: CUstream, libraryPropertyType
-using CUDA: @retry_reclaim, isdebug, initialize_context
+using CUDA: retry_reclaim, isdebug, initialize_context
 using CUDA: CUDA_Runtime, CUDA_Runtime_jll
 
 using CEnum: @cenum

--- a/lib/cudnn/src/libcudnn.jl
+++ b/lib/cudnn/src/libcudnn.jl
@@ -19,7 +19,9 @@ macro check(ex, errs...)
     end
 
     quote
-        res = @retry_reclaim err -> $check $(esc(ex))
+        res = retry_reclaim(err -> $check) do
+            $(esc(ex))
+        end
         if res != CUDNN_STATUS_SUCCESS
             throw_api_error(res)
         end

--- a/lib/cudnn/src/libcudnn.jl
+++ b/lib/cudnn/src/libcudnn.jl
@@ -12,22 +12,16 @@ const cudaStream_t = CUstream
     end
 end
 
-macro check(ex, errs...)
-    check = :(isequal(err, CUDNN_STATUS_ALLOC_FAILED))
-    for err in errs
-        check = :($check || isequal(err, $(esc(err))))
+function check(f, errs...)
+    res = retry_reclaim(in((CUDNN_STATUS_ALLOC_FAILED, errs...))) do
+        f()
     end
 
-    quote
-        res = retry_reclaim(err -> $check) do
-            $(esc(ex))
-        end
-        if res != CUDNN_STATUS_SUCCESS
-            throw_api_error(res)
-        end
-
-        nothing
+    if res != CUDNN_STATUS_SUCCESS
+        throw_api_error(res)
     end
+
+    return
 end
 
 mutable struct cudnnContext end

--- a/lib/cudnn/test/tensor.jl
+++ b/lib/cudnn/test/tensor.jl
@@ -6,8 +6,7 @@ using cuDNN:
     cudnnDataType,
     cudnnDataType_t,
     CUDNN_TENSOR_NCHW,
-    CUDNN_STATUS_SUCCESS,
-    @retry_reclaim
+    CUDNN_STATUS_SUCCESS
 
 x = CUDA.rand(1,1,1,2)
 
@@ -29,4 +28,6 @@ fd = FD(x)
 
 @test DT(Float32) isa cudnnDataType_t
 
-@test (@retry_reclaim(x->(x!==CUDNN_STATUS_SUCCESS),cudnnCreateTensorDescriptor(Ref{cudnnTensorDescriptor_t}(C_NULL)))) isa Nothing
+@test (CUDA.retry_reclaim(x->(x!==CUDNN_STATUS_SUCCESS)) do
+        cudnnCreateTensorDescriptor(Ref{cudnnTensorDescriptor_t}(C_NULL))
+    end) isa Nothing

--- a/lib/cufft/CUFFT.jl
+++ b/lib/cufft/CUFFT.jl
@@ -6,7 +6,7 @@ using ..CUDA_Runtime
 
 using ..CUDA
 using ..CUDA: CUstream, cuComplex, cuDoubleComplex, libraryPropertyType
-using ..CUDA: unsafe_free!, @retry_reclaim, initialize_context
+using ..CUDA: unsafe_free!, retry_reclaim, initialize_context
 
 using CEnum: @cenum
 

--- a/lib/cufft/libcufft.jl
+++ b/lib/cufft/libcufft.jl
@@ -19,7 +19,9 @@ macro check(ex, errs...)
     end
 
     quote
-        res = @retry_reclaim err -> $check $(esc(ex))
+        res = retry_reclaim(err -> $check) do
+            $(esc(ex))
+        end
         if res != CUFFT_SUCCESS
             throw_api_error(res)
         end

--- a/lib/cufft/libcufft.jl
+++ b/lib/cufft/libcufft.jl
@@ -12,22 +12,16 @@ const cudaStream_t = CUstream
     end
 end
 
-macro check(ex, errs...)
-    check = :(isequal(err, CUFFT_ALLOC_FAILED))
-    for err in errs
-        check = :($check || isequal(err, $(esc(err))))
+function check(f, errs...)
+    res = retry_reclaim(in((CUFFT_ALLOC_FAILED, errs...))) do
+        f()
     end
 
-    quote
-        res = retry_reclaim(err -> $check) do
-            $(esc(ex))
-        end
-        if res != CUFFT_SUCCESS
-            throw_api_error(res)
-        end
-
-        nothing
+    if res != CUFFT_SUCCESS
+        throw_api_error(res)
     end
+
+    return
 end
 
 @cenum cufftResult_t::UInt32 begin

--- a/lib/cupti/CUPTI.jl
+++ b/lib/cupti/CUPTI.jl
@@ -5,7 +5,7 @@ using ..APIUtils
 using ..CUDA_Runtime
 
 using ..CUDA
-using ..CUDA: @retry_reclaim, initialize_context
+using ..CUDA: retry_reclaim, initialize_context
 using ..CUDA: CUuuid, CUcontext, CUstream, CUdevice, CUdevice_attribute,
               CUgraph, CUgraphNode, CUgraphNodeType, CUgraphExec, CUaccessPolicyWindow
 

--- a/lib/cupti/libcupti.jl
+++ b/lib/cupti/libcupti.jl
@@ -19,7 +19,9 @@ macro check(ex, errs...)
     end
 
     quote
-        res = @retry_reclaim err -> $check $(esc(ex))
+        res = retry_reclaim(err -> $check) do
+            $(esc(ex))
+        end
         if res != CUPTI_SUCCESS
             throw_api_error(res)
         end

--- a/lib/cupti/libcupti.jl
+++ b/lib/cupti/libcupti.jl
@@ -12,22 +12,16 @@ const uint32_t = UInt32
     end
 end
 
-macro check(ex, errs...)
-    check = :(isequal(err, CUPTI_ERROR_OUT_OF_MEMORY))
-    for err in errs
-        check = :($check || isequal(err, $(esc(err))))
+function check(f, errs...)
+    res = retry_reclaim(in((CUPTI_ERROR_OUT_OF_MEMORY, errs...))) do
+        f()
     end
 
-    quote
-        res = retry_reclaim(err -> $check) do
-            $(esc(ex))
-        end
-        if res != CUPTI_SUCCESS
-            throw_api_error(res)
-        end
-
-        nothing
+    if res != CUPTI_SUCCESS
+        throw_api_error(res)
     end
+
+    return
 end
 
 macro CUPTI_PROFILER_STRUCT_SIZE(type, lastfield)

--- a/lib/curand/CURAND.jl
+++ b/lib/curand/CURAND.jl
@@ -6,7 +6,7 @@ using ..CUDA_Runtime
 
 using ..CUDA
 using ..CUDA: CUstream, libraryPropertyType, DEVICE_ATTRIBUTE_MAX_THREADS_PER_BLOCK
-using ..CUDA: @retry_reclaim, initialize_context
+using ..CUDA: retry_reclaim, initialize_context
 
 using CEnum: @cenum
 

--- a/lib/curand/libcurand.jl
+++ b/lib/curand/libcurand.jl
@@ -19,7 +19,9 @@ macro check(ex, errs...)
     end
 
     quote
-        res = @retry_reclaim err -> $check $(esc(ex))
+        res = retry_reclaim(err -> $check) do
+            $(esc(ex))
+        end
         if res != CURAND_STATUS_SUCCESS
             throw_api_error(res)
         end

--- a/lib/curand/libcurand.jl
+++ b/lib/curand/libcurand.jl
@@ -12,22 +12,16 @@ const cudaStream_t = CUstream
     end
 end
 
-macro check(ex, errs...)
-    check = :(isequal(err, CURAND_STATUS_ALLOCATION_FAILED))
-    for err in errs
-        check = :($check || isequal(err, $(esc(err))))
+function check(f, errs...)
+    res = retry_reclaim(in((CURAND_STATUS_ALLOCATION_FAILED, errs...))) do
+        f()
     end
 
-    quote
-        res = retry_reclaim(err -> $check) do
-            $(esc(ex))
-        end
-        if res != CURAND_STATUS_SUCCESS
-            throw_api_error(res)
-        end
-
-        nothing
+    if res != CURAND_STATUS_SUCCESS
+        throw_api_error(res)
     end
+
+    return
 end
 
 @cenum curandStatus::UInt32 begin

--- a/lib/curand/random.jl
+++ b/lib/curand/random.jl
@@ -49,7 +49,9 @@ function Random.seed!(rng::RNG, seed=make_seed(), offset=0)
     update_stream(rng)
     curandSetPseudoRandomGeneratorSeed(rng, seed)
     curandSetGeneratorOffset(rng, offset)
-    @check unsafe_curandGenerateSeeds(rng) CURAND_STATUS_PREEXISTING_FAILURE
+    check(CURAND_STATUS_PREEXISTING_FAILURE) do
+        unsafe_curandGenerateSeeds(rng)
+    end
     return
 end
 

--- a/lib/curand/wrappers.jl
+++ b/lib/curand/wrappers.jl
@@ -2,7 +2,9 @@
 
 function curandCreateGenerator(typ)
   handle_ref = Ref{curandGenerator_t}()
-  @check unsafe_curandCreateGenerator(handle_ref, typ) CURAND_STATUS_INITIALIZATION_FAILED
+  check(CURAND_STATUS_INITIALIZATION_FAILED) do
+    unsafe_curandCreateGenerator(handle_ref, typ)
+  end
   handle_ref[]
 end
 

--- a/lib/cusolver/CUSOLVER.jl
+++ b/lib/cusolver/CUSOLVER.jl
@@ -6,7 +6,7 @@ using ..CUDA_Runtime
 
 using ..CUDA
 using ..CUDA: CUstream, cuComplex, cuDoubleComplex, libraryPropertyType, cudaDataType
-using ..CUDA: @allowscalar, assertscalar, unsafe_free!, @retry_reclaim, initialize_context
+using ..CUDA: @allowscalar, assertscalar, unsafe_free!, retry_reclaim, initialize_context
 
 using ..CUBLAS: cublasFillMode_t, cublasOperation_t, cublasSideMode_t, cublasDiagType_t
 using ..CUSPARSE: cusparseMatDescr_t

--- a/lib/cusolver/dense.jl
+++ b/lib/cusolver/dense.jl
@@ -7,7 +7,9 @@ using ..CUBLAS: unsafe_batch
 
 function cusolverDnCreate()
   handle_ref = Ref{cusolverDnHandle_t}()
-  @check unsafe_cusolverDnCreate(handle_ref) CUSOLVER_STATUS_NOT_INITIALIZED CUSOLVER_STATUS_INTERNAL_ERROR
+  check(CUSOLVER_STATUS_NOT_INITIALIZED, CUSOLVER_STATUS_INTERNAL_ERROR) do
+    unsafe_cusolverDnCreate(handle_ref)
+  end
   return handle_ref[]
 end
 

--- a/lib/cusolver/libcusolver.jl
+++ b/lib/cusolver/libcusolver.jl
@@ -19,7 +19,9 @@ macro check(ex, errs...)
     end
 
     quote
-        res = @retry_reclaim err -> $check $(esc(ex))
+        res = retry_reclaim(err -> $check) do
+            $(esc(ex))
+        end
         if res != CUSOLVER_STATUS_SUCCESS
             throw_api_error(res)
         end

--- a/lib/cusolver/libcusolver.jl
+++ b/lib/cusolver/libcusolver.jl
@@ -12,22 +12,16 @@ const cudaStream_t = CUstream
     end
 end
 
-macro check(ex, errs...)
-    check = :(isequal(err, CUSOLVER_STATUS_ALLOC_FAILED))
-    for err in errs
-        check = :($check || isequal(err, $(esc(err))))
+function check(f, errs...)
+    res = retry_reclaim(in((CUSOLVER_STATUS_ALLOC_FAILED, errs...))) do
+        f()
     end
 
-    quote
-        res = retry_reclaim(err -> $check) do
-            $(esc(ex))
-        end
-        if res != CUSOLVER_STATUS_SUCCESS
-            throw_api_error(res)
-        end
-
-        nothing
+    if res != CUSOLVER_STATUS_SUCCESS
+        throw_api_error(res)
     end
+
+    return
 end
 
 mutable struct cusolverDnContext end

--- a/lib/cusolver/sparse.jl
+++ b/lib/cusolver/sparse.jl
@@ -6,7 +6,9 @@ using ..CUSPARSE: CuSparseMatrixCSR, CuSparseMatrixCSC, CuMatrixDescriptor
 
 function cusolverSpCreate()
   handle_ref = Ref{cusolverSpHandle_t}()
-  @check unsafe_cusolverSpCreate(handle_ref) CUSOLVER_STATUS_NOT_INITIALIZED CUSOLVER_STATUS_INTERNAL_ERROR
+  check(CUSOLVER_STATUS_NOT_INITIALIZED, CUSOLVER_STATUS_INTERNAL_ERROR) do
+    unsafe_cusolverSpCreate(handle_ref)
+  end
   return handle_ref[]
 end
 

--- a/lib/cusolver/sparse.jl
+++ b/lib/cusolver/sparse.jl
@@ -12,8 +12,8 @@ end
 
 function cusolverMgCreate()
   handle_ref = Ref{cusolverMgHandle_t}()
-  res = @retry_reclaim err->isequal(err, CUSOLVER_STATUS_ALLOC_FAILED) ||
-                            isequal(err, CUSOLVER_STATUS_NOT_INITIALIZED) begin
+  res = retry_reclaim(err->isequal(err, CUSOLVER_STATUS_ALLOC_FAILED) ||
+                           isequal(err, CUSOLVER_STATUS_NOT_INITIALIZED)) do
     unsafe_cusolverMgCreate(handle_ref)
   end
   if res != CUSOLVER_STATUS_SUCCESS

--- a/lib/cusparse/CUSPARSE.jl
+++ b/lib/cusparse/CUSPARSE.jl
@@ -6,7 +6,7 @@ using ..CUDA_Runtime
 
 using ..CUDA
 using ..CUDA: CUstream, cuComplex, cuDoubleComplex, libraryPropertyType, cudaDataType
-using ..CUDA: unsafe_free!, @retry_reclaim, initialize_context, i32, @allowscalar
+using ..CUDA: unsafe_free!, retry_reclaim, initialize_context, i32, @allowscalar
 
 using CEnum: @cenum
 

--- a/lib/cusparse/libcusparse.jl
+++ b/lib/cusparse/libcusparse.jl
@@ -12,22 +12,16 @@ const cudaStream_t = CUstream
     end
 end
 
-macro check(ex, errs...)
-    check = :(isequal(err, CUSPARSE_STATUS_ALLOC_FAILED))
-    for err in errs
-        check = :($check || isequal(err, $(esc(err))))
+function check(f, errs...)
+    res = retry_reclaim(in((CUSPARSE_STATUS_ALLOC_FAILED, errs...))) do
+        f()
     end
 
-    quote
-        res = retry_reclaim(err -> $check) do
-            $(esc(ex))
-        end
-        if res != CUSPARSE_STATUS_SUCCESS
-            throw_api_error(res)
-        end
-
-        nothing
+    if res != CUSPARSE_STATUS_SUCCESS
+        throw_api_error(res)
     end
+
+    return
 end
 
 mutable struct cusparseContext end

--- a/lib/cusparse/libcusparse.jl
+++ b/lib/cusparse/libcusparse.jl
@@ -19,7 +19,9 @@ macro check(ex, errs...)
     end
 
     quote
-        res = @retry_reclaim err -> $check $(esc(ex))
+        res = retry_reclaim(err -> $check) do
+            $(esc(ex))
+        end
         if res != CUSPARSE_STATUS_SUCCESS
             throw_api_error(res)
         end

--- a/lib/cusparse/management.jl
+++ b/lib/cusparse/management.jl
@@ -2,7 +2,9 @@
 
 function cusparseCreate()
     handle = Ref{cusparseHandle_t}()
-    @check unsafe_cusparseCreate(handle) CUSPARSE_STATUS_NOT_INITIALIZED
+    check(CUSPARSE_STATUS_NOT_INITIALIZED) do
+        unsafe_cusparseCreate(handle)
+    end
     handle[]
 end
 

--- a/lib/custatevec/src/cuStateVec.jl
+++ b/lib/custatevec/src/cuStateVec.jl
@@ -2,7 +2,7 @@ module cuStateVec
 
 using CUDA
 using CUDA: CUstream, cudaDataType, @checked, HandleCache, with_workspace, libraryPropertyType
-using CUDA: unsafe_free!, @retry_reclaim, initialize_context, isdebug
+using CUDA: unsafe_free!, retry_reclaim, initialize_context, isdebug
 using CUDA: CUDA_Runtime, CUDA_Runtime_jll
 
 using CEnum: @cenum

--- a/lib/custatevec/src/libcustatevec.jl
+++ b/lib/custatevec/src/libcustatevec.jl
@@ -15,22 +15,16 @@ const int2 = Tuple{Int32,Int32}
     end
 end
 
-macro check(ex, errs...)
-    check = :(isequal(err, CUSTATEVEC_STATUS_ALLOC_FAILED))
-    for err in errs
-        check = :($check || isequal(err, $(esc(err))))
+function check(f, errs...)
+    res = retry_reclaim(in((CUSTATEVEC_STATUS_ALLOC_FAILED, errs...))) do
+        f()
     end
 
-    quote
-        res = retry_reclaim(err -> $check) do
-            $(esc(ex))
-        end
-        if res != CUSTATEVEC_STATUS_SUCCESS
-            throw_api_error(res)
-        end
-
-        nothing
+    if res != CUSTATEVEC_STATUS_SUCCESS
+        throw_api_error(res)
     end
+
+    return
 end
 
 const custatevecIndex_t = Int64

--- a/lib/custatevec/src/libcustatevec.jl
+++ b/lib/custatevec/src/libcustatevec.jl
@@ -22,7 +22,9 @@ macro check(ex, errs...)
     end
 
     quote
-        res = @retry_reclaim err -> $check $(esc(ex))
+        res = retry_reclaim(err -> $check) do
+            $(esc(ex))
+        end
         if res != CUSTATEVEC_STATUS_SUCCESS
             throw_api_error(res)
         end

--- a/lib/cutensor/src/cuTENSOR.jl
+++ b/lib/cutensor/src/cuTENSOR.jl
@@ -3,7 +3,7 @@ module cuTENSOR
 using CUDA
 using CUDA.APIUtils
 using CUDA: CUstream, cudaDataType
-using CUDA: @retry_reclaim, initialize_context, isdebug
+using CUDA: retry_reclaim, initialize_context, isdebug
 using CUDA: CUDA_Runtime, CUDA_Runtime_jll
 
 using CEnum: @cenum

--- a/lib/cutensor/src/libcutensor.jl
+++ b/lib/cutensor/src/libcutensor.jl
@@ -12,22 +12,16 @@ const cudaStream_t = CUstream
     end
 end
 
-macro check(ex, errs...)
-    check = :(isequal(err, CUTENSOR_STATUS_ALLOC_FAILED))
-    for err in errs
-        check = :($check || isequal(err, $(esc(err))))
+function check(f, errs...)
+    res = retry_reclaim(in((CUTENSOR_STATUS_ALLOC_FAILED, errs...))) do
+        f()
     end
 
-    quote
-        res = retry_reclaim(err -> $check) do
-            $(esc(ex))
-        end
-        if res != CUTENSOR_STATUS_SUCCESS
-            throw_api_error(res)
-        end
-
-        nothing
+    if res != CUTENSOR_STATUS_SUCCESS
+        throw_api_error(res)
     end
+
+    return
 end
 
 @cenum cutensorOperator_t::UInt32 begin

--- a/lib/cutensor/src/libcutensor.jl
+++ b/lib/cutensor/src/libcutensor.jl
@@ -19,7 +19,9 @@ macro check(ex, errs...)
     end
 
     quote
-        res = @retry_reclaim err -> $check $(esc(ex))
+        res = retry_reclaim(err -> $check) do
+            $(esc(ex))
+        end
         if res != CUTENSOR_STATUS_SUCCESS
             throw_api_error(res)
         end

--- a/lib/cutensornet/src/cuTensorNet.jl
+++ b/lib/cutensornet/src/cuTensorNet.jl
@@ -3,7 +3,7 @@ module cuTensorNet
 using LinearAlgebra
 using CUDA
 using CUDA: CUstream, cudaDataType, @checked, HandleCache, with_workspace
-using CUDA: @retry_reclaim, initialize_context, isdebug
+using CUDA: retry_reclaim, initialize_context, isdebug
 using CUDA: CUDA_Runtime, CUDA_Runtime_jll
 
 using cuTENSOR

--- a/lib/cutensornet/src/libcutensornet.jl
+++ b/lib/cutensornet/src/libcutensornet.jl
@@ -19,7 +19,9 @@ macro check(ex, errs...)
     end
 
     quote
-        res = @retry_reclaim err -> $check $(esc(ex))
+        res = retry_reclaim(err -> $check) do
+            $(esc(ex))
+        end
         if res != CUTENSORNET_STATUS_SUCCESS
             throw_api_error(res)
         end

--- a/lib/nvml/libnvml.jl
+++ b/lib/nvml/libnvml.jl
@@ -20,15 +20,13 @@ function initialize_context()
     end
 end
 
-macro check(ex)
-    quote
-        res = $(esc(ex))
-        if res != NVML_SUCCESS
-            throw_api_error(res)
-        end
-
-        nothing
+function check(f)
+    res = f()
+    if res != NVML_SUCCESS
+        throw_api_error(res)
     end
+
+    return
 end
 
 @cenum nvmlReturn_enum::UInt32 begin

--- a/lib/utils/call.jl
+++ b/lib/utils/call.jl
@@ -9,9 +9,9 @@ export @checked, with_workspace, @debug_ccall
     end
 
 Macro for wrapping a function definition returning a status code. Two versions of the
-function will be generated: `foo`, with the function body wrapped by an invocation of the
-`@check` macro (to be implemented by the caller of this macro), and `unsafe_foo` where no
-such invocation is present and the status code is returned to the caller.
+function will be generated: `foo`, with the function execution wrapped by an invocation of
+the `check` function (to be implemented by the caller of this macro), and `unsafe_foo` where
+no such invocation is present and the status code is returned to the caller.
 """
 macro checked(ex)
     # parse the function definition
@@ -23,7 +23,9 @@ macro checked(ex)
 
     # generate a "safe" version that performs a check
     safe_body = quote
-        @check $body
+        check() do
+            $body
+        end
     end
     safe_sig = Expr(:call, sig.args[1], sig.args[2:end]...)
     safe_def = Expr(:function, safe_sig, safe_body)

--- a/res/wrap/README.md
+++ b/res/wrap/README.md
@@ -24,7 +24,7 @@ The possible values for `library` are `"all"` (default), `"cuda"`, `"nvml"`, `"c
 For each library, the script performs the following steps:
 
 - generate wrappers with Clang.jl
-- rewrite the headers: wrap functions that result status codes with `@check`, add calls to
+- rewrite the headers: wrap functions that result status codes with `check`, add calls to
   API initializers, etc.
 
 You should always review any changes to the headers! Specifically, verify that pointer

--- a/res/wrap/libcublas_prologue.jl
+++ b/res/wrap/libcublas_prologue.jl
@@ -17,7 +17,9 @@ macro check(ex, errs...)
     end
 
     quote
-        res = @retry_reclaim err->$check $(esc(ex))
+        res = retry_reclaim(err -> $check) do
+            $(esc(ex))
+        end
         if res != CUBLAS_STATUS_SUCCESS
             throw_api_error(res)
         end

--- a/res/wrap/libcuda_prologue.jl
+++ b/res/wrap/libcuda_prologue.jl
@@ -26,13 +26,11 @@ end
     end
 end
 
-macro check(ex)
-    quote
-        res = $(esc(ex))
-        if res != SUCCESS
-            throw_api_error(res)
-        end
-
-        nothing
+function check(f)
+    res = f()
+    if res != SUCCESS
+        throw_api_error(res)
     end
+
+    return
 end

--- a/res/wrap/libcudnn_prologue.jl
+++ b/res/wrap/libcudnn_prologue.jl
@@ -17,7 +17,9 @@ macro check(ex, errs...)
     end
 
     quote
-        res = @retry_reclaim err->$check $(esc(ex))
+        res = retry_reclaim(err -> $check) do
+            $(esc(ex))
+        end
         if res != CUDNN_STATUS_SUCCESS
             throw_api_error(res)
         end

--- a/res/wrap/libcudnn_prologue.jl
+++ b/res/wrap/libcudnn_prologue.jl
@@ -10,20 +10,14 @@ const cudaStream_t = CUstream
     end
 end
 
-macro check(ex, errs...)
-    check = :(isequal(err, CUDNN_STATUS_ALLOC_FAILED))
-    for err in errs
-        check = :($check || isequal(err, $(esc(err))))
+function check(f, errs...)
+    res = retry_reclaim(in((CUDNN_STATUS_ALLOC_FAILED, errs...))) do
+        f()
     end
 
-    quote
-        res = retry_reclaim(err -> $check) do
-            $(esc(ex))
-        end
-        if res != CUDNN_STATUS_SUCCESS
-            throw_api_error(res)
-        end
-
-        nothing
+    if res != CUDNN_STATUS_SUCCESS
+        throw_api_error(res)
     end
+
+    return
 end

--- a/res/wrap/libcufft_prologue.jl
+++ b/res/wrap/libcufft_prologue.jl
@@ -17,7 +17,9 @@ macro check(ex, errs...)
     end
 
     quote
-        res = @retry_reclaim err->$check $(esc(ex))
+        res = retry_reclaim(err -> $check) do
+            $(esc(ex))
+        end
         if res != CUFFT_SUCCESS
             throw_api_error(res)
         end

--- a/res/wrap/libcufft_prologue.jl
+++ b/res/wrap/libcufft_prologue.jl
@@ -10,20 +10,15 @@ const cudaStream_t = CUstream
     end
 end
 
-macro check(ex, errs...)
-    check = :(isequal(err, CUFFT_ALLOC_FAILED))
-    for err in errs
-        check = :($check || isequal(err, $(esc(err))))
+function check(f, errs...)
+    res = retry_reclaim(in((CUFFT_ALLOC_FAILED, errs...))) do
+        f()
     end
 
-    quote
-        res = retry_reclaim(err -> $check) do
-            $(esc(ex))
-        end
-        if res != CUFFT_SUCCESS
-            throw_api_error(res)
-        end
-
-        nothing
+    if res != CUFFT_SUCCESS
+        throw_api_error(res)
     end
+
+    return
 end
+

--- a/res/wrap/libcupti_prologue.jl
+++ b/res/wrap/libcupti_prologue.jl
@@ -17,7 +17,9 @@ macro check(ex, errs...)
     end
 
     quote
-        res = @retry_reclaim err->$check $(esc(ex))
+        res = retry_reclaim(err -> $check) do
+            $(esc(ex))
+        end
         if res != CUPTI_SUCCESS
             throw_api_error(res)
         end

--- a/res/wrap/libcupti_prologue.jl
+++ b/res/wrap/libcupti_prologue.jl
@@ -10,22 +10,16 @@ const uint32_t = UInt32
     end
 end
 
-macro check(ex, errs...)
-    check = :(isequal(err, CUPTI_ERROR_OUT_OF_MEMORY))
-    for err in errs
-        check = :($check || isequal(err, $(esc(err))))
+function check(f, errs...)
+    res = retry_reclaim(in((CUPTI_ERROR_OUT_OF_MEMORY, errs...))) do
+        f()
     end
 
-    quote
-        res = retry_reclaim(err -> $check) do
-            $(esc(ex))
-        end
-        if res != CUPTI_SUCCESS
-            throw_api_error(res)
-        end
-
-        nothing
+    if res != CUPTI_SUCCESS
+        throw_api_error(res)
     end
+
+    return
 end
 
 macro CUPTI_PROFILER_STRUCT_SIZE(type, lastfield)

--- a/res/wrap/libcurand_prologue.jl
+++ b/res/wrap/libcurand_prologue.jl
@@ -10,20 +10,14 @@ const cudaStream_t = CUstream
     end
 end
 
-macro check(ex, errs...)
-    check = :(isequal(err, CURAND_STATUS_ALLOCATION_FAILED))
-    for err in errs
-        check = :($check || isequal(err, $(esc(err))))
+function check(f, errs...)
+    res = retry_reclaim(in((CURAND_STATUS_ALLOCATION_FAILED, errs...))) do
+        f()
     end
 
-    quote
-        res = retry_reclaim(err -> $check) do
-            $(esc(ex))
-        end
-        if res != CURAND_STATUS_SUCCESS
-            throw_api_error(res)
-        end
-
-        nothing
+    if res != CURAND_STATUS_SUCCESS
+        throw_api_error(res)
     end
+
+    return
 end

--- a/res/wrap/libcurand_prologue.jl
+++ b/res/wrap/libcurand_prologue.jl
@@ -17,7 +17,9 @@ macro check(ex, errs...)
     end
 
     quote
-        res = @retry_reclaim err->$check $(esc(ex))
+        res = retry_reclaim(err -> $check) do
+            $(esc(ex))
+        end
         if res != CURAND_STATUS_SUCCESS
             throw_api_error(res)
         end

--- a/res/wrap/libcusolver_prologue.jl
+++ b/res/wrap/libcusolver_prologue.jl
@@ -10,20 +10,14 @@ const cudaStream_t = CUstream
     end
 end
 
-macro check(ex, errs...)
-    check = :(isequal(err, CUSOLVER_STATUS_ALLOC_FAILED))
-    for err in errs
-        check = :($check || isequal(err, $(esc(err))))
+function check(f, errs...)
+    res = retry_reclaim(in((CUSOLVER_STATUS_ALLOC_FAILED, errs...))) do
+        f()
     end
 
-    quote
-        res = retry_reclaim(err -> $check) do
-            $(esc(ex))
-        end
-        if res != CUSOLVER_STATUS_SUCCESS
-            throw_api_error(res)
-        end
-
-        nothing
+    if res != CUSOLVER_STATUS_SUCCESS
+        throw_api_error(res)
     end
+
+    return
 end

--- a/res/wrap/libcusolver_prologue.jl
+++ b/res/wrap/libcusolver_prologue.jl
@@ -17,7 +17,9 @@ macro check(ex, errs...)
     end
 
     quote
-        res = @retry_reclaim err->$check $(esc(ex))
+        res = retry_reclaim(err -> $check) do
+            $(esc(ex))
+        end
         if res != CUSOLVER_STATUS_SUCCESS
             throw_api_error(res)
         end

--- a/res/wrap/libcusparse_prologue.jl
+++ b/res/wrap/libcusparse_prologue.jl
@@ -17,7 +17,9 @@ macro check(ex, errs...)
     end
 
     quote
-        res = @retry_reclaim err->$check $(esc(ex))
+        res = retry_reclaim(err -> $check) do
+            $(esc(ex))
+        end
         if res != CUSPARSE_STATUS_SUCCESS
             throw_api_error(res)
         end

--- a/res/wrap/libcusparse_prologue.jl
+++ b/res/wrap/libcusparse_prologue.jl
@@ -10,20 +10,14 @@ const cudaStream_t = CUstream
     end
 end
 
-macro check(ex, errs...)
-    check = :(isequal(err, CUSPARSE_STATUS_ALLOC_FAILED))
-    for err in errs
-        check = :($check || isequal(err, $(esc(err))))
+function check(f, errs...)
+    res = retry_reclaim(in((CUSPARSE_STATUS_ALLOC_FAILED, errs...))) do
+        f()
     end
 
-    quote
-        res = retry_reclaim(err -> $check) do
-            $(esc(ex))
-        end
-        if res != CUSPARSE_STATUS_SUCCESS
-            throw_api_error(res)
-        end
-
-        nothing
+    if res != CUSPARSE_STATUS_SUCCESS
+        throw_api_error(res)
     end
+
+    return
 end

--- a/res/wrap/libcustatevec_prologue.jl
+++ b/res/wrap/libcustatevec_prologue.jl
@@ -20,7 +20,9 @@ macro check(ex, errs...)
     end
 
     quote
-        res = @retry_reclaim err->$check $(esc(ex))
+        res = retry_reclaim(err -> $check) do
+            $(esc(ex))
+        end
         if res != CUSTATEVEC_STATUS_SUCCESS
             throw_api_error(res)
         end

--- a/res/wrap/libcustatevec_prologue.jl
+++ b/res/wrap/libcustatevec_prologue.jl
@@ -13,20 +13,14 @@ const int2 = Tuple{Int32,Int32}
     end
 end
 
-macro check(ex, errs...)
-    check = :(isequal(err, CUSTATEVEC_STATUS_ALLOC_FAILED))
-    for err in errs
-        check = :($check || isequal(err, $(esc(err))))
+function check(f, errs...)
+    res = retry_reclaim(in((CUSTATEVEC_STATUS_ALLOC_FAILED, errs...))) do
+        f()
     end
 
-    quote
-        res = retry_reclaim(err -> $check) do
-            $(esc(ex))
-        end
-        if res != CUSTATEVEC_STATUS_SUCCESS
-            throw_api_error(res)
-        end
-
-        nothing
+    if res != CUSTATEVEC_STATUS_SUCCESS
+        throw_api_error(res)
     end
+
+    return
 end

--- a/res/wrap/libcutensor_prologue.jl
+++ b/res/wrap/libcutensor_prologue.jl
@@ -10,20 +10,14 @@ const cudaStream_t = CUstream
     end
 end
 
-macro check(ex, errs...)
-    check = :(isequal(err, CUTENSOR_STATUS_ALLOC_FAILED))
-    for err in errs
-        check = :($check || isequal(err, $(esc(err))))
+function check(f, errs...)
+    res = retry_reclaim(in((CUTENSOR_STATUS_ALLOC_FAILED, errs...))) do
+        f()
     end
 
-    quote
-        res = retry_reclaim(err -> $check) do
-            $(esc(ex))
-        end
-        if res != CUTENSOR_STATUS_SUCCESS
-            throw_api_error(res)
-        end
-
-        nothing
+    if res != CUTENSOR_STATUS_SUCCESS
+        throw_api_error(res)
     end
+
+    return
 end

--- a/res/wrap/libcutensor_prologue.jl
+++ b/res/wrap/libcutensor_prologue.jl
@@ -17,7 +17,9 @@ macro check(ex, errs...)
     end
 
     quote
-        res = @retry_reclaim err->$check $(esc(ex))
+        res = retry_reclaim(err -> $check) do
+            $(esc(ex))
+        end
         if res != CUTENSOR_STATUS_SUCCESS
             throw_api_error(res)
         end

--- a/res/wrap/libcutensornet_prologue.jl
+++ b/res/wrap/libcutensornet_prologue.jl
@@ -17,7 +17,9 @@ macro check(ex, errs...)
     end
 
     quote
-        res = @retry_reclaim err->$check $(esc(ex))
+        res = retry_reclaim(err -> $check) do
+            $(esc(ex))
+        end
         if res != CUTENSORNET_STATUS_SUCCESS
             throw_api_error(res)
         end

--- a/res/wrap/libcutensornet_prologue.jl
+++ b/res/wrap/libcutensornet_prologue.jl
@@ -10,20 +10,14 @@ const cudaStream_t = CUstream
     end
 end
 
-macro check(ex, errs...)
-    check = :(isequal(err, CUTENSORNET_STATUS_ALLOC_FAILED))
-    for err in errs
-        check = :($check || isequal(err, $(esc(err))))
+function check(f, errs...)
+    res = retry_reclaim(in((CUTENSORNET_STATUS_ALLOC_FAILED, errs...))) do
+        f()
     end
 
-    quote
-        res = retry_reclaim(err -> $check) do
-            $(esc(ex))
-        end
-        if res != CUTENSORNET_STATUS_SUCCESS
-            throw_api_error(res)
-        end
-
-        nothing
+    if res != CUTENSORNET_STATUS_SUCCESS
+        throw_api_error(res)
     end
+
+    return
 end

--- a/res/wrap/libnvml_prologue.jl
+++ b/res/wrap/libnvml_prologue.jl
@@ -18,13 +18,11 @@ function initialize_context()
     end
 end
 
-macro check(ex)
-    quote
-        res = $(esc(ex))
-        if res != NVML_SUCCESS
-            throw_api_error(res)
-        end
-
-        nothing
+function check(f)
+    res = f()
+    if res != NVML_SUCCESS
+        throw_api_error(res)
     end
+
+    return
 end

--- a/test/apiutils.jl
+++ b/test/apiutils.jl
@@ -15,11 +15,9 @@ end
         using CUDA.APIUtils
 
         const checks = Ref(0)
-        macro check(ex)
-            esc(quote
-                $checks[] += 1
-                $ex
-            end)
+        function check(f)
+            checks[] += 1
+            f()
         end
 
         @checked function foo()

--- a/test/pool.jl
+++ b/test/pool.jl
@@ -27,8 +27,12 @@ end
     CUDA.reclaim(1024)
     CUDA.reclaim()
 
-    @test CUDA.@retry_reclaim(isequal(42), 42) == 42
-    @test CUDA.@retry_reclaim(isequal(42), 41) == 41
+    @test CUDA.retry_reclaim(isequal(42)) do
+            42
+        end == 42
+    @test CUDA.retry_reclaim(isequal(42)) do
+            41
+        end == 41
 end
 
 @testset "memory_status" begin


### PR DESCRIPTION
Apparently lowering is pretty slow, so expanding the many `@retry_reclaim` macros took significant time (around 6ms each). Replacing it with a regular function cuts down the time to around 1.5ms, significantly improving the time to compile the package.

Before:

```
julia> @time Base.compilecache(pkg)
 28.516434 seconds (4.16 k allocations: 379.914 KiB)

BenchmarkTools.Trial: 10000 samples with 998 evaluations.
 Range (min … max):  14.018 ns … 260.649 ns  ┊ GC (min … max): 0.00% … 87.61%
 Time  (median):     14.689 ns               ┊ GC (median):    0.00%
 Time  (mean ± σ):   15.337 ns ±   4.029 ns  ┊ GC (mean ± σ):  0.40% ±  1.54%

      ▆█
  ▂▂▂▄██▇▃▃▂▂▂▃▆▅▄▄▃▄▄▃▃▄▃▃▃▃▃▃▃▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▁▂▁▁▂▁▁▁▁▁▁▁▁▁▂ ▃
  14 ns           Histogram: frequency by time         19.6 ns <

 Memory estimate: 16 bytes, allocs estimate: 1.
```

After:
```
julia> @time Base.compilecache(pkg)
 22.752074 seconds (4.16 k allocations: 379.914 KiB)

❯ jl +dev --project -e 'using CUDA, BenchmarkTools; display(@benchmark CUBLAS.cublasGetProperty(CUDA.MAJOR_VERSION))'
BenchmarkTools.Trial: 10000 samples with 998 evaluations.
 Range (min … max):  14.198 ns … 253.505 ns  ┊ GC (min … max): 0.00% … 88.39%
 Time  (median):     14.754 ns               ┊ GC (median):    0.00%
 Time  (mean ± σ):   15.411 ns ±   4.154 ns  ┊ GC (mean ± σ):  0.42% ±  1.53%

      ▅█▂
  ▂▂▂▂███▄▃▂▂▂▂▂▃▅▆▅▃▄▄▃▃▃▃▃▃▃▃▃▃▃▃▃▃▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▁▁▁▁▁▂ ▃
  14.2 ns         Histogram: frequency by time         18.8 ns <

 Memory estimate: 16 bytes, allocs estimate: 1.
```

There's still about 12s of that spent in lowering, much of which spent expanding `@cuda`. But that is a separate issue.

Helps with https://github.com/JuliaGPU/CUDA.jl/issues/1684