### PR TITLE
Fixes for Windows

### DIFF
--- a/docs/src/development/kernel.md
+++ b/docs/src/development/kernel.md
@@ -66,28 +66,6 @@ julia> a
  42
 ```
 
-Kernels can also mutate `Ref` boxes:
-
-```julia
-function my_kernel(a)
-    a[] = 42
-    return
-end
-```
-
-```julia-repl
-julia> box = Ref(1)
-
-julia> CUDA.@sync @cuda my_kernel(box);
-
-julia> box[]
-42
-```
-
-Note the `CUDA.@sync` here: GPU operations always execute asynchronously, so we need to
-wait for the GPU to finish before we can access the result. This is not needed when using
-`CuArray`s, as they automatically synchronize on access.
-
 
 ## Launch configuration and indexing
 

--- a/lib/nvml/device.jl
+++ b/lib/nvml/device.jl
@@ -214,10 +214,18 @@ supported_graphics_clocks(dev::Device) =
 
 function clock_event_reasons(dev::Device)
     current_events = Ref{Culonglong}()
-    nvmlDeviceGetCurrentClocksEventReasons(dev, current_events)
+    if version() >= v"12.2"
+        nvmlDeviceGetCurrentClocksEventReasons(dev, current_events)
+    else
+        nvmlDeviceGetCurrentClocksThrottleReasons(dev, current_events)
+    end
 
     supported_events = Ref{Culonglong}(0)
-    nvmlDeviceGetSupportedClocksEventReasons(dev, supported_events)
+    if version() >= v"12.2"
+        nvmlDeviceGetSupportedClocksEventReasons(dev, supported_events)
+    else
+        nvmlDeviceGetSupportedClocksThrottleReasons(dev, supported_events)
+    end
 
     reasons = [
         # Nothing is running on the GPU and the clocks are dropping to Idle state

--- a/test/core/execution.jl
+++ b/test/core/execution.jl
@@ -599,17 +599,6 @@ end
     @test f(2) == 2
 end
 
-@testset "Ref boxes" begin
-    function kernel(x)
-        x[] += 1
-        return
-    end
-
-    box = Ref(1)
-    CUDA.@sync @cuda kernel(box)
-    @test box[] == 2
-end
-
 end
 
 ############################################################################################

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -54,7 +54,7 @@ end
 include("setup.jl")     # make sure everything is precompiled
 
 # choose tests
-const tests = ["core$(path_separator)initialization"]    # needs to run first
+const tests = ["core/initialization"]    # needs to run first
 const test_runners = Dict()
 ## GPUArrays testsuite
 for name in keys(TestSuite.tests)
@@ -62,8 +62,8 @@ for name in keys(TestSuite.tests)
         # GPUArrays' scalar indexing tests assume that indexing is not supported
         continue
     end
-    push!(tests, "gpuarrays$(path_separator)$name")
-    test_runners["gpuarrays$(path_separator)$name"] = ()->TestSuite.tests[name](CuArray)
+    push!(tests, "gpuarrays/$name")
+    test_runners["gpuarrays/$name"] = ()->TestSuite.tests[name](CuArray)
 end
 ## files in the test folder
 for (rootpath, dirs, files) in walkdir(@__DIR__)
@@ -84,6 +84,11 @@ for (rootpath, dirs, files) in walkdir(@__DIR__)
     files = map(files) do file
       joinpath(subdir, file)
     end
+  end
+
+  # unify path separators
+  files = map(files) do file
+    replace(file, path_separator => '/')
   end
 
   append!(tests, files)
@@ -327,9 +332,9 @@ try
 
                     # tests that muck with the context should not be timed with CUDA events,
                     # since they won't be valid at the end of the test anymore.
-                    time_source = in(test, ["core$(path_separator)initialization",
-                                            "base$(path_separator)examples",
-                                            "base$(path_separator)exceptions"]) ? :julia : :cuda
+                    time_source = in(test, ["core/initialization",
+                                            "base/examples",
+                                            "base/exceptions"]) ? :julia : :cuda
 
                     # run the test
                     running_tests[test] = now()


### PR DESCRIPTION
Among other things, reverts https://github.com/JuliaGPU/CUDA.jl/pull/2109 (cc @utkarsh530). Turns out that broadcast's (ab)use of `Ref` boxes for scalar arguments is a problem: Ephemeral objects like that get freed quickly, leading to illegal memory accesses on the GPU. We could root all arguments, but that would make launching kernels more expensive. I'm inclined to just not support a use case like that, at least for now. If people care greatly about this, please comment in https://github.com/JuliaGPU/CUDA.jl/issues/267. For now, this should fix https://github.com/FluxML/Zygote.jl/issues/1473.