### PR TITLE
Fix typo in docs/src/development/troubleshooting.md

### DIFF
--- a/docs/src/development/troubleshooting.md
+++ b/docs/src/development/troubleshooting.md
@@ -47,7 +47,7 @@ type `Union{}`:
 
 ```julia
 julia> function kernel(a)
-         @inbounds a[threadId().x] = CUDA.sin(a[threadIdx().x])
+         @inbounds a[threadIdx().x] = CUDA.sin(a[threadIdx().x])
          return
        end
 


### PR DESCRIPTION
The `threadId` / `threadIdx` typo is used in the previous section to produce certain error messages, but this section looks at a different error