### PR TITLE
Allow StaticArray eltype in matmat{vec,mul}

### DIFF
--- a/lib/cublas/linalg.jl
+++ b/lib/cublas/linalg.jl
@@ -190,7 +190,7 @@ function LinearAlgebra.generic_matvecmul!(Y::CuVector, tA::AbstractChar, A::Stri
     end
 
     T = eltype(Y)
-    alpha, beta = promote(_add.alpha, _add.beta, zero(T))
+    alpha, beta = _add.alpha, _add.beta
     if alpha isa Union{Bool,T} && beta isa Union{Bool,T}
         if T <: CublasFloat && eltype(A) == eltype(B) == T
             if tA in ('N', 'T', 'C')
@@ -273,7 +273,7 @@ end
 
 function LinearAlgebra.generic_matmatmul!(C::CuVecOrMat, tA, tB, A::StridedCuVecOrMat, B::StridedCuVecOrMat, _add::MulAddMul)
     T = eltype(C)
-    alpha, beta = promote(_add.alpha, _add.beta, zero(T))
+    alpha, beta = _add.alpha, _add.beta
     mA, nA = size(A, tA == 'N' ? 1 : 2), size(A, tA == 'N' ? 2 : 1)
     mB, nB = size(B, tB == 'N' ? 1 : 2), size(B, tB == 'N' ? 2 : 1)
 

--- a/test/libraries/cublas.jl
+++ b/test/libraries/cublas.jl
@@ -4,6 +4,7 @@ using CUDA.CUBLAS: band, bandex
 using LinearAlgebra
 
 using BFloat16s
+using StaticArrays
 
 @test CUBLAS.version() isa VersionNumber
 @test CUBLAS.version().major == CUBLAS.cublasGetProperty(CUDA.MAJOR_VERSION)
@@ -605,6 +606,14 @@ end
             W = @view p[reshape(1:(16),4,4)]
             W*b
         end
+    end
+
+    @testset "StaticArray eltype" begin
+       A = CuArray(rand(SVector{2, Float64}, 3, 3))
+       B = CuArray(rand(Float64, 3, 1))
+       C = A * B
+       hC = Array(A) * Array(B)
+       @test Array(C) ≈ hC
     end
 end
 
@@ -2015,4 +2024,12 @@ end
             @test C ≈ h_C
         end
     end # extensions
+
+    @testset "StaticArray eltype" begin
+       A = CuArray(rand(SVector{2, Float32}, 3, 3))
+       B = CuArray(rand(Float32, 3, 3))
+       C = A * B
+       hC = Array(A) * Array(B)
+       @test Array(C) ≈ hC
+    end
 end # elty


### PR DESCRIPTION
Here we avoid promotion since it is not defined between scalar numbers
and static array types.

Fixes #1953

Co-authored-by: Mason McCallum <masonamccallum@gmail.com>