### PR TITLE
Improve PTX ISA selection

### DIFF
--- a/src/compatibility.jl
+++ b/src/compatibility.jl
@@ -1,9 +1,13 @@
 # compatibility of Julia, CUDA and LLVM
 
+# NOTE: Target architectures with suffix “a”, such as sm_90a, include
+# architecture-accelerated features that are supported on the specified architecture only,
+# hence such targets do not follow the onion layer model. Therefore, PTX code generated for
+# such targets cannot be run on later generation devices. Architecture-accelerated features
+# can only be used with targets that support these features.
+
 const lowest = v"0"
 const highest = v"999"
-
-join_capabilities(vers) = join(map(ver->"$(ver.major).$(ver.minor)", sort(collect(vers))), ", ", " and ")
 
 
 ## version range
@@ -28,30 +32,31 @@ Base.intersect(v::VersionNumber, r::VersionRange) =
 # - https://en.wikipedia.org/wiki/CUDA#GPUs_supported
 # - ptxas |& grep -A 10 '\--gpu-name'
 const cuda_cap_db = Dict(
-    v"1.0" => between(lowest, v"6.5"),
-    v"1.1" => between(lowest, v"6.5"),
-    v"1.2" => between(lowest, v"6.5"),
-    v"1.3" => between(lowest, v"6.5"),
-    v"2.0" => between(lowest, v"8.0"),
-    v"2.1" => between(lowest, v"8.0"),
-    v"3.0" => between(v"4.2", v"10.2"),
-    v"3.2" => between(v"6.0", v"10.2"),
-    v"3.5" => between(v"5.0", v"11.8"),
-    v"3.7" => between(v"6.5", highest),
-    v"5.0" => between(v"6.0", highest),
-    v"5.2" => between(v"7.0", highest),
-    v"5.3" => between(v"7.5", highest),
-    v"6.0" => between(v"8.0", highest),
-    v"6.1" => between(v"8.0", highest),
-    v"6.2" => between(v"8.0", highest),
-    v"7.0" => between(v"9.0", highest),
-    v"7.2" => between(v"9.2", highest),
-    v"7.5" => between(v"10.0", highest),
-    v"8.0" => between(v"11.0", highest),
-    v"8.6" => between(v"11.1", highest),
-    v"8.7" => between(v"11.4", highest),
-    v"8.9" => between(v"11.8", highest),
-    v"9.0" => between(v"11.8", highest),
+    v"1.0"   => between(lowest, v"6.5"),
+    v"1.1"   => between(lowest, v"6.5"),
+    v"1.2"   => between(lowest, v"6.5"),
+    v"1.3"   => between(lowest, v"6.5"),
+    v"2.0"   => between(lowest, v"8.0"),
+    v"2.1"   => between(lowest, v"8.0"),
+    v"3.0"   => between(v"4.2", v"10.2"),
+    v"3.2"   => between(v"6.0", v"10.2"),
+    v"3.5"   => between(v"5.0", v"11.8"),
+    v"3.7"   => between(v"6.5", highest),
+    v"5.0"   => between(v"6.0", highest),
+    v"5.2"   => between(v"7.0", highest),
+    v"5.3"   => between(v"7.5", highest),
+    v"6.0"   => between(v"8.0", highest),
+    v"6.1"   => between(v"8.0", highest),
+    v"6.2"   => between(v"8.0", highest),
+    v"7.0"   => between(v"9.0", highest),
+    v"7.2"   => between(v"9.2", highest),
+    v"7.5"   => between(v"10.0", highest),
+    v"8.0"   => between(v"11.0", highest),
+    v"8.6"   => between(v"11.1", highest),
+    v"8.7"   => between(v"11.4", highest),
+    v"8.9"   => between(v"11.8", highest),
+    v"9.0"   => between(v"11.8", highest),
+    #v"9.0a" => between(v"12.0", highest),
 )
 
 function cuda_cap_support(ver::VersionNumber)
@@ -104,6 +109,8 @@ const cuda_ptx_db = Dict(
     v"7.7" => between(v"11.7", highest),
     v"7.8" => between(v"11.8", highest),
     v"8.0" => between(v"12.0", highest),
+    v"8.1" => between(v"12.1", highest),
+    v"8.2" => between(v"12.2", highest),
 )
 
 function cuda_ptx_support(ver::VersionNumber)
@@ -121,26 +128,27 @@ end
 
 # Source: LLVM/lib/Target/NVPTX/NVPTX.td
 const llvm_cap_db = Dict(
-    v"2.0" => between(v"3.2", highest),
-    v"2.1" => between(v"3.2", highest),
-    v"3.0" => between(v"3.2", highest),
-    v"3.2" => between(v"3.7", highest),
-    v"3.5" => between(v"3.2", highest),
-    v"3.7" => between(v"3.7", highest),
-    v"5.0" => between(v"3.5", highest),
-    v"5.2" => between(v"3.7", highest),
-    v"5.3" => between(v"3.7", highest),
-    v"6.0" => between(v"3.9", highest),
-    v"6.1" => between(v"3.9", highest),
-    v"6.2" => between(v"3.9", highest),
-    v"7.0" => between(v"6.0", highest),
-    v"7.2" => between(v"7.0", highest),
-    v"7.5" => between(v"8.0", highest),
-    v"8.0" => between(v"11.0", highest),
-    v"8.6" => between(v"13.0", highest),
-    v"8.7" => between(v"16.0", highest),
-    v"8.9" => between(v"16.0", highest),
-    v"9.0" => between(v"16.0", highest),
+    v"2.0"   => between(v"3.2", highest),
+    v"2.1"   => between(v"3.2", highest),
+    v"3.0"   => between(v"3.2", highest),
+    v"3.2"   => between(v"3.7", highest),
+    v"3.5"   => between(v"3.2", highest),
+    v"3.7"   => between(v"3.7", highest),
+    v"5.0"   => between(v"3.5", highest),
+    v"5.2"   => between(v"3.7", highest),
+    v"5.3"   => between(v"3.7", highest),
+    v"6.0"   => between(v"3.9", highest),
+    v"6.1"   => between(v"3.9", highest),
+    v"6.2"   => between(v"3.9", highest),
+    v"7.0"   => between(v"6.0", highest),
+    v"7.2"   => between(v"7.0", highest),
+    v"7.5"   => between(v"8.0", highest),
+    v"8.0"   => between(v"11.0", highest),
+    v"8.6"   => between(v"13.0", highest),
+    v"8.7"   => between(v"16.0", highest),
+    v"8.9"   => between(v"16.0", highest),
+    v"9.0"   => between(v"16.0", highest),
+    #v"9.0a" => between(v"17.0", highest),
 )
 
 function llvm_cap_support(ver::VersionNumber)

--- a/src/compatibility.jl
+++ b/src/compatibility.jl
@@ -223,16 +223,3 @@ function cuda_compat(driver=driver_version(), runtime=runtime_version())
 
     return (cap=cap_support, ptx=ptx_support)
 end
-
-function supported_toolchain()
-    llvm_support = llvm_compat()
-    cuda_support = cuda_compat()
-
-    target_support = sort(collect(llvm_support.cap ∩ cuda_support.cap))
-    isempty(target_support) && error("Your toolchain does not support any device capability")
-
-    ptx_support = sort(collect(llvm_support.ptx ∩ cuda_support.ptx))
-    isempty(ptx_support) && error("Your toolchain does not support any PTX ISA")
-
-    return (cap=target_support, ptx=ptx_support)
-end

--- a/src/compatibility.jl
+++ b/src/compatibility.jl
@@ -72,8 +72,7 @@ end
 
 ## PTX ISAs supported by the CUDA toolkit
 
-# Source:
-# - PTX ISA document, Release History table
+# Source: PTX ISA document, Release History table
 const cuda_ptx_db = Dict(
     v"1.0" => between(v"1.0", highest),
     v"1.1" => between(v"1.1", highest),
@@ -116,6 +115,47 @@ const cuda_ptx_db = Dict(
 function cuda_ptx_support(ver::VersionNumber)
     caps = Set{VersionNumber}()
     for (cap,r) in cuda_ptx_db
+        if ver in r
+            push!(caps, cap)
+        end
+    end
+    return caps
+end
+
+
+## devices supported by each PTX ISA
+
+# Source: PTX ISA document, Release History table
+const ptx_cap_db = Dict(
+    v"1.0"   => between(v"1.0", highest),
+    v"1.1"   => between(v"1.0", highest),
+    v"1.2"   => between(v"1.2", highest),
+    v"1.3"   => between(v"1.2", highest),
+    v"2.0"   => between(v"2.0", highest),
+    v"3.0"   => between(v"3.1", highest),
+    v"3.2"   => between(v"4.0", highest),
+    v"3.5"   => between(v"3.1", highest),
+    v"3.7"   => between(v"4.1", highest),
+    v"5.0"   => between(v"4.0", highest),
+    v"5.2"   => between(v"4.1", highest),
+    v"5.3"   => between(v"4.2", highest),
+    v"6.0"   => between(v"5.0", highest),
+    v"6.1"   => between(v"5.0", highest),
+    v"6.2"   => between(v"5.0", highest),
+    v"7.0"   => between(v"6.0", highest),
+    v"7.2"   => between(v"6.1", highest),
+    v"7.5"   => between(v"6.3", highest),
+    v"8.0"   => between(v"7.0", highest),
+    v"8.6"   => between(v"7.1", highest),
+    v"8.7"   => between(v"7.4", highest),
+    v"8.9"   => between(v"7.8", highest),
+    v"9.0"   => between(v"7.8", highest),
+    #v"9.0a" => between(v"8.0", highest)
+)
+
+function ptx_cap_support(ver::VersionNumber)
+    caps = Set{VersionNumber}()
+    for (cap,r) in ptx_cap_db
         if ver in r
             push!(caps, cap)
         end
@@ -222,4 +262,8 @@ function cuda_compat(driver=driver_version(), runtime=runtime_version())
     ptx_support = sort(collect(driver_ptx_support ∩ toolkit_ptx_support))
 
     return (cap=cap_support, ptx=ptx_support)
+end
+
+function ptx_compat(ptx)
+    return (cap=ptx_cap_support(ptx),)
 end

--- a/src/compiler/compilation.jl
+++ b/src/compiler/compilation.jl
@@ -167,9 +167,9 @@ end
     end
 
     # determine the PTX ISA to use
-    requested_ptx = something(ptx, v"6.3")  # we only need 6.2, but NVPTX lacks support
-    llvm_ptxs = filter(<=(requested_ptx), llvm_support.ptx)
-    cuda_ptxs = filter(<=(requested_ptx), cuda_support.ptx)
+    requested_ptx = something(ptx, v"6.2")
+    llvm_ptxs = filter(>=(requested_ptx), llvm_support.ptx)
+    cuda_ptxs = filter(>=(requested_ptx), cuda_support.ptx)
     if ptx !== nothing
         # the user requested a specific PTX ISA
         ## use the highest ISA supported by LLVM

--- a/src/compiler/execution.jl
+++ b/src/compiler/execution.jl
@@ -6,7 +6,7 @@ export @cuda, cudaconvert, cufunction, dynamic_cufunction, nextwarp, prevwarp
 ## high-level @cuda interface
 
 const MACRO_KWARGS = [:dynamic, :launch]
-const COMPILER_KWARGS = [:kernel, :name, :always_inline, :minthreads, :maxthreads, :blocks_per_sm, :maxregs, :fastmath]
+const COMPILER_KWARGS = [:kernel, :name, :always_inline, :minthreads, :maxthreads, :blocks_per_sm, :maxregs, :fastmath, :cap, :ptx]
 const LAUNCH_KWARGS = [:cooperative, :blocks, :threads, :shmem, :stream]
 
 
@@ -307,6 +307,7 @@ The following keyword arguments are supported:
 - `name`: override the name that the kernel will have in the generated code
 - `always_inline`: inline all function calls in the kernel
 - `fastmath`: use less precise square roots and flush denormals
+- `cap` and `ptx`: to override the compute capability and PTX version to compile for
 
 The output of this function is automatically cached, i.e. you can simply call `cufunction`
 in a hot path without degrading performance. New code will be generated automatically, when

--- a/src/device/runtime.jl
+++ b/src/device/runtime.jl
@@ -16,10 +16,10 @@ function precompile_runtime()
     caps = llvm_compat().cap
     ptx = maximum(llvm_compat().ptx)
     JuliaContext() do ctx
-        for cap in caps
+        for cap in caps, debuginfo in [false, true]
             # NOTE: this often runs when we don't have a functioning set-up,
             #       so we don't use `compiler_config` which requires NVML
-            target = PTXCompilerTarget(; cap, ptx)
+            target = PTXCompilerTarget(; cap, ptx, debuginfo)
             params = CUDACompilerParams(; cap, ptx)
             config = CompilerConfig(target, params)
             job = CompilerJob(mi, config)

--- a/src/device/runtime.jl
+++ b/src/device/runtime.jl
@@ -8,16 +8,19 @@ import Base.Sys: WORD_SIZE
 # reset the runtime cache from global scope, so that any change triggers recompilation
 GPUCompiler.reset_runtime()
 
-# load or build the runtime for the most likely compilation job given a compute capability
-function precompile_runtime(caps=CUDA.llvm_compat(LLVM.version()).cap)
+# load or build the runtime for the most likely compilation jobs
+function precompile_runtime()
     f = ()->return
     mi = methodinstance(typeof(f), Tuple{})
-    params = CUDACompilerParams()
+
+    caps = llvm_compat().cap
+    ptx = maximum(llvm_compat().ptx)
     JuliaContext() do ctx
         for cap in caps
             # NOTE: this often runs when we don't have a functioning set-up,
             #       so we don't use `compiler_config` which requires NVML
-            target = PTXCompilerTarget(; cap)
+            target = PTXCompilerTarget(; cap, ptx)
+            params = CUDACompilerParams(; cap, ptx)
             config = CompilerConfig(target, params)
             job = CompilerJob(mi, config)
             GPUCompiler.load_runtime(job)

--- a/src/utilities.jl
+++ b/src/utilities.jl
@@ -99,8 +99,6 @@ function versioninfo(io::IO=stdout)
     println(io, "Toolchain:")
     println(io, "- Julia: $VERSION")
     println(io, "- LLVM: $(LLVM.version())")
-    println(io, "- PTX ISA support: $(join(map(ver->"$(ver.major).$(ver.minor)", supported_toolchain().ptx), ", "))")
-    println(io, "- Device capability support: $(join(map(ver->"sm_$(ver.major)$(ver.minor)", supported_toolchain().cap), ", "))")
     println(io)
 
     env = filter(var->startswith(var, "JULIA_CUDA"), keys(ENV))

--- a/test/core/device/intrinsics.jl
+++ b/test/core/device/intrinsics.jl
@@ -101,12 +101,11 @@ end
 ############################################################################################
 
 @testset "clock and nanosleep" begin
+
 @on_device clock(UInt32)
 @on_device clock(UInt64)
+@on_device nanosleep(UInt32(16))
 
-if CUDA.driver_version() >= v"10.0" && v"6.2" in CUDA.supported_toolchain().ptx
-    @on_device nanosleep(UInt32(16))
-end
 end
 
 @testset "parallel synchronization and communication" begin


### PR DESCRIPTION
Instead of hard-coding it to 6.3, select the highest version available. We now also differentiate between what LLVM supports, which is part of the CompilerTarget, and what the CUDA toolkit does, which we now store in the CUDACompilerParams. For the compute capability, that means emitting code for e.g. sm_89 and passing `-arch=sm_90` to `ptxas`. For the PTX ISA, that's not possible, so we string-replace the `.version` directive in the generated assembly. Feels icky, but I think it should work (on the condition we don't use instructions that are deprecated between the PTX ISA used by LLVM, and the one we replace it with, but that's generally a very small window).

One annoying aspect is that the `compute_version()` and `ptx_isa()` getters for kernel code currently return the LLVM-level compatibility, so we might not generate the best code. However, I don't think we can bump this to the CUDA-level compatibility, as that may risk running into LLVM selection errors. And it doesn't seem worth splitting into `llvm_compute_capability` and `cuda_compute_capability`, where the latter can only use inline assembly.

Fixes https://github.com/JuliaGPU/CUDA.jl/issues/2080