### PR TITLE
Disable tests that cause GC corruption on 1.10.

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -31,9 +31,6 @@ steps:
               - "nightly"
           adjustments:
             - with:
-                julia: "1.10-nightly"
-              soft_fail: true
-            - with:
                 julia: "nightly"
               soft_fail: true
 

--- a/test/libraries/cusparse/reduce.jl
+++ b/test/libraries/cusparse/reduce.jl
@@ -1,6 +1,7 @@
 using CUDA.CUSPARSE, SparseArrays
 
-if VERSION >= v"1.7"
+# XXX: these tests cause GC corruption on 1.10+ (see JuliaGPU/CUDA.jl#2027)
+if VERSION >= v"1.7" && VERSION < v"1.10-"
 
 m,n = 5,6
 p = 0.5


### PR DESCRIPTION
Works around https://github.com/JuliaGPU/CUDA.jl/issues/2027