### PR TITLE
[CUSPARSE] Update the wrapper of cusparseSpSV_updateMatrix

### DIFF
--- a/lib/cusparse/helpers.jl
+++ b/lib/cusparse/helpers.jl
@@ -36,6 +36,14 @@ end
 mutable struct CuDenseVectorDescriptor
     handle::cusparseDnVecDescr_t
 
+    function CuDenseVectorDescriptor(T::DataType, n::Integer)
+        desc_ref = Ref{cusparseDnVecDescr_t}()
+        cusparseCreateDnVec(desc_ref, n, CU_NULL, T)
+        obj = new(desc_ref[])
+        finalizer(cusparseDestroyDnVec, obj)
+        obj
+    end
+
     function CuDenseVectorDescriptor(x::DenseCuVector)
         desc_ref = Ref{cusparseDnVecDescr_t}()
         cusparseCreateDnVec(desc_ref, length(x), x, eltype(x))
@@ -70,6 +78,18 @@ Base.unsafe_convert(::Type{cusparseSpVecDescr_t}, desc::CuSparseVectorDescriptor
 
 mutable struct CuDenseMatrixDescriptor
     handle::cusparseDnMatDescr_t
+
+    function CuDenseMatrixDescriptor(T::DataType, m::Integer, n::Integer; transposed::Bool=false)
+        desc_ref = Ref{cusparseDnMatDescr_t}()
+        if transposed
+            cusparseCreateDnMat(desc_ref, n, m, m, CU_NULL, T, 'R')
+        else
+            cusparseCreateDnMat(desc_ref, m, n, m, CU_NULL, T, 'C')
+        end
+        obj = new(desc_ref[])
+        finalizer(cusparseDestroyDnMat, obj)
+        obj
+    end
 
     function CuDenseMatrixDescriptor(A::DenseCuMatrix; transposed::Bool=false)
         desc_ref = Ref{cusparseDnMatDescr_t}()

--- a/lib/cusparse/libcusparse.jl
+++ b/lib/cusparse/libcusparse.jl
@@ -5538,7 +5538,7 @@ end
     initialize_context()
     @ccall libcusparse.cusparseSpSV_updateMatrix(handle::cusparseHandle_t,
                                                  spsvDescr::cusparseSpSVDescr_t,
-                                                 newValues::Ptr{Cvoid},
+                                                 newValues::CuPtr{Cvoid},
                                                  updatePart::cusparseSpSVUpdate_t)::cusparseStatus_t
 end
 

--- a/res/wrap/cusparse.toml
+++ b/res/wrap/cusparse.toml
@@ -2652,6 +2652,9 @@ needs_context = false
 [api.cusparseSpSV_analysis.argtypes]
 10 = "CuPtr{Cvoid}"
 
+[api.cusparseSpSV_updateMatrix.argtypes]
+3 = "CuPtr{Cvoid}"
+
 [api.cusparseSpGEMMreuse_workEstimation.argtypes]
 10 = "CuPtr{Cvoid}"
 


### PR DESCRIPTION
I also added two constructors.
They are needed if we want to perform the analysis of sparse triangular solves (`spsv` / `spsm`) without providing the right-hand side(s).