### PR TITLE
Wrapper with tests for `gemmBatchedEx!`

### DIFF
--- a/lib/cublas/wrappers.jl
+++ b/lib/cublas/wrappers.jl
@@ -945,7 +945,7 @@ function gemmBatchedEx!(transA::Char, transB::Char,
         cublasGemmBatchedEx(handle(), transA, transB, m, n, k, Ref{computeT}(alpha), Aptrs, eltype(A[1]), lda, Bptrs,
                             eltype(B[1]), ldb, Ref{computeT}(beta), Cptrs, eltype(C[1]), ldc, length(A), computeType, algo)
     else
-        throw("Not implemented for CUDA versio <11")
+        error("Not implemented for CUDA 11 and below.")
     end
     unsafe_free!(Cptrs)
     unsafe_free!(Bptrs)

--- a/lib/cublas/wrappers.jl
+++ b/lib/cublas/wrappers.jl
@@ -887,7 +887,7 @@ function gemmEx!(transA::Char, transB::Char,
     k = size(A, transA == 'N' ? 2 : 1)
     n = size(B, transB == 'N' ? 2 : 1)
     if m != size(C,1) || n != size(C,2) || k != size(B, transB == 'N' ? 1 : 2)
-        throw(DimensionMismatch(""))
+        throw(DimensionMismatch("A has dimension $(size(A)), B has dimension $(size(B)) and C has dimension $(size(C))"))
     end
     lda = max(1,stride(A,2))
     ldb = max(1,stride(B,2))
@@ -917,14 +917,14 @@ function gemmBatchedEx!(transA::Char, transB::Char,
                  @nospecialize(C::Vector{<:StridedCuVecOrMat});
                  algo::cublasGemmAlgo_t=CUBLAS_GEMM_DEFAULT)
     if length(A) != length(B) || length(A) != length(C)
-        throw(DimensionMismatch(""))
+        throw(DimensionMismatch("Lengths of inputs must be the same"))
     end
-    for (As,Bs,Cs) in zip(A,B,C)
+    for (i, (As,Bs,Cs)) in enumerate(zip(A,B,C))
         m = size(As, transA == 'N' ? 1 : 2)
         k = size(As, transA == 'N' ? 2 : 1)
         n = size(Bs, transB == 'N' ? 2 : 1)
         if m != size(Cs,1) || n != size(Cs,2) || k != size(Bs, transB == 'N' ? 1 : 2)
-            throw(DimensionMismatch(""))
+            throw(DimensionMismatch("Input $i: A has dimension $(size(As)), B has dimension $(size(Bs)), C has dimension $(size(Cs))"))
         end
     end
     m = size(A[1], transA == 'N' ? 1 : 2)

--- a/test/libraries/cublas.jl
+++ b/test/libraries/cublas.jl
@@ -1604,6 +1604,16 @@ end
             @test_throws DimensionMismatch CUBLAS.gemm_strided_batched!('N', 'N', alpha, bd_A, bd_B, beta, bd_bad)
         end
 
+        @testset "gemmStridedBatchedEx!" begin
+            CUBLAS.gemmStridedBatchedEx!('N', 'N', alpha, bd_A, bd_B, beta, bd_C)
+            for i in 1:nbatch
+                bC[:, :, i] = (alpha * bA[:, :, i]) * bB[:, :, i] + beta * bC[:, :, i]
+            end
+            h_C = Array(bd_C)
+            @test bC ≈ h_C
+            @test_throws DimensionMismatch CUBLAS.gemmStridedBatchedEx!('N', 'N', alpha, bd_A, bd_B, beta, bd_bad)
+        end
+
         @testset "gemm_strided_batched" begin
             bd_C = CUBLAS.gemm_strided_batched('N', 'N', bd_A, bd_B)
 

--- a/test/libraries/cublas.jl
+++ b/test/libraries/cublas.jl
@@ -1564,11 +1564,23 @@ end
         @testset "gemm_batched" begin
             bd_C = CUBLAS.gemm_batched('N','N',bd_A,bd_B)
             for i in 1:length(bA)
-                bC = bA[i]*bB[i]
+                bC[i] = bA[i]*bB[i]
                 h_C = Array(bd_C[i])
-                @test bC ≈ h_C
+                @test bC[i] ≈ h_C
             end
             @test_throws DimensionMismatch CUBLAS.gemm_batched('N','N',alpha,bd_A,bd_bad)
+        end
+
+        @testset "gemmBatchedEx!" begin
+            # C = (alpha*A)*B + beta*C
+            CUBLAS.gemmBatchedEx!('N','N',alpha,bd_A,bd_B,beta,bd_C)
+            for i in 1:length(bd_C)
+                bC[i] = (alpha*bA[i])*bB[i] + beta*bC[i]
+                h_C = Array(bd_C[i])
+                #compare
+                @test bC[i] ≈ h_C
+            end
+            @test_throws DimensionMismatch CUBLAS.gemmBatchedEx!('N','N',alpha,bd_A,bd_bad,beta,bd_C)
         end
 
         nbatch = 10


### PR DESCRIPTION
This introduces a wrapper for `gemmBatchedEx!`, allowing for batched mixed precision matrix multiplication. Based on the approach used for existing `gemmEx!` and `gemm_batched!`.