### PR TITLE
NVML: Add support for clock queries.

### DIFF
--- a/lib/nvml/device.jl
+++ b/lib/nvml/device.jl
@@ -29,8 +29,7 @@ function Base.show(io::IO, ::MIME"text/plain", dev::Device)
 end
 
 
-
-# iteration
+## iteration
 
 struct DeviceIterator end
 
@@ -51,8 +50,7 @@ end
 Base.IteratorSize(::DeviceIterator) = Base.HasLength()
 
 
-
-# queries
+## properties
 
 function name(dev::Device)
     buf = Vector{Cchar}(undef, NVML_DEVICE_NAME_V2_BUFFER_SIZE)
@@ -86,33 +84,8 @@ function index(dev::Device)
     return Int(index[])
 end
 
-# watt
-function power_usage(dev::Device)
-    ref = Ref{Cuint}()
-    nvmlDeviceGetPowerUsage(dev, ref)
-    return ref[] / 1000
-end
 
-# joules
-function energy_consumption(dev::Device)
-    ref = Ref{Culonglong}()
-    nvmlDeviceGetTotalEnergyConsumption(dev, ref)
-    return ref[] / 1000
-end
-
-# bytes
-function memory_info(dev::Device)
-    ref = Ref{nvmlMemory_t}()
-    nvmlDeviceGetMemoryInfo(dev, ref)
-    return (total=Int(ref[].total), free=Int(ref[].free), used=Int(ref[].used))
-end
-
-# percent
-function utilization_rates(dev::Device)
-    ref = Ref{nvmlUtilization_t}()
-    nvmlDeviceGetUtilizationRates(dev, ref)
-    return (compute=Int(ref[].gpu)/100, memory=Int(ref[].memory)/100)
-end
+## compute properties
 
 function compute_mode(dev::Device)
     ref = Ref{nvmlComputeMode_t}()
@@ -153,4 +126,162 @@ function compute_processes(dev::Device)
             pid => (used_gpu_memory=used_gpu_memory,)
         end
     )
+end
+
+
+## clocks
+
+function foreach_clock(f, dev::Device)
+    for (type, clock) in [:graphics => NVML_CLOCK_GRAPHICS,
+                          :sm => NVML_CLOCK_SM,
+                          :memory => NVML_CLOCK_MEM,
+                          :video => NVML_CLOCK_VIDEO,]
+        try
+            f(type, clock)
+        catch err
+            if isa(err, NVML.NVMLError) && err.code == NVML.ERROR_NOT_SUPPORTED
+                continue
+            end
+            rethrow()
+        end
+    end
+end
+
+# default clock speeds
+function default_applications_clock(dev::Device)
+    info = Dict{Symbol, Int}()
+    foreach_clock(dev) do type, clock
+        ref = Ref{Cuint}()
+        nvmlDeviceGetDefaultApplicationsClock(dev, clock, ref)
+        info[type] = Int(ref[])
+    end
+    return NamedTuple(info)
+end
+
+# configured clock speeds
+function applications_clock(dev::Device)
+    info = Dict{Symbol, Int}()
+    foreach_clock(dev) do type, clock
+        ref = Ref{Cuint}()
+        nvmlDeviceGetApplicationsClock(dev, clock, ref)
+        info[type] = Int(ref[])
+    end
+    return NamedTuple(info)
+end
+
+# current clock speeds
+function clock_info(dev::Device)
+    info = Dict{Symbol, Int}()
+    foreach_clock(dev) do type, clock
+        ref = Ref{Cuint}()
+        nvmlDeviceGetClockInfo(dev, clock, ref)
+        info[type] = Int(ref[])
+    end
+    return NamedTuple(info)
+end
+
+# max clock speeds
+function max_clock_info(dev::Device)
+    info = Dict{Symbol, Int}()
+    foreach_clock(dev) do type, clock
+        ref = Ref{Cuint}()
+        nvmlDeviceGetMaxClockInfo(dev, clock, ref)
+        info[type] = Int(ref[])
+    end
+    return NamedTuple(info)
+end
+
+function supported_memory_clocks(dev::Device)
+    count_ref = Ref{Cuint}(0)
+    unsafe_nvmlDeviceGetSupportedMemoryClocks(dev, count_ref, C_NULL)
+    count::Cuint = count_ref[]
+    clocks = Vector{Cuint}(undef, count)
+    nvmlDeviceGetSupportedMemoryClocks(dev, Ref(count), clocks)
+    return Int.(clocks)
+end
+
+function supported_graphics_clocks(dev::Device, memory_clock)
+    count_ref = Ref{Cuint}(0)
+    unsafe_nvmlDeviceGetSupportedGraphicsClocks(dev, memory_clock, count_ref, C_NULL)
+    count::Cuint = count_ref[]
+    clocks = Vector{Cuint}(undef, count)
+    nvmlDeviceGetSupportedGraphicsClocks(dev, memory_clock, Ref(count), clocks)
+    return Int.(clocks)
+end
+
+supported_graphics_clocks(dev::Device) =
+    union(supported_graphics_clocks.(Ref(dev), supported_memory_clocks(dev))...)
+
+function clock_event_reasons(dev::Device)
+    current_events = Ref{Culonglong}()
+    nvmlDeviceGetCurrentClocksEventReasons(dev, current_events)
+
+    supported_events = Ref{Culonglong}(0)
+    nvmlDeviceGetSupportedClocksEventReasons(dev, supported_events)
+
+    reasons = [
+        # Nothing is running on the GPU and the clocks are dropping to Idle state
+        :idle                   => nvmlClocksEventReasonGpuIdle,
+        # Clocks have been limited by applications clocks
+        :application_setting    => nvmlClocksEventReasonApplicationsClocksSetting,
+        # The clocks have been optimized to ensure not to exceed currently set power limits
+        :sw_power_cap           => nvmlClocksEventReasonSwPowerCap,
+        # Hardware-driven reduction because of thermals, power limits, ...
+        :hw_slow                => nvmlClocksThrottleReasonHwSlowdown,
+        # This GPU has been added to a Sync boost group with nvidia-smi or DCGM
+        :sync_boost             => nvmlClocksEventReasonSyncBoost,
+        # Software-driven clock reduction for thermal reasons
+        :sw_thermal             => nvmlClocksEventReasonSwThermalSlowdown,
+        # Hardware-driven clock reduction for thermal reasons
+        :hw_thermal             => nvmlClocksThrottleReasonHwThermalSlowdown,
+        # Hardware-driven clock reduction for external (e.g. PSU) power reasons
+        :hw_power_brake         => nvmlClocksThrottleReasonHwPowerBrakeSlowdown,
+        # GPU clocks are limited by current setting of Display clocks
+        :display_setting        => nvmlClocksEventReasonDisplayClockSetting,
+    ]
+    info = Dict{Symbol, Bool}()
+    for (name, reason) in reasons
+        if (supported_events[] & reason) == reason
+            info[name] = (current_events[] & reason) == reason
+        end
+    end
+    return NamedTuple(info)
+end
+
+
+## other queries
+
+# watt
+function power_usage(dev::Device)
+    ref = Ref{Cuint}()
+    nvmlDeviceGetPowerUsage(dev, ref)
+    return ref[] / 1000
+end
+
+# joules
+function energy_consumption(dev::Device)
+    ref = Ref{Culonglong}()
+    nvmlDeviceGetTotalEnergyConsumption(dev, ref)
+    return ref[] / 1000
+end
+
+# bytes
+function memory_info(dev::Device)
+    ref = Ref{nvmlMemory_t}()
+    nvmlDeviceGetMemoryInfo(dev, ref)
+    return (total=Int(ref[].total), free=Int(ref[].free), used=Int(ref[].used))
+end
+
+# percent
+function utilization_rates(dev::Device)
+    ref = Ref{nvmlUtilization_t}()
+    nvmlDeviceGetUtilizationRates(dev, ref)
+    return (compute=Int(ref[].gpu)/100, memory=Int(ref[].memory)/100)
+end
+
+# degrees C
+function temperature(dev::Device, sensor=NVML_TEMPERATURE_GPU)
+    ref = Ref{Cuint}()
+    nvmlDeviceGetTemperature(dev, sensor, ref)
+    return Int(ref[])
 end

--- a/lib/nvml/device.jl
+++ b/lib/nvml/device.jl
@@ -265,6 +265,13 @@ function energy_consumption(dev::Device)
     return ref[] / 1000
 end
 
+# degrees C
+function temperature(dev::Device, sensor=NVML_TEMPERATURE_GPU)
+    ref = Ref{Cuint}()
+    nvmlDeviceGetTemperature(dev, sensor, ref)
+    return Int(ref[])
+end
+
 # bytes
 function memory_info(dev::Device)
     ref = Ref{nvmlMemory_t}()
@@ -277,11 +284,4 @@ function utilization_rates(dev::Device)
     ref = Ref{nvmlUtilization_t}()
     nvmlDeviceGetUtilizationRates(dev, ref)
     return (compute=Int(ref[].gpu)/100, memory=Int(ref[].memory)/100)
-end
-
-# degrees C
-function temperature(dev::Device, sensor=NVML_TEMPERATURE_GPU)
-    ref = Ref{Cuint}()
-    nvmlDeviceGetTemperature(dev, sensor, ref)
-    return Int(ref[])
 end

--- a/test/core/nvml.jl
+++ b/test/core/nvml.jl
@@ -1,12 +1,14 @@
 using CUDA.NVML
 
-macro maybe_unsupported(ex)
+macro test_maybe_unsupported(ex)
     quote
-        try
+        unsupported = try
             $(esc(ex))
+            false
         catch err
-            (isa(err, NVML.NVMLError) && err.code == NVML.ERROR_NOT_SUPPORTED) || rethrow()
+            isa(err, NVML.NVMLError) && err.code == NVML.ERROR_NOT_SUPPORTED
         end
+        @test $(esc(ex)) skip=unsupported
     end
 end
 
@@ -34,18 +36,32 @@ end
 
     # tests for the parent device
     let dev = NVML.Device(parent_uuid(cuda_dev))
+        # basic properties
         @test NVML.uuid(dev) == parent_uuid(cuda_dev)
-        NVML.brand(dev)
+        @test NVML.brand(dev) isa NVML.nvmlBrandType_t
         @test occursin(NVML.name(dev), name(cuda_dev))
-        @maybe_unsupported NVML.serial(dev)
+        @test_maybe_unsupported NVML.serial(dev) isa String
 
-        @maybe_unsupported NVML.power_usage(dev)
-        @maybe_unsupported NVML.energy_consumption(dev)
-
-        @maybe_unsupported NVML.utilization_rates(dev)
-
-        NVML.compute_mode(dev)
+        # compute properties
+        @test NVML.compute_mode(dev) isa NVML.nvmlComputeMode_t
         @test NVML.compute_capability(dev) == capability(cuda_dev)
+        @test_maybe_unsupported NVML.compute_processes(dev) isa Union{Nothing,Dict}
+
+        # clocks
+        @test_maybe_unsupported NVML.default_applications_clock(dev) isa NamedTuple
+        @test_maybe_unsupported NVML.applications_clock(dev) isa NamedTuple
+        @test_maybe_unsupported NVML.clock_info(dev) isa NamedTuple
+        @test_maybe_unsupported NVML.max_clock_info(dev) isa NamedTuple
+        @test_maybe_unsupported NVML.supported_memory_clocks(dev) isa Vector
+        @test_maybe_unsupported NVML.supported_graphics_clocks(dev) isa Vector
+        @test_maybe_unsupported NVML.clock_event_reasons(dev) isa NamedTuple
+
+        # other queries
+        @test_maybe_unsupported NVML.power_usage(dev) isa Number
+        @test_maybe_unsupported NVML.energy_consumption(dev) isa Number
+        @test_maybe_unsupported NVML.temperature(dev) isa Number
+        @test_maybe_unsupported NVML.memory_info(dev) isa NamedTuple
+        @test_maybe_unsupported NVML.utilization_rates(dev) isa NamedTuple
     end
 
     # tests for the compute instance
@@ -58,7 +74,7 @@ end
         context()
         # FIXME: https://github.com/NVIDIA/gpu-monitoring-tools/issues/63
         #@test getpid() in keys(NVML.compute_processes(dev))
-        NVML.compute_processes(dev)
+        @test_maybe_unsupported NVML.compute_processes(dev) isa Union{Nothing,Dict}
     end
 end
 


### PR DESCRIPTION
```
julia> NVML.clock_event_reasons(dev)
(idle = false, display_setting = false, hw_power_brake = false, sw_power_cap = false, application_setting = false, hw_slow = false, sync_boost = false, sw_thermal = false, hw_thermal = false)

julia> NVML.clock_info(dev)
(sm = 915, graphics = 915, memory = 5000, video = 1500)
```

Can be useful to ensure the GPU isn't throttled while benchmarking. Couldn't trigger that locally though.