### PR TITLE
Align variables in constant memory by 256 bit

### DIFF
--- a/src/device/random.jl
+++ b/src/device/random.jl
@@ -168,6 +168,7 @@ function emit_constant_array(name::Symbol, data::AbstractArray{T}) where {T}
         T_global = LLVM.ArrayType(T_val, length(data))
         # XXX: why can't we use a single name like emit_shmem
         gv = GlobalVariable(mod, T_global, "gpu_$(name)_data", AS.Constant)
+        alignment!(gv, 16)
         linkage!(gv, LLVM.API.LLVMInternalLinkage)
         initializer!(gv, ConstantArray(data; ctx))
 


### PR DESCRIPTION
The ptx shows that the alignment is working:
```.const .align 16 .b8 gpu_centre_radius_data[7744] = {...};```
Also, I was able to do manual 128 bit loads after this change.