### PR TITLE
Batched SVD added (gesvdjBatched and gesvdaStridedBatched)

### DIFF
--- a/lib/cusolver/linalg.jl
+++ b/lib/cusolver/linalg.jl
@@ -252,8 +252,7 @@ function _svd!(A::CuMatrix{T}, full::Bool, alg::JacobiAlgorithm) where T
     return SVD(U, S, V')
 end
 function _svd!(A::CuArray{T,3}, full::Bool, alg::JacobiAlgorithm) where T
-    # @assert size(A,1) <= 32 && size(A,2) <= 32 # see cuSolver API for gesvdjBatched
-    U, S, V = gesvdj!('V', Int(!full), A)
+    U, S, V = gesvdj!('V', A)
     return CuSVDBatched(U, S, V)
 end
 
@@ -282,7 +281,8 @@ LinearAlgebra.svdvals(A::CuMatOrBatched; alg::SVDAlgorithm=JacobiAlgorithm()) =
 _svdvals!(A::CuMatOrBatched{T}, alg::SVDAlgorithm) where T =
     throw(ArgumentError("Unsupported value for `alg` keyword."))
 _svdvals!(A::CuMatrix{T}, alg::QRAlgorithm) where T = gesvd!('N', 'N', A::CuMatrix{T})[2]
-_svdvals!(A::CuMatOrBatched{T}, alg::JacobiAlgorithm) where T = gesvdj!('N', 1, A::CuMatOrBatched{T})[2]
+_svdvals!(A::CuMatrix{T}, alg::JacobiAlgorithm) where T = gesvdj!('N', 1, A::CuMatOrBatched{T})[2]
+_svdvals!(A::CuArray{T,3}, alg::JacobiAlgorithm) where T = gesvdj!('N', A::CuArray{T,3})[2]
 _svdvals!(A::CuArray{T,3}, alg::ApproximateAlgorithm; rank=min(size(A,1), size(A,2))) where T = gesvda!('N', A::CuArray{T,3}; rank=rank)[2]
 
 ### opnorm2, enabled by svdvals

--- a/lib/cusolver/linalg.jl
+++ b/lib/cusolver/linalg.jl
@@ -392,8 +392,8 @@ function _svd!(A::CuArray{T,3}, full::Bool, alg::JacobiAlgorithm) where T
     return CuSVDBatched(U, S, V)
 end
 
-function _svd!(A::CuArray{T,3}, full::Bool, alg::ApproximateAlgorithm) where T
-    U, S, V = gesvda!('V', Int(!full), A)
+function _svd!(A::CuArray{T,3}, full::Bool, alg::ApproximateAlgorithm; rank::Int=min(size(A,1), size(A,2))) where T
+    U, S, V = gesvda!('V', A; rank=rank)
     return CuSVDBatched(U, S, V)
 end
 
@@ -449,15 +449,16 @@ end
 
 end
 
-LinearAlgebra.svdvals!(A::CuMatrix{T}; alg::SVDAlgorithm=JacobiAlgorithm()) where {T} =
+LinearAlgebra.svdvals!(A::CuMatOrBatched{T}; alg::SVDAlgorithm=JacobiAlgorithm()) where {T} =
     _svdvals!(A, alg)
-LinearAlgebra.svdvals(A::CuMatrix; alg::SVDAlgorithm=JacobiAlgorithm()) =
+LinearAlgebra.svdvals(A::CuMatOrBatched; alg::SVDAlgorithm=JacobiAlgorithm()) =
     _svdvals!(copy_cublasfloat(A), alg)
 
-_svdvals!(A::CuMatrix{T}, alg::SVDAlgorithm) where T =
+_svdvals!(A::CuMatOrBatched{T}, alg::SVDAlgorithm) where T =
     throw(ArgumentError("Unsupported value for `alg` keyword."))
 _svdvals!(A::CuMatrix{T}, alg::QRAlgorithm) where T = gesvd!('N', 'N', A::CuMatrix{T})[2]
-_svdvals!(A::CuMatrix{T}, alg::JacobiAlgorithm) where T = gesvdj!('N', 1, A::CuMatrix{T})[2]
+_svdvals!(A::CuMatOrBatched{T}, alg::JacobiAlgorithm) where T = gesvdj!('N', 1, A::CuMatOrBatched{T})[2]
+_svdvals!(A::CuArray{T,3}, alg::ApproximateAlgorithm; rank=min(size(A,1), size(A,2))) where T = gesvda!('N', A::CuArray{T,3}; rank=rank)[2]
 
 ### opnorm2, enabled by svdvals
 


### PR DESCRIPTION
`gesvdjBatched` and `gesvdaStridedBatched` are now accessable for performing SVD on a sequence of matrices, represented by a 3 dimensional tensor (3rd dimension is the batch dimension). `Linalg.svd` has been overloaded accordingly for 3 dim tensors. 

- [x] tests added