### PR TITLE
Avoid allocations during derived array construction.

### DIFF
--- a/src/array.jl
+++ b/src/array.jl
@@ -654,7 +654,8 @@ end
 
 ## derived arrays
 
-function GPUArrays.derive(::Type{T}, N::Int, a::CuArray, dims::Dims, offset::Int) where {T}
+function GPUArrays.derive(::Type{T}, n::Int, a::CuArray, dims::Dims{N}, offset::Int) where {T,N}
+  @assert n == N
   offset = (a.offset * Base.elsize(a)) ÷ sizeof(T) + offset
   CuArray{T,N}(a.data, dims; a.maxsize, offset)
 end


### PR DESCRIPTION
Addresses the added allocations in https://github.com/JuliaGPU/CUDA.jl/issues/2112.

There's no reason this API takes an `N::Int` param; we should change that in GPUArrays, but let's just do the local fix now.