### PR TITLE
rand: seed kernels from the host.

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -19,7 +19,7 @@ steps:
           cuda: "*"
         commands: |
           julia --project -e '
-              # make sure the 1.6-era Manifest works on this Julia version
+              # make sure the 1.7-era Manifest works on this Julia version
               using Pkg
               Pkg.resolve()
 
@@ -32,7 +32,6 @@ steps:
         matrix:
           setup:
             julia:
-              - "1.6"
               - "1.7"
               - "1.8"
               - "1.9"
@@ -315,10 +314,10 @@ steps:
         matrix:
           setup:
             julia:
-              - "1.6"
               - "1.7"
               - "1.8"
               - "1.9"
+              - "1.10"
               - "nightly"
           adjustments:
             - with:

--- a/src/compiler/compilation.jl
+++ b/src/compiler/compilation.jl
@@ -42,6 +42,62 @@ GPUCompiler.method_table(@nospecialize(job::CUDACompilerJob)) = method_table
 
 GPUCompiler.kernel_state_type(job::CUDACompilerJob) = KernelState
 
+function GPUCompiler.finish_module!(@nospecialize(job::CUDACompilerJob),
+                                    mod::LLVM.Module, entry::LLVM.Function)
+    entry = invoke(GPUCompiler.finish_module!,
+                   Tuple{CompilerJob{PTXCompilerTarget}, LLVM.Module, LLVM.Function},
+                   job, mod, entry)
+
+    # if this kernel uses our RNG, we should prime the shared state.
+    # XXX: these transformations should really happen at the Julia IR level...
+    if haskey(globals(mod), "global_random_keys")
+        f = initialize_rng_state
+        ft = typeof(f)
+        tt = Tuple{}
+
+        # don't recurse into `initialize_rng_state()` itself
+        if job.source.specTypes.parameters[1] == ft
+            return entry
+        end
+
+        # create a deferred compilation job for `initialize_rng_state()`
+        src = methodinstance(ft, tt, GPUCompiler.tls_world_age())
+        cfg = CompilerConfig(job.config; kernel=false, name=nothing)
+        job = CompilerJob(src, cfg, job.world)
+        id = length(GPUCompiler.deferred_codegen_jobs) + 1
+        GPUCompiler.deferred_codegen_jobs[id] = job
+
+        # generate IR for calls to `deferred_codegen` and the resulting function pointer
+        top_bb = first(blocks(entry))
+        bb = BasicBlock(top_bb, "initialize_rng")
+        LLVM.@dispose builder=IRBuilder() begin
+            position!(builder, bb)
+
+            # call the `deferred_codegen` marker function
+            T_ptr = LLVM.Int64Type()
+            deferred_codegen_ft = LLVM.FunctionType(T_ptr, [T_ptr])
+            deferred_codegen = if haskey(functions(mod), "deferred_codegen")
+                functions(mod)["deferred_codegen"]
+            else
+                LLVM.Function(mod, "deferred_codegen", deferred_codegen_ft)
+            end
+            fptr = call!(builder, deferred_codegen_ft, deferred_codegen, [ConstantInt(id)])
+
+            # call the `initialize_rng_state` function
+            rt = Core.Compiler.return_type(f, tt)
+            llvm_rt = convert(LLVMType, rt)
+            llvm_ft = LLVM.FunctionType(llvm_rt)
+            fptr = inttoptr!(builder, fptr, LLVM.PointerType(llvm_ft))
+            call!(builder, llvm_ft, fptr)
+            br!(builder, top_bb)
+        end
+
+        # XXX: put some of the above behind GPUCompiler abstractions
+        #      (e.g., a compile-time version of `deferred_codegen`)
+    end
+    return entry
+end
+
 
 ## compiler implementation (cache, configure, compile, and link)
 

--- a/src/compiler/compilation.jl
+++ b/src/compiler/compilation.jl
@@ -72,6 +72,12 @@ function GPUCompiler.finish_module!(@nospecialize(job::CUDACompilerJob),
         bb = BasicBlock(top_bb, "initialize_rng")
         LLVM.@dispose builder=IRBuilder() begin
             position!(builder, bb)
+            subprogram = LLVM.get_subprogram(entry)
+            if subprogram !== nothing
+                loc = DILocation(0, 0, subprogram)
+                debuglocation!(builder, loc)
+            end
+            debuglocation!(builder, first(instructions(top_bb)))
 
             # call the `deferred_codegen` marker function
             T_ptr = LLVM.Int64Type()

--- a/src/compiler/execution.jl
+++ b/src/compiler/execution.jl
@@ -212,9 +212,9 @@ end
         end
     end
 
-    # add the kernel state
+    # add the kernel state, passing an instance with a unique seed
     pushfirst!(call_t, KernelState)
-    pushfirst!(call_args, :(kernel.state))
+    pushfirst!(call_args, :(KernelState(kernel.state.exception_flag, Random.rand(UInt32))))
 
     # finalize types
     call_tt = Base.to_tuple_type(call_t)
@@ -328,7 +328,7 @@ function cufunction(f::F, tt::TT=Tuple{}; kwargs...) where {F,TT}
         if kernel === nothing
             # create the kernel state object
             exception_ptr = create_exceptions!(fun.mod)
-            state = KernelState(exception_ptr)
+            state = KernelState(exception_ptr, UInt32(0))
 
             kernel = HostKernel{F,tt}(f, fun, state)
             _kernel_instances[key] = kernel

--- a/src/device/random.jl
+++ b/src/device/random.jl
@@ -6,19 +6,7 @@ import RandomNumbers
 
 # global state
 
-# shared memory with the actual seed, per warp, loaded lazily or overridden by calling `seed!`
-@eval @inline function global_random_keys()
-    ptr = Base.llvmcall(
-        $("""@global_random_keys = weak addrspace($(AS.Shared)) global [32 x i32] zeroinitializer, align 32
-             define i8 addrspace($(AS.Shared))* @entry() #0 {
-                 %ptr = getelementptr inbounds [32 x i32], [32 x i32] addrspace($(AS.Shared))* @global_random_keys, i64 0, i64 0
-                 %untyped_ptr = bitcast i32 addrspace($(AS.Shared))* %ptr to i8 addrspace($(AS.Shared))*
-                 ret i8 addrspace($(AS.Shared))* %untyped_ptr
-             }
-             attributes #0 = { alwaysinline }
-          """, "entry"), LLVMPtr{UInt32, AS.Shared}, Tuple{})
-    CuDeviceArray{UInt32,1,AS.Shared}(ptr, (32,))
-end
+# XXX: sharing state means that with multiple generators we can't guarantee determinism.
 
 # shared memory with per-warp counters, incremented when generating numbers
 @eval @inline function global_random_counters()
@@ -43,19 +31,6 @@ using Random123: philox2x_round, philox2x_bumpkey
 
 # GPU-compatible/optimized version of the generator from Random123.jl
 struct Philox2x32{R} <: RandomNumbers.AbstractRNG{UInt64}
-    @inline function Philox2x32{R}() where R
-        rng = new{R}()
-        if rng.key == 0
-            # initialize the key. this happens when first accessing the (0-initialized)
-            # shared memory key from each block. if we ever want to make the device seed
-            # controlable from the host, this would be the place to read a global seed.
-            #
-            # note however that it is undefined how shared memory persists across e.g.
-            # launches, so we may not be able to rely on the zero initalization then.
-            rng.key = Random.make_seed()
-        end
-        return rng
-    end
 end
 
 # default to 7 rounds; enough to pass SmallCrush
@@ -69,7 +44,7 @@ end
     if field === :seed
         @inbounds global_random_seed()[1]
     elseif field === :key
-        @inbounds global_random_keys()[warpId]
+        kernel_state().random_seed
     elseif field === :ctr1
         @inbounds global_random_counters()[warpId]
     elseif field === :ctr2
@@ -85,9 +60,7 @@ end
                                (threadIdx().z - 1i32) * blockDim().x * blockDim().y
     warpId = (threadId - 1i32) >> 0x5 + 1i32  # fld1
 
-    if field === :key
-        @inbounds global_random_keys()[warpId] = x
-    elseif field === :ctr1
+    if field === :ctr1
         @inbounds global_random_counters()[warpId] = x
     end
 end
@@ -139,7 +112,9 @@ function Random.rand(rng::Philox2x32{R},::Type{UInt64}) where {R}
     # update the warp counter
     # NOTE: this performs the same update on every thread in the warp, but each warp writes
     #       to a unique location so the duplicate writes are innocuous
-    # XXX: what if this overflows? we can't increment ctr2. bump the key?
+    # NOTE: this update is not guaranteed to be visible in subsequent kernel launche,
+    #       e.g., see JuliaGPU/CUDA.jl#2008
+    # XXX: what if this overflows? we can't increment ctr2, and the key is immutable.
     rng.ctr1 += 1i32
 
     # NOTE: it's too expensive to keep both numbers around in case the user only wanted one,

--- a/src/device/runtime.jl
+++ b/src/device/runtime.jl
@@ -28,14 +28,13 @@ end
 
 struct KernelState
     exception_flag::Ptr{Cvoid}
+    random_seed::UInt32
 end
 
 @inline @generated kernel_state() = GPUCompiler.kernel_state_value(KernelState)
 
-exception_flag() = kernel_state().exception_flag
-
 function signal_exception()
-    ptr = exception_flag()
+    ptr = kernel_state().exception_flag
     if ptr !== C_NULL
         unsafe_store!(convert(Ptr{Int}, ptr), 1)
         threadfence_system()


### PR DESCRIPTION
We should not (and cannot) rely on the fact that updating shared memory will be visible across kernel launches. In some cases, it isn't, which combined with pre-initialized shared memory (resulting in us not hitting the make_seed path) causes identical values for the key and counters, resulting in identical random numbers getting generated.

Avoid this by passing a seed from the host. Even in the case that updates to counters don't survive to the next kernel, now the key will be different, resulting in new numbers being generated.

Fixes https://github.com/JuliaGPU/CUDA.jl/issues/2008