### PR TITLE
Remove unneeded make_seed definition.

### DIFF
--- a/src/device/random.jl
+++ b/src/device/random.jl
@@ -50,8 +50,6 @@ function initialize_rng_state()
     @inbounds global_random_counters()[warpId] = 0
 end
 
-@device_override Random.make_seed() = clock(UInt32)
-
 
 # generators
 


### PR DESCRIPTION
This has been removed on nightly, and we don't need it anymore now that we seed from the host.