### PR TITLE
Improve Tegra detection.

### DIFF
--- a/lib/cudadrv/version.jl
+++ b/lib/cudadrv/version.jl
@@ -96,4 +96,16 @@ end
 
 ## helpers
 
-is_tegra() = Sys.islinux() && isfile("/etc/nv_tegra_release")
+function is_tegra()
+    if !Sys.islinux()
+        return false
+    end
+    if isfile("/etc/nv_tegra_release")
+        return true
+    end
+    if isfile("/proc/device-tree/compatible") &&
+        contains(read("/proc/device-tree/compatible", String), "tegra")
+        return true
+    end
+    return false
+end


### PR DESCRIPTION
`/etc/nv_tegra_release` may not exist -- it didn't on specific Jetpack versions, and also doesn't on Nix -- so try some more things to detect Tegra.