### PR TITLE
Slightly rework error handling

### DIFF
--- a/lib/cublas/libcublas.jl
+++ b/lib/cublas/libcublas.jl
@@ -12,16 +12,15 @@ const cudaStream_t = CUstream
     end
 end
 
-function check(f, errs...)
-    res = retry_reclaim(in((CUBLAS_STATUS_ALLOC_FAILED, errs...))) do
-        return f()
-    end
+@inline function check(f)
+    retry_if(res) = res in (CUBLAS_STATUS_NOT_INITIALIZED,
+                            CUBLAS_STATUS_ALLOC_FAILED,
+                            CUBLAS_STATUS_INTERNAL_ERROR)
+    res = retry_reclaim(f, retry_if)
 
     if res != CUBLAS_STATUS_SUCCESS
         throw_api_error(res)
     end
-
-    return
 end
 
 mutable struct cublasContext end

--- a/lib/cublas/wrappers.jl
+++ b/lib/cublas/wrappers.jl
@@ -11,6 +11,14 @@ function cublasCreate()
   handle_ref[]
 end
 
+function cublasGetVersion(handle)
+  version = Ref{Cint}()
+  cublasGetVersion_v2(handle, version)
+  major, ver = divrem(version[], 10000)
+  minor, patch = divrem(ver, 100)
+  VersionNumber(major, minor, patch)
+end
+
 function cublasXtCreate()
   handle_ref = Ref{cublasXtHandle_t}()
   check(CUBLAS_STATUS_NOT_INITIALIZED) do

--- a/lib/cublas/wrappers.jl
+++ b/lib/cublas/wrappers.jl
@@ -6,7 +6,7 @@
 function cublasCreate()
   handle_ref = Ref{cublasHandle_t}()
   check(CUBLAS_STATUS_NOT_INITIALIZED) do
-    unsafe_cublasCreate_v2(handle_ref)
+    unchecked_cublasCreate_v2(handle_ref)
   end
   handle_ref[]
 end
@@ -14,7 +14,7 @@ end
 function cublasXtCreate()
   handle_ref = Ref{cublasXtHandle_t}()
   check(CUBLAS_STATUS_NOT_INITIALIZED) do
-    unsafe_cublasXtCreate(handle_ref)
+    unchecked_cublasXtCreate(handle_ref)
   end
   handle_ref[]
 end

--- a/lib/cublas/wrappers.jl
+++ b/lib/cublas/wrappers.jl
@@ -5,9 +5,7 @@
 
 function cublasCreate()
   handle_ref = Ref{cublasHandle_t}()
-  check(CUBLAS_STATUS_NOT_INITIALIZED) do
-    unchecked_cublasCreate_v2(handle_ref)
-  end
+  cublasCreate_v2(handle_ref)
   handle_ref[]
 end
 
@@ -21,9 +19,7 @@ end
 
 function cublasXtCreate()
   handle_ref = Ref{cublasXtHandle_t}()
-  check(CUBLAS_STATUS_NOT_INITIALIZED) do
-    unchecked_cublasXtCreate(handle_ref)
-  end
+  cublasXtCreate(handle_ref)
   handle_ref[]
 end
 

--- a/lib/cudadrv/devices.jl
+++ b/lib/cudadrv/devices.jl
@@ -20,7 +20,7 @@ struct CuDevice
 
     global function current_device()
         device_ref = Ref{CUdevice}()
-        res = unsafe_cuCtxGetDevice(device_ref)
+        res = unchecked_cuCtxGetDevice(device_ref)
         res == ERROR_INVALID_CONTEXT && throw(UndefRefError())
         res != SUCCESS && throw_api_error(res)
         return _CuDevice(device_ref[])
@@ -49,7 +49,7 @@ Returns whether there is an active device.
 """
 function has_device()
     device_ref = Ref{CUdevice}()
-    res = unsafe_cuCtxGetDevice(device_ref)
+    res = unchecked_cuCtxGetDevice(device_ref)
     if res == SUCCESS
         return true
     elseif res == ERROR_INVALID_CONTEXT

--- a/lib/cudadrv/events.jl
+++ b/lib/cudadrv/events.jl
@@ -58,7 +58,7 @@ Return `false` if there is outstanding work preceding the most recent
 call to `record(e)` and `true` if all captured work has been completed.
 """
 function isdone(e::CuEvent)
-    res = unsafe_cuEventQuery(e)
+    res = unchecked_cuEventQuery(e)
     if res == ERROR_NOT_READY
         return false
     elseif res == SUCCESS

--- a/lib/cudadrv/execution.jl
+++ b/lib/cudadrv/execution.jl
@@ -55,37 +55,35 @@ function launch(f::CuFunction, args::Vararg{Any,N}; blocks::CuDim=1, threads::Cu
     blockdim = CuDim3(blocks)
     threaddim = CuDim3(threads)
 
-    res = pack_arguments(args...) do kernelParams
-        if cooperative
-            unchecked_cuLaunchCooperativeKernel(f,
-                                             blockdim.x, blockdim.y, blockdim.z,
-                                             threaddim.x, threaddim.y, threaddim.z,
-                                             shmem, stream, kernelParams)
-        else
-            unchecked_cuLaunchKernel(f,
-                                  blockdim.x, blockdim.y, blockdim.z,
-                                  threaddim.x, threaddim.y, threaddim.z,
-                                  shmem, stream, kernelParams, C_NULL)
+    try
+        pack_arguments(args...) do kernelParams
+            if cooperative
+                cuLaunchCooperativeKernel(f,
+                                          blockdim.x, blockdim.y, blockdim.z,
+                                          threaddim.x, threaddim.y, threaddim.z,
+                                          shmem, stream, kernelParams)
+            else
+                cuLaunchKernel(f,
+                               blockdim.x, blockdim.y, blockdim.z,
+                               threaddim.x, threaddim.y, threaddim.z,
+                               shmem, stream, kernelParams, C_NULL)
+            end
         end
-    end
-    if res != CUDA_SUCCESS
-        diagnose_launch_failure(f, res; blockdim, threaddim, shmem)
+    catch err
+        diagnose_launch_failure(f, err; blockdim, threaddim, shmem)
     end
 end
 
-@noinline function diagnose_launch_failure(f, res; blockdim, threaddim, shmem)
-    if res != CUDA_ERROR_INVALID_VALUE
-        throw_api_error(res)
-    end
-    function throw_extended_error(message)
-        throw(CuError(res, message))
+@noinline function diagnose_launch_failure(f, err; blockdim, threaddim, shmem)
+    if !isa(err, CuError) || err.code != ERROR_INVALID_VALUE
+        rethrow()
     end
 
     # essentials
     (blockdim.x>0 && blockdim.y>0 && blockdim.z>0) ||
-        throw_extended_error("Grid dimensions should be non-null")
+        error("Grid dimensions should be non-null")
     (threaddim.x>0 && threaddim.y>0 && threaddim.z>0) ||
-        throw_extended_error("Block dimensions should be non-null")
+        error("Block dimensions should be non-null")
 
     # check device limits
     dev = device()
@@ -95,7 +93,7 @@ end
                        attribute(dev, DEVICE_ATTRIBUTE_MAX_BLOCK_DIM_Z))
     for dim in (:x, :y, :z)
         if getfield(threaddim, dim) > getfield(threadlim, dim)
-            throw_extended_error("Number of threads in $(dim)-dimension exceeds device limit ($(getfield(threaddim, dim)) > $(getfield(threadlim, dim))).")
+            error("Number of threads in $(dim)-dimension exceeds device limit ($(getfield(threaddim, dim)) > $(getfield(threadlim, dim))).")
         end
     end
     ## grid size limit
@@ -104,16 +102,16 @@ end
                       attribute(dev, DEVICE_ATTRIBUTE_MAX_GRID_DIM_Z))
     for dim in (:x, :y, :z)
         if getfield(blockdim, dim) > getfield(blocklim, dim)
-            throw_extended_error("Number of blocks in $(dim)-dimension exceeds device limit ($(getfield(blockdim, dim)) > $(getfield(blocklim, dim))).")
+            error("Number of blocks in $(dim)-dimension exceeds device limit ($(getfield(blockdim, dim)) > $(getfield(blocklim, dim))).")
         end
     end
     ## shared memory limit
     shmem_lim = attribute(dev, DEVICE_ATTRIBUTE_MAX_SHARED_MEMORY_PER_BLOCK)
     if shmem > shmem_lim
-        throw_extended_error("Amount of dynamic shared memory exceeds device limit ($(Base.format_bytes(shmem)) > $(Base.format_bytes(shmem_lim))).")
+        error("Amount of dynamic shared memory exceeds device limit ($(Base.format_bytes(shmem)) > $(Base.format_bytes(shmem_lim))).")
     end
 
-    throw_api_error(res)
+    rethrow()
 end
 
 # convert the argument values to match the kernel's signature (specified by the user)

--- a/lib/cudadrv/execution.jl
+++ b/lib/cudadrv/execution.jl
@@ -57,12 +57,12 @@ function launch(f::CuFunction, args::Vararg{Any,N}; blocks::CuDim=1, threads::Cu
 
     res = pack_arguments(args...) do kernelParams
         if cooperative
-            unsafe_cuLaunchCooperativeKernel(f,
+            unchecked_cuLaunchCooperativeKernel(f,
                                              blockdim.x, blockdim.y, blockdim.z,
                                              threaddim.x, threaddim.y, threaddim.z,
                                              shmem, stream, kernelParams)
         else
-            unsafe_cuLaunchKernel(f,
+            unchecked_cuLaunchKernel(f,
                                   blockdim.x, blockdim.y, blockdim.z,
                                   threaddim.x, threaddim.y, threaddim.z,
                                   shmem, stream, kernelParams, C_NULL)

--- a/lib/cudadrv/graph.jl
+++ b/lib/cudadrv/graph.jl
@@ -37,7 +37,7 @@ mutable struct CuGraph
             f()
         finally
             handle_ref = Ref{CUgraph}()
-            err = unsafe_cuStreamEndCapture(stream(), handle_ref)
+            err = unchecked_cuStreamEndCapture(stream(), handle_ref)
             if err == ERROR_STREAM_CAPTURE_INVALIDATED && !throw_error
                 return nothing
             elseif err != CUDA_SUCCESS

--- a/lib/cudadrv/memory.jl
+++ b/lib/cudadrv/memory.jl
@@ -855,7 +855,7 @@ function is_pinned(ptr::Ptr)
     # calling `memory_type` with an expensive try/catch we perform low-level API calls.
     ptr = reinterpret(CuPtr{Nothing}, ptr)
     data_ref = Ref{Cuint}()
-    res = unsafe_cuPointerGetAttribute(data_ref, POINTER_ATTRIBUTE_MEMORY_TYPE, ptr)
+    res = unchecked_cuPointerGetAttribute(data_ref, POINTER_ATTRIBUTE_MEMORY_TYPE, ptr)
     if res == ERROR_INVALID_VALUE
         false
     elseif res == SUCCESS

--- a/lib/cudadrv/module.jl
+++ b/lib/cudadrv/module.jl
@@ -46,7 +46,7 @@ mutable struct CuModule
         #        that would require a redesign of the memory pool,
         #        so maybe do so when we replace it with CUDA 11.2's pool.
         res = GC.@preserve data retry_reclaim(isequal(ERROR_OUT_OF_MEMORY)) do
-            unsafe_cuModuleLoadDataEx(handle_ref, pointer(data),
+            unchecked_cuModuleLoadDataEx(handle_ref, pointer(data),
                                       length(optionKeys),
                                       optionKeys, optionVals)
         end

--- a/lib/cudadrv/module.jl
+++ b/lib/cudadrv/module.jl
@@ -5,6 +5,30 @@ export
 
 include(joinpath("module", "jit.jl"))
 
+function checked_cuModuleLoadDataEx(_module, image, numOptions, options, optionValues)
+    # XXX: cuModuleLoadData is sensitive to memory pressure, and can segfault when
+    #      running close to OOM on CUDA 11.2 / driver 460 (NVIDIA bug #3284677).
+    #
+    #      this happens often when using the stream-ordered memory allocator, because
+    #      the reserve of available memory we try to maintain is often not actually
+    #      available, but cached by the allocator. by configuring the allocator with a
+    #      release threshold, we have it actually free up that memory, but that requires
+    #      synchronizing all streams to make sure pending frees are actually executed.
+    device_synchronize()
+
+    # FIXME: maybe all CUDA API calls need to run under retry_reclaim?
+    #        that would require a redesign of the memory pool,
+    #        so maybe do so when we replace it with CUDA 11.2's pool.
+    res = retry_reclaim(isequal(ERROR_OUT_OF_MEMORY)) do
+        unchecked_cuModuleLoadDataEx(_module, image, numOptions, options, optionValues)
+    end
+    if res != SUCCESS
+        throw(CuError(res))
+    end
+
+    return
+end
+
 
 """
     CuModule(data, options::Dict{CUjit_option,Any})
@@ -29,43 +53,28 @@ mutable struct CuModule
         end
         optionKeys, optionVals = encode(options)
 
-        # XXX: cuModuleLoadData is sensitive to memory pressure, and can segfault when
-        #      running close to OOM on CUDA 11.2 / driver 460 (NVIDIA bug #3284677).
-        #
-        #      this happens often when using the stream-ordered memory allocator, because
-        #      the reserve of available memory we try to maintain is often not actually
-        #      available, but cached by the allocator. by configuring the allocator with a
-        #      release threshold, we have it actually free up that memory, but that requires
-        #      synchronizing all streams to make sure pending frees are actually executed.
-        device_synchronize()
-        #
-        # XXX: our custom legacy stream sync doesn't release memory (NVIDIA bug #3383169)
-        cuCtxSynchronize()
-
-        # FIXME: maybe all CUDA API calls need to run under retry_reclaim?
-        #        that would require a redesign of the memory pool,
-        #        so maybe do so when we replace it with CUDA 11.2's pool.
-        res = GC.@preserve data retry_reclaim(isequal(ERROR_OUT_OF_MEMORY)) do
-            unchecked_cuModuleLoadDataEx(handle_ref, pointer(data),
-                                      length(optionKeys),
-                                      optionKeys, optionVals)
-        end
-        if res == ERROR_NO_BINARY_FOR_GPU ||
-           res == ERROR_INVALID_IMAGE ||
-           res == ERROR_INVALID_PTX
-            options = decode(optionKeys, optionVals)
-            throw(CuError(res, unsafe_string(pointer(options[JIT_ERROR_LOG_BUFFER]))))
-        elseif res != SUCCESS
-            throw_api_error(res)
-        end
-
-        @debug begin
-            options = decode(optionKeys, optionVals)
-            if isempty(options[JIT_INFO_LOG_BUFFER])
-                """JIT info log is empty"""
+        try
+            GC.@preserve data begin
+                checked_cuModuleLoadDataEx(handle_ref, pointer(data),
+                                           length(optionKeys),
+                                           optionKeys, optionVals)
+            end
+        catch err
+            if isa(err, CuError) && err.code in (ERROR_NO_BINARY_FOR_GPU,
+                                                 ERROR_INVALID_IMAGE,
+                                                 ERROR_INVALID_PTX)
+                options = decode(optionKeys, optionVals)
+                error(unsafe_string(pointer(options[JIT_ERROR_LOG_BUFFER])))
             else
-                """JIT info log:
-                   $(options[JIT_INFO_LOG_BUFFER])"""
+                rethrow()
+            end
+        end
+
+        if isdebug(:CuModule)
+            options = decode(optionKeys, optionVals)
+            if !isempty(options[JIT_INFO_LOG_BUFFER])
+                @debug """JIT info log:
+                          $(options[JIT_INFO_LOG_BUFFER])"""
             end
         end
 

--- a/lib/cudadrv/module/linker.jl
+++ b/lib/cudadrv/module/linker.jl
@@ -71,7 +71,7 @@ function add_data!(link::CuLink, name::String, code::String)
         # source and binary, so do the conversion (ensuring no embedded NULLs) ourselves
         data = Base.unsafe_convert(Cstring, code)
 
-        res = unsafe_cuLinkAddData_v2(link, JIT_INPUT_PTX, pointer(data), length(code),
+        res = unchecked_cuLinkAddData_v2(link, JIT_INPUT_PTX, pointer(data), length(code),
                                       name, 0, C_NULL, C_NULL)
         if res == ERROR_NO_BINARY_FOR_GPU ||
         res == ERROR_INVALID_IMAGE ||
@@ -89,7 +89,7 @@ end
 Add object code to a pending link operation.
 """
 function add_data!(link::CuLink, name::String, data::Vector{UInt8})
-    res = unsafe_cuLinkAddData_v2(link, JIT_INPUT_OBJECT, data, length(data),
+    res = unchecked_cuLinkAddData_v2(link, JIT_INPUT_OBJECT, data, length(data),
                                   name, 0, C_NULL, C_NULL)
     if res == ERROR_NO_BINARY_FOR_GPU ||
        res == ERROR_INVALID_IMAGE ||
@@ -133,7 +133,7 @@ function complete(link::CuLink)
     cubin_ref = Ref{Ptr{Cvoid}}()
     size_ref = Ref{Csize_t}()
 
-    res = unsafe_cuLinkComplete(link, cubin_ref, size_ref)
+    res = unchecked_cuLinkComplete(link, cubin_ref, size_ref)
     if res == CUDA_ERROR_NO_BINARY_FOR_GPU || res == CUDA_ERROR_INVALID_IMAGE
         options = decode(link.optionKeys, link.optionVals)
         throw(CuError(res, options[JIT_ERROR_LOG_BUFFER]))

--- a/lib/cudadrv/module/linker.jl
+++ b/lib/cudadrv/module/linker.jl
@@ -71,14 +71,18 @@ function add_data!(link::CuLink, name::String, code::String)
         # source and binary, so do the conversion (ensuring no embedded NULLs) ourselves
         data = Base.unsafe_convert(Cstring, code)
 
-        res = unchecked_cuLinkAddData_v2(link, JIT_INPUT_PTX, pointer(data), length(code),
-                                      name, 0, C_NULL, C_NULL)
-        if res == ERROR_NO_BINARY_FOR_GPU ||
-        res == ERROR_INVALID_IMAGE ||
-        res == ERROR_INVALID_PTX
-            throw(CuError(res, unsafe_string(pointer(link.options[JIT_ERROR_LOG_BUFFER]))))
-        elseif res != SUCCESS
-            throw_api_error(res)
+        try
+            cuLinkAddData_v2(link, JIT_INPUT_PTX, pointer(data), length(code), name, 0,
+                             C_NULL, C_NULL)
+        catch err
+            if isa(err, CuError) && err.code in (ERROR_NO_BINARY_FOR_GPU,
+                                                 ERROR_INVALID_IMAGE,
+                                                 ERROR_INVALID_PTX)
+                options = decode(link.optionKeys, link.optionVals)
+                error(unsafe_string(pointer(link.options[JIT_ERROR_LOG_BUFFER])))
+            else
+                rethrow()
+            end
         end
     end
 end
@@ -89,14 +93,17 @@ end
 Add object code to a pending link operation.
 """
 function add_data!(link::CuLink, name::String, data::Vector{UInt8})
-    res = unchecked_cuLinkAddData_v2(link, JIT_INPUT_OBJECT, data, length(data),
-                                  name, 0, C_NULL, C_NULL)
-    if res == ERROR_NO_BINARY_FOR_GPU ||
-       res == ERROR_INVALID_IMAGE ||
-       res == ERROR_INVALID_PTX
-        throw(CuError(res, unsafe_string(pointer(link.options[JIT_ERROR_LOG_BUFFER]))))
-    elseif res != SUCCESS
-        throw_api_error(res)
+    try
+        cuLinkAddData_v2(link, JIT_INPUT_OBJECT, data, length(data), name, 0, C_NULL, C_NULL)
+    catch err
+        if isa(err, CuError) && err.code in (ERROR_NO_BINARY_FOR_GPU,
+                                             ERROR_INVALID_IMAGE,
+                                             ERROR_INVALID_PTX)
+            options = decode(link.optionKeys, link.optionVals)
+            error(unsafe_string(pointer(link.options[JIT_ERROR_LOG_BUFFER])))
+        else
+            rethrow()
+        end
     end
 end
 
@@ -133,21 +140,22 @@ function complete(link::CuLink)
     cubin_ref = Ref{Ptr{Cvoid}}()
     size_ref = Ref{Csize_t}()
 
-    res = unchecked_cuLinkComplete(link, cubin_ref, size_ref)
-    if res == CUDA_ERROR_NO_BINARY_FOR_GPU || res == CUDA_ERROR_INVALID_IMAGE
-        options = decode(link.optionKeys, link.optionVals)
-        throw(CuError(res, options[JIT_ERROR_LOG_BUFFER]))
-    elseif res != SUCCESS
-        throw_api_error(res)
+    try
+        cuLinkComplete(link, cubin_ref, size_ref)
+    catch err
+        if isa(err, CuError) && (err.code == ERROR_NO_BINARY_FOR_GPU || err.code == ERROR_INVALID_IMAGE)
+            options = decode(link.optionKeys, link.optionVals)
+            error(options[JIT_ERROR_LOG_BUFFER])
+        else
+            rethrow()
+        end
     end
 
-    @debug begin
+    if isdebug(:CuLink)
         options = decode(link.optionKeys, link.optionVals)
-        if isempty(options[JIT_INFO_LOG_BUFFER])
-            """JIT info log is empty"""
-        else
-            """JIT info log:
-               $(options[JIT_INFO_LOG_BUFFER])"""
+        if !isempty(options[JIT_INFO_LOG_BUFFER])
+            @debug """JIT info log:
+                      $(options[JIT_INFO_LOG_BUFFER])"""
         end
     end
 

--- a/lib/cudadrv/stream.jl
+++ b/lib/cudadrv/stream.jl
@@ -102,7 +102,7 @@ Return `false` if a stream is busy (has task running or queued)
 and `true` if that stream is free.
 """
 function isdone(s::CuStream)
-    res = unsafe_cuStreamQuery(s)
+    res = unchecked_cuStreamQuery(s)
     if res == ERROR_NOT_READY
         return false
     elseif res == SUCCESS

--- a/lib/cudadrv/synchronization.jl
+++ b/lib/cudadrv/synchronization.jl
@@ -120,13 +120,13 @@ function synchronization_worker(data)
         take!(chan) do v
             if v isa CuContext
                 context!(v)
-                unsafe_cuCtxSynchronize()
+                unchecked_cuCtxSynchronize()
             elseif v isa CuStream
                 context!(v.ctx)
-                unsafe_cuStreamSynchronize(v)
+                unchecked_cuStreamSynchronize(v)
             elseif v isa CuEvent
                 context!(v.ctx)
-                unsafe_cuEventSynchronize(v)
+                unchecked_cuEventSynchronize(v)
             end
         end
     end
@@ -234,7 +234,7 @@ function nonblocking_synchronize(stream::CuStream)
                     err isa EOFError && break
                     rethrow()
                 end
-                if unsafe_cuStreamQuery(stream) != ERROR_NOT_READY
+                if unchecked_cuStreamQuery(stream) != ERROR_NOT_READY
                     break
                 end
             end

--- a/lib/cudnn/src/base.jl
+++ b/lib/cudnn/src/base.jl
@@ -1,7 +1,7 @@
 function cudnnCreate()
     handle_ref = Ref{cudnnHandle_t}()
     check(CUDNN_STATUS_NOT_INITIALIZED,CUDNN_STATUS_INTERNAL_ERROR) do
-      unsafe_cudnnCreate(handle_ref)
+      unchecked_cudnnCreate(handle_ref)
     end
     return handle_ref[]
 end

--- a/lib/cudnn/src/base.jl
+++ b/lib/cudnn/src/base.jl
@@ -1,8 +1,6 @@
 function cudnnCreate()
     handle_ref = Ref{cudnnHandle_t}()
-    check(CUDNN_STATUS_NOT_INITIALIZED,CUDNN_STATUS_INTERNAL_ERROR) do
-      unchecked_cudnnCreate(handle_ref)
-    end
+    cudnnCreate(handle_ref)
     return handle_ref[]
 end
 

--- a/lib/cudnn/src/libcudnn.jl
+++ b/lib/cudnn/src/libcudnn.jl
@@ -12,16 +12,15 @@ const cudaStream_t = CUstream
     end
 end
 
-function check(f, errs...)
-    res = retry_reclaim(in((CUDNN_STATUS_ALLOC_FAILED, errs...))) do
-        return f()
-    end
+@inline function check(f)
+    retry_if(res) = res in (CUDNN_STATUS_NOT_INITIALIZED,
+                            CUDNN_STATUS_ALLOC_FAILED,
+                            CUDNN_STATUS_INTERNAL_ERROR)
+    res = retry_reclaim(f, retry_if)
 
     if res != CUDNN_STATUS_SUCCESS
         throw_api_error(res)
     end
-
-    return
 end
 
 mutable struct cudnnContext end

--- a/lib/cudnn/test/tensor.jl
+++ b/lib/cudnn/test/tensor.jl
@@ -28,6 +28,4 @@ fd = FD(x)
 
 @test DT(Float32) isa cudnnDataType_t
 
-@test (CUDA.retry_reclaim(x->(x!==CUDNN_STATUS_SUCCESS)) do
-        cudnnCreateTensorDescriptor(Ref{cudnnTensorDescriptor_t}(C_NULL))
-    end) isa Nothing
+@test cudnnCreateTensorDescriptor(Ref{cudnnTensorDescriptor_t}(C_NULL)) isa Nothing

--- a/lib/cufft/libcufft.jl
+++ b/lib/cufft/libcufft.jl
@@ -12,16 +12,14 @@ const cudaStream_t = CUstream
     end
 end
 
-function check(f, errs...)
-    res = retry_reclaim(in((CUFFT_ALLOC_FAILED, errs...))) do
-        return f()
-    end
+@inline function check(f)
+    retry_if(res) = res in (CUFFT_ALLOC_FAILED,
+                            CUFFT_INTERNAL_ERROR)
+    res = retry_reclaim(f, retry_if)
 
     if res != CUFFT_SUCCESS
         throw_api_error(res)
     end
-
-    return
 end
 
 @cenum cufftResult_t::UInt32 begin

--- a/lib/cupti/libcupti.jl
+++ b/lib/cupti/libcupti.jl
@@ -12,16 +12,15 @@ const uint32_t = UInt32
     end
 end
 
-function check(f, errs...)
-    res = retry_reclaim(in((CUPTI_ERROR_OUT_OF_MEMORY, errs...))) do
-        return f()
-    end
+@inline function check(f)
+    retry_if(res) = res in (CUPTI_ERROR_OUT_OF_MEMORY,
+                            CUPTI_ERROR_NOT_INITIALIZED,
+                            CUPTI_ERROR_UNKNOWN)
+    res = retry_reclaim(f, retry_if)
 
     if res != CUPTI_SUCCESS
         throw_api_error(res)
     end
-
-    return
 end
 
 macro CUPTI_PROFILER_STRUCT_SIZE(type, lastfield)

--- a/lib/curand/libcurand.jl
+++ b/lib/curand/libcurand.jl
@@ -12,16 +12,16 @@ const cudaStream_t = CUstream
     end
 end
 
-function check(f, errs...)
-    res = retry_reclaim(in((CURAND_STATUS_ALLOCATION_FAILED, errs...))) do
-        return f()
-    end
+@inline function check(f)
+    retry_if(res) = res in (CURAND_STATUS_ALLOCATION_FAILED,
+                            CURAND_STATUS_PREEXISTING_FAILURE,
+                            CURAND_STATUS_INITIALIZATION_FAILED,
+                            CURAND_STATUS_INTERNAL_ERROR)
+    res = retry_reclaim(f, retry_if)
 
     if res != CURAND_STATUS_SUCCESS
         throw_api_error(res)
     end
-
-    return
 end
 
 @cenum curandStatus::UInt32 begin

--- a/lib/curand/random.jl
+++ b/lib/curand/random.jl
@@ -50,7 +50,7 @@ function Random.seed!(rng::RNG, seed=make_seed(), offset=0)
     curandSetPseudoRandomGeneratorSeed(rng, seed)
     curandSetGeneratorOffset(rng, offset)
     check(CURAND_STATUS_PREEXISTING_FAILURE) do
-        unsafe_curandGenerateSeeds(rng)
+        unchecked_curandGenerateSeeds(rng)
     end
     return
 end

--- a/lib/curand/random.jl
+++ b/lib/curand/random.jl
@@ -49,9 +49,7 @@ function Random.seed!(rng::RNG, seed=make_seed(), offset=0)
     update_stream(rng)
     curandSetPseudoRandomGeneratorSeed(rng, seed)
     curandSetGeneratorOffset(rng, offset)
-    check(CURAND_STATUS_PREEXISTING_FAILURE) do
-        unchecked_curandGenerateSeeds(rng)
-    end
+    curandGenerateSeeds(rng)
     return
 end
 

--- a/lib/curand/wrappers.jl
+++ b/lib/curand/wrappers.jl
@@ -2,9 +2,7 @@
 
 function curandCreateGenerator(typ)
   handle_ref = Ref{curandGenerator_t}()
-  check(CURAND_STATUS_INITIALIZATION_FAILED) do
-    unchecked_curandCreateGenerator(handle_ref, typ)
-  end
+  curandCreateGenerator(handle_ref, typ)
   handle_ref[]
 end
 

--- a/lib/curand/wrappers.jl
+++ b/lib/curand/wrappers.jl
@@ -3,7 +3,7 @@
 function curandCreateGenerator(typ)
   handle_ref = Ref{curandGenerator_t}()
   check(CURAND_STATUS_INITIALIZATION_FAILED) do
-    unsafe_curandCreateGenerator(handle_ref, typ)
+    unchecked_curandCreateGenerator(handle_ref, typ)
   end
   handle_ref[]
 end

--- a/lib/cusolver/dense.jl
+++ b/lib/cusolver/dense.jl
@@ -7,9 +7,7 @@ using ..CUBLAS: unsafe_batch
 
 function cusolverDnCreate()
   handle_ref = Ref{cusolverDnHandle_t}()
-  check(CUSOLVER_STATUS_NOT_INITIALIZED, CUSOLVER_STATUS_INTERNAL_ERROR) do
-    unchecked_cusolverDnCreate(handle_ref)
-  end
+  cusolverDnCreate(handle_ref)
   return handle_ref[]
 end
 

--- a/lib/cusolver/dense.jl
+++ b/lib/cusolver/dense.jl
@@ -8,7 +8,7 @@ using ..CUBLAS: unsafe_batch
 function cusolverDnCreate()
   handle_ref = Ref{cusolverDnHandle_t}()
   check(CUSOLVER_STATUS_NOT_INITIALIZED, CUSOLVER_STATUS_INTERNAL_ERROR) do
-    unsafe_cusolverDnCreate(handle_ref)
+    unchecked_cusolverDnCreate(handle_ref)
   end
   return handle_ref[]
 end

--- a/lib/cusolver/libcusolver.jl
+++ b/lib/cusolver/libcusolver.jl
@@ -12,16 +12,15 @@ const cudaStream_t = CUstream
     end
 end
 
-function check(f, errs...)
-    res = retry_reclaim(in((CUSOLVER_STATUS_ALLOC_FAILED, errs...))) do
-        return f()
-    end
+@inline function check(f)
+    retry_if(res) = res in (CUSOLVER_STATUS_NOT_INITIALIZED,
+                            CUSOLVER_STATUS_ALLOC_FAILED,
+                            CUSOLVER_STATUS_INTERNAL_ERROR)
+    res = retry_reclaim(f, retry_if)
 
     if res != CUSOLVER_STATUS_SUCCESS
         throw_api_error(res)
     end
-
-    return
 end
 
 mutable struct cusolverDnContext end

--- a/lib/cusolver/sparse.jl
+++ b/lib/cusolver/sparse.jl
@@ -7,7 +7,7 @@ using ..CUSPARSE: CuSparseMatrixCSR, CuSparseMatrixCSC, CuMatrixDescriptor
 function cusolverSpCreate()
   handle_ref = Ref{cusolverSpHandle_t}()
   check(CUSOLVER_STATUS_NOT_INITIALIZED, CUSOLVER_STATUS_INTERNAL_ERROR) do
-    unsafe_cusolverSpCreate(handle_ref)
+    unchecked_cusolverSpCreate(handle_ref)
   end
   return handle_ref[]
 end
@@ -16,7 +16,7 @@ function cusolverMgCreate()
   handle_ref = Ref{cusolverMgHandle_t}()
   res = retry_reclaim(err->isequal(err, CUSOLVER_STATUS_ALLOC_FAILED) ||
                            isequal(err, CUSOLVER_STATUS_NOT_INITIALIZED)) do
-    unsafe_cusolverMgCreate(handle_ref)
+    unchecked_cusolverMgCreate(handle_ref)
   end
   if res != CUSOLVER_STATUS_SUCCESS
     throw_api_error(res)

--- a/lib/cusolver/sparse.jl
+++ b/lib/cusolver/sparse.jl
@@ -6,21 +6,13 @@ using ..CUSPARSE: CuSparseMatrixCSR, CuSparseMatrixCSC, CuMatrixDescriptor
 
 function cusolverSpCreate()
   handle_ref = Ref{cusolverSpHandle_t}()
-  check(CUSOLVER_STATUS_NOT_INITIALIZED, CUSOLVER_STATUS_INTERNAL_ERROR) do
-    unchecked_cusolverSpCreate(handle_ref)
-  end
+  cusolverSpCreate(handle_ref)
   return handle_ref[]
 end
 
 function cusolverMgCreate()
   handle_ref = Ref{cusolverMgHandle_t}()
-  res = retry_reclaim(err->isequal(err, CUSOLVER_STATUS_ALLOC_FAILED) ||
-                           isequal(err, CUSOLVER_STATUS_NOT_INITIALIZED)) do
-    unchecked_cusolverMgCreate(handle_ref)
-  end
-  if res != CUSOLVER_STATUS_SUCCESS
-    throw_api_error(res)
-  end
+  cusolverMgCreate(handle_ref)
   return handle_ref[]
 end
 

--- a/lib/cusparse/libcusparse.jl
+++ b/lib/cusparse/libcusparse.jl
@@ -12,16 +12,15 @@ const cudaStream_t = CUstream
     end
 end
 
-function check(f, errs...)
-    res = retry_reclaim(in((CUSPARSE_STATUS_ALLOC_FAILED, errs...))) do
-        return f()
-    end
+@inline function check(f)
+    retry_if(res) = res in (CUSPARSE_STATUS_NOT_INITIALIZED,
+                            CUSPARSE_STATUS_ALLOC_FAILED,
+                            CUSPARSE_STATUS_INTERNAL_ERROR)
+    res = retry_reclaim(f, retry_if)
 
     if res != CUSPARSE_STATUS_SUCCESS
         throw_api_error(res)
     end
-
-    return
 end
 
 mutable struct cusparseContext end

--- a/lib/cusparse/management.jl
+++ b/lib/cusparse/management.jl
@@ -2,9 +2,7 @@
 
 function cusparseCreate()
     handle = Ref{cusparseHandle_t}()
-    check(CUSPARSE_STATUS_NOT_INITIALIZED) do
-        unchecked_cusparseCreate(handle)
-    end
+    cusparseCreate(handle)
     handle[]
 end
 

--- a/lib/cusparse/management.jl
+++ b/lib/cusparse/management.jl
@@ -3,7 +3,7 @@
 function cusparseCreate()
     handle = Ref{cusparseHandle_t}()
     check(CUSPARSE_STATUS_NOT_INITIALIZED) do
-        unsafe_cusparseCreate(handle)
+        unchecked_cusparseCreate(handle)
     end
     handle[]
 end

--- a/lib/custatevec/src/libcustatevec.jl
+++ b/lib/custatevec/src/libcustatevec.jl
@@ -15,16 +15,15 @@ const int2 = Tuple{Int32,Int32}
     end
 end
 
-function check(f, errs...)
-    res = retry_reclaim(in((CUSTATEVEC_STATUS_ALLOC_FAILED, errs...))) do
-        return f()
-    end
+@inline function check(f)
+    retry_if(res) = res in (CUSTATEVEC_STATUS_NOT_INITIALIZED,
+                            CUSTATEVEC_STATUS_ALLOC_FAILED,
+                            CUSTATEVEC_STATUS_INTERNAL_ERROR)
+    res = retry_reclaim(f, retry_if)
 
     if res != CUSTATEVEC_STATUS_SUCCESS
         throw_api_error(res)
     end
-
-    return
 end
 
 const custatevecIndex_t = Int64

--- a/lib/cutensor/src/libcutensor.jl
+++ b/lib/cutensor/src/libcutensor.jl
@@ -12,16 +12,15 @@ const cudaStream_t = CUstream
     end
 end
 
-function check(f, errs...)
-    res = retry_reclaim(in((CUTENSOR_STATUS_ALLOC_FAILED, errs...))) do
-        return f()
-    end
+@inline function check(f)
+    retry_if(res) = res in (CUTENSOR_STATUS_NOT_INITIALIZED,
+                            CUTENSOR_STATUS_ALLOC_FAILED,
+                            CUTENSOR_STATUS_INTERNAL_ERROR)
+    res = retry_reclaim(f, retry_if)
 
     if res != CUTENSOR_STATUS_SUCCESS
         throw_api_error(res)
     end
-
-    return
 end
 
 @cenum cutensorDataType_t::UInt32 begin

--- a/lib/cutensor/src/utils.jl
+++ b/lib/cutensor/src/utils.jl
@@ -19,7 +19,7 @@ end
 function cutensorCreate()
   handle_ref = Ref{cutensorHandle_t}()
   check(CUTENSOR_STATUS_NOT_INITIALIZED) do
-    unsafe_cutensorCreate(handle_ref)
+    unchecked_cutensorCreate(handle_ref)
   end
   handle_ref[]
 end

--- a/lib/cutensor/src/utils.jl
+++ b/lib/cutensor/src/utils.jl
@@ -18,9 +18,7 @@ end
 
 function cutensorCreate()
   handle_ref = Ref{cutensorHandle_t}()
-  check(CUTENSOR_STATUS_NOT_INITIALIZED) do
-    unchecked_cutensorCreate(handle_ref)
-  end
+  cutensorCreate(handle_ref)
   handle_ref[]
 end
 

--- a/lib/cutensornet/src/libcutensornet.jl
+++ b/lib/cutensornet/src/libcutensornet.jl
@@ -12,16 +12,15 @@ const cudaStream_t = CUstream
     end
 end
 
-function check(f, errs...)
-    res = retry_reclaim(in((CUTENSORNET_STATUS_ALLOC_FAILED, errs...))) do
-        return f()
-    end
+@inline function check(f)
+    retry_if(res) = res in (CUTENSORNET_STATUS_NOT_INITIALIZED,
+                            CUTENSORNET_STATUS_ALLOC_FAILED,
+                            CUTENSORNET_STATUS_INTERNAL_ERROR)
+    res = retry_reclaim(f, retry_if)
 
     if res != CUTENSORNET_STATUS_SUCCESS
         throw_api_error(res)
     end
-
-    return
 end
 
 @cenum cutensornetStatus_t::UInt32 begin

--- a/lib/nvml/device.jl
+++ b/lib/nvml/device.jl
@@ -102,7 +102,7 @@ end
 
 function compute_processes(dev::Device)
     count_ref = Ref{Cuint}(0)
-    res = unsafe_nvmlDeviceGetComputeRunningProcesses(dev, count_ref, C_NULL)
+    res = unchecked_nvmlDeviceGetComputeRunningProcesses(dev, count_ref, C_NULL)
     if res == NVML_SUCCESS
         return nothing
     elseif res !== NVML_ERROR_INSUFFICIENT_SIZE
@@ -193,7 +193,7 @@ end
 
 function supported_memory_clocks(dev::Device)
     count_ref = Ref{Cuint}(0)
-    unsafe_nvmlDeviceGetSupportedMemoryClocks(dev, count_ref, C_NULL)
+    unchecked_nvmlDeviceGetSupportedMemoryClocks(dev, count_ref, C_NULL)
     count::Cuint = count_ref[]
     clocks = Vector{Cuint}(undef, count)
     nvmlDeviceGetSupportedMemoryClocks(dev, Ref(count), clocks)
@@ -202,7 +202,7 @@ end
 
 function supported_graphics_clocks(dev::Device, memory_clock)
     count_ref = Ref{Cuint}(0)
-    unsafe_nvmlDeviceGetSupportedGraphicsClocks(dev, memory_clock, count_ref, C_NULL)
+    unchecked_nvmlDeviceGetSupportedGraphicsClocks(dev, memory_clock, count_ref, C_NULL)
     count::Cuint = count_ref[]
     clocks = Vector{Cuint}(undef, count)
     nvmlDeviceGetSupportedGraphicsClocks(dev, memory_clock, Ref(count), clocks)

--- a/lib/nvml/libnvml.jl
+++ b/lib/nvml/libnvml.jl
@@ -8,7 +8,7 @@ end
 const initialized = Ref(false)
 function initialize_context()
     if !initialized[]
-        res = unsafe_nvmlInitWithFlags(0)
+        res = unchecked_nvmlInitWithFlags(0)
         if res !== NVML_SUCCESS
             # NOTE: we can't call nvmlErrorString during initialization
             error("NVML could not be initialized ($res)")

--- a/lib/utils/call.jl
+++ b/lib/utils/call.jl
@@ -10,8 +10,8 @@ export @checked, with_workspace, with_workspaces, @debug_ccall
 
 Macro for wrapping a function definition returning a status code. Two versions of the
 function will be generated: `foo`, with the function execution wrapped by an invocation of
-the `check` function (to be implemented by the caller of this macro), and `unsafe_foo` where
-no such invocation is present and the status code is returned to the caller.
+the `check` function (to be implemented by the caller of this macro), and `unchecked_foo`
+where no such invocation is present and the status code is returned to the caller.
 """
 macro checked(ex)
     # parse the function definition
@@ -30,11 +30,11 @@ macro checked(ex)
     safe_sig = Expr(:call, sig.args[1], sig.args[2:end]...)
     safe_def = Expr(:function, safe_sig, safe_body)
 
-    # generate a "unsafe" version that returns the error code instead
-    unsafe_sig = Expr(:call, Symbol("unsafe_", sig.args[1]), sig.args[2:end]...)
-    unsafe_def = Expr(:function, unsafe_sig, body)
+    # generate a "unchecked" version that returns the error code instead
+    unchecked_sig = Expr(:call, Symbol("unchecked_", sig.args[1]), sig.args[2:end]...)
+    unchecked_def = Expr(:function, unchecked_sig, body)
 
-    return esc(:($safe_def, $unsafe_def))
+    return esc(:($safe_def, $unchecked_def))
 end
 
 """

--- a/res/wrap/libcublas_prologue.jl
+++ b/res/wrap/libcublas_prologue.jl
@@ -10,14 +10,13 @@ const cudaStream_t = CUstream
     end
 end
 
-function check(f, errs...)
-    res = retry_reclaim(in((CUBLAS_STATUS_ALLOC_FAILED, errs...))) do
-        f()
-    end
+@inline function check(f)
+    retry_if(res) = res in (CUBLAS_STATUS_NOT_INITIALIZED,
+                            CUBLAS_STATUS_ALLOC_FAILED,
+                            CUBLAS_STATUS_INTERNAL_ERROR)
+    res = retry_reclaim(f, retry_if)
 
     if res != CUBLAS_STATUS_SUCCESS
         throw_api_error(res)
     end
-
-    return
 end

--- a/res/wrap/libcudnn_prologue.jl
+++ b/res/wrap/libcudnn_prologue.jl
@@ -10,14 +10,13 @@ const cudaStream_t = CUstream
     end
 end
 
-function check(f, errs...)
-    res = retry_reclaim(in((CUDNN_STATUS_ALLOC_FAILED, errs...))) do
-        f()
-    end
+@inline function check(f)
+    retry_if(res) = res in (CUDNN_STATUS_NOT_INITIALIZED,
+                            CUDNN_STATUS_ALLOC_FAILED,
+                            CUDNN_STATUS_INTERNAL_ERROR)
+    res = retry_reclaim(f, retry_if)
 
     if res != CUDNN_STATUS_SUCCESS
         throw_api_error(res)
     end
-
-    return
 end

--- a/res/wrap/libcufft_prologue.jl
+++ b/res/wrap/libcufft_prologue.jl
@@ -10,15 +10,12 @@ const cudaStream_t = CUstream
     end
 end
 
-function check(f, errs...)
-    res = retry_reclaim(in((CUFFT_ALLOC_FAILED, errs...))) do
-        f()
-    end
+@inline function check(f)
+    retry_if(res) = res in (CUFFT_ALLOC_FAILED,
+                            CUFFT_INTERNAL_ERROR)
+    res = retry_reclaim(f, retry_if)
 
     if res != CUFFT_SUCCESS
         throw_api_error(res)
     end
-
-    return
 end
-

--- a/res/wrap/libcupti_prologue.jl
+++ b/res/wrap/libcupti_prologue.jl
@@ -10,16 +10,15 @@ const uint32_t = UInt32
     end
 end
 
-function check(f, errs...)
-    res = retry_reclaim(in((CUPTI_ERROR_OUT_OF_MEMORY, errs...))) do
-        f()
-    end
+@inline function check(f)
+    retry_if(res) = res in (CUPTI_ERROR_OUT_OF_MEMORY,
+                            CUPTI_ERROR_NOT_INITIALIZED,
+                            CUPTI_ERROR_UNKNOWN)
+    res = retry_reclaim(f, retry_if)
 
     if res != CUPTI_SUCCESS
         throw_api_error(res)
     end
-
-    return
 end
 
 macro CUPTI_PROFILER_STRUCT_SIZE(type, lastfield)

--- a/res/wrap/libcurand_prologue.jl
+++ b/res/wrap/libcurand_prologue.jl
@@ -10,14 +10,14 @@ const cudaStream_t = CUstream
     end
 end
 
-function check(f, errs...)
-    res = retry_reclaim(in((CURAND_STATUS_ALLOCATION_FAILED, errs...))) do
-        f()
-    end
+@inline function check(f)
+    retry_if(res) = res in (CURAND_STATUS_ALLOCATION_FAILED,
+                            CURAND_STATUS_PREEXISTING_FAILURE,
+                            CURAND_STATUS_INITIALIZATION_FAILED,
+                            CURAND_STATUS_INTERNAL_ERROR)
+    res = retry_reclaim(f, retry_if)
 
     if res != CURAND_STATUS_SUCCESS
         throw_api_error(res)
     end
-
-    return
 end

--- a/res/wrap/libcusolver_prologue.jl
+++ b/res/wrap/libcusolver_prologue.jl
@@ -10,14 +10,13 @@ const cudaStream_t = CUstream
     end
 end
 
-function check(f, errs...)
-    res = retry_reclaim(in((CUSOLVER_STATUS_ALLOC_FAILED, errs...))) do
-        f()
-    end
+@inline function check(f)
+    retry_if(res) = res in (CUSOLVER_STATUS_NOT_INITIALIZED,
+                            CUSOLVER_STATUS_ALLOC_FAILED,
+                            CUSOLVER_STATUS_INTERNAL_ERROR)
+    res = retry_reclaim(f, retry_if)
 
     if res != CUSOLVER_STATUS_SUCCESS
         throw_api_error(res)
     end
-
-    return
 end

--- a/res/wrap/libcusparse_prologue.jl
+++ b/res/wrap/libcusparse_prologue.jl
@@ -10,14 +10,13 @@ const cudaStream_t = CUstream
     end
 end
 
-function check(f, errs...)
-    res = retry_reclaim(in((CUSPARSE_STATUS_ALLOC_FAILED, errs...))) do
-        f()
-    end
+@inline function check(f)
+    retry_if(res) = res in (CUSPARSE_STATUS_NOT_INITIALIZED,
+                            CUSPARSE_STATUS_ALLOC_FAILED,
+                            CUSPARSE_STATUS_INTERNAL_ERROR)
+    res = retry_reclaim(f, retry_if)
 
     if res != CUSPARSE_STATUS_SUCCESS
         throw_api_error(res)
     end
-
-    return
 end

--- a/res/wrap/libcustatevec_prologue.jl
+++ b/res/wrap/libcustatevec_prologue.jl
@@ -13,14 +13,13 @@ const int2 = Tuple{Int32,Int32}
     end
 end
 
-function check(f, errs...)
-    res = retry_reclaim(in((CUSTATEVEC_STATUS_ALLOC_FAILED, errs...))) do
-        f()
-    end
+@inline function check(f)
+    retry_if(res) = res in (CUSTATEVEC_STATUS_NOT_INITIALIZED,
+                            CUSTATEVEC_STATUS_ALLOC_FAILED,
+                            CUSTATEVEC_STATUS_INTERNAL_ERROR)
+    res = retry_reclaim(f, retry_if)
 
     if res != CUSTATEVEC_STATUS_SUCCESS
         throw_api_error(res)
     end
-
-    return
 end

--- a/res/wrap/libcutensor_prologue.jl
+++ b/res/wrap/libcutensor_prologue.jl
@@ -10,14 +10,13 @@ const cudaStream_t = CUstream
     end
 end
 
-function check(f, errs...)
-    res = retry_reclaim(in((CUTENSOR_STATUS_ALLOC_FAILED, errs...))) do
-        f()
-    end
+@inline function check(f)
+    retry_if(res) = res in (CUTENSOR_STATUS_NOT_INITIALIZED,
+                            CUTENSOR_STATUS_ALLOC_FAILED,
+                            CUTENSOR_STATUS_INTERNAL_ERROR)
+    res = retry_reclaim(f, retry_if)
 
     if res != CUTENSOR_STATUS_SUCCESS
         throw_api_error(res)
     end
-
-    return
 end

--- a/res/wrap/libcutensornet_prologue.jl
+++ b/res/wrap/libcutensornet_prologue.jl
@@ -10,14 +10,13 @@ const cudaStream_t = CUstream
     end
 end
 
-function check(f, errs...)
-    res = retry_reclaim(in((CUTENSORNET_STATUS_ALLOC_FAILED, errs...))) do
-        f()
-    end
+@inline function check(f)
+    retry_if(res) = res in (CUTENSORNET_STATUS_NOT_INITIALIZED,
+                            CUTENSORNET_STATUS_ALLOC_FAILED,
+                            CUTENSORNET_STATUS_INTERNAL_ERROR)
+    res = retry_reclaim(f, retry_if)
 
     if res != CUTENSORNET_STATUS_SUCCESS
         throw_api_error(res)
     end
-
-    return
 end

--- a/res/wrap/libnvml_prologue.jl
+++ b/res/wrap/libnvml_prologue.jl
@@ -6,7 +6,7 @@ end
 const initialized = Ref(false)
 function initialize_context()
     if !initialized[]
-        res = unsafe_nvmlInitWithFlags(0)
+        res = unchecked_nvmlInitWithFlags(0)
         if res !== NVML_SUCCESS
             # NOTE: we can't call nvmlErrorString during initialization
             error("NVML could not be initialized ($res)")

--- a/test/core/apiutils.jl
+++ b/test/core/apiutils.jl
@@ -28,6 +28,6 @@ end
     @test mod.checks[] == 0
     @test mod.foo() == getpid()
     @test mod.checks[] == 1
-    @test mod.unsafe_foo() == getpid()
+    @test mod.unchecked_foo() == getpid()
     @test mod.checks[] == 1
 end

--- a/test/core/cudadrv.jl
+++ b/test/core/cudadrv.jl
@@ -717,7 +717,7 @@ let
     @test md != md2
 end
 
-@test_throws CuError(CUDA.ERROR_INVALID_IMAGE) CuModule("foobar")
+@test_throws Exception CuModule("foobar")
 
 @testset "globals" begin
     md = CuModuleFile(joinpath(@__DIR__, "ptx/global.ptx"))
@@ -747,7 +747,7 @@ end
     # TODO: test with valid object code
     # NOTE: apparently, on Windows cuLinkAddData! _does_ accept object data containing \0
     if !Sys.iswindows()
-        @test_throws CuError(CUDA.ERROR_UNKNOWN) add_data!(link, "vadd_parent", UInt8[0])
+        @test_throws Exception add_data!(link, "vadd_parent", UInt8[0])
     end
 end
 
@@ -756,12 +756,10 @@ end
         .version 3.1
         .target sm_999
         .address_size 64"""
-    @test_throws CuError(CUDA.ERROR_INVALID_PTX) CuModule(invalid_code)
-    @test_throws "ptxas fatal"                   CuModule(invalid_code)
+    @test_throws "ptxas fatal" CuModule(invalid_code)
 
     link = CuLink()
-    @test_throws CuError(CUDA.ERROR_INVALID_PTX) add_data!(link, "dummy", invalid_code)
-    @test_throws                                 "ptxas fatal" add_data!(link, "dummy", invalid_code)
+    @test_throws "ptxas fatal" add_data!(link, "dummy", invalid_code)
 end
 
 let


### PR DESCRIPTION
- simplify some of the custom error detection routines, now just always retrying API calls if they hit alloc_fail|init_fail|internal
- in already expensive call chains, use try/catch to preserve the failing API call
- simplify `retry_reclaim` a bit, halving the overhead it imposes
- add launch failure diagnostics