### PR TITLE
Make "CUDA.jl" a link on the doc entry page

### DIFF
--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -1,6 +1,6 @@
 # CUDA programming in Julia
 
-The CUDA.jl package is the main entrypoint for programming NVIDIA GPUs in Julia. The package
+The [CUDA.jl](https://github.com/JuliaGPU/CUDA.jl) package is the main entrypoint for programming NVIDIA GPUs in Julia. The package
 makes it possible to do so at various abstraction levels, from easy-to-use arrays down to
 hand-written kernels using low-level CUDA APIs.
 


### PR DESCRIPTION
It's very useful to have a link to the repository on the doc entry page. This PR makes the very first mention of "CUDA.jl" a corresponding link.