### PR TITLE
Update benchmarks for 1.8 and 1.9

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -304,6 +304,8 @@ steps:
             julia:
               - "1.6"
               - "1.7"
+              - "1.8"
+              - "1.9"
         timeout_in_minutes: 30
 
 env:

--- a/lib/cudadrv/state.jl
+++ b/lib/cudadrv/state.jl
@@ -69,7 +69,7 @@ end
 function task_local_state!(args...)
     tls = task_local_storage()
     if haskey(tls, :CUDA)
-        validate_task_local_state(@inbounds(tls[:CUDA]))
+        validate_task_local_state(@inbounds(tls[:CUDA])::TaskLocalState)
     else
         # verify that CUDA.jl is functional. this doesn't belong here, but since we can't
         # error during `__init__`, we do it here instead as this is the first function

--- a/perf/kernel.jl
+++ b/perf/kernel.jl
@@ -2,15 +2,11 @@ using CUDA: i32
 
 group = addgroup!(SUITE, "kernel")
 
-dummy_kernel() = nothing
-group["launch"] = @benchmarkable @cuda dummy_kernel()
+group["launch"] = @benchmarkable @cuda identity(nothing)
 
-wanted_threads = 10000
 group["occupancy"] = @benchmarkable begin
-    kernel = @cuda launch=false dummy_kernel()
-    config = launch_configuration(kernel.fun)
-    threads = min($wanted_threads, config.threads)
-    blocks = cld($wanted_threads, threads)
+    kernel = @cuda launch=false identity(nothing)
+    launch_configuration(kernel.fun)
 end
 
 src = CUDA.rand(Float32, 512, 1000)

--- a/perf/latency.jl
+++ b/perf/latency.jl
@@ -15,7 +15,7 @@ function main()
 
     # time to precompile the package and its dependencies
     precompile_cmd =
-        `$base_cmd -e "pkg = Base.identify_package("CUDA")
+        `$base_cmd -e "pkg = Base.identify_package(\"CUDA\")
                        Base.compilecache(pkg)"`
     results["precompile"] = @benchmark run($precompile_cmd) evals=1 seconds=60
 

--- a/perf/latency.jl
+++ b/perf/latency.jl
@@ -15,9 +15,8 @@ function main()
 
     # time to precompile the package and its dependencies
     precompile_cmd =
-        `$base_cmd -e "uuid = Base.UUID(\"052768ef-5323-5732-b1bb-66c8b64840ba\")
-                    id = Base.PkgId(uuid, \"CUDA\")
-                    Base.compilecache(id)"`
+        `$base_cmd -e "pkg = Base.identify_package("CUDA")
+                       Base.compilecache(pkg)"`
     results["precompile"] = @benchmark run($precompile_cmd) evals=1 seconds=60
 
     # time to actually import the package
@@ -28,8 +27,8 @@ function main()
     # time to actually compile a kernel
     ttfp_cmd =
         `$base_cmd -e "using CUDA
-                    kernel() = return
-                    CUDA.code_ptx(devnull, kernel, Tuple{}; kernel=true)"`
+                       kernel() = return
+                       CUDA.code_ptx(devnull, kernel, Tuple{}; kernel=true)"`
     results["ttfp"] = @benchmark run($ttfp_cmd) evals=1 seconds=60
 
     results

--- a/perf/latency.jl
+++ b/perf/latency.jl
@@ -25,12 +25,6 @@ function main()
         `$base_cmd -e "using CUDA"`
     results["import"] = @benchmark run($import_cmd) evals=1 seconds=30
 
-    # time to initialize CUDA and all other libraries
-    initialize_time =
-        `$base_cmd -e "using CUDA
-                       CUDA.driver_version()"`
-    results["initialize"] = @benchmark run($initialize_time) evals=1 seconds=30
-
     # time to actually compile a kernel
     ttfp_cmd =
         `$base_cmd -e "using CUDA

--- a/src/compiler/compilation.jl
+++ b/src/compiler/compilation.jl
@@ -47,11 +47,11 @@ GPUCompiler.kernel_state_type(job::CUDACompilerJob) = KernelState
 ## compiler implementation (cache, configure, compile, and link)
 
 # cache of compilation caches, per context
-const _compiler_caches = Dict{CuContext, Dict{Any, Any}}();
+const _compiler_caches = Dict{CuContext, Dict{Any, CuFunction}}();
 function compiler_cache(ctx::CuContext)
     cache = get(_compiler_caches, ctx, nothing)
     if cache === nothing
-        cache = Dict{Any, Any}()
+        cache = Dict{Any, CuFunction}()
         _compiler_caches[ctx] = cache
     end
     return cache


### PR DESCRIPTION
Also includes some micro-optimizations that make kernel launch really efficient on 1.10:

```
julia> @benchmark cufunction(identity, Tuple{Nothing})
BenchmarkTools.Trial: 10000 samples with 767 evaluations.
 Range (min … max):  166.140 ns …  1.673 μs  ┊ GC (min … max): 0.00% … 88.29%
 Time  (median):     171.237 ns              ┊ GC (median):    0.00%
 Time  (mean ± σ):   173.108 ns ± 30.041 ns  ┊ GC (mean ± σ):  0.37% ±  1.93%

        ▁▃▆███▅▃▁
  ▁▁▂▂▄▆█████████▇▆▅▄▄▃▃▂▂▂▂▂▂▂▂▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▂▁▁▁▁▁▁▁ ▃
  166 ns          Histogram: frequency by time          193 ns <

 Memory estimate: 32 bytes, allocs estimate: 1.

julia> @benchmark @cuda identity(nothing)
BenchmarkTools.Trial: 10000 samples with 9 evaluations.
 Range (min … max):  2.030 μs …   5.024 μs  ┊ GC (min … max): 0.00% … 0.00%
 Time  (median):     2.252 μs               ┊ GC (median):    0.00%
 Time  (mean ± σ):   2.286 μs ± 165.630 ns  ┊ GC (mean ± σ):  0.00% ± 0.00%

            ▃▆███▅▇▁▁▁
  ▂▁▂▂▂▂▂▃▃▆██████████▇▇▆▆▆▅▅▄▃▃▃▃▃▃▃▃▂▂▂▂▂▂▂▂▂▁▂▂▂▂▂▂▂▂▂▂▂▂▂ ▄
  2.03 μs         Histogram: frequency by time        2.86 μs <

 Memory estimate: 96 bytes, allocs estimate: 2.
```