### PR TITLE
Make nonblocking synchronize optional

### DIFF
--- a/lib/cudadrv/context.jl
+++ b/lib/cudadrv/context.jl
@@ -322,7 +322,9 @@ device_synchronize() = nonblocking_synchronize()
 @inline function nonblocking_synchronize()
     # perform as much of the sync as possible without blocking in CUDA.
     # XXX: remove this using a yield callback, or by synchronizing on a dedicated thread?
-    nonblocking_synchronize(legacy_stream())
+    if CUDA._use_nonblocking_synchronize[]
+        nonblocking_synchronize(legacy_stream())
+    end
 
     # even though the GPU should be idle now, CUDA hooks work to the actual API call.
     # see NVIDIA bug #3383169 for more details.

--- a/lib/cudadrv/events.jl
+++ b/lib/cudadrv/events.jl
@@ -52,7 +52,9 @@ Waits for an event to complete.
 function synchronize(e::CuEvent)
     # perform as much of the sync as possible without blocking in CUDA.
     # XXX: remove this using a yield callback, or by synchronizing on a dedicated thread?
-    nonblocking_synchronize(e)
+    if CUDA._use_nonblocking_synchronize[]
+        nonblocking_synchronize(e)
+    end
 
     # even though the GPU should be idle now, CUDA hooks work to the actual API call.
     # see NVIDIA bug #3383169 for more details.

--- a/lib/cudadrv/stream.jl
+++ b/lib/cudadrv/stream.jl
@@ -127,7 +127,9 @@ function synchronize(stream::CuStream=stream(); blocking=nothing)
 
     # perform as much of the sync as possible without blocking in CUDA.
     # XXX: remove this using a yield callback, or by synchronizing on a dedicated stream?
-    nonblocking_synchronize(stream)
+    if CUDA._use_nonblocking_synchronize[]
+        nonblocking_synchronize(stream)
+    end
 
     # even though the GPU should be idle now, CUDA hooks work to the actual API call.
     # see NVIDIA bug #3383169 for more details.

--- a/src/initialization.jl
+++ b/src/initialization.jl
@@ -28,6 +28,8 @@ function functional(show_reason::Bool=false)
     return false
 end
 
+const _use_nonblocking_synchronize = Ref{Bool}(true)
+
 function __init__()
     precompiling = ccall(:jl_generating_output, Cint, ()) != 0
 
@@ -181,6 +183,10 @@ function __init__()
                      Please install the CUDA toolkit, and call `CUDA.set_runtime_version!("local")` to use it.
                      For more information, see JuliaGPU/CUDA.jl#1978."""
         end
+    end
+
+    if haskey(ENV, "JULIA_CUDA_NONBLOCKING_SYNCHRONIZE")
+        _use_nonblocking_synchronize[] = parse(Bool, ENV["JULIA_CUDA_NONBLOCKING_SYNCHRONIZE"])
     end
 
     _initialized[] = true


### PR DESCRIPTION
This addresses https://github.com/JuliaGPU/CUDA.jl/issues/1910 by adding the boolean environment variable `JULIA_CUDA_NONBLOCKING_SYNCHRONIZE` to control if nonblocking synchronizes are used or not.