### PR TITLE
Rework unique context management.

### DIFF
--- a/lib/cudadrv/context.jl
+++ b/lib/cudadrv/context.jl
@@ -26,29 +26,22 @@ mutable struct CuContext
     handle::CUcontext
     valid::Bool
 
-    function new_unique(handle)
-        # XXX: this makes it dangerous to call this function from finalizers.
-        #      can we do without the lock?
-        Base.@lock context_lock get!(valid_contexts, handle) do
-            new(handle, true)
-        end
-    end
-
     function CuContext(dev::CuDevice, flags=0)
         handle_ref = Ref{CUcontext}()
         cuCtxCreate_v2(handle_ref, flags, dev)
-        new_unique(handle_ref[])
+        UniqueCuContext(handle_ref[])
     end
 
     global function current_context()
         handle_ref = Ref{CUcontext}()
         cuCtxGetCurrent(handle_ref)
         handle_ref[] == C_NULL && throw(UndefRefError())
-        new_unique(handle_ref[])
+        UniqueCuContext(handle_ref[])
     end
 
-    # for outer constructors
-    global _CuContext(handle::CUcontext) = new_unique(handle)
+    global UnsafeCuContext(handle::CUcontext) = new(handle, true)
+
+    unsafe
 end
 
 """
@@ -74,20 +67,50 @@ function has_context()
     handle_ref[] != C_NULL
 end
 
-# the `valid` bit serves two purposes: make sure we don't double-free a context (in case we
-# early-freed it ourselves before the GC kicked in), and to make sure we don't free derived
-# resources after the owning context has been destroyed (which can happen due to
-# out-of-order finalizer execution)
-const valid_contexts = Dict{CUcontext,CuContext}()
-const context_lock = ReentrantLock()
+# we need to know when a context has been destroyed, to make sure we don't destroy resources
+# after the owning context has been destroyed already. this is complicated by the fact that
+# contexts obtained from a primary context have the same handle before and after primary
+# context destruction, so we cannot use a simple mapping from context handle to a validity
+# bit. instead, we unique the context objects and put a validity bit in there.
 isvalid(ctx::CuContext) = ctx.valid
-# NOTE: we can't just look up by the handle, because contexts derived from a primary one
-#       have the same handle even though they might have been destroyed in the meantime.
 function invalidate!(ctx::CuContext)
-    Base.@lock context_lock delete!(valid_contexts, ctx.handle)
     ctx.valid = false
     return
 end
+# to make this work, every function returning a context (e.g. `cuCtxGetCurrent`, attribute
+# functions, etc) need to return the same context objects. because looking up a context is a
+# very common operation (often executed from finalizers), we need to ensure this look-up is
+# fast and lockless. this rules out using a dictionary, so we use a plain array containing
+# context objects.
+const MAX_CONTEXTS = 1024
+const context_objects = Vector{CuContext}(undef, MAX_CONTEXTS)
+function UniqueCuContext(handle::CUcontext)
+    # look if there's an existing object for this handle
+    i = 1
+    @inbounds while i <= MAX_CONTEXTS && isassigned(context_objects, i)
+        if context_objects[i].handle == handle
+            if isvalid(context_objects[i])
+                return context_objects[i]
+            else
+                # this object was invalidated, so we can reuse its slot
+                break
+            end
+        end
+        i += 1
+    end
+    if i == MAX_CONTEXTS
+        error("Exceeded maximum amount of CUDA contexts. This is unexpected; please file an issue.")
+    end
+
+    # we've got a slot we can write to
+    # XXX: this write is racy, but we cannot take a lock...
+    new_object = UnsafeCuContext(handle)
+    context_objects[i] = new_object
+    return new_object
+end
+# because we're unable to take locks, the code above is racy... this may result in multiple
+# objects for the same context, which can lead to data being freed after the owning context
+# was destroyed. this however should be rare, and only result in errors during process exit.
 
 """
     unsafe_destroy!(ctx::CuContext)
@@ -194,7 +217,7 @@ by using the `do`-block syntax.
 function CuContext(pctx::CuPrimaryContext)
     handle_ref = Ref{CUcontext}()
     cuDevicePrimaryCtxRetain(handle_ref, pctx.dev)
-    ctx = _CuContext(handle_ref[])
+    ctx = UniqueCuContext(handle_ref[])
     Base.@lock derived_lock derived_contexts[pctx] = ctx
     return ctx
 end

--- a/lib/cudadrv/memory.jl
+++ b/lib/cudadrv/memory.jl
@@ -817,7 +817,7 @@ end
 Identify the context a CUDA memory buffer was allocated in.
 """
 context(ptr::Union{Ptr,CuPtr}) =
-    _CuContext(attribute(CUcontext, ptr, POINTER_ATTRIBUTE_CONTEXT))
+    UniqueCuContext(attribute(CUcontext, ptr, POINTER_ATTRIBUTE_CONTEXT))
 
 """
     device(ptr)

--- a/lib/cupti/wrappers.jl
+++ b/lib/cupti/wrappers.jl
@@ -187,7 +187,7 @@ function process(f, cfg::ActivityConfig)
 
     # extract typed activity records
     for (ctx_handle, stream_id, buf_ptr, sz, valid_sz) in cfg.results
-        ctx = CUDA._CuContext(ctx_handle)
+        ctx = CUDA.UniqueCuContext(ctx_handle)
         # XXX: can we reconstruct the stream from the stream ID?
 
         record_ptr = Ref{Ptr{CUpti_Activity}}(C_NULL)


### PR DESCRIPTION
This PR switches from a reentrant lock + dict for unique context creation (which is needed for tracking resources so that we can safely free them) to a simple linear scan of an array and a spinlock. Hopefully it fixes https://github.com/JuliaGPU/CUDA.jl/issues/2171.