### PR TITLE
Add the structures ILU0Info() and IC0Info() for the preconditioners

### DIFF
--- a/lib/cusparse/helpers.jl
+++ b/lib/cusparse/helpers.jl
@@ -262,3 +262,31 @@ mutable struct CuSparseSpSMDescriptor
 end
 
 Base.unsafe_convert(::Type{cusparseSpSMDescr_t}, desc::CuSparseSpSMDescriptor) = desc.handle
+
+mutable struct IC0Info
+    info::csric02Info_t
+
+    function IC0Info()
+        info_ref = Ref{csric02Info_t}()
+        cusparseCreateCsric02Info(info_ref)
+        obj = new(info_ref[])
+        finalizer(cusparseDestroyCsric02Info, obj)
+        obj
+    end
+end
+
+Base.unsafe_convert(::Type{csric02Info_t}, info::IC0Info) = info.info
+
+mutable struct ILU0Info
+    info::csrilu02Info_t
+
+    function ILU0Info()
+        info_ref = Ref{csrilu02Info_t}()
+        cusparseCreateCsrilu02Info(info_ref)
+        obj = new(info_ref[])
+        finalizer(cusparseDestroyCsrilu02Info, obj)
+        obj
+    end
+end
+
+Base.unsafe_convert(::Type{csrilu02Info_t}, info::ILU0Info) = info.info

--- a/lib/cusparse/helpers.jl
+++ b/lib/cusparse/helpers.jl
@@ -277,6 +277,20 @@ end
 
 Base.unsafe_convert(::Type{csric02Info_t}, info::IC0Info) = info.info
 
+mutable struct IC0InfoBSR
+    info::bsric02Info_t
+
+    function IC0InfoBSR()
+        info_ref = Ref{bsric02Info_t}()
+        cusparseCreateBsric02Info(info_ref)
+        obj = new(info_ref[])
+        finalizer(cusparseDestroyBsric02Info, obj)
+        obj
+    end
+end
+
+Base.unsafe_convert(::Type{bsric02Info_t}, info::IC0InfoBSR) = info.info
+
 mutable struct ILU0Info
     info::csrilu02Info_t
 
@@ -290,3 +304,17 @@ mutable struct ILU0Info
 end
 
 Base.unsafe_convert(::Type{csrilu02Info_t}, info::ILU0Info) = info.info
+
+mutable struct ILU0InfoBSR
+    info::bsrilu02Info_t
+
+    function ILU0InfoBSR()
+        info_ref = Ref{bsrilu02Info_t}()
+        cusparseCreateBsrilu02Info(info_ref)
+        obj = new(info_ref[])
+        finalizer(cusparseDestroyBsrilu02Info, obj)
+        obj
+    end
+end
+
+Base.unsafe_convert(::Type{bsrilu02Info_t}, info::ILU0InfoBSR) = info.info

--- a/lib/cusparse/preconditioners.jl
+++ b/lib/cusparse/preconditioners.jl
@@ -54,7 +54,7 @@ for (bname,aname,sname,elty) in ((:cusparseScsric02_bufferSize, :cusparseScsric0
                         CUSPARSE_SOLVE_POLICY_USE_LEVEL, buffer)
                 posit = Ref{Cint}(1)
                 cusparseXcsric02_zeroPivot(handle(), info, posit)
-                if posit[] ≥ 0
+                if posit[] >= 0
                     error("Structural/numerical zero in A at ($(posit[]),$(posit[])))")
                 end
                 $sname(handle(), m, nnz(A),
@@ -92,7 +92,7 @@ for (bname,aname,sname,elty) in ((:cusparseScsric02_bufferSize, :cusparseScsric0
                         CUSPARSE_SOLVE_POLICY_USE_LEVEL, buffer)
                 posit = Ref{Cint}(1)
                 cusparseXcsric02_zeroPivot(handle(), info, posit)
-                if posit[] ≥ 0
+                if posit[] >= 0
                     error("Structural/numerical zero in A at ($(posit[]),$(posit[])))")
                 end
                 $sname(handle(), m, nnz(A),
@@ -131,7 +131,7 @@ for (bname,aname,sname,elty) in ((:cusparseScsrilu02_bufferSize, :cusparseScsril
                         CUSPARSE_SOLVE_POLICY_USE_LEVEL, buffer)
                 posit = Ref{Cint}(1)
                 cusparseXcsrilu02_zeroPivot(handle(), info, posit)
-                if posit[] ≥ 0
+                if posit[] >= 0
                     error("Structural zero in A at ($(posit[]),$(posit[])))")
                 end
                 $sname(handle(), m, nnz(A),
@@ -170,7 +170,7 @@ for (bname,aname,sname,elty) in ((:cusparseScsrilu02_bufferSize, :cusparseScsril
                         CUSPARSE_SOLVE_POLICY_USE_LEVEL, buffer)
                 posit = Ref{Cint}(1)
                 cusparseXcsrilu02_zeroPivot(handle(), info, posit)
-                if posit[] ≥ 0
+                if posit[] >= 0
                     error("Structural zero in A at ($(posit[]),$(posit[])))")
                 end
                 $sname(handle(), m, nnz(A),
@@ -195,31 +195,27 @@ for (bname,aname,sname,elty) in ((:cusparseSbsric02_bufferSize, :cusparseSbsric0
                 throw(DimensionMismatch("A must be square, but has dimensions ($m,$n)!"))
             end
             mb = div(m,A.blockDim)
-            info = bsric02Info_t[0]
-            cusparseCreateBsric02Info(info)
+            info = IC0InfoBSR()
 
             function bufferSize()
                 out = Ref{Cint}(1)
-                $bname(handle(), A.dir, mb, nnz(A), desc,
-                       nonzeros(A), A.rowPtr, A.colVal, A.blockDim, info[1],
-                       out)
+                $bname(handle(), A.dir, mb, nnz(A), desc, nonzeros(A),
+                       A.rowPtr, A.colVal, A.blockDim, info, out)
                 return out[]
             end
             with_workspace(bufferSize) do buffer
-                    $aname(handle(), A.dir, mb, nnz(A), desc,
-                           nonzeros(A), A.rowPtr, A.colVal, A.blockDim, info[1],
-                           CUSPARSE_SOLVE_POLICY_USE_LEVEL, buffer)
-                    posit = Ref{Cint}(1)
-                    cusparseXbsric02_zeroPivot(handle(), info[1], posit)
-                    if posit[] ≥ 0
-                        cusparseDestroyBsric02Info(info[1])
-                        error("Structural/numerical zero in A at ($(posit[]),$(posit[])))")
-                    end
-                    $sname(handle(), A.dir, mb, nnz(A), desc,
-                           nonzeros(A), A.rowPtr, A.colVal, A.blockDim, info[1],
-                           CUSPARSE_SOLVE_POLICY_USE_LEVEL, buffer)
+                $aname(handle(), A.dir, mb, nnz(A), desc,
+                       nonzeros(A), A.rowPtr, A.colVal, A.blockDim, info,
+                       CUSPARSE_SOLVE_POLICY_USE_LEVEL, buffer)
+                posit = Ref{Cint}(1)
+                cusparseXbsric02_zeroPivot(handle(), info, posit)
+                if posit[] >= 0
+                    error("Structural/numerical zero in A at ($(posit[]),$(posit[])))")
                 end
-            cusparseDestroyBsric02Info(info[1])
+                $sname(handle(), A.dir, mb, nnz(A), desc,
+                       nonzeros(A), A.rowPtr, A.colVal, A.blockDim, info,
+                       CUSPARSE_SOLVE_POLICY_USE_LEVEL, buffer)
+            end
             A
         end
     end
@@ -238,31 +234,27 @@ for (bname,aname,sname,elty) in ((:cusparseSbsrilu02_bufferSize, :cusparseSbsril
                 throw(DimensionMismatch("A must be square, but has dimensions ($m,$n)!"))
             end
             mb = div(m,A.blockDim)
-            info = bsrilu02Info_t[0]
-            cusparseCreateBsrilu02Info(info)
+            info = ILU0InfoBSR()
 
             function bufferSize()
                 out = Ref{Cint}(1)
-                $bname(handle(), A.dir, mb, nnz(A), desc,
-                       nonzeros(A), A.rowPtr, A.colVal, A.blockDim, info[1],
-                       out)
+                $bname(handle(), A.dir, mb, nnz(A), desc, nonzeros(A),
+                       A.rowPtr, A.colVal, A.blockDim, info, out)
                 return out[]
             end
             with_workspace(bufferSize) do buffer
                 $aname(handle(), A.dir, mb, nnz(A), desc,
-                        nonzeros(A), A.rowPtr, A.colVal, A.blockDim, info[1],
+                        nonzeros(A), A.rowPtr, A.colVal, A.blockDim, info,
                         CUSPARSE_SOLVE_POLICY_USE_LEVEL, buffer)
                 posit = Ref{Cint}(1)
-                cusparseXbsrilu02_zeroPivot(handle(), info[1], posit)
-                if posit[] ≥ 0
-                    cusparseDestroyBsrilu02Info(info[1])
+                cusparseXbsrilu02_zeroPivot(handle(), info, posit)
+                if posit[] >= 0
                     error("Structural/numerical zero in A at ($(posit[]),$(posit[])))")
                 end
                 $sname(handle(), A.dir, mb, nnz(A), desc,
-                        nonzeros(A), A.rowPtr, A.colVal, A.blockDim, info[1],
+                        nonzeros(A), A.rowPtr, A.colVal, A.blockDim, info,
                         CUSPARSE_SOLVE_POLICY_USE_LEVEL, buffer)
             end
-            cusparseDestroyBsrilu02Info(info[1])
             A
         end
     end

--- a/lib/cusparse/preconditioners.jl
+++ b/lib/cusparse/preconditioners.jl
@@ -40,29 +40,27 @@ for (bname,aname,sname,elty) in ((:cusparseScsric02_bufferSize, :cusparseScsric0
             if m != n
                 throw(DimensionMismatch("A must be square, but has dimensions ($m,$n)!"))
             end
-            info = csric02Info_t[0]
-            cusparseCreateCsric02Info(info)
+            info = IC0Info()
 
             function bufferSize()
                 out = Ref{Cint}(1)
-                $bname(handle(), m, nnz(A), desc, nonzeros(A), A.rowPtr, A.colVal, info[1],
+                $bname(handle(), m, nnz(A), desc, nonzeros(A), A.rowPtr, A.colVal, info,
                        out)
                 return out[]
             end
             with_workspace(bufferSize) do buffer
                 $aname(handle(), m, nnz(A), desc,
-                        nonzeros(A), A.rowPtr, A.colVal, info[1],
+                        nonzeros(A), A.rowPtr, A.colVal, info,
                         CUSPARSE_SOLVE_POLICY_USE_LEVEL, buffer)
                 posit = Ref{Cint}(1)
-                cusparseXcsric02_zeroPivot(handle(), info[1], posit)
-                if posit[] >= 0
+                cusparseXcsric02_zeroPivot(handle(), info, posit)
+                if posit[] ≥ 0
                     error("Structural/numerical zero in A at ($(posit[]),$(posit[])))")
                 end
                 $sname(handle(), m, nnz(A),
-                        desc, nonzeros(A), A.rowPtr, A.colVal, info[1],
+                        desc, nonzeros(A), A.rowPtr, A.colVal, info,
                         CUSPARSE_SOLVE_POLICY_USE_LEVEL, buffer)
             end
-            cusparseDestroyCsric02Info(info[1])
             A
         end
     end
@@ -80,29 +78,27 @@ for (bname,aname,sname,elty) in ((:cusparseScsric02_bufferSize, :cusparseScsric0
             if m != n
                 throw(DimensionMismatch("A must be square, but has dimensions ($m,$n)!"))
             end
-            info = csric02Info_t[0]
-            cusparseCreateCsric02Info(info)
+            info = IC0Info()
 
             function bufferSize()
                 out = Ref{Cint}(1)
                 $bname(handle(), m, nnz(A), desc, nonzeros(A), A.colPtr, rowvals(A),
-                       info[1], out)
+                       info, out)
                 return out[]
             end
             with_workspace(bufferSize) do buffer
                 $aname(handle(), m, nnz(A), desc,
-                        nonzeros(A), A.colPtr, rowvals(A), info[1],
+                        nonzeros(A), A.colPtr, rowvals(A), info,
                         CUSPARSE_SOLVE_POLICY_USE_LEVEL, buffer)
                 posit = Ref{Cint}(1)
-                cusparseXcsric02_zeroPivot(handle(), info[1], posit)
-                if posit[] >= 0
+                cusparseXcsric02_zeroPivot(handle(), info, posit)
+                if posit[] ≥ 0
                     error("Structural/numerical zero in A at ($(posit[]),$(posit[])))")
                 end
                 $sname(handle(), m, nnz(A),
-                        desc, nonzeros(A), A.colPtr, rowvals(A), info[1],
+                        desc, nonzeros(A), A.colPtr, rowvals(A), info,
                         CUSPARSE_SOLVE_POLICY_USE_LEVEL, buffer)
             end
-            cusparseDestroyCsric02Info(info[1])
             A
         end
     end
@@ -120,30 +116,28 @@ for (bname,aname,sname,elty) in ((:cusparseScsrilu02_bufferSize, :cusparseScsril
             if m != n
                 throw(DimensionMismatch("A must be square, but has dimensions ($m,$n)!"))
             end
-            info = csrilu02Info_t[0]
-            cusparseCreateCsrilu02Info(info)
+            info = ILU0Info()
 
             function bufferSize()
                 out = Ref{Cint}(1)
                 $bname(handle(), m, nnz(A), desc,
-                       nonzeros(A), A.rowPtr, A.colVal, info[1],
+                       nonzeros(A), A.rowPtr, A.colVal, info,
                        out)
                 return out[]
             end
             with_workspace(bufferSize) do buffer
                 $aname(handle(), m, nnz(A), desc,
-                        nonzeros(A), A.rowPtr, A.colVal, info[1],
+                        nonzeros(A), A.rowPtr, A.colVal, info,
                         CUSPARSE_SOLVE_POLICY_USE_LEVEL, buffer)
                 posit = Ref{Cint}(1)
-                cusparseXcsrilu02_zeroPivot(handle(), info[1], posit)
-                if posit[] >= 0
+                cusparseXcsrilu02_zeroPivot(handle(), info, posit)
+                if posit[] ≥ 0
                     error("Structural zero in A at ($(posit[]),$(posit[])))")
                 end
                 $sname(handle(), m, nnz(A),
-                        desc, nonzeros(A), A.rowPtr, A.colVal, info[1],
+                        desc, nonzeros(A), A.rowPtr, A.colVal, info,
                         CUSPARSE_SOLVE_POLICY_USE_LEVEL, buffer)
             end
-            cusparseDestroyCsrilu02Info(info[1])
             A
         end
     end
@@ -161,30 +155,28 @@ for (bname,aname,sname,elty) in ((:cusparseScsrilu02_bufferSize, :cusparseScsril
             if m != n
                 throw(DimensionMismatch("A must be square, but has dimensions ($m,$n)!"))
             end
-            info = csrilu02Info_t[0]
-            cusparseCreateCsrilu02Info(info)
+            info = ILU0Info()
 
             function bufferSize()
                 out = Ref{Cint}(1)
                 $bname(handle(), m, nnz(A), desc,
-                       nonzeros(A), A.colPtr, rowvals(A), info[1],
+                       nonzeros(A), A.colPtr, rowvals(A), info,
                        out)
                 return out[]
             end
             with_workspace(bufferSize) do buffer
                 $aname(handle(), m, nnz(A), desc,
-                        nonzeros(A), A.colPtr, rowvals(A), info[1],
+                        nonzeros(A), A.colPtr, rowvals(A), info,
                         CUSPARSE_SOLVE_POLICY_USE_LEVEL, buffer)
                 posit = Ref{Cint}(1)
-                cusparseXcsrilu02_zeroPivot(handle(), info[1], posit)
-                if posit[] >= 0
+                cusparseXcsrilu02_zeroPivot(handle(), info, posit)
+                if posit[] ≥ 0
                     error("Structural zero in A at ($(posit[]),$(posit[])))")
                 end
                 $sname(handle(), m, nnz(A),
-                        desc, nonzeros(A), A.colPtr, rowvals(A), info[1],
+                        desc, nonzeros(A), A.colPtr, rowvals(A), info,
                         CUSPARSE_SOLVE_POLICY_USE_LEVEL, buffer)
             end
-            cusparseDestroyCsrilu02Info(info[1])
             A
         end
     end
@@ -219,7 +211,8 @@ for (bname,aname,sname,elty) in ((:cusparseSbsric02_bufferSize, :cusparseSbsric0
                            CUSPARSE_SOLVE_POLICY_USE_LEVEL, buffer)
                     posit = Ref{Cint}(1)
                     cusparseXbsric02_zeroPivot(handle(), info[1], posit)
-                    if posit[] >= 0
+                    if posit[] ≥ 0
+                        cusparseDestroyBsric02Info(info[1])
                         error("Structural/numerical zero in A at ($(posit[]),$(posit[])))")
                     end
                     $sname(handle(), A.dir, mb, nnz(A), desc,
@@ -261,7 +254,8 @@ for (bname,aname,sname,elty) in ((:cusparseSbsrilu02_bufferSize, :cusparseSbsril
                         CUSPARSE_SOLVE_POLICY_USE_LEVEL, buffer)
                 posit = Ref{Cint}(1)
                 cusparseXbsrilu02_zeroPivot(handle(), info[1], posit)
-                if posit[] >= 0
+                if posit[] ≥ 0
+                    cusparseDestroyBsrilu02Info(info[1])
                     error("Structural/numerical zero in A at ($(posit[]),$(posit[])))")
                 end
                 $sname(handle(), A.dir, mb, nnz(A), desc,


### PR DESCRIPTION
The internal structure that contains the `info` during the computation of the preconditioner was not destroyed if a null pivot was encountered.
For CSC / CSR formats, I added structures such that we don't take care of that.
For BSR format, I destroy the structure if a null pivot is encountered, I didn't added structures because we don't use often this format...