### PR TITLE
RFC: Add a lock to CuArray for improved thread safety

### DIFF
--- a/src/array.jl
+++ b/src/array.jl
@@ -75,6 +75,7 @@ end
 
 mutable struct CuArray{T,N,B} <: AbstractGPUArray{T,N}
   storage::Union{Nothing,ArrayStorage{B}}
+  lock::ReentrantLock
 
   maxsize::Int  # maximum data size; excluding any selector bytes
   offset::Int   # offset of the data in the buffer, in number of elements
@@ -92,14 +93,14 @@ mutable struct CuArray{T,N,B} <: AbstractGPUArray{T,N}
     end
     buf = alloc(B, bufsize)
     storage = ArrayStorage(buf, 1)
-    obj = new{T,N,B}(storage, maxsize, 0, dims)
+    obj = new{T,N,B}(storage, ReentrantLock(), maxsize, 0, dims)
     finalizer(unsafe_finalize!, obj)
   end
 
   function CuArray{T,N}(storage::ArrayStorage{B}, dims::Dims{N};
                         maxsize::Int=prod(dims) * sizeof(T), offset::Int=0) where {T,N,B}
     check_eltype(T)
-    return new{T,N,B}(storage, maxsize, offset, dims)
+    return new{T,N,B}(storage, ReentrantLock(), maxsize, offset, dims)
   end
 end
 


### PR DESCRIPTION
This PR adds a lock to `CuArray` so that we can protect against operations that mutate the array object. Note that this doesn't need to extend to the contained `ArrayStorage`, as that should already be threadsafe, as that's an immutable struct with the refcount being handled atomically.

@ToucheSir encountered a case where multithreaded use of `unsafe_free!`, both manually and from finalizers, resulted in a UndefRefError accessing the context. It's not entirely clear to me whether that's an error accessing the thread-local context, or the array context, so @ToucheSir please post the full backtrace.

Currently, `unsafe_free!` assumes that it doesn't need a lock, because (1) finalizers don't run concurrently to regular code, and (2) `unsafe_free!` doesn't make sense to be called from multiple threads. It may make sense to protect the operation though, because technically it's legal to call `unsafe_free!` multiple times.

In addition, I suspect we'll need to protect other operations too (like `resize!`) so it probably doesn't hurt adding a lock anyway.

cc @vchuravy 