### PR TITLE
Added few SparseArrays functions

### DIFF
--- a/lib/cusparse/array.jl
+++ b/lib/cusparse/array.jl
@@ -301,6 +301,26 @@ SparseArrays.nonzeros(g::AbstractCuSparseArray) = g.nzVal
 SparseArrays.nonzeroinds(g::AbstractCuSparseVector) = g.iPtr
 
 SparseArrays.rowvals(g::CuSparseMatrixCSC) = g.rowVal
+SparseArrays.getcolptr(S::CuSparseMatrixCSC) = S.colPtr
+
+function SparseArrays.findnz(S::MT) where {MT <: AbstractCuSparseMatrix}
+    S2 = CuSparseMatrixCOO(S)
+    I = S2.rowInd
+    J = S2.colInd
+    V = S2.nzVal
+
+    # To make it compatible with the SparseArrays.jl version
+    idxs = sortperm(J)
+    I = I[idxs]
+    J = J[idxs]
+    V = V[idxs]
+
+    return (I, J, V)
+end
+
+function SparseArrays.sparsevec(I::CuArray{Ti}, V::CuArray{Tv}, n::Integer) where {Ti,Tv}
+    CuSparseVector(I, V, n)
+end
 
 LinearAlgebra.issymmetric(M::Union{CuSparseMatrixCSC,CuSparseMatrixCSR}) = size(M, 1) == size(M, 2) ? norm(M - transpose(M), Inf) == 0 : false
 LinearAlgebra.ishermitian(M::Union{CuSparseMatrixCSC,CuSparseMatrixCSR}) = size(M, 1) == size(M, 2) ? norm(M - adjoint(M), Inf) == 0 : false

--- a/test/libraries/cusparse.jl
+++ b/test/libraries/cusparse.jl
@@ -107,19 +107,18 @@ blockdim = 5
     @test !istriu(d_x)
     @test istril(d_x)
 
-    m = 50
-    A = sprand(m, m, 0.2)
+    A = sprand(n, n, 0.2)
     d_A = CuSparseMatrixCSC(A)
     @test Array(getcolptr(d_A)) == getcolptr(A)
     i, j, v = findnz(A)
     d_i, d_j, d_v = findnz(d_A)
     @test Array(d_i) == i && Array(d_j) == j && Array(d_v) == v
-    i = unique(sort(rand(1:m, 10)))
+    i = unique(sort(rand(1:n, 10)))
     vals = rand(length(i))
     d_i = CuArray(i)
     d_vals = CuArray(vals)
-    v = sparsevec(i, vals, m)
-    d_v = sparsevec(d_i, d_vals, m)
+    v = sparsevec(i, vals, n)
+    d_v = sparsevec(d_i, d_vals, n)
     @test Array(d_v.iPtr) == v.nzind
     @test Array(d_v.nzVal) == v.nzval
     @test d_v.len == v.n


### PR DESCRIPTION
I added the following SparseArrays functions:

- `SparseArrays.getcolptr(S::CuSparseMatrixCSC)`
- `SparseArrays.findnz(S::MT) where {MT <: AbstractCuSparseMatrix}`
- `SparseArrays.sparsevec(I::CuArray{Ti}, V::CuArray{Tv}, n::Integer) where {Ti,Tv}`