### PR TITLE
Check mathType only if not Float32

### DIFF
--- a/lib/cudnn/src/convolution.jl
+++ b/lib/cudnn/src/convolution.jl
@@ -267,7 +267,7 @@ end
 function cudnnConvolutionAlgoPerfChoose(convDesc, tensorDesc, perfResults, n)
     mathType = Ref{cudnnMathType_t}(CUDNN_DEFAULT_MATH)
     cudnnGetConvolutionMathType(convDesc, mathType)
-    skipMathTypeCheck = begin  # See https://github.com/JuliaGPU/CUDA.jl/pull/1943#issuecomment-1605267932
+    skipMathTypeCheck = let  # See https://github.com/JuliaGPU/CUDA.jl/pull/1943#issuecomment-1605267932
         dtype, _ = cudnnGetTensorDescriptor(tensorDesc)
         dtype == Float32
     end

--- a/lib/cudnn/src/convolution.jl
+++ b/lib/cudnn/src/convolution.jl
@@ -192,7 +192,7 @@ function cudnnConvolutionFwdAlgoPerf(xDesc, x, wDesc, w, convDesc, yDesc, y, bia
         with_workspace(workspaceSize) do workspace
             cudnnFindConvolutionForwardAlgorithmEx(handle(),xDesc,x,wDesc,w,convDesc,yDesc,yTmp,requestedAlgoCount,returnedAlgoCount,perfResults,workspace,sizeof(workspace))
         end
-        val = cudnnConvolutionAlgoPerfChoose(perfResults, returnedAlgoCount[1])
+        val = cudnnConvolutionAlgoPerfChoose(convDesc, xDesc, perfResults, returnedAlgoCount[1])
         lock(cudnnConvolutionFwdAlgoPerfCacheLock) do
             cudnnConvolutionFwdAlgoPerfCache[key] = val
         end
@@ -223,7 +223,7 @@ function cudnnConvolutionBwdDataAlgoPerf(wDesc, w, dyDesc, dy, convDesc, dxDesc,
         with_workspace(workspaceSize) do workspace
             cudnnFindConvolutionBackwardDataAlgorithmEx(handle(),wDesc,w,dyDesc,dy,convDesc,dxDesc,dxTmp,requestedAlgoCount,returnedAlgoCount,perfResults,workspace,sizeof(workspace))
         end
-        val = cudnnConvolutionAlgoPerfChoose(perfResults, returnedAlgoCount[1])
+        val = cudnnConvolutionAlgoPerfChoose(convDesc, wDesc, perfResults, returnedAlgoCount[1])
         lock(cudnnConvolutionBwdDataAlgoPerfCacheLock) do
             cudnnConvolutionBwdDataAlgoPerfCache[key] = val
         end
@@ -254,7 +254,7 @@ function cudnnConvolutionBwdFilterAlgoPerf(xDesc, x, dyDesc, dy, convDesc, dwDes
         with_workspace(workspaceSize) do workspace
             cudnnFindConvolutionBackwardFilterAlgorithmEx(handle(),xDesc,x,dyDesc,dy,convDesc,dwDesc,dwTmp,requestedAlgoCount,returnedAlgoCount,perfResults,workspace,sizeof(workspace))
         end
-        val = cudnnConvolutionAlgoPerfChoose(perfResults, returnedAlgoCount[1])
+        val = cudnnConvolutionAlgoPerfChoose(convDesc, xDesc, perfResults, returnedAlgoCount[1])
         lock(cudnnConvolutionBwdFilterAlgoPerfCacheLock) do
             cudnnConvolutionBwdFilterAlgoPerfCache[key] = val
         end
@@ -264,20 +264,29 @@ end
 
 
 # Return algorithm with best memory that is within 10% of best time
-function cudnnConvolutionAlgoPerfChoose(ps, n)
-    (ibest,mbest,tbest) = (0,Inf,Inf)
-    for i in 1:n
+function cudnnConvolutionAlgoPerfChoose(convDesc, tensorDesc, perfResults, n)
+    mathType = Ref{cudnnMathType_t}(CUDNN_DEFAULT_MATH)
+    cudnnGetConvolutionMathType(convDesc, mathType)
+    skipMathTypeCheck = begin  # See https://github.com/JuliaGPU/CUDA.jl/pull/1943#issuecomment-1605267932
+        dtype, _ = cudnnGetTensorDescriptor(tensorDesc)
+        dtype == Float32
+    end
+
+    ibest, mbest, tbest = 0, Inf, Inf
+    for (i, ps) in enumerate(perfResults)
+        i > n && break
         # These metrics are written in a sorted fashion where the first element has the lowest compute time.
-        if ps[i].status == CUDNN_STATUS_SUCCESS && ps[i].memory < mbest && ps[i].time < tbest * 1.1
-            (ibest,mbest,tbest) = (i,ps[i].memory,ps[i].time)
+        if ((skipMathTypeCheck || ps.mathType == mathType[])
+            && ps.status == CUDNN_STATUS_SUCCESS && ps.memory < mbest && ps.time < tbest * 1.1)
+            ibest, mbest, tbest = i, ps.memory, ps.time
         end
     end
     if ibest == 0
         @warn "No valid algorithm found, probably bad params for convolution." maxlog=1
-        ibest = findfirst(p->p.algo==0, ps)
+        ibest = findfirst(p->p.algo==0, perfResults)
         ibest === nothing && error("Cannot find backup algorithm for convolution, giving up.")
     end
-    return ps[ibest]
+    return perfResults[ibest]
 end
 
 

--- a/lib/cudnn/src/convolution.jl
+++ b/lib/cudnn/src/convolution.jl
@@ -223,7 +223,7 @@ function cudnnConvolutionBwdDataAlgoPerf(wDesc, w, dyDesc, dy, convDesc, dxDesc,
         with_workspace(workspaceSize) do workspace
             cudnnFindConvolutionBackwardDataAlgorithmEx(handle(),wDesc,w,dyDesc,dy,convDesc,dxDesc,dxTmp,requestedAlgoCount,returnedAlgoCount,perfResults,workspace,sizeof(workspace))
         end
-        val = cudnnConvolutionAlgoPerfChoose(convDesc, wDesc, perfResults, returnedAlgoCount[1])
+        val = cudnnConvolutionAlgoPerfChoose(convDesc, dyDesc, perfResults, returnedAlgoCount[1])
         lock(cudnnConvolutionBwdDataAlgoPerfCacheLock) do
             cudnnConvolutionBwdDataAlgoPerfCache[key] = val
         end

--- a/lib/cudnn/src/convolution.jl
+++ b/lib/cudnn/src/convolution.jl
@@ -192,7 +192,7 @@ function cudnnConvolutionFwdAlgoPerf(xDesc, x, wDesc, w, convDesc, yDesc, y, bia
         with_workspace(workspaceSize) do workspace
             cudnnFindConvolutionForwardAlgorithmEx(handle(),xDesc,x,wDesc,w,convDesc,yDesc,yTmp,requestedAlgoCount,returnedAlgoCount,perfResults,workspace,sizeof(workspace))
         end
-        val = cudnnConvolutionAlgoPerfChoose(convDesc, perfResults, returnedAlgoCount[1])
+        val = cudnnConvolutionAlgoPerfChoose(perfResults, returnedAlgoCount[1])
         lock(cudnnConvolutionFwdAlgoPerfCacheLock) do
             cudnnConvolutionFwdAlgoPerfCache[key] = val
         end
@@ -223,7 +223,7 @@ function cudnnConvolutionBwdDataAlgoPerf(wDesc, w, dyDesc, dy, convDesc, dxDesc,
         with_workspace(workspaceSize) do workspace
             cudnnFindConvolutionBackwardDataAlgorithmEx(handle(),wDesc,w,dyDesc,dy,convDesc,dxDesc,dxTmp,requestedAlgoCount,returnedAlgoCount,perfResults,workspace,sizeof(workspace))
         end
-        val = cudnnConvolutionAlgoPerfChoose(convDesc, perfResults, returnedAlgoCount[1])
+        val = cudnnConvolutionAlgoPerfChoose(perfResults, returnedAlgoCount[1])
         lock(cudnnConvolutionBwdDataAlgoPerfCacheLock) do
             cudnnConvolutionBwdDataAlgoPerfCache[key] = val
         end
@@ -254,7 +254,7 @@ function cudnnConvolutionBwdFilterAlgoPerf(xDesc, x, dyDesc, dy, convDesc, dwDes
         with_workspace(workspaceSize) do workspace
             cudnnFindConvolutionBackwardFilterAlgorithmEx(handle(),xDesc,x,dyDesc,dy,convDesc,dwDesc,dwTmp,requestedAlgoCount,returnedAlgoCount,perfResults,workspace,sizeof(workspace))
         end
-        val = cudnnConvolutionAlgoPerfChoose(convDesc, perfResults, returnedAlgoCount[1])
+        val = cudnnConvolutionAlgoPerfChoose(perfResults, returnedAlgoCount[1])
         lock(cudnnConvolutionBwdFilterAlgoPerfCacheLock) do
             cudnnConvolutionBwdFilterAlgoPerfCache[key] = val
         end
@@ -264,24 +264,20 @@ end
 
 
 # Return algorithm with best memory that is within 10% of best time
-function cudnnConvolutionAlgoPerfChoose(convDesc, perfResults, n)
-    mathType = Ref{cudnnMathType_t}(CUDNN_DEFAULT_MATH)
-    cudnnGetConvolutionMathType(convDesc, mathType)
-
-    ibest, mbest, tbest = 0, Inf, Inf
-    for (i, ps) in enumerate(perfResults)
-        i > n && break
+function cudnnConvolutionAlgoPerfChoose(ps, n)
+    (ibest,mbest,tbest) = (0,Inf,Inf)
+    for i in 1:n
         # These metrics are written in a sorted fashion where the first element has the lowest compute time.
-        if ps.status == CUDNN_STATUS_SUCCESS && ps.mathType == mathType[] && ps.memory < mbest && ps.time < tbest * 1.1
-            ibest, mbest, tbest = i, ps.memory, ps.time
+        if ps[i].status == CUDNN_STATUS_SUCCESS && ps[i].memory < mbest && ps[i].time < tbest * 1.1
+            (ibest,mbest,tbest) = (i,ps[i].memory,ps[i].time)
         end
     end
     if ibest == 0
         @warn "No valid algorithm found, probably bad params for convolution." maxlog=1
-        ibest = findfirst(p->p.algo==0, perfResults)
+        ibest = findfirst(p->p.algo==0, ps)
         ibest === nothing && error("Cannot find backup algorithm for convolution, giving up.")
     end
-    return perfResults[ibest]
+    return ps[ibest]
 end
 
 


### PR DESCRIPTION
**Summary**
This fixes a bug where the convolution algorithm selector filters out valid algorithms.

**Describe the bug**

I am running relatively simple Deep Learning Vision Models, like ResNet (and custom models) on my nvidia gpu.
Recently, I updated my dependencies and have started to see the following error, along with a huge performance regression:
```
┌ Warning: No valid algorithm found, probably bad params for convolution.
└ @ cuDNN ~/.julia/packages/cuDNN/3J08S/src/convolution.jl:280
```

Here's a MWE reproducing the problem:
```julia
import Pkg; Pkg.activate(temp=true); Pkg.add(["Flux", "Metalhead", "CUDA"])
using Flux, Metalhead, CUDA
model = Metalhead.ResNet(18; pretrain=false) |> gpu;
x = CUDA.rand(Float32, 32, 32, 3, 7);
model(x) |> sum
```

As you can see, this is the "most basic" form of instantiating and evaluating a Flux-based model.
The error has also come up from models that are not from Metalhead, but are self-defined from basic building blocks instead.

Here's some information on my system:
```julia
julia> versioninfo()
Julia Version 1.9.0
Commit 8e630552924 (2023-05-07 11:25 UTC)
Platform Info:
  OS: Linux (x86_64-linux-gnu)
  CPU: 16 × 11th Gen Intel(R) Core(TM) i7-11800H @ 2.30GHz
  WORD_SIZE: 64
  LIBM: libopenlibm
  LLVM: libLLVM-14.0.6 (ORCJIT, tigerlake)
  Threads: 1 on 16 virtual cores
```

```bash
[romeo@Romeo-P1 VAEModels.jl]$ nvidia-smi
Thu Jun  8 04:01:35 2023       
+---------------------------------------------------------------------------------------+
| NVIDIA-SMI 530.41.03              Driver Version: 530.41.03    CUDA Version: 12.1     |
|-----------------------------------------+----------------------+----------------------+
| GPU  Name                  Persistence-M| Bus-Id        Disp.A | Volatile Uncorr. ECC |
| Fan  Temp  Perf            Pwr:Usage/Cap|         Memory-Usage | GPU-Util  Compute M. |
|                                         |                      |               MIG M. |
|=========================================+======================+======================|
|   0  NVIDIA RTX A2000 Laptop GPU     Off| 00000000:01:00.0 Off |                  N/A |
| N/A   55C    P8                8W /  N/A|      2MiB /  4096MiB |      0%      Default |
|                                         |                      |                  N/A |
+-----------------------------------------+----------------------+----------------------+
```

```
julia> CUDA.versioninfo()
CUDA runtime 12.1, artifact installation
CUDA driver 12.1
NVIDIA driver 530.41.3

CUDA libraries: 
- CUBLAS: 12.1.3
- CURAND: 10.3.2
- CUFFT: 11.0.2
- CUSOLVER: 11.4.5
- CUSPARSE: 12.1.0
- CUPTI: 18.0.0
- NVML: 12.0.0+530.41.3

Julia packages: 
- CUDA.jl: 4.3.2
- CUDA_Driver_jll: 0.5.0+1
- CUDA_Runtime_jll: 0.6.0+0
- CUDA_Runtime_Discovery: 0.2.2

Toolchain:
- Julia: 1.9.0
- LLVM: 14.0.6
- PTX ISA support: 3.2, 4.0, 4.1, 4.2, 4.3, 5.0, 6.0, 6.1, 6.3, 6.4, 6.5, 7.0, 7.1, 7.2, 7.3, 7.4, 7.5
- Device capability support: sm_37, sm_50, sm_52, sm_53, sm_60, sm_61, sm_62, sm_70, sm_72, sm_75, sm_80, sm_86

1 device:
  0: NVIDIA RTX A2000 Laptop GPU (sm_86, 2.996 GiB / 4.000 GiB available)

```