### PR TITLE
When freeing memory, use the high-level device getter.

### DIFF
--- a/src/pool.jl
+++ b/src/pool.jl
@@ -479,7 +479,7 @@ end
       error("Trying to free $buf from an unrelated context")
     end
 
-    dev = current_device()
+    dev = device()
     if stream_ordered(dev)
       # mark the pool as active
       pool_mark(dev)


### PR DESCRIPTION
`current_device()` can throw an error when the current thread does not have a context bound, and at the point we free memory there's no guarantee that a context is bound: The preceding call to `context()` only primes the *task* local state, and doesn't set CUDA's *thread* local state. The latter is only set before any API call that needs it, and `cuCtxGetDevice` is explicitly exempt from that so that we can check whether a device is bound (i.e. `has_device`).

Should fix https://github.com/JuliaML/MLUtils.jl/issues/161, cc @ToucheSir