### PR TITLE
Re-introduce the 'blocking' kwargs to at-sync.

### DIFF
--- a/lib/cudadrv/synchronization.jl
+++ b/lib/cudadrv/synchronization.jl
@@ -164,8 +164,8 @@ function nonblocking_synchronize(val)
     return
 end
 
-function device_synchronize()
-    if use_nonblocking_synchronization
+function device_synchronize(; blocking::Bool=false)
+    if use_nonblocking_synchronization && !blocking
         if fast_synchronization(isdone, legacy_stream())
             cuCtxSynchronize()
         else
@@ -178,8 +178,8 @@ function device_synchronize()
     check_exceptions()
 end
 
-function synchronize(stream::CuStream=stream())
-    if use_nonblocking_synchronization
+function synchronize(stream::CuStream=stream(); blocking::Bool=false)
+    if use_nonblocking_synchronization && !blocking
         if fast_synchronization(isdone, stream)
             cuStreamSynchronize(stream)
         else
@@ -192,8 +192,8 @@ function synchronize(stream::CuStream=stream())
     check_exceptions()
 end
 
-function synchronize(event::CuEvent)
-    if use_nonblocking_synchronization
+function synchronize(event::CuEvent; blocking::Bool=false)
+    if use_nonblocking_synchronization && !blocking
         if fast_synchronization(isdone, event)
             cuEventSynchronize(event)
         else
@@ -249,8 +249,8 @@ function nonblocking_synchronize(stream::CuStream)
     return
 end
 
-function device_synchronize()
-    if use_nonblocking_synchronization
+function device_synchronize(; blocking::Bool=false)
+    if use_nonblocking_synchronization && !blocking
         stream = legacy_stream()
         if !fast_synchronization(isdone, stream)
             nonblocking_synchronize(stream)
@@ -261,8 +261,8 @@ function device_synchronize()
     check_exceptions()
 end
 
-function synchronize(stream::CuStream=stream())
-    if use_nonblocking_synchronization
+function synchronize(stream::CuStream=stream(); blocking::Bool=false)
+    if use_nonblocking_synchronization && !blocking
         if !fast_synchronization(isdone, stream)
             nonblocking_synchronize(stream)
         end
@@ -272,8 +272,8 @@ function synchronize(stream::CuStream=stream())
     check_exceptions()
 end
 
-function synchronize(event::CuEvent)
-    if use_nonblocking_synchronization
+function synchronize(event::CuEvent; blocking::Bool=false)
+    if use_nonblocking_synchronization && !blocking
         fast_synchronization(isdone, event)
     end
     cuEventSynchronize(event)

--- a/perf/byval.jl
+++ b/perf/byval.jl
@@ -59,11 +59,11 @@ function main()
     y1 = [similar(x1[1]) for i = 1:num_z_slices]
 
     # reference down to bones add on GPU
-    results["reference"] = @benchmark CUDA.@sync add!($y1[1], $x1[1], $x2[1])
+    results["reference"] = @benchmark CUDA.@sync blocking=true add!($y1[1], $x1[1], $x2[1])
 
     # adding arrays in an array
     for slices = 1:num_z_slices
-        results["slices=$slices"] = @benchmark CUDA.@sync add_z_slices!($y1[1:$slices], $x1[1:$slices], $x2[1:$slices])
+        results["slices=$slices"] = @benchmark CUDA.@sync blocking=true add_z_slices!($y1[1:$slices], $x1[1:$slices], $x2[1:$slices])
     end
 
     # BenchmarkTools captures inputs, JuliaCI/BenchmarkTools.jl#127, so forcibly free them

--- a/perf/cuda.jl
+++ b/perf/cuda.jl
@@ -1,0 +1,14 @@
+group = addgroup!(SUITE, "cuda")
+
+let group = addgroup!(group, "synchronization")
+    let group = addgroup!(group, "stream")
+        group["blocking"] = @benchmarkable synchronize(blocking=true)
+        group["auto"] = @benchmarkable synchronize()
+        group["nonblocking"] = @benchmarkable synchronize(spin=false)
+    end
+    let group = addgroup!(group, "context")
+        group["blocking"] = @benchmarkable device_synchronize(blocking=true)
+        group["auto"] = @benchmarkable device_synchronize()
+        group["nonblocking"] = @benchmarkable device_synchronize(spin=false)
+    end
+end

--- a/perf/cudadevrt.jl
+++ b/perf/cudadevrt.jl
@@ -26,7 +26,7 @@ function main()
     x2 = cu(randn(Float32, (1, n)) .+ Float32(0.5))
     y1 = similar(x1)
 
-    results = @benchmark CUDA.@sync add!($y1, $x1, $x2)
+    results = @benchmark CUDA.@sync blocking=true add!($y1, $x1, $x2)
 
     # BenchmarkTools captures inputs, JuliaCI/BenchmarkTools.jl#127, so forcibly free them
     CUDA.unsafe_free!(x1)

--- a/perf/runbenchmarks.jl
+++ b/perf/runbenchmarks.jl
@@ -17,7 +17,7 @@ end
 # convenience macro to create a benchmark that requires synchronizing the GPU
 macro async_benchmarkable(ex...)
     quote
-        @benchmarkable CUDA.@sync $(ex...)
+        @benchmarkable CUDA.@sync blocking=true $(ex...)
     end
 end
 

--- a/perf/runbenchmarks.jl
+++ b/perf/runbenchmarks.jl
@@ -30,6 +30,7 @@ SUITE = BenchmarkGroup()
 
 # NOTE: don't use spaces in benchmark names (tobami/codespeed#256)
 
+include("cuda.jl")
 include("kernel.jl")
 include("array.jl")
 

--- a/perf/volumerhs.jl
+++ b/perf/volumerhs.jl
@@ -255,8 +255,8 @@ function main()
                 $(Base.format_bytes(CUDA.memory(kernel).shared)) shared memory,
                 $(Base.format_bytes(CUDA.memory(kernel).constant)) constant memory"""
     results = @benchmark begin
-        CUDA.@sync $kernel($rhs, $Q, $vgeo, $(DFloat(grav)), $D, $nelem;
-                           threads=$threads, blocks=$nelem)
+        CUDA.@sync blocking=true $kernel($rhs, $Q, $vgeo, $(DFloat(grav)), $D, $nelem;
+                                         threads=$threads, blocks=$nelem)
     end
 
     # BenchmarkTools captures inputs, JuliaCI/BenchmarkTools.jl#127, so forcibly free them

--- a/test/core/utils.jl
+++ b/test/core/utils.jl
@@ -29,6 +29,8 @@ end
   end
   @test t >= 0
   @test ret == 42
+
+  CUDA.@sync blocking=true identity(nothing)
 end
 
 @testset "versioninfo" begin


### PR DESCRIPTION
This can be used to force a blocking, but low-latency synchronization, e.g., when benchmarking code that uses a single task.

Marked as draft, because I don't want to merge this before I'm convinced that https://github.com/JuliaGPU/CUDA.jl/pull/2059 recovered the performance we lost.