### PR TITLE
Make Ref mutable on the GPU.

### DIFF
--- a/lib/cudadrv/memory.jl
+++ b/lib/cudadrv/memory.jl
@@ -640,6 +640,16 @@ function pin(a::AbstractArray)
     a
 end
 
+function pin(ref::Base.RefValue{T}) where T
+    ctx = context()
+    ptr = Base.unsafe_convert(Ptr{T}, ref)
+    __pin(ptr, sizeof(T))
+    finalizer(ref) do _
+        __unpin(ptr, ctx)
+    end
+    ref
+end
+
 # derived arrays should always pin the parent memory range, because we may end up copying
 # from or to that parent range (containing the derived range), and partially-pinned ranges
 # are not supported:

--- a/test/core/execution.jl
+++ b/test/core/execution.jl
@@ -595,6 +595,17 @@ end
     @test f(2) == 2
 end
 
+@testset "Ref boxes" begin
+    function kernel(x)
+        x[] += 1
+        return
+    end
+
+    box = Ref(1)
+    CUDA.@sync @cuda kernel(box)
+    @test box[] == 2
+end
+
 end
 
 ############################################################################################


### PR DESCRIPTION
As requested by @utkarsh530:

```julia
julia> x = Ref(0)
Base.RefValue{Int64}(0)

julia> function kernel(ref)
           ref[] = threadIdx().x
           return
       end
kernel (generic function with 1 method)

julia> @cuda kernel(x)
CUDA.HostKernel for kernel(CUDA.CuRefValue{Int64})

julia> x
Base.RefValue{Int64}(1)
```

I'm not convinced we want this, because it requires additional API operations when launching a kernel (to pin the memory). Right now, we are essentially passing the Ref as a Tuple, which doesn’t require any API operations, but makes it immutable of course. It's for the same reason that we don't support nested containers.

Fixes https://github.com/JuliaGPU/CUDA.jl/issues/267