### PR TITLE
Better support for unified and host memory

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -79,7 +79,7 @@ steps:
           - JuliaCI/julia#v1:
               version: 1.9
           - JuliaCI/julia-test#v1:
-              test_args: "--quickfail core base"
+              test_args: "--quickfail core base libraries"
           - JuliaCI/julia-coverage#v1:
               dirs:
                 - src

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -241,9 +241,28 @@ steps:
         env:
           JULIA_CUDA_USE_COMPAT: 'false'  # NVIDIA bug #3418723: injection tools prevent probing libcuda
         if: build.message !~ /\[skip tests\]/ &&
-            build.message !~ /\[skip sanitizer\]/ &&
             !build.pull_request.draft
         timeout_in_minutes: 10
+
+      - label: "Unified memory"
+        plugins:
+          - JuliaCI/julia#v1:
+              version: 1.9
+          - JuliaCI/julia-test#v1:
+              test_args: "--quickfail"
+          - JuliaCI/julia-coverage#v1:
+              dirs:
+                - src
+                - lib
+                - examples
+        agents:
+          queue: "juliagpu"
+          cuda: "*"
+        commands: |
+          echo -e "[CUDA]\ndefault_memory = \"unified\"" >LocalPreferences.toml
+        if: build.message !~ /\[skip tests\]/ &&
+            !build.pull_request.draft
+        timeout_in_minutes: 120
 
   # we want to benchmark every commit on the master branch, even if it failed CI
   - wait: ~

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -19,8 +19,7 @@ steps:
           cuda: "*"
         commands: |
           echo -e "[CUDA_Runtime_jll]\nlocal = \"true\"" >LocalPreferences.toml
-        if: build.message !~ /\[skip tests\]/ &&
-            build.message !~ /\[skip julia\]/
+        if: build.message !~ /\[skip tests\]/
         timeout_in_minutes: 120
         matrix:
           setup:
@@ -44,7 +43,7 @@ steps:
           - JuliaCI/julia#v1:
               version: 1.9
           - JuliaCI/julia-test#v1:
-              test_args: "core base libraries"
+              test_args: "--quickfail core base libraries"
           - JuliaCI/julia-coverage#v1:
               dirs:
                 - src
@@ -53,9 +52,7 @@ steps:
         agents:
           queue: "juliagpu"
           cuda: "*"
-        if: build.message !~ /\[skip tests\]/ &&
-            build.message !~ /\[skip cuda\]/ &&
-            !build.pull_request.draft
+        if: build.message !~ /\[skip tests\]/ && !build.pull_request.draft
         timeout_in_minutes: 120
         matrix:
           setup:
@@ -72,6 +69,34 @@ steps:
         commands: |
           echo -e "[CUDA_Runtime_jll]\nversion = \"{{matrix.cuda}}\"" >LocalPreferences.toml
           echo -e "[CUDA_Driver_jll]\ncompat = \"false\"" >>LocalPreferences.toml
+
+  - group: "Memory"
+    key: "memory"
+    depends_on: "julia"
+    steps:
+      - label: "CuArray with {{matrix.memory}} memory"
+        plugins:
+          - JuliaCI/julia#v1:
+              version: 1.9
+          - JuliaCI/julia-test#v1:
+              test_args: "--quickfail core base"
+          - JuliaCI/julia-coverage#v1:
+              dirs:
+                - src
+                - lib
+                - examples
+        agents:
+          queue: "juliagpu"
+          cuda: "*"
+        if: build.message !~ /\[skip tests\]/ && !build.pull_request.draft
+        timeout_in_minutes: 120
+        matrix:
+          setup:
+            memory:
+              - "unified"
+              - "host"
+        commands: |
+          echo -e "[CUDA]\ndefault_memory = \"{{matrix.memory}}\"" >LocalPreferences.toml
 
   - group: ":nesting_dolls: Subpackages"
     depends_on: "cuda"
@@ -104,9 +129,7 @@ steps:
         agents:
           queue: "juliagpu"
           cuda: "*"
-        if: build.message !~ /\[skip tests\]/ &&
-            build.message !~ /\[skip subpackages\]/ &&
-            !build.pull_request.draft
+        if: build.message !~ /\[skip tests\]/ && !build.pull_request.draft
         timeout_in_minutes: 120
         commands: |
           julia --project -e '
@@ -165,9 +188,7 @@ steps:
         agents:
           queue: "juliagpu"
           cuda: "*"
-        if: build.message !~ /\[skip tests\]/ &&
-            build.message !~ /\[skip downstream\]/ &&
-            !build.pull_request.draft
+        if: build.message !~ /\[skip tests\]/ && !build.pull_request.draft
         timeout_in_minutes: 60
         soft_fail:
           - exit_status: 3
@@ -240,29 +261,8 @@ steps:
           cuda: "*"
         env:
           JULIA_CUDA_USE_COMPAT: 'false'  # NVIDIA bug #3418723: injection tools prevent probing libcuda
-        if: build.message !~ /\[skip tests\]/ &&
-            !build.pull_request.draft
+        if: build.message !~ /\[skip tests\]/ && !build.pull_request.draft
         timeout_in_minutes: 10
-
-      - label: "Unified memory"
-        plugins:
-          - JuliaCI/julia#v1:
-              version: 1.9
-          - JuliaCI/julia-test#v1:
-              test_args: "--quickfail"
-          - JuliaCI/julia-coverage#v1:
-              dirs:
-                - src
-                - lib
-                - examples
-        agents:
-          queue: "juliagpu"
-          cuda: "*"
-        commands: |
-          echo -e "[CUDA]\ndefault_memory = \"unified\"" >LocalPreferences.toml
-        if: build.message !~ /\[skip tests\]/ &&
-            !build.pull_request.draft
-        timeout_in_minutes: 120
 
   # we want to benchmark every commit on the master branch, even if it failed CI
   - wait: ~
@@ -293,9 +293,8 @@ steps:
         agents:
           queue: "juliagpu"
           cuda: "*"
-        if: build.message !~ /\[skip benchmarks\]/ &&
-            build.branch !~ /^master$$/ &&
-            !build.pull_request.draft
+        if: build.message !~ /\[skip benchmarks\]/ && !build.pull_request.draft &&
+            build.branch !~ /^master$$/
         timeout_in_minutes: 30
 
       # if we will submit results, use the benchmark queue so that we will
@@ -329,8 +328,7 @@ steps:
           queue: "benchmark"
           gpu: "rtx2070"
           cuda: "*"
-        if: build.message !~ /\[skip benchmarks\]/ &&
-            build.branch =~ /^master$$/
+        if: build.message !~ /\[skip benchmarks\]/ && build.branch =~ /^master$$/
         matrix:
           setup:
             julia:

--- a/LocalPreferences.toml
+++ b/LocalPreferences.toml
@@ -12,6 +12,10 @@
 # making it possible to do use cooperative multitasking.
 #nonblocking_synchronization = true
 
+# which memory type unspecified allocations should default to.
+# possible values: "device", "unified", "host"
+#default_memory = "unified"
+
 [CUDA_Driver_jll]
 # whether to attempt to load a forwards-compatibile userspace driver.
 # only turn this off if you experience issues, e.g., when using a local

--- a/LocalPreferences.toml
+++ b/LocalPreferences.toml
@@ -14,7 +14,7 @@
 
 # which memory type unspecified allocations should default to.
 # possible values: "device", "unified", "host"
-#default_memory = "unified"
+#default_memory = "device"
 
 [CUDA_Driver_jll]
 # whether to attempt to load a forwards-compatibile userspace driver.

--- a/lib/cudadrv/memory.jl
+++ b/lib/cudadrv/memory.jl
@@ -213,6 +213,7 @@ struct UnifiedBuffer <: AbstractBuffer
     ctx::CuContext
     ptr::CuPtr{Cvoid}
     bytesize::Int
+    dirty::Threads.Atomic{Bool}
 end
 
 UnifiedBuffer() = UnifiedBuffer(context(), CU_NULL, 0)
@@ -244,7 +245,7 @@ function alloc(::Type{UnifiedBuffer}, bytesize::Integer,
     ptr_ref = Ref{CuPtr{Cvoid}}()
     CUDA.cuMemAllocManaged(ptr_ref, bytesize, flags)
 
-    return UnifiedBuffer(context(), ptr_ref[], bytesize)
+    return UnifiedBuffer(context(), ptr_ref[], bytesize, Threads.Atomic{Bool}(false), )
 end
 
 

--- a/lib/cudadrv/memory.jl
+++ b/lib/cudadrv/memory.jl
@@ -213,10 +213,9 @@ struct UnifiedBuffer <: AbstractBuffer
     ctx::CuContext
     ptr::CuPtr{Cvoid}
     bytesize::Int
-    dirty::Threads.Atomic{Bool}
 end
 
-UnifiedBuffer() = UnifiedBuffer(context(), CU_NULL, 0, Threads.Atomic{Bool}(false))
+UnifiedBuffer() = UnifiedBuffer(context(), CU_NULL, 0)
 
 Base.pointer(buf::UnifiedBuffer) = buf.ptr
 Base.sizeof(buf::UnifiedBuffer) = buf.bytesize
@@ -245,7 +244,7 @@ function alloc(::Type{UnifiedBuffer}, bytesize::Integer,
     ptr_ref = Ref{CuPtr{Cvoid}}()
     CUDA.cuMemAllocManaged(ptr_ref, bytesize, flags)
 
-    return UnifiedBuffer(context(), ptr_ref[], bytesize, Threads.Atomic{Bool}(false))
+    return UnifiedBuffer(context(), ptr_ref[], bytesize)
 end
 
 

--- a/lib/cudadrv/memory.jl
+++ b/lib/cudadrv/memory.jl
@@ -216,7 +216,7 @@ struct UnifiedBuffer <: AbstractBuffer
     dirty::Threads.Atomic{Bool}
 end
 
-UnifiedBuffer() = UnifiedBuffer(context(), CU_NULL, 0)
+UnifiedBuffer() = UnifiedBuffer(context(), CU_NULL, 0, Threads.Atomic{Bool}(false))
 
 Base.pointer(buf::UnifiedBuffer) = buf.ptr
 Base.sizeof(buf::UnifiedBuffer) = buf.bytesize
@@ -245,7 +245,7 @@ function alloc(::Type{UnifiedBuffer}, bytesize::Integer,
     ptr_ref = Ref{CuPtr{Cvoid}}()
     CUDA.cuMemAllocManaged(ptr_ref, bytesize, flags)
 
-    return UnifiedBuffer(context(), ptr_ref[], bytesize, Threads.Atomic{Bool}(false), )
+    return UnifiedBuffer(context(), ptr_ref[], bytesize, Threads.Atomic{Bool}(false))
 end
 
 

--- a/lib/cusparse/array.jl
+++ b/lib/cusparse/array.jl
@@ -417,9 +417,9 @@ Adapt.adapt_storage(::Type{CuArray}, xs::SparseMatrixCSC) = CuSparseMatrixCSC(xs
 Adapt.adapt_storage(::Type{CuArray{T}}, xs::SparseVector) where {T} = CuSparseVector{T}(xs)
 Adapt.adapt_storage(::Type{CuArray{T}}, xs::SparseMatrixCSC) where {T} = CuSparseMatrixCSC{T}(xs)
 
-Adapt.adapt_storage(::CUDA.CuArrayAdaptor, xs::AbstractSparseArray) =
+Adapt.adapt_storage(::CUDA.CuArrayKernelAdaptor, xs::AbstractSparseArray) =
   adapt(CuArray, xs)
-Adapt.adapt_storage(::CUDA.CuArrayAdaptor, xs::AbstractSparseArray{<:AbstractFloat}) =
+Adapt.adapt_storage(::CUDA.CuArrayKernelAdaptor, xs::AbstractSparseArray{<:AbstractFloat}) =
   adapt(CuArray{Float32}, xs)
 
 Adapt.adapt_storage(::Type{Array}, xs::CuSparseVector) = SparseVector(xs)
@@ -546,7 +546,7 @@ end
 
 # interop with device arrays
 
-function Adapt.adapt_structure(to::CUDA.Adaptor, x::CuSparseVector)
+function Adapt.adapt_structure(to::CUDA.KernelAdaptor, x::CuSparseVector)
     return CuSparseDeviceVector(
         adapt(to, x.iPtr),
         adapt(to, x.nzVal),
@@ -554,7 +554,7 @@ function Adapt.adapt_structure(to::CUDA.Adaptor, x::CuSparseVector)
     )
 end
 
-function Adapt.adapt_structure(to::CUDA.Adaptor, x::CuSparseMatrixCSR)
+function Adapt.adapt_structure(to::CUDA.KernelAdaptor, x::CuSparseMatrixCSR)
     return CuSparseDeviceMatrixCSR(
         adapt(to, x.rowPtr),
         adapt(to, x.colVal),
@@ -563,7 +563,7 @@ function Adapt.adapt_structure(to::CUDA.Adaptor, x::CuSparseMatrixCSR)
     )
 end
 
-function Adapt.adapt_structure(to::CUDA.Adaptor, x::CuSparseMatrixCSC)
+function Adapt.adapt_structure(to::CUDA.KernelAdaptor, x::CuSparseMatrixCSC)
     return CuSparseDeviceMatrixCSC(
         adapt(to, x.colPtr),
         adapt(to, x.rowVal),
@@ -572,7 +572,7 @@ function Adapt.adapt_structure(to::CUDA.Adaptor, x::CuSparseMatrixCSC)
     )
 end
 
-function Adapt.adapt_structure(to::CUDA.Adaptor, x::CuSparseMatrixBSR)
+function Adapt.adapt_structure(to::CUDA.KernelAdaptor, x::CuSparseMatrixBSR)
     return CuSparseDeviceMatrixBSR(
         adapt(to, x.rowPtr),
         adapt(to, x.colVal),
@@ -582,7 +582,7 @@ function Adapt.adapt_structure(to::CUDA.Adaptor, x::CuSparseMatrixBSR)
     )
 end
 
-function Adapt.adapt_structure(to::CUDA.Adaptor, x::CuSparseMatrixCOO)
+function Adapt.adapt_structure(to::CUDA.KernelAdaptor, x::CuSparseMatrixCOO)
     return CuSparseDeviceMatrixCOO(
         adapt(to, x.rowInd),
         adapt(to, x.colInd),

--- a/src/array.jl
+++ b/src/array.jl
@@ -381,12 +381,12 @@ end
 ## indexing
 
 function Base.getindex(x::CuArray{T, <:Any, Mem.UnifiedBuffer}, I::Int) where T
-  ptr = Base.unsafe_convert(Ptr{T}, x)
+  ptr = Base.unsafe_convert(Ptr{T}, x) + Base._memory_offset(x, I)
   unsafe_load(ptr)
 end
 
 function Base.setindex!(x::CuArray{T, <:Any, Mem.UnifiedBuffer}, v, I::Int) where T
-  ptr = Base.unsafe_convert(Ptr{T}, x)
+  ptr = Base.unsafe_convert(Ptr{T}, x) + Base._memory_offset(x, I)
   unsafe_store!(ptr, v)
 end
 

--- a/src/array.jl
+++ b/src/array.jl
@@ -243,7 +243,7 @@ function _unsafe_wrap(::Type{T}, ptr::CuPtr{T}, dims::NTuple{N,Int};
   buf = try
     typ = memory_type(ptr)
     if is_managed(ptr)
-      Mem.UnifiedBuffer(ctx, ptr, sz)
+      Mem.UnifiedBuffer(ctx, ptr, sz, Threads.Atomic{Bool}(false))
     elseif typ == CU_MEMORYTYPE_DEVICE
       # TODO: can we identify whether this pointer was allocated asynchronously?
       Mem.DeviceBuffer(ctx, ptr, sz, false)

--- a/src/array.jl
+++ b/src/array.jl
@@ -333,7 +333,7 @@ const AnyCuVecOrMat{T} = Union{AnyCuVector{T}, AnyCuMatrix{T}}
 end
 
 @inline CuArray{T,N}(xs::AbstractArray{<:Any,N}) where {T,N} =
-  CuArray{T,N,Mem.Device}(xs)
+  CuArray{T,N,default_memory}(xs)
 
 @inline CuArray{T,N}(xs::CuArray{<:Any,N,B}) where {T,N,B} =
   CuArray{T,N,B}(xs)

--- a/src/array.jl
+++ b/src/array.jl
@@ -133,7 +133,7 @@ const CuMatrix{T} = CuArray{T,2}
 const CuVecOrMat{T} = Union{CuVector{T},CuMatrix{T}}
 
 # unspecified memory allocation
-const default_memory = let str = Preferences.@load_preference("default_memory", "unified")
+const default_memory = let str = Preferences.@load_preference("default_memory", "device")
   if str == "device"
     Mem.DeviceBuffer
   elseif str == "unified"

--- a/src/array.jl
+++ b/src/array.jl
@@ -480,11 +480,15 @@ end
 
 ## indexing
 
-Base.getindex(x::CuArray{<:Any, <:Any, <:Union{Mem.Host,Mem.Unified}}, I::Int) =
+function Base.getindex(x::CuArray{<:Any, <:Any, <:Union{Mem.Host,Mem.Unified}}, I::Int)
+  @boundscheck checkbounds(x, I)
   unsafe_load(pointer(x, I; type=Mem.Host))
+end
 
-Base.setindex!(x::CuArray{<:Any, <:Any, <:Union{Mem.Host,Mem.Unified}}, v, I::Int) =
+function Base.setindex!(x::CuArray{<:Any, <:Any, <:Union{Mem.Host,Mem.Unified}}, v, I::Int)
+  @boundscheck checkbounds(x, I)
   unsafe_store!(pointer(x, I; type=Mem.Host), v)
+end
 
 
 ## interop with device arrays

--- a/src/pool.jl
+++ b/src/pool.jl
@@ -451,6 +451,12 @@ end
   end
   buf, time
 end
+@inline function _alloc(::Type{Mem.HostBuffer}, sz; stream::Union{Nothing,CuStream})
+  time = Base.@elapsed begin
+    buf = Mem.alloc(Mem.Host, sz)
+  end
+  buf, time
+end
 
 """
     free(buf)

--- a/src/texture.jl
+++ b/src/texture.jl
@@ -319,6 +319,6 @@ memory_source(::Any) = error("Unknown texture source $(typeof(t))")
 memory_source(::CuArray) = LinearMemory()
 memory_source(::CuTextureArray) = ArrayMemory()
 
-Adapt.adapt_storage(::Adaptor, t::CuTexture{T,N}) where {T,N} =
+Adapt.adapt_storage(::KernelAdaptor, t::CuTexture{T,N}) where {T,N} =
     CuDeviceTexture{T,N,typeof(memory_source(parent(t))),
                     t.normalized_coordinates, typeof(t.interpolation)}(size(t), t.handle)

--- a/src/utilities.jl
+++ b/src/utilities.jl
@@ -110,6 +110,23 @@ function versioninfo(io::IO=stdout)
         println(io)
     end
 
+    prefs = [
+        "nonblocking_synchronization" => Preferences.load_preference(CUDA, "nonblocking_synchronization"),
+        "default_memory" => Preferences.load_preference(CUDA, "default_memory"),
+        "CUDA_Runtime_jll.version" => Preferences.load_preference(CUDA_Runtime_jll, "version"),
+        "CUDA_Runtime_jll.local" => Preferences.load_preference(CUDA_Runtime_jll, "local"),
+        "CUDA_Driver_jll.compat" => Preferences.load_preference(CUDA_Driver_jll, "compat"),
+    ]
+    if any(x->!isnothing(x[2]), prefs)
+        println(io, "Preferences:")
+        for (key, val) in prefs
+            if !isnothing(val)
+                println(io, "- $key: $val")
+            end
+        end
+        println(io)
+    end
+
     devs = devices()
     if isempty(devs)
         println(io, "No CUDA-capable devices.")

--- a/test/base/array.jl
+++ b/test/base/array.jl
@@ -671,7 +671,7 @@ end
   dev = device()
 
   let
-    a = CuVector{Int}(undef, 1)
+    a = CuVector{Int,Mem.DeviceBuffer}(undef, 1)
     @test !is_unified(a)
     @test !is_managed(pointer(a))
   end
@@ -694,12 +694,6 @@ end
   end
 
   let
-    # default ctor: device memory
-    let a = CUDA.rand(1)
-      @test !is_unified(a)
-      @test !is_managed(pointer(a))
-    end
-
     for B = [Mem.DeviceBuffer, Mem.UnifiedBuffer]
       a = CuVector{Float32,B}(rand(Float32, 1))
       @test !xor(B == Mem.UnifiedBuffer, is_unified(a))
@@ -740,12 +734,12 @@ end
     end
 
     # cu: supports unified keyword
-    let a = cu(rand(Float64, 1); unified=true)
-      @test is_unified(a)
+    let a = cu(rand(Float64, 1); device=true)
+      @test !is_unified(a)
       @test eltype(a) == Float32
     end
-    let a = cu(rand(Float64, 1))
-      @test !is_unified(a)
+    let a = cu(rand(Float64, 1); unified=true)
+      @test is_unified(a)
       @test eltype(a) == Float32
     end
   end

--- a/test/core/execution.jl
+++ b/test/core/execution.jl
@@ -470,7 +470,7 @@ end
     @eval struct Host   end
     @eval struct Device end
 
-    Adapt.adapt_storage(::CUDA.Adaptor, a::Host) = Device()
+    Adapt.adapt_storage(::CUDA.KernelAdaptor, a::Host) = Device()
 
     Base.convert(::Type{Int}, ::Host)   = 1
     Base.convert(::Type{Int}, ::Device) = 2

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -58,7 +58,7 @@ const tests = ["core$(path_separator)initialization"]    # needs to run first
 const test_runners = Dict()
 ## GPUArrays testsuite
 for name in keys(TestSuite.tests)
-    if CUDA.default_memory == Mem.Unified && name == "indexing scalar"
+    if CUDA.default_memory != Mem.Device && name == "indexing scalar"
         # GPUArrays' scalar indexing tests assume that indexing is not supported
         continue
     end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -58,6 +58,10 @@ const tests = ["core$(path_separator)initialization"]    # needs to run first
 const test_runners = Dict()
 ## GPUArrays testsuite
 for name in keys(TestSuite.tests)
+    if CUDA.default_memory == Mem.Unified && name == "indexing scalar"
+        # GPUArrays' scalar indexing tests assume that indexing is not supported
+        continue
+    end
     push!(tests, "gpuarrays$(path_separator)$name")
     test_runners["gpuarrays$(path_separator)$name"] = ()->TestSuite.tests[name](CuArray)
 end


### PR DESCRIPTION
This PR includes a couple of unified memory improvements that are long overdue. With most vendors providing mature unified memory architectures, we really should be exploring defaulting to unified memory, as it greatly helps with two major issues that users run into: scalar indexing errors due to abstractarray fallbacks, and out-of-memory situations.

## Scalar iteration

Building on https://github.com/JuliaGPU/GPUArrays.jl/pull/499, CUDA.jl now implements efficient scalar indexing for unified arrays. The performance difference to old-style `@allowscalar` is huge:

```julia
julia> a = cu([1]; unified=true);

julia> a[1]
1

julia> @benchmark a[1]
BenchmarkTools.Trial: 10000 samples with 998 evaluations.
 Range (min … max):  13.145 ns … 29.890 ns  ┊ GC (min … max): 0.00% … 0.00%
 Time  (median):     13.497 ns              ┊ GC (median):    0.00%
 Time  (mean ± σ):   13.521 ns ±  0.357 ns  ┊ GC (mean ± σ):  0.00% ± 0.00%

   ▂            ▁             ▃▃  ▃  █▇  ▅▇▄ ▆▃ ▂▄         ▁  ▂
  ▇█▄▃█▇▁▁▃▁▃▁▁▃█▄▁▆▄▇▁▇█▁▃▇▆▁██▄▇██▁██▆████▄██▅███▁▁▁▁▃▁▁▁█▆ █
  13.1 ns      Histogram: log(frequency) by time      13.7 ns <

 Memory estimate: 0 bytes, allocs estimate: 0.
```

vs.

```julia
julia> b = cu([1]);

julia> b[1]
ERROR: Scalar indexing is disallowed.

julia> CUDA.@allowscalar b[1]
1

julia> @benchmark CUDA.@allowscalar b[1]
 BenchmarkTools.Trial: 10000 samples with 1 evaluation.
 Range (min … max):  11.910 μs … 107.569 μs  ┊ GC (min … max): 0.00% … 0.00%
 Time  (median):     14.620 μs               ┊ GC (median):    0.00%
 Time  (mean ± σ):   14.354 μs ±   2.073 μs  ┊ GC (mean ± σ):  0.00% ± 0.00%

          ▂▁                         ▁▃▆█▄▁
  ▂▂▂▂▃▃▄▆██▇▄▄▄▄▃▃▃▂▂▂▂▂▁▂▂▂▂▂▂▃▃▅▆▇██████▇▆▆▇▆▆▄▄▄▄▄▄▃▃▃▂▃▂▂ ▄
  11.9 μs         Histogram: frequency by time         16.2 μs <

 Memory estimate: 80 bytes, allocs estimate: 2.
```

The `dirty` bit is a bit naive though, as it breaks down when multiple tasks are accessing a single array concurrently. Maybe that's fine though, and users ought to perform manual synchronization when using multiple tasks or streams.

## Default unified memory

I also added a preference to switch the default memory type to `unified`, and added a CI job to test whether the test suite supports that. We should consider if we actually want to switch, for one, because unified memory doesn't have a stream-ordered allocator, so it may make allocations and GC pauses worse. At the same time, it would allow the user to use much more memory, so maybe that helps with GC pressure...

TODO: consider adding a MemAdvice or Prefetch (see https://developer.nvidia.com/blog/maximizing-unified-memory-performance-cuda/)

cc @vchuravy 