### PR TITLE
Mark all CUDA ccalls as GC safe

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -132,7 +132,12 @@ steps:
             println("--- :julia: Instantiating project")
             withenv("JULIA_PKG_PRECOMPILE_AUTO" => 0) do
               Pkg.activate(joinpath(pwd(), "lib", lowercase("{{matrix.package}}")))
-              Pkg.instantiate()
+              try
+                Pkg.instantiate()
+              catch
+                # if we fail to instantiate, assume that we need a newer CUDA.jl
+                Pkg.develop(path=".")
+              end
 
               Pkg.add("CUDA_Runtime_jll")
               write("LocalPreferences.toml", "[CUDA_Runtime_jll]\nversion = \"{{matrix.cuda}}\"")

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "CUDA"
 uuid = "052768ef-5323-5732-b1bb-66c8b64840ba"
-version = "5.2.0"
+version = "5.3.0"
 
 [deps]
 AbstractFFTs = "621f4979-c628-5d54-868e-fcf4e3e8185c"

--- a/lib/cublas/CUBLAS.jl
+++ b/lib/cublas/CUBLAS.jl
@@ -210,12 +210,7 @@ function log_message(ptr)
     return
 end
 
-function _log_message(blob)
-    # see @gcsafe_ccall documentation
-    @static if VERSION < v"1.9"
-        GC.safepoint()
-    end
-
+@gcunsafe_callback function _log_message(blob)
     # the message format isn't documented, but it looks like a message starts with a capital
     # and the severity (e.g. `I!`), and subsequent lines start with a lowercase mark (`!i`)
     #

--- a/lib/cublas/CUBLAS.jl
+++ b/lib/cublas/CUBLAS.jl
@@ -211,6 +211,11 @@ function log_message(ptr)
 end
 
 function _log_message(blob)
+    # see @gcsafe_ccall documentation
+    @static if VERSION < v"1.9"
+        GC.safepoint()
+    end
+
     # the message format isn't documented, but it looks like a message starts with a capital
     # and the severity (e.g. `I!`), and subsequent lines start with a lowercase mark (`!i`)
     #

--- a/lib/cublas/libcublas.jl
+++ b/lib/cublas/libcublas.jl
@@ -47,35 +47,36 @@ end
 
 @checked function cublasCreate_v2(handle)
     initialize_context()
-    @ccall libcublas.cublasCreate_v2(handle::Ref{cublasHandle_t})::cublasStatus_t
+    @gcsafe_ccall libcublas.cublasCreate_v2(handle::Ref{cublasHandle_t})::cublasStatus_t
 end
 
 @checked function cublasDestroy_v2(handle)
     initialize_context()
-    @ccall libcublas.cublasDestroy_v2(handle::cublasHandle_t)::cublasStatus_t
+    @gcsafe_ccall libcublas.cublasDestroy_v2(handle::cublasHandle_t)::cublasStatus_t
 end
 
 @checked function cublasGetVersion_v2(handle, version)
-    @ccall libcublas.cublasGetVersion_v2(handle::cublasHandle_t,
-                                         version::Ref{Cint})::cublasStatus_t
+    @gcsafe_ccall libcublas.cublasGetVersion_v2(handle::cublasHandle_t,
+                                                version::Ref{Cint})::cublasStatus_t
 end
 
 @checked function cublasSetWorkspace_v2(handle, workspace, workspaceSizeInBytes)
     initialize_context()
-    @ccall libcublas.cublasSetWorkspace_v2(handle::cublasHandle_t, workspace::CuPtr{Cvoid},
-                                           workspaceSizeInBytes::Csize_t)::cublasStatus_t
+    @gcsafe_ccall libcublas.cublasSetWorkspace_v2(handle::cublasHandle_t,
+                                                  workspace::CuPtr{Cvoid},
+                                                  workspaceSizeInBytes::Csize_t)::cublasStatus_t
 end
 
 @checked function cublasSetStream_v2(handle, streamId)
     initialize_context()
-    @ccall libcublas.cublasSetStream_v2(handle::cublasHandle_t,
-                                        streamId::cudaStream_t)::cublasStatus_t
+    @gcsafe_ccall libcublas.cublasSetStream_v2(handle::cublasHandle_t,
+                                               streamId::cudaStream_t)::cublasStatus_t
 end
 
 @checked function cublasGetStream_v2(handle, streamId)
     initialize_context()
-    @ccall libcublas.cublasGetStream_v2(handle::cublasHandle_t,
-                                        streamId::Ref{CUstream})::cublasStatus_t
+    @gcsafe_ccall libcublas.cublasGetStream_v2(handle::cublasHandle_t,
+                                               streamId::Ref{CUstream})::cublasStatus_t
 end
 
 @cenum cublasPointerMode_t::UInt32 begin
@@ -85,395 +86,423 @@ end
 
 @checked function cublasGetPointerMode_v2(handle, mode)
     initialize_context()
-    @ccall libcublas.cublasGetPointerMode_v2(handle::cublasHandle_t,
-                                             mode::Ref{cublasPointerMode_t})::cublasStatus_t
+    @gcsafe_ccall libcublas.cublasGetPointerMode_v2(handle::cublasHandle_t,
+                                                    mode::Ref{cublasPointerMode_t})::cublasStatus_t
 end
 
 @checked function cublasSetPointerMode_v2(handle, mode)
     initialize_context()
-    @ccall libcublas.cublasSetPointerMode_v2(handle::cublasHandle_t,
-                                             mode::cublasPointerMode_t)::cublasStatus_t
+    @gcsafe_ccall libcublas.cublasSetPointerMode_v2(handle::cublasHandle_t,
+                                                    mode::cublasPointerMode_t)::cublasStatus_t
 end
 
 @checked function cublasSnrm2_v2(handle, n, x, incx, result)
     initialize_context()
-    @ccall libcublas.cublasSnrm2_v2(handle::cublasHandle_t, n::Cint, x::CuPtr{Cfloat},
-                                    incx::Cint, result::RefOrCuRef{Cfloat})::cublasStatus_t
+    @gcsafe_ccall libcublas.cublasSnrm2_v2(handle::cublasHandle_t, n::Cint,
+                                           x::CuPtr{Cfloat}, incx::Cint,
+                                           result::RefOrCuRef{Cfloat})::cublasStatus_t
 end
 
 @checked function cublasDnrm2_v2(handle, n, x, incx, result)
     initialize_context()
-    @ccall libcublas.cublasDnrm2_v2(handle::cublasHandle_t, n::Cint, x::CuPtr{Cdouble},
-                                    incx::Cint, result::RefOrCuRef{Cdouble})::cublasStatus_t
+    @gcsafe_ccall libcublas.cublasDnrm2_v2(handle::cublasHandle_t, n::Cint,
+                                           x::CuPtr{Cdouble}, incx::Cint,
+                                           result::RefOrCuRef{Cdouble})::cublasStatus_t
 end
 
 @checked function cublasScnrm2_v2(handle, n, x, incx, result)
     initialize_context()
-    @ccall libcublas.cublasScnrm2_v2(handle::cublasHandle_t, n::Cint, x::CuPtr{cuComplex},
-                                     incx::Cint, result::RefOrCuRef{Cfloat})::cublasStatus_t
+    @gcsafe_ccall libcublas.cublasScnrm2_v2(handle::cublasHandle_t, n::Cint,
+                                            x::CuPtr{cuComplex}, incx::Cint,
+                                            result::RefOrCuRef{Cfloat})::cublasStatus_t
 end
 
 @checked function cublasDznrm2_v2(handle, n, x, incx, result)
     initialize_context()
-    @ccall libcublas.cublasDznrm2_v2(handle::cublasHandle_t, n::Cint,
-                                     x::CuPtr{cuDoubleComplex}, incx::Cint,
-                                     result::RefOrCuRef{Cdouble})::cublasStatus_t
+    @gcsafe_ccall libcublas.cublasDznrm2_v2(handle::cublasHandle_t, n::Cint,
+                                            x::CuPtr{cuDoubleComplex}, incx::Cint,
+                                            result::RefOrCuRef{Cdouble})::cublasStatus_t
 end
 
 @checked function cublasSdot_v2(handle, n, x, incx, y, incy, result)
     initialize_context()
-    @ccall libcublas.cublasSdot_v2(handle::cublasHandle_t, n::Cint, x::CuPtr{Cfloat},
-                                   incx::Cint, y::CuPtr{Cfloat}, incy::Cint,
-                                   result::RefOrCuRef{Cfloat})::cublasStatus_t
+    @gcsafe_ccall libcublas.cublasSdot_v2(handle::cublasHandle_t, n::Cint, x::CuPtr{Cfloat},
+                                          incx::Cint, y::CuPtr{Cfloat}, incy::Cint,
+                                          result::RefOrCuRef{Cfloat})::cublasStatus_t
 end
 
 @checked function cublasDdot_v2(handle, n, x, incx, y, incy, result)
     initialize_context()
-    @ccall libcublas.cublasDdot_v2(handle::cublasHandle_t, n::Cint, x::CuPtr{Cdouble},
-                                   incx::Cint, y::CuPtr{Cdouble}, incy::Cint,
-                                   result::RefOrCuRef{Cdouble})::cublasStatus_t
+    @gcsafe_ccall libcublas.cublasDdot_v2(handle::cublasHandle_t, n::Cint,
+                                          x::CuPtr{Cdouble}, incx::Cint, y::CuPtr{Cdouble},
+                                          incy::Cint,
+                                          result::RefOrCuRef{Cdouble})::cublasStatus_t
 end
 
 @checked function cublasCdotu_v2(handle, n, x, incx, y, incy, result)
     initialize_context()
-    @ccall libcublas.cublasCdotu_v2(handle::cublasHandle_t, n::Cint, x::CuPtr{cuComplex},
-                                    incx::Cint, y::CuPtr{cuComplex}, incy::Cint,
-                                    result::RefOrCuRef{cuComplex})::cublasStatus_t
+    @gcsafe_ccall libcublas.cublasCdotu_v2(handle::cublasHandle_t, n::Cint,
+                                           x::CuPtr{cuComplex}, incx::Cint,
+                                           y::CuPtr{cuComplex}, incy::Cint,
+                                           result::RefOrCuRef{cuComplex})::cublasStatus_t
 end
 
 @checked function cublasCdotc_v2(handle, n, x, incx, y, incy, result)
     initialize_context()
-    @ccall libcublas.cublasCdotc_v2(handle::cublasHandle_t, n::Cint, x::CuPtr{cuComplex},
-                                    incx::Cint, y::CuPtr{cuComplex}, incy::Cint,
-                                    result::RefOrCuRef{cuComplex})::cublasStatus_t
+    @gcsafe_ccall libcublas.cublasCdotc_v2(handle::cublasHandle_t, n::Cint,
+                                           x::CuPtr{cuComplex}, incx::Cint,
+                                           y::CuPtr{cuComplex}, incy::Cint,
+                                           result::RefOrCuRef{cuComplex})::cublasStatus_t
 end
 
 @checked function cublasZdotu_v2(handle, n, x, incx, y, incy, result)
     initialize_context()
-    @ccall libcublas.cublasZdotu_v2(handle::cublasHandle_t, n::Cint,
-                                    x::CuPtr{cuDoubleComplex}, incx::Cint,
-                                    y::CuPtr{cuDoubleComplex}, incy::Cint,
-                                    result::RefOrCuRef{cuDoubleComplex})::cublasStatus_t
+    @gcsafe_ccall libcublas.cublasZdotu_v2(handle::cublasHandle_t, n::Cint,
+                                           x::CuPtr{cuDoubleComplex}, incx::Cint,
+                                           y::CuPtr{cuDoubleComplex}, incy::Cint,
+                                           result::RefOrCuRef{cuDoubleComplex})::cublasStatus_t
 end
 
 @checked function cublasZdotc_v2(handle, n, x, incx, y, incy, result)
     initialize_context()
-    @ccall libcublas.cublasZdotc_v2(handle::cublasHandle_t, n::Cint,
-                                    x::CuPtr{cuDoubleComplex}, incx::Cint,
-                                    y::CuPtr{cuDoubleComplex}, incy::Cint,
-                                    result::RefOrCuRef{cuDoubleComplex})::cublasStatus_t
+    @gcsafe_ccall libcublas.cublasZdotc_v2(handle::cublasHandle_t, n::Cint,
+                                           x::CuPtr{cuDoubleComplex}, incx::Cint,
+                                           y::CuPtr{cuDoubleComplex}, incy::Cint,
+                                           result::RefOrCuRef{cuDoubleComplex})::cublasStatus_t
 end
 
 @checked function cublasSscal_v2(handle, n, alpha, x, incx)
     initialize_context()
-    @ccall libcublas.cublasSscal_v2(handle::cublasHandle_t, n::Cint,
-                                    alpha::RefOrCuRef{Cfloat}, x::CuPtr{Cfloat},
-                                    incx::Cint)::cublasStatus_t
+    @gcsafe_ccall libcublas.cublasSscal_v2(handle::cublasHandle_t, n::Cint,
+                                           alpha::RefOrCuRef{Cfloat}, x::CuPtr{Cfloat},
+                                           incx::Cint)::cublasStatus_t
 end
 
 @checked function cublasDscal_v2(handle, n, alpha, x, incx)
     initialize_context()
-    @ccall libcublas.cublasDscal_v2(handle::cublasHandle_t, n::Cint,
-                                    alpha::RefOrCuRef{Cdouble}, x::CuPtr{Cdouble},
-                                    incx::Cint)::cublasStatus_t
+    @gcsafe_ccall libcublas.cublasDscal_v2(handle::cublasHandle_t, n::Cint,
+                                           alpha::RefOrCuRef{Cdouble}, x::CuPtr{Cdouble},
+                                           incx::Cint)::cublasStatus_t
 end
 
 @checked function cublasCscal_v2(handle, n, alpha, x, incx)
     initialize_context()
-    @ccall libcublas.cublasCscal_v2(handle::cublasHandle_t, n::Cint,
-                                    alpha::RefOrCuRef{cuComplex}, x::CuPtr{cuComplex},
-                                    incx::Cint)::cublasStatus_t
+    @gcsafe_ccall libcublas.cublasCscal_v2(handle::cublasHandle_t, n::Cint,
+                                           alpha::RefOrCuRef{cuComplex},
+                                           x::CuPtr{cuComplex}, incx::Cint)::cublasStatus_t
 end
 
 @checked function cublasCsscal_v2(handle, n, alpha, x, incx)
     initialize_context()
-    @ccall libcublas.cublasCsscal_v2(handle::cublasHandle_t, n::Cint,
-                                     alpha::RefOrCuRef{Cfloat}, x::CuPtr{cuComplex},
-                                     incx::Cint)::cublasStatus_t
+    @gcsafe_ccall libcublas.cublasCsscal_v2(handle::cublasHandle_t, n::Cint,
+                                            alpha::RefOrCuRef{Cfloat}, x::CuPtr{cuComplex},
+                                            incx::Cint)::cublasStatus_t
 end
 
 @checked function cublasZscal_v2(handle, n, alpha, x, incx)
     initialize_context()
-    @ccall libcublas.cublasZscal_v2(handle::cublasHandle_t, n::Cint,
-                                    alpha::RefOrCuRef{cuDoubleComplex},
-                                    x::CuPtr{cuDoubleComplex}, incx::Cint)::cublasStatus_t
+    @gcsafe_ccall libcublas.cublasZscal_v2(handle::cublasHandle_t, n::Cint,
+                                           alpha::RefOrCuRef{cuDoubleComplex},
+                                           x::CuPtr{cuDoubleComplex},
+                                           incx::Cint)::cublasStatus_t
 end
 
 @checked function cublasZdscal_v2(handle, n, alpha, x, incx)
     initialize_context()
-    @ccall libcublas.cublasZdscal_v2(handle::cublasHandle_t, n::Cint,
-                                     alpha::RefOrCuRef{Cdouble}, x::CuPtr{cuDoubleComplex},
-                                     incx::Cint)::cublasStatus_t
+    @gcsafe_ccall libcublas.cublasZdscal_v2(handle::cublasHandle_t, n::Cint,
+                                            alpha::RefOrCuRef{Cdouble},
+                                            x::CuPtr{cuDoubleComplex},
+                                            incx::Cint)::cublasStatus_t
 end
 
 @checked function cublasSaxpy_v2(handle, n, alpha, x, incx, y, incy)
     initialize_context()
-    @ccall libcublas.cublasSaxpy_v2(handle::cublasHandle_t, n::Cint,
-                                    alpha::RefOrCuRef{Cfloat}, x::CuPtr{Cfloat}, incx::Cint,
-                                    y::CuPtr{Cfloat}, incy::Cint)::cublasStatus_t
+    @gcsafe_ccall libcublas.cublasSaxpy_v2(handle::cublasHandle_t, n::Cint,
+                                           alpha::RefOrCuRef{Cfloat}, x::CuPtr{Cfloat},
+                                           incx::Cint, y::CuPtr{Cfloat},
+                                           incy::Cint)::cublasStatus_t
 end
 
 @checked function cublasDaxpy_v2(handle, n, alpha, x, incx, y, incy)
     initialize_context()
-    @ccall libcublas.cublasDaxpy_v2(handle::cublasHandle_t, n::Cint,
-                                    alpha::RefOrCuRef{Cdouble}, x::CuPtr{Cdouble},
-                                    incx::Cint, y::CuPtr{Cdouble},
-                                    incy::Cint)::cublasStatus_t
+    @gcsafe_ccall libcublas.cublasDaxpy_v2(handle::cublasHandle_t, n::Cint,
+                                           alpha::RefOrCuRef{Cdouble}, x::CuPtr{Cdouble},
+                                           incx::Cint, y::CuPtr{Cdouble},
+                                           incy::Cint)::cublasStatus_t
 end
 
 @checked function cublasCaxpy_v2(handle, n, alpha, x, incx, y, incy)
     initialize_context()
-    @ccall libcublas.cublasCaxpy_v2(handle::cublasHandle_t, n::Cint,
-                                    alpha::RefOrCuRef{cuComplex}, x::CuPtr{cuComplex},
-                                    incx::Cint, y::CuPtr{cuComplex},
-                                    incy::Cint)::cublasStatus_t
+    @gcsafe_ccall libcublas.cublasCaxpy_v2(handle::cublasHandle_t, n::Cint,
+                                           alpha::RefOrCuRef{cuComplex},
+                                           x::CuPtr{cuComplex}, incx::Cint,
+                                           y::CuPtr{cuComplex}, incy::Cint)::cublasStatus_t
 end
 
 @checked function cublasZaxpy_v2(handle, n, alpha, x, incx, y, incy)
     initialize_context()
-    @ccall libcublas.cublasZaxpy_v2(handle::cublasHandle_t, n::Cint,
-                                    alpha::RefOrCuRef{cuDoubleComplex},
-                                    x::CuPtr{cuDoubleComplex}, incx::Cint,
-                                    y::CuPtr{cuDoubleComplex}, incy::Cint)::cublasStatus_t
+    @gcsafe_ccall libcublas.cublasZaxpy_v2(handle::cublasHandle_t, n::Cint,
+                                           alpha::RefOrCuRef{cuDoubleComplex},
+                                           x::CuPtr{cuDoubleComplex}, incx::Cint,
+                                           y::CuPtr{cuDoubleComplex},
+                                           incy::Cint)::cublasStatus_t
 end
 
 @checked function cublasScopy_v2(handle, n, x, incx, y, incy)
     initialize_context()
-    @ccall libcublas.cublasScopy_v2(handle::cublasHandle_t, n::Cint, x::CuPtr{Cfloat},
-                                    incx::Cint, y::CuPtr{Cfloat},
-                                    incy::Cint)::cublasStatus_t
+    @gcsafe_ccall libcublas.cublasScopy_v2(handle::cublasHandle_t, n::Cint,
+                                           x::CuPtr{Cfloat}, incx::Cint, y::CuPtr{Cfloat},
+                                           incy::Cint)::cublasStatus_t
 end
 
 @checked function cublasDcopy_v2(handle, n, x, incx, y, incy)
     initialize_context()
-    @ccall libcublas.cublasDcopy_v2(handle::cublasHandle_t, n::Cint, x::CuPtr{Cdouble},
-                                    incx::Cint, y::CuPtr{Cdouble},
-                                    incy::Cint)::cublasStatus_t
+    @gcsafe_ccall libcublas.cublasDcopy_v2(handle::cublasHandle_t, n::Cint,
+                                           x::CuPtr{Cdouble}, incx::Cint, y::CuPtr{Cdouble},
+                                           incy::Cint)::cublasStatus_t
 end
 
 @checked function cublasCcopy_v2(handle, n, x, incx, y, incy)
     initialize_context()
-    @ccall libcublas.cublasCcopy_v2(handle::cublasHandle_t, n::Cint, x::CuPtr{cuComplex},
-                                    incx::Cint, y::CuPtr{cuComplex},
-                                    incy::Cint)::cublasStatus_t
+    @gcsafe_ccall libcublas.cublasCcopy_v2(handle::cublasHandle_t, n::Cint,
+                                           x::CuPtr{cuComplex}, incx::Cint,
+                                           y::CuPtr{cuComplex}, incy::Cint)::cublasStatus_t
 end
 
 @checked function cublasZcopy_v2(handle, n, x, incx, y, incy)
     initialize_context()
-    @ccall libcublas.cublasZcopy_v2(handle::cublasHandle_t, n::Cint,
-                                    x::CuPtr{cuDoubleComplex}, incx::Cint,
-                                    y::CuPtr{cuDoubleComplex}, incy::Cint)::cublasStatus_t
+    @gcsafe_ccall libcublas.cublasZcopy_v2(handle::cublasHandle_t, n::Cint,
+                                           x::CuPtr{cuDoubleComplex}, incx::Cint,
+                                           y::CuPtr{cuDoubleComplex},
+                                           incy::Cint)::cublasStatus_t
 end
 
 @checked function cublasSswap_v2(handle, n, x, incx, y, incy)
     initialize_context()
-    @ccall libcublas.cublasSswap_v2(handle::cublasHandle_t, n::Cint, x::CuPtr{Cfloat},
-                                    incx::Cint, y::CuPtr{Cfloat},
-                                    incy::Cint)::cublasStatus_t
+    @gcsafe_ccall libcublas.cublasSswap_v2(handle::cublasHandle_t, n::Cint,
+                                           x::CuPtr{Cfloat}, incx::Cint, y::CuPtr{Cfloat},
+                                           incy::Cint)::cublasStatus_t
 end
 
 @checked function cublasDswap_v2(handle, n, x, incx, y, incy)
     initialize_context()
-    @ccall libcublas.cublasDswap_v2(handle::cublasHandle_t, n::Cint, x::CuPtr{Cdouble},
-                                    incx::Cint, y::CuPtr{Cdouble},
-                                    incy::Cint)::cublasStatus_t
+    @gcsafe_ccall libcublas.cublasDswap_v2(handle::cublasHandle_t, n::Cint,
+                                           x::CuPtr{Cdouble}, incx::Cint, y::CuPtr{Cdouble},
+                                           incy::Cint)::cublasStatus_t
 end
 
 @checked function cublasCswap_v2(handle, n, x, incx, y, incy)
     initialize_context()
-    @ccall libcublas.cublasCswap_v2(handle::cublasHandle_t, n::Cint, x::CuPtr{cuComplex},
-                                    incx::Cint, y::CuPtr{cuComplex},
-                                    incy::Cint)::cublasStatus_t
+    @gcsafe_ccall libcublas.cublasCswap_v2(handle::cublasHandle_t, n::Cint,
+                                           x::CuPtr{cuComplex}, incx::Cint,
+                                           y::CuPtr{cuComplex}, incy::Cint)::cublasStatus_t
 end
 
 @checked function cublasZswap_v2(handle, n, x, incx, y, incy)
     initialize_context()
-    @ccall libcublas.cublasZswap_v2(handle::cublasHandle_t, n::Cint,
-                                    x::CuPtr{cuDoubleComplex}, incx::Cint,
-                                    y::CuPtr{cuDoubleComplex}, incy::Cint)::cublasStatus_t
+    @gcsafe_ccall libcublas.cublasZswap_v2(handle::cublasHandle_t, n::Cint,
+                                           x::CuPtr{cuDoubleComplex}, incx::Cint,
+                                           y::CuPtr{cuDoubleComplex},
+                                           incy::Cint)::cublasStatus_t
 end
 
 @checked function cublasIsamax_v2(handle, n, x, incx, result)
     initialize_context()
-    @ccall libcublas.cublasIsamax_v2(handle::cublasHandle_t, n::Cint, x::CuPtr{Cfloat},
-                                     incx::Cint, result::RefOrCuRef{Cint})::cublasStatus_t
+    @gcsafe_ccall libcublas.cublasIsamax_v2(handle::cublasHandle_t, n::Cint,
+                                            x::CuPtr{Cfloat}, incx::Cint,
+                                            result::RefOrCuRef{Cint})::cublasStatus_t
 end
 
 @checked function cublasIdamax_v2(handle, n, x, incx, result)
     initialize_context()
-    @ccall libcublas.cublasIdamax_v2(handle::cublasHandle_t, n::Cint, x::CuPtr{Cdouble},
-                                     incx::Cint, result::RefOrCuRef{Cint})::cublasStatus_t
+    @gcsafe_ccall libcublas.cublasIdamax_v2(handle::cublasHandle_t, n::Cint,
+                                            x::CuPtr{Cdouble}, incx::Cint,
+                                            result::RefOrCuRef{Cint})::cublasStatus_t
 end
 
 @checked function cublasIcamax_v2(handle, n, x, incx, result)
     initialize_context()
-    @ccall libcublas.cublasIcamax_v2(handle::cublasHandle_t, n::Cint, x::CuPtr{cuComplex},
-                                     incx::Cint, result::RefOrCuRef{Cint})::cublasStatus_t
+    @gcsafe_ccall libcublas.cublasIcamax_v2(handle::cublasHandle_t, n::Cint,
+                                            x::CuPtr{cuComplex}, incx::Cint,
+                                            result::RefOrCuRef{Cint})::cublasStatus_t
 end
 
 @checked function cublasIzamax_v2(handle, n, x, incx, result)
     initialize_context()
-    @ccall libcublas.cublasIzamax_v2(handle::cublasHandle_t, n::Cint,
-                                     x::CuPtr{cuDoubleComplex}, incx::Cint,
-                                     result::RefOrCuRef{Cint})::cublasStatus_t
+    @gcsafe_ccall libcublas.cublasIzamax_v2(handle::cublasHandle_t, n::Cint,
+                                            x::CuPtr{cuDoubleComplex}, incx::Cint,
+                                            result::RefOrCuRef{Cint})::cublasStatus_t
 end
 
 @checked function cublasIsamin_v2(handle, n, x, incx, result)
     initialize_context()
-    @ccall libcublas.cublasIsamin_v2(handle::cublasHandle_t, n::Cint, x::CuPtr{Cfloat},
-                                     incx::Cint, result::RefOrCuRef{Cint})::cublasStatus_t
+    @gcsafe_ccall libcublas.cublasIsamin_v2(handle::cublasHandle_t, n::Cint,
+                                            x::CuPtr{Cfloat}, incx::Cint,
+                                            result::RefOrCuRef{Cint})::cublasStatus_t
 end
 
 @checked function cublasIdamin_v2(handle, n, x, incx, result)
     initialize_context()
-    @ccall libcublas.cublasIdamin_v2(handle::cublasHandle_t, n::Cint, x::CuPtr{Cdouble},
-                                     incx::Cint, result::RefOrCuRef{Cint})::cublasStatus_t
+    @gcsafe_ccall libcublas.cublasIdamin_v2(handle::cublasHandle_t, n::Cint,
+                                            x::CuPtr{Cdouble}, incx::Cint,
+                                            result::RefOrCuRef{Cint})::cublasStatus_t
 end
 
 @checked function cublasIcamin_v2(handle, n, x, incx, result)
     initialize_context()
-    @ccall libcublas.cublasIcamin_v2(handle::cublasHandle_t, n::Cint, x::CuPtr{cuComplex},
-                                     incx::Cint, result::RefOrCuRef{Cint})::cublasStatus_t
+    @gcsafe_ccall libcublas.cublasIcamin_v2(handle::cublasHandle_t, n::Cint,
+                                            x::CuPtr{cuComplex}, incx::Cint,
+                                            result::RefOrCuRef{Cint})::cublasStatus_t
 end
 
 @checked function cublasIzamin_v2(handle, n, x, incx, result)
     initialize_context()
-    @ccall libcublas.cublasIzamin_v2(handle::cublasHandle_t, n::Cint,
-                                     x::CuPtr{cuDoubleComplex}, incx::Cint,
-                                     result::RefOrCuRef{Cint})::cublasStatus_t
+    @gcsafe_ccall libcublas.cublasIzamin_v2(handle::cublasHandle_t, n::Cint,
+                                            x::CuPtr{cuDoubleComplex}, incx::Cint,
+                                            result::RefOrCuRef{Cint})::cublasStatus_t
 end
 
 @checked function cublasSasum_v2(handle, n, x, incx, result)
     initialize_context()
-    @ccall libcublas.cublasSasum_v2(handle::cublasHandle_t, n::Cint, x::CuPtr{Cfloat},
-                                    incx::Cint, result::RefOrCuRef{Cfloat})::cublasStatus_t
+    @gcsafe_ccall libcublas.cublasSasum_v2(handle::cublasHandle_t, n::Cint,
+                                           x::CuPtr{Cfloat}, incx::Cint,
+                                           result::RefOrCuRef{Cfloat})::cublasStatus_t
 end
 
 @checked function cublasDasum_v2(handle, n, x, incx, result)
     initialize_context()
-    @ccall libcublas.cublasDasum_v2(handle::cublasHandle_t, n::Cint, x::CuPtr{Cdouble},
-                                    incx::Cint, result::RefOrCuRef{Cdouble})::cublasStatus_t
+    @gcsafe_ccall libcublas.cublasDasum_v2(handle::cublasHandle_t, n::Cint,
+                                           x::CuPtr{Cdouble}, incx::Cint,
+                                           result::RefOrCuRef{Cdouble})::cublasStatus_t
 end
 
 @checked function cublasScasum_v2(handle, n, x, incx, result)
     initialize_context()
-    @ccall libcublas.cublasScasum_v2(handle::cublasHandle_t, n::Cint, x::CuPtr{cuComplex},
-                                     incx::Cint, result::RefOrCuRef{Cfloat})::cublasStatus_t
+    @gcsafe_ccall libcublas.cublasScasum_v2(handle::cublasHandle_t, n::Cint,
+                                            x::CuPtr{cuComplex}, incx::Cint,
+                                            result::RefOrCuRef{Cfloat})::cublasStatus_t
 end
 
 @checked function cublasDzasum_v2(handle, n, x, incx, result)
     initialize_context()
-    @ccall libcublas.cublasDzasum_v2(handle::cublasHandle_t, n::Cint,
-                                     x::CuPtr{cuDoubleComplex}, incx::Cint,
-                                     result::RefOrCuRef{Cdouble})::cublasStatus_t
+    @gcsafe_ccall libcublas.cublasDzasum_v2(handle::cublasHandle_t, n::Cint,
+                                            x::CuPtr{cuDoubleComplex}, incx::Cint,
+                                            result::RefOrCuRef{Cdouble})::cublasStatus_t
 end
 
 @checked function cublasSrot_v2(handle, n, x, incx, y, incy, c, s)
     initialize_context()
-    @ccall libcublas.cublasSrot_v2(handle::cublasHandle_t, n::Cint, x::CuPtr{Cfloat},
-                                   incx::Cint, y::CuPtr{Cfloat}, incy::Cint,
-                                   c::RefOrCuRef{Cfloat},
-                                   s::RefOrCuRef{Cfloat})::cublasStatus_t
+    @gcsafe_ccall libcublas.cublasSrot_v2(handle::cublasHandle_t, n::Cint, x::CuPtr{Cfloat},
+                                          incx::Cint, y::CuPtr{Cfloat}, incy::Cint,
+                                          c::RefOrCuRef{Cfloat},
+                                          s::RefOrCuRef{Cfloat})::cublasStatus_t
 end
 
 @checked function cublasDrot_v2(handle, n, x, incx, y, incy, c, s)
     initialize_context()
-    @ccall libcublas.cublasDrot_v2(handle::cublasHandle_t, n::Cint, x::CuPtr{Cdouble},
-                                   incx::Cint, y::CuPtr{Cdouble}, incy::Cint,
-                                   c::RefOrCuRef{Cdouble},
-                                   s::RefOrCuRef{Cdouble})::cublasStatus_t
+    @gcsafe_ccall libcublas.cublasDrot_v2(handle::cublasHandle_t, n::Cint,
+                                          x::CuPtr{Cdouble}, incx::Cint, y::CuPtr{Cdouble},
+                                          incy::Cint, c::RefOrCuRef{Cdouble},
+                                          s::RefOrCuRef{Cdouble})::cublasStatus_t
 end
 
 @checked function cublasCrot_v2(handle, n, x, incx, y, incy, c, s)
     initialize_context()
-    @ccall libcublas.cublasCrot_v2(handle::cublasHandle_t, n::Cint, x::CuPtr{cuComplex},
-                                   incx::Cint, y::CuPtr{cuComplex}, incy::Cint,
-                                   c::RefOrCuRef{Cfloat},
-                                   s::RefOrCuRef{cuComplex})::cublasStatus_t
+    @gcsafe_ccall libcublas.cublasCrot_v2(handle::cublasHandle_t, n::Cint,
+                                          x::CuPtr{cuComplex}, incx::Cint,
+                                          y::CuPtr{cuComplex}, incy::Cint,
+                                          c::RefOrCuRef{Cfloat},
+                                          s::RefOrCuRef{cuComplex})::cublasStatus_t
 end
 
 @checked function cublasCsrot_v2(handle, n, x, incx, y, incy, c, s)
     initialize_context()
-    @ccall libcublas.cublasCsrot_v2(handle::cublasHandle_t, n::Cint, x::CuPtr{cuComplex},
-                                    incx::Cint, y::CuPtr{cuComplex}, incy::Cint,
-                                    c::RefOrCuRef{Cfloat},
-                                    s::RefOrCuRef{Cfloat})::cublasStatus_t
+    @gcsafe_ccall libcublas.cublasCsrot_v2(handle::cublasHandle_t, n::Cint,
+                                           x::CuPtr{cuComplex}, incx::Cint,
+                                           y::CuPtr{cuComplex}, incy::Cint,
+                                           c::RefOrCuRef{Cfloat},
+                                           s::RefOrCuRef{Cfloat})::cublasStatus_t
 end
 
 @checked function cublasZrot_v2(handle, n, x, incx, y, incy, c, s)
     initialize_context()
-    @ccall libcublas.cublasZrot_v2(handle::cublasHandle_t, n::Cint,
-                                   x::CuPtr{cuDoubleComplex}, incx::Cint,
-                                   y::CuPtr{cuDoubleComplex}, incy::Cint,
-                                   c::RefOrCuRef{Cdouble},
-                                   s::RefOrCuRef{cuDoubleComplex})::cublasStatus_t
+    @gcsafe_ccall libcublas.cublasZrot_v2(handle::cublasHandle_t, n::Cint,
+                                          x::CuPtr{cuDoubleComplex}, incx::Cint,
+                                          y::CuPtr{cuDoubleComplex}, incy::Cint,
+                                          c::RefOrCuRef{Cdouble},
+                                          s::RefOrCuRef{cuDoubleComplex})::cublasStatus_t
 end
 
 @checked function cublasZdrot_v2(handle, n, x, incx, y, incy, c, s)
     initialize_context()
-    @ccall libcublas.cublasZdrot_v2(handle::cublasHandle_t, n::Cint,
-                                    x::CuPtr{cuDoubleComplex}, incx::Cint,
-                                    y::CuPtr{cuDoubleComplex}, incy::Cint,
-                                    c::RefOrCuRef{Cdouble},
-                                    s::RefOrCuRef{Cdouble})::cublasStatus_t
+    @gcsafe_ccall libcublas.cublasZdrot_v2(handle::cublasHandle_t, n::Cint,
+                                           x::CuPtr{cuDoubleComplex}, incx::Cint,
+                                           y::CuPtr{cuDoubleComplex}, incy::Cint,
+                                           c::RefOrCuRef{Cdouble},
+                                           s::RefOrCuRef{Cdouble})::cublasStatus_t
 end
 
 @checked function cublasSrotg_v2(handle, a, b, c, s)
     initialize_context()
-    @ccall libcublas.cublasSrotg_v2(handle::cublasHandle_t, a::RefOrCuRef{Cfloat},
-                                    b::RefOrCuRef{Cfloat}, c::RefOrCuRef{Cfloat},
-                                    s::RefOrCuRef{Cfloat})::cublasStatus_t
+    @gcsafe_ccall libcublas.cublasSrotg_v2(handle::cublasHandle_t, a::RefOrCuRef{Cfloat},
+                                           b::RefOrCuRef{Cfloat}, c::RefOrCuRef{Cfloat},
+                                           s::RefOrCuRef{Cfloat})::cublasStatus_t
 end
 
 @checked function cublasDrotg_v2(handle, a, b, c, s)
     initialize_context()
-    @ccall libcublas.cublasDrotg_v2(handle::cublasHandle_t, a::RefOrCuRef{Cdouble},
-                                    b::RefOrCuRef{Cdouble}, c::PtrOrCuPtr{Cdouble},
-                                    s::PtrOrCuPtr{Cdouble})::cublasStatus_t
+    @gcsafe_ccall libcublas.cublasDrotg_v2(handle::cublasHandle_t, a::RefOrCuRef{Cdouble},
+                                           b::RefOrCuRef{Cdouble}, c::PtrOrCuPtr{Cdouble},
+                                           s::PtrOrCuPtr{Cdouble})::cublasStatus_t
 end
 
 @checked function cublasCrotg_v2(handle, a, b, c, s)
     initialize_context()
-    @ccall libcublas.cublasCrotg_v2(handle::cublasHandle_t, a::RefOrCuRef{cuComplex},
-                                    b::RefOrCuRef{cuComplex}, c::RefOrCuRef{Cfloat},
-                                    s::RefOrCuRef{cuComplex})::cublasStatus_t
+    @gcsafe_ccall libcublas.cublasCrotg_v2(handle::cublasHandle_t, a::RefOrCuRef{cuComplex},
+                                           b::RefOrCuRef{cuComplex}, c::RefOrCuRef{Cfloat},
+                                           s::RefOrCuRef{cuComplex})::cublasStatus_t
 end
 
 @checked function cublasZrotg_v2(handle, a, b, c, s)
     initialize_context()
-    @ccall libcublas.cublasZrotg_v2(handle::cublasHandle_t, a::RefOrCuRef{cuDoubleComplex},
-                                    b::RefOrCuRef{cuDoubleComplex}, c::RefOrCuRef{Cdouble},
-                                    s::RefOrCuRef{cuDoubleComplex})::cublasStatus_t
+    @gcsafe_ccall libcublas.cublasZrotg_v2(handle::cublasHandle_t,
+                                           a::RefOrCuRef{cuDoubleComplex},
+                                           b::RefOrCuRef{cuDoubleComplex},
+                                           c::RefOrCuRef{Cdouble},
+                                           s::RefOrCuRef{cuDoubleComplex})::cublasStatus_t
 end
 
 @checked function cublasSrotm_v2(handle, n, x, incx, y, incy, param)
     initialize_context()
-    @ccall libcublas.cublasSrotm_v2(handle::cublasHandle_t, n::Cint, x::CuPtr{Cfloat},
-                                    incx::Cint, y::CuPtr{Cfloat}, incy::Cint,
-                                    param::PtrOrCuPtr{Cfloat})::cublasStatus_t
+    @gcsafe_ccall libcublas.cublasSrotm_v2(handle::cublasHandle_t, n::Cint,
+                                           x::CuPtr{Cfloat}, incx::Cint, y::CuPtr{Cfloat},
+                                           incy::Cint,
+                                           param::PtrOrCuPtr{Cfloat})::cublasStatus_t
 end
 
 @checked function cublasDrotm_v2(handle, n, x, incx, y, incy, param)
     initialize_context()
-    @ccall libcublas.cublasDrotm_v2(handle::cublasHandle_t, n::Cint, x::CuPtr{Cdouble},
-                                    incx::Cint, y::CuPtr{Cdouble}, incy::Cint,
-                                    param::PtrOrCuPtr{Cdouble})::cublasStatus_t
+    @gcsafe_ccall libcublas.cublasDrotm_v2(handle::cublasHandle_t, n::Cint,
+                                           x::CuPtr{Cdouble}, incx::Cint, y::CuPtr{Cdouble},
+                                           incy::Cint,
+                                           param::PtrOrCuPtr{Cdouble})::cublasStatus_t
 end
 
 @checked function cublasSrotmg_v2(handle, d1, d2, x1, y1, param)
     initialize_context()
-    @ccall libcublas.cublasSrotmg_v2(handle::cublasHandle_t, d1::RefOrCuRef{Cfloat},
-                                     d2::RefOrCuRef{Cfloat}, x1::RefOrCuRef{Cfloat},
-                                     y1::RefOrCuRef{Cfloat},
-                                     param::PtrOrCuPtr{Cfloat})::cublasStatus_t
+    @gcsafe_ccall libcublas.cublasSrotmg_v2(handle::cublasHandle_t, d1::RefOrCuRef{Cfloat},
+                                            d2::RefOrCuRef{Cfloat}, x1::RefOrCuRef{Cfloat},
+                                            y1::RefOrCuRef{Cfloat},
+                                            param::PtrOrCuPtr{Cfloat})::cublasStatus_t
 end
 
 @checked function cublasDrotmg_v2(handle, d1, d2, x1, y1, param)
     initialize_context()
-    @ccall libcublas.cublasDrotmg_v2(handle::cublasHandle_t, d1::RefOrCuRef{Cdouble},
-                                     d2::RefOrCuRef{Cdouble}, x1::RefOrCuRef{Cdouble},
-                                     y1::RefOrCuRef{Cdouble},
-                                     param::PtrOrCuPtr{Cdouble})::cublasStatus_t
+    @gcsafe_ccall libcublas.cublasDrotmg_v2(handle::cublasHandle_t, d1::RefOrCuRef{Cdouble},
+                                            d2::RefOrCuRef{Cdouble},
+                                            x1::RefOrCuRef{Cdouble},
+                                            y1::RefOrCuRef{Cdouble},
+                                            param::PtrOrCuPtr{Cdouble})::cublasStatus_t
 end
 
 @cenum cublasOperation_t::UInt32 begin
@@ -486,83 +515,89 @@ end
 
 @checked function cublasSgemv_v2(handle, trans, m, n, alpha, A, lda, x, incx, beta, y, incy)
     initialize_context()
-    @ccall libcublas.cublasSgemv_v2(handle::cublasHandle_t, trans::cublasOperation_t,
-                                    m::Cint, n::Cint, alpha::RefOrCuRef{Cfloat},
-                                    A::CuPtr{Cfloat}, lda::Cint, x::CuPtr{Cfloat},
-                                    incx::Cint, beta::RefOrCuRef{Cfloat}, y::CuPtr{Cfloat},
-                                    incy::Cint)::cublasStatus_t
+    @gcsafe_ccall libcublas.cublasSgemv_v2(handle::cublasHandle_t, trans::cublasOperation_t,
+                                           m::Cint, n::Cint, alpha::RefOrCuRef{Cfloat},
+                                           A::CuPtr{Cfloat}, lda::Cint, x::CuPtr{Cfloat},
+                                           incx::Cint, beta::RefOrCuRef{Cfloat},
+                                           y::CuPtr{Cfloat}, incy::Cint)::cublasStatus_t
 end
 
 @checked function cublasDgemv_v2(handle, trans, m, n, alpha, A, lda, x, incx, beta, y, incy)
     initialize_context()
-    @ccall libcublas.cublasDgemv_v2(handle::cublasHandle_t, trans::cublasOperation_t,
-                                    m::Cint, n::Cint, alpha::RefOrCuRef{Cdouble},
-                                    A::CuPtr{Cdouble}, lda::Cint, x::CuPtr{Cdouble},
-                                    incx::Cint, beta::RefOrCuRef{Cdouble},
-                                    y::CuPtr{Cdouble}, incy::Cint)::cublasStatus_t
+    @gcsafe_ccall libcublas.cublasDgemv_v2(handle::cublasHandle_t, trans::cublasOperation_t,
+                                           m::Cint, n::Cint, alpha::RefOrCuRef{Cdouble},
+                                           A::CuPtr{Cdouble}, lda::Cint, x::CuPtr{Cdouble},
+                                           incx::Cint, beta::RefOrCuRef{Cdouble},
+                                           y::CuPtr{Cdouble}, incy::Cint)::cublasStatus_t
 end
 
 @checked function cublasCgemv_v2(handle, trans, m, n, alpha, A, lda, x, incx, beta, y, incy)
     initialize_context()
-    @ccall libcublas.cublasCgemv_v2(handle::cublasHandle_t, trans::cublasOperation_t,
-                                    m::Cint, n::Cint, alpha::RefOrCuRef{cuComplex},
-                                    A::CuPtr{cuComplex}, lda::Cint, x::CuPtr{cuComplex},
-                                    incx::Cint, beta::RefOrCuRef{cuComplex},
-                                    y::CuPtr{cuComplex}, incy::Cint)::cublasStatus_t
+    @gcsafe_ccall libcublas.cublasCgemv_v2(handle::cublasHandle_t, trans::cublasOperation_t,
+                                           m::Cint, n::Cint, alpha::RefOrCuRef{cuComplex},
+                                           A::CuPtr{cuComplex}, lda::Cint,
+                                           x::CuPtr{cuComplex}, incx::Cint,
+                                           beta::RefOrCuRef{cuComplex}, y::CuPtr{cuComplex},
+                                           incy::Cint)::cublasStatus_t
 end
 
 @checked function cublasZgemv_v2(handle, trans, m, n, alpha, A, lda, x, incx, beta, y, incy)
     initialize_context()
-    @ccall libcublas.cublasZgemv_v2(handle::cublasHandle_t, trans::cublasOperation_t,
-                                    m::Cint, n::Cint, alpha::RefOrCuRef{cuDoubleComplex},
-                                    A::CuPtr{cuDoubleComplex}, lda::Cint,
-                                    x::CuPtr{cuDoubleComplex}, incx::Cint,
-                                    beta::RefOrCuRef{cuDoubleComplex},
-                                    y::CuPtr{cuDoubleComplex}, incy::Cint)::cublasStatus_t
+    @gcsafe_ccall libcublas.cublasZgemv_v2(handle::cublasHandle_t, trans::cublasOperation_t,
+                                           m::Cint, n::Cint,
+                                           alpha::RefOrCuRef{cuDoubleComplex},
+                                           A::CuPtr{cuDoubleComplex}, lda::Cint,
+                                           x::CuPtr{cuDoubleComplex}, incx::Cint,
+                                           beta::RefOrCuRef{cuDoubleComplex},
+                                           y::CuPtr{cuDoubleComplex},
+                                           incy::Cint)::cublasStatus_t
 end
 
 @checked function cublasSgbmv_v2(handle, trans, m, n, kl, ku, alpha, A, lda, x, incx, beta,
                                  y, incy)
     initialize_context()
-    @ccall libcublas.cublasSgbmv_v2(handle::cublasHandle_t, trans::cublasOperation_t,
-                                    m::Cint, n::Cint, kl::Cint, ku::Cint,
-                                    alpha::RefOrCuRef{Cfloat}, A::CuPtr{Cfloat}, lda::Cint,
-                                    x::CuPtr{Cfloat}, incx::Cint, beta::RefOrCuRef{Cfloat},
-                                    y::CuPtr{Cfloat}, incy::Cint)::cublasStatus_t
+    @gcsafe_ccall libcublas.cublasSgbmv_v2(handle::cublasHandle_t, trans::cublasOperation_t,
+                                           m::Cint, n::Cint, kl::Cint, ku::Cint,
+                                           alpha::RefOrCuRef{Cfloat}, A::CuPtr{Cfloat},
+                                           lda::Cint, x::CuPtr{Cfloat}, incx::Cint,
+                                           beta::RefOrCuRef{Cfloat}, y::CuPtr{Cfloat},
+                                           incy::Cint)::cublasStatus_t
 end
 
 @checked function cublasDgbmv_v2(handle, trans, m, n, kl, ku, alpha, A, lda, x, incx, beta,
                                  y, incy)
     initialize_context()
-    @ccall libcublas.cublasDgbmv_v2(handle::cublasHandle_t, trans::cublasOperation_t,
-                                    m::Cint, n::Cint, kl::Cint, ku::Cint,
-                                    alpha::RefOrCuRef{Cdouble}, A::CuPtr{Cdouble},
-                                    lda::Cint, x::CuPtr{Cdouble}, incx::Cint,
-                                    beta::RefOrCuRef{Cdouble}, y::CuPtr{Cdouble},
-                                    incy::Cint)::cublasStatus_t
+    @gcsafe_ccall libcublas.cublasDgbmv_v2(handle::cublasHandle_t, trans::cublasOperation_t,
+                                           m::Cint, n::Cint, kl::Cint, ku::Cint,
+                                           alpha::RefOrCuRef{Cdouble}, A::CuPtr{Cdouble},
+                                           lda::Cint, x::CuPtr{Cdouble}, incx::Cint,
+                                           beta::RefOrCuRef{Cdouble}, y::CuPtr{Cdouble},
+                                           incy::Cint)::cublasStatus_t
 end
 
 @checked function cublasCgbmv_v2(handle, trans, m, n, kl, ku, alpha, A, lda, x, incx, beta,
                                  y, incy)
     initialize_context()
-    @ccall libcublas.cublasCgbmv_v2(handle::cublasHandle_t, trans::cublasOperation_t,
-                                    m::Cint, n::Cint, kl::Cint, ku::Cint,
-                                    alpha::RefOrCuRef{cuComplex}, A::CuPtr{cuComplex},
-                                    lda::Cint, x::CuPtr{cuComplex}, incx::Cint,
-                                    beta::RefOrCuRef{cuComplex}, y::CuPtr{cuComplex},
-                                    incy::Cint)::cublasStatus_t
+    @gcsafe_ccall libcublas.cublasCgbmv_v2(handle::cublasHandle_t, trans::cublasOperation_t,
+                                           m::Cint, n::Cint, kl::Cint, ku::Cint,
+                                           alpha::RefOrCuRef{cuComplex},
+                                           A::CuPtr{cuComplex}, lda::Cint,
+                                           x::CuPtr{cuComplex}, incx::Cint,
+                                           beta::RefOrCuRef{cuComplex}, y::CuPtr{cuComplex},
+                                           incy::Cint)::cublasStatus_t
 end
 
 @checked function cublasZgbmv_v2(handle, trans, m, n, kl, ku, alpha, A, lda, x, incx, beta,
                                  y, incy)
     initialize_context()
-    @ccall libcublas.cublasZgbmv_v2(handle::cublasHandle_t, trans::cublasOperation_t,
-                                    m::Cint, n::Cint, kl::Cint, ku::Cint,
-                                    alpha::RefOrCuRef{cuDoubleComplex},
-                                    A::CuPtr{cuDoubleComplex}, lda::Cint,
-                                    x::CuPtr{cuDoubleComplex}, incx::Cint,
-                                    beta::RefOrCuRef{cuDoubleComplex},
-                                    y::CuPtr{cuDoubleComplex}, incy::Cint)::cublasStatus_t
+    @gcsafe_ccall libcublas.cublasZgbmv_v2(handle::cublasHandle_t, trans::cublasOperation_t,
+                                           m::Cint, n::Cint, kl::Cint, ku::Cint,
+                                           alpha::RefOrCuRef{cuDoubleComplex},
+                                           A::CuPtr{cuDoubleComplex}, lda::Cint,
+                                           x::CuPtr{cuDoubleComplex}, incx::Cint,
+                                           beta::RefOrCuRef{cuDoubleComplex},
+                                           y::CuPtr{cuDoubleComplex},
+                                           incy::Cint)::cublasStatus_t
 end
 
 @cenum cublasFillMode_t::UInt32 begin
@@ -578,694 +613,746 @@ end
 
 @checked function cublasStrmv_v2(handle, uplo, trans, diag, n, A, lda, x, incx)
     initialize_context()
-    @ccall libcublas.cublasStrmv_v2(handle::cublasHandle_t, uplo::cublasFillMode_t,
-                                    trans::cublasOperation_t, diag::cublasDiagType_t,
-                                    n::Cint, A::CuPtr{Cfloat}, lda::Cint, x::CuPtr{Cfloat},
-                                    incx::Cint)::cublasStatus_t
+    @gcsafe_ccall libcublas.cublasStrmv_v2(handle::cublasHandle_t, uplo::cublasFillMode_t,
+                                           trans::cublasOperation_t, diag::cublasDiagType_t,
+                                           n::Cint, A::CuPtr{Cfloat}, lda::Cint,
+                                           x::CuPtr{Cfloat}, incx::Cint)::cublasStatus_t
 end
 
 @checked function cublasDtrmv_v2(handle, uplo, trans, diag, n, A, lda, x, incx)
     initialize_context()
-    @ccall libcublas.cublasDtrmv_v2(handle::cublasHandle_t, uplo::cublasFillMode_t,
-                                    trans::cublasOperation_t, diag::cublasDiagType_t,
-                                    n::Cint, A::CuPtr{Cdouble}, lda::Cint,
-                                    x::CuPtr{Cdouble}, incx::Cint)::cublasStatus_t
+    @gcsafe_ccall libcublas.cublasDtrmv_v2(handle::cublasHandle_t, uplo::cublasFillMode_t,
+                                           trans::cublasOperation_t, diag::cublasDiagType_t,
+                                           n::Cint, A::CuPtr{Cdouble}, lda::Cint,
+                                           x::CuPtr{Cdouble}, incx::Cint)::cublasStatus_t
 end
 
 @checked function cublasCtrmv_v2(handle, uplo, trans, diag, n, A, lda, x, incx)
     initialize_context()
-    @ccall libcublas.cublasCtrmv_v2(handle::cublasHandle_t, uplo::cublasFillMode_t,
-                                    trans::cublasOperation_t, diag::cublasDiagType_t,
-                                    n::Cint, A::CuPtr{cuComplex}, lda::Cint,
-                                    x::CuPtr{cuComplex}, incx::Cint)::cublasStatus_t
+    @gcsafe_ccall libcublas.cublasCtrmv_v2(handle::cublasHandle_t, uplo::cublasFillMode_t,
+                                           trans::cublasOperation_t, diag::cublasDiagType_t,
+                                           n::Cint, A::CuPtr{cuComplex}, lda::Cint,
+                                           x::CuPtr{cuComplex}, incx::Cint)::cublasStatus_t
 end
 
 @checked function cublasZtrmv_v2(handle, uplo, trans, diag, n, A, lda, x, incx)
     initialize_context()
-    @ccall libcublas.cublasZtrmv_v2(handle::cublasHandle_t, uplo::cublasFillMode_t,
-                                    trans::cublasOperation_t, diag::cublasDiagType_t,
-                                    n::Cint, A::CuPtr{cuDoubleComplex}, lda::Cint,
-                                    x::CuPtr{cuDoubleComplex}, incx::Cint)::cublasStatus_t
+    @gcsafe_ccall libcublas.cublasZtrmv_v2(handle::cublasHandle_t, uplo::cublasFillMode_t,
+                                           trans::cublasOperation_t, diag::cublasDiagType_t,
+                                           n::Cint, A::CuPtr{cuDoubleComplex}, lda::Cint,
+                                           x::CuPtr{cuDoubleComplex},
+                                           incx::Cint)::cublasStatus_t
 end
 
 @checked function cublasStbmv_v2(handle, uplo, trans, diag, n, k, A, lda, x, incx)
     initialize_context()
-    @ccall libcublas.cublasStbmv_v2(handle::cublasHandle_t, uplo::cublasFillMode_t,
-                                    trans::cublasOperation_t, diag::cublasDiagType_t,
-                                    n::Cint, k::Cint, A::CuPtr{Cfloat}, lda::Cint,
-                                    x::CuPtr{Cfloat}, incx::Cint)::cublasStatus_t
+    @gcsafe_ccall libcublas.cublasStbmv_v2(handle::cublasHandle_t, uplo::cublasFillMode_t,
+                                           trans::cublasOperation_t, diag::cublasDiagType_t,
+                                           n::Cint, k::Cint, A::CuPtr{Cfloat}, lda::Cint,
+                                           x::CuPtr{Cfloat}, incx::Cint)::cublasStatus_t
 end
 
 @checked function cublasDtbmv_v2(handle, uplo, trans, diag, n, k, A, lda, x, incx)
     initialize_context()
-    @ccall libcublas.cublasDtbmv_v2(handle::cublasHandle_t, uplo::cublasFillMode_t,
-                                    trans::cublasOperation_t, diag::cublasDiagType_t,
-                                    n::Cint, k::Cint, A::CuPtr{Cdouble}, lda::Cint,
-                                    x::CuPtr{Cdouble}, incx::Cint)::cublasStatus_t
+    @gcsafe_ccall libcublas.cublasDtbmv_v2(handle::cublasHandle_t, uplo::cublasFillMode_t,
+                                           trans::cublasOperation_t, diag::cublasDiagType_t,
+                                           n::Cint, k::Cint, A::CuPtr{Cdouble}, lda::Cint,
+                                           x::CuPtr{Cdouble}, incx::Cint)::cublasStatus_t
 end
 
 @checked function cublasCtbmv_v2(handle, uplo, trans, diag, n, k, A, lda, x, incx)
     initialize_context()
-    @ccall libcublas.cublasCtbmv_v2(handle::cublasHandle_t, uplo::cublasFillMode_t,
-                                    trans::cublasOperation_t, diag::cublasDiagType_t,
-                                    n::Cint, k::Cint, A::CuPtr{cuComplex}, lda::Cint,
-                                    x::CuPtr{cuComplex}, incx::Cint)::cublasStatus_t
+    @gcsafe_ccall libcublas.cublasCtbmv_v2(handle::cublasHandle_t, uplo::cublasFillMode_t,
+                                           trans::cublasOperation_t, diag::cublasDiagType_t,
+                                           n::Cint, k::Cint, A::CuPtr{cuComplex}, lda::Cint,
+                                           x::CuPtr{cuComplex}, incx::Cint)::cublasStatus_t
 end
 
 @checked function cublasZtbmv_v2(handle, uplo, trans, diag, n, k, A, lda, x, incx)
     initialize_context()
-    @ccall libcublas.cublasZtbmv_v2(handle::cublasHandle_t, uplo::cublasFillMode_t,
-                                    trans::cublasOperation_t, diag::cublasDiagType_t,
-                                    n::Cint, k::Cint, A::CuPtr{cuDoubleComplex}, lda::Cint,
-                                    x::CuPtr{cuDoubleComplex}, incx::Cint)::cublasStatus_t
+    @gcsafe_ccall libcublas.cublasZtbmv_v2(handle::cublasHandle_t, uplo::cublasFillMode_t,
+                                           trans::cublasOperation_t, diag::cublasDiagType_t,
+                                           n::Cint, k::Cint, A::CuPtr{cuDoubleComplex},
+                                           lda::Cint, x::CuPtr{cuDoubleComplex},
+                                           incx::Cint)::cublasStatus_t
 end
 
 @checked function cublasStpmv_v2(handle, uplo, trans, diag, n, AP, x, incx)
     initialize_context()
-    @ccall libcublas.cublasStpmv_v2(handle::cublasHandle_t, uplo::cublasFillMode_t,
-                                    trans::cublasOperation_t, diag::cublasDiagType_t,
-                                    n::Cint, AP::CuPtr{Cfloat}, x::CuPtr{Cfloat},
-                                    incx::Cint)::cublasStatus_t
+    @gcsafe_ccall libcublas.cublasStpmv_v2(handle::cublasHandle_t, uplo::cublasFillMode_t,
+                                           trans::cublasOperation_t, diag::cublasDiagType_t,
+                                           n::Cint, AP::CuPtr{Cfloat}, x::CuPtr{Cfloat},
+                                           incx::Cint)::cublasStatus_t
 end
 
 @checked function cublasDtpmv_v2(handle, uplo, trans, diag, n, AP, x, incx)
     initialize_context()
-    @ccall libcublas.cublasDtpmv_v2(handle::cublasHandle_t, uplo::cublasFillMode_t,
-                                    trans::cublasOperation_t, diag::cublasDiagType_t,
-                                    n::Cint, AP::CuPtr{Cdouble}, x::CuPtr{Cdouble},
-                                    incx::Cint)::cublasStatus_t
+    @gcsafe_ccall libcublas.cublasDtpmv_v2(handle::cublasHandle_t, uplo::cublasFillMode_t,
+                                           trans::cublasOperation_t, diag::cublasDiagType_t,
+                                           n::Cint, AP::CuPtr{Cdouble}, x::CuPtr{Cdouble},
+                                           incx::Cint)::cublasStatus_t
 end
 
 @checked function cublasCtpmv_v2(handle, uplo, trans, diag, n, AP, x, incx)
     initialize_context()
-    @ccall libcublas.cublasCtpmv_v2(handle::cublasHandle_t, uplo::cublasFillMode_t,
-                                    trans::cublasOperation_t, diag::cublasDiagType_t,
-                                    n::Cint, AP::CuPtr{cuComplex}, x::CuPtr{cuComplex},
-                                    incx::Cint)::cublasStatus_t
+    @gcsafe_ccall libcublas.cublasCtpmv_v2(handle::cublasHandle_t, uplo::cublasFillMode_t,
+                                           trans::cublasOperation_t, diag::cublasDiagType_t,
+                                           n::Cint, AP::CuPtr{cuComplex},
+                                           x::CuPtr{cuComplex}, incx::Cint)::cublasStatus_t
 end
 
 @checked function cublasZtpmv_v2(handle, uplo, trans, diag, n, AP, x, incx)
     initialize_context()
-    @ccall libcublas.cublasZtpmv_v2(handle::cublasHandle_t, uplo::cublasFillMode_t,
-                                    trans::cublasOperation_t, diag::cublasDiagType_t,
-                                    n::Cint, AP::CuPtr{cuDoubleComplex},
-                                    x::CuPtr{cuDoubleComplex}, incx::Cint)::cublasStatus_t
+    @gcsafe_ccall libcublas.cublasZtpmv_v2(handle::cublasHandle_t, uplo::cublasFillMode_t,
+                                           trans::cublasOperation_t, diag::cublasDiagType_t,
+                                           n::Cint, AP::CuPtr{cuDoubleComplex},
+                                           x::CuPtr{cuDoubleComplex},
+                                           incx::Cint)::cublasStatus_t
 end
 
 @checked function cublasStrsv_v2(handle, uplo, trans, diag, n, A, lda, x, incx)
     initialize_context()
-    @ccall libcublas.cublasStrsv_v2(handle::cublasHandle_t, uplo::cublasFillMode_t,
-                                    trans::cublasOperation_t, diag::cublasDiagType_t,
-                                    n::Cint, A::CuPtr{Cfloat}, lda::Cint, x::CuPtr{Cfloat},
-                                    incx::Cint)::cublasStatus_t
+    @gcsafe_ccall libcublas.cublasStrsv_v2(handle::cublasHandle_t, uplo::cublasFillMode_t,
+                                           trans::cublasOperation_t, diag::cublasDiagType_t,
+                                           n::Cint, A::CuPtr{Cfloat}, lda::Cint,
+                                           x::CuPtr{Cfloat}, incx::Cint)::cublasStatus_t
 end
 
 @checked function cublasDtrsv_v2(handle, uplo, trans, diag, n, A, lda, x, incx)
     initialize_context()
-    @ccall libcublas.cublasDtrsv_v2(handle::cublasHandle_t, uplo::cublasFillMode_t,
-                                    trans::cublasOperation_t, diag::cublasDiagType_t,
-                                    n::Cint, A::CuPtr{Cdouble}, lda::Cint,
-                                    x::CuPtr{Cdouble}, incx::Cint)::cublasStatus_t
+    @gcsafe_ccall libcublas.cublasDtrsv_v2(handle::cublasHandle_t, uplo::cublasFillMode_t,
+                                           trans::cublasOperation_t, diag::cublasDiagType_t,
+                                           n::Cint, A::CuPtr{Cdouble}, lda::Cint,
+                                           x::CuPtr{Cdouble}, incx::Cint)::cublasStatus_t
 end
 
 @checked function cublasCtrsv_v2(handle, uplo, trans, diag, n, A, lda, x, incx)
     initialize_context()
-    @ccall libcublas.cublasCtrsv_v2(handle::cublasHandle_t, uplo::cublasFillMode_t,
-                                    trans::cublasOperation_t, diag::cublasDiagType_t,
-                                    n::Cint, A::CuPtr{cuComplex}, lda::Cint,
-                                    x::CuPtr{cuComplex}, incx::Cint)::cublasStatus_t
+    @gcsafe_ccall libcublas.cublasCtrsv_v2(handle::cublasHandle_t, uplo::cublasFillMode_t,
+                                           trans::cublasOperation_t, diag::cublasDiagType_t,
+                                           n::Cint, A::CuPtr{cuComplex}, lda::Cint,
+                                           x::CuPtr{cuComplex}, incx::Cint)::cublasStatus_t
 end
 
 @checked function cublasZtrsv_v2(handle, uplo, trans, diag, n, A, lda, x, incx)
     initialize_context()
-    @ccall libcublas.cublasZtrsv_v2(handle::cublasHandle_t, uplo::cublasFillMode_t,
-                                    trans::cublasOperation_t, diag::cublasDiagType_t,
-                                    n::Cint, A::CuPtr{cuDoubleComplex}, lda::Cint,
-                                    x::CuPtr{cuDoubleComplex}, incx::Cint)::cublasStatus_t
+    @gcsafe_ccall libcublas.cublasZtrsv_v2(handle::cublasHandle_t, uplo::cublasFillMode_t,
+                                           trans::cublasOperation_t, diag::cublasDiagType_t,
+                                           n::Cint, A::CuPtr{cuDoubleComplex}, lda::Cint,
+                                           x::CuPtr{cuDoubleComplex},
+                                           incx::Cint)::cublasStatus_t
 end
 
 @checked function cublasStpsv_v2(handle, uplo, trans, diag, n, AP, x, incx)
     initialize_context()
-    @ccall libcublas.cublasStpsv_v2(handle::cublasHandle_t, uplo::cublasFillMode_t,
-                                    trans::cublasOperation_t, diag::cublasDiagType_t,
-                                    n::Cint, AP::CuPtr{Cfloat}, x::CuPtr{Cfloat},
-                                    incx::Cint)::cublasStatus_t
+    @gcsafe_ccall libcublas.cublasStpsv_v2(handle::cublasHandle_t, uplo::cublasFillMode_t,
+                                           trans::cublasOperation_t, diag::cublasDiagType_t,
+                                           n::Cint, AP::CuPtr{Cfloat}, x::CuPtr{Cfloat},
+                                           incx::Cint)::cublasStatus_t
 end
 
 @checked function cublasDtpsv_v2(handle, uplo, trans, diag, n, AP, x, incx)
     initialize_context()
-    @ccall libcublas.cublasDtpsv_v2(handle::cublasHandle_t, uplo::cublasFillMode_t,
-                                    trans::cublasOperation_t, diag::cublasDiagType_t,
-                                    n::Cint, AP::CuPtr{Cdouble}, x::CuPtr{Cdouble},
-                                    incx::Cint)::cublasStatus_t
+    @gcsafe_ccall libcublas.cublasDtpsv_v2(handle::cublasHandle_t, uplo::cublasFillMode_t,
+                                           trans::cublasOperation_t, diag::cublasDiagType_t,
+                                           n::Cint, AP::CuPtr{Cdouble}, x::CuPtr{Cdouble},
+                                           incx::Cint)::cublasStatus_t
 end
 
 @checked function cublasCtpsv_v2(handle, uplo, trans, diag, n, AP, x, incx)
     initialize_context()
-    @ccall libcublas.cublasCtpsv_v2(handle::cublasHandle_t, uplo::cublasFillMode_t,
-                                    trans::cublasOperation_t, diag::cublasDiagType_t,
-                                    n::Cint, AP::CuPtr{cuComplex}, x::CuPtr{cuComplex},
-                                    incx::Cint)::cublasStatus_t
+    @gcsafe_ccall libcublas.cublasCtpsv_v2(handle::cublasHandle_t, uplo::cublasFillMode_t,
+                                           trans::cublasOperation_t, diag::cublasDiagType_t,
+                                           n::Cint, AP::CuPtr{cuComplex},
+                                           x::CuPtr{cuComplex}, incx::Cint)::cublasStatus_t
 end
 
 @checked function cublasZtpsv_v2(handle, uplo, trans, diag, n, AP, x, incx)
     initialize_context()
-    @ccall libcublas.cublasZtpsv_v2(handle::cublasHandle_t, uplo::cublasFillMode_t,
-                                    trans::cublasOperation_t, diag::cublasDiagType_t,
-                                    n::Cint, AP::CuPtr{cuDoubleComplex},
-                                    x::CuPtr{cuDoubleComplex}, incx::Cint)::cublasStatus_t
+    @gcsafe_ccall libcublas.cublasZtpsv_v2(handle::cublasHandle_t, uplo::cublasFillMode_t,
+                                           trans::cublasOperation_t, diag::cublasDiagType_t,
+                                           n::Cint, AP::CuPtr{cuDoubleComplex},
+                                           x::CuPtr{cuDoubleComplex},
+                                           incx::Cint)::cublasStatus_t
 end
 
 @checked function cublasStbsv_v2(handle, uplo, trans, diag, n, k, A, lda, x, incx)
     initialize_context()
-    @ccall libcublas.cublasStbsv_v2(handle::cublasHandle_t, uplo::cublasFillMode_t,
-                                    trans::cublasOperation_t, diag::cublasDiagType_t,
-                                    n::Cint, k::Cint, A::CuPtr{Cfloat}, lda::Cint,
-                                    x::CuPtr{Cfloat}, incx::Cint)::cublasStatus_t
+    @gcsafe_ccall libcublas.cublasStbsv_v2(handle::cublasHandle_t, uplo::cublasFillMode_t,
+                                           trans::cublasOperation_t, diag::cublasDiagType_t,
+                                           n::Cint, k::Cint, A::CuPtr{Cfloat}, lda::Cint,
+                                           x::CuPtr{Cfloat}, incx::Cint)::cublasStatus_t
 end
 
 @checked function cublasDtbsv_v2(handle, uplo, trans, diag, n, k, A, lda, x, incx)
     initialize_context()
-    @ccall libcublas.cublasDtbsv_v2(handle::cublasHandle_t, uplo::cublasFillMode_t,
-                                    trans::cublasOperation_t, diag::cublasDiagType_t,
-                                    n::Cint, k::Cint, A::CuPtr{Cdouble}, lda::Cint,
-                                    x::CuPtr{Cdouble}, incx::Cint)::cublasStatus_t
+    @gcsafe_ccall libcublas.cublasDtbsv_v2(handle::cublasHandle_t, uplo::cublasFillMode_t,
+                                           trans::cublasOperation_t, diag::cublasDiagType_t,
+                                           n::Cint, k::Cint, A::CuPtr{Cdouble}, lda::Cint,
+                                           x::CuPtr{Cdouble}, incx::Cint)::cublasStatus_t
 end
 
 @checked function cublasCtbsv_v2(handle, uplo, trans, diag, n, k, A, lda, x, incx)
     initialize_context()
-    @ccall libcublas.cublasCtbsv_v2(handle::cublasHandle_t, uplo::cublasFillMode_t,
-                                    trans::cublasOperation_t, diag::cublasDiagType_t,
-                                    n::Cint, k::Cint, A::CuPtr{cuComplex}, lda::Cint,
-                                    x::CuPtr{cuComplex}, incx::Cint)::cublasStatus_t
+    @gcsafe_ccall libcublas.cublasCtbsv_v2(handle::cublasHandle_t, uplo::cublasFillMode_t,
+                                           trans::cublasOperation_t, diag::cublasDiagType_t,
+                                           n::Cint, k::Cint, A::CuPtr{cuComplex}, lda::Cint,
+                                           x::CuPtr{cuComplex}, incx::Cint)::cublasStatus_t
 end
 
 @checked function cublasZtbsv_v2(handle, uplo, trans, diag, n, k, A, lda, x, incx)
     initialize_context()
-    @ccall libcublas.cublasZtbsv_v2(handle::cublasHandle_t, uplo::cublasFillMode_t,
-                                    trans::cublasOperation_t, diag::cublasDiagType_t,
-                                    n::Cint, k::Cint, A::CuPtr{cuDoubleComplex}, lda::Cint,
-                                    x::CuPtr{cuDoubleComplex}, incx::Cint)::cublasStatus_t
+    @gcsafe_ccall libcublas.cublasZtbsv_v2(handle::cublasHandle_t, uplo::cublasFillMode_t,
+                                           trans::cublasOperation_t, diag::cublasDiagType_t,
+                                           n::Cint, k::Cint, A::CuPtr{cuDoubleComplex},
+                                           lda::Cint, x::CuPtr{cuDoubleComplex},
+                                           incx::Cint)::cublasStatus_t
 end
 
 @checked function cublasSsymv_v2(handle, uplo, n, alpha, A, lda, x, incx, beta, y, incy)
     initialize_context()
-    @ccall libcublas.cublasSsymv_v2(handle::cublasHandle_t, uplo::cublasFillMode_t, n::Cint,
-                                    alpha::RefOrCuRef{Cfloat}, A::CuPtr{Cfloat}, lda::Cint,
-                                    x::CuPtr{Cfloat}, incx::Cint, beta::RefOrCuRef{Cfloat},
-                                    y::CuPtr{Cfloat}, incy::Cint)::cublasStatus_t
+    @gcsafe_ccall libcublas.cublasSsymv_v2(handle::cublasHandle_t, uplo::cublasFillMode_t,
+                                           n::Cint, alpha::RefOrCuRef{Cfloat},
+                                           A::CuPtr{Cfloat}, lda::Cint, x::CuPtr{Cfloat},
+                                           incx::Cint, beta::RefOrCuRef{Cfloat},
+                                           y::CuPtr{Cfloat}, incy::Cint)::cublasStatus_t
 end
 
 @checked function cublasDsymv_v2(handle, uplo, n, alpha, A, lda, x, incx, beta, y, incy)
     initialize_context()
-    @ccall libcublas.cublasDsymv_v2(handle::cublasHandle_t, uplo::cublasFillMode_t, n::Cint,
-                                    alpha::RefOrCuRef{Cdouble}, A::CuPtr{Cdouble},
-                                    lda::Cint, x::CuPtr{Cdouble}, incx::Cint,
-                                    beta::RefOrCuRef{Cdouble}, y::CuPtr{Cdouble},
-                                    incy::Cint)::cublasStatus_t
+    @gcsafe_ccall libcublas.cublasDsymv_v2(handle::cublasHandle_t, uplo::cublasFillMode_t,
+                                           n::Cint, alpha::RefOrCuRef{Cdouble},
+                                           A::CuPtr{Cdouble}, lda::Cint, x::CuPtr{Cdouble},
+                                           incx::Cint, beta::RefOrCuRef{Cdouble},
+                                           y::CuPtr{Cdouble}, incy::Cint)::cublasStatus_t
 end
 
 @checked function cublasCsymv_v2(handle, uplo, n, alpha, A, lda, x, incx, beta, y, incy)
     initialize_context()
-    @ccall libcublas.cublasCsymv_v2(handle::cublasHandle_t, uplo::cublasFillMode_t, n::Cint,
-                                    alpha::RefOrCuRef{cuComplex}, A::CuPtr{cuComplex},
-                                    lda::Cint, x::CuPtr{cuComplex}, incx::Cint,
-                                    beta::RefOrCuRef{cuComplex}, y::CuPtr{cuComplex},
-                                    incy::Cint)::cublasStatus_t
+    @gcsafe_ccall libcublas.cublasCsymv_v2(handle::cublasHandle_t, uplo::cublasFillMode_t,
+                                           n::Cint, alpha::RefOrCuRef{cuComplex},
+                                           A::CuPtr{cuComplex}, lda::Cint,
+                                           x::CuPtr{cuComplex}, incx::Cint,
+                                           beta::RefOrCuRef{cuComplex}, y::CuPtr{cuComplex},
+                                           incy::Cint)::cublasStatus_t
 end
 
 @checked function cublasZsymv_v2(handle, uplo, n, alpha, A, lda, x, incx, beta, y, incy)
     initialize_context()
-    @ccall libcublas.cublasZsymv_v2(handle::cublasHandle_t, uplo::cublasFillMode_t, n::Cint,
-                                    alpha::RefOrCuRef{cuDoubleComplex},
-                                    A::CuPtr{cuDoubleComplex}, lda::Cint,
-                                    x::CuPtr{cuDoubleComplex}, incx::Cint,
-                                    beta::RefOrCuRef{cuDoubleComplex},
-                                    y::CuPtr{cuDoubleComplex}, incy::Cint)::cublasStatus_t
+    @gcsafe_ccall libcublas.cublasZsymv_v2(handle::cublasHandle_t, uplo::cublasFillMode_t,
+                                           n::Cint, alpha::RefOrCuRef{cuDoubleComplex},
+                                           A::CuPtr{cuDoubleComplex}, lda::Cint,
+                                           x::CuPtr{cuDoubleComplex}, incx::Cint,
+                                           beta::RefOrCuRef{cuDoubleComplex},
+                                           y::CuPtr{cuDoubleComplex},
+                                           incy::Cint)::cublasStatus_t
 end
 
 @checked function cublasChemv_v2(handle, uplo, n, alpha, A, lda, x, incx, beta, y, incy)
     initialize_context()
-    @ccall libcublas.cublasChemv_v2(handle::cublasHandle_t, uplo::cublasFillMode_t, n::Cint,
-                                    alpha::RefOrCuRef{cuComplex}, A::CuPtr{cuComplex},
-                                    lda::Cint, x::CuPtr{cuComplex}, incx::Cint,
-                                    beta::RefOrCuRef{cuComplex}, y::CuPtr{cuComplex},
-                                    incy::Cint)::cublasStatus_t
+    @gcsafe_ccall libcublas.cublasChemv_v2(handle::cublasHandle_t, uplo::cublasFillMode_t,
+                                           n::Cint, alpha::RefOrCuRef{cuComplex},
+                                           A::CuPtr{cuComplex}, lda::Cint,
+                                           x::CuPtr{cuComplex}, incx::Cint,
+                                           beta::RefOrCuRef{cuComplex}, y::CuPtr{cuComplex},
+                                           incy::Cint)::cublasStatus_t
 end
 
 @checked function cublasZhemv_v2(handle, uplo, n, alpha, A, lda, x, incx, beta, y, incy)
     initialize_context()
-    @ccall libcublas.cublasZhemv_v2(handle::cublasHandle_t, uplo::cublasFillMode_t, n::Cint,
-                                    alpha::RefOrCuRef{cuDoubleComplex},
-                                    A::CuPtr{cuDoubleComplex}, lda::Cint,
-                                    x::CuPtr{cuDoubleComplex}, incx::Cint,
-                                    beta::RefOrCuRef{cuDoubleComplex},
-                                    y::CuPtr{cuDoubleComplex}, incy::Cint)::cublasStatus_t
+    @gcsafe_ccall libcublas.cublasZhemv_v2(handle::cublasHandle_t, uplo::cublasFillMode_t,
+                                           n::Cint, alpha::RefOrCuRef{cuDoubleComplex},
+                                           A::CuPtr{cuDoubleComplex}, lda::Cint,
+                                           x::CuPtr{cuDoubleComplex}, incx::Cint,
+                                           beta::RefOrCuRef{cuDoubleComplex},
+                                           y::CuPtr{cuDoubleComplex},
+                                           incy::Cint)::cublasStatus_t
 end
 
 @checked function cublasSsbmv_v2(handle, uplo, n, k, alpha, A, lda, x, incx, beta, y, incy)
     initialize_context()
-    @ccall libcublas.cublasSsbmv_v2(handle::cublasHandle_t, uplo::cublasFillMode_t, n::Cint,
-                                    k::Cint, alpha::RefOrCuRef{Cfloat}, A::CuPtr{Cfloat},
-                                    lda::Cint, x::CuPtr{Cfloat}, incx::Cint,
-                                    beta::RefOrCuRef{Cfloat}, y::CuPtr{Cfloat},
-                                    incy::Cint)::cublasStatus_t
+    @gcsafe_ccall libcublas.cublasSsbmv_v2(handle::cublasHandle_t, uplo::cublasFillMode_t,
+                                           n::Cint, k::Cint, alpha::RefOrCuRef{Cfloat},
+                                           A::CuPtr{Cfloat}, lda::Cint, x::CuPtr{Cfloat},
+                                           incx::Cint, beta::RefOrCuRef{Cfloat},
+                                           y::CuPtr{Cfloat}, incy::Cint)::cublasStatus_t
 end
 
 @checked function cublasDsbmv_v2(handle, uplo, n, k, alpha, A, lda, x, incx, beta, y, incy)
     initialize_context()
-    @ccall libcublas.cublasDsbmv_v2(handle::cublasHandle_t, uplo::cublasFillMode_t, n::Cint,
-                                    k::Cint, alpha::RefOrCuRef{Cdouble}, A::CuPtr{Cdouble},
-                                    lda::Cint, x::CuPtr{Cdouble}, incx::Cint,
-                                    beta::RefOrCuRef{Cdouble}, y::CuPtr{Cdouble},
-                                    incy::Cint)::cublasStatus_t
+    @gcsafe_ccall libcublas.cublasDsbmv_v2(handle::cublasHandle_t, uplo::cublasFillMode_t,
+                                           n::Cint, k::Cint, alpha::RefOrCuRef{Cdouble},
+                                           A::CuPtr{Cdouble}, lda::Cint, x::CuPtr{Cdouble},
+                                           incx::Cint, beta::RefOrCuRef{Cdouble},
+                                           y::CuPtr{Cdouble}, incy::Cint)::cublasStatus_t
 end
 
 @checked function cublasChbmv_v2(handle, uplo, n, k, alpha, A, lda, x, incx, beta, y, incy)
     initialize_context()
-    @ccall libcublas.cublasChbmv_v2(handle::cublasHandle_t, uplo::cublasFillMode_t, n::Cint,
-                                    k::Cint, alpha::RefOrCuRef{cuComplex},
-                                    A::CuPtr{cuComplex}, lda::Cint, x::CuPtr{cuComplex},
-                                    incx::Cint, beta::RefOrCuRef{cuComplex},
-                                    y::CuPtr{cuComplex}, incy::Cint)::cublasStatus_t
+    @gcsafe_ccall libcublas.cublasChbmv_v2(handle::cublasHandle_t, uplo::cublasFillMode_t,
+                                           n::Cint, k::Cint, alpha::RefOrCuRef{cuComplex},
+                                           A::CuPtr{cuComplex}, lda::Cint,
+                                           x::CuPtr{cuComplex}, incx::Cint,
+                                           beta::RefOrCuRef{cuComplex}, y::CuPtr{cuComplex},
+                                           incy::Cint)::cublasStatus_t
 end
 
 @checked function cublasZhbmv_v2(handle, uplo, n, k, alpha, A, lda, x, incx, beta, y, incy)
     initialize_context()
-    @ccall libcublas.cublasZhbmv_v2(handle::cublasHandle_t, uplo::cublasFillMode_t, n::Cint,
-                                    k::Cint, alpha::RefOrCuRef{cuDoubleComplex},
-                                    A::CuPtr{cuDoubleComplex}, lda::Cint,
-                                    x::CuPtr{cuDoubleComplex}, incx::Cint,
-                                    beta::RefOrCuRef{cuDoubleComplex},
-                                    y::CuPtr{cuDoubleComplex}, incy::Cint)::cublasStatus_t
+    @gcsafe_ccall libcublas.cublasZhbmv_v2(handle::cublasHandle_t, uplo::cublasFillMode_t,
+                                           n::Cint, k::Cint,
+                                           alpha::RefOrCuRef{cuDoubleComplex},
+                                           A::CuPtr{cuDoubleComplex}, lda::Cint,
+                                           x::CuPtr{cuDoubleComplex}, incx::Cint,
+                                           beta::RefOrCuRef{cuDoubleComplex},
+                                           y::CuPtr{cuDoubleComplex},
+                                           incy::Cint)::cublasStatus_t
 end
 
 @checked function cublasSspmv_v2(handle, uplo, n, alpha, AP, x, incx, beta, y, incy)
     initialize_context()
-    @ccall libcublas.cublasSspmv_v2(handle::cublasHandle_t, uplo::cublasFillMode_t, n::Cint,
-                                    alpha::RefOrCuRef{Cfloat}, AP::CuPtr{Cfloat},
-                                    x::CuPtr{Cfloat}, incx::Cint, beta::RefOrCuRef{Cfloat},
-                                    y::CuPtr{Cfloat}, incy::Cint)::cublasStatus_t
+    @gcsafe_ccall libcublas.cublasSspmv_v2(handle::cublasHandle_t, uplo::cublasFillMode_t,
+                                           n::Cint, alpha::RefOrCuRef{Cfloat},
+                                           AP::CuPtr{Cfloat}, x::CuPtr{Cfloat}, incx::Cint,
+                                           beta::RefOrCuRef{Cfloat}, y::CuPtr{Cfloat},
+                                           incy::Cint)::cublasStatus_t
 end
 
 @checked function cublasDspmv_v2(handle, uplo, n, alpha, AP, x, incx, beta, y, incy)
     initialize_context()
-    @ccall libcublas.cublasDspmv_v2(handle::cublasHandle_t, uplo::cublasFillMode_t, n::Cint,
-                                    alpha::RefOrCuRef{Cdouble}, AP::CuPtr{Cdouble},
-                                    x::CuPtr{Cdouble}, incx::Cint,
-                                    beta::RefOrCuRef{Cdouble}, y::CuPtr{Cdouble},
-                                    incy::Cint)::cublasStatus_t
+    @gcsafe_ccall libcublas.cublasDspmv_v2(handle::cublasHandle_t, uplo::cublasFillMode_t,
+                                           n::Cint, alpha::RefOrCuRef{Cdouble},
+                                           AP::CuPtr{Cdouble}, x::CuPtr{Cdouble},
+                                           incx::Cint, beta::RefOrCuRef{Cdouble},
+                                           y::CuPtr{Cdouble}, incy::Cint)::cublasStatus_t
 end
 
 @checked function cublasChpmv_v2(handle, uplo, n, alpha, AP, x, incx, beta, y, incy)
     initialize_context()
-    @ccall libcublas.cublasChpmv_v2(handle::cublasHandle_t, uplo::cublasFillMode_t, n::Cint,
-                                    alpha::RefOrCuRef{cuComplex}, AP::CuPtr{cuComplex},
-                                    x::CuPtr{cuComplex}, incx::Cint,
-                                    beta::RefOrCuRef{cuComplex}, y::CuPtr{cuComplex},
-                                    incy::Cint)::cublasStatus_t
+    @gcsafe_ccall libcublas.cublasChpmv_v2(handle::cublasHandle_t, uplo::cublasFillMode_t,
+                                           n::Cint, alpha::RefOrCuRef{cuComplex},
+                                           AP::CuPtr{cuComplex}, x::CuPtr{cuComplex},
+                                           incx::Cint, beta::RefOrCuRef{cuComplex},
+                                           y::CuPtr{cuComplex}, incy::Cint)::cublasStatus_t
 end
 
 @checked function cublasZhpmv_v2(handle, uplo, n, alpha, AP, x, incx, beta, y, incy)
     initialize_context()
-    @ccall libcublas.cublasZhpmv_v2(handle::cublasHandle_t, uplo::cublasFillMode_t, n::Cint,
-                                    alpha::RefOrCuRef{cuDoubleComplex},
-                                    AP::CuPtr{cuDoubleComplex}, x::CuPtr{cuDoubleComplex},
-                                    incx::Cint, beta::RefOrCuRef{cuDoubleComplex},
-                                    y::CuPtr{cuDoubleComplex}, incy::Cint)::cublasStatus_t
+    @gcsafe_ccall libcublas.cublasZhpmv_v2(handle::cublasHandle_t, uplo::cublasFillMode_t,
+                                           n::Cint, alpha::RefOrCuRef{cuDoubleComplex},
+                                           AP::CuPtr{cuDoubleComplex},
+                                           x::CuPtr{cuDoubleComplex}, incx::Cint,
+                                           beta::RefOrCuRef{cuDoubleComplex},
+                                           y::CuPtr{cuDoubleComplex},
+                                           incy::Cint)::cublasStatus_t
 end
 
 @checked function cublasSger_v2(handle, m, n, alpha, x, incx, y, incy, A, lda)
     initialize_context()
-    @ccall libcublas.cublasSger_v2(handle::cublasHandle_t, m::Cint, n::Cint,
-                                   alpha::RefOrCuRef{Cfloat}, x::CuPtr{Cfloat}, incx::Cint,
-                                   y::CuPtr{Cfloat}, incy::Cint, A::CuPtr{Cfloat},
-                                   lda::Cint)::cublasStatus_t
+    @gcsafe_ccall libcublas.cublasSger_v2(handle::cublasHandle_t, m::Cint, n::Cint,
+                                          alpha::RefOrCuRef{Cfloat}, x::CuPtr{Cfloat},
+                                          incx::Cint, y::CuPtr{Cfloat}, incy::Cint,
+                                          A::CuPtr{Cfloat}, lda::Cint)::cublasStatus_t
 end
 
 @checked function cublasDger_v2(handle, m, n, alpha, x, incx, y, incy, A, lda)
     initialize_context()
-    @ccall libcublas.cublasDger_v2(handle::cublasHandle_t, m::Cint, n::Cint,
-                                   alpha::RefOrCuRef{Cdouble}, x::CuPtr{Cdouble},
-                                   incx::Cint, y::CuPtr{Cdouble}, incy::Cint,
-                                   A::CuPtr{Cdouble}, lda::Cint)::cublasStatus_t
+    @gcsafe_ccall libcublas.cublasDger_v2(handle::cublasHandle_t, m::Cint, n::Cint,
+                                          alpha::RefOrCuRef{Cdouble}, x::CuPtr{Cdouble},
+                                          incx::Cint, y::CuPtr{Cdouble}, incy::Cint,
+                                          A::CuPtr{Cdouble}, lda::Cint)::cublasStatus_t
 end
 
 @checked function cublasCgeru_v2(handle, m, n, alpha, x, incx, y, incy, A, lda)
     initialize_context()
-    @ccall libcublas.cublasCgeru_v2(handle::cublasHandle_t, m::Cint, n::Cint,
-                                    alpha::RefOrCuRef{cuComplex}, x::CuPtr{cuComplex},
-                                    incx::Cint, y::CuPtr{cuComplex}, incy::Cint,
-                                    A::CuPtr{cuComplex}, lda::Cint)::cublasStatus_t
+    @gcsafe_ccall libcublas.cublasCgeru_v2(handle::cublasHandle_t, m::Cint, n::Cint,
+                                           alpha::RefOrCuRef{cuComplex},
+                                           x::CuPtr{cuComplex}, incx::Cint,
+                                           y::CuPtr{cuComplex}, incy::Cint,
+                                           A::CuPtr{cuComplex}, lda::Cint)::cublasStatus_t
 end
 
 @checked function cublasCgerc_v2(handle, m, n, alpha, x, incx, y, incy, A, lda)
     initialize_context()
-    @ccall libcublas.cublasCgerc_v2(handle::cublasHandle_t, m::Cint, n::Cint,
-                                    alpha::RefOrCuRef{cuComplex}, x::CuPtr{cuComplex},
-                                    incx::Cint, y::CuPtr{cuComplex}, incy::Cint,
-                                    A::CuPtr{cuComplex}, lda::Cint)::cublasStatus_t
+    @gcsafe_ccall libcublas.cublasCgerc_v2(handle::cublasHandle_t, m::Cint, n::Cint,
+                                           alpha::RefOrCuRef{cuComplex},
+                                           x::CuPtr{cuComplex}, incx::Cint,
+                                           y::CuPtr{cuComplex}, incy::Cint,
+                                           A::CuPtr{cuComplex}, lda::Cint)::cublasStatus_t
 end
 
 @checked function cublasZgeru_v2(handle, m, n, alpha, x, incx, y, incy, A, lda)
     initialize_context()
-    @ccall libcublas.cublasZgeru_v2(handle::cublasHandle_t, m::Cint, n::Cint,
-                                    alpha::RefOrCuRef{cuDoubleComplex},
-                                    x::CuPtr{cuDoubleComplex}, incx::Cint,
-                                    y::CuPtr{cuDoubleComplex}, incy::Cint,
-                                    A::CuPtr{cuDoubleComplex}, lda::Cint)::cublasStatus_t
+    @gcsafe_ccall libcublas.cublasZgeru_v2(handle::cublasHandle_t, m::Cint, n::Cint,
+                                           alpha::RefOrCuRef{cuDoubleComplex},
+                                           x::CuPtr{cuDoubleComplex}, incx::Cint,
+                                           y::CuPtr{cuDoubleComplex}, incy::Cint,
+                                           A::CuPtr{cuDoubleComplex},
+                                           lda::Cint)::cublasStatus_t
 end
 
 @checked function cublasZgerc_v2(handle, m, n, alpha, x, incx, y, incy, A, lda)
     initialize_context()
-    @ccall libcublas.cublasZgerc_v2(handle::cublasHandle_t, m::Cint, n::Cint,
-                                    alpha::RefOrCuRef{cuDoubleComplex},
-                                    x::CuPtr{cuDoubleComplex}, incx::Cint,
-                                    y::CuPtr{cuDoubleComplex}, incy::Cint,
-                                    A::CuPtr{cuDoubleComplex}, lda::Cint)::cublasStatus_t
+    @gcsafe_ccall libcublas.cublasZgerc_v2(handle::cublasHandle_t, m::Cint, n::Cint,
+                                           alpha::RefOrCuRef{cuDoubleComplex},
+                                           x::CuPtr{cuDoubleComplex}, incx::Cint,
+                                           y::CuPtr{cuDoubleComplex}, incy::Cint,
+                                           A::CuPtr{cuDoubleComplex},
+                                           lda::Cint)::cublasStatus_t
 end
 
 @checked function cublasSsyr_v2(handle, uplo, n, alpha, x, incx, A, lda)
     initialize_context()
-    @ccall libcublas.cublasSsyr_v2(handle::cublasHandle_t, uplo::cublasFillMode_t, n::Cint,
-                                   alpha::RefOrCuRef{Cfloat}, x::CuPtr{Cfloat}, incx::Cint,
-                                   A::CuPtr{Cfloat}, lda::Cint)::cublasStatus_t
+    @gcsafe_ccall libcublas.cublasSsyr_v2(handle::cublasHandle_t, uplo::cublasFillMode_t,
+                                          n::Cint, alpha::RefOrCuRef{Cfloat},
+                                          x::CuPtr{Cfloat}, incx::Cint, A::CuPtr{Cfloat},
+                                          lda::Cint)::cublasStatus_t
 end
 
 @checked function cublasDsyr_v2(handle, uplo, n, alpha, x, incx, A, lda)
     initialize_context()
-    @ccall libcublas.cublasDsyr_v2(handle::cublasHandle_t, uplo::cublasFillMode_t, n::Cint,
-                                   alpha::RefOrCuRef{Cdouble}, x::CuPtr{Cdouble},
-                                   incx::Cint, A::CuPtr{Cdouble}, lda::Cint)::cublasStatus_t
+    @gcsafe_ccall libcublas.cublasDsyr_v2(handle::cublasHandle_t, uplo::cublasFillMode_t,
+                                          n::Cint, alpha::RefOrCuRef{Cdouble},
+                                          x::CuPtr{Cdouble}, incx::Cint, A::CuPtr{Cdouble},
+                                          lda::Cint)::cublasStatus_t
 end
 
 @checked function cublasCsyr_v2(handle, uplo, n, alpha, x, incx, A, lda)
     initialize_context()
-    @ccall libcublas.cublasCsyr_v2(handle::cublasHandle_t, uplo::cublasFillMode_t, n::Cint,
-                                   alpha::RefOrCuRef{cuComplex}, x::CuPtr{cuComplex},
-                                   incx::Cint, A::CuPtr{cuComplex},
-                                   lda::Cint)::cublasStatus_t
+    @gcsafe_ccall libcublas.cublasCsyr_v2(handle::cublasHandle_t, uplo::cublasFillMode_t,
+                                          n::Cint, alpha::RefOrCuRef{cuComplex},
+                                          x::CuPtr{cuComplex}, incx::Cint,
+                                          A::CuPtr{cuComplex}, lda::Cint)::cublasStatus_t
 end
 
 @checked function cublasZsyr_v2(handle, uplo, n, alpha, x, incx, A, lda)
     initialize_context()
-    @ccall libcublas.cublasZsyr_v2(handle::cublasHandle_t, uplo::cublasFillMode_t, n::Cint,
-                                   alpha::RefOrCuRef{cuDoubleComplex},
-                                   x::CuPtr{cuDoubleComplex}, incx::Cint,
-                                   A::CuPtr{cuDoubleComplex}, lda::Cint)::cublasStatus_t
+    @gcsafe_ccall libcublas.cublasZsyr_v2(handle::cublasHandle_t, uplo::cublasFillMode_t,
+                                          n::Cint, alpha::RefOrCuRef{cuDoubleComplex},
+                                          x::CuPtr{cuDoubleComplex}, incx::Cint,
+                                          A::CuPtr{cuDoubleComplex},
+                                          lda::Cint)::cublasStatus_t
 end
 
 @checked function cublasCher_v2(handle, uplo, n, alpha, x, incx, A, lda)
     initialize_context()
-    @ccall libcublas.cublasCher_v2(handle::cublasHandle_t, uplo::cublasFillMode_t, n::Cint,
-                                   alpha::RefOrCuRef{Cfloat}, x::CuPtr{cuComplex},
-                                   incx::Cint, A::CuPtr{cuComplex},
-                                   lda::Cint)::cublasStatus_t
+    @gcsafe_ccall libcublas.cublasCher_v2(handle::cublasHandle_t, uplo::cublasFillMode_t,
+                                          n::Cint, alpha::RefOrCuRef{Cfloat},
+                                          x::CuPtr{cuComplex}, incx::Cint,
+                                          A::CuPtr{cuComplex}, lda::Cint)::cublasStatus_t
 end
 
 @checked function cublasZher_v2(handle, uplo, n, alpha, x, incx, A, lda)
     initialize_context()
-    @ccall libcublas.cublasZher_v2(handle::cublasHandle_t, uplo::cublasFillMode_t, n::Cint,
-                                   alpha::RefOrCuRef{Cdouble}, x::CuPtr{cuDoubleComplex},
-                                   incx::Cint, A::CuPtr{cuDoubleComplex},
-                                   lda::Cint)::cublasStatus_t
+    @gcsafe_ccall libcublas.cublasZher_v2(handle::cublasHandle_t, uplo::cublasFillMode_t,
+                                          n::Cint, alpha::RefOrCuRef{Cdouble},
+                                          x::CuPtr{cuDoubleComplex}, incx::Cint,
+                                          A::CuPtr{cuDoubleComplex},
+                                          lda::Cint)::cublasStatus_t
 end
 
 @checked function cublasSspr_v2(handle, uplo, n, alpha, x, incx, AP)
     initialize_context()
-    @ccall libcublas.cublasSspr_v2(handle::cublasHandle_t, uplo::cublasFillMode_t, n::Cint,
-                                   alpha::RefOrCuRef{Cfloat}, x::CuPtr{Cfloat}, incx::Cint,
-                                   AP::CuPtr{Cfloat})::cublasStatus_t
+    @gcsafe_ccall libcublas.cublasSspr_v2(handle::cublasHandle_t, uplo::cublasFillMode_t,
+                                          n::Cint, alpha::RefOrCuRef{Cfloat},
+                                          x::CuPtr{Cfloat}, incx::Cint,
+                                          AP::CuPtr{Cfloat})::cublasStatus_t
 end
 
 @checked function cublasDspr_v2(handle, uplo, n, alpha, x, incx, AP)
     initialize_context()
-    @ccall libcublas.cublasDspr_v2(handle::cublasHandle_t, uplo::cublasFillMode_t, n::Cint,
-                                   alpha::RefOrCuRef{Cdouble}, x::CuPtr{Cdouble},
-                                   incx::Cint, AP::CuPtr{Cdouble})::cublasStatus_t
+    @gcsafe_ccall libcublas.cublasDspr_v2(handle::cublasHandle_t, uplo::cublasFillMode_t,
+                                          n::Cint, alpha::RefOrCuRef{Cdouble},
+                                          x::CuPtr{Cdouble}, incx::Cint,
+                                          AP::CuPtr{Cdouble})::cublasStatus_t
 end
 
 @checked function cublasChpr_v2(handle, uplo, n, alpha, x, incx, AP)
     initialize_context()
-    @ccall libcublas.cublasChpr_v2(handle::cublasHandle_t, uplo::cublasFillMode_t, n::Cint,
-                                   alpha::RefOrCuRef{Cfloat}, x::CuPtr{cuComplex},
-                                   incx::Cint, AP::CuPtr{cuComplex})::cublasStatus_t
+    @gcsafe_ccall libcublas.cublasChpr_v2(handle::cublasHandle_t, uplo::cublasFillMode_t,
+                                          n::Cint, alpha::RefOrCuRef{Cfloat},
+                                          x::CuPtr{cuComplex}, incx::Cint,
+                                          AP::CuPtr{cuComplex})::cublasStatus_t
 end
 
 @checked function cublasZhpr_v2(handle, uplo, n, alpha, x, incx, AP)
     initialize_context()
-    @ccall libcublas.cublasZhpr_v2(handle::cublasHandle_t, uplo::cublasFillMode_t, n::Cint,
-                                   alpha::RefOrCuRef{Cdouble}, x::CuPtr{cuDoubleComplex},
-                                   incx::Cint, AP::CuPtr{cuDoubleComplex})::cublasStatus_t
+    @gcsafe_ccall libcublas.cublasZhpr_v2(handle::cublasHandle_t, uplo::cublasFillMode_t,
+                                          n::Cint, alpha::RefOrCuRef{Cdouble},
+                                          x::CuPtr{cuDoubleComplex}, incx::Cint,
+                                          AP::CuPtr{cuDoubleComplex})::cublasStatus_t
 end
 
 @checked function cublasSsyr2_v2(handle, uplo, n, alpha, x, incx, y, incy, A, lda)
     initialize_context()
-    @ccall libcublas.cublasSsyr2_v2(handle::cublasHandle_t, uplo::cublasFillMode_t, n::Cint,
-                                    alpha::RefOrCuRef{Cfloat}, x::CuPtr{Cfloat}, incx::Cint,
-                                    y::CuPtr{Cfloat}, incy::Cint, A::CuPtr{Cfloat},
-                                    lda::Cint)::cublasStatus_t
+    @gcsafe_ccall libcublas.cublasSsyr2_v2(handle::cublasHandle_t, uplo::cublasFillMode_t,
+                                           n::Cint, alpha::RefOrCuRef{Cfloat},
+                                           x::CuPtr{Cfloat}, incx::Cint, y::CuPtr{Cfloat},
+                                           incy::Cint, A::CuPtr{Cfloat},
+                                           lda::Cint)::cublasStatus_t
 end
 
 @checked function cublasDsyr2_v2(handle, uplo, n, alpha, x, incx, y, incy, A, lda)
     initialize_context()
-    @ccall libcublas.cublasDsyr2_v2(handle::cublasHandle_t, uplo::cublasFillMode_t, n::Cint,
-                                    alpha::RefOrCuRef{Cdouble}, x::CuPtr{Cdouble},
-                                    incx::Cint, y::CuPtr{Cdouble}, incy::Cint,
-                                    A::CuPtr{Cdouble}, lda::Cint)::cublasStatus_t
+    @gcsafe_ccall libcublas.cublasDsyr2_v2(handle::cublasHandle_t, uplo::cublasFillMode_t,
+                                           n::Cint, alpha::RefOrCuRef{Cdouble},
+                                           x::CuPtr{Cdouble}, incx::Cint, y::CuPtr{Cdouble},
+                                           incy::Cint, A::CuPtr{Cdouble},
+                                           lda::Cint)::cublasStatus_t
 end
 
 @checked function cublasCsyr2_v2(handle, uplo, n, alpha, x, incx, y, incy, A, lda)
     initialize_context()
-    @ccall libcublas.cublasCsyr2_v2(handle::cublasHandle_t, uplo::cublasFillMode_t, n::Cint,
-                                    alpha::RefOrCuRef{cuComplex}, x::CuPtr{cuComplex},
-                                    incx::Cint, y::CuPtr{cuComplex}, incy::Cint,
-                                    A::CuPtr{cuComplex}, lda::Cint)::cublasStatus_t
+    @gcsafe_ccall libcublas.cublasCsyr2_v2(handle::cublasHandle_t, uplo::cublasFillMode_t,
+                                           n::Cint, alpha::RefOrCuRef{cuComplex},
+                                           x::CuPtr{cuComplex}, incx::Cint,
+                                           y::CuPtr{cuComplex}, incy::Cint,
+                                           A::CuPtr{cuComplex}, lda::Cint)::cublasStatus_t
 end
 
 @checked function cublasZsyr2_v2(handle, uplo, n, alpha, x, incx, y, incy, A, lda)
     initialize_context()
-    @ccall libcublas.cublasZsyr2_v2(handle::cublasHandle_t, uplo::cublasFillMode_t, n::Cint,
-                                    alpha::RefOrCuRef{cuDoubleComplex},
-                                    x::CuPtr{cuDoubleComplex}, incx::Cint,
-                                    y::CuPtr{cuDoubleComplex}, incy::Cint,
-                                    A::CuPtr{cuDoubleComplex}, lda::Cint)::cublasStatus_t
+    @gcsafe_ccall libcublas.cublasZsyr2_v2(handle::cublasHandle_t, uplo::cublasFillMode_t,
+                                           n::Cint, alpha::RefOrCuRef{cuDoubleComplex},
+                                           x::CuPtr{cuDoubleComplex}, incx::Cint,
+                                           y::CuPtr{cuDoubleComplex}, incy::Cint,
+                                           A::CuPtr{cuDoubleComplex},
+                                           lda::Cint)::cublasStatus_t
 end
 
 @checked function cublasCher2_v2(handle, uplo, n, alpha, x, incx, y, incy, A, lda)
     initialize_context()
-    @ccall libcublas.cublasCher2_v2(handle::cublasHandle_t, uplo::cublasFillMode_t, n::Cint,
-                                    alpha::RefOrCuRef{cuComplex}, x::CuPtr{cuComplex},
-                                    incx::Cint, y::CuPtr{cuComplex}, incy::Cint,
-                                    A::CuPtr{cuComplex}, lda::Cint)::cublasStatus_t
+    @gcsafe_ccall libcublas.cublasCher2_v2(handle::cublasHandle_t, uplo::cublasFillMode_t,
+                                           n::Cint, alpha::RefOrCuRef{cuComplex},
+                                           x::CuPtr{cuComplex}, incx::Cint,
+                                           y::CuPtr{cuComplex}, incy::Cint,
+                                           A::CuPtr{cuComplex}, lda::Cint)::cublasStatus_t
 end
 
 @checked function cublasZher2_v2(handle, uplo, n, alpha, x, incx, y, incy, A, lda)
     initialize_context()
-    @ccall libcublas.cublasZher2_v2(handle::cublasHandle_t, uplo::cublasFillMode_t, n::Cint,
-                                    alpha::RefOrCuRef{cuDoubleComplex},
-                                    x::CuPtr{cuDoubleComplex}, incx::Cint,
-                                    y::CuPtr{cuDoubleComplex}, incy::Cint,
-                                    A::CuPtr{cuDoubleComplex}, lda::Cint)::cublasStatus_t
+    @gcsafe_ccall libcublas.cublasZher2_v2(handle::cublasHandle_t, uplo::cublasFillMode_t,
+                                           n::Cint, alpha::RefOrCuRef{cuDoubleComplex},
+                                           x::CuPtr{cuDoubleComplex}, incx::Cint,
+                                           y::CuPtr{cuDoubleComplex}, incy::Cint,
+                                           A::CuPtr{cuDoubleComplex},
+                                           lda::Cint)::cublasStatus_t
 end
 
 @checked function cublasSspr2_v2(handle, uplo, n, alpha, x, incx, y, incy, AP)
     initialize_context()
-    @ccall libcublas.cublasSspr2_v2(handle::cublasHandle_t, uplo::cublasFillMode_t, n::Cint,
-                                    alpha::RefOrCuRef{Cfloat}, x::CuPtr{Cfloat}, incx::Cint,
-                                    y::CuPtr{Cfloat}, incy::Cint,
-                                    AP::CuPtr{Cfloat})::cublasStatus_t
+    @gcsafe_ccall libcublas.cublasSspr2_v2(handle::cublasHandle_t, uplo::cublasFillMode_t,
+                                           n::Cint, alpha::RefOrCuRef{Cfloat},
+                                           x::CuPtr{Cfloat}, incx::Cint, y::CuPtr{Cfloat},
+                                           incy::Cint, AP::CuPtr{Cfloat})::cublasStatus_t
 end
 
 @checked function cublasDspr2_v2(handle, uplo, n, alpha, x, incx, y, incy, AP)
     initialize_context()
-    @ccall libcublas.cublasDspr2_v2(handle::cublasHandle_t, uplo::cublasFillMode_t, n::Cint,
-                                    alpha::RefOrCuRef{Cdouble}, x::CuPtr{Cdouble},
-                                    incx::Cint, y::CuPtr{Cdouble}, incy::Cint,
-                                    AP::CuPtr{Cdouble})::cublasStatus_t
+    @gcsafe_ccall libcublas.cublasDspr2_v2(handle::cublasHandle_t, uplo::cublasFillMode_t,
+                                           n::Cint, alpha::RefOrCuRef{Cdouble},
+                                           x::CuPtr{Cdouble}, incx::Cint, y::CuPtr{Cdouble},
+                                           incy::Cint, AP::CuPtr{Cdouble})::cublasStatus_t
 end
 
 @checked function cublasChpr2_v2(handle, uplo, n, alpha, x, incx, y, incy, AP)
     initialize_context()
-    @ccall libcublas.cublasChpr2_v2(handle::cublasHandle_t, uplo::cublasFillMode_t, n::Cint,
-                                    alpha::RefOrCuRef{cuComplex}, x::CuPtr{cuComplex},
-                                    incx::Cint, y::CuPtr{cuComplex}, incy::Cint,
-                                    AP::CuPtr{cuComplex})::cublasStatus_t
+    @gcsafe_ccall libcublas.cublasChpr2_v2(handle::cublasHandle_t, uplo::cublasFillMode_t,
+                                           n::Cint, alpha::RefOrCuRef{cuComplex},
+                                           x::CuPtr{cuComplex}, incx::Cint,
+                                           y::CuPtr{cuComplex}, incy::Cint,
+                                           AP::CuPtr{cuComplex})::cublasStatus_t
 end
 
 @checked function cublasZhpr2_v2(handle, uplo, n, alpha, x, incx, y, incy, AP)
     initialize_context()
-    @ccall libcublas.cublasZhpr2_v2(handle::cublasHandle_t, uplo::cublasFillMode_t, n::Cint,
-                                    alpha::RefOrCuRef{cuDoubleComplex},
-                                    x::CuPtr{cuDoubleComplex}, incx::Cint,
-                                    y::CuPtr{cuDoubleComplex}, incy::Cint,
-                                    AP::CuPtr{cuDoubleComplex})::cublasStatus_t
+    @gcsafe_ccall libcublas.cublasZhpr2_v2(handle::cublasHandle_t, uplo::cublasFillMode_t,
+                                           n::Cint, alpha::RefOrCuRef{cuDoubleComplex},
+                                           x::CuPtr{cuDoubleComplex}, incx::Cint,
+                                           y::CuPtr{cuDoubleComplex}, incy::Cint,
+                                           AP::CuPtr{cuDoubleComplex})::cublasStatus_t
 end
 
 @checked function cublasSgemm_v2(handle, transa, transb, m, n, k, alpha, A, lda, B, ldb,
                                  beta, C, ldc)
     initialize_context()
-    @ccall libcublas.cublasSgemm_v2(handle::cublasHandle_t, transa::cublasOperation_t,
-                                    transb::cublasOperation_t, m::Cint, n::Cint, k::Cint,
-                                    alpha::RefOrCuRef{Cfloat}, A::CuPtr{Cfloat}, lda::Cint,
-                                    B::CuPtr{Cfloat}, ldb::Cint, beta::RefOrCuRef{Cfloat},
-                                    C::CuPtr{Cfloat}, ldc::Cint)::cublasStatus_t
+    @gcsafe_ccall libcublas.cublasSgemm_v2(handle::cublasHandle_t,
+                                           transa::cublasOperation_t,
+                                           transb::cublasOperation_t, m::Cint, n::Cint,
+                                           k::Cint, alpha::RefOrCuRef{Cfloat},
+                                           A::CuPtr{Cfloat}, lda::Cint, B::CuPtr{Cfloat},
+                                           ldb::Cint, beta::RefOrCuRef{Cfloat},
+                                           C::CuPtr{Cfloat}, ldc::Cint)::cublasStatus_t
 end
 
 @checked function cublasDgemm_v2(handle, transa, transb, m, n, k, alpha, A, lda, B, ldb,
                                  beta, C, ldc)
     initialize_context()
-    @ccall libcublas.cublasDgemm_v2(handle::cublasHandle_t, transa::cublasOperation_t,
-                                    transb::cublasOperation_t, m::Cint, n::Cint, k::Cint,
-                                    alpha::RefOrCuRef{Cdouble}, A::CuPtr{Cdouble},
-                                    lda::Cint, B::CuPtr{Cdouble}, ldb::Cint,
-                                    beta::RefOrCuRef{Cdouble}, C::CuPtr{Cdouble},
-                                    ldc::Cint)::cublasStatus_t
+    @gcsafe_ccall libcublas.cublasDgemm_v2(handle::cublasHandle_t,
+                                           transa::cublasOperation_t,
+                                           transb::cublasOperation_t, m::Cint, n::Cint,
+                                           k::Cint, alpha::RefOrCuRef{Cdouble},
+                                           A::CuPtr{Cdouble}, lda::Cint, B::CuPtr{Cdouble},
+                                           ldb::Cint, beta::RefOrCuRef{Cdouble},
+                                           C::CuPtr{Cdouble}, ldc::Cint)::cublasStatus_t
 end
 
 @checked function cublasCgemm_v2(handle, transa, transb, m, n, k, alpha, A, lda, B, ldb,
                                  beta, C, ldc)
     initialize_context()
-    @ccall libcublas.cublasCgemm_v2(handle::cublasHandle_t, transa::cublasOperation_t,
-                                    transb::cublasOperation_t, m::Cint, n::Cint, k::Cint,
-                                    alpha::RefOrCuRef{cuComplex}, A::CuPtr{cuComplex},
-                                    lda::Cint, B::CuPtr{cuComplex}, ldb::Cint,
-                                    beta::RefOrCuRef{cuComplex}, C::CuPtr{cuComplex},
-                                    ldc::Cint)::cublasStatus_t
+    @gcsafe_ccall libcublas.cublasCgemm_v2(handle::cublasHandle_t,
+                                           transa::cublasOperation_t,
+                                           transb::cublasOperation_t, m::Cint, n::Cint,
+                                           k::Cint, alpha::RefOrCuRef{cuComplex},
+                                           A::CuPtr{cuComplex}, lda::Cint,
+                                           B::CuPtr{cuComplex}, ldb::Cint,
+                                           beta::RefOrCuRef{cuComplex}, C::CuPtr{cuComplex},
+                                           ldc::Cint)::cublasStatus_t
 end
 
 @checked function cublasZgemm_v2(handle, transa, transb, m, n, k, alpha, A, lda, B, ldb,
                                  beta, C, ldc)
     initialize_context()
-    @ccall libcublas.cublasZgemm_v2(handle::cublasHandle_t, transa::cublasOperation_t,
-                                    transb::cublasOperation_t, m::Cint, n::Cint, k::Cint,
-                                    alpha::RefOrCuRef{cuDoubleComplex},
-                                    A::CuPtr{cuDoubleComplex}, lda::Cint,
-                                    B::CuPtr{cuDoubleComplex}, ldb::Cint,
-                                    beta::RefOrCuRef{cuDoubleComplex},
-                                    C::CuPtr{cuDoubleComplex}, ldc::Cint)::cublasStatus_t
+    @gcsafe_ccall libcublas.cublasZgemm_v2(handle::cublasHandle_t,
+                                           transa::cublasOperation_t,
+                                           transb::cublasOperation_t, m::Cint, n::Cint,
+                                           k::Cint, alpha::RefOrCuRef{cuDoubleComplex},
+                                           A::CuPtr{cuDoubleComplex}, lda::Cint,
+                                           B::CuPtr{cuDoubleComplex}, ldb::Cint,
+                                           beta::RefOrCuRef{cuDoubleComplex},
+                                           C::CuPtr{cuDoubleComplex},
+                                           ldc::Cint)::cublasStatus_t
 end
 
 @checked function cublasSsyrk_v2(handle, uplo, trans, n, k, alpha, A, lda, beta, C, ldc)
     initialize_context()
-    @ccall libcublas.cublasSsyrk_v2(handle::cublasHandle_t, uplo::cublasFillMode_t,
-                                    trans::cublasOperation_t, n::Cint, k::Cint,
-                                    alpha::RefOrCuRef{Cfloat}, A::CuPtr{Cfloat}, lda::Cint,
-                                    beta::RefOrCuRef{Cfloat}, C::CuPtr{Cfloat},
-                                    ldc::Cint)::cublasStatus_t
+    @gcsafe_ccall libcublas.cublasSsyrk_v2(handle::cublasHandle_t, uplo::cublasFillMode_t,
+                                           trans::cublasOperation_t, n::Cint, k::Cint,
+                                           alpha::RefOrCuRef{Cfloat}, A::CuPtr{Cfloat},
+                                           lda::Cint, beta::RefOrCuRef{Cfloat},
+                                           C::CuPtr{Cfloat}, ldc::Cint)::cublasStatus_t
 end
 
 @checked function cublasDsyrk_v2(handle, uplo, trans, n, k, alpha, A, lda, beta, C, ldc)
     initialize_context()
-    @ccall libcublas.cublasDsyrk_v2(handle::cublasHandle_t, uplo::cublasFillMode_t,
-                                    trans::cublasOperation_t, n::Cint, k::Cint,
-                                    alpha::RefOrCuRef{Cdouble}, A::CuPtr{Cdouble},
-                                    lda::Cint, beta::RefOrCuRef{Cdouble}, C::CuPtr{Cdouble},
-                                    ldc::Cint)::cublasStatus_t
+    @gcsafe_ccall libcublas.cublasDsyrk_v2(handle::cublasHandle_t, uplo::cublasFillMode_t,
+                                           trans::cublasOperation_t, n::Cint, k::Cint,
+                                           alpha::RefOrCuRef{Cdouble}, A::CuPtr{Cdouble},
+                                           lda::Cint, beta::RefOrCuRef{Cdouble},
+                                           C::CuPtr{Cdouble}, ldc::Cint)::cublasStatus_t
 end
 
 @checked function cublasCsyrk_v2(handle, uplo, trans, n, k, alpha, A, lda, beta, C, ldc)
     initialize_context()
-    @ccall libcublas.cublasCsyrk_v2(handle::cublasHandle_t, uplo::cublasFillMode_t,
-                                    trans::cublasOperation_t, n::Cint, k::Cint,
-                                    alpha::RefOrCuRef{cuComplex}, A::CuPtr{cuComplex},
-                                    lda::Cint, beta::RefOrCuRef{cuComplex},
-                                    C::CuPtr{cuComplex}, ldc::Cint)::cublasStatus_t
+    @gcsafe_ccall libcublas.cublasCsyrk_v2(handle::cublasHandle_t, uplo::cublasFillMode_t,
+                                           trans::cublasOperation_t, n::Cint, k::Cint,
+                                           alpha::RefOrCuRef{cuComplex},
+                                           A::CuPtr{cuComplex}, lda::Cint,
+                                           beta::RefOrCuRef{cuComplex}, C::CuPtr{cuComplex},
+                                           ldc::Cint)::cublasStatus_t
 end
 
 @checked function cublasZsyrk_v2(handle, uplo, trans, n, k, alpha, A, lda, beta, C, ldc)
     initialize_context()
-    @ccall libcublas.cublasZsyrk_v2(handle::cublasHandle_t, uplo::cublasFillMode_t,
-                                    trans::cublasOperation_t, n::Cint, k::Cint,
-                                    alpha::RefOrCuRef{cuDoubleComplex},
-                                    A::CuPtr{cuDoubleComplex}, lda::Cint,
-                                    beta::RefOrCuRef{cuDoubleComplex},
-                                    C::CuPtr{cuDoubleComplex}, ldc::Cint)::cublasStatus_t
+    @gcsafe_ccall libcublas.cublasZsyrk_v2(handle::cublasHandle_t, uplo::cublasFillMode_t,
+                                           trans::cublasOperation_t, n::Cint, k::Cint,
+                                           alpha::RefOrCuRef{cuDoubleComplex},
+                                           A::CuPtr{cuDoubleComplex}, lda::Cint,
+                                           beta::RefOrCuRef{cuDoubleComplex},
+                                           C::CuPtr{cuDoubleComplex},
+                                           ldc::Cint)::cublasStatus_t
 end
 
 @checked function cublasCherk_v2(handle, uplo, trans, n, k, alpha, A, lda, beta, C, ldc)
     initialize_context()
-    @ccall libcublas.cublasCherk_v2(handle::cublasHandle_t, uplo::cublasFillMode_t,
-                                    trans::cublasOperation_t, n::Cint, k::Cint,
-                                    alpha::RefOrCuRef{Cfloat}, A::CuPtr{cuComplex},
-                                    lda::Cint, beta::RefOrCuRef{Cfloat},
-                                    C::CuPtr{cuComplex}, ldc::Cint)::cublasStatus_t
+    @gcsafe_ccall libcublas.cublasCherk_v2(handle::cublasHandle_t, uplo::cublasFillMode_t,
+                                           trans::cublasOperation_t, n::Cint, k::Cint,
+                                           alpha::RefOrCuRef{Cfloat}, A::CuPtr{cuComplex},
+                                           lda::Cint, beta::RefOrCuRef{Cfloat},
+                                           C::CuPtr{cuComplex}, ldc::Cint)::cublasStatus_t
 end
 
 @checked function cublasZherk_v2(handle, uplo, trans, n, k, alpha, A, lda, beta, C, ldc)
     initialize_context()
-    @ccall libcublas.cublasZherk_v2(handle::cublasHandle_t, uplo::cublasFillMode_t,
-                                    trans::cublasOperation_t, n::Cint, k::Cint,
-                                    alpha::RefOrCuRef{Cdouble}, A::CuPtr{cuDoubleComplex},
-                                    lda::Cint, beta::RefOrCuRef{Cdouble},
-                                    C::CuPtr{cuDoubleComplex}, ldc::Cint)::cublasStatus_t
+    @gcsafe_ccall libcublas.cublasZherk_v2(handle::cublasHandle_t, uplo::cublasFillMode_t,
+                                           trans::cublasOperation_t, n::Cint, k::Cint,
+                                           alpha::RefOrCuRef{Cdouble},
+                                           A::CuPtr{cuDoubleComplex}, lda::Cint,
+                                           beta::RefOrCuRef{Cdouble},
+                                           C::CuPtr{cuDoubleComplex},
+                                           ldc::Cint)::cublasStatus_t
 end
 
 @checked function cublasSsyr2k_v2(handle, uplo, trans, n, k, alpha, A, lda, B, ldb, beta, C,
                                   ldc)
     initialize_context()
-    @ccall libcublas.cublasSsyr2k_v2(handle::cublasHandle_t, uplo::cublasFillMode_t,
-                                     trans::cublasOperation_t, n::Cint, k::Cint,
-                                     alpha::RefOrCuRef{Cfloat}, A::CuPtr{Cfloat}, lda::Cint,
-                                     B::CuPtr{Cfloat}, ldb::Cint, beta::RefOrCuRef{Cfloat},
-                                     C::CuPtr{Cfloat}, ldc::Cint)::cublasStatus_t
+    @gcsafe_ccall libcublas.cublasSsyr2k_v2(handle::cublasHandle_t, uplo::cublasFillMode_t,
+                                            trans::cublasOperation_t, n::Cint, k::Cint,
+                                            alpha::RefOrCuRef{Cfloat}, A::CuPtr{Cfloat},
+                                            lda::Cint, B::CuPtr{Cfloat}, ldb::Cint,
+                                            beta::RefOrCuRef{Cfloat}, C::CuPtr{Cfloat},
+                                            ldc::Cint)::cublasStatus_t
 end
 
 @checked function cublasDsyr2k_v2(handle, uplo, trans, n, k, alpha, A, lda, B, ldb, beta, C,
                                   ldc)
     initialize_context()
-    @ccall libcublas.cublasDsyr2k_v2(handle::cublasHandle_t, uplo::cublasFillMode_t,
-                                     trans::cublasOperation_t, n::Cint, k::Cint,
-                                     alpha::RefOrCuRef{Cdouble}, A::CuPtr{Cdouble},
-                                     lda::Cint, B::CuPtr{Cdouble}, ldb::Cint,
-                                     beta::RefOrCuRef{Cdouble}, C::CuPtr{Cdouble},
-                                     ldc::Cint)::cublasStatus_t
+    @gcsafe_ccall libcublas.cublasDsyr2k_v2(handle::cublasHandle_t, uplo::cublasFillMode_t,
+                                            trans::cublasOperation_t, n::Cint, k::Cint,
+                                            alpha::RefOrCuRef{Cdouble}, A::CuPtr{Cdouble},
+                                            lda::Cint, B::CuPtr{Cdouble}, ldb::Cint,
+                                            beta::RefOrCuRef{Cdouble}, C::CuPtr{Cdouble},
+                                            ldc::Cint)::cublasStatus_t
 end
 
 @checked function cublasCsyr2k_v2(handle, uplo, trans, n, k, alpha, A, lda, B, ldb, beta, C,
                                   ldc)
     initialize_context()
-    @ccall libcublas.cublasCsyr2k_v2(handle::cublasHandle_t, uplo::cublasFillMode_t,
-                                     trans::cublasOperation_t, n::Cint, k::Cint,
-                                     alpha::RefOrCuRef{cuComplex}, A::CuPtr{cuComplex},
-                                     lda::Cint, B::CuPtr{cuComplex}, ldb::Cint,
-                                     beta::RefOrCuRef{cuComplex}, C::CuPtr{cuComplex},
-                                     ldc::Cint)::cublasStatus_t
+    @gcsafe_ccall libcublas.cublasCsyr2k_v2(handle::cublasHandle_t, uplo::cublasFillMode_t,
+                                            trans::cublasOperation_t, n::Cint, k::Cint,
+                                            alpha::RefOrCuRef{cuComplex},
+                                            A::CuPtr{cuComplex}, lda::Cint,
+                                            B::CuPtr{cuComplex}, ldb::Cint,
+                                            beta::RefOrCuRef{cuComplex},
+                                            C::CuPtr{cuComplex}, ldc::Cint)::cublasStatus_t
 end
 
 @checked function cublasZsyr2k_v2(handle, uplo, trans, n, k, alpha, A, lda, B, ldb, beta, C,
                                   ldc)
     initialize_context()
-    @ccall libcublas.cublasZsyr2k_v2(handle::cublasHandle_t, uplo::cublasFillMode_t,
-                                     trans::cublasOperation_t, n::Cint, k::Cint,
-                                     alpha::RefOrCuRef{cuDoubleComplex},
-                                     A::CuPtr{cuDoubleComplex}, lda::Cint,
-                                     B::CuPtr{cuDoubleComplex}, ldb::Cint,
-                                     beta::RefOrCuRef{cuDoubleComplex},
-                                     C::CuPtr{cuDoubleComplex}, ldc::Cint)::cublasStatus_t
+    @gcsafe_ccall libcublas.cublasZsyr2k_v2(handle::cublasHandle_t, uplo::cublasFillMode_t,
+                                            trans::cublasOperation_t, n::Cint, k::Cint,
+                                            alpha::RefOrCuRef{cuDoubleComplex},
+                                            A::CuPtr{cuDoubleComplex}, lda::Cint,
+                                            B::CuPtr{cuDoubleComplex}, ldb::Cint,
+                                            beta::RefOrCuRef{cuDoubleComplex},
+                                            C::CuPtr{cuDoubleComplex},
+                                            ldc::Cint)::cublasStatus_t
 end
 
 @checked function cublasCher2k_v2(handle, uplo, trans, n, k, alpha, A, lda, B, ldb, beta, C,
                                   ldc)
     initialize_context()
-    @ccall libcublas.cublasCher2k_v2(handle::cublasHandle_t, uplo::cublasFillMode_t,
-                                     trans::cublasOperation_t, n::Cint, k::Cint,
-                                     alpha::RefOrCuRef{cuComplex}, A::CuPtr{cuComplex},
-                                     lda::Cint, B::CuPtr{cuComplex}, ldb::Cint,
-                                     beta::RefOrCuRef{Cfloat}, C::CuPtr{cuComplex},
-                                     ldc::Cint)::cublasStatus_t
+    @gcsafe_ccall libcublas.cublasCher2k_v2(handle::cublasHandle_t, uplo::cublasFillMode_t,
+                                            trans::cublasOperation_t, n::Cint, k::Cint,
+                                            alpha::RefOrCuRef{cuComplex},
+                                            A::CuPtr{cuComplex}, lda::Cint,
+                                            B::CuPtr{cuComplex}, ldb::Cint,
+                                            beta::RefOrCuRef{Cfloat}, C::CuPtr{cuComplex},
+                                            ldc::Cint)::cublasStatus_t
 end
 
 @checked function cublasZher2k_v2(handle, uplo, trans, n, k, alpha, A, lda, B, ldb, beta, C,
                                   ldc)
     initialize_context()
-    @ccall libcublas.cublasZher2k_v2(handle::cublasHandle_t, uplo::cublasFillMode_t,
-                                     trans::cublasOperation_t, n::Cint, k::Cint,
-                                     alpha::RefOrCuRef{cuDoubleComplex},
-                                     A::CuPtr{cuDoubleComplex}, lda::Cint,
-                                     B::CuPtr{cuDoubleComplex}, ldb::Cint,
-                                     beta::RefOrCuRef{Cdouble}, C::CuPtr{cuDoubleComplex},
-                                     ldc::Cint)::cublasStatus_t
+    @gcsafe_ccall libcublas.cublasZher2k_v2(handle::cublasHandle_t, uplo::cublasFillMode_t,
+                                            trans::cublasOperation_t, n::Cint, k::Cint,
+                                            alpha::RefOrCuRef{cuDoubleComplex},
+                                            A::CuPtr{cuDoubleComplex}, lda::Cint,
+                                            B::CuPtr{cuDoubleComplex}, ldb::Cint,
+                                            beta::RefOrCuRef{Cdouble},
+                                            C::CuPtr{cuDoubleComplex},
+                                            ldc::Cint)::cublasStatus_t
 end
 
 @cenum cublasSideMode_t::UInt32 begin
@@ -1276,1494 +1363,1683 @@ end
 @checked function cublasSsymm_v2(handle, side, uplo, m, n, alpha, A, lda, B, ldb, beta, C,
                                  ldc)
     initialize_context()
-    @ccall libcublas.cublasSsymm_v2(handle::cublasHandle_t, side::cublasSideMode_t,
-                                    uplo::cublasFillMode_t, m::Cint, n::Cint,
-                                    alpha::RefOrCuRef{Cfloat}, A::CuPtr{Cfloat}, lda::Cint,
-                                    B::CuPtr{Cfloat}, ldb::Cint, beta::RefOrCuRef{Cfloat},
-                                    C::CuPtr{Cfloat}, ldc::Cint)::cublasStatus_t
+    @gcsafe_ccall libcublas.cublasSsymm_v2(handle::cublasHandle_t, side::cublasSideMode_t,
+                                           uplo::cublasFillMode_t, m::Cint, n::Cint,
+                                           alpha::RefOrCuRef{Cfloat}, A::CuPtr{Cfloat},
+                                           lda::Cint, B::CuPtr{Cfloat}, ldb::Cint,
+                                           beta::RefOrCuRef{Cfloat}, C::CuPtr{Cfloat},
+                                           ldc::Cint)::cublasStatus_t
 end
 
 @checked function cublasDsymm_v2(handle, side, uplo, m, n, alpha, A, lda, B, ldb, beta, C,
                                  ldc)
     initialize_context()
-    @ccall libcublas.cublasDsymm_v2(handle::cublasHandle_t, side::cublasSideMode_t,
-                                    uplo::cublasFillMode_t, m::Cint, n::Cint,
-                                    alpha::RefOrCuRef{Cdouble}, A::CuPtr{Cdouble},
-                                    lda::Cint, B::CuPtr{Cdouble}, ldb::Cint,
-                                    beta::RefOrCuRef{Cdouble}, C::CuPtr{Cdouble},
-                                    ldc::Cint)::cublasStatus_t
+    @gcsafe_ccall libcublas.cublasDsymm_v2(handle::cublasHandle_t, side::cublasSideMode_t,
+                                           uplo::cublasFillMode_t, m::Cint, n::Cint,
+                                           alpha::RefOrCuRef{Cdouble}, A::CuPtr{Cdouble},
+                                           lda::Cint, B::CuPtr{Cdouble}, ldb::Cint,
+                                           beta::RefOrCuRef{Cdouble}, C::CuPtr{Cdouble},
+                                           ldc::Cint)::cublasStatus_t
 end
 
 @checked function cublasCsymm_v2(handle, side, uplo, m, n, alpha, A, lda, B, ldb, beta, C,
                                  ldc)
     initialize_context()
-    @ccall libcublas.cublasCsymm_v2(handle::cublasHandle_t, side::cublasSideMode_t,
-                                    uplo::cublasFillMode_t, m::Cint, n::Cint,
-                                    alpha::RefOrCuRef{cuComplex}, A::CuPtr{cuComplex},
-                                    lda::Cint, B::CuPtr{cuComplex}, ldb::Cint,
-                                    beta::RefOrCuRef{cuComplex}, C::CuPtr{cuComplex},
-                                    ldc::Cint)::cublasStatus_t
+    @gcsafe_ccall libcublas.cublasCsymm_v2(handle::cublasHandle_t, side::cublasSideMode_t,
+                                           uplo::cublasFillMode_t, m::Cint, n::Cint,
+                                           alpha::RefOrCuRef{cuComplex},
+                                           A::CuPtr{cuComplex}, lda::Cint,
+                                           B::CuPtr{cuComplex}, ldb::Cint,
+                                           beta::RefOrCuRef{cuComplex}, C::CuPtr{cuComplex},
+                                           ldc::Cint)::cublasStatus_t
 end
 
 @checked function cublasZsymm_v2(handle, side, uplo, m, n, alpha, A, lda, B, ldb, beta, C,
                                  ldc)
     initialize_context()
-    @ccall libcublas.cublasZsymm_v2(handle::cublasHandle_t, side::cublasSideMode_t,
-                                    uplo::cublasFillMode_t, m::Cint, n::Cint,
-                                    alpha::RefOrCuRef{cuDoubleComplex},
-                                    A::CuPtr{cuDoubleComplex}, lda::Cint,
-                                    B::CuPtr{cuDoubleComplex}, ldb::Cint,
-                                    beta::RefOrCuRef{cuDoubleComplex},
-                                    C::CuPtr{cuDoubleComplex}, ldc::Cint)::cublasStatus_t
+    @gcsafe_ccall libcublas.cublasZsymm_v2(handle::cublasHandle_t, side::cublasSideMode_t,
+                                           uplo::cublasFillMode_t, m::Cint, n::Cint,
+                                           alpha::RefOrCuRef{cuDoubleComplex},
+                                           A::CuPtr{cuDoubleComplex}, lda::Cint,
+                                           B::CuPtr{cuDoubleComplex}, ldb::Cint,
+                                           beta::RefOrCuRef{cuDoubleComplex},
+                                           C::CuPtr{cuDoubleComplex},
+                                           ldc::Cint)::cublasStatus_t
 end
 
 @checked function cublasChemm_v2(handle, side, uplo, m, n, alpha, A, lda, B, ldb, beta, C,
                                  ldc)
     initialize_context()
-    @ccall libcublas.cublasChemm_v2(handle::cublasHandle_t, side::cublasSideMode_t,
-                                    uplo::cublasFillMode_t, m::Cint, n::Cint,
-                                    alpha::RefOrCuRef{cuComplex}, A::CuPtr{cuComplex},
-                                    lda::Cint, B::CuPtr{cuComplex}, ldb::Cint,
-                                    beta::RefOrCuRef{cuComplex}, C::CuPtr{cuComplex},
-                                    ldc::Cint)::cublasStatus_t
+    @gcsafe_ccall libcublas.cublasChemm_v2(handle::cublasHandle_t, side::cublasSideMode_t,
+                                           uplo::cublasFillMode_t, m::Cint, n::Cint,
+                                           alpha::RefOrCuRef{cuComplex},
+                                           A::CuPtr{cuComplex}, lda::Cint,
+                                           B::CuPtr{cuComplex}, ldb::Cint,
+                                           beta::RefOrCuRef{cuComplex}, C::CuPtr{cuComplex},
+                                           ldc::Cint)::cublasStatus_t
 end
 
 @checked function cublasZhemm_v2(handle, side, uplo, m, n, alpha, A, lda, B, ldb, beta, C,
                                  ldc)
     initialize_context()
-    @ccall libcublas.cublasZhemm_v2(handle::cublasHandle_t, side::cublasSideMode_t,
-                                    uplo::cublasFillMode_t, m::Cint, n::Cint,
-                                    alpha::RefOrCuRef{cuDoubleComplex},
-                                    A::CuPtr{cuDoubleComplex}, lda::Cint,
-                                    B::CuPtr{cuDoubleComplex}, ldb::Cint,
-                                    beta::RefOrCuRef{cuDoubleComplex},
-                                    C::CuPtr{cuDoubleComplex}, ldc::Cint)::cublasStatus_t
+    @gcsafe_ccall libcublas.cublasZhemm_v2(handle::cublasHandle_t, side::cublasSideMode_t,
+                                           uplo::cublasFillMode_t, m::Cint, n::Cint,
+                                           alpha::RefOrCuRef{cuDoubleComplex},
+                                           A::CuPtr{cuDoubleComplex}, lda::Cint,
+                                           B::CuPtr{cuDoubleComplex}, ldb::Cint,
+                                           beta::RefOrCuRef{cuDoubleComplex},
+                                           C::CuPtr{cuDoubleComplex},
+                                           ldc::Cint)::cublasStatus_t
 end
 
 @checked function cublasStrsm_v2(handle, side, uplo, trans, diag, m, n, alpha, A, lda, B,
                                  ldb)
     initialize_context()
-    @ccall libcublas.cublasStrsm_v2(handle::cublasHandle_t, side::cublasSideMode_t,
-                                    uplo::cublasFillMode_t, trans::cublasOperation_t,
-                                    diag::cublasDiagType_t, m::Cint, n::Cint,
-                                    alpha::RefOrCuRef{Cfloat}, A::CuPtr{Cfloat}, lda::Cint,
-                                    B::CuPtr{Cfloat}, ldb::Cint)::cublasStatus_t
+    @gcsafe_ccall libcublas.cublasStrsm_v2(handle::cublasHandle_t, side::cublasSideMode_t,
+                                           uplo::cublasFillMode_t, trans::cublasOperation_t,
+                                           diag::cublasDiagType_t, m::Cint, n::Cint,
+                                           alpha::RefOrCuRef{Cfloat}, A::CuPtr{Cfloat},
+                                           lda::Cint, B::CuPtr{Cfloat},
+                                           ldb::Cint)::cublasStatus_t
 end
 
 @checked function cublasDtrsm_v2(handle, side, uplo, trans, diag, m, n, alpha, A, lda, B,
                                  ldb)
     initialize_context()
-    @ccall libcublas.cublasDtrsm_v2(handle::cublasHandle_t, side::cublasSideMode_t,
-                                    uplo::cublasFillMode_t, trans::cublasOperation_t,
-                                    diag::cublasDiagType_t, m::Cint, n::Cint,
-                                    alpha::RefOrCuRef{Cdouble}, A::CuPtr{Cdouble},
-                                    lda::Cint, B::CuPtr{Cdouble}, ldb::Cint)::cublasStatus_t
+    @gcsafe_ccall libcublas.cublasDtrsm_v2(handle::cublasHandle_t, side::cublasSideMode_t,
+                                           uplo::cublasFillMode_t, trans::cublasOperation_t,
+                                           diag::cublasDiagType_t, m::Cint, n::Cint,
+                                           alpha::RefOrCuRef{Cdouble}, A::CuPtr{Cdouble},
+                                           lda::Cint, B::CuPtr{Cdouble},
+                                           ldb::Cint)::cublasStatus_t
 end
 
 @checked function cublasCtrsm_v2(handle, side, uplo, trans, diag, m, n, alpha, A, lda, B,
                                  ldb)
     initialize_context()
-    @ccall libcublas.cublasCtrsm_v2(handle::cublasHandle_t, side::cublasSideMode_t,
-                                    uplo::cublasFillMode_t, trans::cublasOperation_t,
-                                    diag::cublasDiagType_t, m::Cint, n::Cint,
-                                    alpha::RefOrCuRef{cuComplex}, A::CuPtr{cuComplex},
-                                    lda::Cint, B::CuPtr{cuComplex},
-                                    ldb::Cint)::cublasStatus_t
+    @gcsafe_ccall libcublas.cublasCtrsm_v2(handle::cublasHandle_t, side::cublasSideMode_t,
+                                           uplo::cublasFillMode_t, trans::cublasOperation_t,
+                                           diag::cublasDiagType_t, m::Cint, n::Cint,
+                                           alpha::RefOrCuRef{cuComplex},
+                                           A::CuPtr{cuComplex}, lda::Cint,
+                                           B::CuPtr{cuComplex}, ldb::Cint)::cublasStatus_t
 end
 
 @checked function cublasZtrsm_v2(handle, side, uplo, trans, diag, m, n, alpha, A, lda, B,
                                  ldb)
     initialize_context()
-    @ccall libcublas.cublasZtrsm_v2(handle::cublasHandle_t, side::cublasSideMode_t,
-                                    uplo::cublasFillMode_t, trans::cublasOperation_t,
-                                    diag::cublasDiagType_t, m::Cint, n::Cint,
-                                    alpha::RefOrCuRef{cuDoubleComplex},
-                                    A::CuPtr{cuDoubleComplex}, lda::Cint,
-                                    B::CuPtr{cuDoubleComplex}, ldb::Cint)::cublasStatus_t
+    @gcsafe_ccall libcublas.cublasZtrsm_v2(handle::cublasHandle_t, side::cublasSideMode_t,
+                                           uplo::cublasFillMode_t, trans::cublasOperation_t,
+                                           diag::cublasDiagType_t, m::Cint, n::Cint,
+                                           alpha::RefOrCuRef{cuDoubleComplex},
+                                           A::CuPtr{cuDoubleComplex}, lda::Cint,
+                                           B::CuPtr{cuDoubleComplex},
+                                           ldb::Cint)::cublasStatus_t
 end
 
 @checked function cublasStrmm_v2(handle, side, uplo, trans, diag, m, n, alpha, A, lda, B,
                                  ldb, C, ldc)
     initialize_context()
-    @ccall libcublas.cublasStrmm_v2(handle::cublasHandle_t, side::cublasSideMode_t,
-                                    uplo::cublasFillMode_t, trans::cublasOperation_t,
-                                    diag::cublasDiagType_t, m::Cint, n::Cint,
-                                    alpha::RefOrCuRef{Cfloat}, A::CuPtr{Cfloat}, lda::Cint,
-                                    B::CuPtr{Cfloat}, ldb::Cint, C::CuPtr{Cfloat},
-                                    ldc::Cint)::cublasStatus_t
+    @gcsafe_ccall libcublas.cublasStrmm_v2(handle::cublasHandle_t, side::cublasSideMode_t,
+                                           uplo::cublasFillMode_t, trans::cublasOperation_t,
+                                           diag::cublasDiagType_t, m::Cint, n::Cint,
+                                           alpha::RefOrCuRef{Cfloat}, A::CuPtr{Cfloat},
+                                           lda::Cint, B::CuPtr{Cfloat}, ldb::Cint,
+                                           C::CuPtr{Cfloat}, ldc::Cint)::cublasStatus_t
 end
 
 @checked function cublasDtrmm_v2(handle, side, uplo, trans, diag, m, n, alpha, A, lda, B,
                                  ldb, C, ldc)
     initialize_context()
-    @ccall libcublas.cublasDtrmm_v2(handle::cublasHandle_t, side::cublasSideMode_t,
-                                    uplo::cublasFillMode_t, trans::cublasOperation_t,
-                                    diag::cublasDiagType_t, m::Cint, n::Cint,
-                                    alpha::RefOrCuRef{Cdouble}, A::CuPtr{Cdouble},
-                                    lda::Cint, B::CuPtr{Cdouble}, ldb::Cint,
-                                    C::CuPtr{Cdouble}, ldc::Cint)::cublasStatus_t
+    @gcsafe_ccall libcublas.cublasDtrmm_v2(handle::cublasHandle_t, side::cublasSideMode_t,
+                                           uplo::cublasFillMode_t, trans::cublasOperation_t,
+                                           diag::cublasDiagType_t, m::Cint, n::Cint,
+                                           alpha::RefOrCuRef{Cdouble}, A::CuPtr{Cdouble},
+                                           lda::Cint, B::CuPtr{Cdouble}, ldb::Cint,
+                                           C::CuPtr{Cdouble}, ldc::Cint)::cublasStatus_t
 end
 
 @checked function cublasCtrmm_v2(handle, side, uplo, trans, diag, m, n, alpha, A, lda, B,
                                  ldb, C, ldc)
     initialize_context()
-    @ccall libcublas.cublasCtrmm_v2(handle::cublasHandle_t, side::cublasSideMode_t,
-                                    uplo::cublasFillMode_t, trans::cublasOperation_t,
-                                    diag::cublasDiagType_t, m::Cint, n::Cint,
-                                    alpha::RefOrCuRef{cuComplex}, A::CuPtr{cuComplex},
-                                    lda::Cint, B::CuPtr{cuComplex}, ldb::Cint,
-                                    C::CuPtr{cuComplex}, ldc::Cint)::cublasStatus_t
+    @gcsafe_ccall libcublas.cublasCtrmm_v2(handle::cublasHandle_t, side::cublasSideMode_t,
+                                           uplo::cublasFillMode_t, trans::cublasOperation_t,
+                                           diag::cublasDiagType_t, m::Cint, n::Cint,
+                                           alpha::RefOrCuRef{cuComplex},
+                                           A::CuPtr{cuComplex}, lda::Cint,
+                                           B::CuPtr{cuComplex}, ldb::Cint,
+                                           C::CuPtr{cuComplex}, ldc::Cint)::cublasStatus_t
 end
 
 @checked function cublasZtrmm_v2(handle, side, uplo, trans, diag, m, n, alpha, A, lda, B,
                                  ldb, C, ldc)
     initialize_context()
-    @ccall libcublas.cublasZtrmm_v2(handle::cublasHandle_t, side::cublasSideMode_t,
-                                    uplo::cublasFillMode_t, trans::cublasOperation_t,
-                                    diag::cublasDiagType_t, m::Cint, n::Cint,
-                                    alpha::RefOrCuRef{cuDoubleComplex},
-                                    A::CuPtr{cuDoubleComplex}, lda::Cint,
-                                    B::CuPtr{cuDoubleComplex}, ldb::Cint,
-                                    C::CuPtr{cuDoubleComplex}, ldc::Cint)::cublasStatus_t
+    @gcsafe_ccall libcublas.cublasZtrmm_v2(handle::cublasHandle_t, side::cublasSideMode_t,
+                                           uplo::cublasFillMode_t, trans::cublasOperation_t,
+                                           diag::cublasDiagType_t, m::Cint, n::Cint,
+                                           alpha::RefOrCuRef{cuDoubleComplex},
+                                           A::CuPtr{cuDoubleComplex}, lda::Cint,
+                                           B::CuPtr{cuDoubleComplex}, ldb::Cint,
+                                           C::CuPtr{cuDoubleComplex},
+                                           ldc::Cint)::cublasStatus_t
 end
 
 @checked function cublasSnrm2_v2_64(handle, n, x, incx, result)
     initialize_context()
-    @ccall libcublas.cublasSnrm2_v2_64(handle::cublasHandle_t, n::Int64, x::CuPtr{Cfloat},
-                                       incx::Int64,
-                                       result::RefOrCuRef{Cfloat})::cublasStatus_t
+    @gcsafe_ccall libcublas.cublasSnrm2_v2_64(handle::cublasHandle_t, n::Int64,
+                                              x::CuPtr{Cfloat}, incx::Int64,
+                                              result::RefOrCuRef{Cfloat})::cublasStatus_t
 end
 
 @checked function cublasDnrm2_v2_64(handle, n, x, incx, result)
     initialize_context()
-    @ccall libcublas.cublasDnrm2_v2_64(handle::cublasHandle_t, n::Int64, x::CuPtr{Cdouble},
-                                       incx::Int64,
-                                       result::RefOrCuRef{Cdouble})::cublasStatus_t
+    @gcsafe_ccall libcublas.cublasDnrm2_v2_64(handle::cublasHandle_t, n::Int64,
+                                              x::CuPtr{Cdouble}, incx::Int64,
+                                              result::RefOrCuRef{Cdouble})::cublasStatus_t
 end
 
 @checked function cublasScnrm2_v2_64(handle, n, x, incx, result)
     initialize_context()
-    @ccall libcublas.cublasScnrm2_v2_64(handle::cublasHandle_t, n::Int64,
-                                        x::CuPtr{cuComplex}, incx::Int64,
-                                        result::RefOrCuRef{Cfloat})::cublasStatus_t
+    @gcsafe_ccall libcublas.cublasScnrm2_v2_64(handle::cublasHandle_t, n::Int64,
+                                               x::CuPtr{cuComplex}, incx::Int64,
+                                               result::RefOrCuRef{Cfloat})::cublasStatus_t
 end
 
 @checked function cublasDznrm2_v2_64(handle, n, x, incx, result)
     initialize_context()
-    @ccall libcublas.cublasDznrm2_v2_64(handle::cublasHandle_t, n::Int64,
-                                        x::CuPtr{cuDoubleComplex}, incx::Int64,
-                                        result::RefOrCuRef{Cdouble})::cublasStatus_t
+    @gcsafe_ccall libcublas.cublasDznrm2_v2_64(handle::cublasHandle_t, n::Int64,
+                                               x::CuPtr{cuDoubleComplex}, incx::Int64,
+                                               result::RefOrCuRef{Cdouble})::cublasStatus_t
 end
 
 @checked function cublasSdot_v2_64(handle, n, x, incx, y, incy, result)
     initialize_context()
-    @ccall libcublas.cublasSdot_v2_64(handle::cublasHandle_t, n::Int64, x::CuPtr{Cfloat},
-                                      incx::Int64, y::CuPtr{Cfloat}, incy::Int64,
-                                      result::RefOrCuRef{Cfloat})::cublasStatus_t
+    @gcsafe_ccall libcublas.cublasSdot_v2_64(handle::cublasHandle_t, n::Int64,
+                                             x::CuPtr{Cfloat}, incx::Int64,
+                                             y::CuPtr{Cfloat}, incy::Int64,
+                                             result::RefOrCuRef{Cfloat})::cublasStatus_t
 end
 
 @checked function cublasDdot_v2_64(handle, n, x, incx, y, incy, result)
     initialize_context()
-    @ccall libcublas.cublasDdot_v2_64(handle::cublasHandle_t, n::Int64, x::CuPtr{Cdouble},
-                                      incx::Int64, y::CuPtr{Cdouble}, incy::Int64,
-                                      result::RefOrCuRef{Cdouble})::cublasStatus_t
+    @gcsafe_ccall libcublas.cublasDdot_v2_64(handle::cublasHandle_t, n::Int64,
+                                             x::CuPtr{Cdouble}, incx::Int64,
+                                             y::CuPtr{Cdouble}, incy::Int64,
+                                             result::RefOrCuRef{Cdouble})::cublasStatus_t
 end
 
 @checked function cublasCdotu_v2_64(handle, n, x, incx, y, incy, result)
     initialize_context()
-    @ccall libcublas.cublasCdotu_v2_64(handle::cublasHandle_t, n::Int64,
-                                       x::CuPtr{cuComplex}, incx::Int64,
-                                       y::CuPtr{cuComplex}, incy::Int64,
-                                       result::RefOrCuRef{cuComplex})::cublasStatus_t
+    @gcsafe_ccall libcublas.cublasCdotu_v2_64(handle::cublasHandle_t, n::Int64,
+                                              x::CuPtr{cuComplex}, incx::Int64,
+                                              y::CuPtr{cuComplex}, incy::Int64,
+                                              result::RefOrCuRef{cuComplex})::cublasStatus_t
 end
 
 @checked function cublasCdotc_v2_64(handle, n, x, incx, y, incy, result)
     initialize_context()
-    @ccall libcublas.cublasCdotc_v2_64(handle::cublasHandle_t, n::Int64,
-                                       x::CuPtr{cuComplex}, incx::Int64,
-                                       y::CuPtr{cuComplex}, incy::Int64,
-                                       result::RefOrCuRef{cuComplex})::cublasStatus_t
+    @gcsafe_ccall libcublas.cublasCdotc_v2_64(handle::cublasHandle_t, n::Int64,
+                                              x::CuPtr{cuComplex}, incx::Int64,
+                                              y::CuPtr{cuComplex}, incy::Int64,
+                                              result::RefOrCuRef{cuComplex})::cublasStatus_t
 end
 
 @checked function cublasZdotu_v2_64(handle, n, x, incx, y, incy, result)
     initialize_context()
-    @ccall libcublas.cublasZdotu_v2_64(handle::cublasHandle_t, n::Int64,
-                                       x::CuPtr{cuDoubleComplex}, incx::Int64,
-                                       y::CuPtr{cuDoubleComplex}, incy::Int64,
-                                       result::RefOrCuRef{cuDoubleComplex})::cublasStatus_t
+    @gcsafe_ccall libcublas.cublasZdotu_v2_64(handle::cublasHandle_t, n::Int64,
+                                              x::CuPtr{cuDoubleComplex}, incx::Int64,
+                                              y::CuPtr{cuDoubleComplex}, incy::Int64,
+                                              result::RefOrCuRef{cuDoubleComplex})::cublasStatus_t
 end
 
 @checked function cublasZdotc_v2_64(handle, n, x, incx, y, incy, result)
     initialize_context()
-    @ccall libcublas.cublasZdotc_v2_64(handle::cublasHandle_t, n::Int64,
-                                       x::CuPtr{cuDoubleComplex}, incx::Int64,
-                                       y::CuPtr{cuDoubleComplex}, incy::Int64,
-                                       result::RefOrCuRef{cuDoubleComplex})::cublasStatus_t
+    @gcsafe_ccall libcublas.cublasZdotc_v2_64(handle::cublasHandle_t, n::Int64,
+                                              x::CuPtr{cuDoubleComplex}, incx::Int64,
+                                              y::CuPtr{cuDoubleComplex}, incy::Int64,
+                                              result::RefOrCuRef{cuDoubleComplex})::cublasStatus_t
 end
 
 @checked function cublasSscal_v2_64(handle, n, alpha, x, incx)
     initialize_context()
-    @ccall libcublas.cublasSscal_v2_64(handle::cublasHandle_t, n::Int64,
-                                       alpha::RefOrCuRef{Cfloat}, x::CuPtr{Cfloat},
-                                       incx::Int64)::cublasStatus_t
+    @gcsafe_ccall libcublas.cublasSscal_v2_64(handle::cublasHandle_t, n::Int64,
+                                              alpha::RefOrCuRef{Cfloat}, x::CuPtr{Cfloat},
+                                              incx::Int64)::cublasStatus_t
 end
 
 @checked function cublasDscal_v2_64(handle, n, alpha, x, incx)
     initialize_context()
-    @ccall libcublas.cublasDscal_v2_64(handle::cublasHandle_t, n::Int64,
-                                       alpha::RefOrCuRef{Cdouble}, x::CuPtr{Cdouble},
-                                       incx::Int64)::cublasStatus_t
+    @gcsafe_ccall libcublas.cublasDscal_v2_64(handle::cublasHandle_t, n::Int64,
+                                              alpha::RefOrCuRef{Cdouble}, x::CuPtr{Cdouble},
+                                              incx::Int64)::cublasStatus_t
 end
 
 @checked function cublasCscal_v2_64(handle, n, alpha, x, incx)
     initialize_context()
-    @ccall libcublas.cublasCscal_v2_64(handle::cublasHandle_t, n::Int64,
-                                       alpha::RefOrCuRef{cuComplex}, x::CuPtr{cuComplex},
-                                       incx::Int64)::cublasStatus_t
+    @gcsafe_ccall libcublas.cublasCscal_v2_64(handle::cublasHandle_t, n::Int64,
+                                              alpha::RefOrCuRef{cuComplex},
+                                              x::CuPtr{cuComplex},
+                                              incx::Int64)::cublasStatus_t
 end
 
 @checked function cublasCsscal_v2_64(handle, n, alpha, x, incx)
     initialize_context()
-    @ccall libcublas.cublasCsscal_v2_64(handle::cublasHandle_t, n::Int64,
-                                        alpha::RefOrCuRef{Cfloat}, x::CuPtr{cuComplex},
-                                        incx::Int64)::cublasStatus_t
+    @gcsafe_ccall libcublas.cublasCsscal_v2_64(handle::cublasHandle_t, n::Int64,
+                                               alpha::RefOrCuRef{Cfloat},
+                                               x::CuPtr{cuComplex},
+                                               incx::Int64)::cublasStatus_t
 end
 
 @checked function cublasZscal_v2_64(handle, n, alpha, x, incx)
     initialize_context()
-    @ccall libcublas.cublasZscal_v2_64(handle::cublasHandle_t, n::Int64,
-                                       alpha::RefOrCuRef{cuDoubleComplex},
-                                       x::CuPtr{cuDoubleComplex},
-                                       incx::Int64)::cublasStatus_t
+    @gcsafe_ccall libcublas.cublasZscal_v2_64(handle::cublasHandle_t, n::Int64,
+                                              alpha::RefOrCuRef{cuDoubleComplex},
+                                              x::CuPtr{cuDoubleComplex},
+                                              incx::Int64)::cublasStatus_t
 end
 
 @checked function cublasZdscal_v2_64(handle, n, alpha, x, incx)
     initialize_context()
-    @ccall libcublas.cublasZdscal_v2_64(handle::cublasHandle_t, n::Int64,
-                                        alpha::RefOrCuRef{Cdouble},
-                                        x::CuPtr{cuDoubleComplex},
-                                        incx::Int64)::cublasStatus_t
+    @gcsafe_ccall libcublas.cublasZdscal_v2_64(handle::cublasHandle_t, n::Int64,
+                                               alpha::RefOrCuRef{Cdouble},
+                                               x::CuPtr{cuDoubleComplex},
+                                               incx::Int64)::cublasStatus_t
 end
 
 @checked function cublasSaxpy_v2_64(handle, n, alpha, x, incx, y, incy)
     initialize_context()
-    @ccall libcublas.cublasSaxpy_v2_64(handle::cublasHandle_t, n::Int64,
-                                       alpha::RefOrCuRef{Cfloat}, x::CuPtr{Cfloat},
-                                       incx::Int64, y::CuPtr{Cfloat},
-                                       incy::Int64)::cublasStatus_t
+    @gcsafe_ccall libcublas.cublasSaxpy_v2_64(handle::cublasHandle_t, n::Int64,
+                                              alpha::RefOrCuRef{Cfloat}, x::CuPtr{Cfloat},
+                                              incx::Int64, y::CuPtr{Cfloat},
+                                              incy::Int64)::cublasStatus_t
 end
 
 @checked function cublasDaxpy_v2_64(handle, n, alpha, x, incx, y, incy)
     initialize_context()
-    @ccall libcublas.cublasDaxpy_v2_64(handle::cublasHandle_t, n::Int64,
-                                       alpha::RefOrCuRef{Cdouble}, x::CuPtr{Cdouble},
-                                       incx::Int64, y::CuPtr{Cdouble},
-                                       incy::Int64)::cublasStatus_t
+    @gcsafe_ccall libcublas.cublasDaxpy_v2_64(handle::cublasHandle_t, n::Int64,
+                                              alpha::RefOrCuRef{Cdouble}, x::CuPtr{Cdouble},
+                                              incx::Int64, y::CuPtr{Cdouble},
+                                              incy::Int64)::cublasStatus_t
 end
 
 @checked function cublasCaxpy_v2_64(handle, n, alpha, x, incx, y, incy)
     initialize_context()
-    @ccall libcublas.cublasCaxpy_v2_64(handle::cublasHandle_t, n::Int64,
-                                       alpha::RefOrCuRef{cuComplex}, x::CuPtr{cuComplex},
-                                       incx::Int64, y::CuPtr{cuComplex},
-                                       incy::Int64)::cublasStatus_t
+    @gcsafe_ccall libcublas.cublasCaxpy_v2_64(handle::cublasHandle_t, n::Int64,
+                                              alpha::RefOrCuRef{cuComplex},
+                                              x::CuPtr{cuComplex}, incx::Int64,
+                                              y::CuPtr{cuComplex},
+                                              incy::Int64)::cublasStatus_t
 end
 
 @checked function cublasZaxpy_v2_64(handle, n, alpha, x, incx, y, incy)
     initialize_context()
-    @ccall libcublas.cublasZaxpy_v2_64(handle::cublasHandle_t, n::Int64,
-                                       alpha::RefOrCuRef{cuDoubleComplex},
-                                       x::CuPtr{cuDoubleComplex}, incx::Int64,
-                                       y::CuPtr{cuDoubleComplex},
-                                       incy::Int64)::cublasStatus_t
+    @gcsafe_ccall libcublas.cublasZaxpy_v2_64(handle::cublasHandle_t, n::Int64,
+                                              alpha::RefOrCuRef{cuDoubleComplex},
+                                              x::CuPtr{cuDoubleComplex}, incx::Int64,
+                                              y::CuPtr{cuDoubleComplex},
+                                              incy::Int64)::cublasStatus_t
 end
 
 @checked function cublasScopy_v2_64(handle, n, x, incx, y, incy)
     initialize_context()
-    @ccall libcublas.cublasScopy_v2_64(handle::cublasHandle_t, n::Int64, x::CuPtr{Cfloat},
-                                       incx::Int64, y::CuPtr{Cfloat},
-                                       incy::Int64)::cublasStatus_t
+    @gcsafe_ccall libcublas.cublasScopy_v2_64(handle::cublasHandle_t, n::Int64,
+                                              x::CuPtr{Cfloat}, incx::Int64,
+                                              y::CuPtr{Cfloat}, incy::Int64)::cublasStatus_t
 end
 
 @checked function cublasDcopy_v2_64(handle, n, x, incx, y, incy)
     initialize_context()
-    @ccall libcublas.cublasDcopy_v2_64(handle::cublasHandle_t, n::Int64, x::CuPtr{Cdouble},
-                                       incx::Int64, y::CuPtr{Cdouble},
-                                       incy::Int64)::cublasStatus_t
+    @gcsafe_ccall libcublas.cublasDcopy_v2_64(handle::cublasHandle_t, n::Int64,
+                                              x::CuPtr{Cdouble}, incx::Int64,
+                                              y::CuPtr{Cdouble},
+                                              incy::Int64)::cublasStatus_t
 end
 
 @checked function cublasCcopy_v2_64(handle, n, x, incx, y, incy)
     initialize_context()
-    @ccall libcublas.cublasCcopy_v2_64(handle::cublasHandle_t, n::Int64,
-                                       x::CuPtr{cuComplex}, incx::Int64,
-                                       y::CuPtr{cuComplex}, incy::Int64)::cublasStatus_t
+    @gcsafe_ccall libcublas.cublasCcopy_v2_64(handle::cublasHandle_t, n::Int64,
+                                              x::CuPtr{cuComplex}, incx::Int64,
+                                              y::CuPtr{cuComplex},
+                                              incy::Int64)::cublasStatus_t
 end
 
 @checked function cublasZcopy_v2_64(handle, n, x, incx, y, incy)
     initialize_context()
-    @ccall libcublas.cublasZcopy_v2_64(handle::cublasHandle_t, n::Int64,
-                                       x::CuPtr{cuDoubleComplex}, incx::Int64,
-                                       y::CuPtr{cuDoubleComplex},
-                                       incy::Int64)::cublasStatus_t
+    @gcsafe_ccall libcublas.cublasZcopy_v2_64(handle::cublasHandle_t, n::Int64,
+                                              x::CuPtr{cuDoubleComplex}, incx::Int64,
+                                              y::CuPtr{cuDoubleComplex},
+                                              incy::Int64)::cublasStatus_t
 end
 
 @checked function cublasSswap_v2_64(handle, n, x, incx, y, incy)
     initialize_context()
-    @ccall libcublas.cublasSswap_v2_64(handle::cublasHandle_t, n::Int64, x::CuPtr{Cfloat},
-                                       incx::Int64, y::CuPtr{Cfloat},
-                                       incy::Int64)::cublasStatus_t
+    @gcsafe_ccall libcublas.cublasSswap_v2_64(handle::cublasHandle_t, n::Int64,
+                                              x::CuPtr{Cfloat}, incx::Int64,
+                                              y::CuPtr{Cfloat}, incy::Int64)::cublasStatus_t
 end
 
 @checked function cublasDswap_v2_64(handle, n, x, incx, y, incy)
     initialize_context()
-    @ccall libcublas.cublasDswap_v2_64(handle::cublasHandle_t, n::Int64, x::CuPtr{Cdouble},
-                                       incx::Int64, y::CuPtr{Cdouble},
-                                       incy::Int64)::cublasStatus_t
+    @gcsafe_ccall libcublas.cublasDswap_v2_64(handle::cublasHandle_t, n::Int64,
+                                              x::CuPtr{Cdouble}, incx::Int64,
+                                              y::CuPtr{Cdouble},
+                                              incy::Int64)::cublasStatus_t
 end
 
 @checked function cublasCswap_v2_64(handle, n, x, incx, y, incy)
     initialize_context()
-    @ccall libcublas.cublasCswap_v2_64(handle::cublasHandle_t, n::Int64,
-                                       x::CuPtr{cuComplex}, incx::Int64,
-                                       y::CuPtr{cuComplex}, incy::Int64)::cublasStatus_t
+    @gcsafe_ccall libcublas.cublasCswap_v2_64(handle::cublasHandle_t, n::Int64,
+                                              x::CuPtr{cuComplex}, incx::Int64,
+                                              y::CuPtr{cuComplex},
+                                              incy::Int64)::cublasStatus_t
 end
 
 @checked function cublasZswap_v2_64(handle, n, x, incx, y, incy)
     initialize_context()
-    @ccall libcublas.cublasZswap_v2_64(handle::cublasHandle_t, n::Int64,
-                                       x::CuPtr{cuDoubleComplex}, incx::Int64,
-                                       y::CuPtr{cuDoubleComplex},
-                                       incy::Int64)::cublasStatus_t
+    @gcsafe_ccall libcublas.cublasZswap_v2_64(handle::cublasHandle_t, n::Int64,
+                                              x::CuPtr{cuDoubleComplex}, incx::Int64,
+                                              y::CuPtr{cuDoubleComplex},
+                                              incy::Int64)::cublasStatus_t
 end
 
 @checked function cublasIsamax_v2_64(handle, n, x, incx, result)
     initialize_context()
-    @ccall libcublas.cublasIsamax_v2_64(handle::cublasHandle_t, n::Int64, x::CuPtr{Cfloat},
-                                        incx::Int64,
-                                        result::RefOrCuRef{Cint})::cublasStatus_t
+    @gcsafe_ccall libcublas.cublasIsamax_v2_64(handle::cublasHandle_t, n::Int64,
+                                               x::CuPtr{Cfloat}, incx::Int64,
+                                               result::RefOrCuRef{Cint})::cublasStatus_t
 end
 
 @checked function cublasIdamax_v2_64(handle, n, x, incx, result)
     initialize_context()
-    @ccall libcublas.cublasIdamax_v2_64(handle::cublasHandle_t, n::Int64, x::CuPtr{Cdouble},
-                                        incx::Int64,
-                                        result::RefOrCuRef{Cint})::cublasStatus_t
+    @gcsafe_ccall libcublas.cublasIdamax_v2_64(handle::cublasHandle_t, n::Int64,
+                                               x::CuPtr{Cdouble}, incx::Int64,
+                                               result::RefOrCuRef{Cint})::cublasStatus_t
 end
 
 @checked function cublasIcamax_v2_64(handle, n, x, incx, result)
     initialize_context()
-    @ccall libcublas.cublasIcamax_v2_64(handle::cublasHandle_t, n::Int64,
-                                        x::CuPtr{cuComplex}, incx::Int64,
-                                        result::RefOrCuRef{Cint})::cublasStatus_t
+    @gcsafe_ccall libcublas.cublasIcamax_v2_64(handle::cublasHandle_t, n::Int64,
+                                               x::CuPtr{cuComplex}, incx::Int64,
+                                               result::RefOrCuRef{Cint})::cublasStatus_t
 end
 
 @checked function cublasIzamax_v2_64(handle, n, x, incx, result)
     initialize_context()
-    @ccall libcublas.cublasIzamax_v2_64(handle::cublasHandle_t, n::Int64,
-                                        x::CuPtr{cuDoubleComplex}, incx::Int64,
-                                        result::RefOrCuRef{Cint})::cublasStatus_t
+    @gcsafe_ccall libcublas.cublasIzamax_v2_64(handle::cublasHandle_t, n::Int64,
+                                               x::CuPtr{cuDoubleComplex}, incx::Int64,
+                                               result::RefOrCuRef{Cint})::cublasStatus_t
 end
 
 @checked function cublasIsamin_v2_64(handle, n, x, incx, result)
     initialize_context()
-    @ccall libcublas.cublasIsamin_v2_64(handle::cublasHandle_t, n::Int64, x::CuPtr{Cfloat},
-                                        incx::Int64,
-                                        result::RefOrCuRef{Cint})::cublasStatus_t
+    @gcsafe_ccall libcublas.cublasIsamin_v2_64(handle::cublasHandle_t, n::Int64,
+                                               x::CuPtr{Cfloat}, incx::Int64,
+                                               result::RefOrCuRef{Cint})::cublasStatus_t
 end
 
 @checked function cublasIdamin_v2_64(handle, n, x, incx, result)
     initialize_context()
-    @ccall libcublas.cublasIdamin_v2_64(handle::cublasHandle_t, n::Int64, x::CuPtr{Cdouble},
-                                        incx::Int64,
-                                        result::RefOrCuRef{Cint})::cublasStatus_t
+    @gcsafe_ccall libcublas.cublasIdamin_v2_64(handle::cublasHandle_t, n::Int64,
+                                               x::CuPtr{Cdouble}, incx::Int64,
+                                               result::RefOrCuRef{Cint})::cublasStatus_t
 end
 
 @checked function cublasIcamin_v2_64(handle, n, x, incx, result)
     initialize_context()
-    @ccall libcublas.cublasIcamin_v2_64(handle::cublasHandle_t, n::Int64,
-                                        x::CuPtr{cuComplex}, incx::Int64,
-                                        result::RefOrCuRef{Cint})::cublasStatus_t
+    @gcsafe_ccall libcublas.cublasIcamin_v2_64(handle::cublasHandle_t, n::Int64,
+                                               x::CuPtr{cuComplex}, incx::Int64,
+                                               result::RefOrCuRef{Cint})::cublasStatus_t
 end
 
 @checked function cublasIzamin_v2_64(handle, n, x, incx, result)
     initialize_context()
-    @ccall libcublas.cublasIzamin_v2_64(handle::cublasHandle_t, n::Int64,
-                                        x::CuPtr{cuDoubleComplex}, incx::Int64,
-                                        result::RefOrCuRef{Cint})::cublasStatus_t
+    @gcsafe_ccall libcublas.cublasIzamin_v2_64(handle::cublasHandle_t, n::Int64,
+                                               x::CuPtr{cuDoubleComplex}, incx::Int64,
+                                               result::RefOrCuRef{Cint})::cublasStatus_t
 end
 
 @checked function cublasSasum_v2_64(handle, n, x, incx, result)
     initialize_context()
-    @ccall libcublas.cublasSasum_v2_64(handle::cublasHandle_t, n::Int64, x::CuPtr{Cfloat},
-                                       incx::Int64,
-                                       result::RefOrCuRef{Cfloat})::cublasStatus_t
+    @gcsafe_ccall libcublas.cublasSasum_v2_64(handle::cublasHandle_t, n::Int64,
+                                              x::CuPtr{Cfloat}, incx::Int64,
+                                              result::RefOrCuRef{Cfloat})::cublasStatus_t
 end
 
 @checked function cublasDasum_v2_64(handle, n, x, incx, result)
     initialize_context()
-    @ccall libcublas.cublasDasum_v2_64(handle::cublasHandle_t, n::Int64, x::CuPtr{Cdouble},
-                                       incx::Int64,
-                                       result::RefOrCuRef{Cdouble})::cublasStatus_t
+    @gcsafe_ccall libcublas.cublasDasum_v2_64(handle::cublasHandle_t, n::Int64,
+                                              x::CuPtr{Cdouble}, incx::Int64,
+                                              result::RefOrCuRef{Cdouble})::cublasStatus_t
 end
 
 @checked function cublasScasum_v2_64(handle, n, x, incx, result)
     initialize_context()
-    @ccall libcublas.cublasScasum_v2_64(handle::cublasHandle_t, n::Int64,
-                                        x::CuPtr{cuComplex}, incx::Int64,
-                                        result::RefOrCuRef{Cfloat})::cublasStatus_t
+    @gcsafe_ccall libcublas.cublasScasum_v2_64(handle::cublasHandle_t, n::Int64,
+                                               x::CuPtr{cuComplex}, incx::Int64,
+                                               result::RefOrCuRef{Cfloat})::cublasStatus_t
 end
 
 @checked function cublasDzasum_v2_64(handle, n, x, incx, result)
     initialize_context()
-    @ccall libcublas.cublasDzasum_v2_64(handle::cublasHandle_t, n::Int64,
-                                        x::CuPtr{cuDoubleComplex}, incx::Int64,
-                                        result::RefOrCuRef{Cdouble})::cublasStatus_t
+    @gcsafe_ccall libcublas.cublasDzasum_v2_64(handle::cublasHandle_t, n::Int64,
+                                               x::CuPtr{cuDoubleComplex}, incx::Int64,
+                                               result::RefOrCuRef{Cdouble})::cublasStatus_t
 end
 
 @checked function cublasSrot_v2_64(handle, n, x, incx, y, incy, c, s)
     initialize_context()
-    @ccall libcublas.cublasSrot_v2_64(handle::cublasHandle_t, n::Int64, x::CuPtr{Cfloat},
-                                      incx::Int64, y::CuPtr{Cfloat}, incy::Int64,
-                                      c::RefOrCuRef{Cfloat},
-                                      s::RefOrCuRef{Cfloat})::cublasStatus_t
+    @gcsafe_ccall libcublas.cublasSrot_v2_64(handle::cublasHandle_t, n::Int64,
+                                             x::CuPtr{Cfloat}, incx::Int64,
+                                             y::CuPtr{Cfloat}, incy::Int64,
+                                             c::RefOrCuRef{Cfloat},
+                                             s::RefOrCuRef{Cfloat})::cublasStatus_t
 end
 
 @checked function cublasDrot_v2_64(handle, n, x, incx, y, incy, c, s)
     initialize_context()
-    @ccall libcublas.cublasDrot_v2_64(handle::cublasHandle_t, n::Int64, x::CuPtr{Cdouble},
-                                      incx::Int64, y::CuPtr{Cdouble}, incy::Int64,
-                                      c::RefOrCuRef{Cdouble},
-                                      s::RefOrCuRef{Cdouble})::cublasStatus_t
+    @gcsafe_ccall libcublas.cublasDrot_v2_64(handle::cublasHandle_t, n::Int64,
+                                             x::CuPtr{Cdouble}, incx::Int64,
+                                             y::CuPtr{Cdouble}, incy::Int64,
+                                             c::RefOrCuRef{Cdouble},
+                                             s::RefOrCuRef{Cdouble})::cublasStatus_t
 end
 
 @checked function cublasCrot_v2_64(handle, n, x, incx, y, incy, c, s)
     initialize_context()
-    @ccall libcublas.cublasCrot_v2_64(handle::cublasHandle_t, n::Int64, x::CuPtr{cuComplex},
-                                      incx::Int64, y::CuPtr{cuComplex}, incy::Int64,
-                                      c::RefOrCuRef{Cfloat},
-                                      s::RefOrCuRef{cuComplex})::cublasStatus_t
+    @gcsafe_ccall libcublas.cublasCrot_v2_64(handle::cublasHandle_t, n::Int64,
+                                             x::CuPtr{cuComplex}, incx::Int64,
+                                             y::CuPtr{cuComplex}, incy::Int64,
+                                             c::RefOrCuRef{Cfloat},
+                                             s::RefOrCuRef{cuComplex})::cublasStatus_t
 end
 
 @checked function cublasCsrot_v2_64(handle, n, x, incx, y, incy, c, s)
     initialize_context()
-    @ccall libcublas.cublasCsrot_v2_64(handle::cublasHandle_t, n::Int64,
-                                       x::CuPtr{cuComplex}, incx::Int64,
-                                       y::CuPtr{cuComplex}, incy::Int64,
-                                       c::RefOrCuRef{Cfloat},
-                                       s::RefOrCuRef{Cfloat})::cublasStatus_t
+    @gcsafe_ccall libcublas.cublasCsrot_v2_64(handle::cublasHandle_t, n::Int64,
+                                              x::CuPtr{cuComplex}, incx::Int64,
+                                              y::CuPtr{cuComplex}, incy::Int64,
+                                              c::RefOrCuRef{Cfloat},
+                                              s::RefOrCuRef{Cfloat})::cublasStatus_t
 end
 
 @checked function cublasZrot_v2_64(handle, n, x, incx, y, incy, c, s)
     initialize_context()
-    @ccall libcublas.cublasZrot_v2_64(handle::cublasHandle_t, n::Int64,
-                                      x::CuPtr{cuDoubleComplex}, incx::Int64,
-                                      y::CuPtr{cuDoubleComplex}, incy::Int64,
-                                      c::RefOrCuRef{Cdouble},
-                                      s::RefOrCuRef{cuDoubleComplex})::cublasStatus_t
+    @gcsafe_ccall libcublas.cublasZrot_v2_64(handle::cublasHandle_t, n::Int64,
+                                             x::CuPtr{cuDoubleComplex}, incx::Int64,
+                                             y::CuPtr{cuDoubleComplex}, incy::Int64,
+                                             c::RefOrCuRef{Cdouble},
+                                             s::RefOrCuRef{cuDoubleComplex})::cublasStatus_t
 end
 
 @checked function cublasZdrot_v2_64(handle, n, x, incx, y, incy, c, s)
     initialize_context()
-    @ccall libcublas.cublasZdrot_v2_64(handle::cublasHandle_t, n::Int64,
-                                       x::CuPtr{cuDoubleComplex}, incx::Int64,
-                                       y::CuPtr{cuDoubleComplex}, incy::Int64,
-                                       c::RefOrCuRef{Cdouble},
-                                       s::RefOrCuRef{Cdouble})::cublasStatus_t
+    @gcsafe_ccall libcublas.cublasZdrot_v2_64(handle::cublasHandle_t, n::Int64,
+                                              x::CuPtr{cuDoubleComplex}, incx::Int64,
+                                              y::CuPtr{cuDoubleComplex}, incy::Int64,
+                                              c::RefOrCuRef{Cdouble},
+                                              s::RefOrCuRef{Cdouble})::cublasStatus_t
 end
 
 @checked function cublasSrotm_v2_64(handle, n, x, incx, y, incy, param)
     initialize_context()
-    @ccall libcublas.cublasSrotm_v2_64(handle::cublasHandle_t, n::Int64, x::CuPtr{Cfloat},
-                                       incx::Int64, y::CuPtr{Cfloat}, incy::Int64,
-                                       param::PtrOrCuPtr{Cfloat})::cublasStatus_t
+    @gcsafe_ccall libcublas.cublasSrotm_v2_64(handle::cublasHandle_t, n::Int64,
+                                              x::CuPtr{Cfloat}, incx::Int64,
+                                              y::CuPtr{Cfloat}, incy::Int64,
+                                              param::PtrOrCuPtr{Cfloat})::cublasStatus_t
 end
 
 @checked function cublasDrotm_v2_64(handle, n, x, incx, y, incy, param)
     initialize_context()
-    @ccall libcublas.cublasDrotm_v2_64(handle::cublasHandle_t, n::Int64, x::CuPtr{Cdouble},
-                                       incx::Int64, y::CuPtr{Cdouble}, incy::Int64,
-                                       param::PtrOrCuPtr{Cdouble})::cublasStatus_t
+    @gcsafe_ccall libcublas.cublasDrotm_v2_64(handle::cublasHandle_t, n::Int64,
+                                              x::CuPtr{Cdouble}, incx::Int64,
+                                              y::CuPtr{Cdouble}, incy::Int64,
+                                              param::PtrOrCuPtr{Cdouble})::cublasStatus_t
 end
 
 @checked function cublasSgemv_v2_64(handle, trans, m, n, alpha, A, lda, x, incx, beta, y,
                                     incy)
     initialize_context()
-    @ccall libcublas.cublasSgemv_v2_64(handle::cublasHandle_t, trans::cublasOperation_t,
-                                       m::Int64, n::Int64, alpha::RefOrCuRef{Cfloat},
-                                       A::CuPtr{Cfloat}, lda::Int64, x::CuPtr{Cfloat},
-                                       incx::Int64, beta::RefOrCuRef{Cfloat},
-                                       y::CuPtr{Cfloat}, incy::Int64)::cublasStatus_t
+    @gcsafe_ccall libcublas.cublasSgemv_v2_64(handle::cublasHandle_t,
+                                              trans::cublasOperation_t, m::Int64, n::Int64,
+                                              alpha::RefOrCuRef{Cfloat}, A::CuPtr{Cfloat},
+                                              lda::Int64, x::CuPtr{Cfloat}, incx::Int64,
+                                              beta::RefOrCuRef{Cfloat}, y::CuPtr{Cfloat},
+                                              incy::Int64)::cublasStatus_t
 end
 
 @checked function cublasDgemv_v2_64(handle, trans, m, n, alpha, A, lda, x, incx, beta, y,
                                     incy)
     initialize_context()
-    @ccall libcublas.cublasDgemv_v2_64(handle::cublasHandle_t, trans::cublasOperation_t,
-                                       m::Int64, n::Int64, alpha::RefOrCuRef{Cdouble},
-                                       A::CuPtr{Cdouble}, lda::Int64, x::CuPtr{Cdouble},
-                                       incx::Int64, beta::RefOrCuRef{Cdouble},
-                                       y::CuPtr{Cdouble}, incy::Int64)::cublasStatus_t
+    @gcsafe_ccall libcublas.cublasDgemv_v2_64(handle::cublasHandle_t,
+                                              trans::cublasOperation_t, m::Int64, n::Int64,
+                                              alpha::RefOrCuRef{Cdouble}, A::CuPtr{Cdouble},
+                                              lda::Int64, x::CuPtr{Cdouble}, incx::Int64,
+                                              beta::RefOrCuRef{Cdouble}, y::CuPtr{Cdouble},
+                                              incy::Int64)::cublasStatus_t
 end
 
 @checked function cublasCgemv_v2_64(handle, trans, m, n, alpha, A, lda, x, incx, beta, y,
                                     incy)
     initialize_context()
-    @ccall libcublas.cublasCgemv_v2_64(handle::cublasHandle_t, trans::cublasOperation_t,
-                                       m::Int64, n::Int64, alpha::RefOrCuRef{cuComplex},
-                                       A::CuPtr{cuComplex}, lda::Int64, x::CuPtr{cuComplex},
-                                       incx::Int64, beta::RefOrCuRef{cuComplex},
-                                       y::CuPtr{cuComplex}, incy::Int64)::cublasStatus_t
+    @gcsafe_ccall libcublas.cublasCgemv_v2_64(handle::cublasHandle_t,
+                                              trans::cublasOperation_t, m::Int64, n::Int64,
+                                              alpha::RefOrCuRef{cuComplex},
+                                              A::CuPtr{cuComplex}, lda::Int64,
+                                              x::CuPtr{cuComplex}, incx::Int64,
+                                              beta::RefOrCuRef{cuComplex},
+                                              y::CuPtr{cuComplex},
+                                              incy::Int64)::cublasStatus_t
 end
 
 @checked function cublasZgemv_v2_64(handle, trans, m, n, alpha, A, lda, x, incx, beta, y,
                                     incy)
     initialize_context()
-    @ccall libcublas.cublasZgemv_v2_64(handle::cublasHandle_t, trans::cublasOperation_t,
-                                       m::Int64, n::Int64,
-                                       alpha::RefOrCuRef{cuDoubleComplex},
-                                       A::CuPtr{cuDoubleComplex}, lda::Int64,
-                                       x::CuPtr{cuDoubleComplex}, incx::Int64,
-                                       beta::RefOrCuRef{cuDoubleComplex},
-                                       y::CuPtr{cuDoubleComplex},
-                                       incy::Int64)::cublasStatus_t
+    @gcsafe_ccall libcublas.cublasZgemv_v2_64(handle::cublasHandle_t,
+                                              trans::cublasOperation_t, m::Int64, n::Int64,
+                                              alpha::RefOrCuRef{cuDoubleComplex},
+                                              A::CuPtr{cuDoubleComplex}, lda::Int64,
+                                              x::CuPtr{cuDoubleComplex}, incx::Int64,
+                                              beta::RefOrCuRef{cuDoubleComplex},
+                                              y::CuPtr{cuDoubleComplex},
+                                              incy::Int64)::cublasStatus_t
 end
 
 @checked function cublasSgbmv_v2_64(handle, trans, m, n, kl, ku, alpha, A, lda, x, incx,
                                     beta, y, incy)
     initialize_context()
-    @ccall libcublas.cublasSgbmv_v2_64(handle::cublasHandle_t, trans::cublasOperation_t,
-                                       m::Int64, n::Int64, kl::Int64, ku::Int64,
-                                       alpha::RefOrCuRef{Cfloat}, A::CuPtr{Cfloat},
-                                       lda::Int64, x::CuPtr{Cfloat}, incx::Int64,
-                                       beta::RefOrCuRef{Cfloat}, y::CuPtr{Cfloat},
-                                       incy::Int64)::cublasStatus_t
+    @gcsafe_ccall libcublas.cublasSgbmv_v2_64(handle::cublasHandle_t,
+                                              trans::cublasOperation_t, m::Int64, n::Int64,
+                                              kl::Int64, ku::Int64,
+                                              alpha::RefOrCuRef{Cfloat}, A::CuPtr{Cfloat},
+                                              lda::Int64, x::CuPtr{Cfloat}, incx::Int64,
+                                              beta::RefOrCuRef{Cfloat}, y::CuPtr{Cfloat},
+                                              incy::Int64)::cublasStatus_t
 end
 
 @checked function cublasDgbmv_v2_64(handle, trans, m, n, kl, ku, alpha, A, lda, x, incx,
                                     beta, y, incy)
     initialize_context()
-    @ccall libcublas.cublasDgbmv_v2_64(handle::cublasHandle_t, trans::cublasOperation_t,
-                                       m::Int64, n::Int64, kl::Int64, ku::Int64,
-                                       alpha::RefOrCuRef{Cdouble}, A::CuPtr{Cdouble},
-                                       lda::Int64, x::CuPtr{Cdouble}, incx::Int64,
-                                       beta::RefOrCuRef{Cdouble}, y::CuPtr{Cdouble},
-                                       incy::Int64)::cublasStatus_t
+    @gcsafe_ccall libcublas.cublasDgbmv_v2_64(handle::cublasHandle_t,
+                                              trans::cublasOperation_t, m::Int64, n::Int64,
+                                              kl::Int64, ku::Int64,
+                                              alpha::RefOrCuRef{Cdouble}, A::CuPtr{Cdouble},
+                                              lda::Int64, x::CuPtr{Cdouble}, incx::Int64,
+                                              beta::RefOrCuRef{Cdouble}, y::CuPtr{Cdouble},
+                                              incy::Int64)::cublasStatus_t
 end
 
 @checked function cublasCgbmv_v2_64(handle, trans, m, n, kl, ku, alpha, A, lda, x, incx,
                                     beta, y, incy)
     initialize_context()
-    @ccall libcublas.cublasCgbmv_v2_64(handle::cublasHandle_t, trans::cublasOperation_t,
-                                       m::Int64, n::Int64, kl::Int64, ku::Int64,
-                                       alpha::RefOrCuRef{cuComplex}, A::CuPtr{cuComplex},
-                                       lda::Int64, x::CuPtr{cuComplex}, incx::Int64,
-                                       beta::RefOrCuRef{cuComplex}, y::CuPtr{cuComplex},
-                                       incy::Int64)::cublasStatus_t
+    @gcsafe_ccall libcublas.cublasCgbmv_v2_64(handle::cublasHandle_t,
+                                              trans::cublasOperation_t, m::Int64, n::Int64,
+                                              kl::Int64, ku::Int64,
+                                              alpha::RefOrCuRef{cuComplex},
+                                              A::CuPtr{cuComplex}, lda::Int64,
+                                              x::CuPtr{cuComplex}, incx::Int64,
+                                              beta::RefOrCuRef{cuComplex},
+                                              y::CuPtr{cuComplex},
+                                              incy::Int64)::cublasStatus_t
 end
 
 @checked function cublasZgbmv_v2_64(handle, trans, m, n, kl, ku, alpha, A, lda, x, incx,
                                     beta, y, incy)
     initialize_context()
-    @ccall libcublas.cublasZgbmv_v2_64(handle::cublasHandle_t, trans::cublasOperation_t,
-                                       m::Int64, n::Int64, kl::Int64, ku::Int64,
-                                       alpha::RefOrCuRef{cuDoubleComplex},
-                                       A::CuPtr{cuDoubleComplex}, lda::Int64,
-                                       x::CuPtr{cuDoubleComplex}, incx::Int64,
-                                       beta::RefOrCuRef{cuDoubleComplex},
-                                       y::CuPtr{cuDoubleComplex},
-                                       incy::Int64)::cublasStatus_t
+    @gcsafe_ccall libcublas.cublasZgbmv_v2_64(handle::cublasHandle_t,
+                                              trans::cublasOperation_t, m::Int64, n::Int64,
+                                              kl::Int64, ku::Int64,
+                                              alpha::RefOrCuRef{cuDoubleComplex},
+                                              A::CuPtr{cuDoubleComplex}, lda::Int64,
+                                              x::CuPtr{cuDoubleComplex}, incx::Int64,
+                                              beta::RefOrCuRef{cuDoubleComplex},
+                                              y::CuPtr{cuDoubleComplex},
+                                              incy::Int64)::cublasStatus_t
 end
 
 @checked function cublasStrmv_v2_64(handle, uplo, trans, diag, n, A, lda, x, incx)
     initialize_context()
-    @ccall libcublas.cublasStrmv_v2_64(handle::cublasHandle_t, uplo::cublasFillMode_t,
-                                       trans::cublasOperation_t, diag::cublasDiagType_t,
-                                       n::Int64, A::CuPtr{Cfloat}, lda::Int64,
-                                       x::CuPtr{Cfloat}, incx::Int64)::cublasStatus_t
+    @gcsafe_ccall libcublas.cublasStrmv_v2_64(handle::cublasHandle_t,
+                                              uplo::cublasFillMode_t,
+                                              trans::cublasOperation_t,
+                                              diag::cublasDiagType_t, n::Int64,
+                                              A::CuPtr{Cfloat}, lda::Int64,
+                                              x::CuPtr{Cfloat}, incx::Int64)::cublasStatus_t
 end
 
 @checked function cublasDtrmv_v2_64(handle, uplo, trans, diag, n, A, lda, x, incx)
     initialize_context()
-    @ccall libcublas.cublasDtrmv_v2_64(handle::cublasHandle_t, uplo::cublasFillMode_t,
-                                       trans::cublasOperation_t, diag::cublasDiagType_t,
-                                       n::Int64, A::CuPtr{Cdouble}, lda::Int64,
-                                       x::CuPtr{Cdouble}, incx::Int64)::cublasStatus_t
+    @gcsafe_ccall libcublas.cublasDtrmv_v2_64(handle::cublasHandle_t,
+                                              uplo::cublasFillMode_t,
+                                              trans::cublasOperation_t,
+                                              diag::cublasDiagType_t, n::Int64,
+                                              A::CuPtr{Cdouble}, lda::Int64,
+                                              x::CuPtr{Cdouble},
+                                              incx::Int64)::cublasStatus_t
 end
 
 @checked function cublasCtrmv_v2_64(handle, uplo, trans, diag, n, A, lda, x, incx)
     initialize_context()
-    @ccall libcublas.cublasCtrmv_v2_64(handle::cublasHandle_t, uplo::cublasFillMode_t,
-                                       trans::cublasOperation_t, diag::cublasDiagType_t,
-                                       n::Int64, A::CuPtr{cuComplex}, lda::Int64,
-                                       x::CuPtr{cuComplex}, incx::Int64)::cublasStatus_t
+    @gcsafe_ccall libcublas.cublasCtrmv_v2_64(handle::cublasHandle_t,
+                                              uplo::cublasFillMode_t,
+                                              trans::cublasOperation_t,
+                                              diag::cublasDiagType_t, n::Int64,
+                                              A::CuPtr{cuComplex}, lda::Int64,
+                                              x::CuPtr{cuComplex},
+                                              incx::Int64)::cublasStatus_t
 end
 
 @checked function cublasZtrmv_v2_64(handle, uplo, trans, diag, n, A, lda, x, incx)
     initialize_context()
-    @ccall libcublas.cublasZtrmv_v2_64(handle::cublasHandle_t, uplo::cublasFillMode_t,
-                                       trans::cublasOperation_t, diag::cublasDiagType_t,
-                                       n::Int64, A::CuPtr{cuDoubleComplex}, lda::Int64,
-                                       x::CuPtr{cuDoubleComplex},
-                                       incx::Int64)::cublasStatus_t
+    @gcsafe_ccall libcublas.cublasZtrmv_v2_64(handle::cublasHandle_t,
+                                              uplo::cublasFillMode_t,
+                                              trans::cublasOperation_t,
+                                              diag::cublasDiagType_t, n::Int64,
+                                              A::CuPtr{cuDoubleComplex}, lda::Int64,
+                                              x::CuPtr{cuDoubleComplex},
+                                              incx::Int64)::cublasStatus_t
 end
 
 @checked function cublasStbmv_v2_64(handle, uplo, trans, diag, n, k, A, lda, x, incx)
     initialize_context()
-    @ccall libcublas.cublasStbmv_v2_64(handle::cublasHandle_t, uplo::cublasFillMode_t,
-                                       trans::cublasOperation_t, diag::cublasDiagType_t,
-                                       n::Int64, k::Int64, A::CuPtr{Cfloat}, lda::Int64,
-                                       x::CuPtr{Cfloat}, incx::Int64)::cublasStatus_t
+    @gcsafe_ccall libcublas.cublasStbmv_v2_64(handle::cublasHandle_t,
+                                              uplo::cublasFillMode_t,
+                                              trans::cublasOperation_t,
+                                              diag::cublasDiagType_t, n::Int64, k::Int64,
+                                              A::CuPtr{Cfloat}, lda::Int64,
+                                              x::CuPtr{Cfloat}, incx::Int64)::cublasStatus_t
 end
 
 @checked function cublasDtbmv_v2_64(handle, uplo, trans, diag, n, k, A, lda, x, incx)
     initialize_context()
-    @ccall libcublas.cublasDtbmv_v2_64(handle::cublasHandle_t, uplo::cublasFillMode_t,
-                                       trans::cublasOperation_t, diag::cublasDiagType_t,
-                                       n::Int64, k::Int64, A::CuPtr{Cdouble}, lda::Int64,
-                                       x::CuPtr{Cdouble}, incx::Int64)::cublasStatus_t
+    @gcsafe_ccall libcublas.cublasDtbmv_v2_64(handle::cublasHandle_t,
+                                              uplo::cublasFillMode_t,
+                                              trans::cublasOperation_t,
+                                              diag::cublasDiagType_t, n::Int64, k::Int64,
+                                              A::CuPtr{Cdouble}, lda::Int64,
+                                              x::CuPtr{Cdouble},
+                                              incx::Int64)::cublasStatus_t
 end
 
 @checked function cublasCtbmv_v2_64(handle, uplo, trans, diag, n, k, A, lda, x, incx)
     initialize_context()
-    @ccall libcublas.cublasCtbmv_v2_64(handle::cublasHandle_t, uplo::cublasFillMode_t,
-                                       trans::cublasOperation_t, diag::cublasDiagType_t,
-                                       n::Int64, k::Int64, A::CuPtr{cuComplex}, lda::Int64,
-                                       x::CuPtr{cuComplex}, incx::Int64)::cublasStatus_t
+    @gcsafe_ccall libcublas.cublasCtbmv_v2_64(handle::cublasHandle_t,
+                                              uplo::cublasFillMode_t,
+                                              trans::cublasOperation_t,
+                                              diag::cublasDiagType_t, n::Int64, k::Int64,
+                                              A::CuPtr{cuComplex}, lda::Int64,
+                                              x::CuPtr{cuComplex},
+                                              incx::Int64)::cublasStatus_t
 end
 
 @checked function cublasZtbmv_v2_64(handle, uplo, trans, diag, n, k, A, lda, x, incx)
     initialize_context()
-    @ccall libcublas.cublasZtbmv_v2_64(handle::cublasHandle_t, uplo::cublasFillMode_t,
-                                       trans::cublasOperation_t, diag::cublasDiagType_t,
-                                       n::Int64, k::Int64, A::CuPtr{cuDoubleComplex},
-                                       lda::Int64, x::CuPtr{cuDoubleComplex},
-                                       incx::Int64)::cublasStatus_t
+    @gcsafe_ccall libcublas.cublasZtbmv_v2_64(handle::cublasHandle_t,
+                                              uplo::cublasFillMode_t,
+                                              trans::cublasOperation_t,
+                                              diag::cublasDiagType_t, n::Int64, k::Int64,
+                                              A::CuPtr{cuDoubleComplex}, lda::Int64,
+                                              x::CuPtr{cuDoubleComplex},
+                                              incx::Int64)::cublasStatus_t
 end
 
 @checked function cublasStpmv_v2_64(handle, uplo, trans, diag, n, AP, x, incx)
     initialize_context()
-    @ccall libcublas.cublasStpmv_v2_64(handle::cublasHandle_t, uplo::cublasFillMode_t,
-                                       trans::cublasOperation_t, diag::cublasDiagType_t,
-                                       n::Int64, AP::CuPtr{Cfloat}, x::CuPtr{Cfloat},
-                                       incx::Int64)::cublasStatus_t
+    @gcsafe_ccall libcublas.cublasStpmv_v2_64(handle::cublasHandle_t,
+                                              uplo::cublasFillMode_t,
+                                              trans::cublasOperation_t,
+                                              diag::cublasDiagType_t, n::Int64,
+                                              AP::CuPtr{Cfloat}, x::CuPtr{Cfloat},
+                                              incx::Int64)::cublasStatus_t
 end
 
 @checked function cublasDtpmv_v2_64(handle, uplo, trans, diag, n, AP, x, incx)
     initialize_context()
-    @ccall libcublas.cublasDtpmv_v2_64(handle::cublasHandle_t, uplo::cublasFillMode_t,
-                                       trans::cublasOperation_t, diag::cublasDiagType_t,
-                                       n::Int64, AP::CuPtr{Cdouble}, x::CuPtr{Cdouble},
-                                       incx::Int64)::cublasStatus_t
+    @gcsafe_ccall libcublas.cublasDtpmv_v2_64(handle::cublasHandle_t,
+                                              uplo::cublasFillMode_t,
+                                              trans::cublasOperation_t,
+                                              diag::cublasDiagType_t, n::Int64,
+                                              AP::CuPtr{Cdouble}, x::CuPtr{Cdouble},
+                                              incx::Int64)::cublasStatus_t
 end
 
 @checked function cublasCtpmv_v2_64(handle, uplo, trans, diag, n, AP, x, incx)
     initialize_context()
-    @ccall libcublas.cublasCtpmv_v2_64(handle::cublasHandle_t, uplo::cublasFillMode_t,
-                                       trans::cublasOperation_t, diag::cublasDiagType_t,
-                                       n::Int64, AP::CuPtr{cuComplex}, x::CuPtr{cuComplex},
-                                       incx::Int64)::cublasStatus_t
+    @gcsafe_ccall libcublas.cublasCtpmv_v2_64(handle::cublasHandle_t,
+                                              uplo::cublasFillMode_t,
+                                              trans::cublasOperation_t,
+                                              diag::cublasDiagType_t, n::Int64,
+                                              AP::CuPtr{cuComplex}, x::CuPtr{cuComplex},
+                                              incx::Int64)::cublasStatus_t
 end
 
 @checked function cublasZtpmv_v2_64(handle, uplo, trans, diag, n, AP, x, incx)
     initialize_context()
-    @ccall libcublas.cublasZtpmv_v2_64(handle::cublasHandle_t, uplo::cublasFillMode_t,
-                                       trans::cublasOperation_t, diag::cublasDiagType_t,
-                                       n::Int64, AP::CuPtr{cuDoubleComplex},
-                                       x::CuPtr{cuDoubleComplex},
-                                       incx::Int64)::cublasStatus_t
+    @gcsafe_ccall libcublas.cublasZtpmv_v2_64(handle::cublasHandle_t,
+                                              uplo::cublasFillMode_t,
+                                              trans::cublasOperation_t,
+                                              diag::cublasDiagType_t, n::Int64,
+                                              AP::CuPtr{cuDoubleComplex},
+                                              x::CuPtr{cuDoubleComplex},
+                                              incx::Int64)::cublasStatus_t
 end
 
 @checked function cublasStrsv_v2_64(handle, uplo, trans, diag, n, A, lda, x, incx)
     initialize_context()
-    @ccall libcublas.cublasStrsv_v2_64(handle::cublasHandle_t, uplo::cublasFillMode_t,
-                                       trans::cublasOperation_t, diag::cublasDiagType_t,
-                                       n::Int64, A::CuPtr{Cfloat}, lda::Int64,
-                                       x::CuPtr{Cfloat}, incx::Int64)::cublasStatus_t
+    @gcsafe_ccall libcublas.cublasStrsv_v2_64(handle::cublasHandle_t,
+                                              uplo::cublasFillMode_t,
+                                              trans::cublasOperation_t,
+                                              diag::cublasDiagType_t, n::Int64,
+                                              A::CuPtr{Cfloat}, lda::Int64,
+                                              x::CuPtr{Cfloat}, incx::Int64)::cublasStatus_t
 end
 
 @checked function cublasDtrsv_v2_64(handle, uplo, trans, diag, n, A, lda, x, incx)
     initialize_context()
-    @ccall libcublas.cublasDtrsv_v2_64(handle::cublasHandle_t, uplo::cublasFillMode_t,
-                                       trans::cublasOperation_t, diag::cublasDiagType_t,
-                                       n::Int64, A::CuPtr{Cdouble}, lda::Int64,
-                                       x::CuPtr{Cdouble}, incx::Int64)::cublasStatus_t
+    @gcsafe_ccall libcublas.cublasDtrsv_v2_64(handle::cublasHandle_t,
+                                              uplo::cublasFillMode_t,
+                                              trans::cublasOperation_t,
+                                              diag::cublasDiagType_t, n::Int64,
+                                              A::CuPtr{Cdouble}, lda::Int64,
+                                              x::CuPtr{Cdouble},
+                                              incx::Int64)::cublasStatus_t
 end
 
 @checked function cublasCtrsv_v2_64(handle, uplo, trans, diag, n, A, lda, x, incx)
     initialize_context()
-    @ccall libcublas.cublasCtrsv_v2_64(handle::cublasHandle_t, uplo::cublasFillMode_t,
-                                       trans::cublasOperation_t, diag::cublasDiagType_t,
-                                       n::Int64, A::CuPtr{cuComplex}, lda::Int64,
-                                       x::CuPtr{cuComplex}, incx::Int64)::cublasStatus_t
+    @gcsafe_ccall libcublas.cublasCtrsv_v2_64(handle::cublasHandle_t,
+                                              uplo::cublasFillMode_t,
+                                              trans::cublasOperation_t,
+                                              diag::cublasDiagType_t, n::Int64,
+                                              A::CuPtr{cuComplex}, lda::Int64,
+                                              x::CuPtr{cuComplex},
+                                              incx::Int64)::cublasStatus_t
 end
 
 @checked function cublasZtrsv_v2_64(handle, uplo, trans, diag, n, A, lda, x, incx)
     initialize_context()
-    @ccall libcublas.cublasZtrsv_v2_64(handle::cublasHandle_t, uplo::cublasFillMode_t,
-                                       trans::cublasOperation_t, diag::cublasDiagType_t,
-                                       n::Int64, A::CuPtr{cuDoubleComplex}, lda::Int64,
-                                       x::CuPtr{cuDoubleComplex},
-                                       incx::Int64)::cublasStatus_t
+    @gcsafe_ccall libcublas.cublasZtrsv_v2_64(handle::cublasHandle_t,
+                                              uplo::cublasFillMode_t,
+                                              trans::cublasOperation_t,
+                                              diag::cublasDiagType_t, n::Int64,
+                                              A::CuPtr{cuDoubleComplex}, lda::Int64,
+                                              x::CuPtr{cuDoubleComplex},
+                                              incx::Int64)::cublasStatus_t
 end
 
 @checked function cublasStpsv_v2_64(handle, uplo, trans, diag, n, AP, x, incx)
     initialize_context()
-    @ccall libcublas.cublasStpsv_v2_64(handle::cublasHandle_t, uplo::cublasFillMode_t,
-                                       trans::cublasOperation_t, diag::cublasDiagType_t,
-                                       n::Int64, AP::CuPtr{Cfloat}, x::CuPtr{Cfloat},
-                                       incx::Int64)::cublasStatus_t
+    @gcsafe_ccall libcublas.cublasStpsv_v2_64(handle::cublasHandle_t,
+                                              uplo::cublasFillMode_t,
+                                              trans::cublasOperation_t,
+                                              diag::cublasDiagType_t, n::Int64,
+                                              AP::CuPtr{Cfloat}, x::CuPtr{Cfloat},
+                                              incx::Int64)::cublasStatus_t
 end
 
 @checked function cublasDtpsv_v2_64(handle, uplo, trans, diag, n, AP, x, incx)
     initialize_context()
-    @ccall libcublas.cublasDtpsv_v2_64(handle::cublasHandle_t, uplo::cublasFillMode_t,
-                                       trans::cublasOperation_t, diag::cublasDiagType_t,
-                                       n::Int64, AP::CuPtr{Cdouble}, x::CuPtr{Cdouble},
-                                       incx::Int64)::cublasStatus_t
+    @gcsafe_ccall libcublas.cublasDtpsv_v2_64(handle::cublasHandle_t,
+                                              uplo::cublasFillMode_t,
+                                              trans::cublasOperation_t,
+                                              diag::cublasDiagType_t, n::Int64,
+                                              AP::CuPtr{Cdouble}, x::CuPtr{Cdouble},
+                                              incx::Int64)::cublasStatus_t
 end
 
 @checked function cublasCtpsv_v2_64(handle, uplo, trans, diag, n, AP, x, incx)
     initialize_context()
-    @ccall libcublas.cublasCtpsv_v2_64(handle::cublasHandle_t, uplo::cublasFillMode_t,
-                                       trans::cublasOperation_t, diag::cublasDiagType_t,
-                                       n::Int64, AP::CuPtr{cuComplex}, x::CuPtr{cuComplex},
-                                       incx::Int64)::cublasStatus_t
+    @gcsafe_ccall libcublas.cublasCtpsv_v2_64(handle::cublasHandle_t,
+                                              uplo::cublasFillMode_t,
+                                              trans::cublasOperation_t,
+                                              diag::cublasDiagType_t, n::Int64,
+                                              AP::CuPtr{cuComplex}, x::CuPtr{cuComplex},
+                                              incx::Int64)::cublasStatus_t
 end
 
 @checked function cublasZtpsv_v2_64(handle, uplo, trans, diag, n, AP, x, incx)
     initialize_context()
-    @ccall libcublas.cublasZtpsv_v2_64(handle::cublasHandle_t, uplo::cublasFillMode_t,
-                                       trans::cublasOperation_t, diag::cublasDiagType_t,
-                                       n::Int64, AP::CuPtr{cuDoubleComplex},
-                                       x::CuPtr{cuDoubleComplex},
-                                       incx::Int64)::cublasStatus_t
+    @gcsafe_ccall libcublas.cublasZtpsv_v2_64(handle::cublasHandle_t,
+                                              uplo::cublasFillMode_t,
+                                              trans::cublasOperation_t,
+                                              diag::cublasDiagType_t, n::Int64,
+                                              AP::CuPtr{cuDoubleComplex},
+                                              x::CuPtr{cuDoubleComplex},
+                                              incx::Int64)::cublasStatus_t
 end
 
 @checked function cublasStbsv_v2_64(handle, uplo, trans, diag, n, k, A, lda, x, incx)
     initialize_context()
-    @ccall libcublas.cublasStbsv_v2_64(handle::cublasHandle_t, uplo::cublasFillMode_t,
-                                       trans::cublasOperation_t, diag::cublasDiagType_t,
-                                       n::Int64, k::Int64, A::CuPtr{Cfloat}, lda::Int64,
-                                       x::CuPtr{Cfloat}, incx::Int64)::cublasStatus_t
+    @gcsafe_ccall libcublas.cublasStbsv_v2_64(handle::cublasHandle_t,
+                                              uplo::cublasFillMode_t,
+                                              trans::cublasOperation_t,
+                                              diag::cublasDiagType_t, n::Int64, k::Int64,
+                                              A::CuPtr{Cfloat}, lda::Int64,
+                                              x::CuPtr{Cfloat}, incx::Int64)::cublasStatus_t
 end
 
 @checked function cublasDtbsv_v2_64(handle, uplo, trans, diag, n, k, A, lda, x, incx)
     initialize_context()
-    @ccall libcublas.cublasDtbsv_v2_64(handle::cublasHandle_t, uplo::cublasFillMode_t,
-                                       trans::cublasOperation_t, diag::cublasDiagType_t,
-                                       n::Int64, k::Int64, A::CuPtr{Cdouble}, lda::Int64,
-                                       x::CuPtr{Cdouble}, incx::Int64)::cublasStatus_t
+    @gcsafe_ccall libcublas.cublasDtbsv_v2_64(handle::cublasHandle_t,
+                                              uplo::cublasFillMode_t,
+                                              trans::cublasOperation_t,
+                                              diag::cublasDiagType_t, n::Int64, k::Int64,
+                                              A::CuPtr{Cdouble}, lda::Int64,
+                                              x::CuPtr{Cdouble},
+                                              incx::Int64)::cublasStatus_t
 end
 
 @checked function cublasCtbsv_v2_64(handle, uplo, trans, diag, n, k, A, lda, x, incx)
     initialize_context()
-    @ccall libcublas.cublasCtbsv_v2_64(handle::cublasHandle_t, uplo::cublasFillMode_t,
-                                       trans::cublasOperation_t, diag::cublasDiagType_t,
-                                       n::Int64, k::Int64, A::CuPtr{cuComplex}, lda::Int64,
-                                       x::CuPtr{cuComplex}, incx::Int64)::cublasStatus_t
+    @gcsafe_ccall libcublas.cublasCtbsv_v2_64(handle::cublasHandle_t,
+                                              uplo::cublasFillMode_t,
+                                              trans::cublasOperation_t,
+                                              diag::cublasDiagType_t, n::Int64, k::Int64,
+                                              A::CuPtr{cuComplex}, lda::Int64,
+                                              x::CuPtr{cuComplex},
+                                              incx::Int64)::cublasStatus_t
 end
 
 @checked function cublasZtbsv_v2_64(handle, uplo, trans, diag, n, k, A, lda, x, incx)
     initialize_context()
-    @ccall libcublas.cublasZtbsv_v2_64(handle::cublasHandle_t, uplo::cublasFillMode_t,
-                                       trans::cublasOperation_t, diag::cublasDiagType_t,
-                                       n::Int64, k::Int64, A::CuPtr{cuDoubleComplex},
-                                       lda::Int64, x::CuPtr{cuDoubleComplex},
-                                       incx::Int64)::cublasStatus_t
+    @gcsafe_ccall libcublas.cublasZtbsv_v2_64(handle::cublasHandle_t,
+                                              uplo::cublasFillMode_t,
+                                              trans::cublasOperation_t,
+                                              diag::cublasDiagType_t, n::Int64, k::Int64,
+                                              A::CuPtr{cuDoubleComplex}, lda::Int64,
+                                              x::CuPtr{cuDoubleComplex},
+                                              incx::Int64)::cublasStatus_t
 end
 
 @checked function cublasSsymv_v2_64(handle, uplo, n, alpha, A, lda, x, incx, beta, y, incy)
     initialize_context()
-    @ccall libcublas.cublasSsymv_v2_64(handle::cublasHandle_t, uplo::cublasFillMode_t,
-                                       n::Int64, alpha::RefOrCuRef{Cfloat},
-                                       A::CuPtr{Cfloat}, lda::Int64, x::CuPtr{Cfloat},
-                                       incx::Int64, beta::RefOrCuRef{Cfloat},
-                                       y::CuPtr{Cfloat}, incy::Int64)::cublasStatus_t
+    @gcsafe_ccall libcublas.cublasSsymv_v2_64(handle::cublasHandle_t,
+                                              uplo::cublasFillMode_t, n::Int64,
+                                              alpha::RefOrCuRef{Cfloat}, A::CuPtr{Cfloat},
+                                              lda::Int64, x::CuPtr{Cfloat}, incx::Int64,
+                                              beta::RefOrCuRef{Cfloat}, y::CuPtr{Cfloat},
+                                              incy::Int64)::cublasStatus_t
 end
 
 @checked function cublasDsymv_v2_64(handle, uplo, n, alpha, A, lda, x, incx, beta, y, incy)
     initialize_context()
-    @ccall libcublas.cublasDsymv_v2_64(handle::cublasHandle_t, uplo::cublasFillMode_t,
-                                       n::Int64, alpha::RefOrCuRef{Cdouble},
-                                       A::CuPtr{Cdouble}, lda::Int64, x::CuPtr{Cdouble},
-                                       incx::Int64, beta::RefOrCuRef{Cdouble},
-                                       y::CuPtr{Cdouble}, incy::Int64)::cublasStatus_t
+    @gcsafe_ccall libcublas.cublasDsymv_v2_64(handle::cublasHandle_t,
+                                              uplo::cublasFillMode_t, n::Int64,
+                                              alpha::RefOrCuRef{Cdouble}, A::CuPtr{Cdouble},
+                                              lda::Int64, x::CuPtr{Cdouble}, incx::Int64,
+                                              beta::RefOrCuRef{Cdouble}, y::CuPtr{Cdouble},
+                                              incy::Int64)::cublasStatus_t
 end
 
 @checked function cublasCsymv_v2_64(handle, uplo, n, alpha, A, lda, x, incx, beta, y, incy)
     initialize_context()
-    @ccall libcublas.cublasCsymv_v2_64(handle::cublasHandle_t, uplo::cublasFillMode_t,
-                                       n::Int64, alpha::RefOrCuRef{cuComplex},
-                                       A::CuPtr{cuComplex}, lda::Int64, x::CuPtr{cuComplex},
-                                       incx::Int64, beta::RefOrCuRef{cuComplex},
-                                       y::CuPtr{cuComplex}, incy::Int64)::cublasStatus_t
+    @gcsafe_ccall libcublas.cublasCsymv_v2_64(handle::cublasHandle_t,
+                                              uplo::cublasFillMode_t, n::Int64,
+                                              alpha::RefOrCuRef{cuComplex},
+                                              A::CuPtr{cuComplex}, lda::Int64,
+                                              x::CuPtr{cuComplex}, incx::Int64,
+                                              beta::RefOrCuRef{cuComplex},
+                                              y::CuPtr{cuComplex},
+                                              incy::Int64)::cublasStatus_t
 end
 
 @checked function cublasZsymv_v2_64(handle, uplo, n, alpha, A, lda, x, incx, beta, y, incy)
     initialize_context()
-    @ccall libcublas.cublasZsymv_v2_64(handle::cublasHandle_t, uplo::cublasFillMode_t,
-                                       n::Int64, alpha::RefOrCuRef{cuDoubleComplex},
-                                       A::CuPtr{cuDoubleComplex}, lda::Int64,
-                                       x::CuPtr{cuDoubleComplex}, incx::Int64,
-                                       beta::RefOrCuRef{cuDoubleComplex},
-                                       y::CuPtr{cuDoubleComplex},
-                                       incy::Int64)::cublasStatus_t
+    @gcsafe_ccall libcublas.cublasZsymv_v2_64(handle::cublasHandle_t,
+                                              uplo::cublasFillMode_t, n::Int64,
+                                              alpha::RefOrCuRef{cuDoubleComplex},
+                                              A::CuPtr{cuDoubleComplex}, lda::Int64,
+                                              x::CuPtr{cuDoubleComplex}, incx::Int64,
+                                              beta::RefOrCuRef{cuDoubleComplex},
+                                              y::CuPtr{cuDoubleComplex},
+                                              incy::Int64)::cublasStatus_t
 end
 
 @checked function cublasChemv_v2_64(handle, uplo, n, alpha, A, lda, x, incx, beta, y, incy)
     initialize_context()
-    @ccall libcublas.cublasChemv_v2_64(handle::cublasHandle_t, uplo::cublasFillMode_t,
-                                       n::Int64, alpha::RefOrCuRef{cuComplex},
-                                       A::CuPtr{cuComplex}, lda::Int64, x::CuPtr{cuComplex},
-                                       incx::Int64, beta::RefOrCuRef{cuComplex},
-                                       y::CuPtr{cuComplex}, incy::Int64)::cublasStatus_t
+    @gcsafe_ccall libcublas.cublasChemv_v2_64(handle::cublasHandle_t,
+                                              uplo::cublasFillMode_t, n::Int64,
+                                              alpha::RefOrCuRef{cuComplex},
+                                              A::CuPtr{cuComplex}, lda::Int64,
+                                              x::CuPtr{cuComplex}, incx::Int64,
+                                              beta::RefOrCuRef{cuComplex},
+                                              y::CuPtr{cuComplex},
+                                              incy::Int64)::cublasStatus_t
 end
 
 @checked function cublasZhemv_v2_64(handle, uplo, n, alpha, A, lda, x, incx, beta, y, incy)
     initialize_context()
-    @ccall libcublas.cublasZhemv_v2_64(handle::cublasHandle_t, uplo::cublasFillMode_t,
-                                       n::Int64, alpha::RefOrCuRef{cuDoubleComplex},
-                                       A::CuPtr{cuDoubleComplex}, lda::Int64,
-                                       x::CuPtr{cuDoubleComplex}, incx::Int64,
-                                       beta::RefOrCuRef{cuDoubleComplex},
-                                       y::CuPtr{cuDoubleComplex},
-                                       incy::Int64)::cublasStatus_t
+    @gcsafe_ccall libcublas.cublasZhemv_v2_64(handle::cublasHandle_t,
+                                              uplo::cublasFillMode_t, n::Int64,
+                                              alpha::RefOrCuRef{cuDoubleComplex},
+                                              A::CuPtr{cuDoubleComplex}, lda::Int64,
+                                              x::CuPtr{cuDoubleComplex}, incx::Int64,
+                                              beta::RefOrCuRef{cuDoubleComplex},
+                                              y::CuPtr{cuDoubleComplex},
+                                              incy::Int64)::cublasStatus_t
 end
 
 @checked function cublasSsbmv_v2_64(handle, uplo, n, k, alpha, A, lda, x, incx, beta, y,
                                     incy)
     initialize_context()
-    @ccall libcublas.cublasSsbmv_v2_64(handle::cublasHandle_t, uplo::cublasFillMode_t,
-                                       n::Int64, k::Int64, alpha::RefOrCuRef{Cfloat},
-                                       A::CuPtr{Cfloat}, lda::Int64, x::CuPtr{Cfloat},
-                                       incx::Int64, beta::RefOrCuRef{Cfloat},
-                                       y::CuPtr{Cfloat}, incy::Int64)::cublasStatus_t
+    @gcsafe_ccall libcublas.cublasSsbmv_v2_64(handle::cublasHandle_t,
+                                              uplo::cublasFillMode_t, n::Int64, k::Int64,
+                                              alpha::RefOrCuRef{Cfloat}, A::CuPtr{Cfloat},
+                                              lda::Int64, x::CuPtr{Cfloat}, incx::Int64,
+                                              beta::RefOrCuRef{Cfloat}, y::CuPtr{Cfloat},
+                                              incy::Int64)::cublasStatus_t
 end
 
 @checked function cublasDsbmv_v2_64(handle, uplo, n, k, alpha, A, lda, x, incx, beta, y,
                                     incy)
     initialize_context()
-    @ccall libcublas.cublasDsbmv_v2_64(handle::cublasHandle_t, uplo::cublasFillMode_t,
-                                       n::Int64, k::Int64, alpha::RefOrCuRef{Cdouble},
-                                       A::CuPtr{Cdouble}, lda::Int64, x::CuPtr{Cdouble},
-                                       incx::Int64, beta::RefOrCuRef{Cdouble},
-                                       y::CuPtr{Cdouble}, incy::Int64)::cublasStatus_t
+    @gcsafe_ccall libcublas.cublasDsbmv_v2_64(handle::cublasHandle_t,
+                                              uplo::cublasFillMode_t, n::Int64, k::Int64,
+                                              alpha::RefOrCuRef{Cdouble}, A::CuPtr{Cdouble},
+                                              lda::Int64, x::CuPtr{Cdouble}, incx::Int64,
+                                              beta::RefOrCuRef{Cdouble}, y::CuPtr{Cdouble},
+                                              incy::Int64)::cublasStatus_t
 end
 
 @checked function cublasChbmv_v2_64(handle, uplo, n, k, alpha, A, lda, x, incx, beta, y,
                                     incy)
     initialize_context()
-    @ccall libcublas.cublasChbmv_v2_64(handle::cublasHandle_t, uplo::cublasFillMode_t,
-                                       n::Int64, k::Int64, alpha::RefOrCuRef{cuComplex},
-                                       A::CuPtr{cuComplex}, lda::Int64, x::CuPtr{cuComplex},
-                                       incx::Int64, beta::RefOrCuRef{cuComplex},
-                                       y::CuPtr{cuComplex}, incy::Int64)::cublasStatus_t
+    @gcsafe_ccall libcublas.cublasChbmv_v2_64(handle::cublasHandle_t,
+                                              uplo::cublasFillMode_t, n::Int64, k::Int64,
+                                              alpha::RefOrCuRef{cuComplex},
+                                              A::CuPtr{cuComplex}, lda::Int64,
+                                              x::CuPtr{cuComplex}, incx::Int64,
+                                              beta::RefOrCuRef{cuComplex},
+                                              y::CuPtr{cuComplex},
+                                              incy::Int64)::cublasStatus_t
 end
 
 @checked function cublasZhbmv_v2_64(handle, uplo, n, k, alpha, A, lda, x, incx, beta, y,
                                     incy)
     initialize_context()
-    @ccall libcublas.cublasZhbmv_v2_64(handle::cublasHandle_t, uplo::cublasFillMode_t,
-                                       n::Int64, k::Int64,
-                                       alpha::RefOrCuRef{cuDoubleComplex},
-                                       A::CuPtr{cuDoubleComplex}, lda::Int64,
-                                       x::CuPtr{cuDoubleComplex}, incx::Int64,
-                                       beta::RefOrCuRef{cuDoubleComplex},
-                                       y::CuPtr{cuDoubleComplex},
-                                       incy::Int64)::cublasStatus_t
+    @gcsafe_ccall libcublas.cublasZhbmv_v2_64(handle::cublasHandle_t,
+                                              uplo::cublasFillMode_t, n::Int64, k::Int64,
+                                              alpha::RefOrCuRef{cuDoubleComplex},
+                                              A::CuPtr{cuDoubleComplex}, lda::Int64,
+                                              x::CuPtr{cuDoubleComplex}, incx::Int64,
+                                              beta::RefOrCuRef{cuDoubleComplex},
+                                              y::CuPtr{cuDoubleComplex},
+                                              incy::Int64)::cublasStatus_t
 end
 
 @checked function cublasSspmv_v2_64(handle, uplo, n, alpha, AP, x, incx, beta, y, incy)
     initialize_context()
-    @ccall libcublas.cublasSspmv_v2_64(handle::cublasHandle_t, uplo::cublasFillMode_t,
-                                       n::Int64, alpha::RefOrCuRef{Cfloat},
-                                       AP::CuPtr{Cfloat}, x::CuPtr{Cfloat}, incx::Int64,
-                                       beta::RefOrCuRef{Cfloat}, y::CuPtr{Cfloat},
-                                       incy::Int64)::cublasStatus_t
+    @gcsafe_ccall libcublas.cublasSspmv_v2_64(handle::cublasHandle_t,
+                                              uplo::cublasFillMode_t, n::Int64,
+                                              alpha::RefOrCuRef{Cfloat}, AP::CuPtr{Cfloat},
+                                              x::CuPtr{Cfloat}, incx::Int64,
+                                              beta::RefOrCuRef{Cfloat}, y::CuPtr{Cfloat},
+                                              incy::Int64)::cublasStatus_t
 end
 
 @checked function cublasDspmv_v2_64(handle, uplo, n, alpha, AP, x, incx, beta, y, incy)
     initialize_context()
-    @ccall libcublas.cublasDspmv_v2_64(handle::cublasHandle_t, uplo::cublasFillMode_t,
-                                       n::Int64, alpha::RefOrCuRef{Cdouble},
-                                       AP::CuPtr{Cdouble}, x::CuPtr{Cdouble}, incx::Int64,
-                                       beta::RefOrCuRef{Cdouble}, y::CuPtr{Cdouble},
-                                       incy::Int64)::cublasStatus_t
+    @gcsafe_ccall libcublas.cublasDspmv_v2_64(handle::cublasHandle_t,
+                                              uplo::cublasFillMode_t, n::Int64,
+                                              alpha::RefOrCuRef{Cdouble},
+                                              AP::CuPtr{Cdouble}, x::CuPtr{Cdouble},
+                                              incx::Int64, beta::RefOrCuRef{Cdouble},
+                                              y::CuPtr{Cdouble},
+                                              incy::Int64)::cublasStatus_t
 end
 
 @checked function cublasChpmv_v2_64(handle, uplo, n, alpha, AP, x, incx, beta, y, incy)
     initialize_context()
-    @ccall libcublas.cublasChpmv_v2_64(handle::cublasHandle_t, uplo::cublasFillMode_t,
-                                       n::Int64, alpha::RefOrCuRef{cuComplex},
-                                       AP::CuPtr{cuComplex}, x::CuPtr{cuComplex},
-                                       incx::Int64, beta::RefOrCuRef{cuComplex},
-                                       y::CuPtr{cuComplex}, incy::Int64)::cublasStatus_t
+    @gcsafe_ccall libcublas.cublasChpmv_v2_64(handle::cublasHandle_t,
+                                              uplo::cublasFillMode_t, n::Int64,
+                                              alpha::RefOrCuRef{cuComplex},
+                                              AP::CuPtr{cuComplex}, x::CuPtr{cuComplex},
+                                              incx::Int64, beta::RefOrCuRef{cuComplex},
+                                              y::CuPtr{cuComplex},
+                                              incy::Int64)::cublasStatus_t
 end
 
 @checked function cublasZhpmv_v2_64(handle, uplo, n, alpha, AP, x, incx, beta, y, incy)
     initialize_context()
-    @ccall libcublas.cublasZhpmv_v2_64(handle::cublasHandle_t, uplo::cublasFillMode_t,
-                                       n::Int64, alpha::RefOrCuRef{cuDoubleComplex},
-                                       AP::CuPtr{cuDoubleComplex},
-                                       x::CuPtr{cuDoubleComplex}, incx::Int64,
-                                       beta::RefOrCuRef{cuDoubleComplex},
-                                       y::CuPtr{cuDoubleComplex},
-                                       incy::Int64)::cublasStatus_t
+    @gcsafe_ccall libcublas.cublasZhpmv_v2_64(handle::cublasHandle_t,
+                                              uplo::cublasFillMode_t, n::Int64,
+                                              alpha::RefOrCuRef{cuDoubleComplex},
+                                              AP::CuPtr{cuDoubleComplex},
+                                              x::CuPtr{cuDoubleComplex}, incx::Int64,
+                                              beta::RefOrCuRef{cuDoubleComplex},
+                                              y::CuPtr{cuDoubleComplex},
+                                              incy::Int64)::cublasStatus_t
 end
 
 @checked function cublasSger_v2_64(handle, m, n, alpha, x, incx, y, incy, A, lda)
     initialize_context()
-    @ccall libcublas.cublasSger_v2_64(handle::cublasHandle_t, m::Int64, n::Int64,
-                                      alpha::RefOrCuRef{Cfloat}, x::CuPtr{Cfloat},
-                                      incx::Int64, y::CuPtr{Cfloat}, incy::Int64,
-                                      A::CuPtr{Cfloat}, lda::Int64)::cublasStatus_t
+    @gcsafe_ccall libcublas.cublasSger_v2_64(handle::cublasHandle_t, m::Int64, n::Int64,
+                                             alpha::RefOrCuRef{Cfloat}, x::CuPtr{Cfloat},
+                                             incx::Int64, y::CuPtr{Cfloat}, incy::Int64,
+                                             A::CuPtr{Cfloat}, lda::Int64)::cublasStatus_t
 end
 
 @checked function cublasDger_v2_64(handle, m, n, alpha, x, incx, y, incy, A, lda)
     initialize_context()
-    @ccall libcublas.cublasDger_v2_64(handle::cublasHandle_t, m::Int64, n::Int64,
-                                      alpha::RefOrCuRef{Cdouble}, x::CuPtr{Cdouble},
-                                      incx::Int64, y::CuPtr{Cdouble}, incy::Int64,
-                                      A::CuPtr{Cdouble}, lda::Int64)::cublasStatus_t
+    @gcsafe_ccall libcublas.cublasDger_v2_64(handle::cublasHandle_t, m::Int64, n::Int64,
+                                             alpha::RefOrCuRef{Cdouble}, x::CuPtr{Cdouble},
+                                             incx::Int64, y::CuPtr{Cdouble}, incy::Int64,
+                                             A::CuPtr{Cdouble}, lda::Int64)::cublasStatus_t
 end
 
 @checked function cublasCgeru_v2_64(handle, m, n, alpha, x, incx, y, incy, A, lda)
     initialize_context()
-    @ccall libcublas.cublasCgeru_v2_64(handle::cublasHandle_t, m::Int64, n::Int64,
-                                       alpha::RefOrCuRef{cuComplex}, x::CuPtr{cuComplex},
-                                       incx::Int64, y::CuPtr{cuComplex}, incy::Int64,
-                                       A::CuPtr{cuComplex}, lda::Int64)::cublasStatus_t
+    @gcsafe_ccall libcublas.cublasCgeru_v2_64(handle::cublasHandle_t, m::Int64, n::Int64,
+                                              alpha::RefOrCuRef{cuComplex},
+                                              x::CuPtr{cuComplex}, incx::Int64,
+                                              y::CuPtr{cuComplex}, incy::Int64,
+                                              A::CuPtr{cuComplex},
+                                              lda::Int64)::cublasStatus_t
 end
 
 @checked function cublasCgerc_v2_64(handle, m, n, alpha, x, incx, y, incy, A, lda)
     initialize_context()
-    @ccall libcublas.cublasCgerc_v2_64(handle::cublasHandle_t, m::Int64, n::Int64,
-                                       alpha::RefOrCuRef{cuComplex}, x::CuPtr{cuComplex},
-                                       incx::Int64, y::CuPtr{cuComplex}, incy::Int64,
-                                       A::CuPtr{cuComplex}, lda::Int64)::cublasStatus_t
+    @gcsafe_ccall libcublas.cublasCgerc_v2_64(handle::cublasHandle_t, m::Int64, n::Int64,
+                                              alpha::RefOrCuRef{cuComplex},
+                                              x::CuPtr{cuComplex}, incx::Int64,
+                                              y::CuPtr{cuComplex}, incy::Int64,
+                                              A::CuPtr{cuComplex},
+                                              lda::Int64)::cublasStatus_t
 end
 
 @checked function cublasZgeru_v2_64(handle, m, n, alpha, x, incx, y, incy, A, lda)
     initialize_context()
-    @ccall libcublas.cublasZgeru_v2_64(handle::cublasHandle_t, m::Int64, n::Int64,
-                                       alpha::RefOrCuRef{cuDoubleComplex},
-                                       x::CuPtr{cuDoubleComplex}, incx::Int64,
-                                       y::CuPtr{cuDoubleComplex}, incy::Int64,
-                                       A::CuPtr{cuDoubleComplex},
-                                       lda::Int64)::cublasStatus_t
+    @gcsafe_ccall libcublas.cublasZgeru_v2_64(handle::cublasHandle_t, m::Int64, n::Int64,
+                                              alpha::RefOrCuRef{cuDoubleComplex},
+                                              x::CuPtr{cuDoubleComplex}, incx::Int64,
+                                              y::CuPtr{cuDoubleComplex}, incy::Int64,
+                                              A::CuPtr{cuDoubleComplex},
+                                              lda::Int64)::cublasStatus_t
 end
 
 @checked function cublasZgerc_v2_64(handle, m, n, alpha, x, incx, y, incy, A, lda)
     initialize_context()
-    @ccall libcublas.cublasZgerc_v2_64(handle::cublasHandle_t, m::Int64, n::Int64,
-                                       alpha::RefOrCuRef{cuDoubleComplex},
-                                       x::CuPtr{cuDoubleComplex}, incx::Int64,
-                                       y::CuPtr{cuDoubleComplex}, incy::Int64,
-                                       A::CuPtr{cuDoubleComplex},
-                                       lda::Int64)::cublasStatus_t
+    @gcsafe_ccall libcublas.cublasZgerc_v2_64(handle::cublasHandle_t, m::Int64, n::Int64,
+                                              alpha::RefOrCuRef{cuDoubleComplex},
+                                              x::CuPtr{cuDoubleComplex}, incx::Int64,
+                                              y::CuPtr{cuDoubleComplex}, incy::Int64,
+                                              A::CuPtr{cuDoubleComplex},
+                                              lda::Int64)::cublasStatus_t
 end
 
 @checked function cublasSsyr_v2_64(handle, uplo, n, alpha, x, incx, A, lda)
     initialize_context()
-    @ccall libcublas.cublasSsyr_v2_64(handle::cublasHandle_t, uplo::cublasFillMode_t,
-                                      n::Int64, alpha::RefOrCuRef{Cfloat}, x::CuPtr{Cfloat},
-                                      incx::Int64, A::CuPtr{Cfloat},
-                                      lda::Int64)::cublasStatus_t
+    @gcsafe_ccall libcublas.cublasSsyr_v2_64(handle::cublasHandle_t, uplo::cublasFillMode_t,
+                                             n::Int64, alpha::RefOrCuRef{Cfloat},
+                                             x::CuPtr{Cfloat}, incx::Int64,
+                                             A::CuPtr{Cfloat}, lda::Int64)::cublasStatus_t
 end
 
 @checked function cublasDsyr_v2_64(handle, uplo, n, alpha, x, incx, A, lda)
     initialize_context()
-    @ccall libcublas.cublasDsyr_v2_64(handle::cublasHandle_t, uplo::cublasFillMode_t,
-                                      n::Int64, alpha::RefOrCuRef{Cdouble},
-                                      x::CuPtr{Cdouble}, incx::Int64, A::CuPtr{Cdouble},
-                                      lda::Int64)::cublasStatus_t
+    @gcsafe_ccall libcublas.cublasDsyr_v2_64(handle::cublasHandle_t, uplo::cublasFillMode_t,
+                                             n::Int64, alpha::RefOrCuRef{Cdouble},
+                                             x::CuPtr{Cdouble}, incx::Int64,
+                                             A::CuPtr{Cdouble}, lda::Int64)::cublasStatus_t
 end
 
 @checked function cublasCsyr_v2_64(handle, uplo, n, alpha, x, incx, A, lda)
     initialize_context()
-    @ccall libcublas.cublasCsyr_v2_64(handle::cublasHandle_t, uplo::cublasFillMode_t,
-                                      n::Int64, alpha::RefOrCuRef{cuComplex},
-                                      x::CuPtr{cuComplex}, incx::Int64, A::CuPtr{cuComplex},
-                                      lda::Int64)::cublasStatus_t
+    @gcsafe_ccall libcublas.cublasCsyr_v2_64(handle::cublasHandle_t, uplo::cublasFillMode_t,
+                                             n::Int64, alpha::RefOrCuRef{cuComplex},
+                                             x::CuPtr{cuComplex}, incx::Int64,
+                                             A::CuPtr{cuComplex},
+                                             lda::Int64)::cublasStatus_t
 end
 
 @checked function cublasZsyr_v2_64(handle, uplo, n, alpha, x, incx, A, lda)
     initialize_context()
-    @ccall libcublas.cublasZsyr_v2_64(handle::cublasHandle_t, uplo::cublasFillMode_t,
-                                      n::Int64, alpha::RefOrCuRef{cuDoubleComplex},
-                                      x::CuPtr{cuDoubleComplex}, incx::Int64,
-                                      A::CuPtr{cuDoubleComplex}, lda::Int64)::cublasStatus_t
+    @gcsafe_ccall libcublas.cublasZsyr_v2_64(handle::cublasHandle_t, uplo::cublasFillMode_t,
+                                             n::Int64, alpha::RefOrCuRef{cuDoubleComplex},
+                                             x::CuPtr{cuDoubleComplex}, incx::Int64,
+                                             A::CuPtr{cuDoubleComplex},
+                                             lda::Int64)::cublasStatus_t
 end
 
 @checked function cublasCher_v2_64(handle, uplo, n, alpha, x, incx, A, lda)
     initialize_context()
-    @ccall libcublas.cublasCher_v2_64(handle::cublasHandle_t, uplo::cublasFillMode_t,
-                                      n::Int64, alpha::RefOrCuRef{Cfloat},
-                                      x::CuPtr{cuComplex}, incx::Int64, A::CuPtr{cuComplex},
-                                      lda::Int64)::cublasStatus_t
+    @gcsafe_ccall libcublas.cublasCher_v2_64(handle::cublasHandle_t, uplo::cublasFillMode_t,
+                                             n::Int64, alpha::RefOrCuRef{Cfloat},
+                                             x::CuPtr{cuComplex}, incx::Int64,
+                                             A::CuPtr{cuComplex},
+                                             lda::Int64)::cublasStatus_t
 end
 
 @checked function cublasZher_v2_64(handle, uplo, n, alpha, x, incx, A, lda)
     initialize_context()
-    @ccall libcublas.cublasZher_v2_64(handle::cublasHandle_t, uplo::cublasFillMode_t,
-                                      n::Int64, alpha::RefOrCuRef{Cdouble},
-                                      x::CuPtr{cuDoubleComplex}, incx::Int64,
-                                      A::CuPtr{cuDoubleComplex}, lda::Int64)::cublasStatus_t
+    @gcsafe_ccall libcublas.cublasZher_v2_64(handle::cublasHandle_t, uplo::cublasFillMode_t,
+                                             n::Int64, alpha::RefOrCuRef{Cdouble},
+                                             x::CuPtr{cuDoubleComplex}, incx::Int64,
+                                             A::CuPtr{cuDoubleComplex},
+                                             lda::Int64)::cublasStatus_t
 end
 
 @checked function cublasSspr_v2_64(handle, uplo, n, alpha, x, incx, AP)
     initialize_context()
-    @ccall libcublas.cublasSspr_v2_64(handle::cublasHandle_t, uplo::cublasFillMode_t,
-                                      n::Int64, alpha::RefOrCuRef{Cfloat}, x::CuPtr{Cfloat},
-                                      incx::Int64, AP::CuPtr{Cfloat})::cublasStatus_t
+    @gcsafe_ccall libcublas.cublasSspr_v2_64(handle::cublasHandle_t, uplo::cublasFillMode_t,
+                                             n::Int64, alpha::RefOrCuRef{Cfloat},
+                                             x::CuPtr{Cfloat}, incx::Int64,
+                                             AP::CuPtr{Cfloat})::cublasStatus_t
 end
 
 @checked function cublasDspr_v2_64(handle, uplo, n, alpha, x, incx, AP)
     initialize_context()
-    @ccall libcublas.cublasDspr_v2_64(handle::cublasHandle_t, uplo::cublasFillMode_t,
-                                      n::Int64, alpha::RefOrCuRef{Cdouble},
-                                      x::CuPtr{Cdouble}, incx::Int64,
-                                      AP::CuPtr{Cdouble})::cublasStatus_t
+    @gcsafe_ccall libcublas.cublasDspr_v2_64(handle::cublasHandle_t, uplo::cublasFillMode_t,
+                                             n::Int64, alpha::RefOrCuRef{Cdouble},
+                                             x::CuPtr{Cdouble}, incx::Int64,
+                                             AP::CuPtr{Cdouble})::cublasStatus_t
 end
 
 @checked function cublasChpr_v2_64(handle, uplo, n, alpha, x, incx, AP)
     initialize_context()
-    @ccall libcublas.cublasChpr_v2_64(handle::cublasHandle_t, uplo::cublasFillMode_t,
-                                      n::Int64, alpha::RefOrCuRef{Cfloat},
-                                      x::CuPtr{cuComplex}, incx::Int64,
-                                      AP::CuPtr{cuComplex})::cublasStatus_t
+    @gcsafe_ccall libcublas.cublasChpr_v2_64(handle::cublasHandle_t, uplo::cublasFillMode_t,
+                                             n::Int64, alpha::RefOrCuRef{Cfloat},
+                                             x::CuPtr{cuComplex}, incx::Int64,
+                                             AP::CuPtr{cuComplex})::cublasStatus_t
 end
 
 @checked function cublasZhpr_v2_64(handle, uplo, n, alpha, x, incx, AP)
     initialize_context()
-    @ccall libcublas.cublasZhpr_v2_64(handle::cublasHandle_t, uplo::cublasFillMode_t,
-                                      n::Int64, alpha::RefOrCuRef{Cdouble},
-                                      x::CuPtr{cuDoubleComplex}, incx::Int64,
-                                      AP::CuPtr{cuDoubleComplex})::cublasStatus_t
+    @gcsafe_ccall libcublas.cublasZhpr_v2_64(handle::cublasHandle_t, uplo::cublasFillMode_t,
+                                             n::Int64, alpha::RefOrCuRef{Cdouble},
+                                             x::CuPtr{cuDoubleComplex}, incx::Int64,
+                                             AP::CuPtr{cuDoubleComplex})::cublasStatus_t
 end
 
 @checked function cublasSsyr2_v2_64(handle, uplo, n, alpha, x, incx, y, incy, A, lda)
     initialize_context()
-    @ccall libcublas.cublasSsyr2_v2_64(handle::cublasHandle_t, uplo::cublasFillMode_t,
-                                       n::Int64, alpha::RefOrCuRef{Cfloat},
-                                       x::CuPtr{Cfloat}, incx::Int64, y::CuPtr{Cfloat},
-                                       incy::Int64, A::CuPtr{Cfloat},
-                                       lda::Int64)::cublasStatus_t
+    @gcsafe_ccall libcublas.cublasSsyr2_v2_64(handle::cublasHandle_t,
+                                              uplo::cublasFillMode_t, n::Int64,
+                                              alpha::RefOrCuRef{Cfloat}, x::CuPtr{Cfloat},
+                                              incx::Int64, y::CuPtr{Cfloat}, incy::Int64,
+                                              A::CuPtr{Cfloat}, lda::Int64)::cublasStatus_t
 end
 
 @checked function cublasDsyr2_v2_64(handle, uplo, n, alpha, x, incx, y, incy, A, lda)
     initialize_context()
-    @ccall libcublas.cublasDsyr2_v2_64(handle::cublasHandle_t, uplo::cublasFillMode_t,
-                                       n::Int64, alpha::RefOrCuRef{Cdouble},
-                                       x::CuPtr{Cdouble}, incx::Int64, y::CuPtr{Cdouble},
-                                       incy::Int64, A::CuPtr{Cdouble},
-                                       lda::Int64)::cublasStatus_t
+    @gcsafe_ccall libcublas.cublasDsyr2_v2_64(handle::cublasHandle_t,
+                                              uplo::cublasFillMode_t, n::Int64,
+                                              alpha::RefOrCuRef{Cdouble}, x::CuPtr{Cdouble},
+                                              incx::Int64, y::CuPtr{Cdouble}, incy::Int64,
+                                              A::CuPtr{Cdouble}, lda::Int64)::cublasStatus_t
 end
 
 @checked function cublasCsyr2_v2_64(handle, uplo, n, alpha, x, incx, y, incy, A, lda)
     initialize_context()
-    @ccall libcublas.cublasCsyr2_v2_64(handle::cublasHandle_t, uplo::cublasFillMode_t,
-                                       n::Int64, alpha::RefOrCuRef{cuComplex},
-                                       x::CuPtr{cuComplex}, incx::Int64,
-                                       y::CuPtr{cuComplex}, incy::Int64,
-                                       A::CuPtr{cuComplex}, lda::Int64)::cublasStatus_t
+    @gcsafe_ccall libcublas.cublasCsyr2_v2_64(handle::cublasHandle_t,
+                                              uplo::cublasFillMode_t, n::Int64,
+                                              alpha::RefOrCuRef{cuComplex},
+                                              x::CuPtr{cuComplex}, incx::Int64,
+                                              y::CuPtr{cuComplex}, incy::Int64,
+                                              A::CuPtr{cuComplex},
+                                              lda::Int64)::cublasStatus_t
 end
 
 @checked function cublasZsyr2_v2_64(handle, uplo, n, alpha, x, incx, y, incy, A, lda)
     initialize_context()
-    @ccall libcublas.cublasZsyr2_v2_64(handle::cublasHandle_t, uplo::cublasFillMode_t,
-                                       n::Int64, alpha::RefOrCuRef{cuDoubleComplex},
-                                       x::CuPtr{cuDoubleComplex}, incx::Int64,
-                                       y::CuPtr{cuDoubleComplex}, incy::Int64,
-                                       A::CuPtr{cuDoubleComplex},
-                                       lda::Int64)::cublasStatus_t
+    @gcsafe_ccall libcublas.cublasZsyr2_v2_64(handle::cublasHandle_t,
+                                              uplo::cublasFillMode_t, n::Int64,
+                                              alpha::RefOrCuRef{cuDoubleComplex},
+                                              x::CuPtr{cuDoubleComplex}, incx::Int64,
+                                              y::CuPtr{cuDoubleComplex}, incy::Int64,
+                                              A::CuPtr{cuDoubleComplex},
+                                              lda::Int64)::cublasStatus_t
 end
 
 @checked function cublasCher2_v2_64(handle, uplo, n, alpha, x, incx, y, incy, A, lda)
     initialize_context()
-    @ccall libcublas.cublasCher2_v2_64(handle::cublasHandle_t, uplo::cublasFillMode_t,
-                                       n::Int64, alpha::RefOrCuRef{cuComplex},
-                                       x::CuPtr{cuComplex}, incx::Int64,
-                                       y::CuPtr{cuComplex}, incy::Int64,
-                                       A::CuPtr{cuComplex}, lda::Int64)::cublasStatus_t
+    @gcsafe_ccall libcublas.cublasCher2_v2_64(handle::cublasHandle_t,
+                                              uplo::cublasFillMode_t, n::Int64,
+                                              alpha::RefOrCuRef{cuComplex},
+                                              x::CuPtr{cuComplex}, incx::Int64,
+                                              y::CuPtr{cuComplex}, incy::Int64,
+                                              A::CuPtr{cuComplex},
+                                              lda::Int64)::cublasStatus_t
 end
 
 @checked function cublasZher2_v2_64(handle, uplo, n, alpha, x, incx, y, incy, A, lda)
     initialize_context()
-    @ccall libcublas.cublasZher2_v2_64(handle::cublasHandle_t, uplo::cublasFillMode_t,
-                                       n::Int64, alpha::RefOrCuRef{cuDoubleComplex},
-                                       x::CuPtr{cuDoubleComplex}, incx::Int64,
-                                       y::CuPtr{cuDoubleComplex}, incy::Int64,
-                                       A::CuPtr{cuDoubleComplex},
-                                       lda::Int64)::cublasStatus_t
+    @gcsafe_ccall libcublas.cublasZher2_v2_64(handle::cublasHandle_t,
+                                              uplo::cublasFillMode_t, n::Int64,
+                                              alpha::RefOrCuRef{cuDoubleComplex},
+                                              x::CuPtr{cuDoubleComplex}, incx::Int64,
+                                              y::CuPtr{cuDoubleComplex}, incy::Int64,
+                                              A::CuPtr{cuDoubleComplex},
+                                              lda::Int64)::cublasStatus_t
 end
 
 @checked function cublasSspr2_v2_64(handle, uplo, n, alpha, x, incx, y, incy, AP)
     initialize_context()
-    @ccall libcublas.cublasSspr2_v2_64(handle::cublasHandle_t, uplo::cublasFillMode_t,
-                                       n::Int64, alpha::RefOrCuRef{Cfloat},
-                                       x::CuPtr{Cfloat}, incx::Int64, y::CuPtr{Cfloat},
-                                       incy::Int64, AP::CuPtr{Cfloat})::cublasStatus_t
+    @gcsafe_ccall libcublas.cublasSspr2_v2_64(handle::cublasHandle_t,
+                                              uplo::cublasFillMode_t, n::Int64,
+                                              alpha::RefOrCuRef{Cfloat}, x::CuPtr{Cfloat},
+                                              incx::Int64, y::CuPtr{Cfloat}, incy::Int64,
+                                              AP::CuPtr{Cfloat})::cublasStatus_t
 end
 
 @checked function cublasDspr2_v2_64(handle, uplo, n, alpha, x, incx, y, incy, AP)
     initialize_context()
-    @ccall libcublas.cublasDspr2_v2_64(handle::cublasHandle_t, uplo::cublasFillMode_t,
-                                       n::Int64, alpha::RefOrCuRef{Cdouble},
-                                       x::CuPtr{Cdouble}, incx::Int64, y::CuPtr{Cdouble},
-                                       incy::Int64, AP::CuPtr{Cdouble})::cublasStatus_t
+    @gcsafe_ccall libcublas.cublasDspr2_v2_64(handle::cublasHandle_t,
+                                              uplo::cublasFillMode_t, n::Int64,
+                                              alpha::RefOrCuRef{Cdouble}, x::CuPtr{Cdouble},
+                                              incx::Int64, y::CuPtr{Cdouble}, incy::Int64,
+                                              AP::CuPtr{Cdouble})::cublasStatus_t
 end
 
 @checked function cublasChpr2_v2_64(handle, uplo, n, alpha, x, incx, y, incy, AP)
     initialize_context()
-    @ccall libcublas.cublasChpr2_v2_64(handle::cublasHandle_t, uplo::cublasFillMode_t,
-                                       n::Int64, alpha::RefOrCuRef{cuComplex},
-                                       x::CuPtr{cuComplex}, incx::Int64,
-                                       y::CuPtr{cuComplex}, incy::Int64,
-                                       AP::CuPtr{cuComplex})::cublasStatus_t
+    @gcsafe_ccall libcublas.cublasChpr2_v2_64(handle::cublasHandle_t,
+                                              uplo::cublasFillMode_t, n::Int64,
+                                              alpha::RefOrCuRef{cuComplex},
+                                              x::CuPtr{cuComplex}, incx::Int64,
+                                              y::CuPtr{cuComplex}, incy::Int64,
+                                              AP::CuPtr{cuComplex})::cublasStatus_t
 end
 
 @checked function cublasZhpr2_v2_64(handle, uplo, n, alpha, x, incx, y, incy, AP)
     initialize_context()
-    @ccall libcublas.cublasZhpr2_v2_64(handle::cublasHandle_t, uplo::cublasFillMode_t,
-                                       n::Int64, alpha::RefOrCuRef{cuDoubleComplex},
-                                       x::CuPtr{cuDoubleComplex}, incx::Int64,
-                                       y::CuPtr{cuDoubleComplex}, incy::Int64,
-                                       AP::CuPtr{cuDoubleComplex})::cublasStatus_t
+    @gcsafe_ccall libcublas.cublasZhpr2_v2_64(handle::cublasHandle_t,
+                                              uplo::cublasFillMode_t, n::Int64,
+                                              alpha::RefOrCuRef{cuDoubleComplex},
+                                              x::CuPtr{cuDoubleComplex}, incx::Int64,
+                                              y::CuPtr{cuDoubleComplex}, incy::Int64,
+                                              AP::CuPtr{cuDoubleComplex})::cublasStatus_t
 end
 
 @checked function cublasSgemm_v2_64(handle, transa, transb, m, n, k, alpha, A, lda, B, ldb,
                                     beta, C, ldc)
     initialize_context()
-    @ccall libcublas.cublasSgemm_v2_64(handle::cublasHandle_t, transa::cublasOperation_t,
-                                       transb::cublasOperation_t, m::Int64, n::Int64,
-                                       k::Int64, alpha::RefOrCuRef{Cfloat},
-                                       A::CuPtr{Cfloat}, lda::Int64, B::CuPtr{Cfloat},
-                                       ldb::Int64, beta::RefOrCuRef{Cfloat},
-                                       C::CuPtr{Cfloat}, ldc::Int64)::cublasStatus_t
+    @gcsafe_ccall libcublas.cublasSgemm_v2_64(handle::cublasHandle_t,
+                                              transa::cublasOperation_t,
+                                              transb::cublasOperation_t, m::Int64, n::Int64,
+                                              k::Int64, alpha::RefOrCuRef{Cfloat},
+                                              A::CuPtr{Cfloat}, lda::Int64,
+                                              B::CuPtr{Cfloat}, ldb::Int64,
+                                              beta::RefOrCuRef{Cfloat}, C::CuPtr{Cfloat},
+                                              ldc::Int64)::cublasStatus_t
 end
 
 @checked function cublasDgemm_v2_64(handle, transa, transb, m, n, k, alpha, A, lda, B, ldb,
                                     beta, C, ldc)
     initialize_context()
-    @ccall libcublas.cublasDgemm_v2_64(handle::cublasHandle_t, transa::cublasOperation_t,
-                                       transb::cublasOperation_t, m::Int64, n::Int64,
-                                       k::Int64, alpha::RefOrCuRef{Cdouble},
-                                       A::CuPtr{Cdouble}, lda::Int64, B::CuPtr{Cdouble},
-                                       ldb::Int64, beta::RefOrCuRef{Cdouble},
-                                       C::CuPtr{Cdouble}, ldc::Int64)::cublasStatus_t
+    @gcsafe_ccall libcublas.cublasDgemm_v2_64(handle::cublasHandle_t,
+                                              transa::cublasOperation_t,
+                                              transb::cublasOperation_t, m::Int64, n::Int64,
+                                              k::Int64, alpha::RefOrCuRef{Cdouble},
+                                              A::CuPtr{Cdouble}, lda::Int64,
+                                              B::CuPtr{Cdouble}, ldb::Int64,
+                                              beta::RefOrCuRef{Cdouble}, C::CuPtr{Cdouble},
+                                              ldc::Int64)::cublasStatus_t
 end
 
 @checked function cublasCgemm_v2_64(handle, transa, transb, m, n, k, alpha, A, lda, B, ldb,
                                     beta, C, ldc)
     initialize_context()
-    @ccall libcublas.cublasCgemm_v2_64(handle::cublasHandle_t, transa::cublasOperation_t,
-                                       transb::cublasOperation_t, m::Int64, n::Int64,
-                                       k::Int64, alpha::RefOrCuRef{cuComplex},
-                                       A::CuPtr{cuComplex}, lda::Int64, B::CuPtr{cuComplex},
-                                       ldb::Int64, beta::RefOrCuRef{cuComplex},
-                                       C::CuPtr{cuComplex}, ldc::Int64)::cublasStatus_t
+    @gcsafe_ccall libcublas.cublasCgemm_v2_64(handle::cublasHandle_t,
+                                              transa::cublasOperation_t,
+                                              transb::cublasOperation_t, m::Int64, n::Int64,
+                                              k::Int64, alpha::RefOrCuRef{cuComplex},
+                                              A::CuPtr{cuComplex}, lda::Int64,
+                                              B::CuPtr{cuComplex}, ldb::Int64,
+                                              beta::RefOrCuRef{cuComplex},
+                                              C::CuPtr{cuComplex},
+                                              ldc::Int64)::cublasStatus_t
 end
 
 @checked function cublasZgemm_v2_64(handle, transa, transb, m, n, k, alpha, A, lda, B, ldb,
                                     beta, C, ldc)
     initialize_context()
-    @ccall libcublas.cublasZgemm_v2_64(handle::cublasHandle_t, transa::cublasOperation_t,
-                                       transb::cublasOperation_t, m::Int64, n::Int64,
-                                       k::Int64, alpha::RefOrCuRef{cuDoubleComplex},
-                                       A::CuPtr{cuDoubleComplex}, lda::Int64,
-                                       B::CuPtr{cuDoubleComplex}, ldb::Int64,
-                                       beta::RefOrCuRef{cuDoubleComplex},
-                                       C::CuPtr{cuDoubleComplex},
-                                       ldc::Int64)::cublasStatus_t
+    @gcsafe_ccall libcublas.cublasZgemm_v2_64(handle::cublasHandle_t,
+                                              transa::cublasOperation_t,
+                                              transb::cublasOperation_t, m::Int64, n::Int64,
+                                              k::Int64, alpha::RefOrCuRef{cuDoubleComplex},
+                                              A::CuPtr{cuDoubleComplex}, lda::Int64,
+                                              B::CuPtr{cuDoubleComplex}, ldb::Int64,
+                                              beta::RefOrCuRef{cuDoubleComplex},
+                                              C::CuPtr{cuDoubleComplex},
+                                              ldc::Int64)::cublasStatus_t
 end
 
 @checked function cublasSsyrk_v2_64(handle, uplo, trans, n, k, alpha, A, lda, beta, C, ldc)
     initialize_context()
-    @ccall libcublas.cublasSsyrk_v2_64(handle::cublasHandle_t, uplo::cublasFillMode_t,
-                                       trans::cublasOperation_t, n::Int64, k::Int64,
-                                       alpha::RefOrCuRef{Cfloat}, A::CuPtr{Cfloat},
-                                       lda::Int64, beta::RefOrCuRef{Cfloat},
-                                       C::CuPtr{Cfloat}, ldc::Int64)::cublasStatus_t
+    @gcsafe_ccall libcublas.cublasSsyrk_v2_64(handle::cublasHandle_t,
+                                              uplo::cublasFillMode_t,
+                                              trans::cublasOperation_t, n::Int64, k::Int64,
+                                              alpha::RefOrCuRef{Cfloat}, A::CuPtr{Cfloat},
+                                              lda::Int64, beta::RefOrCuRef{Cfloat},
+                                              C::CuPtr{Cfloat}, ldc::Int64)::cublasStatus_t
 end
 
 @checked function cublasDsyrk_v2_64(handle, uplo, trans, n, k, alpha, A, lda, beta, C, ldc)
     initialize_context()
-    @ccall libcublas.cublasDsyrk_v2_64(handle::cublasHandle_t, uplo::cublasFillMode_t,
-                                       trans::cublasOperation_t, n::Int64, k::Int64,
-                                       alpha::RefOrCuRef{Cdouble}, A::CuPtr{Cdouble},
-                                       lda::Int64, beta::RefOrCuRef{Cdouble},
-                                       C::CuPtr{Cdouble}, ldc::Int64)::cublasStatus_t
+    @gcsafe_ccall libcublas.cublasDsyrk_v2_64(handle::cublasHandle_t,
+                                              uplo::cublasFillMode_t,
+                                              trans::cublasOperation_t, n::Int64, k::Int64,
+                                              alpha::RefOrCuRef{Cdouble}, A::CuPtr{Cdouble},
+                                              lda::Int64, beta::RefOrCuRef{Cdouble},
+                                              C::CuPtr{Cdouble}, ldc::Int64)::cublasStatus_t
 end
 
 @checked function cublasCsyrk_v2_64(handle, uplo, trans, n, k, alpha, A, lda, beta, C, ldc)
     initialize_context()
-    @ccall libcublas.cublasCsyrk_v2_64(handle::cublasHandle_t, uplo::cublasFillMode_t,
-                                       trans::cublasOperation_t, n::Int64, k::Int64,
-                                       alpha::RefOrCuRef{cuComplex}, A::CuPtr{cuComplex},
-                                       lda::Int64, beta::RefOrCuRef{cuComplex},
-                                       C::CuPtr{cuComplex}, ldc::Int64)::cublasStatus_t
+    @gcsafe_ccall libcublas.cublasCsyrk_v2_64(handle::cublasHandle_t,
+                                              uplo::cublasFillMode_t,
+                                              trans::cublasOperation_t, n::Int64, k::Int64,
+                                              alpha::RefOrCuRef{cuComplex},
+                                              A::CuPtr{cuComplex}, lda::Int64,
+                                              beta::RefOrCuRef{cuComplex},
+                                              C::CuPtr{cuComplex},
+                                              ldc::Int64)::cublasStatus_t
 end
 
 @checked function cublasZsyrk_v2_64(handle, uplo, trans, n, k, alpha, A, lda, beta, C, ldc)
     initialize_context()
-    @ccall libcublas.cublasZsyrk_v2_64(handle::cublasHandle_t, uplo::cublasFillMode_t,
-                                       trans::cublasOperation_t, n::Int64, k::Int64,
-                                       alpha::RefOrCuRef{cuDoubleComplex},
-                                       A::CuPtr{cuDoubleComplex}, lda::Int64,
-                                       beta::RefOrCuRef{cuDoubleComplex},
-                                       C::CuPtr{cuDoubleComplex},
-                                       ldc::Int64)::cublasStatus_t
+    @gcsafe_ccall libcublas.cublasZsyrk_v2_64(handle::cublasHandle_t,
+                                              uplo::cublasFillMode_t,
+                                              trans::cublasOperation_t, n::Int64, k::Int64,
+                                              alpha::RefOrCuRef{cuDoubleComplex},
+                                              A::CuPtr{cuDoubleComplex}, lda::Int64,
+                                              beta::RefOrCuRef{cuDoubleComplex},
+                                              C::CuPtr{cuDoubleComplex},
+                                              ldc::Int64)::cublasStatus_t
 end
 
 @checked function cublasCherk_v2_64(handle, uplo, trans, n, k, alpha, A, lda, beta, C, ldc)
     initialize_context()
-    @ccall libcublas.cublasCherk_v2_64(handle::cublasHandle_t, uplo::cublasFillMode_t,
-                                       trans::cublasOperation_t, n::Int64, k::Int64,
-                                       alpha::RefOrCuRef{Cfloat}, A::CuPtr{cuComplex},
-                                       lda::Int64, beta::RefOrCuRef{Cfloat},
-                                       C::CuPtr{cuComplex}, ldc::Int64)::cublasStatus_t
+    @gcsafe_ccall libcublas.cublasCherk_v2_64(handle::cublasHandle_t,
+                                              uplo::cublasFillMode_t,
+                                              trans::cublasOperation_t, n::Int64, k::Int64,
+                                              alpha::RefOrCuRef{Cfloat},
+                                              A::CuPtr{cuComplex}, lda::Int64,
+                                              beta::RefOrCuRef{Cfloat}, C::CuPtr{cuComplex},
+                                              ldc::Int64)::cublasStatus_t
 end
 
 @checked function cublasZherk_v2_64(handle, uplo, trans, n, k, alpha, A, lda, beta, C, ldc)
     initialize_context()
-    @ccall libcublas.cublasZherk_v2_64(handle::cublasHandle_t, uplo::cublasFillMode_t,
-                                       trans::cublasOperation_t, n::Int64, k::Int64,
-                                       alpha::RefOrCuRef{Cdouble},
-                                       A::CuPtr{cuDoubleComplex}, lda::Int64,
-                                       beta::RefOrCuRef{Cdouble}, C::CuPtr{cuDoubleComplex},
-                                       ldc::Int64)::cublasStatus_t
+    @gcsafe_ccall libcublas.cublasZherk_v2_64(handle::cublasHandle_t,
+                                              uplo::cublasFillMode_t,
+                                              trans::cublasOperation_t, n::Int64, k::Int64,
+                                              alpha::RefOrCuRef{Cdouble},
+                                              A::CuPtr{cuDoubleComplex}, lda::Int64,
+                                              beta::RefOrCuRef{Cdouble},
+                                              C::CuPtr{cuDoubleComplex},
+                                              ldc::Int64)::cublasStatus_t
 end
 
 @checked function cublasSsyr2k_v2_64(handle, uplo, trans, n, k, alpha, A, lda, B, ldb, beta,
                                      C, ldc)
     initialize_context()
-    @ccall libcublas.cublasSsyr2k_v2_64(handle::cublasHandle_t, uplo::cublasFillMode_t,
-                                        trans::cublasOperation_t, n::Int64, k::Int64,
-                                        alpha::RefOrCuRef{Cfloat}, A::CuPtr{Cfloat},
-                                        lda::Int64, B::CuPtr{Cfloat}, ldb::Int64,
-                                        beta::RefOrCuRef{Cfloat}, C::CuPtr{Cfloat},
-                                        ldc::Int64)::cublasStatus_t
+    @gcsafe_ccall libcublas.cublasSsyr2k_v2_64(handle::cublasHandle_t,
+                                               uplo::cublasFillMode_t,
+                                               trans::cublasOperation_t, n::Int64, k::Int64,
+                                               alpha::RefOrCuRef{Cfloat}, A::CuPtr{Cfloat},
+                                               lda::Int64, B::CuPtr{Cfloat}, ldb::Int64,
+                                               beta::RefOrCuRef{Cfloat}, C::CuPtr{Cfloat},
+                                               ldc::Int64)::cublasStatus_t
 end
 
 @checked function cublasDsyr2k_v2_64(handle, uplo, trans, n, k, alpha, A, lda, B, ldb, beta,
                                      C, ldc)
     initialize_context()
-    @ccall libcublas.cublasDsyr2k_v2_64(handle::cublasHandle_t, uplo::cublasFillMode_t,
-                                        trans::cublasOperation_t, n::Int64, k::Int64,
-                                        alpha::RefOrCuRef{Cdouble}, A::CuPtr{Cdouble},
-                                        lda::Int64, B::CuPtr{Cdouble}, ldb::Int64,
-                                        beta::RefOrCuRef{Cdouble}, C::CuPtr{Cdouble},
-                                        ldc::Int64)::cublasStatus_t
+    @gcsafe_ccall libcublas.cublasDsyr2k_v2_64(handle::cublasHandle_t,
+                                               uplo::cublasFillMode_t,
+                                               trans::cublasOperation_t, n::Int64, k::Int64,
+                                               alpha::RefOrCuRef{Cdouble},
+                                               A::CuPtr{Cdouble}, lda::Int64,
+                                               B::CuPtr{Cdouble}, ldb::Int64,
+                                               beta::RefOrCuRef{Cdouble}, C::CuPtr{Cdouble},
+                                               ldc::Int64)::cublasStatus_t
 end
 
 @checked function cublasCsyr2k_v2_64(handle, uplo, trans, n, k, alpha, A, lda, B, ldb, beta,
                                      C, ldc)
     initialize_context()
-    @ccall libcublas.cublasCsyr2k_v2_64(handle::cublasHandle_t, uplo::cublasFillMode_t,
-                                        trans::cublasOperation_t, n::Int64, k::Int64,
-                                        alpha::RefOrCuRef{cuComplex}, A::CuPtr{cuComplex},
-                                        lda::Int64, B::CuPtr{cuComplex}, ldb::Int64,
-                                        beta::RefOrCuRef{cuComplex}, C::CuPtr{cuComplex},
-                                        ldc::Int64)::cublasStatus_t
+    @gcsafe_ccall libcublas.cublasCsyr2k_v2_64(handle::cublasHandle_t,
+                                               uplo::cublasFillMode_t,
+                                               trans::cublasOperation_t, n::Int64, k::Int64,
+                                               alpha::RefOrCuRef{cuComplex},
+                                               A::CuPtr{cuComplex}, lda::Int64,
+                                               B::CuPtr{cuComplex}, ldb::Int64,
+                                               beta::RefOrCuRef{cuComplex},
+                                               C::CuPtr{cuComplex},
+                                               ldc::Int64)::cublasStatus_t
 end
 
 @checked function cublasZsyr2k_v2_64(handle, uplo, trans, n, k, alpha, A, lda, B, ldb, beta,
                                      C, ldc)
     initialize_context()
-    @ccall libcublas.cublasZsyr2k_v2_64(handle::cublasHandle_t, uplo::cublasFillMode_t,
-                                        trans::cublasOperation_t, n::Int64, k::Int64,
-                                        alpha::RefOrCuRef{cuDoubleComplex},
-                                        A::CuPtr{cuDoubleComplex}, lda::Int64,
-                                        B::CuPtr{cuDoubleComplex}, ldb::Int64,
-                                        beta::RefOrCuRef{cuDoubleComplex},
-                                        C::CuPtr{cuDoubleComplex},
-                                        ldc::Int64)::cublasStatus_t
+    @gcsafe_ccall libcublas.cublasZsyr2k_v2_64(handle::cublasHandle_t,
+                                               uplo::cublasFillMode_t,
+                                               trans::cublasOperation_t, n::Int64, k::Int64,
+                                               alpha::RefOrCuRef{cuDoubleComplex},
+                                               A::CuPtr{cuDoubleComplex}, lda::Int64,
+                                               B::CuPtr{cuDoubleComplex}, ldb::Int64,
+                                               beta::RefOrCuRef{cuDoubleComplex},
+                                               C::CuPtr{cuDoubleComplex},
+                                               ldc::Int64)::cublasStatus_t
 end
 
 @checked function cublasCher2k_v2_64(handle, uplo, trans, n, k, alpha, A, lda, B, ldb, beta,
                                      C, ldc)
     initialize_context()
-    @ccall libcublas.cublasCher2k_v2_64(handle::cublasHandle_t, uplo::cublasFillMode_t,
-                                        trans::cublasOperation_t, n::Int64, k::Int64,
-                                        alpha::RefOrCuRef{cuComplex}, A::CuPtr{cuComplex},
-                                        lda::Int64, B::CuPtr{cuComplex}, ldb::Int64,
-                                        beta::RefOrCuRef{Cfloat}, C::CuPtr{cuComplex},
-                                        ldc::Int64)::cublasStatus_t
+    @gcsafe_ccall libcublas.cublasCher2k_v2_64(handle::cublasHandle_t,
+                                               uplo::cublasFillMode_t,
+                                               trans::cublasOperation_t, n::Int64, k::Int64,
+                                               alpha::RefOrCuRef{cuComplex},
+                                               A::CuPtr{cuComplex}, lda::Int64,
+                                               B::CuPtr{cuComplex}, ldb::Int64,
+                                               beta::RefOrCuRef{Cfloat},
+                                               C::CuPtr{cuComplex},
+                                               ldc::Int64)::cublasStatus_t
 end
 
 @checked function cublasZher2k_v2_64(handle, uplo, trans, n, k, alpha, A, lda, B, ldb, beta,
                                      C, ldc)
     initialize_context()
-    @ccall libcublas.cublasZher2k_v2_64(handle::cublasHandle_t, uplo::cublasFillMode_t,
-                                        trans::cublasOperation_t, n::Int64, k::Int64,
-                                        alpha::RefOrCuRef{cuDoubleComplex},
-                                        A::CuPtr{cuDoubleComplex}, lda::Int64,
-                                        B::CuPtr{cuDoubleComplex}, ldb::Int64,
-                                        beta::RefOrCuRef{Cdouble},
-                                        C::CuPtr{cuDoubleComplex},
-                                        ldc::Int64)::cublasStatus_t
+    @gcsafe_ccall libcublas.cublasZher2k_v2_64(handle::cublasHandle_t,
+                                               uplo::cublasFillMode_t,
+                                               trans::cublasOperation_t, n::Int64, k::Int64,
+                                               alpha::RefOrCuRef{cuDoubleComplex},
+                                               A::CuPtr{cuDoubleComplex}, lda::Int64,
+                                               B::CuPtr{cuDoubleComplex}, ldb::Int64,
+                                               beta::RefOrCuRef{Cdouble},
+                                               C::CuPtr{cuDoubleComplex},
+                                               ldc::Int64)::cublasStatus_t
 end
 
 @checked function cublasSsymm_v2_64(handle, side, uplo, m, n, alpha, A, lda, B, ldb, beta,
                                     C, ldc)
     initialize_context()
-    @ccall libcublas.cublasSsymm_v2_64(handle::cublasHandle_t, side::cublasSideMode_t,
-                                       uplo::cublasFillMode_t, m::Int64, n::Int64,
-                                       alpha::RefOrCuRef{Cfloat}, A::CuPtr{Cfloat},
-                                       lda::Int64, B::CuPtr{Cfloat}, ldb::Int64,
-                                       beta::RefOrCuRef{Cfloat}, C::CuPtr{Cfloat},
-                                       ldc::Int64)::cublasStatus_t
+    @gcsafe_ccall libcublas.cublasSsymm_v2_64(handle::cublasHandle_t,
+                                              side::cublasSideMode_t,
+                                              uplo::cublasFillMode_t, m::Int64, n::Int64,
+                                              alpha::RefOrCuRef{Cfloat}, A::CuPtr{Cfloat},
+                                              lda::Int64, B::CuPtr{Cfloat}, ldb::Int64,
+                                              beta::RefOrCuRef{Cfloat}, C::CuPtr{Cfloat},
+                                              ldc::Int64)::cublasStatus_t
 end
 
 @checked function cublasDsymm_v2_64(handle, side, uplo, m, n, alpha, A, lda, B, ldb, beta,
                                     C, ldc)
     initialize_context()
-    @ccall libcublas.cublasDsymm_v2_64(handle::cublasHandle_t, side::cublasSideMode_t,
-                                       uplo::cublasFillMode_t, m::Int64, n::Int64,
-                                       alpha::RefOrCuRef{Cdouble}, A::CuPtr{Cdouble},
-                                       lda::Int64, B::CuPtr{Cdouble}, ldb::Int64,
-                                       beta::RefOrCuRef{Cdouble}, C::CuPtr{Cdouble},
-                                       ldc::Int64)::cublasStatus_t
+    @gcsafe_ccall libcublas.cublasDsymm_v2_64(handle::cublasHandle_t,
+                                              side::cublasSideMode_t,
+                                              uplo::cublasFillMode_t, m::Int64, n::Int64,
+                                              alpha::RefOrCuRef{Cdouble}, A::CuPtr{Cdouble},
+                                              lda::Int64, B::CuPtr{Cdouble}, ldb::Int64,
+                                              beta::RefOrCuRef{Cdouble}, C::CuPtr{Cdouble},
+                                              ldc::Int64)::cublasStatus_t
 end
 
 @checked function cublasCsymm_v2_64(handle, side, uplo, m, n, alpha, A, lda, B, ldb, beta,
                                     C, ldc)
     initialize_context()
-    @ccall libcublas.cublasCsymm_v2_64(handle::cublasHandle_t, side::cublasSideMode_t,
-                                       uplo::cublasFillMode_t, m::Int64, n::Int64,
-                                       alpha::RefOrCuRef{cuComplex}, A::CuPtr{cuComplex},
-                                       lda::Int64, B::CuPtr{cuComplex}, ldb::Int64,
-                                       beta::RefOrCuRef{cuComplex}, C::CuPtr{cuComplex},
-                                       ldc::Int64)::cublasStatus_t
+    @gcsafe_ccall libcublas.cublasCsymm_v2_64(handle::cublasHandle_t,
+                                              side::cublasSideMode_t,
+                                              uplo::cublasFillMode_t, m::Int64, n::Int64,
+                                              alpha::RefOrCuRef{cuComplex},
+                                              A::CuPtr{cuComplex}, lda::Int64,
+                                              B::CuPtr{cuComplex}, ldb::Int64,
+                                              beta::RefOrCuRef{cuComplex},
+                                              C::CuPtr{cuComplex},
+                                              ldc::Int64)::cublasStatus_t
 end
 
 @checked function cublasZsymm_v2_64(handle, side, uplo, m, n, alpha, A, lda, B, ldb, beta,
                                     C, ldc)
     initialize_context()
-    @ccall libcublas.cublasZsymm_v2_64(handle::cublasHandle_t, side::cublasSideMode_t,
-                                       uplo::cublasFillMode_t, m::Int64, n::Int64,
-                                       alpha::RefOrCuRef{cuDoubleComplex},
-                                       A::CuPtr{cuDoubleComplex}, lda::Int64,
-                                       B::CuPtr{cuDoubleComplex}, ldb::Int64,
-                                       beta::RefOrCuRef{cuDoubleComplex},
-                                       C::CuPtr{cuDoubleComplex},
-                                       ldc::Int64)::cublasStatus_t
+    @gcsafe_ccall libcublas.cublasZsymm_v2_64(handle::cublasHandle_t,
+                                              side::cublasSideMode_t,
+                                              uplo::cublasFillMode_t, m::Int64, n::Int64,
+                                              alpha::RefOrCuRef{cuDoubleComplex},
+                                              A::CuPtr{cuDoubleComplex}, lda::Int64,
+                                              B::CuPtr{cuDoubleComplex}, ldb::Int64,
+                                              beta::RefOrCuRef{cuDoubleComplex},
+                                              C::CuPtr{cuDoubleComplex},
+                                              ldc::Int64)::cublasStatus_t
 end
 
 @checked function cublasChemm_v2_64(handle, side, uplo, m, n, alpha, A, lda, B, ldb, beta,
                                     C, ldc)
     initialize_context()
-    @ccall libcublas.cublasChemm_v2_64(handle::cublasHandle_t, side::cublasSideMode_t,
-                                       uplo::cublasFillMode_t, m::Int64, n::Int64,
-                                       alpha::RefOrCuRef{cuComplex}, A::CuPtr{cuComplex},
-                                       lda::Int64, B::CuPtr{cuComplex}, ldb::Int64,
-                                       beta::RefOrCuRef{cuComplex}, C::CuPtr{cuComplex},
-                                       ldc::Int64)::cublasStatus_t
+    @gcsafe_ccall libcublas.cublasChemm_v2_64(handle::cublasHandle_t,
+                                              side::cublasSideMode_t,
+                                              uplo::cublasFillMode_t, m::Int64, n::Int64,
+                                              alpha::RefOrCuRef{cuComplex},
+                                              A::CuPtr{cuComplex}, lda::Int64,
+                                              B::CuPtr{cuComplex}, ldb::Int64,
+                                              beta::RefOrCuRef{cuComplex},
+                                              C::CuPtr{cuComplex},
+                                              ldc::Int64)::cublasStatus_t
 end
 
 @checked function cublasZhemm_v2_64(handle, side, uplo, m, n, alpha, A, lda, B, ldb, beta,
                                     C, ldc)
     initialize_context()
-    @ccall libcublas.cublasZhemm_v2_64(handle::cublasHandle_t, side::cublasSideMode_t,
-                                       uplo::cublasFillMode_t, m::Int64, n::Int64,
-                                       alpha::RefOrCuRef{cuDoubleComplex},
-                                       A::CuPtr{cuDoubleComplex}, lda::Int64,
-                                       B::CuPtr{cuDoubleComplex}, ldb::Int64,
-                                       beta::RefOrCuRef{cuDoubleComplex},
-                                       C::CuPtr{cuDoubleComplex},
-                                       ldc::Int64)::cublasStatus_t
+    @gcsafe_ccall libcublas.cublasZhemm_v2_64(handle::cublasHandle_t,
+                                              side::cublasSideMode_t,
+                                              uplo::cublasFillMode_t, m::Int64, n::Int64,
+                                              alpha::RefOrCuRef{cuDoubleComplex},
+                                              A::CuPtr{cuDoubleComplex}, lda::Int64,
+                                              B::CuPtr{cuDoubleComplex}, ldb::Int64,
+                                              beta::RefOrCuRef{cuDoubleComplex},
+                                              C::CuPtr{cuDoubleComplex},
+                                              ldc::Int64)::cublasStatus_t
 end
 
 @checked function cublasStrsm_v2_64(handle, side, uplo, trans, diag, m, n, alpha, A, lda, B,
                                     ldb)
     initialize_context()
-    @ccall libcublas.cublasStrsm_v2_64(handle::cublasHandle_t, side::cublasSideMode_t,
-                                       uplo::cublasFillMode_t, trans::cublasOperation_t,
-                                       diag::cublasDiagType_t, m::Int64, n::Int64,
-                                       alpha::RefOrCuRef{Cfloat}, A::CuPtr{Cfloat},
-                                       lda::Int64, B::CuPtr{Cfloat},
-                                       ldb::Int64)::cublasStatus_t
+    @gcsafe_ccall libcublas.cublasStrsm_v2_64(handle::cublasHandle_t,
+                                              side::cublasSideMode_t,
+                                              uplo::cublasFillMode_t,
+                                              trans::cublasOperation_t,
+                                              diag::cublasDiagType_t, m::Int64, n::Int64,
+                                              alpha::RefOrCuRef{Cfloat}, A::CuPtr{Cfloat},
+                                              lda::Int64, B::CuPtr{Cfloat},
+                                              ldb::Int64)::cublasStatus_t
 end
 
 @checked function cublasDtrsm_v2_64(handle, side, uplo, trans, diag, m, n, alpha, A, lda, B,
                                     ldb)
     initialize_context()
-    @ccall libcublas.cublasDtrsm_v2_64(handle::cublasHandle_t, side::cublasSideMode_t,
-                                       uplo::cublasFillMode_t, trans::cublasOperation_t,
-                                       diag::cublasDiagType_t, m::Int64, n::Int64,
-                                       alpha::RefOrCuRef{Cdouble}, A::CuPtr{Cdouble},
-                                       lda::Int64, B::CuPtr{Cdouble},
-                                       ldb::Int64)::cublasStatus_t
+    @gcsafe_ccall libcublas.cublasDtrsm_v2_64(handle::cublasHandle_t,
+                                              side::cublasSideMode_t,
+                                              uplo::cublasFillMode_t,
+                                              trans::cublasOperation_t,
+                                              diag::cublasDiagType_t, m::Int64, n::Int64,
+                                              alpha::RefOrCuRef{Cdouble}, A::CuPtr{Cdouble},
+                                              lda::Int64, B::CuPtr{Cdouble},
+                                              ldb::Int64)::cublasStatus_t
 end
 
 @checked function cublasCtrsm_v2_64(handle, side, uplo, trans, diag, m, n, alpha, A, lda, B,
                                     ldb)
     initialize_context()
-    @ccall libcublas.cublasCtrsm_v2_64(handle::cublasHandle_t, side::cublasSideMode_t,
-                                       uplo::cublasFillMode_t, trans::cublasOperation_t,
-                                       diag::cublasDiagType_t, m::Int64, n::Int64,
-                                       alpha::RefOrCuRef{cuComplex}, A::CuPtr{cuComplex},
-                                       lda::Int64, B::CuPtr{cuComplex},
-                                       ldb::Int64)::cublasStatus_t
+    @gcsafe_ccall libcublas.cublasCtrsm_v2_64(handle::cublasHandle_t,
+                                              side::cublasSideMode_t,
+                                              uplo::cublasFillMode_t,
+                                              trans::cublasOperation_t,
+                                              diag::cublasDiagType_t, m::Int64, n::Int64,
+                                              alpha::RefOrCuRef{cuComplex},
+                                              A::CuPtr{cuComplex}, lda::Int64,
+                                              B::CuPtr{cuComplex},
+                                              ldb::Int64)::cublasStatus_t
 end
 
 @checked function cublasZtrsm_v2_64(handle, side, uplo, trans, diag, m, n, alpha, A, lda, B,
                                     ldb)
     initialize_context()
-    @ccall libcublas.cublasZtrsm_v2_64(handle::cublasHandle_t, side::cublasSideMode_t,
-                                       uplo::cublasFillMode_t, trans::cublasOperation_t,
-                                       diag::cublasDiagType_t, m::Int64, n::Int64,
-                                       alpha::RefOrCuRef{cuDoubleComplex},
-                                       A::CuPtr{cuDoubleComplex}, lda::Int64,
-                                       B::CuPtr{cuDoubleComplex},
-                                       ldb::Int64)::cublasStatus_t
+    @gcsafe_ccall libcublas.cublasZtrsm_v2_64(handle::cublasHandle_t,
+                                              side::cublasSideMode_t,
+                                              uplo::cublasFillMode_t,
+                                              trans::cublasOperation_t,
+                                              diag::cublasDiagType_t, m::Int64, n::Int64,
+                                              alpha::RefOrCuRef{cuDoubleComplex},
+                                              A::CuPtr{cuDoubleComplex}, lda::Int64,
+                                              B::CuPtr{cuDoubleComplex},
+                                              ldb::Int64)::cublasStatus_t
 end
 
 @checked function cublasStrmm_v2_64(handle, side, uplo, trans, diag, m, n, alpha, A, lda, B,
                                     ldb, C, ldc)
     initialize_context()
-    @ccall libcublas.cublasStrmm_v2_64(handle::cublasHandle_t, side::cublasSideMode_t,
-                                       uplo::cublasFillMode_t, trans::cublasOperation_t,
-                                       diag::cublasDiagType_t, m::Int64, n::Int64,
-                                       alpha::RefOrCuRef{Cfloat}, A::CuPtr{Cfloat},
-                                       lda::Int64, B::CuPtr{Cfloat}, ldb::Int64,
-                                       C::CuPtr{Cfloat}, ldc::Int64)::cublasStatus_t
+    @gcsafe_ccall libcublas.cublasStrmm_v2_64(handle::cublasHandle_t,
+                                              side::cublasSideMode_t,
+                                              uplo::cublasFillMode_t,
+                                              trans::cublasOperation_t,
+                                              diag::cublasDiagType_t, m::Int64, n::Int64,
+                                              alpha::RefOrCuRef{Cfloat}, A::CuPtr{Cfloat},
+                                              lda::Int64, B::CuPtr{Cfloat}, ldb::Int64,
+                                              C::CuPtr{Cfloat}, ldc::Int64)::cublasStatus_t
 end
 
 @checked function cublasDtrmm_v2_64(handle, side, uplo, trans, diag, m, n, alpha, A, lda, B,
                                     ldb, C, ldc)
     initialize_context()
-    @ccall libcublas.cublasDtrmm_v2_64(handle::cublasHandle_t, side::cublasSideMode_t,
-                                       uplo::cublasFillMode_t, trans::cublasOperation_t,
-                                       diag::cublasDiagType_t, m::Int64, n::Int64,
-                                       alpha::RefOrCuRef{Cdouble}, A::CuPtr{Cdouble},
-                                       lda::Int64, B::CuPtr{Cdouble}, ldb::Int64,
-                                       C::CuPtr{Cdouble}, ldc::Int64)::cublasStatus_t
+    @gcsafe_ccall libcublas.cublasDtrmm_v2_64(handle::cublasHandle_t,
+                                              side::cublasSideMode_t,
+                                              uplo::cublasFillMode_t,
+                                              trans::cublasOperation_t,
+                                              diag::cublasDiagType_t, m::Int64, n::Int64,
+                                              alpha::RefOrCuRef{Cdouble}, A::CuPtr{Cdouble},
+                                              lda::Int64, B::CuPtr{Cdouble}, ldb::Int64,
+                                              C::CuPtr{Cdouble}, ldc::Int64)::cublasStatus_t
 end
 
 @checked function cublasCtrmm_v2_64(handle, side, uplo, trans, diag, m, n, alpha, A, lda, B,
                                     ldb, C, ldc)
     initialize_context()
-    @ccall libcublas.cublasCtrmm_v2_64(handle::cublasHandle_t, side::cublasSideMode_t,
-                                       uplo::cublasFillMode_t, trans::cublasOperation_t,
-                                       diag::cublasDiagType_t, m::Int64, n::Int64,
-                                       alpha::RefOrCuRef{cuComplex}, A::CuPtr{cuComplex},
-                                       lda::Int64, B::CuPtr{cuComplex}, ldb::Int64,
-                                       C::CuPtr{cuComplex}, ldc::Int64)::cublasStatus_t
+    @gcsafe_ccall libcublas.cublasCtrmm_v2_64(handle::cublasHandle_t,
+                                              side::cublasSideMode_t,
+                                              uplo::cublasFillMode_t,
+                                              trans::cublasOperation_t,
+                                              diag::cublasDiagType_t, m::Int64, n::Int64,
+                                              alpha::RefOrCuRef{cuComplex},
+                                              A::CuPtr{cuComplex}, lda::Int64,
+                                              B::CuPtr{cuComplex}, ldb::Int64,
+                                              C::CuPtr{cuComplex},
+                                              ldc::Int64)::cublasStatus_t
 end
 
 @checked function cublasZtrmm_v2_64(handle, side, uplo, trans, diag, m, n, alpha, A, lda, B,
                                     ldb, C, ldc)
     initialize_context()
-    @ccall libcublas.cublasZtrmm_v2_64(handle::cublasHandle_t, side::cublasSideMode_t,
-                                       uplo::cublasFillMode_t, trans::cublasOperation_t,
-                                       diag::cublasDiagType_t, m::Int64, n::Int64,
-                                       alpha::RefOrCuRef{cuDoubleComplex},
-                                       A::CuPtr{cuDoubleComplex}, lda::Int64,
-                                       B::CuPtr{cuDoubleComplex}, ldb::Int64,
-                                       C::CuPtr{cuDoubleComplex},
-                                       ldc::Int64)::cublasStatus_t
+    @gcsafe_ccall libcublas.cublasZtrmm_v2_64(handle::cublasHandle_t,
+                                              side::cublasSideMode_t,
+                                              uplo::cublasFillMode_t,
+                                              trans::cublasOperation_t,
+                                              diag::cublasDiagType_t, m::Int64, n::Int64,
+                                              alpha::RefOrCuRef{cuDoubleComplex},
+                                              A::CuPtr{cuDoubleComplex}, lda::Int64,
+                                              B::CuPtr{cuDoubleComplex}, ldb::Int64,
+                                              C::CuPtr{cuDoubleComplex},
+                                              ldc::Int64)::cublasStatus_t
 end
 
 @cenum cublasAtomicsMode_t::UInt32 begin
@@ -2846,1359 +3122,1484 @@ end
 const cublasLogCallback = Ptr{Cvoid}
 
 @checked function cublasGetProperty(type, value)
-    @ccall libcublas.cublasGetProperty(type::libraryPropertyType,
-                                       value::Ref{Cint})::cublasStatus_t
+    @gcsafe_ccall libcublas.cublasGetProperty(type::libraryPropertyType,
+                                              value::Ref{Cint})::cublasStatus_t
 end
 
 function cublasGetCudartVersion()
-    @ccall libcublas.cublasGetCudartVersion()::Csize_t
+    @gcsafe_ccall libcublas.cublasGetCudartVersion()::Csize_t
 end
 
 @checked function cublasGetAtomicsMode(handle, mode)
     initialize_context()
-    @ccall libcublas.cublasGetAtomicsMode(handle::cublasHandle_t,
-                                          mode::Ref{cublasAtomicsMode_t})::cublasStatus_t
+    @gcsafe_ccall libcublas.cublasGetAtomicsMode(handle::cublasHandle_t,
+                                                 mode::Ref{cublasAtomicsMode_t})::cublasStatus_t
 end
 
 @checked function cublasSetAtomicsMode(handle, mode)
     initialize_context()
-    @ccall libcublas.cublasSetAtomicsMode(handle::cublasHandle_t,
-                                          mode::cublasAtomicsMode_t)::cublasStatus_t
+    @gcsafe_ccall libcublas.cublasSetAtomicsMode(handle::cublasHandle_t,
+                                                 mode::cublasAtomicsMode_t)::cublasStatus_t
 end
 
 @checked function cublasGetMathMode(handle, mode)
     initialize_context()
-    @ccall libcublas.cublasGetMathMode(handle::cublasHandle_t,
-                                       mode::Ref{UInt32})::cublasStatus_t
+    @gcsafe_ccall libcublas.cublasGetMathMode(handle::cublasHandle_t,
+                                              mode::Ref{UInt32})::cublasStatus_t
 end
 
 @checked function cublasSetMathMode(handle, mode)
     initialize_context()
-    @ccall libcublas.cublasSetMathMode(handle::cublasHandle_t,
-                                       mode::cublasMath_t)::cublasStatus_t
+    @gcsafe_ccall libcublas.cublasSetMathMode(handle::cublasHandle_t,
+                                              mode::cublasMath_t)::cublasStatus_t
 end
 
 @checked function cublasGetSmCountTarget(handle, smCountTarget)
     initialize_context()
-    @ccall libcublas.cublasGetSmCountTarget(handle::cublasHandle_t,
-                                            smCountTarget::Ptr{Cint})::cublasStatus_t
+    @gcsafe_ccall libcublas.cublasGetSmCountTarget(handle::cublasHandle_t,
+                                                   smCountTarget::Ptr{Cint})::cublasStatus_t
 end
 
 @checked function cublasSetSmCountTarget(handle, smCountTarget)
     initialize_context()
-    @ccall libcublas.cublasSetSmCountTarget(handle::cublasHandle_t,
-                                            smCountTarget::Cint)::cublasStatus_t
+    @gcsafe_ccall libcublas.cublasSetSmCountTarget(handle::cublasHandle_t,
+                                                   smCountTarget::Cint)::cublasStatus_t
 end
 
 function cublasGetStatusName(status)
     initialize_context()
-    @ccall libcublas.cublasGetStatusName(status::cublasStatus_t)::Cstring
+    @gcsafe_ccall libcublas.cublasGetStatusName(status::cublasStatus_t)::Cstring
 end
 
 function cublasGetStatusString(status)
     initialize_context()
-    @ccall libcublas.cublasGetStatusString(status::cublasStatus_t)::Cstring
+    @gcsafe_ccall libcublas.cublasGetStatusString(status::cublasStatus_t)::Cstring
 end
 
 @checked function cublasLoggerConfigure(logIsOn, logToStdOut, logToStdErr, logFileName)
     initialize_context()
-    @ccall libcublas.cublasLoggerConfigure(logIsOn::Cint, logToStdOut::Cint,
-                                           logToStdErr::Cint,
-                                           logFileName::Cstring)::cublasStatus_t
+    @gcsafe_ccall libcublas.cublasLoggerConfigure(logIsOn::Cint, logToStdOut::Cint,
+                                                  logToStdErr::Cint,
+                                                  logFileName::Cstring)::cublasStatus_t
 end
 
 @checked function cublasSetLoggerCallback(userCallback)
-    @ccall libcublas.cublasSetLoggerCallback(userCallback::cublasLogCallback)::cublasStatus_t
+    @gcsafe_ccall libcublas.cublasSetLoggerCallback(userCallback::cublasLogCallback)::cublasStatus_t
 end
 
 @checked function cublasGetLoggerCallback(userCallback)
-    @ccall libcublas.cublasGetLoggerCallback(userCallback::Ref{cublasLogCallback})::cublasStatus_t
+    @gcsafe_ccall libcublas.cublasGetLoggerCallback(userCallback::Ref{cublasLogCallback})::cublasStatus_t
 end
 
 @checked function cublasSetVector(n, elemSize, x, incx, devicePtr, incy)
     initialize_context()
-    @ccall libcublas.cublasSetVector(n::Cint, elemSize::Cint, x::Ptr{Cvoid}, incx::Cint,
-                                     devicePtr::CuPtr{Cvoid}, incy::Cint)::cublasStatus_t
+    @gcsafe_ccall libcublas.cublasSetVector(n::Cint, elemSize::Cint, x::Ptr{Cvoid},
+                                            incx::Cint, devicePtr::CuPtr{Cvoid},
+                                            incy::Cint)::cublasStatus_t
 end
 
 @checked function cublasSetVector_64(n, elemSize, x, incx, devicePtr, incy)
     initialize_context()
-    @ccall libcublas.cublasSetVector_64(n::Int64, elemSize::Int64, x::Ptr{Cvoid},
-                                        incx::Int64, devicePtr::CuPtr{Cvoid},
-                                        incy::Int64)::cublasStatus_t
+    @gcsafe_ccall libcublas.cublasSetVector_64(n::Int64, elemSize::Int64, x::Ptr{Cvoid},
+                                               incx::Int64, devicePtr::CuPtr{Cvoid},
+                                               incy::Int64)::cublasStatus_t
 end
 
 @checked function cublasGetVector(n, elemSize, x, incx, y, incy)
     initialize_context()
-    @ccall libcublas.cublasGetVector(n::Cint, elemSize::Cint, x::CuPtr{Cvoid}, incx::Cint,
-                                     y::Ptr{Cvoid}, incy::Cint)::cublasStatus_t
+    @gcsafe_ccall libcublas.cublasGetVector(n::Cint, elemSize::Cint, x::CuPtr{Cvoid},
+                                            incx::Cint, y::Ptr{Cvoid},
+                                            incy::Cint)::cublasStatus_t
 end
 
 @checked function cublasGetVector_64(n, elemSize, x, incx, y, incy)
     initialize_context()
-    @ccall libcublas.cublasGetVector_64(n::Int64, elemSize::Int64, x::CuPtr{Cvoid},
-                                        incx::Int64, y::Ptr{Cvoid},
-                                        incy::Int64)::cublasStatus_t
+    @gcsafe_ccall libcublas.cublasGetVector_64(n::Int64, elemSize::Int64, x::CuPtr{Cvoid},
+                                               incx::Int64, y::Ptr{Cvoid},
+                                               incy::Int64)::cublasStatus_t
 end
 
 @checked function cublasSetMatrix(rows, cols, elemSize, A, lda, B, ldb)
     initialize_context()
-    @ccall libcublas.cublasSetMatrix(rows::Cint, cols::Cint, elemSize::Cint, A::Ptr{Cvoid},
-                                     lda::Cint, B::CuPtr{Cvoid}, ldb::Cint)::cublasStatus_t
+    @gcsafe_ccall libcublas.cublasSetMatrix(rows::Cint, cols::Cint, elemSize::Cint,
+                                            A::Ptr{Cvoid}, lda::Cint, B::CuPtr{Cvoid},
+                                            ldb::Cint)::cublasStatus_t
 end
 
 @checked function cublasSetMatrix_64(rows, cols, elemSize, A, lda, B, ldb)
     initialize_context()
-    @ccall libcublas.cublasSetMatrix_64(rows::Int64, cols::Int64, elemSize::Int64,
-                                        A::Ptr{Cvoid}, lda::Int64, B::CuPtr{Cvoid},
-                                        ldb::Int64)::cublasStatus_t
+    @gcsafe_ccall libcublas.cublasSetMatrix_64(rows::Int64, cols::Int64, elemSize::Int64,
+                                               A::Ptr{Cvoid}, lda::Int64, B::CuPtr{Cvoid},
+                                               ldb::Int64)::cublasStatus_t
 end
 
 @checked function cublasGetMatrix(rows, cols, elemSize, A, lda, B, ldb)
     initialize_context()
-    @ccall libcublas.cublasGetMatrix(rows::Cint, cols::Cint, elemSize::Cint,
-                                     A::CuPtr{Cvoid}, lda::Cint, B::Ptr{Cvoid},
-                                     ldb::Cint)::cublasStatus_t
+    @gcsafe_ccall libcublas.cublasGetMatrix(rows::Cint, cols::Cint, elemSize::Cint,
+                                            A::CuPtr{Cvoid}, lda::Cint, B::Ptr{Cvoid},
+                                            ldb::Cint)::cublasStatus_t
 end
 
 @checked function cublasGetMatrix_64(rows, cols, elemSize, A, lda, B, ldb)
     initialize_context()
-    @ccall libcublas.cublasGetMatrix_64(rows::Int64, cols::Int64, elemSize::Int64,
-                                        A::CuPtr{Cvoid}, lda::Int64, B::Ptr{Cvoid},
-                                        ldb::Int64)::cublasStatus_t
+    @gcsafe_ccall libcublas.cublasGetMatrix_64(rows::Int64, cols::Int64, elemSize::Int64,
+                                               A::CuPtr{Cvoid}, lda::Int64, B::Ptr{Cvoid},
+                                               ldb::Int64)::cublasStatus_t
 end
 
 @checked function cublasSetVectorAsync(n, elemSize, hostPtr, incx, devicePtr, incy, stream)
     initialize_context()
-    @ccall libcublas.cublasSetVectorAsync(n::Cint, elemSize::Cint, hostPtr::Ptr{Cvoid},
-                                          incx::Cint, devicePtr::CuPtr{Cvoid}, incy::Cint,
-                                          stream::cudaStream_t)::cublasStatus_t
+    @gcsafe_ccall libcublas.cublasSetVectorAsync(n::Cint, elemSize::Cint,
+                                                 hostPtr::Ptr{Cvoid}, incx::Cint,
+                                                 devicePtr::CuPtr{Cvoid}, incy::Cint,
+                                                 stream::cudaStream_t)::cublasStatus_t
 end
 
 @checked function cublasSetVectorAsync_64(n, elemSize, hostPtr, incx, devicePtr, incy,
                                           stream)
     initialize_context()
-    @ccall libcublas.cublasSetVectorAsync_64(n::Int64, elemSize::Int64, hostPtr::Ptr{Cvoid},
-                                             incx::Int64, devicePtr::CuPtr{Cvoid},
-                                             incy::Int64,
-                                             stream::cudaStream_t)::cublasStatus_t
+    @gcsafe_ccall libcublas.cublasSetVectorAsync_64(n::Int64, elemSize::Int64,
+                                                    hostPtr::Ptr{Cvoid}, incx::Int64,
+                                                    devicePtr::CuPtr{Cvoid}, incy::Int64,
+                                                    stream::cudaStream_t)::cublasStatus_t
 end
 
 @checked function cublasGetVectorAsync(n, elemSize, devicePtr, incx, hostPtr, incy, stream)
     initialize_context()
-    @ccall libcublas.cublasGetVectorAsync(n::Cint, elemSize::Cint, devicePtr::CuPtr{Cvoid},
-                                          incx::Cint, hostPtr::Ptr{Cvoid}, incy::Cint,
-                                          stream::cudaStream_t)::cublasStatus_t
+    @gcsafe_ccall libcublas.cublasGetVectorAsync(n::Cint, elemSize::Cint,
+                                                 devicePtr::CuPtr{Cvoid}, incx::Cint,
+                                                 hostPtr::Ptr{Cvoid}, incy::Cint,
+                                                 stream::cudaStream_t)::cublasStatus_t
 end
 
 @checked function cublasGetVectorAsync_64(n, elemSize, devicePtr, incx, hostPtr, incy,
                                           stream)
     initialize_context()
-    @ccall libcublas.cublasGetVectorAsync_64(n::Int64, elemSize::Int64,
-                                             devicePtr::CuPtr{Cvoid}, incx::Int64,
-                                             hostPtr::Ptr{Cvoid}, incy::Int64,
-                                             stream::cudaStream_t)::cublasStatus_t
+    @gcsafe_ccall libcublas.cublasGetVectorAsync_64(n::Int64, elemSize::Int64,
+                                                    devicePtr::CuPtr{Cvoid}, incx::Int64,
+                                                    hostPtr::Ptr{Cvoid}, incy::Int64,
+                                                    stream::cudaStream_t)::cublasStatus_t
 end
 
 @checked function cublasSetMatrixAsync(rows, cols, elemSize, A, lda, B, ldb, stream)
     initialize_context()
-    @ccall libcublas.cublasSetMatrixAsync(rows::Cint, cols::Cint, elemSize::Cint,
-                                          A::Ptr{Cvoid}, lda::Cint, B::CuPtr{Cvoid},
-                                          ldb::Cint, stream::cudaStream_t)::cublasStatus_t
+    @gcsafe_ccall libcublas.cublasSetMatrixAsync(rows::Cint, cols::Cint, elemSize::Cint,
+                                                 A::Ptr{Cvoid}, lda::Cint, B::CuPtr{Cvoid},
+                                                 ldb::Cint,
+                                                 stream::cudaStream_t)::cublasStatus_t
 end
 
 @checked function cublasSetMatrixAsync_64(rows, cols, elemSize, A, lda, B, ldb, stream)
     initialize_context()
-    @ccall libcublas.cublasSetMatrixAsync_64(rows::Int64, cols::Int64, elemSize::Int64,
-                                             A::Ptr{Cvoid}, lda::Int64, B::CuPtr{Cvoid},
-                                             ldb::Int64,
-                                             stream::cudaStream_t)::cublasStatus_t
+    @gcsafe_ccall libcublas.cublasSetMatrixAsync_64(rows::Int64, cols::Int64,
+                                                    elemSize::Int64, A::Ptr{Cvoid},
+                                                    lda::Int64, B::CuPtr{Cvoid}, ldb::Int64,
+                                                    stream::cudaStream_t)::cublasStatus_t
 end
 
 @checked function cublasGetMatrixAsync(rows, cols, elemSize, A, lda, B, ldb, stream)
     initialize_context()
-    @ccall libcublas.cublasGetMatrixAsync(rows::Cint, cols::Cint, elemSize::Cint,
-                                          A::CuPtr{Cvoid}, lda::Cint, B::Ptr{Cvoid},
-                                          ldb::Cint, stream::cudaStream_t)::cublasStatus_t
+    @gcsafe_ccall libcublas.cublasGetMatrixAsync(rows::Cint, cols::Cint, elemSize::Cint,
+                                                 A::CuPtr{Cvoid}, lda::Cint, B::Ptr{Cvoid},
+                                                 ldb::Cint,
+                                                 stream::cudaStream_t)::cublasStatus_t
 end
 
 @checked function cublasGetMatrixAsync_64(rows, cols, elemSize, A, lda, B, ldb, stream)
     initialize_context()
-    @ccall libcublas.cublasGetMatrixAsync_64(rows::Int64, cols::Int64, elemSize::Int64,
-                                             A::CuPtr{Cvoid}, lda::Int64, B::Ptr{Cvoid},
-                                             ldb::Int64,
-                                             stream::cudaStream_t)::cublasStatus_t
+    @gcsafe_ccall libcublas.cublasGetMatrixAsync_64(rows::Int64, cols::Int64,
+                                                    elemSize::Int64, A::CuPtr{Cvoid},
+                                                    lda::Int64, B::Ptr{Cvoid}, ldb::Int64,
+                                                    stream::cudaStream_t)::cublasStatus_t
 end
 
 function cublasXerbla(srName, info)
     initialize_context()
-    @ccall libcublas.cublasXerbla(srName::Cstring, info::Cint)::Cvoid
+    @gcsafe_ccall libcublas.cublasXerbla(srName::Cstring, info::Cint)::Cvoid
 end
 
 @checked function cublasNrm2Ex(handle, n, x, xType, incx, result, resultType, executionType)
     initialize_context()
-    @ccall libcublas.cublasNrm2Ex(handle::cublasHandle_t, n::Cint, x::CuPtr{Cvoid},
-                                  xType::cudaDataType, incx::Cint,
-                                  result::PtrOrCuPtr{Cvoid}, resultType::cudaDataType,
-                                  executionType::cudaDataType)::cublasStatus_t
+    @gcsafe_ccall libcublas.cublasNrm2Ex(handle::cublasHandle_t, n::Cint, x::CuPtr{Cvoid},
+                                         xType::cudaDataType, incx::Cint,
+                                         result::PtrOrCuPtr{Cvoid},
+                                         resultType::cudaDataType,
+                                         executionType::cudaDataType)::cublasStatus_t
 end
 
 @checked function cublasNrm2Ex_64(handle, n, x, xType, incx, result, resultType,
                                   executionType)
     initialize_context()
-    @ccall libcublas.cublasNrm2Ex_64(handle::cublasHandle_t, n::Int64, x::CuPtr{Cvoid},
-                                     xType::cudaDataType, incx::Int64,
-                                     result::PtrOrCuPtr{Cvoid}, resultType::cudaDataType,
-                                     executionType::cudaDataType)::cublasStatus_t
+    @gcsafe_ccall libcublas.cublasNrm2Ex_64(handle::cublasHandle_t, n::Int64,
+                                            x::CuPtr{Cvoid}, xType::cudaDataType,
+                                            incx::Int64, result::PtrOrCuPtr{Cvoid},
+                                            resultType::cudaDataType,
+                                            executionType::cudaDataType)::cublasStatus_t
 end
 
 @checked function cublasDotEx(handle, n, x, xType, incx, y, yType, incy, result, resultType,
                               executionType)
     initialize_context()
-    @ccall libcublas.cublasDotEx(handle::cublasHandle_t, n::Cint, x::CuPtr{Cvoid},
-                                 xType::cudaDataType, incx::Cint, y::CuPtr{Cvoid},
-                                 yType::cudaDataType, incy::Cint, result::PtrOrCuPtr{Cvoid},
-                                 resultType::cudaDataType,
-                                 executionType::cudaDataType)::cublasStatus_t
+    @gcsafe_ccall libcublas.cublasDotEx(handle::cublasHandle_t, n::Cint, x::CuPtr{Cvoid},
+                                        xType::cudaDataType, incx::Cint, y::CuPtr{Cvoid},
+                                        yType::cudaDataType, incy::Cint,
+                                        result::PtrOrCuPtr{Cvoid}, resultType::cudaDataType,
+                                        executionType::cudaDataType)::cublasStatus_t
 end
 
 @checked function cublasDotEx_64(handle, n, x, xType, incx, y, yType, incy, result,
                                  resultType, executionType)
     initialize_context()
-    @ccall libcublas.cublasDotEx_64(handle::cublasHandle_t, n::Int64, x::CuPtr{Cvoid},
-                                    xType::cudaDataType, incx::Int64, y::CuPtr{Cvoid},
-                                    yType::cudaDataType, incy::Int64,
-                                    result::PtrOrCuPtr{Cvoid}, resultType::cudaDataType,
-                                    executionType::cudaDataType)::cublasStatus_t
+    @gcsafe_ccall libcublas.cublasDotEx_64(handle::cublasHandle_t, n::Int64,
+                                           x::CuPtr{Cvoid}, xType::cudaDataType,
+                                           incx::Int64, y::CuPtr{Cvoid},
+                                           yType::cudaDataType, incy::Int64,
+                                           result::PtrOrCuPtr{Cvoid},
+                                           resultType::cudaDataType,
+                                           executionType::cudaDataType)::cublasStatus_t
 end
 
 @checked function cublasDotcEx(handle, n, x, xType, incx, y, yType, incy, result,
                                resultType, executionType)
     initialize_context()
-    @ccall libcublas.cublasDotcEx(handle::cublasHandle_t, n::Cint, x::CuPtr{Cvoid},
-                                  xType::cudaDataType, incx::Cint, y::CuPtr{Cvoid},
-                                  yType::cudaDataType, incy::Cint,
-                                  result::PtrOrCuPtr{Cvoid}, resultType::cudaDataType,
-                                  executionType::cudaDataType)::cublasStatus_t
+    @gcsafe_ccall libcublas.cublasDotcEx(handle::cublasHandle_t, n::Cint, x::CuPtr{Cvoid},
+                                         xType::cudaDataType, incx::Cint, y::CuPtr{Cvoid},
+                                         yType::cudaDataType, incy::Cint,
+                                         result::PtrOrCuPtr{Cvoid},
+                                         resultType::cudaDataType,
+                                         executionType::cudaDataType)::cublasStatus_t
 end
 
 @checked function cublasDotcEx_64(handle, n, x, xType, incx, y, yType, incy, result,
                                   resultType, executionType)
     initialize_context()
-    @ccall libcublas.cublasDotcEx_64(handle::cublasHandle_t, n::Int64, x::CuPtr{Cvoid},
-                                     xType::cudaDataType, incx::Int64, y::CuPtr{Cvoid},
-                                     yType::cudaDataType, incy::Int64,
-                                     result::PtrOrCuPtr{Cvoid}, resultType::cudaDataType,
-                                     executionType::cudaDataType)::cublasStatus_t
+    @gcsafe_ccall libcublas.cublasDotcEx_64(handle::cublasHandle_t, n::Int64,
+                                            x::CuPtr{Cvoid}, xType::cudaDataType,
+                                            incx::Int64, y::CuPtr{Cvoid},
+                                            yType::cudaDataType, incy::Int64,
+                                            result::PtrOrCuPtr{Cvoid},
+                                            resultType::cudaDataType,
+                                            executionType::cudaDataType)::cublasStatus_t
 end
 
 @checked function cublasScalEx(handle, n, alpha, alphaType, x, xType, incx, executionType)
     initialize_context()
-    @ccall libcublas.cublasScalEx(handle::cublasHandle_t, n::Cint, alpha::PtrOrCuPtr{Cvoid},
-                                  alphaType::cudaDataType, x::CuPtr{Cvoid},
-                                  xType::cudaDataType, incx::Cint,
-                                  executionType::cudaDataType)::cublasStatus_t
+    @gcsafe_ccall libcublas.cublasScalEx(handle::cublasHandle_t, n::Cint,
+                                         alpha::PtrOrCuPtr{Cvoid}, alphaType::cudaDataType,
+                                         x::CuPtr{Cvoid}, xType::cudaDataType, incx::Cint,
+                                         executionType::cudaDataType)::cublasStatus_t
 end
 
 @checked function cublasScalEx_64(handle, n, alpha, alphaType, x, xType, incx,
                                   executionType)
     initialize_context()
-    @ccall libcublas.cublasScalEx_64(handle::cublasHandle_t, n::Int64,
-                                     alpha::PtrOrCuPtr{Cvoid}, alphaType::cudaDataType,
-                                     x::CuPtr{Cvoid}, xType::cudaDataType, incx::Int64,
-                                     executionType::cudaDataType)::cublasStatus_t
+    @gcsafe_ccall libcublas.cublasScalEx_64(handle::cublasHandle_t, n::Int64,
+                                            alpha::PtrOrCuPtr{Cvoid},
+                                            alphaType::cudaDataType, x::CuPtr{Cvoid},
+                                            xType::cudaDataType, incx::Int64,
+                                            executionType::cudaDataType)::cublasStatus_t
 end
 
 @checked function cublasAxpyEx(handle, n, alpha, alphaType, x, xType, incx, y, yType, incy,
                                executiontype)
     initialize_context()
-    @ccall libcublas.cublasAxpyEx(handle::cublasHandle_t, n::Cint, alpha::PtrOrCuPtr{Cvoid},
-                                  alphaType::cudaDataType, x::CuPtr{Cvoid},
-                                  xType::cudaDataType, incx::Cint, y::CuPtr{Cvoid},
-                                  yType::cudaDataType, incy::Cint,
-                                  executiontype::cudaDataType)::cublasStatus_t
+    @gcsafe_ccall libcublas.cublasAxpyEx(handle::cublasHandle_t, n::Cint,
+                                         alpha::PtrOrCuPtr{Cvoid}, alphaType::cudaDataType,
+                                         x::CuPtr{Cvoid}, xType::cudaDataType, incx::Cint,
+                                         y::CuPtr{Cvoid}, yType::cudaDataType, incy::Cint,
+                                         executiontype::cudaDataType)::cublasStatus_t
 end
 
 @checked function cublasAxpyEx_64(handle, n, alpha, alphaType, x, xType, incx, y, yType,
                                   incy, executiontype)
     initialize_context()
-    @ccall libcublas.cublasAxpyEx_64(handle::cublasHandle_t, n::Int64,
-                                     alpha::PtrOrCuPtr{Cvoid}, alphaType::cudaDataType,
-                                     x::CuPtr{Cvoid}, xType::cudaDataType, incx::Int64,
-                                     y::CuPtr{Cvoid}, yType::cudaDataType, incy::Int64,
-                                     executiontype::cudaDataType)::cublasStatus_t
+    @gcsafe_ccall libcublas.cublasAxpyEx_64(handle::cublasHandle_t, n::Int64,
+                                            alpha::PtrOrCuPtr{Cvoid},
+                                            alphaType::cudaDataType, x::CuPtr{Cvoid},
+                                            xType::cudaDataType, incx::Int64,
+                                            y::CuPtr{Cvoid}, yType::cudaDataType,
+                                            incy::Int64,
+                                            executiontype::cudaDataType)::cublasStatus_t
 end
 
 @checked function cublasCopyEx(handle, n, x, xType, incx, y, yType, incy)
     initialize_context()
-    @ccall libcublas.cublasCopyEx(handle::cublasHandle_t, n::Cint, x::CuPtr{Cvoid},
-                                  xType::cudaDataType, incx::Cint, y::CuPtr{Cvoid},
-                                  yType::cudaDataType, incy::Cint)::cublasStatus_t
+    @gcsafe_ccall libcublas.cublasCopyEx(handle::cublasHandle_t, n::Cint, x::CuPtr{Cvoid},
+                                         xType::cudaDataType, incx::Cint, y::CuPtr{Cvoid},
+                                         yType::cudaDataType, incy::Cint)::cublasStatus_t
 end
 
 @checked function cublasCopyEx_64(handle, n, x, xType, incx, y, yType, incy)
     initialize_context()
-    @ccall libcublas.cublasCopyEx_64(handle::cublasHandle_t, n::Int64, x::CuPtr{Cvoid},
-                                     xType::cudaDataType, incx::Int64, y::CuPtr{Cvoid},
-                                     yType::cudaDataType, incy::Int64)::cublasStatus_t
+    @gcsafe_ccall libcublas.cublasCopyEx_64(handle::cublasHandle_t, n::Int64,
+                                            x::CuPtr{Cvoid}, xType::cudaDataType,
+                                            incx::Int64, y::CuPtr{Cvoid},
+                                            yType::cudaDataType,
+                                            incy::Int64)::cublasStatus_t
 end
 
 @checked function cublasSwapEx(handle, n, x, xType, incx, y, yType, incy)
     initialize_context()
-    @ccall libcublas.cublasSwapEx(handle::cublasHandle_t, n::Cint, x::CuPtr{Cvoid},
-                                  xType::cudaDataType, incx::Cint, y::CuPtr{Cvoid},
-                                  yType::cudaDataType, incy::Cint)::cublasStatus_t
+    @gcsafe_ccall libcublas.cublasSwapEx(handle::cublasHandle_t, n::Cint, x::CuPtr{Cvoid},
+                                         xType::cudaDataType, incx::Cint, y::CuPtr{Cvoid},
+                                         yType::cudaDataType, incy::Cint)::cublasStatus_t
 end
 
 @checked function cublasSwapEx_64(handle, n, x, xType, incx, y, yType, incy)
     initialize_context()
-    @ccall libcublas.cublasSwapEx_64(handle::cublasHandle_t, n::Int64, x::CuPtr{Cvoid},
-                                     xType::cudaDataType, incx::Int64, y::CuPtr{Cvoid},
-                                     yType::cudaDataType, incy::Int64)::cublasStatus_t
+    @gcsafe_ccall libcublas.cublasSwapEx_64(handle::cublasHandle_t, n::Int64,
+                                            x::CuPtr{Cvoid}, xType::cudaDataType,
+                                            incx::Int64, y::CuPtr{Cvoid},
+                                            yType::cudaDataType,
+                                            incy::Int64)::cublasStatus_t
 end
 
 @checked function cublasIamaxEx(handle, n, x, xType, incx, result)
     initialize_context()
-    @ccall libcublas.cublasIamaxEx(handle::cublasHandle_t, n::Cint, x::CuPtr{Cvoid},
-                                   xType::cudaDataType, incx::Cint,
-                                   result::RefOrCuRef{Cint})::cublasStatus_t
+    @gcsafe_ccall libcublas.cublasIamaxEx(handle::cublasHandle_t, n::Cint, x::CuPtr{Cvoid},
+                                          xType::cudaDataType, incx::Cint,
+                                          result::RefOrCuRef{Cint})::cublasStatus_t
 end
 
 @checked function cublasIamaxEx_64(handle, n, x, xType, incx, result)
     initialize_context()
-    @ccall libcublas.cublasIamaxEx_64(handle::cublasHandle_t, n::Int64, x::CuPtr{Cvoid},
-                                      xType::cudaDataType, incx::Int64,
-                                      result::RefOrCuRef{Cint})::cublasStatus_t
+    @gcsafe_ccall libcublas.cublasIamaxEx_64(handle::cublasHandle_t, n::Int64,
+                                             x::CuPtr{Cvoid}, xType::cudaDataType,
+                                             incx::Int64,
+                                             result::RefOrCuRef{Cint})::cublasStatus_t
 end
 
 @checked function cublasIaminEx(handle, n, x, xType, incx, result)
     initialize_context()
-    @ccall libcublas.cublasIaminEx(handle::cublasHandle_t, n::Cint, x::CuPtr{Cvoid},
-                                   xType::cudaDataType, incx::Cint,
-                                   result::RefOrCuRef{Cint})::cublasStatus_t
+    @gcsafe_ccall libcublas.cublasIaminEx(handle::cublasHandle_t, n::Cint, x::CuPtr{Cvoid},
+                                          xType::cudaDataType, incx::Cint,
+                                          result::RefOrCuRef{Cint})::cublasStatus_t
 end
 
 @checked function cublasIaminEx_64(handle, n, x, xType, incx, result)
     initialize_context()
-    @ccall libcublas.cublasIaminEx_64(handle::cublasHandle_t, n::Int64, x::CuPtr{Cvoid},
-                                      xType::cudaDataType, incx::Int64,
-                                      result::RefOrCuRef{Cint})::cublasStatus_t
+    @gcsafe_ccall libcublas.cublasIaminEx_64(handle::cublasHandle_t, n::Int64,
+                                             x::CuPtr{Cvoid}, xType::cudaDataType,
+                                             incx::Int64,
+                                             result::RefOrCuRef{Cint})::cublasStatus_t
 end
 
 @checked function cublasAsumEx(handle, n, x, xType, incx, result, resultType, executiontype)
     initialize_context()
-    @ccall libcublas.cublasAsumEx(handle::cublasHandle_t, n::Cint, x::CuPtr{Cvoid},
-                                  xType::cudaDataType, incx::Cint,
-                                  result::PtrOrCuPtr{Cvoid}, resultType::cudaDataType,
-                                  executiontype::cudaDataType)::cublasStatus_t
+    @gcsafe_ccall libcublas.cublasAsumEx(handle::cublasHandle_t, n::Cint, x::CuPtr{Cvoid},
+                                         xType::cudaDataType, incx::Cint,
+                                         result::PtrOrCuPtr{Cvoid},
+                                         resultType::cudaDataType,
+                                         executiontype::cudaDataType)::cublasStatus_t
 end
 
 @checked function cublasAsumEx_64(handle, n, x, xType, incx, result, resultType,
                                   executiontype)
     initialize_context()
-    @ccall libcublas.cublasAsumEx_64(handle::cublasHandle_t, n::Int64, x::CuPtr{Cvoid},
-                                     xType::cudaDataType, incx::Int64,
-                                     result::PtrOrCuPtr{Cvoid}, resultType::cudaDataType,
-                                     executiontype::cudaDataType)::cublasStatus_t
+    @gcsafe_ccall libcublas.cublasAsumEx_64(handle::cublasHandle_t, n::Int64,
+                                            x::CuPtr{Cvoid}, xType::cudaDataType,
+                                            incx::Int64, result::PtrOrCuPtr{Cvoid},
+                                            resultType::cudaDataType,
+                                            executiontype::cudaDataType)::cublasStatus_t
 end
 
 @checked function cublasRotEx(handle, n, x, xType, incx, y, yType, incy, c, s, csType,
                               executiontype)
     initialize_context()
-    @ccall libcublas.cublasRotEx(handle::cublasHandle_t, n::Cint, x::CuPtr{Cvoid},
-                                 xType::cudaDataType, incx::Cint, y::CuPtr{Cvoid},
-                                 yType::cudaDataType, incy::Cint, c::PtrOrCuPtr{Cvoid},
-                                 s::PtrOrCuPtr{Cvoid}, csType::cudaDataType,
-                                 executiontype::cudaDataType)::cublasStatus_t
+    @gcsafe_ccall libcublas.cublasRotEx(handle::cublasHandle_t, n::Cint, x::CuPtr{Cvoid},
+                                        xType::cudaDataType, incx::Cint, y::CuPtr{Cvoid},
+                                        yType::cudaDataType, incy::Cint,
+                                        c::PtrOrCuPtr{Cvoid}, s::PtrOrCuPtr{Cvoid},
+                                        csType::cudaDataType,
+                                        executiontype::cudaDataType)::cublasStatus_t
 end
 
 @checked function cublasRotEx_64(handle, n, x, xType, incx, y, yType, incy, c, s, csType,
                                  executiontype)
     initialize_context()
-    @ccall libcublas.cublasRotEx_64(handle::cublasHandle_t, n::Int64, x::CuPtr{Cvoid},
-                                    xType::cudaDataType, incx::Int64, y::CuPtr{Cvoid},
-                                    yType::cudaDataType, incy::Int64, c::PtrOrCuPtr{Cvoid},
-                                    s::PtrOrCuPtr{Cvoid}, csType::cudaDataType,
-                                    executiontype::cudaDataType)::cublasStatus_t
+    @gcsafe_ccall libcublas.cublasRotEx_64(handle::cublasHandle_t, n::Int64,
+                                           x::CuPtr{Cvoid}, xType::cudaDataType,
+                                           incx::Int64, y::CuPtr{Cvoid},
+                                           yType::cudaDataType, incy::Int64,
+                                           c::PtrOrCuPtr{Cvoid}, s::PtrOrCuPtr{Cvoid},
+                                           csType::cudaDataType,
+                                           executiontype::cudaDataType)::cublasStatus_t
 end
 
 @checked function cublasRotgEx(handle, a, b, abType, c, s, csType, executiontype)
     initialize_context()
-    @ccall libcublas.cublasRotgEx(handle::cublasHandle_t, a::Ptr{Cvoid}, b::Ptr{Cvoid},
-                                  abType::cudaDataType, c::PtrOrCuPtr{Cvoid},
-                                  s::PtrOrCuPtr{Cvoid}, csType::cudaDataType,
-                                  executiontype::cudaDataType)::cublasStatus_t
+    @gcsafe_ccall libcublas.cublasRotgEx(handle::cublasHandle_t, a::Ptr{Cvoid},
+                                         b::Ptr{Cvoid}, abType::cudaDataType,
+                                         c::PtrOrCuPtr{Cvoid}, s::PtrOrCuPtr{Cvoid},
+                                         csType::cudaDataType,
+                                         executiontype::cudaDataType)::cublasStatus_t
 end
 
 @checked function cublasRotmEx(handle, n, x, xType, incx, y, yType, incy, param, paramType,
                                executiontype)
     initialize_context()
-    @ccall libcublas.cublasRotmEx(handle::cublasHandle_t, n::Cint, x::CuPtr{Cvoid},
-                                  xType::cudaDataType, incx::Cint, y::CuPtr{Cvoid},
-                                  yType::cudaDataType, incy::Cint, param::PtrOrCuPtr{Cvoid},
-                                  paramType::cudaDataType,
-                                  executiontype::cudaDataType)::cublasStatus_t
+    @gcsafe_ccall libcublas.cublasRotmEx(handle::cublasHandle_t, n::Cint, x::CuPtr{Cvoid},
+                                         xType::cudaDataType, incx::Cint, y::CuPtr{Cvoid},
+                                         yType::cudaDataType, incy::Cint,
+                                         param::PtrOrCuPtr{Cvoid}, paramType::cudaDataType,
+                                         executiontype::cudaDataType)::cublasStatus_t
 end
 
 @checked function cublasRotmEx_64(handle, n, x, xType, incx, y, yType, incy, param,
                                   paramType, executiontype)
     initialize_context()
-    @ccall libcublas.cublasRotmEx_64(handle::cublasHandle_t, n::Int64, x::CuPtr{Cvoid},
-                                     xType::cudaDataType, incx::Int64, y::CuPtr{Cvoid},
-                                     yType::cudaDataType, incy::Int64,
-                                     param::PtrOrCuPtr{Cvoid}, paramType::cudaDataType,
-                                     executiontype::cudaDataType)::cublasStatus_t
+    @gcsafe_ccall libcublas.cublasRotmEx_64(handle::cublasHandle_t, n::Int64,
+                                            x::CuPtr{Cvoid}, xType::cudaDataType,
+                                            incx::Int64, y::CuPtr{Cvoid},
+                                            yType::cudaDataType, incy::Int64,
+                                            param::PtrOrCuPtr{Cvoid},
+                                            paramType::cudaDataType,
+                                            executiontype::cudaDataType)::cublasStatus_t
 end
 
 @checked function cublasRotmgEx(handle, d1, d1Type, d2, d2Type, x1, x1Type, y1, y1Type,
                                 param, paramType, executiontype)
     initialize_context()
-    @ccall libcublas.cublasRotmgEx(handle::cublasHandle_t, d1::PtrOrCuPtr{Cvoid},
-                                   d1Type::cudaDataType, d2::PtrOrCuPtr{Cvoid},
-                                   d2Type::cudaDataType, x1::PtrOrCuPtr{Cvoid},
-                                   x1Type::cudaDataType, y1::PtrOrCuPtr{Cvoid},
-                                   y1Type::cudaDataType, param::PtrOrCuPtr{Cvoid},
-                                   paramType::cudaDataType,
-                                   executiontype::cudaDataType)::cublasStatus_t
+    @gcsafe_ccall libcublas.cublasRotmgEx(handle::cublasHandle_t, d1::PtrOrCuPtr{Cvoid},
+                                          d1Type::cudaDataType, d2::PtrOrCuPtr{Cvoid},
+                                          d2Type::cudaDataType, x1::PtrOrCuPtr{Cvoid},
+                                          x1Type::cudaDataType, y1::PtrOrCuPtr{Cvoid},
+                                          y1Type::cudaDataType, param::PtrOrCuPtr{Cvoid},
+                                          paramType::cudaDataType,
+                                          executiontype::cudaDataType)::cublasStatus_t
 end
 
 @checked function cublasSgemvBatched(handle, trans, m, n, alpha, Aarray, lda, xarray, incx,
                                      beta, yarray, incy, batchCount)
     initialize_context()
-    @ccall libcublas.cublasSgemvBatched(handle::cublasHandle_t, trans::cublasOperation_t,
-                                        m::Cint, n::Cint, alpha::RefOrCuRef{Cfloat},
-                                        Aarray::CuPtr{Ptr{Cfloat}}, lda::Cint,
-                                        xarray::CuPtr{Ptr{Cfloat}}, incx::Cint,
-                                        beta::RefOrCuRef{Cfloat},
-                                        yarray::CuPtr{Ptr{Cfloat}}, incy::Cint,
-                                        batchCount::Cint)::cublasStatus_t
+    @gcsafe_ccall libcublas.cublasSgemvBatched(handle::cublasHandle_t,
+                                               trans::cublasOperation_t, m::Cint, n::Cint,
+                                               alpha::RefOrCuRef{Cfloat},
+                                               Aarray::CuPtr{Ptr{Cfloat}}, lda::Cint,
+                                               xarray::CuPtr{Ptr{Cfloat}}, incx::Cint,
+                                               beta::RefOrCuRef{Cfloat},
+                                               yarray::CuPtr{Ptr{Cfloat}}, incy::Cint,
+                                               batchCount::Cint)::cublasStatus_t
 end
 
 @checked function cublasSgemvBatched_64(handle, trans, m, n, alpha, Aarray, lda, xarray,
                                         incx, beta, yarray, incy, batchCount)
     initialize_context()
-    @ccall libcublas.cublasSgemvBatched_64(handle::cublasHandle_t, trans::cublasOperation_t,
-                                           m::Int64, n::Int64, alpha::RefOrCuRef{Cfloat},
-                                           Aarray::CuPtr{Ptr{Cfloat}}, lda::Int64,
-                                           xarray::CuPtr{Ptr{Cfloat}}, incx::Int64,
-                                           beta::RefOrCuRef{Cfloat},
-                                           yarray::CuPtr{Ptr{Cfloat}}, incy::Int64,
-                                           batchCount::Int64)::cublasStatus_t
+    @gcsafe_ccall libcublas.cublasSgemvBatched_64(handle::cublasHandle_t,
+                                                  trans::cublasOperation_t, m::Int64,
+                                                  n::Int64, alpha::RefOrCuRef{Cfloat},
+                                                  Aarray::CuPtr{Ptr{Cfloat}}, lda::Int64,
+                                                  xarray::CuPtr{Ptr{Cfloat}}, incx::Int64,
+                                                  beta::RefOrCuRef{Cfloat},
+                                                  yarray::CuPtr{Ptr{Cfloat}}, incy::Int64,
+                                                  batchCount::Int64)::cublasStatus_t
 end
 
 @checked function cublasDgemvBatched(handle, trans, m, n, alpha, Aarray, lda, xarray, incx,
                                      beta, yarray, incy, batchCount)
     initialize_context()
-    @ccall libcublas.cublasDgemvBatched(handle::cublasHandle_t, trans::cublasOperation_t,
-                                        m::Cint, n::Cint, alpha::RefOrCuRef{Cdouble},
-                                        Aarray::CuPtr{Ptr{Cdouble}}, lda::Cint,
-                                        xarray::CuPtr{Ptr{Cdouble}}, incx::Cint,
-                                        beta::RefOrCuRef{Cdouble},
-                                        yarray::CuPtr{Ptr{Cdouble}}, incy::Cint,
-                                        batchCount::Cint)::cublasStatus_t
+    @gcsafe_ccall libcublas.cublasDgemvBatched(handle::cublasHandle_t,
+                                               trans::cublasOperation_t, m::Cint, n::Cint,
+                                               alpha::RefOrCuRef{Cdouble},
+                                               Aarray::CuPtr{Ptr{Cdouble}}, lda::Cint,
+                                               xarray::CuPtr{Ptr{Cdouble}}, incx::Cint,
+                                               beta::RefOrCuRef{Cdouble},
+                                               yarray::CuPtr{Ptr{Cdouble}}, incy::Cint,
+                                               batchCount::Cint)::cublasStatus_t
 end
 
 @checked function cublasDgemvBatched_64(handle, trans, m, n, alpha, Aarray, lda, xarray,
                                         incx, beta, yarray, incy, batchCount)
     initialize_context()
-    @ccall libcublas.cublasDgemvBatched_64(handle::cublasHandle_t, trans::cublasOperation_t,
-                                           m::Int64, n::Int64, alpha::RefOrCuRef{Cdouble},
-                                           Aarray::CuPtr{Ptr{Cdouble}}, lda::Int64,
-                                           xarray::CuPtr{Ptr{Cdouble}}, incx::Int64,
-                                           beta::RefOrCuRef{Cdouble},
-                                           yarray::CuPtr{Ptr{Cdouble}}, incy::Int64,
-                                           batchCount::Int64)::cublasStatus_t
+    @gcsafe_ccall libcublas.cublasDgemvBatched_64(handle::cublasHandle_t,
+                                                  trans::cublasOperation_t, m::Int64,
+                                                  n::Int64, alpha::RefOrCuRef{Cdouble},
+                                                  Aarray::CuPtr{Ptr{Cdouble}}, lda::Int64,
+                                                  xarray::CuPtr{Ptr{Cdouble}}, incx::Int64,
+                                                  beta::RefOrCuRef{Cdouble},
+                                                  yarray::CuPtr{Ptr{Cdouble}}, incy::Int64,
+                                                  batchCount::Int64)::cublasStatus_t
 end
 
 @checked function cublasCgemvBatched(handle, trans, m, n, alpha, Aarray, lda, xarray, incx,
                                      beta, yarray, incy, batchCount)
     initialize_context()
-    @ccall libcublas.cublasCgemvBatched(handle::cublasHandle_t, trans::cublasOperation_t,
-                                        m::Cint, n::Cint, alpha::RefOrCuRef{cuComplex},
-                                        Aarray::CuPtr{Ptr{cuComplex}}, lda::Cint,
-                                        xarray::CuPtr{Ptr{cuComplex}}, incx::Cint,
-                                        beta::RefOrCuRef{cuComplex},
-                                        yarray::CuPtr{Ptr{cuComplex}}, incy::Cint,
-                                        batchCount::Cint)::cublasStatus_t
+    @gcsafe_ccall libcublas.cublasCgemvBatched(handle::cublasHandle_t,
+                                               trans::cublasOperation_t, m::Cint, n::Cint,
+                                               alpha::RefOrCuRef{cuComplex},
+                                               Aarray::CuPtr{Ptr{cuComplex}}, lda::Cint,
+                                               xarray::CuPtr{Ptr{cuComplex}}, incx::Cint,
+                                               beta::RefOrCuRef{cuComplex},
+                                               yarray::CuPtr{Ptr{cuComplex}}, incy::Cint,
+                                               batchCount::Cint)::cublasStatus_t
 end
 
 @checked function cublasCgemvBatched_64(handle, trans, m, n, alpha, Aarray, lda, xarray,
                                         incx, beta, yarray, incy, batchCount)
     initialize_context()
-    @ccall libcublas.cublasCgemvBatched_64(handle::cublasHandle_t, trans::cublasOperation_t,
-                                           m::Int64, n::Int64, alpha::RefOrCuRef{cuComplex},
-                                           Aarray::CuPtr{Ptr{cuComplex}}, lda::Int64,
-                                           xarray::CuPtr{Ptr{cuComplex}}, incx::Int64,
-                                           beta::RefOrCuRef{cuComplex},
-                                           yarray::CuPtr{Ptr{cuComplex}}, incy::Int64,
-                                           batchCount::Int64)::cublasStatus_t
+    @gcsafe_ccall libcublas.cublasCgemvBatched_64(handle::cublasHandle_t,
+                                                  trans::cublasOperation_t, m::Int64,
+                                                  n::Int64, alpha::RefOrCuRef{cuComplex},
+                                                  Aarray::CuPtr{Ptr{cuComplex}}, lda::Int64,
+                                                  xarray::CuPtr{Ptr{cuComplex}},
+                                                  incx::Int64, beta::RefOrCuRef{cuComplex},
+                                                  yarray::CuPtr{Ptr{cuComplex}},
+                                                  incy::Int64,
+                                                  batchCount::Int64)::cublasStatus_t
 end
 
 @checked function cublasZgemvBatched(handle, trans, m, n, alpha, Aarray, lda, xarray, incx,
                                      beta, yarray, incy, batchCount)
     initialize_context()
-    @ccall libcublas.cublasZgemvBatched(handle::cublasHandle_t, trans::cublasOperation_t,
-                                        m::Cint, n::Cint,
-                                        alpha::RefOrCuRef{cuDoubleComplex},
-                                        Aarray::CuPtr{Ptr{cuDoubleComplex}}, lda::Cint,
-                                        xarray::CuPtr{Ptr{cuDoubleComplex}}, incx::Cint,
-                                        beta::RefOrCuRef{cuDoubleComplex},
-                                        yarray::CuPtr{Ptr{cuDoubleComplex}}, incy::Cint,
-                                        batchCount::Cint)::cublasStatus_t
+    @gcsafe_ccall libcublas.cublasZgemvBatched(handle::cublasHandle_t,
+                                               trans::cublasOperation_t, m::Cint, n::Cint,
+                                               alpha::RefOrCuRef{cuDoubleComplex},
+                                               Aarray::CuPtr{Ptr{cuDoubleComplex}},
+                                               lda::Cint,
+                                               xarray::CuPtr{Ptr{cuDoubleComplex}},
+                                               incx::Cint,
+                                               beta::RefOrCuRef{cuDoubleComplex},
+                                               yarray::CuPtr{Ptr{cuDoubleComplex}},
+                                               incy::Cint, batchCount::Cint)::cublasStatus_t
 end
 
 @checked function cublasZgemvBatched_64(handle, trans, m, n, alpha, Aarray, lda, xarray,
                                         incx, beta, yarray, incy, batchCount)
     initialize_context()
-    @ccall libcublas.cublasZgemvBatched_64(handle::cublasHandle_t, trans::cublasOperation_t,
-                                           m::Int64, n::Int64,
-                                           alpha::RefOrCuRef{cuDoubleComplex},
-                                           Aarray::CuPtr{Ptr{cuDoubleComplex}}, lda::Int64,
-                                           xarray::CuPtr{Ptr{cuDoubleComplex}}, incx::Int64,
-                                           beta::RefOrCuRef{cuDoubleComplex},
-                                           yarray::CuPtr{Ptr{cuDoubleComplex}}, incy::Int64,
-                                           batchCount::Int64)::cublasStatus_t
+    @gcsafe_ccall libcublas.cublasZgemvBatched_64(handle::cublasHandle_t,
+                                                  trans::cublasOperation_t, m::Int64,
+                                                  n::Int64,
+                                                  alpha::RefOrCuRef{cuDoubleComplex},
+                                                  Aarray::CuPtr{Ptr{cuDoubleComplex}},
+                                                  lda::Int64,
+                                                  xarray::CuPtr{Ptr{cuDoubleComplex}},
+                                                  incx::Int64,
+                                                  beta::RefOrCuRef{cuDoubleComplex},
+                                                  yarray::CuPtr{Ptr{cuDoubleComplex}},
+                                                  incy::Int64,
+                                                  batchCount::Int64)::cublasStatus_t
 end
 
 @checked function cublasSgemvStridedBatched(handle, trans, m, n, alpha, A, lda, strideA, x,
                                             incx, stridex, beta, y, incy, stridey,
                                             batchCount)
     initialize_context()
-    @ccall libcublas.cublasSgemvStridedBatched(handle::cublasHandle_t,
-                                               trans::cublasOperation_t, m::Cint, n::Cint,
-                                               alpha::RefOrCuRef{Cfloat}, A::CuPtr{Cfloat},
-                                               lda::Cint, strideA::Clonglong,
-                                               x::CuPtr{Cfloat}, incx::Cint,
-                                               stridex::Clonglong, beta::RefOrCuRef{Cfloat},
-                                               y::CuPtr{Cfloat}, incy::Cint,
-                                               stridey::Clonglong,
-                                               batchCount::Cint)::cublasStatus_t
+    @gcsafe_ccall libcublas.cublasSgemvStridedBatched(handle::cublasHandle_t,
+                                                      trans::cublasOperation_t, m::Cint,
+                                                      n::Cint, alpha::RefOrCuRef{Cfloat},
+                                                      A::CuPtr{Cfloat}, lda::Cint,
+                                                      strideA::Clonglong, x::CuPtr{Cfloat},
+                                                      incx::Cint, stridex::Clonglong,
+                                                      beta::RefOrCuRef{Cfloat},
+                                                      y::CuPtr{Cfloat}, incy::Cint,
+                                                      stridey::Clonglong,
+                                                      batchCount::Cint)::cublasStatus_t
 end
 
 @checked function cublasSgemvStridedBatched_64(handle, trans, m, n, alpha, A, lda, strideA,
                                                x, incx, stridex, beta, y, incy, stridey,
                                                batchCount)
     initialize_context()
-    @ccall libcublas.cublasSgemvStridedBatched_64(handle::cublasHandle_t,
-                                                  trans::cublasOperation_t, m::Int64,
-                                                  n::Int64, alpha::RefOrCuRef{Cfloat},
-                                                  A::CuPtr{Cfloat}, lda::Int64,
-                                                  strideA::Clonglong, x::CuPtr{Cfloat},
-                                                  incx::Int64, stridex::Clonglong,
-                                                  beta::RefOrCuRef{Cfloat},
-                                                  y::CuPtr{Cfloat}, incy::Int64,
-                                                  stridey::Clonglong,
-                                                  batchCount::Int64)::cublasStatus_t
+    @gcsafe_ccall libcublas.cublasSgemvStridedBatched_64(handle::cublasHandle_t,
+                                                         trans::cublasOperation_t, m::Int64,
+                                                         n::Int64,
+                                                         alpha::RefOrCuRef{Cfloat},
+                                                         A::CuPtr{Cfloat}, lda::Int64,
+                                                         strideA::Clonglong,
+                                                         x::CuPtr{Cfloat}, incx::Int64,
+                                                         stridex::Clonglong,
+                                                         beta::RefOrCuRef{Cfloat},
+                                                         y::CuPtr{Cfloat}, incy::Int64,
+                                                         stridey::Clonglong,
+                                                         batchCount::Int64)::cublasStatus_t
 end
 
 @checked function cublasDgemvStridedBatched(handle, trans, m, n, alpha, A, lda, strideA, x,
                                             incx, stridex, beta, y, incy, stridey,
                                             batchCount)
     initialize_context()
-    @ccall libcublas.cublasDgemvStridedBatched(handle::cublasHandle_t,
-                                               trans::cublasOperation_t, m::Cint, n::Cint,
-                                               alpha::RefOrCuRef{Cdouble},
-                                               A::CuPtr{Cdouble}, lda::Cint,
-                                               strideA::Clonglong, x::CuPtr{Cdouble},
-                                               incx::Cint, stridex::Clonglong,
-                                               beta::RefOrCuRef{Cdouble}, y::CuPtr{Cdouble},
-                                               incy::Cint, stridey::Clonglong,
-                                               batchCount::Cint)::cublasStatus_t
+    @gcsafe_ccall libcublas.cublasDgemvStridedBatched(handle::cublasHandle_t,
+                                                      trans::cublasOperation_t, m::Cint,
+                                                      n::Cint, alpha::RefOrCuRef{Cdouble},
+                                                      A::CuPtr{Cdouble}, lda::Cint,
+                                                      strideA::Clonglong, x::CuPtr{Cdouble},
+                                                      incx::Cint, stridex::Clonglong,
+                                                      beta::RefOrCuRef{Cdouble},
+                                                      y::CuPtr{Cdouble}, incy::Cint,
+                                                      stridey::Clonglong,
+                                                      batchCount::Cint)::cublasStatus_t
 end
 
 @checked function cublasDgemvStridedBatched_64(handle, trans, m, n, alpha, A, lda, strideA,
                                                x, incx, stridex, beta, y, incy, stridey,
                                                batchCount)
     initialize_context()
-    @ccall libcublas.cublasDgemvStridedBatched_64(handle::cublasHandle_t,
-                                                  trans::cublasOperation_t, m::Int64,
-                                                  n::Int64, alpha::RefOrCuRef{Cdouble},
-                                                  A::CuPtr{Cdouble}, lda::Int64,
-                                                  strideA::Clonglong, x::CuPtr{Cdouble},
-                                                  incx::Int64, stridex::Clonglong,
-                                                  beta::RefOrCuRef{Cdouble},
-                                                  y::CuPtr{Cdouble}, incy::Int64,
-                                                  stridey::Clonglong,
-                                                  batchCount::Int64)::cublasStatus_t
+    @gcsafe_ccall libcublas.cublasDgemvStridedBatched_64(handle::cublasHandle_t,
+                                                         trans::cublasOperation_t, m::Int64,
+                                                         n::Int64,
+                                                         alpha::RefOrCuRef{Cdouble},
+                                                         A::CuPtr{Cdouble}, lda::Int64,
+                                                         strideA::Clonglong,
+                                                         x::CuPtr{Cdouble}, incx::Int64,
+                                                         stridex::Clonglong,
+                                                         beta::RefOrCuRef{Cdouble},
+                                                         y::CuPtr{Cdouble}, incy::Int64,
+                                                         stridey::Clonglong,
+                                                         batchCount::Int64)::cublasStatus_t
 end
 
 @checked function cublasCgemvStridedBatched(handle, trans, m, n, alpha, A, lda, strideA, x,
                                             incx, stridex, beta, y, incy, stridey,
                                             batchCount)
     initialize_context()
-    @ccall libcublas.cublasCgemvStridedBatched(handle::cublasHandle_t,
-                                               trans::cublasOperation_t, m::Cint, n::Cint,
-                                               alpha::RefOrCuRef{cuComplex},
-                                               A::CuPtr{cuComplex}, lda::Cint,
-                                               strideA::Clonglong, x::CuPtr{cuComplex},
-                                               incx::Cint, stridex::Clonglong,
-                                               beta::RefOrCuRef{cuComplex},
-                                               y::CuPtr{cuComplex}, incy::Cint,
-                                               stridey::Clonglong,
-                                               batchCount::Cint)::cublasStatus_t
+    @gcsafe_ccall libcublas.cublasCgemvStridedBatched(handle::cublasHandle_t,
+                                                      trans::cublasOperation_t, m::Cint,
+                                                      n::Cint, alpha::RefOrCuRef{cuComplex},
+                                                      A::CuPtr{cuComplex}, lda::Cint,
+                                                      strideA::Clonglong,
+                                                      x::CuPtr{cuComplex}, incx::Cint,
+                                                      stridex::Clonglong,
+                                                      beta::RefOrCuRef{cuComplex},
+                                                      y::CuPtr{cuComplex}, incy::Cint,
+                                                      stridey::Clonglong,
+                                                      batchCount::Cint)::cublasStatus_t
 end
 
 @checked function cublasCgemvStridedBatched_64(handle, trans, m, n, alpha, A, lda, strideA,
                                                x, incx, stridex, beta, y, incy, stridey,
                                                batchCount)
     initialize_context()
-    @ccall libcublas.cublasCgemvStridedBatched_64(handle::cublasHandle_t,
-                                                  trans::cublasOperation_t, m::Int64,
-                                                  n::Int64, alpha::RefOrCuRef{cuComplex},
-                                                  A::CuPtr{cuComplex}, lda::Int64,
-                                                  strideA::Clonglong, x::CuPtr{cuComplex},
-                                                  incx::Int64, stridex::Clonglong,
-                                                  beta::RefOrCuRef{cuComplex},
-                                                  y::CuPtr{cuComplex}, incy::Int64,
-                                                  stridey::Clonglong,
-                                                  batchCount::Int64)::cublasStatus_t
+    @gcsafe_ccall libcublas.cublasCgemvStridedBatched_64(handle::cublasHandle_t,
+                                                         trans::cublasOperation_t, m::Int64,
+                                                         n::Int64,
+                                                         alpha::RefOrCuRef{cuComplex},
+                                                         A::CuPtr{cuComplex}, lda::Int64,
+                                                         strideA::Clonglong,
+                                                         x::CuPtr{cuComplex}, incx::Int64,
+                                                         stridex::Clonglong,
+                                                         beta::RefOrCuRef{cuComplex},
+                                                         y::CuPtr{cuComplex}, incy::Int64,
+                                                         stridey::Clonglong,
+                                                         batchCount::Int64)::cublasStatus_t
 end
 
 @checked function cublasZgemvStridedBatched(handle, trans, m, n, alpha, A, lda, strideA, x,
                                             incx, stridex, beta, y, incy, stridey,
                                             batchCount)
     initialize_context()
-    @ccall libcublas.cublasZgemvStridedBatched(handle::cublasHandle_t,
-                                               trans::cublasOperation_t, m::Cint, n::Cint,
-                                               alpha::RefOrCuRef{cuDoubleComplex},
-                                               A::CuPtr{cuDoubleComplex}, lda::Cint,
-                                               strideA::Clonglong,
-                                               x::CuPtr{cuDoubleComplex}, incx::Cint,
-                                               stridex::Clonglong,
-                                               beta::RefOrCuRef{cuDoubleComplex},
-                                               y::CuPtr{cuDoubleComplex}, incy::Cint,
-                                               stridey::Clonglong,
-                                               batchCount::Cint)::cublasStatus_t
+    @gcsafe_ccall libcublas.cublasZgemvStridedBatched(handle::cublasHandle_t,
+                                                      trans::cublasOperation_t, m::Cint,
+                                                      n::Cint,
+                                                      alpha::RefOrCuRef{cuDoubleComplex},
+                                                      A::CuPtr{cuDoubleComplex}, lda::Cint,
+                                                      strideA::Clonglong,
+                                                      x::CuPtr{cuDoubleComplex}, incx::Cint,
+                                                      stridex::Clonglong,
+                                                      beta::RefOrCuRef{cuDoubleComplex},
+                                                      y::CuPtr{cuDoubleComplex}, incy::Cint,
+                                                      stridey::Clonglong,
+                                                      batchCount::Cint)::cublasStatus_t
 end
 
 @checked function cublasZgemvStridedBatched_64(handle, trans, m, n, alpha, A, lda, strideA,
                                                x, incx, stridex, beta, y, incy, stridey,
                                                batchCount)
     initialize_context()
-    @ccall libcublas.cublasZgemvStridedBatched_64(handle::cublasHandle_t,
-                                                  trans::cublasOperation_t, m::Int64,
-                                                  n::Int64,
-                                                  alpha::RefOrCuRef{cuDoubleComplex},
-                                                  A::CuPtr{cuDoubleComplex}, lda::Int64,
-                                                  strideA::Clonglong,
-                                                  x::CuPtr{cuDoubleComplex}, incx::Int64,
-                                                  stridex::Clonglong,
-                                                  beta::RefOrCuRef{cuDoubleComplex},
-                                                  y::CuPtr{cuDoubleComplex}, incy::Int64,
-                                                  stridey::Clonglong,
-                                                  batchCount::Int64)::cublasStatus_t
+    @gcsafe_ccall libcublas.cublasZgemvStridedBatched_64(handle::cublasHandle_t,
+                                                         trans::cublasOperation_t, m::Int64,
+                                                         n::Int64,
+                                                         alpha::RefOrCuRef{cuDoubleComplex},
+                                                         A::CuPtr{cuDoubleComplex},
+                                                         lda::Int64, strideA::Clonglong,
+                                                         x::CuPtr{cuDoubleComplex},
+                                                         incx::Int64, stridex::Clonglong,
+                                                         beta::RefOrCuRef{cuDoubleComplex},
+                                                         y::CuPtr{cuDoubleComplex},
+                                                         incy::Int64, stridey::Clonglong,
+                                                         batchCount::Int64)::cublasStatus_t
 end
 
 @checked function cublasCgemm3m(handle, transa, transb, m, n, k, alpha, A, lda, B, ldb,
                                 beta, C, ldc)
     initialize_context()
-    @ccall libcublas.cublasCgemm3m(handle::cublasHandle_t, transa::cublasOperation_t,
-                                   transb::cublasOperation_t, m::Cint, n::Cint, k::Cint,
-                                   alpha::RefOrCuRef{cuComplex}, A::CuPtr{cuComplex},
-                                   lda::Cint, B::CuPtr{cuComplex}, ldb::Cint,
-                                   beta::RefOrCuRef{cuComplex}, C::CuPtr{cuComplex},
-                                   ldc::Cint)::cublasStatus_t
+    @gcsafe_ccall libcublas.cublasCgemm3m(handle::cublasHandle_t, transa::cublasOperation_t,
+                                          transb::cublasOperation_t, m::Cint, n::Cint,
+                                          k::Cint, alpha::RefOrCuRef{cuComplex},
+                                          A::CuPtr{cuComplex}, lda::Cint,
+                                          B::CuPtr{cuComplex}, ldb::Cint,
+                                          beta::RefOrCuRef{cuComplex}, C::CuPtr{cuComplex},
+                                          ldc::Cint)::cublasStatus_t
 end
 
 @checked function cublasCgemm3m_64(handle, transa, transb, m, n, k, alpha, A, lda, B, ldb,
                                    beta, C, ldc)
     initialize_context()
-    @ccall libcublas.cublasCgemm3m_64(handle::cublasHandle_t, transa::cublasOperation_t,
-                                      transb::cublasOperation_t, m::Int64, n::Int64,
-                                      k::Int64, alpha::RefOrCuRef{cuComplex},
-                                      A::CuPtr{cuComplex}, lda::Int64, B::CuPtr{cuComplex},
-                                      ldb::Int64, beta::RefOrCuRef{cuComplex},
-                                      C::CuPtr{cuComplex}, ldc::Int64)::cublasStatus_t
+    @gcsafe_ccall libcublas.cublasCgemm3m_64(handle::cublasHandle_t,
+                                             transa::cublasOperation_t,
+                                             transb::cublasOperation_t, m::Int64, n::Int64,
+                                             k::Int64, alpha::RefOrCuRef{cuComplex},
+                                             A::CuPtr{cuComplex}, lda::Int64,
+                                             B::CuPtr{cuComplex}, ldb::Int64,
+                                             beta::RefOrCuRef{cuComplex},
+                                             C::CuPtr{cuComplex},
+                                             ldc::Int64)::cublasStatus_t
 end
 
 @checked function cublasCgemm3mEx(handle, transa, transb, m, n, k, alpha, A, Atype, lda, B,
                                   Btype, ldb, beta, C, Ctype, ldc)
     initialize_context()
-    @ccall libcublas.cublasCgemm3mEx(handle::cublasHandle_t, transa::cublasOperation_t,
-                                     transb::cublasOperation_t, m::Cint, n::Cint, k::Cint,
-                                     alpha::RefOrCuRef{cuComplex}, A::CuPtr{Cvoid},
-                                     Atype::cudaDataType, lda::Cint, B::CuPtr{Cvoid},
-                                     Btype::cudaDataType, ldb::Cint,
-                                     beta::RefOrCuRef{cuComplex}, C::CuPtr{Cvoid},
-                                     Ctype::cudaDataType, ldc::Cint)::cublasStatus_t
+    @gcsafe_ccall libcublas.cublasCgemm3mEx(handle::cublasHandle_t,
+                                            transa::cublasOperation_t,
+                                            transb::cublasOperation_t, m::Cint, n::Cint,
+                                            k::Cint, alpha::RefOrCuRef{cuComplex},
+                                            A::CuPtr{Cvoid}, Atype::cudaDataType, lda::Cint,
+                                            B::CuPtr{Cvoid}, Btype::cudaDataType, ldb::Cint,
+                                            beta::RefOrCuRef{cuComplex}, C::CuPtr{Cvoid},
+                                            Ctype::cudaDataType, ldc::Cint)::cublasStatus_t
 end
 
 @checked function cublasCgemm3mEx_64(handle, transa, transb, m, n, k, alpha, A, Atype, lda,
                                      B, Btype, ldb, beta, C, Ctype, ldc)
     initialize_context()
-    @ccall libcublas.cublasCgemm3mEx_64(handle::cublasHandle_t, transa::cublasOperation_t,
-                                        transb::cublasOperation_t, m::Int64, n::Int64,
-                                        k::Int64, alpha::RefOrCuRef{cuComplex},
-                                        A::CuPtr{Cvoid}, Atype::cudaDataType, lda::Int64,
-                                        B::CuPtr{Cvoid}, Btype::cudaDataType, ldb::Int64,
-                                        beta::RefOrCuRef{cuComplex}, C::CuPtr{Cvoid},
-                                        Ctype::cudaDataType, ldc::Int64)::cublasStatus_t
+    @gcsafe_ccall libcublas.cublasCgemm3mEx_64(handle::cublasHandle_t,
+                                               transa::cublasOperation_t,
+                                               transb::cublasOperation_t, m::Int64,
+                                               n::Int64, k::Int64,
+                                               alpha::RefOrCuRef{cuComplex},
+                                               A::CuPtr{Cvoid}, Atype::cudaDataType,
+                                               lda::Int64, B::CuPtr{Cvoid},
+                                               Btype::cudaDataType, ldb::Int64,
+                                               beta::RefOrCuRef{cuComplex}, C::CuPtr{Cvoid},
+                                               Ctype::cudaDataType,
+                                               ldc::Int64)::cublasStatus_t
 end
 
 @checked function cublasZgemm3m(handle, transa, transb, m, n, k, alpha, A, lda, B, ldb,
                                 beta, C, ldc)
     initialize_context()
-    @ccall libcublas.cublasZgemm3m(handle::cublasHandle_t, transa::cublasOperation_t,
-                                   transb::cublasOperation_t, m::Cint, n::Cint, k::Cint,
-                                   alpha::RefOrCuRef{cuDoubleComplex},
-                                   A::CuPtr{cuDoubleComplex}, lda::Cint,
-                                   B::CuPtr{cuDoubleComplex}, ldb::Cint,
-                                   beta::RefOrCuRef{cuDoubleComplex},
-                                   C::CuPtr{cuDoubleComplex}, ldc::Cint)::cublasStatus_t
+    @gcsafe_ccall libcublas.cublasZgemm3m(handle::cublasHandle_t, transa::cublasOperation_t,
+                                          transb::cublasOperation_t, m::Cint, n::Cint,
+                                          k::Cint, alpha::RefOrCuRef{cuDoubleComplex},
+                                          A::CuPtr{cuDoubleComplex}, lda::Cint,
+                                          B::CuPtr{cuDoubleComplex}, ldb::Cint,
+                                          beta::RefOrCuRef{cuDoubleComplex},
+                                          C::CuPtr{cuDoubleComplex},
+                                          ldc::Cint)::cublasStatus_t
 end
 
 @checked function cublasZgemm3m_64(handle, transa, transb, m, n, k, alpha, A, lda, B, ldb,
                                    beta, C, ldc)
     initialize_context()
-    @ccall libcublas.cublasZgemm3m_64(handle::cublasHandle_t, transa::cublasOperation_t,
-                                      transb::cublasOperation_t, m::Int64, n::Int64,
-                                      k::Int64, alpha::RefOrCuRef{cuDoubleComplex},
-                                      A::CuPtr{cuDoubleComplex}, lda::Int64,
-                                      B::CuPtr{cuDoubleComplex}, ldb::Int64,
-                                      beta::RefOrCuRef{cuDoubleComplex},
-                                      C::CuPtr{cuDoubleComplex}, ldc::Int64)::cublasStatus_t
+    @gcsafe_ccall libcublas.cublasZgemm3m_64(handle::cublasHandle_t,
+                                             transa::cublasOperation_t,
+                                             transb::cublasOperation_t, m::Int64, n::Int64,
+                                             k::Int64, alpha::RefOrCuRef{cuDoubleComplex},
+                                             A::CuPtr{cuDoubleComplex}, lda::Int64,
+                                             B::CuPtr{cuDoubleComplex}, ldb::Int64,
+                                             beta::RefOrCuRef{cuDoubleComplex},
+                                             C::CuPtr{cuDoubleComplex},
+                                             ldc::Int64)::cublasStatus_t
 end
 
 @checked function cublasSgemmEx(handle, transa, transb, m, n, k, alpha, A, Atype, lda, B,
                                 Btype, ldb, beta, C, Ctype, ldc)
     initialize_context()
-    @ccall libcublas.cublasSgemmEx(handle::cublasHandle_t, transa::cublasOperation_t,
-                                   transb::cublasOperation_t, m::Cint, n::Cint, k::Cint,
-                                   alpha::RefOrCuRef{Cfloat}, A::CuPtr{Cvoid},
-                                   Atype::cudaDataType, lda::Cint, B::CuPtr{Cvoid},
-                                   Btype::cudaDataType, ldb::Cint, beta::RefOrCuRef{Cfloat},
-                                   C::CuPtr{Cvoid}, Ctype::cudaDataType,
-                                   ldc::Cint)::cublasStatus_t
+    @gcsafe_ccall libcublas.cublasSgemmEx(handle::cublasHandle_t, transa::cublasOperation_t,
+                                          transb::cublasOperation_t, m::Cint, n::Cint,
+                                          k::Cint, alpha::RefOrCuRef{Cfloat},
+                                          A::CuPtr{Cvoid}, Atype::cudaDataType, lda::Cint,
+                                          B::CuPtr{Cvoid}, Btype::cudaDataType, ldb::Cint,
+                                          beta::RefOrCuRef{Cfloat}, C::CuPtr{Cvoid},
+                                          Ctype::cudaDataType, ldc::Cint)::cublasStatus_t
 end
 
 @checked function cublasSgemmEx_64(handle, transa, transb, m, n, k, alpha, A, Atype, lda, B,
                                    Btype, ldb, beta, C, Ctype, ldc)
     initialize_context()
-    @ccall libcublas.cublasSgemmEx_64(handle::cublasHandle_t, transa::cublasOperation_t,
-                                      transb::cublasOperation_t, m::Int64, n::Int64,
-                                      k::Int64, alpha::RefOrCuRef{Cfloat}, A::CuPtr{Cvoid},
-                                      Atype::cudaDataType, lda::Int64, B::CuPtr{Cvoid},
-                                      Btype::cudaDataType, ldb::Int64,
-                                      beta::RefOrCuRef{Cfloat}, C::CuPtr{Cvoid},
-                                      Ctype::cudaDataType, ldc::Int64)::cublasStatus_t
+    @gcsafe_ccall libcublas.cublasSgemmEx_64(handle::cublasHandle_t,
+                                             transa::cublasOperation_t,
+                                             transb::cublasOperation_t, m::Int64, n::Int64,
+                                             k::Int64, alpha::RefOrCuRef{Cfloat},
+                                             A::CuPtr{Cvoid}, Atype::cudaDataType,
+                                             lda::Int64, B::CuPtr{Cvoid},
+                                             Btype::cudaDataType, ldb::Int64,
+                                             beta::RefOrCuRef{Cfloat}, C::CuPtr{Cvoid},
+                                             Ctype::cudaDataType,
+                                             ldc::Int64)::cublasStatus_t
 end
 
 @checked function cublasGemmEx(handle, transa, transb, m, n, k, alpha, A, Atype, lda, B,
                                Btype, ldb, beta, C, Ctype, ldc, computeType, algo)
     initialize_context()
-    @ccall libcublas.cublasGemmEx(handle::cublasHandle_t, transa::cublasOperation_t,
-                                  transb::cublasOperation_t, m::Cint, n::Cint, k::Cint,
-                                  alpha::PtrOrCuPtr{Cvoid}, A::CuPtr{Cvoid},
-                                  Atype::cudaDataType, lda::Cint, B::CuPtr{Cvoid},
-                                  Btype::cudaDataType, ldb::Cint, beta::PtrOrCuPtr{Cvoid},
-                                  C::CuPtr{Cvoid}, Ctype::cudaDataType, ldc::Cint,
-                                  computeType::cublasComputeType_t,
-                                  algo::cublasGemmAlgo_t)::cublasStatus_t
+    @gcsafe_ccall libcublas.cublasGemmEx(handle::cublasHandle_t, transa::cublasOperation_t,
+                                         transb::cublasOperation_t, m::Cint, n::Cint,
+                                         k::Cint, alpha::PtrOrCuPtr{Cvoid}, A::CuPtr{Cvoid},
+                                         Atype::cudaDataType, lda::Cint, B::CuPtr{Cvoid},
+                                         Btype::cudaDataType, ldb::Cint,
+                                         beta::PtrOrCuPtr{Cvoid}, C::CuPtr{Cvoid},
+                                         Ctype::cudaDataType, ldc::Cint,
+                                         computeType::cublasComputeType_t,
+                                         algo::cublasGemmAlgo_t)::cublasStatus_t
 end
 
 @checked function cublasGemmEx_64(handle, transa, transb, m, n, k, alpha, A, Atype, lda, B,
                                   Btype, ldb, beta, C, Ctype, ldc, computeType, algo)
     initialize_context()
-    @ccall libcublas.cublasGemmEx_64(handle::cublasHandle_t, transa::cublasOperation_t,
-                                     transb::cublasOperation_t, m::Int64, n::Int64,
-                                     k::Int64, alpha::PtrOrCuPtr{Cvoid}, A::CuPtr{Cvoid},
-                                     Atype::cudaDataType, lda::Int64, B::CuPtr{Cvoid},
-                                     Btype::cudaDataType, ldb::Int64,
-                                     beta::PtrOrCuPtr{Cvoid}, C::CuPtr{Cvoid},
-                                     Ctype::cudaDataType, ldc::Int64,
-                                     computeType::cublasComputeType_t,
-                                     algo::cublasGemmAlgo_t)::cublasStatus_t
+    @gcsafe_ccall libcublas.cublasGemmEx_64(handle::cublasHandle_t,
+                                            transa::cublasOperation_t,
+                                            transb::cublasOperation_t, m::Int64, n::Int64,
+                                            k::Int64, alpha::PtrOrCuPtr{Cvoid},
+                                            A::CuPtr{Cvoid}, Atype::cudaDataType,
+                                            lda::Int64, B::CuPtr{Cvoid},
+                                            Btype::cudaDataType, ldb::Int64,
+                                            beta::PtrOrCuPtr{Cvoid}, C::CuPtr{Cvoid},
+                                            Ctype::cudaDataType, ldc::Int64,
+                                            computeType::cublasComputeType_t,
+                                            algo::cublasGemmAlgo_t)::cublasStatus_t
 end
 
 @checked function cublasCgemmEx(handle, transa, transb, m, n, k, alpha, A, Atype, lda, B,
                                 Btype, ldb, beta, C, Ctype, ldc)
     initialize_context()
-    @ccall libcublas.cublasCgemmEx(handle::cublasHandle_t, transa::cublasOperation_t,
-                                   transb::cublasOperation_t, m::Cint, n::Cint, k::Cint,
-                                   alpha::RefOrCuRef{cuComplex}, A::CuPtr{Cvoid},
-                                   Atype::cudaDataType, lda::Cint, B::CuPtr{Cvoid},
-                                   Btype::cudaDataType, ldb::Cint,
-                                   beta::RefOrCuRef{cuComplex}, C::CuPtr{Cvoid},
-                                   Ctype::cudaDataType, ldc::Cint)::cublasStatus_t
+    @gcsafe_ccall libcublas.cublasCgemmEx(handle::cublasHandle_t, transa::cublasOperation_t,
+                                          transb::cublasOperation_t, m::Cint, n::Cint,
+                                          k::Cint, alpha::RefOrCuRef{cuComplex},
+                                          A::CuPtr{Cvoid}, Atype::cudaDataType, lda::Cint,
+                                          B::CuPtr{Cvoid}, Btype::cudaDataType, ldb::Cint,
+                                          beta::RefOrCuRef{cuComplex}, C::CuPtr{Cvoid},
+                                          Ctype::cudaDataType, ldc::Cint)::cublasStatus_t
 end
 
 @checked function cublasCgemmEx_64(handle, transa, transb, m, n, k, alpha, A, Atype, lda, B,
                                    Btype, ldb, beta, C, Ctype, ldc)
     initialize_context()
-    @ccall libcublas.cublasCgemmEx_64(handle::cublasHandle_t, transa::cublasOperation_t,
-                                      transb::cublasOperation_t, m::Int64, n::Int64,
-                                      k::Int64, alpha::RefOrCuRef{cuComplex},
-                                      A::CuPtr{Cvoid}, Atype::cudaDataType, lda::Int64,
-                                      B::CuPtr{Cvoid}, Btype::cudaDataType, ldb::Int64,
-                                      beta::RefOrCuRef{cuComplex}, C::CuPtr{Cvoid},
-                                      Ctype::cudaDataType, ldc::Int64)::cublasStatus_t
+    @gcsafe_ccall libcublas.cublasCgemmEx_64(handle::cublasHandle_t,
+                                             transa::cublasOperation_t,
+                                             transb::cublasOperation_t, m::Int64, n::Int64,
+                                             k::Int64, alpha::RefOrCuRef{cuComplex},
+                                             A::CuPtr{Cvoid}, Atype::cudaDataType,
+                                             lda::Int64, B::CuPtr{Cvoid},
+                                             Btype::cudaDataType, ldb::Int64,
+                                             beta::RefOrCuRef{cuComplex}, C::CuPtr{Cvoid},
+                                             Ctype::cudaDataType,
+                                             ldc::Int64)::cublasStatus_t
 end
 
 @checked function cublasCsyrkEx(handle, uplo, trans, n, k, alpha, A, Atype, lda, beta, C,
                                 Ctype, ldc)
     initialize_context()
-    @ccall libcublas.cublasCsyrkEx(handle::cublasHandle_t, uplo::cublasFillMode_t,
-                                   trans::cublasOperation_t, n::Cint, k::Cint,
-                                   alpha::RefOrCuRef{cuComplex}, A::CuPtr{Cvoid},
-                                   Atype::cudaDataType, lda::Cint,
-                                   beta::RefOrCuRef{cuComplex}, C::CuPtr{Cvoid},
-                                   Ctype::cudaDataType, ldc::Cint)::cublasStatus_t
+    @gcsafe_ccall libcublas.cublasCsyrkEx(handle::cublasHandle_t, uplo::cublasFillMode_t,
+                                          trans::cublasOperation_t, n::Cint, k::Cint,
+                                          alpha::RefOrCuRef{cuComplex}, A::CuPtr{Cvoid},
+                                          Atype::cudaDataType, lda::Cint,
+                                          beta::RefOrCuRef{cuComplex}, C::CuPtr{Cvoid},
+                                          Ctype::cudaDataType, ldc::Cint)::cublasStatus_t
 end
 
 @checked function cublasCsyrkEx_64(handle, uplo, trans, n, k, alpha, A, Atype, lda, beta, C,
                                    Ctype, ldc)
     initialize_context()
-    @ccall libcublas.cublasCsyrkEx_64(handle::cublasHandle_t, uplo::cublasFillMode_t,
-                                      trans::cublasOperation_t, n::Int64, k::Int64,
-                                      alpha::RefOrCuRef{cuComplex}, A::CuPtr{Cvoid},
-                                      Atype::cudaDataType, lda::Int64,
-                                      beta::RefOrCuRef{cuComplex}, C::CuPtr{Cvoid},
-                                      Ctype::cudaDataType, ldc::Int64)::cublasStatus_t
+    @gcsafe_ccall libcublas.cublasCsyrkEx_64(handle::cublasHandle_t, uplo::cublasFillMode_t,
+                                             trans::cublasOperation_t, n::Int64, k::Int64,
+                                             alpha::RefOrCuRef{cuComplex}, A::CuPtr{Cvoid},
+                                             Atype::cudaDataType, lda::Int64,
+                                             beta::RefOrCuRef{cuComplex}, C::CuPtr{Cvoid},
+                                             Ctype::cudaDataType,
+                                             ldc::Int64)::cublasStatus_t
 end
 
 @checked function cublasCsyrk3mEx(handle, uplo, trans, n, k, alpha, A, Atype, lda, beta, C,
                                   Ctype, ldc)
     initialize_context()
-    @ccall libcublas.cublasCsyrk3mEx(handle::cublasHandle_t, uplo::cublasFillMode_t,
-                                     trans::cublasOperation_t, n::Cint, k::Cint,
-                                     alpha::RefOrCuRef{cuComplex}, A::CuPtr{Cvoid},
-                                     Atype::cudaDataType, lda::Cint,
-                                     beta::RefOrCuRef{cuComplex}, C::CuPtr{Cvoid},
-                                     Ctype::cudaDataType, ldc::Cint)::cublasStatus_t
+    @gcsafe_ccall libcublas.cublasCsyrk3mEx(handle::cublasHandle_t, uplo::cublasFillMode_t,
+                                            trans::cublasOperation_t, n::Cint, k::Cint,
+                                            alpha::RefOrCuRef{cuComplex}, A::CuPtr{Cvoid},
+                                            Atype::cudaDataType, lda::Cint,
+                                            beta::RefOrCuRef{cuComplex}, C::CuPtr{Cvoid},
+                                            Ctype::cudaDataType, ldc::Cint)::cublasStatus_t
 end
 
 @checked function cublasCsyrk3mEx_64(handle, uplo, trans, n, k, alpha, A, Atype, lda, beta,
                                      C, Ctype, ldc)
     initialize_context()
-    @ccall libcublas.cublasCsyrk3mEx_64(handle::cublasHandle_t, uplo::cublasFillMode_t,
-                                        trans::cublasOperation_t, n::Int64, k::Int64,
-                                        alpha::RefOrCuRef{cuComplex}, A::CuPtr{Cvoid},
-                                        Atype::cudaDataType, lda::Int64,
-                                        beta::RefOrCuRef{cuComplex}, C::CuPtr{Cvoid},
-                                        Ctype::cudaDataType, ldc::Int64)::cublasStatus_t
+    @gcsafe_ccall libcublas.cublasCsyrk3mEx_64(handle::cublasHandle_t,
+                                               uplo::cublasFillMode_t,
+                                               trans::cublasOperation_t, n::Int64, k::Int64,
+                                               alpha::RefOrCuRef{cuComplex},
+                                               A::CuPtr{Cvoid}, Atype::cudaDataType,
+                                               lda::Int64, beta::RefOrCuRef{cuComplex},
+                                               C::CuPtr{Cvoid}, Ctype::cudaDataType,
+                                               ldc::Int64)::cublasStatus_t
 end
 
 @checked function cublasCherkEx(handle, uplo, trans, n, k, alpha, A, Atype, lda, beta, C,
                                 Ctype, ldc)
     initialize_context()
-    @ccall libcublas.cublasCherkEx(handle::cublasHandle_t, uplo::cublasFillMode_t,
-                                   trans::cublasOperation_t, n::Cint, k::Cint,
-                                   alpha::RefOrCuRef{Cfloat}, A::CuPtr{Cvoid},
-                                   Atype::cudaDataType, lda::Cint, beta::RefOrCuRef{Cfloat},
-                                   C::CuPtr{Cvoid}, Ctype::cudaDataType,
-                                   ldc::Cint)::cublasStatus_t
+    @gcsafe_ccall libcublas.cublasCherkEx(handle::cublasHandle_t, uplo::cublasFillMode_t,
+                                          trans::cublasOperation_t, n::Cint, k::Cint,
+                                          alpha::RefOrCuRef{Cfloat}, A::CuPtr{Cvoid},
+                                          Atype::cudaDataType, lda::Cint,
+                                          beta::RefOrCuRef{Cfloat}, C::CuPtr{Cvoid},
+                                          Ctype::cudaDataType, ldc::Cint)::cublasStatus_t
 end
 
 @checked function cublasCherkEx_64(handle, uplo, trans, n, k, alpha, A, Atype, lda, beta, C,
                                    Ctype, ldc)
     initialize_context()
-    @ccall libcublas.cublasCherkEx_64(handle::cublasHandle_t, uplo::cublasFillMode_t,
-                                      trans::cublasOperation_t, n::Int64, k::Int64,
-                                      alpha::RefOrCuRef{Cfloat}, A::CuPtr{Cvoid},
-                                      Atype::cudaDataType, lda::Int64,
-                                      beta::RefOrCuRef{Cfloat}, C::CuPtr{Cvoid},
-                                      Ctype::cudaDataType, ldc::Int64)::cublasStatus_t
+    @gcsafe_ccall libcublas.cublasCherkEx_64(handle::cublasHandle_t, uplo::cublasFillMode_t,
+                                             trans::cublasOperation_t, n::Int64, k::Int64,
+                                             alpha::RefOrCuRef{Cfloat}, A::CuPtr{Cvoid},
+                                             Atype::cudaDataType, lda::Int64,
+                                             beta::RefOrCuRef{Cfloat}, C::CuPtr{Cvoid},
+                                             Ctype::cudaDataType,
+                                             ldc::Int64)::cublasStatus_t
 end
 
 @checked function cublasCherk3mEx(handle, uplo, trans, n, k, alpha, A, Atype, lda, beta, C,
                                   Ctype, ldc)
     initialize_context()
-    @ccall libcublas.cublasCherk3mEx(handle::cublasHandle_t, uplo::cublasFillMode_t,
-                                     trans::cublasOperation_t, n::Cint, k::Cint,
-                                     alpha::RefOrCuRef{Cfloat}, A::CuPtr{Cvoid},
-                                     Atype::cudaDataType, lda::Cint,
-                                     beta::RefOrCuRef{Cfloat}, C::CuPtr{Cvoid},
-                                     Ctype::cudaDataType, ldc::Cint)::cublasStatus_t
+    @gcsafe_ccall libcublas.cublasCherk3mEx(handle::cublasHandle_t, uplo::cublasFillMode_t,
+                                            trans::cublasOperation_t, n::Cint, k::Cint,
+                                            alpha::RefOrCuRef{Cfloat}, A::CuPtr{Cvoid},
+                                            Atype::cudaDataType, lda::Cint,
+                                            beta::RefOrCuRef{Cfloat}, C::CuPtr{Cvoid},
+                                            Ctype::cudaDataType, ldc::Cint)::cublasStatus_t
 end
 
 @checked function cublasCherk3mEx_64(handle, uplo, trans, n, k, alpha, A, Atype, lda, beta,
                                      C, Ctype, ldc)
     initialize_context()
-    @ccall libcublas.cublasCherk3mEx_64(handle::cublasHandle_t, uplo::cublasFillMode_t,
-                                        trans::cublasOperation_t, n::Int64, k::Int64,
-                                        alpha::RefOrCuRef{Cfloat}, A::CuPtr{Cvoid},
-                                        Atype::cudaDataType, lda::Int64,
-                                        beta::RefOrCuRef{Cfloat}, C::CuPtr{Cvoid},
-                                        Ctype::cudaDataType, ldc::Int64)::cublasStatus_t
+    @gcsafe_ccall libcublas.cublasCherk3mEx_64(handle::cublasHandle_t,
+                                               uplo::cublasFillMode_t,
+                                               trans::cublasOperation_t, n::Int64, k::Int64,
+                                               alpha::RefOrCuRef{Cfloat}, A::CuPtr{Cvoid},
+                                               Atype::cudaDataType, lda::Int64,
+                                               beta::RefOrCuRef{Cfloat}, C::CuPtr{Cvoid},
+                                               Ctype::cudaDataType,
+                                               ldc::Int64)::cublasStatus_t
 end
 
 @checked function cublasSsyrkx(handle, uplo, trans, n, k, alpha, A, lda, B, ldb, beta, C,
                                ldc)
     initialize_context()
-    @ccall libcublas.cublasSsyrkx(handle::cublasHandle_t, uplo::cublasFillMode_t,
-                                  trans::cublasOperation_t, n::Cint, k::Cint,
-                                  alpha::RefOrCuRef{Cfloat}, A::CuPtr{Cfloat}, lda::Cint,
-                                  B::CuPtr{Cfloat}, ldb::Cint, beta::RefOrCuRef{Cfloat},
-                                  C::CuPtr{Cfloat}, ldc::Cint)::cublasStatus_t
+    @gcsafe_ccall libcublas.cublasSsyrkx(handle::cublasHandle_t, uplo::cublasFillMode_t,
+                                         trans::cublasOperation_t, n::Cint, k::Cint,
+                                         alpha::RefOrCuRef{Cfloat}, A::CuPtr{Cfloat},
+                                         lda::Cint, B::CuPtr{Cfloat}, ldb::Cint,
+                                         beta::RefOrCuRef{Cfloat}, C::CuPtr{Cfloat},
+                                         ldc::Cint)::cublasStatus_t
 end
 
 @checked function cublasSsyrkx_64(handle, uplo, trans, n, k, alpha, A, lda, B, ldb, beta, C,
                                   ldc)
     initialize_context()
-    @ccall libcublas.cublasSsyrkx_64(handle::cublasHandle_t, uplo::cublasFillMode_t,
-                                     trans::cublasOperation_t, n::Int64, k::Int64,
-                                     alpha::RefOrCuRef{Cfloat}, A::CuPtr{Cfloat},
-                                     lda::Int64, B::CuPtr{Cfloat}, ldb::Int64,
-                                     beta::RefOrCuRef{Cfloat}, C::CuPtr{Cfloat},
-                                     ldc::Int64)::cublasStatus_t
+    @gcsafe_ccall libcublas.cublasSsyrkx_64(handle::cublasHandle_t, uplo::cublasFillMode_t,
+                                            trans::cublasOperation_t, n::Int64, k::Int64,
+                                            alpha::RefOrCuRef{Cfloat}, A::CuPtr{Cfloat},
+                                            lda::Int64, B::CuPtr{Cfloat}, ldb::Int64,
+                                            beta::RefOrCuRef{Cfloat}, C::CuPtr{Cfloat},
+                                            ldc::Int64)::cublasStatus_t
 end
 
 @checked function cublasDsyrkx(handle, uplo, trans, n, k, alpha, A, lda, B, ldb, beta, C,
                                ldc)
     initialize_context()
-    @ccall libcublas.cublasDsyrkx(handle::cublasHandle_t, uplo::cublasFillMode_t,
-                                  trans::cublasOperation_t, n::Cint, k::Cint,
-                                  alpha::RefOrCuRef{Cdouble}, A::CuPtr{Cdouble}, lda::Cint,
-                                  B::CuPtr{Cdouble}, ldb::Cint, beta::RefOrCuRef{Cdouble},
-                                  C::CuPtr{Cdouble}, ldc::Cint)::cublasStatus_t
+    @gcsafe_ccall libcublas.cublasDsyrkx(handle::cublasHandle_t, uplo::cublasFillMode_t,
+                                         trans::cublasOperation_t, n::Cint, k::Cint,
+                                         alpha::RefOrCuRef{Cdouble}, A::CuPtr{Cdouble},
+                                         lda::Cint, B::CuPtr{Cdouble}, ldb::Cint,
+                                         beta::RefOrCuRef{Cdouble}, C::CuPtr{Cdouble},
+                                         ldc::Cint)::cublasStatus_t
 end
 
 @checked function cublasDsyrkx_64(handle, uplo, trans, n, k, alpha, A, lda, B, ldb, beta, C,
                                   ldc)
     initialize_context()
-    @ccall libcublas.cublasDsyrkx_64(handle::cublasHandle_t, uplo::cublasFillMode_t,
-                                     trans::cublasOperation_t, n::Int64, k::Int64,
-                                     alpha::RefOrCuRef{Cdouble}, A::CuPtr{Cdouble},
-                                     lda::Int64, B::CuPtr{Cdouble}, ldb::Int64,
-                                     beta::RefOrCuRef{Cdouble}, C::CuPtr{Cdouble},
-                                     ldc::Int64)::cublasStatus_t
+    @gcsafe_ccall libcublas.cublasDsyrkx_64(handle::cublasHandle_t, uplo::cublasFillMode_t,
+                                            trans::cublasOperation_t, n::Int64, k::Int64,
+                                            alpha::RefOrCuRef{Cdouble}, A::CuPtr{Cdouble},
+                                            lda::Int64, B::CuPtr{Cdouble}, ldb::Int64,
+                                            beta::RefOrCuRef{Cdouble}, C::CuPtr{Cdouble},
+                                            ldc::Int64)::cublasStatus_t
 end
 
 @checked function cublasCsyrkx(handle, uplo, trans, n, k, alpha, A, lda, B, ldb, beta, C,
                                ldc)
     initialize_context()
-    @ccall libcublas.cublasCsyrkx(handle::cublasHandle_t, uplo::cublasFillMode_t,
-                                  trans::cublasOperation_t, n::Cint, k::Cint,
-                                  alpha::RefOrCuRef{cuComplex}, A::CuPtr{cuComplex},
-                                  lda::Cint, B::CuPtr{cuComplex}, ldb::Cint,
-                                  beta::RefOrCuRef{cuComplex}, C::CuPtr{cuComplex},
-                                  ldc::Cint)::cublasStatus_t
+    @gcsafe_ccall libcublas.cublasCsyrkx(handle::cublasHandle_t, uplo::cublasFillMode_t,
+                                         trans::cublasOperation_t, n::Cint, k::Cint,
+                                         alpha::RefOrCuRef{cuComplex}, A::CuPtr{cuComplex},
+                                         lda::Cint, B::CuPtr{cuComplex}, ldb::Cint,
+                                         beta::RefOrCuRef{cuComplex}, C::CuPtr{cuComplex},
+                                         ldc::Cint)::cublasStatus_t
 end
 
 @checked function cublasCsyrkx_64(handle, uplo, trans, n, k, alpha, A, lda, B, ldb, beta, C,
                                   ldc)
     initialize_context()
-    @ccall libcublas.cublasCsyrkx_64(handle::cublasHandle_t, uplo::cublasFillMode_t,
-                                     trans::cublasOperation_t, n::Int64, k::Int64,
-                                     alpha::RefOrCuRef{cuComplex}, A::CuPtr{cuComplex},
-                                     lda::Int64, B::CuPtr{cuComplex}, ldb::Int64,
-                                     beta::RefOrCuRef{cuComplex}, C::CuPtr{cuComplex},
-                                     ldc::Int64)::cublasStatus_t
+    @gcsafe_ccall libcublas.cublasCsyrkx_64(handle::cublasHandle_t, uplo::cublasFillMode_t,
+                                            trans::cublasOperation_t, n::Int64, k::Int64,
+                                            alpha::RefOrCuRef{cuComplex},
+                                            A::CuPtr{cuComplex}, lda::Int64,
+                                            B::CuPtr{cuComplex}, ldb::Int64,
+                                            beta::RefOrCuRef{cuComplex},
+                                            C::CuPtr{cuComplex}, ldc::Int64)::cublasStatus_t
 end
 
 @checked function cublasZsyrkx(handle, uplo, trans, n, k, alpha, A, lda, B, ldb, beta, C,
                                ldc)
     initialize_context()
-    @ccall libcublas.cublasZsyrkx(handle::cublasHandle_t, uplo::cublasFillMode_t,
-                                  trans::cublasOperation_t, n::Cint, k::Cint,
-                                  alpha::RefOrCuRef{cuDoubleComplex},
-                                  A::CuPtr{cuDoubleComplex}, lda::Cint,
-                                  B::CuPtr{cuDoubleComplex}, ldb::Cint,
-                                  beta::RefOrCuRef{cuDoubleComplex},
-                                  C::CuPtr{cuDoubleComplex}, ldc::Cint)::cublasStatus_t
+    @gcsafe_ccall libcublas.cublasZsyrkx(handle::cublasHandle_t, uplo::cublasFillMode_t,
+                                         trans::cublasOperation_t, n::Cint, k::Cint,
+                                         alpha::RefOrCuRef{cuDoubleComplex},
+                                         A::CuPtr{cuDoubleComplex}, lda::Cint,
+                                         B::CuPtr{cuDoubleComplex}, ldb::Cint,
+                                         beta::RefOrCuRef{cuDoubleComplex},
+                                         C::CuPtr{cuDoubleComplex},
+                                         ldc::Cint)::cublasStatus_t
 end
 
 @checked function cublasZsyrkx_64(handle, uplo, trans, n, k, alpha, A, lda, B, ldb, beta, C,
                                   ldc)
     initialize_context()
-    @ccall libcublas.cublasZsyrkx_64(handle::cublasHandle_t, uplo::cublasFillMode_t,
-                                     trans::cublasOperation_t, n::Int64, k::Int64,
-                                     alpha::RefOrCuRef{cuDoubleComplex},
-                                     A::CuPtr{cuDoubleComplex}, lda::Int64,
-                                     B::CuPtr{cuDoubleComplex}, ldb::Int64,
-                                     beta::RefOrCuRef{cuDoubleComplex},
-                                     C::CuPtr{cuDoubleComplex}, ldc::Int64)::cublasStatus_t
+    @gcsafe_ccall libcublas.cublasZsyrkx_64(handle::cublasHandle_t, uplo::cublasFillMode_t,
+                                            trans::cublasOperation_t, n::Int64, k::Int64,
+                                            alpha::RefOrCuRef{cuDoubleComplex},
+                                            A::CuPtr{cuDoubleComplex}, lda::Int64,
+                                            B::CuPtr{cuDoubleComplex}, ldb::Int64,
+                                            beta::RefOrCuRef{cuDoubleComplex},
+                                            C::CuPtr{cuDoubleComplex},
+                                            ldc::Int64)::cublasStatus_t
 end
 
 @checked function cublasCherkx(handle, uplo, trans, n, k, alpha, A, lda, B, ldb, beta, C,
                                ldc)
     initialize_context()
-    @ccall libcublas.cublasCherkx(handle::cublasHandle_t, uplo::cublasFillMode_t,
-                                  trans::cublasOperation_t, n::Cint, k::Cint,
-                                  alpha::RefOrCuRef{cuComplex}, A::CuPtr{cuComplex},
-                                  lda::Cint, B::CuPtr{cuComplex}, ldb::Cint,
-                                  beta::RefOrCuRef{Cfloat}, C::CuPtr{cuComplex},
-                                  ldc::Cint)::cublasStatus_t
+    @gcsafe_ccall libcublas.cublasCherkx(handle::cublasHandle_t, uplo::cublasFillMode_t,
+                                         trans::cublasOperation_t, n::Cint, k::Cint,
+                                         alpha::RefOrCuRef{cuComplex}, A::CuPtr{cuComplex},
+                                         lda::Cint, B::CuPtr{cuComplex}, ldb::Cint,
+                                         beta::RefOrCuRef{Cfloat}, C::CuPtr{cuComplex},
+                                         ldc::Cint)::cublasStatus_t
 end
 
 @checked function cublasCherkx_64(handle, uplo, trans, n, k, alpha, A, lda, B, ldb, beta, C,
                                   ldc)
     initialize_context()
-    @ccall libcublas.cublasCherkx_64(handle::cublasHandle_t, uplo::cublasFillMode_t,
-                                     trans::cublasOperation_t, n::Int64, k::Int64,
-                                     alpha::RefOrCuRef{cuComplex}, A::CuPtr{cuComplex},
-                                     lda::Int64, B::CuPtr{cuComplex}, ldb::Int64,
-                                     beta::RefOrCuRef{Cfloat}, C::CuPtr{cuComplex},
-                                     ldc::Int64)::cublasStatus_t
+    @gcsafe_ccall libcublas.cublasCherkx_64(handle::cublasHandle_t, uplo::cublasFillMode_t,
+                                            trans::cublasOperation_t, n::Int64, k::Int64,
+                                            alpha::RefOrCuRef{cuComplex},
+                                            A::CuPtr{cuComplex}, lda::Int64,
+                                            B::CuPtr{cuComplex}, ldb::Int64,
+                                            beta::RefOrCuRef{Cfloat}, C::CuPtr{cuComplex},
+                                            ldc::Int64)::cublasStatus_t
 end
 
 @checked function cublasZherkx(handle, uplo, trans, n, k, alpha, A, lda, B, ldb, beta, C,
                                ldc)
     initialize_context()
-    @ccall libcublas.cublasZherkx(handle::cublasHandle_t, uplo::cublasFillMode_t,
-                                  trans::cublasOperation_t, n::Cint, k::Cint,
-                                  alpha::RefOrCuRef{cuDoubleComplex},
-                                  A::CuPtr{cuDoubleComplex}, lda::Cint,
-                                  B::CuPtr{cuDoubleComplex}, ldb::Cint,
-                                  beta::RefOrCuRef{Cdouble}, C::CuPtr{cuDoubleComplex},
-                                  ldc::Cint)::cublasStatus_t
+    @gcsafe_ccall libcublas.cublasZherkx(handle::cublasHandle_t, uplo::cublasFillMode_t,
+                                         trans::cublasOperation_t, n::Cint, k::Cint,
+                                         alpha::RefOrCuRef{cuDoubleComplex},
+                                         A::CuPtr{cuDoubleComplex}, lda::Cint,
+                                         B::CuPtr{cuDoubleComplex}, ldb::Cint,
+                                         beta::RefOrCuRef{Cdouble},
+                                         C::CuPtr{cuDoubleComplex},
+                                         ldc::Cint)::cublasStatus_t
 end
 
 @checked function cublasZherkx_64(handle, uplo, trans, n, k, alpha, A, lda, B, ldb, beta, C,
                                   ldc)
     initialize_context()
-    @ccall libcublas.cublasZherkx_64(handle::cublasHandle_t, uplo::cublasFillMode_t,
-                                     trans::cublasOperation_t, n::Int64, k::Int64,
-                                     alpha::RefOrCuRef{cuDoubleComplex},
-                                     A::CuPtr{cuDoubleComplex}, lda::Int64,
-                                     B::CuPtr{cuDoubleComplex}, ldb::Int64,
-                                     beta::RefOrCuRef{Cdouble}, C::CuPtr{cuDoubleComplex},
-                                     ldc::Int64)::cublasStatus_t
+    @gcsafe_ccall libcublas.cublasZherkx_64(handle::cublasHandle_t, uplo::cublasFillMode_t,
+                                            trans::cublasOperation_t, n::Int64, k::Int64,
+                                            alpha::RefOrCuRef{cuDoubleComplex},
+                                            A::CuPtr{cuDoubleComplex}, lda::Int64,
+                                            B::CuPtr{cuDoubleComplex}, ldb::Int64,
+                                            beta::RefOrCuRef{Cdouble},
+                                            C::CuPtr{cuDoubleComplex},
+                                            ldc::Int64)::cublasStatus_t
 end
 
 @checked function cublasSgemmBatched(handle, transa, transb, m, n, k, alpha, Aarray, lda,
                                      Barray, ldb, beta, Carray, ldc, batchCount)
     initialize_context()
-    @ccall libcublas.cublasSgemmBatched(handle::cublasHandle_t, transa::cublasOperation_t,
-                                        transb::cublasOperation_t, m::Cint, n::Cint,
-                                        k::Cint, alpha::RefOrCuRef{Cfloat},
-                                        Aarray::CuPtr{Ptr{Cfloat}}, lda::Cint,
-                                        Barray::CuPtr{Ptr{Cfloat}}, ldb::Cint,
-                                        beta::RefOrCuRef{Cfloat},
-                                        Carray::CuPtr{Ptr{Cfloat}}, ldc::Cint,
-                                        batchCount::Cint)::cublasStatus_t
+    @gcsafe_ccall libcublas.cublasSgemmBatched(handle::cublasHandle_t,
+                                               transa::cublasOperation_t,
+                                               transb::cublasOperation_t, m::Cint, n::Cint,
+                                               k::Cint, alpha::RefOrCuRef{Cfloat},
+                                               Aarray::CuPtr{Ptr{Cfloat}}, lda::Cint,
+                                               Barray::CuPtr{Ptr{Cfloat}}, ldb::Cint,
+                                               beta::RefOrCuRef{Cfloat},
+                                               Carray::CuPtr{Ptr{Cfloat}}, ldc::Cint,
+                                               batchCount::Cint)::cublasStatus_t
 end
 
 @checked function cublasSgemmBatched_64(handle, transa, transb, m, n, k, alpha, Aarray, lda,
                                         Barray, ldb, beta, Carray, ldc, batchCount)
     initialize_context()
-    @ccall libcublas.cublasSgemmBatched_64(handle::cublasHandle_t,
-                                           transa::cublasOperation_t,
-                                           transb::cublasOperation_t, m::Int64, n::Int64,
-                                           k::Int64, alpha::RefOrCuRef{Cfloat},
-                                           Aarray::CuPtr{Ptr{Cfloat}}, lda::Int64,
-                                           Barray::CuPtr{Ptr{Cfloat}}, ldb::Int64,
-                                           beta::RefOrCuRef{Cfloat},
-                                           Carray::CuPtr{Ptr{Cfloat}}, ldc::Int64,
-                                           batchCount::Int64)::cublasStatus_t
+    @gcsafe_ccall libcublas.cublasSgemmBatched_64(handle::cublasHandle_t,
+                                                  transa::cublasOperation_t,
+                                                  transb::cublasOperation_t, m::Int64,
+                                                  n::Int64, k::Int64,
+                                                  alpha::RefOrCuRef{Cfloat},
+                                                  Aarray::CuPtr{Ptr{Cfloat}}, lda::Int64,
+                                                  Barray::CuPtr{Ptr{Cfloat}}, ldb::Int64,
+                                                  beta::RefOrCuRef{Cfloat},
+                                                  Carray::CuPtr{Ptr{Cfloat}}, ldc::Int64,
+                                                  batchCount::Int64)::cublasStatus_t
 end
 
 @checked function cublasDgemmBatched(handle, transa, transb, m, n, k, alpha, Aarray, lda,
                                      Barray, ldb, beta, Carray, ldc, batchCount)
     initialize_context()
-    @ccall libcublas.cublasDgemmBatched(handle::cublasHandle_t, transa::cublasOperation_t,
-                                        transb::cublasOperation_t, m::Cint, n::Cint,
-                                        k::Cint, alpha::RefOrCuRef{Cdouble},
-                                        Aarray::CuPtr{Ptr{Cdouble}}, lda::Cint,
-                                        Barray::CuPtr{Ptr{Cdouble}}, ldb::Cint,
-                                        beta::RefOrCuRef{Cdouble},
-                                        Carray::CuPtr{Ptr{Cdouble}}, ldc::Cint,
-                                        batchCount::Cint)::cublasStatus_t
+    @gcsafe_ccall libcublas.cublasDgemmBatched(handle::cublasHandle_t,
+                                               transa::cublasOperation_t,
+                                               transb::cublasOperation_t, m::Cint, n::Cint,
+                                               k::Cint, alpha::RefOrCuRef{Cdouble},
+                                               Aarray::CuPtr{Ptr{Cdouble}}, lda::Cint,
+                                               Barray::CuPtr{Ptr{Cdouble}}, ldb::Cint,
+                                               beta::RefOrCuRef{Cdouble},
+                                               Carray::CuPtr{Ptr{Cdouble}}, ldc::Cint,
+                                               batchCount::Cint)::cublasStatus_t
 end
 
 @checked function cublasDgemmBatched_64(handle, transa, transb, m, n, k, alpha, Aarray, lda,
                                         Barray, ldb, beta, Carray, ldc, batchCount)
     initialize_context()
-    @ccall libcublas.cublasDgemmBatched_64(handle::cublasHandle_t,
-                                           transa::cublasOperation_t,
-                                           transb::cublasOperation_t, m::Int64, n::Int64,
-                                           k::Int64, alpha::RefOrCuRef{Cdouble},
-                                           Aarray::CuPtr{Ptr{Cdouble}}, lda::Int64,
-                                           Barray::CuPtr{Ptr{Cdouble}}, ldb::Int64,
-                                           beta::RefOrCuRef{Cdouble},
-                                           Carray::CuPtr{Ptr{Cdouble}}, ldc::Int64,
-                                           batchCount::Int64)::cublasStatus_t
+    @gcsafe_ccall libcublas.cublasDgemmBatched_64(handle::cublasHandle_t,
+                                                  transa::cublasOperation_t,
+                                                  transb::cublasOperation_t, m::Int64,
+                                                  n::Int64, k::Int64,
+                                                  alpha::RefOrCuRef{Cdouble},
+                                                  Aarray::CuPtr{Ptr{Cdouble}}, lda::Int64,
+                                                  Barray::CuPtr{Ptr{Cdouble}}, ldb::Int64,
+                                                  beta::RefOrCuRef{Cdouble},
+                                                  Carray::CuPtr{Ptr{Cdouble}}, ldc::Int64,
+                                                  batchCount::Int64)::cublasStatus_t
 end
 
 @checked function cublasCgemmBatched(handle, transa, transb, m, n, k, alpha, Aarray, lda,
                                      Barray, ldb, beta, Carray, ldc, batchCount)
     initialize_context()
-    @ccall libcublas.cublasCgemmBatched(handle::cublasHandle_t, transa::cublasOperation_t,
-                                        transb::cublasOperation_t, m::Cint, n::Cint,
-                                        k::Cint, alpha::RefOrCuRef{cuComplex},
-                                        Aarray::CuPtr{Ptr{cuComplex}}, lda::Cint,
-                                        Barray::CuPtr{Ptr{cuComplex}}, ldb::Cint,
-                                        beta::RefOrCuRef{cuComplex},
-                                        Carray::CuPtr{Ptr{cuComplex}}, ldc::Cint,
-                                        batchCount::Cint)::cublasStatus_t
+    @gcsafe_ccall libcublas.cublasCgemmBatched(handle::cublasHandle_t,
+                                               transa::cublasOperation_t,
+                                               transb::cublasOperation_t, m::Cint, n::Cint,
+                                               k::Cint, alpha::RefOrCuRef{cuComplex},
+                                               Aarray::CuPtr{Ptr{cuComplex}}, lda::Cint,
+                                               Barray::CuPtr{Ptr{cuComplex}}, ldb::Cint,
+                                               beta::RefOrCuRef{cuComplex},
+                                               Carray::CuPtr{Ptr{cuComplex}}, ldc::Cint,
+                                               batchCount::Cint)::cublasStatus_t
 end
 
 @checked function cublasCgemmBatched_64(handle, transa, transb, m, n, k, alpha, Aarray, lda,
                                         Barray, ldb, beta, Carray, ldc, batchCount)
     initialize_context()
-    @ccall libcublas.cublasCgemmBatched_64(handle::cublasHandle_t,
-                                           transa::cublasOperation_t,
-                                           transb::cublasOperation_t, m::Int64, n::Int64,
-                                           k::Int64, alpha::RefOrCuRef{cuComplex},
-                                           Aarray::CuPtr{Ptr{cuComplex}}, lda::Int64,
-                                           Barray::CuPtr{Ptr{cuComplex}}, ldb::Int64,
-                                           beta::RefOrCuRef{cuComplex},
-                                           Carray::CuPtr{Ptr{cuComplex}}, ldc::Int64,
-                                           batchCount::Int64)::cublasStatus_t
+    @gcsafe_ccall libcublas.cublasCgemmBatched_64(handle::cublasHandle_t,
+                                                  transa::cublasOperation_t,
+                                                  transb::cublasOperation_t, m::Int64,
+                                                  n::Int64, k::Int64,
+                                                  alpha::RefOrCuRef{cuComplex},
+                                                  Aarray::CuPtr{Ptr{cuComplex}}, lda::Int64,
+                                                  Barray::CuPtr{Ptr{cuComplex}}, ldb::Int64,
+                                                  beta::RefOrCuRef{cuComplex},
+                                                  Carray::CuPtr{Ptr{cuComplex}}, ldc::Int64,
+                                                  batchCount::Int64)::cublasStatus_t
 end
 
 @checked function cublasCgemm3mBatched(handle, transa, transb, m, n, k, alpha, Aarray, lda,
                                        Barray, ldb, beta, Carray, ldc, batchCount)
     initialize_context()
-    @ccall libcublas.cublasCgemm3mBatched(handle::cublasHandle_t, transa::cublasOperation_t,
-                                          transb::cublasOperation_t, m::Cint, n::Cint,
-                                          k::Cint, alpha::RefOrCuRef{cuComplex},
-                                          Aarray::CuPtr{Ptr{cuComplex}}, lda::Cint,
-                                          Barray::CuPtr{Ptr{cuComplex}}, ldb::Cint,
-                                          beta::RefOrCuRef{cuComplex},
-                                          Carray::CuPtr{Ptr{cuComplex}}, ldc::Cint,
-                                          batchCount::Cint)::cublasStatus_t
+    @gcsafe_ccall libcublas.cublasCgemm3mBatched(handle::cublasHandle_t,
+                                                 transa::cublasOperation_t,
+                                                 transb::cublasOperation_t, m::Cint,
+                                                 n::Cint, k::Cint,
+                                                 alpha::RefOrCuRef{cuComplex},
+                                                 Aarray::CuPtr{Ptr{cuComplex}}, lda::Cint,
+                                                 Barray::CuPtr{Ptr{cuComplex}}, ldb::Cint,
+                                                 beta::RefOrCuRef{cuComplex},
+                                                 Carray::CuPtr{Ptr{cuComplex}}, ldc::Cint,
+                                                 batchCount::Cint)::cublasStatus_t
 end
 
 @checked function cublasCgemm3mBatched_64(handle, transa, transb, m, n, k, alpha, Aarray,
                                           lda, Barray, ldb, beta, Carray, ldc, batchCount)
     initialize_context()
-    @ccall libcublas.cublasCgemm3mBatched_64(handle::cublasHandle_t,
-                                             transa::cublasOperation_t,
-                                             transb::cublasOperation_t, m::Int64, n::Int64,
-                                             k::Int64, alpha::RefOrCuRef{cuComplex},
-                                             Aarray::CuPtr{Ptr{cuComplex}}, lda::Int64,
-                                             Barray::CuPtr{Ptr{cuComplex}}, ldb::Int64,
-                                             beta::RefOrCuRef{cuComplex},
-                                             Carray::CuPtr{Ptr{cuComplex}}, ldc::Int64,
-                                             batchCount::Int64)::cublasStatus_t
+    @gcsafe_ccall libcublas.cublasCgemm3mBatched_64(handle::cublasHandle_t,
+                                                    transa::cublasOperation_t,
+                                                    transb::cublasOperation_t, m::Int64,
+                                                    n::Int64, k::Int64,
+                                                    alpha::RefOrCuRef{cuComplex},
+                                                    Aarray::CuPtr{Ptr{cuComplex}},
+                                                    lda::Int64,
+                                                    Barray::CuPtr{Ptr{cuComplex}},
+                                                    ldb::Int64, beta::RefOrCuRef{cuComplex},
+                                                    Carray::CuPtr{Ptr{cuComplex}},
+                                                    ldc::Int64,
+                                                    batchCount::Int64)::cublasStatus_t
 end
 
 @checked function cublasZgemmBatched(handle, transa, transb, m, n, k, alpha, Aarray, lda,
                                      Barray, ldb, beta, Carray, ldc, batchCount)
     initialize_context()
-    @ccall libcublas.cublasZgemmBatched(handle::cublasHandle_t, transa::cublasOperation_t,
-                                        transb::cublasOperation_t, m::Cint, n::Cint,
-                                        k::Cint, alpha::RefOrCuRef{cuDoubleComplex},
-                                        Aarray::CuPtr{Ptr{cuDoubleComplex}}, lda::Cint,
-                                        Barray::CuPtr{Ptr{cuDoubleComplex}}, ldb::Cint,
-                                        beta::RefOrCuRef{cuDoubleComplex},
-                                        Carray::CuPtr{Ptr{cuDoubleComplex}}, ldc::Cint,
-                                        batchCount::Cint)::cublasStatus_t
+    @gcsafe_ccall libcublas.cublasZgemmBatched(handle::cublasHandle_t,
+                                               transa::cublasOperation_t,
+                                               transb::cublasOperation_t, m::Cint, n::Cint,
+                                               k::Cint, alpha::RefOrCuRef{cuDoubleComplex},
+                                               Aarray::CuPtr{Ptr{cuDoubleComplex}},
+                                               lda::Cint,
+                                               Barray::CuPtr{Ptr{cuDoubleComplex}},
+                                               ldb::Cint, beta::RefOrCuRef{cuDoubleComplex},
+                                               Carray::CuPtr{Ptr{cuDoubleComplex}},
+                                               ldc::Cint, batchCount::Cint)::cublasStatus_t
 end
 
 @checked function cublasZgemmBatched_64(handle, transa, transb, m, n, k, alpha, Aarray, lda,
                                         Barray, ldb, beta, Carray, ldc, batchCount)
     initialize_context()
-    @ccall libcublas.cublasZgemmBatched_64(handle::cublasHandle_t,
-                                           transa::cublasOperation_t,
-                                           transb::cublasOperation_t, m::Int64, n::Int64,
-                                           k::Int64, alpha::RefOrCuRef{cuDoubleComplex},
-                                           Aarray::CuPtr{Ptr{cuDoubleComplex}}, lda::Int64,
-                                           Barray::CuPtr{Ptr{cuDoubleComplex}}, ldb::Int64,
-                                           beta::RefOrCuRef{cuDoubleComplex},
-                                           Carray::CuPtr{Ptr{cuDoubleComplex}}, ldc::Int64,
-                                           batchCount::Int64)::cublasStatus_t
+    @gcsafe_ccall libcublas.cublasZgemmBatched_64(handle::cublasHandle_t,
+                                                  transa::cublasOperation_t,
+                                                  transb::cublasOperation_t, m::Int64,
+                                                  n::Int64, k::Int64,
+                                                  alpha::RefOrCuRef{cuDoubleComplex},
+                                                  Aarray::CuPtr{Ptr{cuDoubleComplex}},
+                                                  lda::Int64,
+                                                  Barray::CuPtr{Ptr{cuDoubleComplex}},
+                                                  ldb::Int64,
+                                                  beta::RefOrCuRef{cuDoubleComplex},
+                                                  Carray::CuPtr{Ptr{cuDoubleComplex}},
+                                                  ldc::Int64,
+                                                  batchCount::Int64)::cublasStatus_t
 end
 
 @checked function cublasSgemmStridedBatched(handle, transa, transb, m, n, k, alpha, A, lda,
                                             strideA, B, ldb, strideB, beta, C, ldc, strideC,
                                             batchCount)
     initialize_context()
-    @ccall libcublas.cublasSgemmStridedBatched(handle::cublasHandle_t,
-                                               transa::cublasOperation_t,
-                                               transb::cublasOperation_t, m::Cint, n::Cint,
-                                               k::Cint, alpha::RefOrCuRef{Cfloat},
-                                               A::CuPtr{Cfloat}, lda::Cint,
-                                               strideA::Clonglong, B::CuPtr{Cfloat},
-                                               ldb::Cint, strideB::Clonglong,
-                                               beta::RefOrCuRef{Cfloat}, C::CuPtr{Cfloat},
-                                               ldc::Cint, strideC::Clonglong,
-                                               batchCount::Cint)::cublasStatus_t
+    @gcsafe_ccall libcublas.cublasSgemmStridedBatched(handle::cublasHandle_t,
+                                                      transa::cublasOperation_t,
+                                                      transb::cublasOperation_t, m::Cint,
+                                                      n::Cint, k::Cint,
+                                                      alpha::RefOrCuRef{Cfloat},
+                                                      A::CuPtr{Cfloat}, lda::Cint,
+                                                      strideA::Clonglong, B::CuPtr{Cfloat},
+                                                      ldb::Cint, strideB::Clonglong,
+                                                      beta::RefOrCuRef{Cfloat},
+                                                      C::CuPtr{Cfloat}, ldc::Cint,
+                                                      strideC::Clonglong,
+                                                      batchCount::Cint)::cublasStatus_t
 end
 
 @checked function cublasSgemmStridedBatched_64(handle, transa, transb, m, n, k, alpha, A,
                                                lda, strideA, B, ldb, strideB, beta, C, ldc,
                                                strideC, batchCount)
     initialize_context()
-    @ccall libcublas.cublasSgemmStridedBatched_64(handle::cublasHandle_t,
-                                                  transa::cublasOperation_t,
-                                                  transb::cublasOperation_t, m::Int64,
-                                                  n::Int64, k::Int64,
-                                                  alpha::RefOrCuRef{Cfloat},
-                                                  A::CuPtr{Cfloat}, lda::Int64,
-                                                  strideA::Clonglong, B::CuPtr{Cfloat},
-                                                  ldb::Int64, strideB::Clonglong,
-                                                  beta::RefOrCuRef{Cfloat},
-                                                  C::CuPtr{Cfloat}, ldc::Int64,
-                                                  strideC::Clonglong,
-                                                  batchCount::Int64)::cublasStatus_t
+    @gcsafe_ccall libcublas.cublasSgemmStridedBatched_64(handle::cublasHandle_t,
+                                                         transa::cublasOperation_t,
+                                                         transb::cublasOperation_t,
+                                                         m::Int64, n::Int64, k::Int64,
+                                                         alpha::RefOrCuRef{Cfloat},
+                                                         A::CuPtr{Cfloat}, lda::Int64,
+                                                         strideA::Clonglong,
+                                                         B::CuPtr{Cfloat}, ldb::Int64,
+                                                         strideB::Clonglong,
+                                                         beta::RefOrCuRef{Cfloat},
+                                                         C::CuPtr{Cfloat}, ldc::Int64,
+                                                         strideC::Clonglong,
+                                                         batchCount::Int64)::cublasStatus_t
 end
 
 @checked function cublasDgemmStridedBatched(handle, transa, transb, m, n, k, alpha, A, lda,
                                             strideA, B, ldb, strideB, beta, C, ldc, strideC,
                                             batchCount)
     initialize_context()
-    @ccall libcublas.cublasDgemmStridedBatched(handle::cublasHandle_t,
-                                               transa::cublasOperation_t,
-                                               transb::cublasOperation_t, m::Cint, n::Cint,
-                                               k::Cint, alpha::RefOrCuRef{Cdouble},
-                                               A::CuPtr{Cdouble}, lda::Cint,
-                                               strideA::Clonglong, B::CuPtr{Cdouble},
-                                               ldb::Cint, strideB::Clonglong,
-                                               beta::RefOrCuRef{Cdouble}, C::CuPtr{Cdouble},
-                                               ldc::Cint, strideC::Clonglong,
-                                               batchCount::Cint)::cublasStatus_t
+    @gcsafe_ccall libcublas.cublasDgemmStridedBatched(handle::cublasHandle_t,
+                                                      transa::cublasOperation_t,
+                                                      transb::cublasOperation_t, m::Cint,
+                                                      n::Cint, k::Cint,
+                                                      alpha::RefOrCuRef{Cdouble},
+                                                      A::CuPtr{Cdouble}, lda::Cint,
+                                                      strideA::Clonglong, B::CuPtr{Cdouble},
+                                                      ldb::Cint, strideB::Clonglong,
+                                                      beta::RefOrCuRef{Cdouble},
+                                                      C::CuPtr{Cdouble}, ldc::Cint,
+                                                      strideC::Clonglong,
+                                                      batchCount::Cint)::cublasStatus_t
 end
 
 @checked function cublasDgemmStridedBatched_64(handle, transa, transb, m, n, k, alpha, A,
                                                lda, strideA, B, ldb, strideB, beta, C, ldc,
                                                strideC, batchCount)
     initialize_context()
-    @ccall libcublas.cublasDgemmStridedBatched_64(handle::cublasHandle_t,
-                                                  transa::cublasOperation_t,
-                                                  transb::cublasOperation_t, m::Int64,
-                                                  n::Int64, k::Int64,
-                                                  alpha::RefOrCuRef{Cdouble},
-                                                  A::CuPtr{Cdouble}, lda::Int64,
-                                                  strideA::Clonglong, B::CuPtr{Cdouble},
-                                                  ldb::Int64, strideB::Clonglong,
-                                                  beta::RefOrCuRef{Cdouble},
-                                                  C::CuPtr{Cdouble}, ldc::Int64,
-                                                  strideC::Clonglong,
-                                                  batchCount::Int64)::cublasStatus_t
+    @gcsafe_ccall libcublas.cublasDgemmStridedBatched_64(handle::cublasHandle_t,
+                                                         transa::cublasOperation_t,
+                                                         transb::cublasOperation_t,
+                                                         m::Int64, n::Int64, k::Int64,
+                                                         alpha::RefOrCuRef{Cdouble},
+                                                         A::CuPtr{Cdouble}, lda::Int64,
+                                                         strideA::Clonglong,
+                                                         B::CuPtr{Cdouble}, ldb::Int64,
+                                                         strideB::Clonglong,
+                                                         beta::RefOrCuRef{Cdouble},
+                                                         C::CuPtr{Cdouble}, ldc::Int64,
+                                                         strideC::Clonglong,
+                                                         batchCount::Int64)::cublasStatus_t
 end
 
 @checked function cublasCgemmStridedBatched(handle, transa, transb, m, n, k, alpha, A, lda,
                                             strideA, B, ldb, strideB, beta, C, ldc, strideC,
                                             batchCount)
     initialize_context()
-    @ccall libcublas.cublasCgemmStridedBatched(handle::cublasHandle_t,
-                                               transa::cublasOperation_t,
-                                               transb::cublasOperation_t, m::Cint, n::Cint,
-                                               k::Cint, alpha::RefOrCuRef{cuComplex},
-                                               A::CuPtr{cuComplex}, lda::Cint,
-                                               strideA::Clonglong, B::CuPtr{cuComplex},
-                                               ldb::Cint, strideB::Clonglong,
-                                               beta::RefOrCuRef{cuComplex},
-                                               C::CuPtr{cuComplex}, ldc::Cint,
-                                               strideC::Clonglong,
-                                               batchCount::Cint)::cublasStatus_t
+    @gcsafe_ccall libcublas.cublasCgemmStridedBatched(handle::cublasHandle_t,
+                                                      transa::cublasOperation_t,
+                                                      transb::cublasOperation_t, m::Cint,
+                                                      n::Cint, k::Cint,
+                                                      alpha::RefOrCuRef{cuComplex},
+                                                      A::CuPtr{cuComplex}, lda::Cint,
+                                                      strideA::Clonglong,
+                                                      B::CuPtr{cuComplex}, ldb::Cint,
+                                                      strideB::Clonglong,
+                                                      beta::RefOrCuRef{cuComplex},
+                                                      C::CuPtr{cuComplex}, ldc::Cint,
+                                                      strideC::Clonglong,
+                                                      batchCount::Cint)::cublasStatus_t
 end
 
 @checked function cublasCgemmStridedBatched_64(handle, transa, transb, m, n, k, alpha, A,
                                                lda, strideA, B, ldb, strideB, beta, C, ldc,
                                                strideC, batchCount)
     initialize_context()
-    @ccall libcublas.cublasCgemmStridedBatched_64(handle::cublasHandle_t,
-                                                  transa::cublasOperation_t,
-                                                  transb::cublasOperation_t, m::Int64,
-                                                  n::Int64, k::Int64,
-                                                  alpha::RefOrCuRef{cuComplex},
-                                                  A::CuPtr{cuComplex}, lda::Int64,
-                                                  strideA::Clonglong, B::CuPtr{cuComplex},
-                                                  ldb::Int64, strideB::Clonglong,
-                                                  beta::RefOrCuRef{cuComplex},
-                                                  C::CuPtr{cuComplex}, ldc::Int64,
-                                                  strideC::Clonglong,
-                                                  batchCount::Int64)::cublasStatus_t
+    @gcsafe_ccall libcublas.cublasCgemmStridedBatched_64(handle::cublasHandle_t,
+                                                         transa::cublasOperation_t,
+                                                         transb::cublasOperation_t,
+                                                         m::Int64, n::Int64, k::Int64,
+                                                         alpha::RefOrCuRef{cuComplex},
+                                                         A::CuPtr{cuComplex}, lda::Int64,
+                                                         strideA::Clonglong,
+                                                         B::CuPtr{cuComplex}, ldb::Int64,
+                                                         strideB::Clonglong,
+                                                         beta::RefOrCuRef{cuComplex},
+                                                         C::CuPtr{cuComplex}, ldc::Int64,
+                                                         strideC::Clonglong,
+                                                         batchCount::Int64)::cublasStatus_t
 end
 
 @checked function cublasCgemm3mStridedBatched(handle, transa, transb, m, n, k, alpha, A,
                                               lda, strideA, B, ldb, strideB, beta, C, ldc,
                                               strideC, batchCount)
     initialize_context()
-    @ccall libcublas.cublasCgemm3mStridedBatched(handle::cublasHandle_t,
-                                                 transa::cublasOperation_t,
-                                                 transb::cublasOperation_t, m::Cint,
-                                                 n::Cint, k::Cint,
-                                                 alpha::RefOrCuRef{cuComplex},
-                                                 A::CuPtr{cuComplex}, lda::Cint,
-                                                 strideA::Clonglong, B::CuPtr{cuComplex},
-                                                 ldb::Cint, strideB::Clonglong,
-                                                 beta::RefOrCuRef{cuComplex},
-                                                 C::CuPtr{cuComplex}, ldc::Cint,
-                                                 strideC::Clonglong,
-                                                 batchCount::Cint)::cublasStatus_t
+    @gcsafe_ccall libcublas.cublasCgemm3mStridedBatched(handle::cublasHandle_t,
+                                                        transa::cublasOperation_t,
+                                                        transb::cublasOperation_t, m::Cint,
+                                                        n::Cint, k::Cint,
+                                                        alpha::RefOrCuRef{cuComplex},
+                                                        A::CuPtr{cuComplex}, lda::Cint,
+                                                        strideA::Clonglong,
+                                                        B::CuPtr{cuComplex}, ldb::Cint,
+                                                        strideB::Clonglong,
+                                                        beta::RefOrCuRef{cuComplex},
+                                                        C::CuPtr{cuComplex}, ldc::Cint,
+                                                        strideC::Clonglong,
+                                                        batchCount::Cint)::cublasStatus_t
 end
 
 @checked function cublasCgemm3mStridedBatched_64(handle, transa, transb, m, n, k, alpha, A,
                                                  lda, strideA, B, ldb, strideB, beta, C,
                                                  ldc, strideC, batchCount)
     initialize_context()
-    @ccall libcublas.cublasCgemm3mStridedBatched_64(handle::cublasHandle_t,
-                                                    transa::cublasOperation_t,
-                                                    transb::cublasOperation_t, m::Int64,
-                                                    n::Int64, k::Int64,
-                                                    alpha::RefOrCuRef{cuComplex},
-                                                    A::CuPtr{cuComplex}, lda::Int64,
-                                                    strideA::Clonglong, B::CuPtr{cuComplex},
-                                                    ldb::Int64, strideB::Clonglong,
-                                                    beta::RefOrCuRef{cuComplex},
-                                                    C::CuPtr{cuComplex}, ldc::Int64,
-                                                    strideC::Clonglong,
-                                                    batchCount::Int64)::cublasStatus_t
+    @gcsafe_ccall libcublas.cublasCgemm3mStridedBatched_64(handle::cublasHandle_t,
+                                                           transa::cublasOperation_t,
+                                                           transb::cublasOperation_t,
+                                                           m::Int64, n::Int64, k::Int64,
+                                                           alpha::RefOrCuRef{cuComplex},
+                                                           A::CuPtr{cuComplex}, lda::Int64,
+                                                           strideA::Clonglong,
+                                                           B::CuPtr{cuComplex}, ldb::Int64,
+                                                           strideB::Clonglong,
+                                                           beta::RefOrCuRef{cuComplex},
+                                                           C::CuPtr{cuComplex}, ldc::Int64,
+                                                           strideC::Clonglong,
+                                                           batchCount::Int64)::cublasStatus_t
 end
 
 @checked function cublasZgemmStridedBatched(handle, transa, transb, m, n, k, alpha, A, lda,
                                             strideA, B, ldb, strideB, beta, C, ldc, strideC,
                                             batchCount)
     initialize_context()
-    @ccall libcublas.cublasZgemmStridedBatched(handle::cublasHandle_t,
-                                               transa::cublasOperation_t,
-                                               transb::cublasOperation_t, m::Cint, n::Cint,
-                                               k::Cint, alpha::RefOrCuRef{cuDoubleComplex},
-                                               A::CuPtr{cuDoubleComplex}, lda::Cint,
-                                               strideA::Clonglong,
-                                               B::CuPtr{cuDoubleComplex}, ldb::Cint,
-                                               strideB::Clonglong,
-                                               beta::RefOrCuRef{cuDoubleComplex},
-                                               C::CuPtr{cuDoubleComplex}, ldc::Cint,
-                                               strideC::Clonglong,
-                                               batchCount::Cint)::cublasStatus_t
+    @gcsafe_ccall libcublas.cublasZgemmStridedBatched(handle::cublasHandle_t,
+                                                      transa::cublasOperation_t,
+                                                      transb::cublasOperation_t, m::Cint,
+                                                      n::Cint, k::Cint,
+                                                      alpha::RefOrCuRef{cuDoubleComplex},
+                                                      A::CuPtr{cuDoubleComplex}, lda::Cint,
+                                                      strideA::Clonglong,
+                                                      B::CuPtr{cuDoubleComplex}, ldb::Cint,
+                                                      strideB::Clonglong,
+                                                      beta::RefOrCuRef{cuDoubleComplex},
+                                                      C::CuPtr{cuDoubleComplex}, ldc::Cint,
+                                                      strideC::Clonglong,
+                                                      batchCount::Cint)::cublasStatus_t
 end
 
 @checked function cublasZgemmStridedBatched_64(handle, transa, transb, m, n, k, alpha, A,
                                                lda, strideA, B, ldb, strideB, beta, C, ldc,
                                                strideC, batchCount)
     initialize_context()
-    @ccall libcublas.cublasZgemmStridedBatched_64(handle::cublasHandle_t,
-                                                  transa::cublasOperation_t,
-                                                  transb::cublasOperation_t, m::Int64,
-                                                  n::Int64, k::Int64,
-                                                  alpha::RefOrCuRef{cuDoubleComplex},
-                                                  A::CuPtr{cuDoubleComplex}, lda::Int64,
-                                                  strideA::Clonglong,
-                                                  B::CuPtr{cuDoubleComplex}, ldb::Int64,
-                                                  strideB::Clonglong,
-                                                  beta::RefOrCuRef{cuDoubleComplex},
-                                                  C::CuPtr{cuDoubleComplex}, ldc::Int64,
-                                                  strideC::Clonglong,
-                                                  batchCount::Int64)::cublasStatus_t
+    @gcsafe_ccall libcublas.cublasZgemmStridedBatched_64(handle::cublasHandle_t,
+                                                         transa::cublasOperation_t,
+                                                         transb::cublasOperation_t,
+                                                         m::Int64, n::Int64, k::Int64,
+                                                         alpha::RefOrCuRef{cuDoubleComplex},
+                                                         A::CuPtr{cuDoubleComplex},
+                                                         lda::Int64, strideA::Clonglong,
+                                                         B::CuPtr{cuDoubleComplex},
+                                                         ldb::Int64, strideB::Clonglong,
+                                                         beta::RefOrCuRef{cuDoubleComplex},
+                                                         C::CuPtr{cuDoubleComplex},
+                                                         ldc::Int64, strideC::Clonglong,
+                                                         batchCount::Int64)::cublasStatus_t
 end
 
 @checked function cublasGemmBatchedEx(handle, transa, transb, m, n, k, alpha, Aarray, Atype,
                                       lda, Barray, Btype, ldb, beta, Carray, Ctype, ldc,
                                       batchCount, computeType, algo)
     initialize_context()
-    @ccall libcublas.cublasGemmBatchedEx(handle::cublasHandle_t, transa::cublasOperation_t,
-                                         transb::cublasOperation_t, m::Cint, n::Cint,
-                                         k::Cint, alpha::PtrOrCuPtr{Cvoid},
-                                         Aarray::CuPtr{Ptr{Cvoid}}, Atype::cudaDataType,
-                                         lda::Cint, Barray::CuPtr{Ptr{Cvoid}},
-                                         Btype::cudaDataType, ldb::Cint,
-                                         beta::PtrOrCuPtr{Cvoid}, Carray::CuPtr{Ptr{Cvoid}},
-                                         Ctype::cudaDataType, ldc::Cint, batchCount::Cint,
-                                         computeType::cublasComputeType_t,
-                                         algo::cublasGemmAlgo_t)::cublasStatus_t
+    @gcsafe_ccall libcublas.cublasGemmBatchedEx(handle::cublasHandle_t,
+                                                transa::cublasOperation_t,
+                                                transb::cublasOperation_t, m::Cint, n::Cint,
+                                                k::Cint, alpha::PtrOrCuPtr{Cvoid},
+                                                Aarray::CuPtr{Ptr{Cvoid}},
+                                                Atype::cudaDataType, lda::Cint,
+                                                Barray::CuPtr{Ptr{Cvoid}},
+                                                Btype::cudaDataType, ldb::Cint,
+                                                beta::PtrOrCuPtr{Cvoid},
+                                                Carray::CuPtr{Ptr{Cvoid}},
+                                                Ctype::cudaDataType, ldc::Cint,
+                                                batchCount::Cint,
+                                                computeType::cublasComputeType_t,
+                                                algo::cublasGemmAlgo_t)::cublasStatus_t
 end
 
 @checked function cublasGemmBatchedEx_64(handle, transa, transb, m, n, k, alpha, Aarray,
                                          Atype, lda, Barray, Btype, ldb, beta, Carray,
                                          Ctype, ldc, batchCount, computeType, algo)
     initialize_context()
-    @ccall libcublas.cublasGemmBatchedEx_64(handle::cublasHandle_t,
-                                            transa::cublasOperation_t,
-                                            transb::cublasOperation_t, m::Int64, n::Int64,
-                                            k::Int64, alpha::PtrOrCuPtr{Cvoid},
-                                            Aarray::CuPtr{Ptr{Cvoid}}, Atype::cudaDataType,
-                                            lda::Int64, Barray::CuPtr{Ptr{Cvoid}},
-                                            Btype::cudaDataType, ldb::Int64,
-                                            beta::PtrOrCuPtr{Cvoid},
-                                            Carray::CuPtr{Ptr{Cvoid}}, Ctype::cudaDataType,
-                                            ldc::Int64, batchCount::Int64,
-                                            computeType::cublasComputeType_t,
-                                            algo::cublasGemmAlgo_t)::cublasStatus_t
+    @gcsafe_ccall libcublas.cublasGemmBatchedEx_64(handle::cublasHandle_t,
+                                                   transa::cublasOperation_t,
+                                                   transb::cublasOperation_t, m::Int64,
+                                                   n::Int64, k::Int64,
+                                                   alpha::PtrOrCuPtr{Cvoid},
+                                                   Aarray::CuPtr{Ptr{Cvoid}},
+                                                   Atype::cudaDataType, lda::Int64,
+                                                   Barray::CuPtr{Ptr{Cvoid}},
+                                                   Btype::cudaDataType, ldb::Int64,
+                                                   beta::PtrOrCuPtr{Cvoid},
+                                                   Carray::CuPtr{Ptr{Cvoid}},
+                                                   Ctype::cudaDataType, ldc::Int64,
+                                                   batchCount::Int64,
+                                                   computeType::cublasComputeType_t,
+                                                   algo::cublasGemmAlgo_t)::cublasStatus_t
 end
 
 @checked function cublasGemmStridedBatchedEx(handle, transa, transb, m, n, k, alpha, A,
@@ -4206,19 +4607,21 @@ end
                                              beta, C, Ctype, ldc, strideC, batchCount,
                                              computeType, algo)
     initialize_context()
-    @ccall libcublas.cublasGemmStridedBatchedEx(handle::cublasHandle_t,
-                                                transa::cublasOperation_t,
-                                                transb::cublasOperation_t, m::Cint, n::Cint,
-                                                k::Cint, alpha::PtrOrCuPtr{Cvoid},
-                                                A::CuPtr{Cvoid}, Atype::cudaDataType,
-                                                lda::Cint, strideA::Clonglong,
-                                                B::CuPtr{Cvoid}, Btype::cudaDataType,
-                                                ldb::Cint, strideB::Clonglong,
-                                                beta::PtrOrCuPtr{Cvoid}, C::CuPtr{Cvoid},
-                                                Ctype::cudaDataType, ldc::Cint,
-                                                strideC::Clonglong, batchCount::Cint,
-                                                computeType::cublasComputeType_t,
-                                                algo::cublasGemmAlgo_t)::cublasStatus_t
+    @gcsafe_ccall libcublas.cublasGemmStridedBatchedEx(handle::cublasHandle_t,
+                                                       transa::cublasOperation_t,
+                                                       transb::cublasOperation_t, m::Cint,
+                                                       n::Cint, k::Cint,
+                                                       alpha::PtrOrCuPtr{Cvoid},
+                                                       A::CuPtr{Cvoid}, Atype::cudaDataType,
+                                                       lda::Cint, strideA::Clonglong,
+                                                       B::CuPtr{Cvoid}, Btype::cudaDataType,
+                                                       ldb::Cint, strideB::Clonglong,
+                                                       beta::PtrOrCuPtr{Cvoid},
+                                                       C::CuPtr{Cvoid}, Ctype::cudaDataType,
+                                                       ldc::Cint, strideC::Clonglong,
+                                                       batchCount::Cint,
+                                                       computeType::cublasComputeType_t,
+                                                       algo::cublasGemmAlgo_t)::cublasStatus_t
 end
 
 @checked function cublasGemmStridedBatchedEx_64(handle, transa, transb, m, n, k, alpha, A,
@@ -4226,547 +4629,614 @@ end
                                                 beta, C, Ctype, ldc, strideC, batchCount,
                                                 computeType, algo)
     initialize_context()
-    @ccall libcublas.cublasGemmStridedBatchedEx_64(handle::cublasHandle_t,
-                                                   transa::cublasOperation_t,
-                                                   transb::cublasOperation_t, m::Int64,
-                                                   n::Int64, k::Int64,
-                                                   alpha::PtrOrCuPtr{Cvoid},
-                                                   A::CuPtr{Cvoid}, Atype::cudaDataType,
-                                                   lda::Int64, strideA::Clonglong,
-                                                   B::CuPtr{Cvoid}, Btype::cudaDataType,
-                                                   ldb::Int64, strideB::Clonglong,
-                                                   beta::PtrOrCuPtr{Cvoid}, C::CuPtr{Cvoid},
-                                                   Ctype::cudaDataType, ldc::Int64,
-                                                   strideC::Clonglong, batchCount::Int64,
-                                                   computeType::cublasComputeType_t,
-                                                   algo::cublasGemmAlgo_t)::cublasStatus_t
+    @gcsafe_ccall libcublas.cublasGemmStridedBatchedEx_64(handle::cublasHandle_t,
+                                                          transa::cublasOperation_t,
+                                                          transb::cublasOperation_t,
+                                                          m::Int64, n::Int64, k::Int64,
+                                                          alpha::PtrOrCuPtr{Cvoid},
+                                                          A::CuPtr{Cvoid},
+                                                          Atype::cudaDataType, lda::Int64,
+                                                          strideA::Clonglong,
+                                                          B::CuPtr{Cvoid},
+                                                          Btype::cudaDataType, ldb::Int64,
+                                                          strideB::Clonglong,
+                                                          beta::PtrOrCuPtr{Cvoid},
+                                                          C::CuPtr{Cvoid},
+                                                          Ctype::cudaDataType, ldc::Int64,
+                                                          strideC::Clonglong,
+                                                          batchCount::Int64,
+                                                          computeType::cublasComputeType_t,
+                                                          algo::cublasGemmAlgo_t)::cublasStatus_t
 end
 
 @checked function cublasSgeam(handle, transa, transb, m, n, alpha, A, lda, beta, B, ldb, C,
                               ldc)
     initialize_context()
-    @ccall libcublas.cublasSgeam(handle::cublasHandle_t, transa::cublasOperation_t,
-                                 transb::cublasOperation_t, m::Cint, n::Cint,
-                                 alpha::RefOrCuRef{Cfloat}, A::CuPtr{Cfloat}, lda::Cint,
-                                 beta::RefOrCuRef{Cfloat}, B::CuPtr{Cfloat}, ldb::Cint,
-                                 C::CuPtr{Cfloat}, ldc::Cint)::cublasStatus_t
+    @gcsafe_ccall libcublas.cublasSgeam(handle::cublasHandle_t, transa::cublasOperation_t,
+                                        transb::cublasOperation_t, m::Cint, n::Cint,
+                                        alpha::RefOrCuRef{Cfloat}, A::CuPtr{Cfloat},
+                                        lda::Cint, beta::RefOrCuRef{Cfloat},
+                                        B::CuPtr{Cfloat}, ldb::Cint, C::CuPtr{Cfloat},
+                                        ldc::Cint)::cublasStatus_t
 end
 
 @checked function cublasSgeam_64(handle, transa, transb, m, n, alpha, A, lda, beta, B, ldb,
                                  C, ldc)
     initialize_context()
-    @ccall libcublas.cublasSgeam_64(handle::cublasHandle_t, transa::cublasOperation_t,
-                                    transb::cublasOperation_t, m::Int64, n::Int64,
-                                    alpha::RefOrCuRef{Cfloat}, A::CuPtr{Cfloat}, lda::Int64,
-                                    beta::RefOrCuRef{Cfloat}, B::CuPtr{Cfloat}, ldb::Int64,
-                                    C::CuPtr{Cfloat}, ldc::Int64)::cublasStatus_t
+    @gcsafe_ccall libcublas.cublasSgeam_64(handle::cublasHandle_t,
+                                           transa::cublasOperation_t,
+                                           transb::cublasOperation_t, m::Int64, n::Int64,
+                                           alpha::RefOrCuRef{Cfloat}, A::CuPtr{Cfloat},
+                                           lda::Int64, beta::RefOrCuRef{Cfloat},
+                                           B::CuPtr{Cfloat}, ldb::Int64, C::CuPtr{Cfloat},
+                                           ldc::Int64)::cublasStatus_t
 end
 
 @checked function cublasDgeam(handle, transa, transb, m, n, alpha, A, lda, beta, B, ldb, C,
                               ldc)
     initialize_context()
-    @ccall libcublas.cublasDgeam(handle::cublasHandle_t, transa::cublasOperation_t,
-                                 transb::cublasOperation_t, m::Cint, n::Cint,
-                                 alpha::RefOrCuRef{Cdouble}, A::CuPtr{Cdouble}, lda::Cint,
-                                 beta::RefOrCuRef{Cdouble}, B::CuPtr{Cdouble}, ldb::Cint,
-                                 C::CuPtr{Cdouble}, ldc::Cint)::cublasStatus_t
+    @gcsafe_ccall libcublas.cublasDgeam(handle::cublasHandle_t, transa::cublasOperation_t,
+                                        transb::cublasOperation_t, m::Cint, n::Cint,
+                                        alpha::RefOrCuRef{Cdouble}, A::CuPtr{Cdouble},
+                                        lda::Cint, beta::RefOrCuRef{Cdouble},
+                                        B::CuPtr{Cdouble}, ldb::Cint, C::CuPtr{Cdouble},
+                                        ldc::Cint)::cublasStatus_t
 end
 
 @checked function cublasDgeam_64(handle, transa, transb, m, n, alpha, A, lda, beta, B, ldb,
                                  C, ldc)
     initialize_context()
-    @ccall libcublas.cublasDgeam_64(handle::cublasHandle_t, transa::cublasOperation_t,
-                                    transb::cublasOperation_t, m::Int64, n::Int64,
-                                    alpha::RefOrCuRef{Cdouble}, A::CuPtr{Cdouble},
-                                    lda::Int64, beta::RefOrCuRef{Cdouble},
-                                    B::CuPtr{Cdouble}, ldb::Int64, C::CuPtr{Cdouble},
-                                    ldc::Int64)::cublasStatus_t
+    @gcsafe_ccall libcublas.cublasDgeam_64(handle::cublasHandle_t,
+                                           transa::cublasOperation_t,
+                                           transb::cublasOperation_t, m::Int64, n::Int64,
+                                           alpha::RefOrCuRef{Cdouble}, A::CuPtr{Cdouble},
+                                           lda::Int64, beta::RefOrCuRef{Cdouble},
+                                           B::CuPtr{Cdouble}, ldb::Int64, C::CuPtr{Cdouble},
+                                           ldc::Int64)::cublasStatus_t
 end
 
 @checked function cublasCgeam(handle, transa, transb, m, n, alpha, A, lda, beta, B, ldb, C,
                               ldc)
     initialize_context()
-    @ccall libcublas.cublasCgeam(handle::cublasHandle_t, transa::cublasOperation_t,
-                                 transb::cublasOperation_t, m::Cint, n::Cint,
-                                 alpha::RefOrCuRef{cuComplex}, A::CuPtr{cuComplex},
-                                 lda::Cint, beta::RefOrCuRef{cuComplex},
-                                 B::CuPtr{cuComplex}, ldb::Cint, C::CuPtr{cuComplex},
-                                 ldc::Cint)::cublasStatus_t
+    @gcsafe_ccall libcublas.cublasCgeam(handle::cublasHandle_t, transa::cublasOperation_t,
+                                        transb::cublasOperation_t, m::Cint, n::Cint,
+                                        alpha::RefOrCuRef{cuComplex}, A::CuPtr{cuComplex},
+                                        lda::Cint, beta::RefOrCuRef{cuComplex},
+                                        B::CuPtr{cuComplex}, ldb::Cint, C::CuPtr{cuComplex},
+                                        ldc::Cint)::cublasStatus_t
 end
 
 @checked function cublasCgeam_64(handle, transa, transb, m, n, alpha, A, lda, beta, B, ldb,
                                  C, ldc)
     initialize_context()
-    @ccall libcublas.cublasCgeam_64(handle::cublasHandle_t, transa::cublasOperation_t,
-                                    transb::cublasOperation_t, m::Int64, n::Int64,
-                                    alpha::RefOrCuRef{cuComplex}, A::CuPtr{cuComplex},
-                                    lda::Int64, beta::RefOrCuRef{cuComplex},
-                                    B::CuPtr{cuComplex}, ldb::Int64, C::CuPtr{cuComplex},
-                                    ldc::Int64)::cublasStatus_t
+    @gcsafe_ccall libcublas.cublasCgeam_64(handle::cublasHandle_t,
+                                           transa::cublasOperation_t,
+                                           transb::cublasOperation_t, m::Int64, n::Int64,
+                                           alpha::RefOrCuRef{cuComplex},
+                                           A::CuPtr{cuComplex}, lda::Int64,
+                                           beta::RefOrCuRef{cuComplex}, B::CuPtr{cuComplex},
+                                           ldb::Int64, C::CuPtr{cuComplex},
+                                           ldc::Int64)::cublasStatus_t
 end
 
 @checked function cublasZgeam(handle, transa, transb, m, n, alpha, A, lda, beta, B, ldb, C,
                               ldc)
     initialize_context()
-    @ccall libcublas.cublasZgeam(handle::cublasHandle_t, transa::cublasOperation_t,
-                                 transb::cublasOperation_t, m::Cint, n::Cint,
-                                 alpha::RefOrCuRef{cuDoubleComplex},
-                                 A::CuPtr{cuDoubleComplex}, lda::Cint,
-                                 beta::RefOrCuRef{cuDoubleComplex},
-                                 B::CuPtr{cuDoubleComplex}, ldb::Cint,
-                                 C::CuPtr{cuDoubleComplex}, ldc::Cint)::cublasStatus_t
+    @gcsafe_ccall libcublas.cublasZgeam(handle::cublasHandle_t, transa::cublasOperation_t,
+                                        transb::cublasOperation_t, m::Cint, n::Cint,
+                                        alpha::RefOrCuRef{cuDoubleComplex},
+                                        A::CuPtr{cuDoubleComplex}, lda::Cint,
+                                        beta::RefOrCuRef{cuDoubleComplex},
+                                        B::CuPtr{cuDoubleComplex}, ldb::Cint,
+                                        C::CuPtr{cuDoubleComplex},
+                                        ldc::Cint)::cublasStatus_t
 end
 
 @checked function cublasZgeam_64(handle, transa, transb, m, n, alpha, A, lda, beta, B, ldb,
                                  C, ldc)
     initialize_context()
-    @ccall libcublas.cublasZgeam_64(handle::cublasHandle_t, transa::cublasOperation_t,
-                                    transb::cublasOperation_t, m::Int64, n::Int64,
-                                    alpha::RefOrCuRef{cuDoubleComplex},
-                                    A::CuPtr{cuDoubleComplex}, lda::Int64,
-                                    beta::RefOrCuRef{cuDoubleComplex},
-                                    B::CuPtr{cuDoubleComplex}, ldb::Int64,
-                                    C::CuPtr{cuDoubleComplex}, ldc::Int64)::cublasStatus_t
+    @gcsafe_ccall libcublas.cublasZgeam_64(handle::cublasHandle_t,
+                                           transa::cublasOperation_t,
+                                           transb::cublasOperation_t, m::Int64, n::Int64,
+                                           alpha::RefOrCuRef{cuDoubleComplex},
+                                           A::CuPtr{cuDoubleComplex}, lda::Int64,
+                                           beta::RefOrCuRef{cuDoubleComplex},
+                                           B::CuPtr{cuDoubleComplex}, ldb::Int64,
+                                           C::CuPtr{cuDoubleComplex},
+                                           ldc::Int64)::cublasStatus_t
 end
 
 @checked function cublasStrsmBatched(handle, side, uplo, trans, diag, m, n, alpha, A, lda,
                                      B, ldb, batchCount)
     initialize_context()
-    @ccall libcublas.cublasStrsmBatched(handle::cublasHandle_t, side::cublasSideMode_t,
-                                        uplo::cublasFillMode_t, trans::cublasOperation_t,
-                                        diag::cublasDiagType_t, m::Cint, n::Cint,
-                                        alpha::RefOrCuRef{Cfloat}, A::CuPtr{Ptr{Cfloat}},
-                                        lda::Cint, B::CuPtr{Ptr{Cfloat}}, ldb::Cint,
-                                        batchCount::Cint)::cublasStatus_t
+    @gcsafe_ccall libcublas.cublasStrsmBatched(handle::cublasHandle_t,
+                                               side::cublasSideMode_t,
+                                               uplo::cublasFillMode_t,
+                                               trans::cublasOperation_t,
+                                               diag::cublasDiagType_t, m::Cint, n::Cint,
+                                               alpha::RefOrCuRef{Cfloat},
+                                               A::CuPtr{Ptr{Cfloat}}, lda::Cint,
+                                               B::CuPtr{Ptr{Cfloat}}, ldb::Cint,
+                                               batchCount::Cint)::cublasStatus_t
 end
 
 @checked function cublasStrsmBatched_64(handle, side, uplo, trans, diag, m, n, alpha, A,
                                         lda, B, ldb, batchCount)
     initialize_context()
-    @ccall libcublas.cublasStrsmBatched_64(handle::cublasHandle_t, side::cublasSideMode_t,
-                                           uplo::cublasFillMode_t, trans::cublasOperation_t,
-                                           diag::cublasDiagType_t, m::Int64, n::Int64,
-                                           alpha::RefOrCuRef{Cfloat}, A::CuPtr{Ptr{Cfloat}},
-                                           lda::Int64, B::CuPtr{Ptr{Cfloat}}, ldb::Int64,
-                                           batchCount::Int64)::cublasStatus_t
+    @gcsafe_ccall libcublas.cublasStrsmBatched_64(handle::cublasHandle_t,
+                                                  side::cublasSideMode_t,
+                                                  uplo::cublasFillMode_t,
+                                                  trans::cublasOperation_t,
+                                                  diag::cublasDiagType_t, m::Int64,
+                                                  n::Int64, alpha::RefOrCuRef{Cfloat},
+                                                  A::CuPtr{Ptr{Cfloat}}, lda::Int64,
+                                                  B::CuPtr{Ptr{Cfloat}}, ldb::Int64,
+                                                  batchCount::Int64)::cublasStatus_t
 end
 
 @checked function cublasDtrsmBatched(handle, side, uplo, trans, diag, m, n, alpha, A, lda,
                                      B, ldb, batchCount)
     initialize_context()
-    @ccall libcublas.cublasDtrsmBatched(handle::cublasHandle_t, side::cublasSideMode_t,
-                                        uplo::cublasFillMode_t, trans::cublasOperation_t,
-                                        diag::cublasDiagType_t, m::Cint, n::Cint,
-                                        alpha::RefOrCuRef{Cdouble}, A::CuPtr{Ptr{Cdouble}},
-                                        lda::Cint, B::CuPtr{Ptr{Cdouble}}, ldb::Cint,
-                                        batchCount::Cint)::cublasStatus_t
+    @gcsafe_ccall libcublas.cublasDtrsmBatched(handle::cublasHandle_t,
+                                               side::cublasSideMode_t,
+                                               uplo::cublasFillMode_t,
+                                               trans::cublasOperation_t,
+                                               diag::cublasDiagType_t, m::Cint, n::Cint,
+                                               alpha::RefOrCuRef{Cdouble},
+                                               A::CuPtr{Ptr{Cdouble}}, lda::Cint,
+                                               B::CuPtr{Ptr{Cdouble}}, ldb::Cint,
+                                               batchCount::Cint)::cublasStatus_t
 end
 
 @checked function cublasDtrsmBatched_64(handle, side, uplo, trans, diag, m, n, alpha, A,
                                         lda, B, ldb, batchCount)
     initialize_context()
-    @ccall libcublas.cublasDtrsmBatched_64(handle::cublasHandle_t, side::cublasSideMode_t,
-                                           uplo::cublasFillMode_t, trans::cublasOperation_t,
-                                           diag::cublasDiagType_t, m::Int64, n::Int64,
-                                           alpha::RefOrCuRef{Cdouble},
-                                           A::CuPtr{Ptr{Cdouble}}, lda::Int64,
-                                           B::CuPtr{Ptr{Cdouble}}, ldb::Int64,
-                                           batchCount::Int64)::cublasStatus_t
+    @gcsafe_ccall libcublas.cublasDtrsmBatched_64(handle::cublasHandle_t,
+                                                  side::cublasSideMode_t,
+                                                  uplo::cublasFillMode_t,
+                                                  trans::cublasOperation_t,
+                                                  diag::cublasDiagType_t, m::Int64,
+                                                  n::Int64, alpha::RefOrCuRef{Cdouble},
+                                                  A::CuPtr{Ptr{Cdouble}}, lda::Int64,
+                                                  B::CuPtr{Ptr{Cdouble}}, ldb::Int64,
+                                                  batchCount::Int64)::cublasStatus_t
 end
 
 @checked function cublasCtrsmBatched(handle, side, uplo, trans, diag, m, n, alpha, A, lda,
                                      B, ldb, batchCount)
     initialize_context()
-    @ccall libcublas.cublasCtrsmBatched(handle::cublasHandle_t, side::cublasSideMode_t,
-                                        uplo::cublasFillMode_t, trans::cublasOperation_t,
-                                        diag::cublasDiagType_t, m::Cint, n::Cint,
-                                        alpha::RefOrCuRef{cuComplex},
-                                        A::CuPtr{Ptr{cuComplex}}, lda::Cint,
-                                        B::CuPtr{Ptr{cuComplex}}, ldb::Cint,
-                                        batchCount::Cint)::cublasStatus_t
+    @gcsafe_ccall libcublas.cublasCtrsmBatched(handle::cublasHandle_t,
+                                               side::cublasSideMode_t,
+                                               uplo::cublasFillMode_t,
+                                               trans::cublasOperation_t,
+                                               diag::cublasDiagType_t, m::Cint, n::Cint,
+                                               alpha::RefOrCuRef{cuComplex},
+                                               A::CuPtr{Ptr{cuComplex}}, lda::Cint,
+                                               B::CuPtr{Ptr{cuComplex}}, ldb::Cint,
+                                               batchCount::Cint)::cublasStatus_t
 end
 
 @checked function cublasCtrsmBatched_64(handle, side, uplo, trans, diag, m, n, alpha, A,
                                         lda, B, ldb, batchCount)
     initialize_context()
-    @ccall libcublas.cublasCtrsmBatched_64(handle::cublasHandle_t, side::cublasSideMode_t,
-                                           uplo::cublasFillMode_t, trans::cublasOperation_t,
-                                           diag::cublasDiagType_t, m::Int64, n::Int64,
-                                           alpha::RefOrCuRef{cuComplex},
-                                           A::CuPtr{Ptr{cuComplex}}, lda::Int64,
-                                           B::CuPtr{Ptr{cuComplex}}, ldb::Int64,
-                                           batchCount::Int64)::cublasStatus_t
+    @gcsafe_ccall libcublas.cublasCtrsmBatched_64(handle::cublasHandle_t,
+                                                  side::cublasSideMode_t,
+                                                  uplo::cublasFillMode_t,
+                                                  trans::cublasOperation_t,
+                                                  diag::cublasDiagType_t, m::Int64,
+                                                  n::Int64, alpha::RefOrCuRef{cuComplex},
+                                                  A::CuPtr{Ptr{cuComplex}}, lda::Int64,
+                                                  B::CuPtr{Ptr{cuComplex}}, ldb::Int64,
+                                                  batchCount::Int64)::cublasStatus_t
 end
 
 @checked function cublasZtrsmBatched(handle, side, uplo, trans, diag, m, n, alpha, A, lda,
                                      B, ldb, batchCount)
     initialize_context()
-    @ccall libcublas.cublasZtrsmBatched(handle::cublasHandle_t, side::cublasSideMode_t,
-                                        uplo::cublasFillMode_t, trans::cublasOperation_t,
-                                        diag::cublasDiagType_t, m::Cint, n::Cint,
-                                        alpha::RefOrCuRef{cuDoubleComplex},
-                                        A::CuPtr{Ptr{cuDoubleComplex}}, lda::Cint,
-                                        B::CuPtr{Ptr{cuDoubleComplex}}, ldb::Cint,
-                                        batchCount::Cint)::cublasStatus_t
+    @gcsafe_ccall libcublas.cublasZtrsmBatched(handle::cublasHandle_t,
+                                               side::cublasSideMode_t,
+                                               uplo::cublasFillMode_t,
+                                               trans::cublasOperation_t,
+                                               diag::cublasDiagType_t, m::Cint, n::Cint,
+                                               alpha::RefOrCuRef{cuDoubleComplex},
+                                               A::CuPtr{Ptr{cuDoubleComplex}}, lda::Cint,
+                                               B::CuPtr{Ptr{cuDoubleComplex}}, ldb::Cint,
+                                               batchCount::Cint)::cublasStatus_t
 end
 
 @checked function cublasZtrsmBatched_64(handle, side, uplo, trans, diag, m, n, alpha, A,
                                         lda, B, ldb, batchCount)
     initialize_context()
-    @ccall libcublas.cublasZtrsmBatched_64(handle::cublasHandle_t, side::cublasSideMode_t,
-                                           uplo::cublasFillMode_t, trans::cublasOperation_t,
-                                           diag::cublasDiagType_t, m::Int64, n::Int64,
-                                           alpha::RefOrCuRef{cuDoubleComplex},
-                                           A::CuPtr{Ptr{cuDoubleComplex}}, lda::Int64,
-                                           B::CuPtr{Ptr{cuDoubleComplex}}, ldb::Int64,
-                                           batchCount::Int64)::cublasStatus_t
+    @gcsafe_ccall libcublas.cublasZtrsmBatched_64(handle::cublasHandle_t,
+                                                  side::cublasSideMode_t,
+                                                  uplo::cublasFillMode_t,
+                                                  trans::cublasOperation_t,
+                                                  diag::cublasDiagType_t, m::Int64,
+                                                  n::Int64,
+                                                  alpha::RefOrCuRef{cuDoubleComplex},
+                                                  A::CuPtr{Ptr{cuDoubleComplex}},
+                                                  lda::Int64,
+                                                  B::CuPtr{Ptr{cuDoubleComplex}},
+                                                  ldb::Int64,
+                                                  batchCount::Int64)::cublasStatus_t
 end
 
 @checked function cublasSdgmm(handle, mode, m, n, A, lda, x, incx, C, ldc)
     initialize_context()
-    @ccall libcublas.cublasSdgmm(handle::cublasHandle_t, mode::cublasSideMode_t, m::Cint,
-                                 n::Cint, A::CuPtr{Cfloat}, lda::Cint, x::CuPtr{Cfloat},
-                                 incx::Cint, C::CuPtr{Cfloat}, ldc::Cint)::cublasStatus_t
+    @gcsafe_ccall libcublas.cublasSdgmm(handle::cublasHandle_t, mode::cublasSideMode_t,
+                                        m::Cint, n::Cint, A::CuPtr{Cfloat}, lda::Cint,
+                                        x::CuPtr{Cfloat}, incx::Cint, C::CuPtr{Cfloat},
+                                        ldc::Cint)::cublasStatus_t
 end
 
 @checked function cublasSdgmm_64(handle, mode, m, n, A, lda, x, incx, C, ldc)
     initialize_context()
-    @ccall libcublas.cublasSdgmm_64(handle::cublasHandle_t, mode::cublasSideMode_t,
-                                    m::Int64, n::Int64, A::CuPtr{Cfloat}, lda::Int64,
-                                    x::CuPtr{Cfloat}, incx::Int64, C::CuPtr{Cfloat},
-                                    ldc::Int64)::cublasStatus_t
+    @gcsafe_ccall libcublas.cublasSdgmm_64(handle::cublasHandle_t, mode::cublasSideMode_t,
+                                           m::Int64, n::Int64, A::CuPtr{Cfloat}, lda::Int64,
+                                           x::CuPtr{Cfloat}, incx::Int64, C::CuPtr{Cfloat},
+                                           ldc::Int64)::cublasStatus_t
 end
 
 @checked function cublasDdgmm(handle, mode, m, n, A, lda, x, incx, C, ldc)
     initialize_context()
-    @ccall libcublas.cublasDdgmm(handle::cublasHandle_t, mode::cublasSideMode_t, m::Cint,
-                                 n::Cint, A::CuPtr{Cdouble}, lda::Cint, x::CuPtr{Cdouble},
-                                 incx::Cint, C::CuPtr{Cdouble}, ldc::Cint)::cublasStatus_t
+    @gcsafe_ccall libcublas.cublasDdgmm(handle::cublasHandle_t, mode::cublasSideMode_t,
+                                        m::Cint, n::Cint, A::CuPtr{Cdouble}, lda::Cint,
+                                        x::CuPtr{Cdouble}, incx::Cint, C::CuPtr{Cdouble},
+                                        ldc::Cint)::cublasStatus_t
 end
 
 @checked function cublasDdgmm_64(handle, mode, m, n, A, lda, x, incx, C, ldc)
     initialize_context()
-    @ccall libcublas.cublasDdgmm_64(handle::cublasHandle_t, mode::cublasSideMode_t,
-                                    m::Int64, n::Int64, A::CuPtr{Cdouble}, lda::Int64,
-                                    x::CuPtr{Cdouble}, incx::Int64, C::CuPtr{Cdouble},
-                                    ldc::Int64)::cublasStatus_t
+    @gcsafe_ccall libcublas.cublasDdgmm_64(handle::cublasHandle_t, mode::cublasSideMode_t,
+                                           m::Int64, n::Int64, A::CuPtr{Cdouble},
+                                           lda::Int64, x::CuPtr{Cdouble}, incx::Int64,
+                                           C::CuPtr{Cdouble}, ldc::Int64)::cublasStatus_t
 end
 
 @checked function cublasCdgmm(handle, mode, m, n, A, lda, x, incx, C, ldc)
     initialize_context()
-    @ccall libcublas.cublasCdgmm(handle::cublasHandle_t, mode::cublasSideMode_t, m::Cint,
-                                 n::Cint, A::CuPtr{cuComplex}, lda::Cint,
-                                 x::CuPtr{cuComplex}, incx::Cint, C::CuPtr{cuComplex},
-                                 ldc::Cint)::cublasStatus_t
+    @gcsafe_ccall libcublas.cublasCdgmm(handle::cublasHandle_t, mode::cublasSideMode_t,
+                                        m::Cint, n::Cint, A::CuPtr{cuComplex}, lda::Cint,
+                                        x::CuPtr{cuComplex}, incx::Cint,
+                                        C::CuPtr{cuComplex}, ldc::Cint)::cublasStatus_t
 end
 
 @checked function cublasCdgmm_64(handle, mode, m, n, A, lda, x, incx, C, ldc)
     initialize_context()
-    @ccall libcublas.cublasCdgmm_64(handle::cublasHandle_t, mode::cublasSideMode_t,
-                                    m::Int64, n::Int64, A::CuPtr{cuComplex}, lda::Int64,
-                                    x::CuPtr{cuComplex}, incx::Int64, C::CuPtr{cuComplex},
-                                    ldc::Int64)::cublasStatus_t
+    @gcsafe_ccall libcublas.cublasCdgmm_64(handle::cublasHandle_t, mode::cublasSideMode_t,
+                                           m::Int64, n::Int64, A::CuPtr{cuComplex},
+                                           lda::Int64, x::CuPtr{cuComplex}, incx::Int64,
+                                           C::CuPtr{cuComplex}, ldc::Int64)::cublasStatus_t
 end
 
 @checked function cublasZdgmm(handle, mode, m, n, A, lda, x, incx, C, ldc)
     initialize_context()
-    @ccall libcublas.cublasZdgmm(handle::cublasHandle_t, mode::cublasSideMode_t, m::Cint,
-                                 n::Cint, A::CuPtr{cuDoubleComplex}, lda::Cint,
-                                 x::CuPtr{cuDoubleComplex}, incx::Cint,
-                                 C::CuPtr{cuDoubleComplex}, ldc::Cint)::cublasStatus_t
+    @gcsafe_ccall libcublas.cublasZdgmm(handle::cublasHandle_t, mode::cublasSideMode_t,
+                                        m::Cint, n::Cint, A::CuPtr{cuDoubleComplex},
+                                        lda::Cint, x::CuPtr{cuDoubleComplex}, incx::Cint,
+                                        C::CuPtr{cuDoubleComplex},
+                                        ldc::Cint)::cublasStatus_t
 end
 
 @checked function cublasZdgmm_64(handle, mode, m, n, A, lda, x, incx, C, ldc)
     initialize_context()
-    @ccall libcublas.cublasZdgmm_64(handle::cublasHandle_t, mode::cublasSideMode_t,
-                                    m::Int64, n::Int64, A::CuPtr{cuDoubleComplex},
-                                    lda::Int64, x::CuPtr{cuDoubleComplex}, incx::Int64,
-                                    C::CuPtr{cuDoubleComplex}, ldc::Int64)::cublasStatus_t
+    @gcsafe_ccall libcublas.cublasZdgmm_64(handle::cublasHandle_t, mode::cublasSideMode_t,
+                                           m::Int64, n::Int64, A::CuPtr{cuDoubleComplex},
+                                           lda::Int64, x::CuPtr{cuDoubleComplex},
+                                           incx::Int64, C::CuPtr{cuDoubleComplex},
+                                           ldc::Int64)::cublasStatus_t
 end
 
 @checked function cublasSmatinvBatched(handle, n, A, lda, Ainv, lda_inv, info, batchSize)
     initialize_context()
-    @ccall libcublas.cublasSmatinvBatched(handle::cublasHandle_t, n::Cint,
-                                          A::CuPtr{Ptr{Cfloat}}, lda::Cint,
-                                          Ainv::CuPtr{Ptr{Cfloat}}, lda_inv::Cint,
-                                          info::CuPtr{Cint},
-                                          batchSize::Cint)::cublasStatus_t
+    @gcsafe_ccall libcublas.cublasSmatinvBatched(handle::cublasHandle_t, n::Cint,
+                                                 A::CuPtr{Ptr{Cfloat}}, lda::Cint,
+                                                 Ainv::CuPtr{Ptr{Cfloat}}, lda_inv::Cint,
+                                                 info::CuPtr{Cint},
+                                                 batchSize::Cint)::cublasStatus_t
 end
 
 @checked function cublasDmatinvBatched(handle, n, A, lda, Ainv, lda_inv, info, batchSize)
     initialize_context()
-    @ccall libcublas.cublasDmatinvBatched(handle::cublasHandle_t, n::Cint,
-                                          A::CuPtr{Ptr{Cdouble}}, lda::Cint,
-                                          Ainv::CuPtr{Ptr{Cdouble}}, lda_inv::Cint,
-                                          info::CuPtr{Cint},
-                                          batchSize::Cint)::cublasStatus_t
+    @gcsafe_ccall libcublas.cublasDmatinvBatched(handle::cublasHandle_t, n::Cint,
+                                                 A::CuPtr{Ptr{Cdouble}}, lda::Cint,
+                                                 Ainv::CuPtr{Ptr{Cdouble}}, lda_inv::Cint,
+                                                 info::CuPtr{Cint},
+                                                 batchSize::Cint)::cublasStatus_t
 end
 
 @checked function cublasCmatinvBatched(handle, n, A, lda, Ainv, lda_inv, info, batchSize)
     initialize_context()
-    @ccall libcublas.cublasCmatinvBatched(handle::cublasHandle_t, n::Cint,
-                                          A::CuPtr{Ptr{cuComplex}}, lda::Cint,
-                                          Ainv::CuPtr{Ptr{cuComplex}}, lda_inv::Cint,
-                                          info::CuPtr{Cint},
-                                          batchSize::Cint)::cublasStatus_t
+    @gcsafe_ccall libcublas.cublasCmatinvBatched(handle::cublasHandle_t, n::Cint,
+                                                 A::CuPtr{Ptr{cuComplex}}, lda::Cint,
+                                                 Ainv::CuPtr{Ptr{cuComplex}}, lda_inv::Cint,
+                                                 info::CuPtr{Cint},
+                                                 batchSize::Cint)::cublasStatus_t
 end
 
 @checked function cublasZmatinvBatched(handle, n, A, lda, Ainv, lda_inv, info, batchSize)
     initialize_context()
-    @ccall libcublas.cublasZmatinvBatched(handle::cublasHandle_t, n::Cint,
-                                          A::CuPtr{Ptr{cuDoubleComplex}}, lda::Cint,
-                                          Ainv::CuPtr{Ptr{cuDoubleComplex}}, lda_inv::Cint,
-                                          info::CuPtr{Cint},
-                                          batchSize::Cint)::cublasStatus_t
+    @gcsafe_ccall libcublas.cublasZmatinvBatched(handle::cublasHandle_t, n::Cint,
+                                                 A::CuPtr{Ptr{cuDoubleComplex}}, lda::Cint,
+                                                 Ainv::CuPtr{Ptr{cuDoubleComplex}},
+                                                 lda_inv::Cint, info::CuPtr{Cint},
+                                                 batchSize::Cint)::cublasStatus_t
 end
 
 @checked function cublasSgeqrfBatched(handle, m, n, Aarray, lda, TauArray, info, batchSize)
     initialize_context()
-    @ccall libcublas.cublasSgeqrfBatched(handle::cublasHandle_t, m::Cint, n::Cint,
-                                         Aarray::CuPtr{Ptr{Cfloat}}, lda::Cint,
-                                         TauArray::CuPtr{Ptr{Cfloat}}, info::Ptr{Cint},
-                                         batchSize::Cint)::cublasStatus_t
+    @gcsafe_ccall libcublas.cublasSgeqrfBatched(handle::cublasHandle_t, m::Cint, n::Cint,
+                                                Aarray::CuPtr{Ptr{Cfloat}}, lda::Cint,
+                                                TauArray::CuPtr{Ptr{Cfloat}},
+                                                info::Ptr{Cint},
+                                                batchSize::Cint)::cublasStatus_t
 end
 
 @checked function cublasDgeqrfBatched(handle, m, n, Aarray, lda, TauArray, info, batchSize)
     initialize_context()
-    @ccall libcublas.cublasDgeqrfBatched(handle::cublasHandle_t, m::Cint, n::Cint,
-                                         Aarray::CuPtr{Ptr{Cdouble}}, lda::Cint,
-                                         TauArray::CuPtr{Ptr{Cdouble}}, info::Ptr{Cint},
-                                         batchSize::Cint)::cublasStatus_t
+    @gcsafe_ccall libcublas.cublasDgeqrfBatched(handle::cublasHandle_t, m::Cint, n::Cint,
+                                                Aarray::CuPtr{Ptr{Cdouble}}, lda::Cint,
+                                                TauArray::CuPtr{Ptr{Cdouble}},
+                                                info::Ptr{Cint},
+                                                batchSize::Cint)::cublasStatus_t
 end
 
 @checked function cublasCgeqrfBatched(handle, m, n, Aarray, lda, TauArray, info, batchSize)
     initialize_context()
-    @ccall libcublas.cublasCgeqrfBatched(handle::cublasHandle_t, m::Cint, n::Cint,
-                                         Aarray::CuPtr{Ptr{cuComplex}}, lda::Cint,
-                                         TauArray::CuPtr{Ptr{cuComplex}}, info::Ptr{Cint},
-                                         batchSize::Cint)::cublasStatus_t
+    @gcsafe_ccall libcublas.cublasCgeqrfBatched(handle::cublasHandle_t, m::Cint, n::Cint,
+                                                Aarray::CuPtr{Ptr{cuComplex}}, lda::Cint,
+                                                TauArray::CuPtr{Ptr{cuComplex}},
+                                                info::Ptr{Cint},
+                                                batchSize::Cint)::cublasStatus_t
 end
 
 @checked function cublasZgeqrfBatched(handle, m, n, Aarray, lda, TauArray, info, batchSize)
     initialize_context()
-    @ccall libcublas.cublasZgeqrfBatched(handle::cublasHandle_t, m::Cint, n::Cint,
-                                         Aarray::CuPtr{Ptr{cuDoubleComplex}}, lda::Cint,
-                                         TauArray::CuPtr{Ptr{cuDoubleComplex}},
-                                         info::Ptr{Cint}, batchSize::Cint)::cublasStatus_t
+    @gcsafe_ccall libcublas.cublasZgeqrfBatched(handle::cublasHandle_t, m::Cint, n::Cint,
+                                                Aarray::CuPtr{Ptr{cuDoubleComplex}},
+                                                lda::Cint,
+                                                TauArray::CuPtr{Ptr{cuDoubleComplex}},
+                                                info::Ptr{Cint},
+                                                batchSize::Cint)::cublasStatus_t
 end
 
 @checked function cublasSgelsBatched(handle, trans, m, n, nrhs, Aarray, lda, Carray, ldc,
                                      info, devInfoArray, batchSize)
     initialize_context()
-    @ccall libcublas.cublasSgelsBatched(handle::cublasHandle_t, trans::cublasOperation_t,
-                                        m::Cint, n::Cint, nrhs::Cint,
-                                        Aarray::CuPtr{Ptr{Cfloat}}, lda::Cint,
-                                        Carray::CuPtr{Ptr{Cfloat}}, ldc::Cint,
-                                        info::Ptr{Cint}, devInfoArray::CuPtr{Cint},
-                                        batchSize::Cint)::cublasStatus_t
+    @gcsafe_ccall libcublas.cublasSgelsBatched(handle::cublasHandle_t,
+                                               trans::cublasOperation_t, m::Cint, n::Cint,
+                                               nrhs::Cint, Aarray::CuPtr{Ptr{Cfloat}},
+                                               lda::Cint, Carray::CuPtr{Ptr{Cfloat}},
+                                               ldc::Cint, info::Ptr{Cint},
+                                               devInfoArray::CuPtr{Cint},
+                                               batchSize::Cint)::cublasStatus_t
 end
 
 @checked function cublasDgelsBatched(handle, trans, m, n, nrhs, Aarray, lda, Carray, ldc,
                                      info, devInfoArray, batchSize)
     initialize_context()
-    @ccall libcublas.cublasDgelsBatched(handle::cublasHandle_t, trans::cublasOperation_t,
-                                        m::Cint, n::Cint, nrhs::Cint,
-                                        Aarray::CuPtr{Ptr{Cdouble}}, lda::Cint,
-                                        Carray::CuPtr{Ptr{Cdouble}}, ldc::Cint,
-                                        info::Ptr{Cint}, devInfoArray::CuPtr{Cint},
-                                        batchSize::Cint)::cublasStatus_t
+    @gcsafe_ccall libcublas.cublasDgelsBatched(handle::cublasHandle_t,
+                                               trans::cublasOperation_t, m::Cint, n::Cint,
+                                               nrhs::Cint, Aarray::CuPtr{Ptr{Cdouble}},
+                                               lda::Cint, Carray::CuPtr{Ptr{Cdouble}},
+                                               ldc::Cint, info::Ptr{Cint},
+                                               devInfoArray::CuPtr{Cint},
+                                               batchSize::Cint)::cublasStatus_t
 end
 
 @checked function cublasCgelsBatched(handle, trans, m, n, nrhs, Aarray, lda, Carray, ldc,
                                      info, devInfoArray, batchSize)
     initialize_context()
-    @ccall libcublas.cublasCgelsBatched(handle::cublasHandle_t, trans::cublasOperation_t,
-                                        m::Cint, n::Cint, nrhs::Cint,
-                                        Aarray::CuPtr{Ptr{cuComplex}}, lda::Cint,
-                                        Carray::CuPtr{Ptr{cuComplex}}, ldc::Cint,
-                                        info::Ptr{Cint}, devInfoArray::CuPtr{Cint},
-                                        batchSize::Cint)::cublasStatus_t
+    @gcsafe_ccall libcublas.cublasCgelsBatched(handle::cublasHandle_t,
+                                               trans::cublasOperation_t, m::Cint, n::Cint,
+                                               nrhs::Cint, Aarray::CuPtr{Ptr{cuComplex}},
+                                               lda::Cint, Carray::CuPtr{Ptr{cuComplex}},
+                                               ldc::Cint, info::Ptr{Cint},
+                                               devInfoArray::CuPtr{Cint},
+                                               batchSize::Cint)::cublasStatus_t
 end
 
 @checked function cublasZgelsBatched(handle, trans, m, n, nrhs, Aarray, lda, Carray, ldc,
                                      info, devInfoArray, batchSize)
     initialize_context()
-    @ccall libcublas.cublasZgelsBatched(handle::cublasHandle_t, trans::cublasOperation_t,
-                                        m::Cint, n::Cint, nrhs::Cint,
-                                        Aarray::CuPtr{Ptr{cuDoubleComplex}}, lda::Cint,
-                                        Carray::CuPtr{Ptr{cuDoubleComplex}}, ldc::Cint,
-                                        info::Ptr{Cint}, devInfoArray::CuPtr{Cint},
-                                        batchSize::Cint)::cublasStatus_t
+    @gcsafe_ccall libcublas.cublasZgelsBatched(handle::cublasHandle_t,
+                                               trans::cublasOperation_t, m::Cint, n::Cint,
+                                               nrhs::Cint,
+                                               Aarray::CuPtr{Ptr{cuDoubleComplex}},
+                                               lda::Cint,
+                                               Carray::CuPtr{Ptr{cuDoubleComplex}},
+                                               ldc::Cint, info::Ptr{Cint},
+                                               devInfoArray::CuPtr{Cint},
+                                               batchSize::Cint)::cublasStatus_t
 end
 
 @checked function cublasStpttr(handle, uplo, n, AP, A, lda)
     initialize_context()
-    @ccall libcublas.cublasStpttr(handle::cublasHandle_t, uplo::cublasFillMode_t, n::Cint,
-                                  AP::CuPtr{Cfloat}, A::CuPtr{Cfloat},
-                                  lda::Cint)::cublasStatus_t
+    @gcsafe_ccall libcublas.cublasStpttr(handle::cublasHandle_t, uplo::cublasFillMode_t,
+                                         n::Cint, AP::CuPtr{Cfloat}, A::CuPtr{Cfloat},
+                                         lda::Cint)::cublasStatus_t
 end
 
 @checked function cublasDtpttr(handle, uplo, n, AP, A, lda)
     initialize_context()
-    @ccall libcublas.cublasDtpttr(handle::cublasHandle_t, uplo::cublasFillMode_t, n::Cint,
-                                  AP::CuPtr{Cdouble}, A::CuPtr{Cdouble},
-                                  lda::Cint)::cublasStatus_t
+    @gcsafe_ccall libcublas.cublasDtpttr(handle::cublasHandle_t, uplo::cublasFillMode_t,
+                                         n::Cint, AP::CuPtr{Cdouble}, A::CuPtr{Cdouble},
+                                         lda::Cint)::cublasStatus_t
 end
 
 @checked function cublasCtpttr(handle, uplo, n, AP, A, lda)
     initialize_context()
-    @ccall libcublas.cublasCtpttr(handle::cublasHandle_t, uplo::cublasFillMode_t, n::Cint,
-                                  AP::CuPtr{cuComplex}, A::CuPtr{cuComplex},
-                                  lda::Cint)::cublasStatus_t
+    @gcsafe_ccall libcublas.cublasCtpttr(handle::cublasHandle_t, uplo::cublasFillMode_t,
+                                         n::Cint, AP::CuPtr{cuComplex}, A::CuPtr{cuComplex},
+                                         lda::Cint)::cublasStatus_t
 end
 
 @checked function cublasZtpttr(handle, uplo, n, AP, A, lda)
     initialize_context()
-    @ccall libcublas.cublasZtpttr(handle::cublasHandle_t, uplo::cublasFillMode_t, n::Cint,
-                                  AP::CuPtr{cuDoubleComplex}, A::CuPtr{cuDoubleComplex},
-                                  lda::Cint)::cublasStatus_t
+    @gcsafe_ccall libcublas.cublasZtpttr(handle::cublasHandle_t, uplo::cublasFillMode_t,
+                                         n::Cint, AP::CuPtr{cuDoubleComplex},
+                                         A::CuPtr{cuDoubleComplex},
+                                         lda::Cint)::cublasStatus_t
 end
 
 @checked function cublasStrttp(handle, uplo, n, A, lda, AP)
     initialize_context()
-    @ccall libcublas.cublasStrttp(handle::cublasHandle_t, uplo::cublasFillMode_t, n::Cint,
-                                  A::CuPtr{Cfloat}, lda::Cint,
-                                  AP::CuPtr{Cfloat})::cublasStatus_t
+    @gcsafe_ccall libcublas.cublasStrttp(handle::cublasHandle_t, uplo::cublasFillMode_t,
+                                         n::Cint, A::CuPtr{Cfloat}, lda::Cint,
+                                         AP::CuPtr{Cfloat})::cublasStatus_t
 end
 
 @checked function cublasDtrttp(handle, uplo, n, A, lda, AP)
     initialize_context()
-    @ccall libcublas.cublasDtrttp(handle::cublasHandle_t, uplo::cublasFillMode_t, n::Cint,
-                                  A::CuPtr{Cdouble}, lda::Cint,
-                                  AP::CuPtr{Cdouble})::cublasStatus_t
+    @gcsafe_ccall libcublas.cublasDtrttp(handle::cublasHandle_t, uplo::cublasFillMode_t,
+                                         n::Cint, A::CuPtr{Cdouble}, lda::Cint,
+                                         AP::CuPtr{Cdouble})::cublasStatus_t
 end
 
 @checked function cublasCtrttp(handle, uplo, n, A, lda, AP)
     initialize_context()
-    @ccall libcublas.cublasCtrttp(handle::cublasHandle_t, uplo::cublasFillMode_t, n::Cint,
-                                  A::CuPtr{cuComplex}, lda::Cint,
-                                  AP::CuPtr{cuComplex})::cublasStatus_t
+    @gcsafe_ccall libcublas.cublasCtrttp(handle::cublasHandle_t, uplo::cublasFillMode_t,
+                                         n::Cint, A::CuPtr{cuComplex}, lda::Cint,
+                                         AP::CuPtr{cuComplex})::cublasStatus_t
 end
 
 @checked function cublasZtrttp(handle, uplo, n, A, lda, AP)
     initialize_context()
-    @ccall libcublas.cublasZtrttp(handle::cublasHandle_t, uplo::cublasFillMode_t, n::Cint,
-                                  A::CuPtr{cuDoubleComplex}, lda::Cint,
-                                  AP::CuPtr{cuDoubleComplex})::cublasStatus_t
+    @gcsafe_ccall libcublas.cublasZtrttp(handle::cublasHandle_t, uplo::cublasFillMode_t,
+                                         n::Cint, A::CuPtr{cuDoubleComplex}, lda::Cint,
+                                         AP::CuPtr{cuDoubleComplex})::cublasStatus_t
 end
 
 @checked function cublasSgetrfBatched(handle, n, A, lda, P, info, batchSize)
     initialize_context()
-    @ccall libcublas.cublasSgetrfBatched(handle::cublasHandle_t, n::Cint,
-                                         A::CuPtr{Ptr{Cfloat}}, lda::Cint, P::CuPtr{Cint},
-                                         info::CuPtr{Cint}, batchSize::Cint)::cublasStatus_t
+    @gcsafe_ccall libcublas.cublasSgetrfBatched(handle::cublasHandle_t, n::Cint,
+                                                A::CuPtr{Ptr{Cfloat}}, lda::Cint,
+                                                P::CuPtr{Cint}, info::CuPtr{Cint},
+                                                batchSize::Cint)::cublasStatus_t
 end
 
 @checked function cublasDgetrfBatched(handle, n, A, lda, P, info, batchSize)
     initialize_context()
-    @ccall libcublas.cublasDgetrfBatched(handle::cublasHandle_t, n::Cint,
-                                         A::CuPtr{Ptr{Cdouble}}, lda::Cint, P::CuPtr{Cint},
-                                         info::CuPtr{Cint}, batchSize::Cint)::cublasStatus_t
+    @gcsafe_ccall libcublas.cublasDgetrfBatched(handle::cublasHandle_t, n::Cint,
+                                                A::CuPtr{Ptr{Cdouble}}, lda::Cint,
+                                                P::CuPtr{Cint}, info::CuPtr{Cint},
+                                                batchSize::Cint)::cublasStatus_t
 end
 
 @checked function cublasCgetrfBatched(handle, n, A, lda, P, info, batchSize)
     initialize_context()
-    @ccall libcublas.cublasCgetrfBatched(handle::cublasHandle_t, n::Cint,
-                                         A::CuPtr{Ptr{cuComplex}}, lda::Cint,
-                                         P::CuPtr{Cint}, info::CuPtr{Cint},
-                                         batchSize::Cint)::cublasStatus_t
+    @gcsafe_ccall libcublas.cublasCgetrfBatched(handle::cublasHandle_t, n::Cint,
+                                                A::CuPtr{Ptr{cuComplex}}, lda::Cint,
+                                                P::CuPtr{Cint}, info::CuPtr{Cint},
+                                                batchSize::Cint)::cublasStatus_t
 end
 
 @checked function cublasZgetrfBatched(handle, n, A, lda, P, info, batchSize)
     initialize_context()
-    @ccall libcublas.cublasZgetrfBatched(handle::cublasHandle_t, n::Cint,
-                                         A::CuPtr{Ptr{cuDoubleComplex}}, lda::Cint,
-                                         P::CuPtr{Cint}, info::CuPtr{Cint},
-                                         batchSize::Cint)::cublasStatus_t
+    @gcsafe_ccall libcublas.cublasZgetrfBatched(handle::cublasHandle_t, n::Cint,
+                                                A::CuPtr{Ptr{cuDoubleComplex}}, lda::Cint,
+                                                P::CuPtr{Cint}, info::CuPtr{Cint},
+                                                batchSize::Cint)::cublasStatus_t
 end
 
 @checked function cublasSgetriBatched(handle, n, A, lda, P, C, ldc, info, batchSize)
     initialize_context()
-    @ccall libcublas.cublasSgetriBatched(handle::cublasHandle_t, n::Cint,
-                                         A::CuPtr{Ptr{Cfloat}}, lda::Cint, P::CuPtr{Cint},
-                                         C::CuPtr{Ptr{Cfloat}}, ldc::Cint,
-                                         info::CuPtr{Cint}, batchSize::Cint)::cublasStatus_t
+    @gcsafe_ccall libcublas.cublasSgetriBatched(handle::cublasHandle_t, n::Cint,
+                                                A::CuPtr{Ptr{Cfloat}}, lda::Cint,
+                                                P::CuPtr{Cint}, C::CuPtr{Ptr{Cfloat}},
+                                                ldc::Cint, info::CuPtr{Cint},
+                                                batchSize::Cint)::cublasStatus_t
 end
 
 @checked function cublasDgetriBatched(handle, n, A, lda, P, C, ldc, info, batchSize)
     initialize_context()
-    @ccall libcublas.cublasDgetriBatched(handle::cublasHandle_t, n::Cint,
-                                         A::CuPtr{Ptr{Cdouble}}, lda::Cint, P::CuPtr{Cint},
-                                         C::CuPtr{Ptr{Cdouble}}, ldc::Cint,
-                                         info::CuPtr{Cint}, batchSize::Cint)::cublasStatus_t
+    @gcsafe_ccall libcublas.cublasDgetriBatched(handle::cublasHandle_t, n::Cint,
+                                                A::CuPtr{Ptr{Cdouble}}, lda::Cint,
+                                                P::CuPtr{Cint}, C::CuPtr{Ptr{Cdouble}},
+                                                ldc::Cint, info::CuPtr{Cint},
+                                                batchSize::Cint)::cublasStatus_t
 end
 
 @checked function cublasCgetriBatched(handle, n, A, lda, P, C, ldc, info, batchSize)
     initialize_context()
-    @ccall libcublas.cublasCgetriBatched(handle::cublasHandle_t, n::Cint,
-                                         A::CuPtr{Ptr{cuComplex}}, lda::Cint,
-                                         P::CuPtr{Cint}, C::CuPtr{Ptr{cuComplex}},
-                                         ldc::Cint, info::CuPtr{Cint},
-                                         batchSize::Cint)::cublasStatus_t
+    @gcsafe_ccall libcublas.cublasCgetriBatched(handle::cublasHandle_t, n::Cint,
+                                                A::CuPtr{Ptr{cuComplex}}, lda::Cint,
+                                                P::CuPtr{Cint}, C::CuPtr{Ptr{cuComplex}},
+                                                ldc::Cint, info::CuPtr{Cint},
+                                                batchSize::Cint)::cublasStatus_t
 end
 
 @checked function cublasZgetriBatched(handle, n, A, lda, P, C, ldc, info, batchSize)
     initialize_context()
-    @ccall libcublas.cublasZgetriBatched(handle::cublasHandle_t, n::Cint,
-                                         A::CuPtr{Ptr{cuDoubleComplex}}, lda::Cint,
-                                         P::CuPtr{Cint}, C::CuPtr{Ptr{cuDoubleComplex}},
-                                         ldc::Cint, info::CuPtr{Cint},
-                                         batchSize::Cint)::cublasStatus_t
+    @gcsafe_ccall libcublas.cublasZgetriBatched(handle::cublasHandle_t, n::Cint,
+                                                A::CuPtr{Ptr{cuDoubleComplex}}, lda::Cint,
+                                                P::CuPtr{Cint},
+                                                C::CuPtr{Ptr{cuDoubleComplex}}, ldc::Cint,
+                                                info::CuPtr{Cint},
+                                                batchSize::Cint)::cublasStatus_t
 end
 
 @checked function cublasSgetrsBatched(handle, trans, n, nrhs, Aarray, lda, devIpiv, Barray,
                                       ldb, info, batchSize)
     initialize_context()
-    @ccall libcublas.cublasSgetrsBatched(handle::cublasHandle_t, trans::cublasOperation_t,
-                                         n::Cint, nrhs::Cint, Aarray::CuPtr{Ptr{Cfloat}},
-                                         lda::Cint, devIpiv::CuPtr{Cint},
-                                         Barray::CuPtr{Ptr{Cfloat}}, ldb::Cint,
-                                         info::Ptr{Cint}, batchSize::Cint)::cublasStatus_t
+    @gcsafe_ccall libcublas.cublasSgetrsBatched(handle::cublasHandle_t,
+                                                trans::cublasOperation_t, n::Cint,
+                                                nrhs::Cint, Aarray::CuPtr{Ptr{Cfloat}},
+                                                lda::Cint, devIpiv::CuPtr{Cint},
+                                                Barray::CuPtr{Ptr{Cfloat}}, ldb::Cint,
+                                                info::Ptr{Cint},
+                                                batchSize::Cint)::cublasStatus_t
 end
 
 @checked function cublasDgetrsBatched(handle, trans, n, nrhs, Aarray, lda, devIpiv, Barray,
                                       ldb, info, batchSize)
     initialize_context()
-    @ccall libcublas.cublasDgetrsBatched(handle::cublasHandle_t, trans::cublasOperation_t,
-                                         n::Cint, nrhs::Cint, Aarray::CuPtr{Ptr{Cdouble}},
-                                         lda::Cint, devIpiv::CuPtr{Cint},
-                                         Barray::CuPtr{Ptr{Cdouble}}, ldb::Cint,
-                                         info::Ptr{Cint}, batchSize::Cint)::cublasStatus_t
+    @gcsafe_ccall libcublas.cublasDgetrsBatched(handle::cublasHandle_t,
+                                                trans::cublasOperation_t, n::Cint,
+                                                nrhs::Cint, Aarray::CuPtr{Ptr{Cdouble}},
+                                                lda::Cint, devIpiv::CuPtr{Cint},
+                                                Barray::CuPtr{Ptr{Cdouble}}, ldb::Cint,
+                                                info::Ptr{Cint},
+                                                batchSize::Cint)::cublasStatus_t
 end
 
 @checked function cublasCgetrsBatched(handle, trans, n, nrhs, Aarray, lda, devIpiv, Barray,
                                       ldb, info, batchSize)
     initialize_context()
-    @ccall libcublas.cublasCgetrsBatched(handle::cublasHandle_t, trans::cublasOperation_t,
-                                         n::Cint, nrhs::Cint, Aarray::CuPtr{Ptr{cuComplex}},
-                                         lda::Cint, devIpiv::CuPtr{Cint},
-                                         Barray::CuPtr{Ptr{cuComplex}}, ldb::Cint,
-                                         info::Ptr{Cint}, batchSize::Cint)::cublasStatus_t
+    @gcsafe_ccall libcublas.cublasCgetrsBatched(handle::cublasHandle_t,
+                                                trans::cublasOperation_t, n::Cint,
+                                                nrhs::Cint, Aarray::CuPtr{Ptr{cuComplex}},
+                                                lda::Cint, devIpiv::CuPtr{Cint},
+                                                Barray::CuPtr{Ptr{cuComplex}}, ldb::Cint,
+                                                info::Ptr{Cint},
+                                                batchSize::Cint)::cublasStatus_t
 end
 
 @checked function cublasZgetrsBatched(handle, trans, n, nrhs, Aarray, lda, devIpiv, Barray,
                                       ldb, info, batchSize)
     initialize_context()
-    @ccall libcublas.cublasZgetrsBatched(handle::cublasHandle_t, trans::cublasOperation_t,
-                                         n::Cint, nrhs::Cint,
-                                         Aarray::CuPtr{Ptr{cuDoubleComplex}}, lda::Cint,
-                                         devIpiv::CuPtr{Cint},
-                                         Barray::CuPtr{Ptr{cuDoubleComplex}}, ldb::Cint,
-                                         info::Ptr{Cint}, batchSize::Cint)::cublasStatus_t
+    @gcsafe_ccall libcublas.cublasZgetrsBatched(handle::cublasHandle_t,
+                                                trans::cublasOperation_t, n::Cint,
+                                                nrhs::Cint,
+                                                Aarray::CuPtr{Ptr{cuDoubleComplex}},
+                                                lda::Cint, devIpiv::CuPtr{Cint},
+                                                Barray::CuPtr{Ptr{cuDoubleComplex}},
+                                                ldb::Cint, info::Ptr{Cint},
+                                                batchSize::Cint)::cublasStatus_t
 end
 
 @checked function cublasUint8gemmBias(handle, transa, transb, transc, m, n, k, A, A_bias,
                                       lda, B, B_bias, ldb, C, C_bias, ldc, C_mult, C_shift)
     initialize_context()
-    @ccall libcublas.cublasUint8gemmBias(handle::cublasHandle_t, transa::cublasOperation_t,
-                                         transb::cublasOperation_t,
-                                         transc::cublasOperation_t, m::Cint, n::Cint,
-                                         k::Cint, A::CuPtr{Cuchar}, A_bias::Cint, lda::Cint,
-                                         B::CuPtr{Cuchar}, B_bias::Cint, ldb::Cint,
-                                         C::CuPtr{Cuchar}, C_bias::Cint, ldc::Cint,
-                                         C_mult::Cint, C_shift::Cint)::cublasStatus_t
+    @gcsafe_ccall libcublas.cublasUint8gemmBias(handle::cublasHandle_t,
+                                                transa::cublasOperation_t,
+                                                transb::cublasOperation_t,
+                                                transc::cublasOperation_t, m::Cint, n::Cint,
+                                                k::Cint, A::CuPtr{Cuchar}, A_bias::Cint,
+                                                lda::Cint, B::CuPtr{Cuchar}, B_bias::Cint,
+                                                ldb::Cint, C::CuPtr{Cuchar}, C_bias::Cint,
+                                                ldc::Cint, C_mult::Cint,
+                                                C_shift::Cint)::cublasStatus_t
 end
 
 mutable struct cublasXtContext end
@@ -4775,41 +5245,41 @@ const cublasXtHandle_t = Ptr{cublasXtContext}
 
 @checked function cublasXtCreate(handle)
     initialize_context()
-    @ccall libcublas.cublasXtCreate(handle::Ptr{cublasXtHandle_t})::cublasStatus_t
+    @gcsafe_ccall libcublas.cublasXtCreate(handle::Ptr{cublasXtHandle_t})::cublasStatus_t
 end
 
 @checked function cublasXtDestroy(handle)
     initialize_context()
-    @ccall libcublas.cublasXtDestroy(handle::cublasXtHandle_t)::cublasStatus_t
+    @gcsafe_ccall libcublas.cublasXtDestroy(handle::cublasXtHandle_t)::cublasStatus_t
 end
 
 @checked function cublasXtGetNumBoards(nbDevices, deviceId, nbBoards)
     initialize_context()
-    @ccall libcublas.cublasXtGetNumBoards(nbDevices::Cint, deviceId::Ptr{Cint},
-                                          nbBoards::Ptr{Cint})::cublasStatus_t
+    @gcsafe_ccall libcublas.cublasXtGetNumBoards(nbDevices::Cint, deviceId::Ptr{Cint},
+                                                 nbBoards::Ptr{Cint})::cublasStatus_t
 end
 
 @checked function cublasXtMaxBoards(nbGpuBoards)
     initialize_context()
-    @ccall libcublas.cublasXtMaxBoards(nbGpuBoards::Ptr{Cint})::cublasStatus_t
+    @gcsafe_ccall libcublas.cublasXtMaxBoards(nbGpuBoards::Ptr{Cint})::cublasStatus_t
 end
 
 @checked function cublasXtDeviceSelect(handle, nbDevices, deviceId)
     initialize_context()
-    @ccall libcublas.cublasXtDeviceSelect(handle::cublasXtHandle_t, nbDevices::Cint,
-                                          deviceId::Ptr{Cint})::cublasStatus_t
+    @gcsafe_ccall libcublas.cublasXtDeviceSelect(handle::cublasXtHandle_t, nbDevices::Cint,
+                                                 deviceId::Ptr{Cint})::cublasStatus_t
 end
 
 @checked function cublasXtSetBlockDim(handle, blockDim)
     initialize_context()
-    @ccall libcublas.cublasXtSetBlockDim(handle::cublasXtHandle_t,
-                                         blockDim::Cint)::cublasStatus_t
+    @gcsafe_ccall libcublas.cublasXtSetBlockDim(handle::cublasXtHandle_t,
+                                                blockDim::Cint)::cublasStatus_t
 end
 
 @checked function cublasXtGetBlockDim(handle, blockDim)
     initialize_context()
-    @ccall libcublas.cublasXtGetBlockDim(handle::cublasXtHandle_t,
-                                         blockDim::Ptr{Cint})::cublasStatus_t
+    @gcsafe_ccall libcublas.cublasXtGetBlockDim(handle::cublasXtHandle_t,
+                                                blockDim::Ptr{Cint})::cublasStatus_t
 end
 
 @cenum cublasXtPinnedMemMode_t::UInt32 begin
@@ -4819,14 +5289,14 @@ end
 
 @checked function cublasXtGetPinningMemMode(handle, mode)
     initialize_context()
-    @ccall libcublas.cublasXtGetPinningMemMode(handle::cublasXtHandle_t,
-                                               mode::Ptr{cublasXtPinnedMemMode_t})::cublasStatus_t
+    @gcsafe_ccall libcublas.cublasXtGetPinningMemMode(handle::cublasXtHandle_t,
+                                                      mode::Ptr{cublasXtPinnedMemMode_t})::cublasStatus_t
 end
 
 @checked function cublasXtSetPinningMemMode(handle, mode)
     initialize_context()
-    @ccall libcublas.cublasXtSetPinningMemMode(handle::cublasXtHandle_t,
-                                               mode::cublasXtPinnedMemMode_t)::cublasStatus_t
+    @gcsafe_ccall libcublas.cublasXtSetPinningMemMode(handle::cublasXtHandle_t,
+                                                      mode::cublasXtPinnedMemMode_t)::cublasStatus_t
 end
 
 @cenum cublasXtOpType_t::UInt32 begin
@@ -4854,463 +5324,505 @@ end
 
 @checked function cublasXtSetCpuRoutine(handle, blasOp, type, blasFunctor)
     initialize_context()
-    @ccall libcublas.cublasXtSetCpuRoutine(handle::cublasXtHandle_t,
-                                           blasOp::cublasXtBlasOp_t, type::cublasXtOpType_t,
-                                           blasFunctor::Ptr{Cvoid})::cublasStatus_t
+    @gcsafe_ccall libcublas.cublasXtSetCpuRoutine(handle::cublasXtHandle_t,
+                                                  blasOp::cublasXtBlasOp_t,
+                                                  type::cublasXtOpType_t,
+                                                  blasFunctor::Ptr{Cvoid})::cublasStatus_t
 end
 
 @checked function cublasXtSetCpuRatio(handle, blasOp, type, ratio)
     initialize_context()
-    @ccall libcublas.cublasXtSetCpuRatio(handle::cublasXtHandle_t, blasOp::cublasXtBlasOp_t,
-                                         type::cublasXtOpType_t,
-                                         ratio::Cfloat)::cublasStatus_t
+    @gcsafe_ccall libcublas.cublasXtSetCpuRatio(handle::cublasXtHandle_t,
+                                                blasOp::cublasXtBlasOp_t,
+                                                type::cublasXtOpType_t,
+                                                ratio::Cfloat)::cublasStatus_t
 end
 
 @checked function cublasXtSgemm(handle, transa, transb, m, n, k, alpha, A, lda, B, ldb,
                                 beta, C, ldc)
     initialize_context()
-    @ccall libcublas.cublasXtSgemm(handle::cublasXtHandle_t, transa::cublasOperation_t,
-                                   transb::cublasOperation_t, m::Csize_t, n::Csize_t,
-                                   k::Csize_t, alpha::RefOrCuRef{Cfloat},
-                                   A::PtrOrCuPtr{Cfloat}, lda::Csize_t,
-                                   B::PtrOrCuPtr{Cfloat}, ldb::Csize_t,
-                                   beta::RefOrCuRef{Cfloat}, C::PtrOrCuPtr{Cfloat},
-                                   ldc::Csize_t)::cublasStatus_t
+    @gcsafe_ccall libcublas.cublasXtSgemm(handle::cublasXtHandle_t,
+                                          transa::cublasOperation_t,
+                                          transb::cublasOperation_t, m::Csize_t, n::Csize_t,
+                                          k::Csize_t, alpha::RefOrCuRef{Cfloat},
+                                          A::PtrOrCuPtr{Cfloat}, lda::Csize_t,
+                                          B::PtrOrCuPtr{Cfloat}, ldb::Csize_t,
+                                          beta::RefOrCuRef{Cfloat}, C::PtrOrCuPtr{Cfloat},
+                                          ldc::Csize_t)::cublasStatus_t
 end
 
 @checked function cublasXtDgemm(handle, transa, transb, m, n, k, alpha, A, lda, B, ldb,
                                 beta, C, ldc)
     initialize_context()
-    @ccall libcublas.cublasXtDgemm(handle::cublasXtHandle_t, transa::cublasOperation_t,
-                                   transb::cublasOperation_t, m::Csize_t, n::Csize_t,
-                                   k::Csize_t, alpha::RefOrCuRef{Cdouble},
-                                   A::PtrOrCuPtr{Cdouble}, lda::Csize_t,
-                                   B::PtrOrCuPtr{Cdouble}, ldb::Csize_t,
-                                   beta::RefOrCuRef{Cdouble}, C::PtrOrCuPtr{Cdouble},
-                                   ldc::Csize_t)::cublasStatus_t
+    @gcsafe_ccall libcublas.cublasXtDgemm(handle::cublasXtHandle_t,
+                                          transa::cublasOperation_t,
+                                          transb::cublasOperation_t, m::Csize_t, n::Csize_t,
+                                          k::Csize_t, alpha::RefOrCuRef{Cdouble},
+                                          A::PtrOrCuPtr{Cdouble}, lda::Csize_t,
+                                          B::PtrOrCuPtr{Cdouble}, ldb::Csize_t,
+                                          beta::RefOrCuRef{Cdouble}, C::PtrOrCuPtr{Cdouble},
+                                          ldc::Csize_t)::cublasStatus_t
 end
 
 @checked function cublasXtCgemm(handle, transa, transb, m, n, k, alpha, A, lda, B, ldb,
                                 beta, C, ldc)
     initialize_context()
-    @ccall libcublas.cublasXtCgemm(handle::cublasXtHandle_t, transa::cublasOperation_t,
-                                   transb::cublasOperation_t, m::Csize_t, n::Csize_t,
-                                   k::Csize_t, alpha::RefOrCuRef{cuComplex},
-                                   A::PtrOrCuPtr{cuComplex}, lda::Csize_t,
-                                   B::PtrOrCuPtr{cuComplex}, ldb::Csize_t,
-                                   beta::RefOrCuRef{cuComplex}, C::PtrOrCuPtr{cuComplex},
-                                   ldc::Csize_t)::cublasStatus_t
+    @gcsafe_ccall libcublas.cublasXtCgemm(handle::cublasXtHandle_t,
+                                          transa::cublasOperation_t,
+                                          transb::cublasOperation_t, m::Csize_t, n::Csize_t,
+                                          k::Csize_t, alpha::RefOrCuRef{cuComplex},
+                                          A::PtrOrCuPtr{cuComplex}, lda::Csize_t,
+                                          B::PtrOrCuPtr{cuComplex}, ldb::Csize_t,
+                                          beta::RefOrCuRef{cuComplex},
+                                          C::PtrOrCuPtr{cuComplex},
+                                          ldc::Csize_t)::cublasStatus_t
 end
 
 @checked function cublasXtZgemm(handle, transa, transb, m, n, k, alpha, A, lda, B, ldb,
                                 beta, C, ldc)
     initialize_context()
-    @ccall libcublas.cublasXtZgemm(handle::cublasXtHandle_t, transa::cublasOperation_t,
-                                   transb::cublasOperation_t, m::Csize_t, n::Csize_t,
-                                   k::Csize_t, alpha::RefOrCuRef{cuDoubleComplex},
-                                   A::PtrOrCuPtr{cuDoubleComplex}, lda::Csize_t,
-                                   B::PtrOrCuPtr{cuDoubleComplex}, ldb::Csize_t,
-                                   beta::RefOrCuRef{cuDoubleComplex},
-                                   C::PtrOrCuPtr{cuDoubleComplex},
-                                   ldc::Csize_t)::cublasStatus_t
+    @gcsafe_ccall libcublas.cublasXtZgemm(handle::cublasXtHandle_t,
+                                          transa::cublasOperation_t,
+                                          transb::cublasOperation_t, m::Csize_t, n::Csize_t,
+                                          k::Csize_t, alpha::RefOrCuRef{cuDoubleComplex},
+                                          A::PtrOrCuPtr{cuDoubleComplex}, lda::Csize_t,
+                                          B::PtrOrCuPtr{cuDoubleComplex}, ldb::Csize_t,
+                                          beta::RefOrCuRef{cuDoubleComplex},
+                                          C::PtrOrCuPtr{cuDoubleComplex},
+                                          ldc::Csize_t)::cublasStatus_t
 end
 
 @checked function cublasXtSsyrk(handle, uplo, trans, n, k, alpha, A, lda, beta, C, ldc)
     initialize_context()
-    @ccall libcublas.cublasXtSsyrk(handle::cublasXtHandle_t, uplo::cublasFillMode_t,
-                                   trans::cublasOperation_t, n::Csize_t, k::Csize_t,
-                                   alpha::RefOrCuRef{Cfloat}, A::PtrOrCuPtr{Cfloat},
-                                   lda::Csize_t, beta::RefOrCuRef{Cfloat},
-                                   C::PtrOrCuPtr{Cfloat}, ldc::Csize_t)::cublasStatus_t
+    @gcsafe_ccall libcublas.cublasXtSsyrk(handle::cublasXtHandle_t, uplo::cublasFillMode_t,
+                                          trans::cublasOperation_t, n::Csize_t, k::Csize_t,
+                                          alpha::RefOrCuRef{Cfloat}, A::PtrOrCuPtr{Cfloat},
+                                          lda::Csize_t, beta::RefOrCuRef{Cfloat},
+                                          C::PtrOrCuPtr{Cfloat},
+                                          ldc::Csize_t)::cublasStatus_t
 end
 
 @checked function cublasXtDsyrk(handle, uplo, trans, n, k, alpha, A, lda, beta, C, ldc)
     initialize_context()
-    @ccall libcublas.cublasXtDsyrk(handle::cublasXtHandle_t, uplo::cublasFillMode_t,
-                                   trans::cublasOperation_t, n::Csize_t, k::Csize_t,
-                                   alpha::RefOrCuRef{Cdouble}, A::PtrOrCuPtr{Cdouble},
-                                   lda::Csize_t, beta::RefOrCuRef{Cdouble},
-                                   C::PtrOrCuPtr{Cdouble}, ldc::Csize_t)::cublasStatus_t
+    @gcsafe_ccall libcublas.cublasXtDsyrk(handle::cublasXtHandle_t, uplo::cublasFillMode_t,
+                                          trans::cublasOperation_t, n::Csize_t, k::Csize_t,
+                                          alpha::RefOrCuRef{Cdouble},
+                                          A::PtrOrCuPtr{Cdouble}, lda::Csize_t,
+                                          beta::RefOrCuRef{Cdouble}, C::PtrOrCuPtr{Cdouble},
+                                          ldc::Csize_t)::cublasStatus_t
 end
 
 @checked function cublasXtCsyrk(handle, uplo, trans, n, k, alpha, A, lda, beta, C, ldc)
     initialize_context()
-    @ccall libcublas.cublasXtCsyrk(handle::cublasXtHandle_t, uplo::cublasFillMode_t,
-                                   trans::cublasOperation_t, n::Csize_t, k::Csize_t,
-                                   alpha::RefOrCuRef{cuComplex}, A::PtrOrCuPtr{cuComplex},
-                                   lda::Csize_t, beta::RefOrCuRef{cuComplex},
-                                   C::PtrOrCuPtr{cuComplex}, ldc::Csize_t)::cublasStatus_t
+    @gcsafe_ccall libcublas.cublasXtCsyrk(handle::cublasXtHandle_t, uplo::cublasFillMode_t,
+                                          trans::cublasOperation_t, n::Csize_t, k::Csize_t,
+                                          alpha::RefOrCuRef{cuComplex},
+                                          A::PtrOrCuPtr{cuComplex}, lda::Csize_t,
+                                          beta::RefOrCuRef{cuComplex},
+                                          C::PtrOrCuPtr{cuComplex},
+                                          ldc::Csize_t)::cublasStatus_t
 end
 
 @checked function cublasXtZsyrk(handle, uplo, trans, n, k, alpha, A, lda, beta, C, ldc)
     initialize_context()
-    @ccall libcublas.cublasXtZsyrk(handle::cublasXtHandle_t, uplo::cublasFillMode_t,
-                                   trans::cublasOperation_t, n::Csize_t, k::Csize_t,
-                                   alpha::RefOrCuRef{cuDoubleComplex},
-                                   A::PtrOrCuPtr{cuDoubleComplex}, lda::Csize_t,
-                                   beta::RefOrCuRef{cuDoubleComplex},
-                                   C::PtrOrCuPtr{cuDoubleComplex},
-                                   ldc::Csize_t)::cublasStatus_t
+    @gcsafe_ccall libcublas.cublasXtZsyrk(handle::cublasXtHandle_t, uplo::cublasFillMode_t,
+                                          trans::cublasOperation_t, n::Csize_t, k::Csize_t,
+                                          alpha::RefOrCuRef{cuDoubleComplex},
+                                          A::PtrOrCuPtr{cuDoubleComplex}, lda::Csize_t,
+                                          beta::RefOrCuRef{cuDoubleComplex},
+                                          C::PtrOrCuPtr{cuDoubleComplex},
+                                          ldc::Csize_t)::cublasStatus_t
 end
 
 @checked function cublasXtCherk(handle, uplo, trans, n, k, alpha, A, lda, beta, C, ldc)
     initialize_context()
-    @ccall libcublas.cublasXtCherk(handle::cublasXtHandle_t, uplo::cublasFillMode_t,
-                                   trans::cublasOperation_t, n::Csize_t, k::Csize_t,
-                                   alpha::RefOrCuRef{Cfloat}, A::PtrOrCuPtr{cuComplex},
-                                   lda::Csize_t, beta::RefOrCuRef{Cfloat},
-                                   C::PtrOrCuPtr{cuComplex}, ldc::Csize_t)::cublasStatus_t
+    @gcsafe_ccall libcublas.cublasXtCherk(handle::cublasXtHandle_t, uplo::cublasFillMode_t,
+                                          trans::cublasOperation_t, n::Csize_t, k::Csize_t,
+                                          alpha::RefOrCuRef{Cfloat},
+                                          A::PtrOrCuPtr{cuComplex}, lda::Csize_t,
+                                          beta::RefOrCuRef{Cfloat},
+                                          C::PtrOrCuPtr{cuComplex},
+                                          ldc::Csize_t)::cublasStatus_t
 end
 
 @checked function cublasXtZherk(handle, uplo, trans, n, k, alpha, A, lda, beta, C, ldc)
     initialize_context()
-    @ccall libcublas.cublasXtZherk(handle::cublasXtHandle_t, uplo::cublasFillMode_t,
-                                   trans::cublasOperation_t, n::Csize_t, k::Csize_t,
-                                   alpha::RefOrCuRef{Cdouble},
-                                   A::PtrOrCuPtr{cuDoubleComplex}, lda::Csize_t,
-                                   beta::RefOrCuRef{Cdouble},
-                                   C::PtrOrCuPtr{cuDoubleComplex},
-                                   ldc::Csize_t)::cublasStatus_t
+    @gcsafe_ccall libcublas.cublasXtZherk(handle::cublasXtHandle_t, uplo::cublasFillMode_t,
+                                          trans::cublasOperation_t, n::Csize_t, k::Csize_t,
+                                          alpha::RefOrCuRef{Cdouble},
+                                          A::PtrOrCuPtr{cuDoubleComplex}, lda::Csize_t,
+                                          beta::RefOrCuRef{Cdouble},
+                                          C::PtrOrCuPtr{cuDoubleComplex},
+                                          ldc::Csize_t)::cublasStatus_t
 end
 
 @checked function cublasXtSsyr2k(handle, uplo, trans, n, k, alpha, A, lda, B, ldb, beta, C,
                                  ldc)
     initialize_context()
-    @ccall libcublas.cublasXtSsyr2k(handle::cublasXtHandle_t, uplo::cublasFillMode_t,
-                                    trans::cublasOperation_t, n::Csize_t, k::Csize_t,
-                                    alpha::RefOrCuRef{Cfloat}, A::PtrOrCuPtr{Cfloat},
-                                    lda::Csize_t, B::PtrOrCuPtr{Cfloat}, ldb::Csize_t,
-                                    beta::RefOrCuRef{Cfloat}, C::PtrOrCuPtr{Cfloat},
-                                    ldc::Csize_t)::cublasStatus_t
+    @gcsafe_ccall libcublas.cublasXtSsyr2k(handle::cublasXtHandle_t, uplo::cublasFillMode_t,
+                                           trans::cublasOperation_t, n::Csize_t, k::Csize_t,
+                                           alpha::RefOrCuRef{Cfloat}, A::PtrOrCuPtr{Cfloat},
+                                           lda::Csize_t, B::PtrOrCuPtr{Cfloat},
+                                           ldb::Csize_t, beta::RefOrCuRef{Cfloat},
+                                           C::PtrOrCuPtr{Cfloat},
+                                           ldc::Csize_t)::cublasStatus_t
 end
 
 @checked function cublasXtDsyr2k(handle, uplo, trans, n, k, alpha, A, lda, B, ldb, beta, C,
                                  ldc)
     initialize_context()
-    @ccall libcublas.cublasXtDsyr2k(handle::cublasXtHandle_t, uplo::cublasFillMode_t,
-                                    trans::cublasOperation_t, n::Csize_t, k::Csize_t,
-                                    alpha::RefOrCuRef{Cdouble}, A::PtrOrCuPtr{Cdouble},
-                                    lda::Csize_t, B::PtrOrCuPtr{Cdouble}, ldb::Csize_t,
-                                    beta::RefOrCuRef{Cdouble}, C::PtrOrCuPtr{Cdouble},
-                                    ldc::Csize_t)::cublasStatus_t
+    @gcsafe_ccall libcublas.cublasXtDsyr2k(handle::cublasXtHandle_t, uplo::cublasFillMode_t,
+                                           trans::cublasOperation_t, n::Csize_t, k::Csize_t,
+                                           alpha::RefOrCuRef{Cdouble},
+                                           A::PtrOrCuPtr{Cdouble}, lda::Csize_t,
+                                           B::PtrOrCuPtr{Cdouble}, ldb::Csize_t,
+                                           beta::RefOrCuRef{Cdouble},
+                                           C::PtrOrCuPtr{Cdouble},
+                                           ldc::Csize_t)::cublasStatus_t
 end
 
 @checked function cublasXtCsyr2k(handle, uplo, trans, n, k, alpha, A, lda, B, ldb, beta, C,
                                  ldc)
     initialize_context()
-    @ccall libcublas.cublasXtCsyr2k(handle::cublasXtHandle_t, uplo::cublasFillMode_t,
-                                    trans::cublasOperation_t, n::Csize_t, k::Csize_t,
-                                    alpha::RefOrCuRef{cuComplex}, A::PtrOrCuPtr{cuComplex},
-                                    lda::Csize_t, B::PtrOrCuPtr{cuComplex}, ldb::Csize_t,
-                                    beta::RefOrCuRef{cuComplex}, C::PtrOrCuPtr{cuComplex},
-                                    ldc::Csize_t)::cublasStatus_t
+    @gcsafe_ccall libcublas.cublasXtCsyr2k(handle::cublasXtHandle_t, uplo::cublasFillMode_t,
+                                           trans::cublasOperation_t, n::Csize_t, k::Csize_t,
+                                           alpha::RefOrCuRef{cuComplex},
+                                           A::PtrOrCuPtr{cuComplex}, lda::Csize_t,
+                                           B::PtrOrCuPtr{cuComplex}, ldb::Csize_t,
+                                           beta::RefOrCuRef{cuComplex},
+                                           C::PtrOrCuPtr{cuComplex},
+                                           ldc::Csize_t)::cublasStatus_t
 end
 
 @checked function cublasXtZsyr2k(handle, uplo, trans, n, k, alpha, A, lda, B, ldb, beta, C,
                                  ldc)
     initialize_context()
-    @ccall libcublas.cublasXtZsyr2k(handle::cublasXtHandle_t, uplo::cublasFillMode_t,
-                                    trans::cublasOperation_t, n::Csize_t, k::Csize_t,
-                                    alpha::RefOrCuRef{cuDoubleComplex},
-                                    A::PtrOrCuPtr{cuDoubleComplex}, lda::Csize_t,
-                                    B::PtrOrCuPtr{cuDoubleComplex}, ldb::Csize_t,
-                                    beta::RefOrCuRef{cuDoubleComplex},
-                                    C::PtrOrCuPtr{cuDoubleComplex},
-                                    ldc::Csize_t)::cublasStatus_t
+    @gcsafe_ccall libcublas.cublasXtZsyr2k(handle::cublasXtHandle_t, uplo::cublasFillMode_t,
+                                           trans::cublasOperation_t, n::Csize_t, k::Csize_t,
+                                           alpha::RefOrCuRef{cuDoubleComplex},
+                                           A::PtrOrCuPtr{cuDoubleComplex}, lda::Csize_t,
+                                           B::PtrOrCuPtr{cuDoubleComplex}, ldb::Csize_t,
+                                           beta::RefOrCuRef{cuDoubleComplex},
+                                           C::PtrOrCuPtr{cuDoubleComplex},
+                                           ldc::Csize_t)::cublasStatus_t
 end
 
 @checked function cublasXtCherkx(handle, uplo, trans, n, k, alpha, A, lda, B, ldb, beta, C,
                                  ldc)
     initialize_context()
-    @ccall libcublas.cublasXtCherkx(handle::cublasXtHandle_t, uplo::cublasFillMode_t,
-                                    trans::cublasOperation_t, n::Csize_t, k::Csize_t,
-                                    alpha::RefOrCuRef{cuComplex}, A::PtrOrCuPtr{cuComplex},
-                                    lda::Csize_t, B::PtrOrCuPtr{cuComplex}, ldb::Csize_t,
-                                    beta::RefOrCuRef{Cfloat}, C::PtrOrCuPtr{cuComplex},
-                                    ldc::Csize_t)::cublasStatus_t
+    @gcsafe_ccall libcublas.cublasXtCherkx(handle::cublasXtHandle_t, uplo::cublasFillMode_t,
+                                           trans::cublasOperation_t, n::Csize_t, k::Csize_t,
+                                           alpha::RefOrCuRef{cuComplex},
+                                           A::PtrOrCuPtr{cuComplex}, lda::Csize_t,
+                                           B::PtrOrCuPtr{cuComplex}, ldb::Csize_t,
+                                           beta::RefOrCuRef{Cfloat},
+                                           C::PtrOrCuPtr{cuComplex},
+                                           ldc::Csize_t)::cublasStatus_t
 end
 
 @checked function cublasXtZherkx(handle, uplo, trans, n, k, alpha, A, lda, B, ldb, beta, C,
                                  ldc)
     initialize_context()
-    @ccall libcublas.cublasXtZherkx(handle::cublasXtHandle_t, uplo::cublasFillMode_t,
-                                    trans::cublasOperation_t, n::Csize_t, k::Csize_t,
-                                    alpha::RefOrCuRef{cuDoubleComplex},
-                                    A::PtrOrCuPtr{cuDoubleComplex}, lda::Csize_t,
-                                    B::PtrOrCuPtr{cuDoubleComplex}, ldb::Csize_t,
-                                    beta::RefOrCuRef{Cdouble},
-                                    C::PtrOrCuPtr{cuDoubleComplex},
-                                    ldc::Csize_t)::cublasStatus_t
+    @gcsafe_ccall libcublas.cublasXtZherkx(handle::cublasXtHandle_t, uplo::cublasFillMode_t,
+                                           trans::cublasOperation_t, n::Csize_t, k::Csize_t,
+                                           alpha::RefOrCuRef{cuDoubleComplex},
+                                           A::PtrOrCuPtr{cuDoubleComplex}, lda::Csize_t,
+                                           B::PtrOrCuPtr{cuDoubleComplex}, ldb::Csize_t,
+                                           beta::RefOrCuRef{Cdouble},
+                                           C::PtrOrCuPtr{cuDoubleComplex},
+                                           ldc::Csize_t)::cublasStatus_t
 end
 
 @checked function cublasXtStrsm(handle, side, uplo, trans, diag, m, n, alpha, A, lda, B,
                                 ldb)
     initialize_context()
-    @ccall libcublas.cublasXtStrsm(handle::cublasXtHandle_t, side::cublasSideMode_t,
-                                   uplo::cublasFillMode_t, trans::cublasOperation_t,
-                                   diag::cublasDiagType_t, m::Csize_t, n::Csize_t,
-                                   alpha::RefOrCuRef{Cfloat}, A::PtrOrCuPtr{Cfloat},
-                                   lda::Csize_t, B::PtrOrCuPtr{Cfloat},
-                                   ldb::Csize_t)::cublasStatus_t
+    @gcsafe_ccall libcublas.cublasXtStrsm(handle::cublasXtHandle_t, side::cublasSideMode_t,
+                                          uplo::cublasFillMode_t, trans::cublasOperation_t,
+                                          diag::cublasDiagType_t, m::Csize_t, n::Csize_t,
+                                          alpha::RefOrCuRef{Cfloat}, A::PtrOrCuPtr{Cfloat},
+                                          lda::Csize_t, B::PtrOrCuPtr{Cfloat},
+                                          ldb::Csize_t)::cublasStatus_t
 end
 
 @checked function cublasXtDtrsm(handle, side, uplo, trans, diag, m, n, alpha, A, lda, B,
                                 ldb)
     initialize_context()
-    @ccall libcublas.cublasXtDtrsm(handle::cublasXtHandle_t, side::cublasSideMode_t,
-                                   uplo::cublasFillMode_t, trans::cublasOperation_t,
-                                   diag::cublasDiagType_t, m::Csize_t, n::Csize_t,
-                                   alpha::RefOrCuRef{Cdouble}, A::PtrOrCuPtr{Cdouble},
-                                   lda::Csize_t, B::PtrOrCuPtr{Cdouble},
-                                   ldb::Csize_t)::cublasStatus_t
+    @gcsafe_ccall libcublas.cublasXtDtrsm(handle::cublasXtHandle_t, side::cublasSideMode_t,
+                                          uplo::cublasFillMode_t, trans::cublasOperation_t,
+                                          diag::cublasDiagType_t, m::Csize_t, n::Csize_t,
+                                          alpha::RefOrCuRef{Cdouble},
+                                          A::PtrOrCuPtr{Cdouble}, lda::Csize_t,
+                                          B::PtrOrCuPtr{Cdouble},
+                                          ldb::Csize_t)::cublasStatus_t
 end
 
 @checked function cublasXtCtrsm(handle, side, uplo, trans, diag, m, n, alpha, A, lda, B,
                                 ldb)
     initialize_context()
-    @ccall libcublas.cublasXtCtrsm(handle::cublasXtHandle_t, side::cublasSideMode_t,
-                                   uplo::cublasFillMode_t, trans::cublasOperation_t,
-                                   diag::cublasDiagType_t, m::Csize_t, n::Csize_t,
-                                   alpha::RefOrCuRef{cuComplex}, A::PtrOrCuPtr{cuComplex},
-                                   lda::Csize_t, B::PtrOrCuPtr{cuComplex},
-                                   ldb::Csize_t)::cublasStatus_t
+    @gcsafe_ccall libcublas.cublasXtCtrsm(handle::cublasXtHandle_t, side::cublasSideMode_t,
+                                          uplo::cublasFillMode_t, trans::cublasOperation_t,
+                                          diag::cublasDiagType_t, m::Csize_t, n::Csize_t,
+                                          alpha::RefOrCuRef{cuComplex},
+                                          A::PtrOrCuPtr{cuComplex}, lda::Csize_t,
+                                          B::PtrOrCuPtr{cuComplex},
+                                          ldb::Csize_t)::cublasStatus_t
 end
 
 @checked function cublasXtZtrsm(handle, side, uplo, trans, diag, m, n, alpha, A, lda, B,
                                 ldb)
     initialize_context()
-    @ccall libcublas.cublasXtZtrsm(handle::cublasXtHandle_t, side::cublasSideMode_t,
-                                   uplo::cublasFillMode_t, trans::cublasOperation_t,
-                                   diag::cublasDiagType_t, m::Csize_t, n::Csize_t,
-                                   alpha::RefOrCuRef{cuDoubleComplex},
-                                   A::PtrOrCuPtr{cuDoubleComplex}, lda::Csize_t,
-                                   B::PtrOrCuPtr{cuDoubleComplex},
-                                   ldb::Csize_t)::cublasStatus_t
+    @gcsafe_ccall libcublas.cublasXtZtrsm(handle::cublasXtHandle_t, side::cublasSideMode_t,
+                                          uplo::cublasFillMode_t, trans::cublasOperation_t,
+                                          diag::cublasDiagType_t, m::Csize_t, n::Csize_t,
+                                          alpha::RefOrCuRef{cuDoubleComplex},
+                                          A::PtrOrCuPtr{cuDoubleComplex}, lda::Csize_t,
+                                          B::PtrOrCuPtr{cuDoubleComplex},
+                                          ldb::Csize_t)::cublasStatus_t
 end
 
 @checked function cublasXtSsymm(handle, side, uplo, m, n, alpha, A, lda, B, ldb, beta, C,
                                 ldc)
     initialize_context()
-    @ccall libcublas.cublasXtSsymm(handle::cublasXtHandle_t, side::cublasSideMode_t,
-                                   uplo::cublasFillMode_t, m::Csize_t, n::Csize_t,
-                                   alpha::RefOrCuRef{Cfloat}, A::PtrOrCuPtr{Cfloat},
-                                   lda::Csize_t, B::PtrOrCuPtr{Cfloat}, ldb::Csize_t,
-                                   beta::RefOrCuRef{Cfloat}, C::PtrOrCuPtr{Cfloat},
-                                   ldc::Csize_t)::cublasStatus_t
+    @gcsafe_ccall libcublas.cublasXtSsymm(handle::cublasXtHandle_t, side::cublasSideMode_t,
+                                          uplo::cublasFillMode_t, m::Csize_t, n::Csize_t,
+                                          alpha::RefOrCuRef{Cfloat}, A::PtrOrCuPtr{Cfloat},
+                                          lda::Csize_t, B::PtrOrCuPtr{Cfloat}, ldb::Csize_t,
+                                          beta::RefOrCuRef{Cfloat}, C::PtrOrCuPtr{Cfloat},
+                                          ldc::Csize_t)::cublasStatus_t
 end
 
 @checked function cublasXtDsymm(handle, side, uplo, m, n, alpha, A, lda, B, ldb, beta, C,
                                 ldc)
     initialize_context()
-    @ccall libcublas.cublasXtDsymm(handle::cublasXtHandle_t, side::cublasSideMode_t,
-                                   uplo::cublasFillMode_t, m::Csize_t, n::Csize_t,
-                                   alpha::RefOrCuRef{Cdouble}, A::PtrOrCuPtr{Cdouble},
-                                   lda::Csize_t, B::PtrOrCuPtr{Cdouble}, ldb::Csize_t,
-                                   beta::RefOrCuRef{Cdouble}, C::PtrOrCuPtr{Cdouble},
-                                   ldc::Csize_t)::cublasStatus_t
+    @gcsafe_ccall libcublas.cublasXtDsymm(handle::cublasXtHandle_t, side::cublasSideMode_t,
+                                          uplo::cublasFillMode_t, m::Csize_t, n::Csize_t,
+                                          alpha::RefOrCuRef{Cdouble},
+                                          A::PtrOrCuPtr{Cdouble}, lda::Csize_t,
+                                          B::PtrOrCuPtr{Cdouble}, ldb::Csize_t,
+                                          beta::RefOrCuRef{Cdouble}, C::PtrOrCuPtr{Cdouble},
+                                          ldc::Csize_t)::cublasStatus_t
 end
 
 @checked function cublasXtCsymm(handle, side, uplo, m, n, alpha, A, lda, B, ldb, beta, C,
                                 ldc)
     initialize_context()
-    @ccall libcublas.cublasXtCsymm(handle::cublasXtHandle_t, side::cublasSideMode_t,
-                                   uplo::cublasFillMode_t, m::Csize_t, n::Csize_t,
-                                   alpha::RefOrCuRef{cuComplex}, A::PtrOrCuPtr{cuComplex},
-                                   lda::Csize_t, B::PtrOrCuPtr{cuComplex}, ldb::Csize_t,
-                                   beta::RefOrCuRef{cuComplex}, C::PtrOrCuPtr{cuComplex},
-                                   ldc::Csize_t)::cublasStatus_t
+    @gcsafe_ccall libcublas.cublasXtCsymm(handle::cublasXtHandle_t, side::cublasSideMode_t,
+                                          uplo::cublasFillMode_t, m::Csize_t, n::Csize_t,
+                                          alpha::RefOrCuRef{cuComplex},
+                                          A::PtrOrCuPtr{cuComplex}, lda::Csize_t,
+                                          B::PtrOrCuPtr{cuComplex}, ldb::Csize_t,
+                                          beta::RefOrCuRef{cuComplex},
+                                          C::PtrOrCuPtr{cuComplex},
+                                          ldc::Csize_t)::cublasStatus_t
 end
 
 @checked function cublasXtZsymm(handle, side, uplo, m, n, alpha, A, lda, B, ldb, beta, C,
                                 ldc)
     initialize_context()
-    @ccall libcublas.cublasXtZsymm(handle::cublasXtHandle_t, side::cublasSideMode_t,
-                                   uplo::cublasFillMode_t, m::Csize_t, n::Csize_t,
-                                   alpha::RefOrCuRef{cuDoubleComplex},
-                                   A::PtrOrCuPtr{cuDoubleComplex}, lda::Csize_t,
-                                   B::PtrOrCuPtr{cuDoubleComplex}, ldb::Csize_t,
-                                   beta::RefOrCuRef{cuDoubleComplex},
-                                   C::PtrOrCuPtr{cuDoubleComplex},
-                                   ldc::Csize_t)::cublasStatus_t
+    @gcsafe_ccall libcublas.cublasXtZsymm(handle::cublasXtHandle_t, side::cublasSideMode_t,
+                                          uplo::cublasFillMode_t, m::Csize_t, n::Csize_t,
+                                          alpha::RefOrCuRef{cuDoubleComplex},
+                                          A::PtrOrCuPtr{cuDoubleComplex}, lda::Csize_t,
+                                          B::PtrOrCuPtr{cuDoubleComplex}, ldb::Csize_t,
+                                          beta::RefOrCuRef{cuDoubleComplex},
+                                          C::PtrOrCuPtr{cuDoubleComplex},
+                                          ldc::Csize_t)::cublasStatus_t
 end
 
 @checked function cublasXtChemm(handle, side, uplo, m, n, alpha, A, lda, B, ldb, beta, C,
                                 ldc)
     initialize_context()
-    @ccall libcublas.cublasXtChemm(handle::cublasXtHandle_t, side::cublasSideMode_t,
-                                   uplo::cublasFillMode_t, m::Csize_t, n::Csize_t,
-                                   alpha::RefOrCuRef{cuComplex}, A::PtrOrCuPtr{cuComplex},
-                                   lda::Csize_t, B::PtrOrCuPtr{cuComplex}, ldb::Csize_t,
-                                   beta::RefOrCuRef{cuComplex}, C::PtrOrCuPtr{cuComplex},
-                                   ldc::Csize_t)::cublasStatus_t
+    @gcsafe_ccall libcublas.cublasXtChemm(handle::cublasXtHandle_t, side::cublasSideMode_t,
+                                          uplo::cublasFillMode_t, m::Csize_t, n::Csize_t,
+                                          alpha::RefOrCuRef{cuComplex},
+                                          A::PtrOrCuPtr{cuComplex}, lda::Csize_t,
+                                          B::PtrOrCuPtr{cuComplex}, ldb::Csize_t,
+                                          beta::RefOrCuRef{cuComplex},
+                                          C::PtrOrCuPtr{cuComplex},
+                                          ldc::Csize_t)::cublasStatus_t
 end
 
 @checked function cublasXtZhemm(handle, side, uplo, m, n, alpha, A, lda, B, ldb, beta, C,
                                 ldc)
     initialize_context()
-    @ccall libcublas.cublasXtZhemm(handle::cublasXtHandle_t, side::cublasSideMode_t,
-                                   uplo::cublasFillMode_t, m::Csize_t, n::Csize_t,
-                                   alpha::RefOrCuRef{cuDoubleComplex},
-                                   A::PtrOrCuPtr{cuDoubleComplex}, lda::Csize_t,
-                                   B::PtrOrCuPtr{cuDoubleComplex}, ldb::Csize_t,
-                                   beta::RefOrCuRef{cuDoubleComplex},
-                                   C::PtrOrCuPtr{cuDoubleComplex},
-                                   ldc::Csize_t)::cublasStatus_t
+    @gcsafe_ccall libcublas.cublasXtZhemm(handle::cublasXtHandle_t, side::cublasSideMode_t,
+                                          uplo::cublasFillMode_t, m::Csize_t, n::Csize_t,
+                                          alpha::RefOrCuRef{cuDoubleComplex},
+                                          A::PtrOrCuPtr{cuDoubleComplex}, lda::Csize_t,
+                                          B::PtrOrCuPtr{cuDoubleComplex}, ldb::Csize_t,
+                                          beta::RefOrCuRef{cuDoubleComplex},
+                                          C::PtrOrCuPtr{cuDoubleComplex},
+                                          ldc::Csize_t)::cublasStatus_t
 end
 
 @checked function cublasXtSsyrkx(handle, uplo, trans, n, k, alpha, A, lda, B, ldb, beta, C,
                                  ldc)
     initialize_context()
-    @ccall libcublas.cublasXtSsyrkx(handle::cublasXtHandle_t, uplo::cublasFillMode_t,
-                                    trans::cublasOperation_t, n::Csize_t, k::Csize_t,
-                                    alpha::RefOrCuRef{Cfloat}, A::PtrOrCuPtr{Cfloat},
-                                    lda::Csize_t, B::PtrOrCuPtr{Cfloat}, ldb::Csize_t,
-                                    beta::RefOrCuRef{Cfloat}, C::PtrOrCuPtr{Cfloat},
-                                    ldc::Csize_t)::cublasStatus_t
+    @gcsafe_ccall libcublas.cublasXtSsyrkx(handle::cublasXtHandle_t, uplo::cublasFillMode_t,
+                                           trans::cublasOperation_t, n::Csize_t, k::Csize_t,
+                                           alpha::RefOrCuRef{Cfloat}, A::PtrOrCuPtr{Cfloat},
+                                           lda::Csize_t, B::PtrOrCuPtr{Cfloat},
+                                           ldb::Csize_t, beta::RefOrCuRef{Cfloat},
+                                           C::PtrOrCuPtr{Cfloat},
+                                           ldc::Csize_t)::cublasStatus_t
 end
 
 @checked function cublasXtDsyrkx(handle, uplo, trans, n, k, alpha, A, lda, B, ldb, beta, C,
                                  ldc)
     initialize_context()
-    @ccall libcublas.cublasXtDsyrkx(handle::cublasXtHandle_t, uplo::cublasFillMode_t,
-                                    trans::cublasOperation_t, n::Csize_t, k::Csize_t,
-                                    alpha::RefOrCuRef{Cdouble}, A::PtrOrCuPtr{Cdouble},
-                                    lda::Csize_t, B::PtrOrCuPtr{Cdouble}, ldb::Csize_t,
-                                    beta::RefOrCuRef{Cdouble}, C::PtrOrCuPtr{Cdouble},
-                                    ldc::Csize_t)::cublasStatus_t
+    @gcsafe_ccall libcublas.cublasXtDsyrkx(handle::cublasXtHandle_t, uplo::cublasFillMode_t,
+                                           trans::cublasOperation_t, n::Csize_t, k::Csize_t,
+                                           alpha::RefOrCuRef{Cdouble},
+                                           A::PtrOrCuPtr{Cdouble}, lda::Csize_t,
+                                           B::PtrOrCuPtr{Cdouble}, ldb::Csize_t,
+                                           beta::RefOrCuRef{Cdouble},
+                                           C::PtrOrCuPtr{Cdouble},
+                                           ldc::Csize_t)::cublasStatus_t
 end
 
 @checked function cublasXtCsyrkx(handle, uplo, trans, n, k, alpha, A, lda, B, ldb, beta, C,
                                  ldc)
     initialize_context()
-    @ccall libcublas.cublasXtCsyrkx(handle::cublasXtHandle_t, uplo::cublasFillMode_t,
-                                    trans::cublasOperation_t, n::Csize_t, k::Csize_t,
-                                    alpha::RefOrCuRef{cuComplex}, A::PtrOrCuPtr{cuComplex},
-                                    lda::Csize_t, B::PtrOrCuPtr{cuComplex}, ldb::Csize_t,
-                                    beta::RefOrCuRef{cuComplex}, C::PtrOrCuPtr{cuComplex},
-                                    ldc::Csize_t)::cublasStatus_t
+    @gcsafe_ccall libcublas.cublasXtCsyrkx(handle::cublasXtHandle_t, uplo::cublasFillMode_t,
+                                           trans::cublasOperation_t, n::Csize_t, k::Csize_t,
+                                           alpha::RefOrCuRef{cuComplex},
+                                           A::PtrOrCuPtr{cuComplex}, lda::Csize_t,
+                                           B::PtrOrCuPtr{cuComplex}, ldb::Csize_t,
+                                           beta::RefOrCuRef{cuComplex},
+                                           C::PtrOrCuPtr{cuComplex},
+                                           ldc::Csize_t)::cublasStatus_t
 end
 
 @checked function cublasXtZsyrkx(handle, uplo, trans, n, k, alpha, A, lda, B, ldb, beta, C,
                                  ldc)
     initialize_context()
-    @ccall libcublas.cublasXtZsyrkx(handle::cublasXtHandle_t, uplo::cublasFillMode_t,
-                                    trans::cublasOperation_t, n::Csize_t, k::Csize_t,
-                                    alpha::RefOrCuRef{cuDoubleComplex},
-                                    A::PtrOrCuPtr{cuDoubleComplex}, lda::Csize_t,
-                                    B::PtrOrCuPtr{cuDoubleComplex}, ldb::Csize_t,
-                                    beta::RefOrCuRef{cuDoubleComplex},
-                                    C::PtrOrCuPtr{cuDoubleComplex},
-                                    ldc::Csize_t)::cublasStatus_t
+    @gcsafe_ccall libcublas.cublasXtZsyrkx(handle::cublasXtHandle_t, uplo::cublasFillMode_t,
+                                           trans::cublasOperation_t, n::Csize_t, k::Csize_t,
+                                           alpha::RefOrCuRef{cuDoubleComplex},
+                                           A::PtrOrCuPtr{cuDoubleComplex}, lda::Csize_t,
+                                           B::PtrOrCuPtr{cuDoubleComplex}, ldb::Csize_t,
+                                           beta::RefOrCuRef{cuDoubleComplex},
+                                           C::PtrOrCuPtr{cuDoubleComplex},
+                                           ldc::Csize_t)::cublasStatus_t
 end
 
 @checked function cublasXtCher2k(handle, uplo, trans, n, k, alpha, A, lda, B, ldb, beta, C,
                                  ldc)
     initialize_context()
-    @ccall libcublas.cublasXtCher2k(handle::cublasXtHandle_t, uplo::cublasFillMode_t,
-                                    trans::cublasOperation_t, n::Csize_t, k::Csize_t,
-                                    alpha::RefOrCuRef{cuComplex}, A::PtrOrCuPtr{cuComplex},
-                                    lda::Csize_t, B::PtrOrCuPtr{cuComplex}, ldb::Csize_t,
-                                    beta::RefOrCuRef{Cfloat}, C::PtrOrCuPtr{cuComplex},
-                                    ldc::Csize_t)::cublasStatus_t
+    @gcsafe_ccall libcublas.cublasXtCher2k(handle::cublasXtHandle_t, uplo::cublasFillMode_t,
+                                           trans::cublasOperation_t, n::Csize_t, k::Csize_t,
+                                           alpha::RefOrCuRef{cuComplex},
+                                           A::PtrOrCuPtr{cuComplex}, lda::Csize_t,
+                                           B::PtrOrCuPtr{cuComplex}, ldb::Csize_t,
+                                           beta::RefOrCuRef{Cfloat},
+                                           C::PtrOrCuPtr{cuComplex},
+                                           ldc::Csize_t)::cublasStatus_t
 end
 
 @checked function cublasXtZher2k(handle, uplo, trans, n, k, alpha, A, lda, B, ldb, beta, C,
                                  ldc)
     initialize_context()
-    @ccall libcublas.cublasXtZher2k(handle::cublasXtHandle_t, uplo::cublasFillMode_t,
-                                    trans::cublasOperation_t, n::Csize_t, k::Csize_t,
-                                    alpha::RefOrCuRef{cuDoubleComplex},
-                                    A::PtrOrCuPtr{cuDoubleComplex}, lda::Csize_t,
-                                    B::PtrOrCuPtr{cuDoubleComplex}, ldb::Csize_t,
-                                    beta::RefOrCuRef{Cdouble},
-                                    C::PtrOrCuPtr{cuDoubleComplex},
-                                    ldc::Csize_t)::cublasStatus_t
+    @gcsafe_ccall libcublas.cublasXtZher2k(handle::cublasXtHandle_t, uplo::cublasFillMode_t,
+                                           trans::cublasOperation_t, n::Csize_t, k::Csize_t,
+                                           alpha::RefOrCuRef{cuDoubleComplex},
+                                           A::PtrOrCuPtr{cuDoubleComplex}, lda::Csize_t,
+                                           B::PtrOrCuPtr{cuDoubleComplex}, ldb::Csize_t,
+                                           beta::RefOrCuRef{Cdouble},
+                                           C::PtrOrCuPtr{cuDoubleComplex},
+                                           ldc::Csize_t)::cublasStatus_t
 end
 
 @checked function cublasXtSspmm(handle, side, uplo, m, n, alpha, AP, B, ldb, beta, C, ldc)
     initialize_context()
-    @ccall libcublas.cublasXtSspmm(handle::cublasXtHandle_t, side::cublasSideMode_t,
-                                   uplo::cublasFillMode_t, m::Csize_t, n::Csize_t,
-                                   alpha::Ref{Cfloat}, AP::Ptr{Cfloat},
-                                   B::PtrOrCuPtr{Cfloat}, ldb::Csize_t, beta::Ref{Cfloat},
-                                   C::PtrOrCuPtr{Cfloat}, ldc::Csize_t)::cublasStatus_t
+    @gcsafe_ccall libcublas.cublasXtSspmm(handle::cublasXtHandle_t, side::cublasSideMode_t,
+                                          uplo::cublasFillMode_t, m::Csize_t, n::Csize_t,
+                                          alpha::Ref{Cfloat}, AP::Ptr{Cfloat},
+                                          B::PtrOrCuPtr{Cfloat}, ldb::Csize_t,
+                                          beta::Ref{Cfloat}, C::PtrOrCuPtr{Cfloat},
+                                          ldc::Csize_t)::cublasStatus_t
 end
 
 @checked function cublasXtDspmm(handle, side, uplo, m, n, alpha, AP, B, ldb, beta, C, ldc)
     initialize_context()
-    @ccall libcublas.cublasXtDspmm(handle::cublasXtHandle_t, side::cublasSideMode_t,
-                                   uplo::cublasFillMode_t, m::Csize_t, n::Csize_t,
-                                   alpha::Ref{Cdouble}, AP::Ptr{Cdouble},
-                                   B::PtrOrCuPtr{Cdouble}, ldb::Csize_t, beta::Ref{Cdouble},
-                                   C::PtrOrCuPtr{Cdouble}, ldc::Csize_t)::cublasStatus_t
+    @gcsafe_ccall libcublas.cublasXtDspmm(handle::cublasXtHandle_t, side::cublasSideMode_t,
+                                          uplo::cublasFillMode_t, m::Csize_t, n::Csize_t,
+                                          alpha::Ref{Cdouble}, AP::Ptr{Cdouble},
+                                          B::PtrOrCuPtr{Cdouble}, ldb::Csize_t,
+                                          beta::Ref{Cdouble}, C::PtrOrCuPtr{Cdouble},
+                                          ldc::Csize_t)::cublasStatus_t
 end
 
 @checked function cublasXtCspmm(handle, side, uplo, m, n, alpha, AP, B, ldb, beta, C, ldc)
     initialize_context()
-    @ccall libcublas.cublasXtCspmm(handle::cublasXtHandle_t, side::cublasSideMode_t,
-                                   uplo::cublasFillMode_t, m::Csize_t, n::Csize_t,
-                                   alpha::Ref{cuComplex}, AP::Ptr{cuComplex},
-                                   B::PtrOrCuPtr{cuComplex}, ldb::Csize_t,
-                                   beta::Ref{cuComplex}, C::PtrOrCuPtr{cuComplex},
-                                   ldc::Csize_t)::cublasStatus_t
+    @gcsafe_ccall libcublas.cublasXtCspmm(handle::cublasXtHandle_t, side::cublasSideMode_t,
+                                          uplo::cublasFillMode_t, m::Csize_t, n::Csize_t,
+                                          alpha::Ref{cuComplex}, AP::Ptr{cuComplex},
+                                          B::PtrOrCuPtr{cuComplex}, ldb::Csize_t,
+                                          beta::Ref{cuComplex}, C::PtrOrCuPtr{cuComplex},
+                                          ldc::Csize_t)::cublasStatus_t
 end
 
 @checked function cublasXtZspmm(handle, side, uplo, m, n, alpha, AP, B, ldb, beta, C, ldc)
     initialize_context()
-    @ccall libcublas.cublasXtZspmm(handle::cublasXtHandle_t, side::cublasSideMode_t,
-                                   uplo::cublasFillMode_t, m::Csize_t, n::Csize_t,
-                                   alpha::Ref{cuDoubleComplex}, AP::Ptr{cuDoubleComplex},
-                                   B::PtrOrCuPtr{cuDoubleComplex}, ldb::Csize_t,
-                                   beta::Ref{cuDoubleComplex},
-                                   C::PtrOrCuPtr{cuDoubleComplex},
-                                   ldc::Csize_t)::cublasStatus_t
+    @gcsafe_ccall libcublas.cublasXtZspmm(handle::cublasXtHandle_t, side::cublasSideMode_t,
+                                          uplo::cublasFillMode_t, m::Csize_t, n::Csize_t,
+                                          alpha::Ref{cuDoubleComplex},
+                                          AP::Ptr{cuDoubleComplex},
+                                          B::PtrOrCuPtr{cuDoubleComplex}, ldb::Csize_t,
+                                          beta::Ref{cuDoubleComplex},
+                                          C::PtrOrCuPtr{cuDoubleComplex},
+                                          ldc::Csize_t)::cublasStatus_t
 end
 
 @checked function cublasXtStrmm(handle, side, uplo, trans, diag, m, n, alpha, A, lda, B,
                                 ldb, C, ldc)
     initialize_context()
-    @ccall libcublas.cublasXtStrmm(handle::cublasXtHandle_t, side::cublasSideMode_t,
-                                   uplo::cublasFillMode_t, trans::cublasOperation_t,
-                                   diag::cublasDiagType_t, m::Csize_t, n::Csize_t,
-                                   alpha::RefOrCuRef{Cfloat}, A::PtrOrCuPtr{Cfloat},
-                                   lda::Csize_t, B::PtrOrCuPtr{Cfloat}, ldb::Csize_t,
-                                   C::PtrOrCuPtr{Cfloat}, ldc::Csize_t)::cublasStatus_t
+    @gcsafe_ccall libcublas.cublasXtStrmm(handle::cublasXtHandle_t, side::cublasSideMode_t,
+                                          uplo::cublasFillMode_t, trans::cublasOperation_t,
+                                          diag::cublasDiagType_t, m::Csize_t, n::Csize_t,
+                                          alpha::RefOrCuRef{Cfloat}, A::PtrOrCuPtr{Cfloat},
+                                          lda::Csize_t, B::PtrOrCuPtr{Cfloat}, ldb::Csize_t,
+                                          C::PtrOrCuPtr{Cfloat},
+                                          ldc::Csize_t)::cublasStatus_t
 end
 
 @checked function cublasXtDtrmm(handle, side, uplo, trans, diag, m, n, alpha, A, lda, B,
                                 ldb, C, ldc)
     initialize_context()
-    @ccall libcublas.cublasXtDtrmm(handle::cublasXtHandle_t, side::cublasSideMode_t,
-                                   uplo::cublasFillMode_t, trans::cublasOperation_t,
-                                   diag::cublasDiagType_t, m::Csize_t, n::Csize_t,
-                                   alpha::RefOrCuRef{Cdouble}, A::PtrOrCuPtr{Cdouble},
-                                   lda::Csize_t, B::PtrOrCuPtr{Cdouble}, ldb::Csize_t,
-                                   C::PtrOrCuPtr{Cdouble}, ldc::Csize_t)::cublasStatus_t
+    @gcsafe_ccall libcublas.cublasXtDtrmm(handle::cublasXtHandle_t, side::cublasSideMode_t,
+                                          uplo::cublasFillMode_t, trans::cublasOperation_t,
+                                          diag::cublasDiagType_t, m::Csize_t, n::Csize_t,
+                                          alpha::RefOrCuRef{Cdouble},
+                                          A::PtrOrCuPtr{Cdouble}, lda::Csize_t,
+                                          B::PtrOrCuPtr{Cdouble}, ldb::Csize_t,
+                                          C::PtrOrCuPtr{Cdouble},
+                                          ldc::Csize_t)::cublasStatus_t
 end
 
 @checked function cublasXtCtrmm(handle, side, uplo, trans, diag, m, n, alpha, A, lda, B,
                                 ldb, C, ldc)
     initialize_context()
-    @ccall libcublas.cublasXtCtrmm(handle::cublasXtHandle_t, side::cublasSideMode_t,
-                                   uplo::cublasFillMode_t, trans::cublasOperation_t,
-                                   diag::cublasDiagType_t, m::Csize_t, n::Csize_t,
-                                   alpha::RefOrCuRef{cuComplex}, A::PtrOrCuPtr{cuComplex},
-                                   lda::Csize_t, B::PtrOrCuPtr{cuComplex}, ldb::Csize_t,
-                                   C::PtrOrCuPtr{cuComplex}, ldc::Csize_t)::cublasStatus_t
+    @gcsafe_ccall libcublas.cublasXtCtrmm(handle::cublasXtHandle_t, side::cublasSideMode_t,
+                                          uplo::cublasFillMode_t, trans::cublasOperation_t,
+                                          diag::cublasDiagType_t, m::Csize_t, n::Csize_t,
+                                          alpha::RefOrCuRef{cuComplex},
+                                          A::PtrOrCuPtr{cuComplex}, lda::Csize_t,
+                                          B::PtrOrCuPtr{cuComplex}, ldb::Csize_t,
+                                          C::PtrOrCuPtr{cuComplex},
+                                          ldc::Csize_t)::cublasStatus_t
 end
 
 @checked function cublasXtZtrmm(handle, side, uplo, trans, diag, m, n, alpha, A, lda, B,
                                 ldb, C, ldc)
     initialize_context()
-    @ccall libcublas.cublasXtZtrmm(handle::cublasXtHandle_t, side::cublasSideMode_t,
-                                   uplo::cublasFillMode_t, trans::cublasOperation_t,
-                                   diag::cublasDiagType_t, m::Csize_t, n::Csize_t,
-                                   alpha::RefOrCuRef{cuDoubleComplex},
-                                   A::PtrOrCuPtr{cuDoubleComplex}, lda::Csize_t,
-                                   B::PtrOrCuPtr{cuDoubleComplex}, ldb::Csize_t,
-                                   C::PtrOrCuPtr{cuDoubleComplex},
-                                   ldc::Csize_t)::cublasStatus_t
+    @gcsafe_ccall libcublas.cublasXtZtrmm(handle::cublasXtHandle_t, side::cublasSideMode_t,
+                                          uplo::cublasFillMode_t, trans::cublasOperation_t,
+                                          diag::cublasDiagType_t, m::Csize_t, n::Csize_t,
+                                          alpha::RefOrCuRef{cuDoubleComplex},
+                                          A::PtrOrCuPtr{cuDoubleComplex}, lda::Csize_t,
+                                          B::PtrOrCuPtr{cuDoubleComplex}, ldb::Csize_t,
+                                          C::PtrOrCuPtr{cuDoubleComplex},
+                                          ldc::Csize_t)::cublasStatus_t
 end
 
 # Float16 functionality is only enabled when using C++ (defining __cplusplus breaks things)

--- a/lib/cudadrv/libcuda.jl
+++ b/lib/cudadrv/libcuda.jl
@@ -153,7 +153,7 @@ const CUcontext = Ptr{CUctx_st}
 
 @checked function cuCtxCreate_v2(pctx, flags, dev)
     @gcsafe_ccall libcuda.cuCtxCreate_v2(pctx::Ptr{CUcontext}, flags::Cuint,
-                                  dev::CUdevice)::CUresult
+                                         dev::CUdevice)::CUresult
 end
 
 mutable struct CUmod_st end
@@ -163,7 +163,7 @@ const CUmodule = Ptr{CUmod_st}
 @checked function cuModuleGetGlobal_v2(dptr, bytes, hmod, name)
     initialize_context()
     @gcsafe_ccall libcuda.cuModuleGetGlobal_v2(dptr::Ptr{CUdeviceptr}, bytes::Ptr{Csize_t},
-                                        hmod::CUmodule, name::Cstring)::CUresult
+                                               hmod::CUmodule, name::Cstring)::CUresult
 end
 
 @checked function cuMemGetInfo_v2(free, total)
@@ -179,8 +179,8 @@ end
 @checked function cuMemAllocPitch_v2(dptr, pPitch, WidthInBytes, Height, ElementSizeBytes)
     initialize_context()
     @gcsafe_ccall libcuda.cuMemAllocPitch_v2(dptr::Ptr{CUdeviceptr}, pPitch::Ptr{Csize_t},
-                                      WidthInBytes::Csize_t, Height::Csize_t,
-                                      ElementSizeBytes::Cuint)::CUresult
+                                             WidthInBytes::Csize_t, Height::Csize_t,
+                                             ElementSizeBytes::Cuint)::CUresult
 end
 
 @checked function cuMemFree_v2(dptr)
@@ -190,37 +190,40 @@ end
 
 @checked function cuMemGetAddressRange_v2(pbase, psize, dptr)
     initialize_context()
-    @gcsafe_ccall libcuda.cuMemGetAddressRange_v2(pbase::Ptr{CUdeviceptr}, psize::Ptr{Csize_t},
-                                           dptr::CUdeviceptr)::CUresult
+    @gcsafe_ccall libcuda.cuMemGetAddressRange_v2(pbase::Ptr{CUdeviceptr},
+                                                  psize::Ptr{Csize_t},
+                                                  dptr::CUdeviceptr)::CUresult
 end
 
 @checked function cuMemAllocHost_v2(pp, bytesize)
     initialize_context()
-    @gcsafe_ccall libcuda.cuMemAllocHost_v2(pp::Ptr{Ptr{Cvoid}}, bytesize::Csize_t)::CUresult
+    @gcsafe_ccall libcuda.cuMemAllocHost_v2(pp::Ptr{Ptr{Cvoid}},
+                                            bytesize::Csize_t)::CUresult
 end
 
 @checked function cuMemHostGetDevicePointer_v2(pdptr, p, Flags)
     initialize_context()
-    @gcsafe_ccall libcuda.cuMemHostGetDevicePointer_v2(pdptr::Ptr{CUdeviceptr}, p::Ptr{Cvoid},
-                                                Flags::Cuint)::CUresult
+    @gcsafe_ccall libcuda.cuMemHostGetDevicePointer_v2(pdptr::Ptr{CUdeviceptr},
+                                                       p::Ptr{Cvoid},
+                                                       Flags::Cuint)::CUresult
 end
 
 @checked function cuMemcpyHtoD_v2(dstDevice, srcHost, ByteCount)
     initialize_context()
     @gcsafe_ccall libcuda.cuMemcpyHtoD_v2(dstDevice::CUdeviceptr, srcHost::Ptr{Cvoid},
-                                   ByteCount::Csize_t)::CUresult
+                                          ByteCount::Csize_t)::CUresult
 end
 
 @checked function cuMemcpyDtoH_v2(dstHost, srcDevice, ByteCount)
     initialize_context()
     @gcsafe_ccall libcuda.cuMemcpyDtoH_v2(dstHost::Ptr{Cvoid}, srcDevice::CUdeviceptr,
-                                   ByteCount::Csize_t)::CUresult
+                                          ByteCount::Csize_t)::CUresult
 end
 
 @checked function cuMemcpyDtoD_v2(dstDevice, srcDevice, ByteCount)
     initialize_context()
     @gcsafe_ccall libcuda.cuMemcpyDtoD_v2(dstDevice::CUdeviceptr, srcDevice::CUdeviceptr,
-                                   ByteCount::Csize_t)::CUresult
+                                          ByteCount::Csize_t)::CUresult
 end
 
 mutable struct CUarray_st end
@@ -228,45 +231,47 @@ mutable struct CUarray_st end
 @checked function cuMemcpyDtoA_v2(dstArray, dstOffset, srcDevice, ByteCount)
     initialize_context()
     @gcsafe_ccall libcuda.cuMemcpyDtoA_v2(dstArray::CUarray, dstOffset::Csize_t,
-                                   srcDevice::CUdeviceptr, ByteCount::Csize_t)::CUresult
+                                          srcDevice::CUdeviceptr,
+                                          ByteCount::Csize_t)::CUresult
 end
 
 @checked function cuMemcpyAtoD_v2(dstDevice, srcArray, srcOffset, ByteCount)
     initialize_context()
     @gcsafe_ccall libcuda.cuMemcpyAtoD_v2(dstDevice::CUdeviceptr, srcArray::CUarray,
-                                   srcOffset::Csize_t, ByteCount::Csize_t)::CUresult
+                                          srcOffset::Csize_t, ByteCount::Csize_t)::CUresult
 end
 
 @checked function cuMemcpyHtoA_v2(dstArray, dstOffset, srcHost, ByteCount)
     initialize_context()
     @gcsafe_ccall libcuda.cuMemcpyHtoA_v2(dstArray::CUarray, dstOffset::Csize_t,
-                                   srcHost::Ptr{Cvoid}, ByteCount::Csize_t)::CUresult
+                                          srcHost::Ptr{Cvoid}, ByteCount::Csize_t)::CUresult
 end
 
 @checked function cuMemcpyAtoH_v2(dstHost, srcArray, srcOffset, ByteCount)
     initialize_context()
     @gcsafe_ccall libcuda.cuMemcpyAtoH_v2(dstHost::Ptr{Cvoid}, srcArray::CUarray,
-                                   srcOffset::Csize_t, ByteCount::Csize_t)::CUresult
+                                          srcOffset::Csize_t, ByteCount::Csize_t)::CUresult
 end
 
 @checked function cuMemcpyAtoA_v2(dstArray, dstOffset, srcArray, srcOffset, ByteCount)
     initialize_context()
-    @gcsafe_ccall libcuda.cuMemcpyAtoA_v2(dstArray::CUarray, dstOffset::Csize_t, srcArray::CUarray,
-                                   srcOffset::Csize_t, ByteCount::Csize_t)::CUresult
+    @gcsafe_ccall libcuda.cuMemcpyAtoA_v2(dstArray::CUarray, dstOffset::Csize_t,
+                                          srcArray::CUarray, srcOffset::Csize_t,
+                                          ByteCount::Csize_t)::CUresult
 end
 
 @checked function cuMemcpyHtoAAsync_v2(dstArray, dstOffset, srcHost, ByteCount, hStream)
     initialize_context()
     @gcsafe_ccall libcuda.cuMemcpyHtoAAsync_v2(dstArray::CUarray, dstOffset::Csize_t,
-                                        srcHost::Ptr{Cvoid}, ByteCount::Csize_t,
-                                        hStream::CUstream)::CUresult
+                                               srcHost::Ptr{Cvoid}, ByteCount::Csize_t,
+                                               hStream::CUstream)::CUresult
 end
 
 @checked function cuMemcpyAtoHAsync_v2(dstHost, srcArray, srcOffset, ByteCount, hStream)
     initialize_context()
     @gcsafe_ccall libcuda.cuMemcpyAtoHAsync_v2(dstHost::Ptr{Cvoid}, srcArray::CUarray,
-                                        srcOffset::Csize_t, ByteCount::Csize_t,
-                                        hStream::CUstream)::CUresult
+                                               srcOffset::Csize_t, ByteCount::Csize_t,
+                                               hStream::CUstream)::CUresult
 end
 
 @cenum CUmemorytype_enum::UInt32 begin
@@ -351,64 +356,73 @@ end
 @checked function cuMemcpyHtoDAsync_v2(dstDevice, srcHost, ByteCount, hStream)
     initialize_context()
     @gcsafe_ccall libcuda.cuMemcpyHtoDAsync_v2(dstDevice::CUdeviceptr, srcHost::Ptr{Cvoid},
-                                        ByteCount::Csize_t, hStream::CUstream)::CUresult
+                                               ByteCount::Csize_t,
+                                               hStream::CUstream)::CUresult
 end
 
 @checked function cuMemcpyDtoHAsync_v2(dstHost, srcDevice, ByteCount, hStream)
     initialize_context()
     @gcsafe_ccall libcuda.cuMemcpyDtoHAsync_v2(dstHost::Ptr{Cvoid}, srcDevice::CUdeviceptr,
-                                        ByteCount::Csize_t, hStream::CUstream)::CUresult
+                                               ByteCount::Csize_t,
+                                               hStream::CUstream)::CUresult
 end
 
 @checked function cuMemcpyDtoDAsync_v2(dstDevice, srcDevice, ByteCount, hStream)
     initialize_context()
-    @gcsafe_ccall libcuda.cuMemcpyDtoDAsync_v2(dstDevice::CUdeviceptr, srcDevice::CUdeviceptr,
-                                        ByteCount::Csize_t, hStream::CUstream)::CUresult
+    @gcsafe_ccall libcuda.cuMemcpyDtoDAsync_v2(dstDevice::CUdeviceptr,
+                                               srcDevice::CUdeviceptr, ByteCount::Csize_t,
+                                               hStream::CUstream)::CUresult
 end
 
 @checked function cuMemcpy2DAsync_v2(pCopy, hStream)
     initialize_context()
     @gcsafe_ccall libcuda.cuMemcpy2DAsync_v2(pCopy::Ptr{CUDA_MEMCPY2D},
-                                      hStream::CUstream)::CUresult
+                                             hStream::CUstream)::CUresult
 end
 
 @checked function cuMemcpy3DAsync_v2(pCopy, hStream)
     initialize_context()
     @gcsafe_ccall libcuda.cuMemcpy3DAsync_v2(pCopy::Ptr{CUDA_MEMCPY3D},
-                                      hStream::CUstream)::CUresult
+                                             hStream::CUstream)::CUresult
 end
 
 @checked function cuMemsetD8_v2(dstDevice, uc, N)
     initialize_context()
-    @gcsafe_ccall libcuda.cuMemsetD8_v2(dstDevice::CUdeviceptr, uc::Cuchar, N::Csize_t)::CUresult
+    @gcsafe_ccall libcuda.cuMemsetD8_v2(dstDevice::CUdeviceptr, uc::Cuchar,
+                                        N::Csize_t)::CUresult
 end
 
 @checked function cuMemsetD16_v2(dstDevice, us, N)
     initialize_context()
-    @gcsafe_ccall libcuda.cuMemsetD16_v2(dstDevice::CUdeviceptr, us::Cushort, N::Csize_t)::CUresult
+    @gcsafe_ccall libcuda.cuMemsetD16_v2(dstDevice::CUdeviceptr, us::Cushort,
+                                         N::Csize_t)::CUresult
 end
 
 @checked function cuMemsetD32_v2(dstDevice, ui, N)
     initialize_context()
-    @gcsafe_ccall libcuda.cuMemsetD32_v2(dstDevice::CUdeviceptr, ui::Cuint, N::Csize_t)::CUresult
+    @gcsafe_ccall libcuda.cuMemsetD32_v2(dstDevice::CUdeviceptr, ui::Cuint,
+                                         N::Csize_t)::CUresult
 end
 
 @checked function cuMemsetD2D8_v2(dstDevice, dstPitch, uc, Width, Height)
     initialize_context()
-    @gcsafe_ccall libcuda.cuMemsetD2D8_v2(dstDevice::CUdeviceptr, dstPitch::Csize_t, uc::Cuchar,
-                                   Width::Csize_t, Height::Csize_t)::CUresult
+    @gcsafe_ccall libcuda.cuMemsetD2D8_v2(dstDevice::CUdeviceptr, dstPitch::Csize_t,
+                                          uc::Cuchar, Width::Csize_t,
+                                          Height::Csize_t)::CUresult
 end
 
 @checked function cuMemsetD2D16_v2(dstDevice, dstPitch, us, Width, Height)
     initialize_context()
-    @gcsafe_ccall libcuda.cuMemsetD2D16_v2(dstDevice::CUdeviceptr, dstPitch::Csize_t, us::Cushort,
-                                    Width::Csize_t, Height::Csize_t)::CUresult
+    @gcsafe_ccall libcuda.cuMemsetD2D16_v2(dstDevice::CUdeviceptr, dstPitch::Csize_t,
+                                           us::Cushort, Width::Csize_t,
+                                           Height::Csize_t)::CUresult
 end
 
 @checked function cuMemsetD2D32_v2(dstDevice, dstPitch, ui, Width, Height)
     initialize_context()
-    @gcsafe_ccall libcuda.cuMemsetD2D32_v2(dstDevice::CUdeviceptr, dstPitch::Csize_t, ui::Cuint,
-                                    Width::Csize_t, Height::Csize_t)::CUresult
+    @gcsafe_ccall libcuda.cuMemsetD2D32_v2(dstDevice::CUdeviceptr, dstPitch::Csize_t,
+                                           ui::Cuint, Width::Csize_t,
+                                           Height::Csize_t)::CUresult
 end
 
 @cenum CUarray_format_enum::UInt32 begin
@@ -465,13 +479,13 @@ const CUDA_ARRAY_DESCRIPTOR = CUDA_ARRAY_DESCRIPTOR_v2
 @checked function cuArrayCreate_v2(pHandle, pAllocateArray)
     initialize_context()
     @gcsafe_ccall libcuda.cuArrayCreate_v2(pHandle::Ptr{CUarray},
-                                    pAllocateArray::Ptr{CUDA_ARRAY_DESCRIPTOR})::CUresult
+                                           pAllocateArray::Ptr{CUDA_ARRAY_DESCRIPTOR})::CUresult
 end
 
 @checked function cuArrayGetDescriptor_v2(pArrayDescriptor, hArray)
     initialize_context()
     @gcsafe_ccall libcuda.cuArrayGetDescriptor_v2(pArrayDescriptor::Ptr{CUDA_ARRAY_DESCRIPTOR},
-                                           hArray::CUarray)::CUresult
+                                                  hArray::CUarray)::CUresult
 end
 
 struct CUDA_ARRAY3D_DESCRIPTOR_st
@@ -490,13 +504,13 @@ const CUDA_ARRAY3D_DESCRIPTOR = CUDA_ARRAY3D_DESCRIPTOR_v2
 @checked function cuArray3DCreate_v2(pHandle, pAllocateArray)
     initialize_context()
     @gcsafe_ccall libcuda.cuArray3DCreate_v2(pHandle::Ptr{CUarray},
-                                      pAllocateArray::Ptr{CUDA_ARRAY3D_DESCRIPTOR})::CUresult
+                                             pAllocateArray::Ptr{CUDA_ARRAY3D_DESCRIPTOR})::CUresult
 end
 
 @checked function cuArray3DGetDescriptor_v2(pArrayDescriptor, hArray)
     initialize_context()
     @gcsafe_ccall libcuda.cuArray3DGetDescriptor_v2(pArrayDescriptor::Ptr{CUDA_ARRAY3D_DESCRIPTOR},
-                                             hArray::CUarray)::CUresult
+                                                    hArray::CUarray)::CUresult
 end
 
 mutable struct CUtexref_st end
@@ -506,13 +520,13 @@ const CUtexref = Ptr{CUtexref_st}
 @checked function cuTexRefSetAddress_v2(ByteOffset, hTexRef, dptr, bytes)
     initialize_context()
     @gcsafe_ccall libcuda.cuTexRefSetAddress_v2(ByteOffset::Ptr{Csize_t}, hTexRef::CUtexref,
-                                         dptr::CUdeviceptr, bytes::Csize_t)::CUresult
+                                                dptr::CUdeviceptr, bytes::Csize_t)::CUresult
 end
 
 @checked function cuTexRefGetAddress_v2(pdptr, hTexRef)
     initialize_context()
     @gcsafe_ccall libcuda.cuTexRefGetAddress_v2(pdptr::Ptr{CUdeviceptr},
-                                         hTexRef::CUtexref)::CUresult
+                                                hTexRef::CUtexref)::CUresult
 end
 
 mutable struct CUgraphicsResource_st end
@@ -522,8 +536,8 @@ const CUgraphicsResource = Ptr{CUgraphicsResource_st}
 @checked function cuGraphicsResourceGetMappedPointer_v2(pDevPtr, pSize, resource)
     initialize_context()
     @gcsafe_ccall libcuda.cuGraphicsResourceGetMappedPointer_v2(pDevPtr::Ptr{CUdeviceptr},
-                                                         pSize::Ptr{Csize_t},
-                                                         resource::CUgraphicsResource)::CUresult
+                                                                pSize::Ptr{Csize_t},
+                                                                resource::CUgraphicsResource)::CUresult
 end
 
 @checked function cuCtxDestroy_v2(ctx)
@@ -555,8 +569,9 @@ end
 @checked function cuTexRefSetAddress2D_v3(hTexRef, desc, dptr, Pitch)
     initialize_context()
     @gcsafe_ccall libcuda.cuTexRefSetAddress2D_v3(hTexRef::CUtexref,
-                                           desc::Ptr{CUDA_ARRAY_DESCRIPTOR},
-                                           dptr::CUdeviceptr, Pitch::Csize_t)::CUresult
+                                                  desc::Ptr{CUDA_ARRAY_DESCRIPTOR},
+                                                  dptr::CUdeviceptr,
+                                                  Pitch::Csize_t)::CUresult
 end
 
 @cenum CUjit_option_enum::UInt32 begin
@@ -604,8 +619,8 @@ const CUlinkState = Ptr{CUlinkState_st}
 @checked function cuLinkCreate_v2(numOptions, options, optionValues, stateOut)
     initialize_context()
     @gcsafe_ccall libcuda.cuLinkCreate_v2(numOptions::Cuint, options::Ptr{CUjit_option},
-                                   optionValues::Ptr{Ptr{Cvoid}},
-                                   stateOut::Ptr{CUlinkState})::CUresult
+                                          optionValues::Ptr{Ptr{Cvoid}},
+                                          stateOut::Ptr{CUlinkState})::CUresult
 end
 
 @cenum CUjitInputType_enum::UInt32 begin
@@ -624,28 +639,29 @@ const CUjitInputType = CUjitInputType_enum
                                    optionValues)
     initialize_context()
     @gcsafe_ccall libcuda.cuLinkAddData_v2(state::CUlinkState, type::CUjitInputType,
-                                    data::Ptr{Cvoid}, size::Csize_t, name::Cstring,
-                                    numOptions::Cuint, options::Ptr{CUjit_option},
-                                    optionValues::Ptr{Ptr{Cvoid}})::CUresult
+                                           data::Ptr{Cvoid}, size::Csize_t, name::Cstring,
+                                           numOptions::Cuint, options::Ptr{CUjit_option},
+                                           optionValues::Ptr{Ptr{Cvoid}})::CUresult
 end
 
 @checked function cuLinkAddFile_v2(state, type, path, numOptions, options, optionValues)
     initialize_context()
-    @gcsafe_ccall libcuda.cuLinkAddFile_v2(state::CUlinkState, type::CUjitInputType, path::Cstring,
-                                    numOptions::Cuint, options::Ptr{CUjit_option},
-                                    optionValues::Ptr{Ptr{Cvoid}})::CUresult
+    @gcsafe_ccall libcuda.cuLinkAddFile_v2(state::CUlinkState, type::CUjitInputType,
+                                           path::Cstring, numOptions::Cuint,
+                                           options::Ptr{CUjit_option},
+                                           optionValues::Ptr{Ptr{Cvoid}})::CUresult
 end
 
 @checked function cuMemHostRegister_v2(p, bytesize, Flags)
     initialize_context()
     @gcsafe_ccall libcuda.cuMemHostRegister_v2(p::Ptr{Cvoid}, bytesize::Csize_t,
-                                        Flags::Cuint)::CUresult
+                                               Flags::Cuint)::CUresult
 end
 
 @checked function cuGraphicsResourceSetMapFlags_v2(resource, flags)
     initialize_context()
     @gcsafe_ccall libcuda.cuGraphicsResourceSetMapFlags_v2(resource::CUgraphicsResource,
-                                                    flags::Cuint)::CUresult
+                                                           flags::Cuint)::CUresult
 end
 
 @cenum CUstreamCaptureMode_enum::UInt32 begin
@@ -659,7 +675,7 @@ const CUstreamCaptureMode = CUstreamCaptureMode_enum
 @checked function cuStreamBeginCapture_v2(hStream, mode)
     initialize_context()
     @gcsafe_ccall libcuda.cuStreamBeginCapture_v2(hStream::CUstream,
-                                           mode::CUstreamCaptureMode)::CUresult
+                                                  mode::CUstreamCaptureMode)::CUresult
 end
 
 @checked function cuDevicePrimaryCtxRelease_v2(dev)
@@ -671,7 +687,8 @@ end
 end
 
 @checked function cuDevicePrimaryCtxSetFlags_v2(dev, flags)
-    @gcsafe_ccall libcuda.cuDevicePrimaryCtxSetFlags_v2(dev::CUdevice, flags::Cuint)::CUresult
+    @gcsafe_ccall libcuda.cuDevicePrimaryCtxSetFlags_v2(dev::CUdevice,
+                                                        flags::Cuint)::CUresult
 end
 
 struct CUipcMemHandle_st
@@ -684,8 +701,9 @@ const CUipcMemHandle = CUipcMemHandle_v1
 
 @checked function cuIpcOpenMemHandle_v2(pdptr, handle, Flags)
     initialize_context()
-    @gcsafe_ccall libcuda.cuIpcOpenMemHandle_v2(pdptr::Ptr{CUdeviceptr}, handle::CUipcMemHandle,
-                                         Flags::Cuint)::CUresult
+    @gcsafe_ccall libcuda.cuIpcOpenMemHandle_v2(pdptr::Ptr{CUdeviceptr},
+                                                handle::CUipcMemHandle,
+                                                Flags::Cuint)::CUresult
 end
 
 mutable struct CUgraphExec_st end
@@ -699,7 +717,8 @@ const CUgraph = Ptr{CUgraph_st}
 @checked function cuGraphInstantiateWithFlags(phGraphExec, hGraph, flags)
     initialize_context()
     @gcsafe_ccall libcuda.cuGraphInstantiateWithFlags(phGraphExec::Ptr{CUgraphExec},
-                                               hGraph::CUgraph, flags::Culonglong)::CUresult
+                                                      hGraph::CUgraph,
+                                                      flags::Culonglong)::CUresult
 end
 
 @cenum CUgraphExecUpdateResult_enum::UInt32 begin
@@ -733,7 +752,7 @@ const CUgraphExecUpdateResultInfo = CUgraphExecUpdateResultInfo_v1
 @checked function cuGraphExecUpdate_v2(hGraphExec, hGraph, resultInfo)
     initialize_context()
     @gcsafe_ccall libcuda.cuGraphExecUpdate_v2(hGraphExec::CUgraphExec, hGraph::CUgraph,
-                                        resultInfo::Ptr{CUgraphExecUpdateResultInfo})::CUresult
+                                               resultInfo::Ptr{CUgraphExecUpdateResultInfo})::CUresult
 end
 
 const cuuint64_t = UInt64
@@ -749,8 +768,8 @@ const CUdriverProcAddressQueryResult = CUdriverProcAddressQueryResult_enum
 @checked function cuGetProcAddress_v2(symbol, pfn, cudaVersion, flags, symbolStatus)
     initialize_context()
     @gcsafe_ccall libcuda.cuGetProcAddress_v2(symbol::Cstring, pfn::Ptr{Ptr{Cvoid}},
-                                       cudaVersion::Cint, flags::cuuint64_t,
-                                       symbolStatus::Ptr{CUdriverProcAddressQueryResult})::CUresult
+                                              cudaVersion::Cint, flags::cuuint64_t,
+                                              symbolStatus::Ptr{CUdriverProcAddressQueryResult})::CUresult
 end
 
 mutable struct CUfunc_st end
@@ -783,29 +802,30 @@ const CUDA_KERNEL_NODE_PARAMS = CUDA_KERNEL_NODE_PARAMS_v2
 @checked function cuGraphAddKernelNode_v2(phGraphNode, hGraph, dependencies,
                                           numDependencies, nodeParams)
     initialize_context()
-    @gcsafe_ccall libcuda.cuGraphAddKernelNode_v2(phGraphNode::Ptr{CUgraphNode}, hGraph::CUgraph,
-                                           dependencies::Ptr{CUgraphNode},
-                                           numDependencies::Csize_t,
-                                           nodeParams::Ptr{CUDA_KERNEL_NODE_PARAMS})::CUresult
+    @gcsafe_ccall libcuda.cuGraphAddKernelNode_v2(phGraphNode::Ptr{CUgraphNode},
+                                                  hGraph::CUgraph,
+                                                  dependencies::Ptr{CUgraphNode},
+                                                  numDependencies::Csize_t,
+                                                  nodeParams::Ptr{CUDA_KERNEL_NODE_PARAMS})::CUresult
 end
 
 @checked function cuGraphKernelNodeGetParams_v2(hNode, nodeParams)
     initialize_context()
     @gcsafe_ccall libcuda.cuGraphKernelNodeGetParams_v2(hNode::CUgraphNode,
-                                                 nodeParams::Ptr{CUDA_KERNEL_NODE_PARAMS})::CUresult
+                                                        nodeParams::Ptr{CUDA_KERNEL_NODE_PARAMS})::CUresult
 end
 
 @checked function cuGraphKernelNodeSetParams_v2(hNode, nodeParams)
     initialize_context()
     @gcsafe_ccall libcuda.cuGraphKernelNodeSetParams_v2(hNode::CUgraphNode,
-                                                 nodeParams::Ptr{CUDA_KERNEL_NODE_PARAMS})::CUresult
+                                                        nodeParams::Ptr{CUDA_KERNEL_NODE_PARAMS})::CUresult
 end
 
 @checked function cuGraphExecKernelNodeSetParams_v2(hGraphExec, hNode, nodeParams)
     initialize_context()
     @gcsafe_ccall libcuda.cuGraphExecKernelNodeSetParams_v2(hGraphExec::CUgraphExec,
-                                                     hNode::CUgraphNode,
-                                                     nodeParams::Ptr{CUDA_KERNEL_NODE_PARAMS})::CUresult
+                                                            hNode::CUgraphNode,
+                                                            nodeParams::Ptr{CUDA_KERNEL_NODE_PARAMS})::CUresult
 end
 
 const cuuint32_t = UInt32
@@ -813,25 +833,25 @@ const cuuint32_t = UInt32
 @checked function cuStreamWriteValue32_v2(stream, addr, value, flags)
     initialize_context()
     @gcsafe_ccall libcuda.cuStreamWriteValue32_v2(stream::CUstream, addr::CUdeviceptr,
-                                           value::cuuint32_t, flags::Cuint)::CUresult
+                                                  value::cuuint32_t, flags::Cuint)::CUresult
 end
 
 @checked function cuStreamWaitValue32_v2(stream, addr, value, flags)
     initialize_context()
     @gcsafe_ccall libcuda.cuStreamWaitValue32_v2(stream::CUstream, addr::CUdeviceptr,
-                                          value::cuuint32_t, flags::Cuint)::CUresult
+                                                 value::cuuint32_t, flags::Cuint)::CUresult
 end
 
 @checked function cuStreamWriteValue64_v2(stream, addr, value, flags)
     initialize_context()
     @gcsafe_ccall libcuda.cuStreamWriteValue64_v2(stream::CUstream, addr::CUdeviceptr,
-                                           value::cuuint64_t, flags::Cuint)::CUresult
+                                                  value::cuuint64_t, flags::Cuint)::CUresult
 end
 
 @checked function cuStreamWaitValue64_v2(stream, addr, value, flags)
     initialize_context()
     @gcsafe_ccall libcuda.cuStreamWaitValue64_v2(stream::CUstream, addr::CUdeviceptr,
-                                          value::cuuint64_t, flags::Cuint)::CUresult
+                                                 value::cuuint64_t, flags::Cuint)::CUresult
 end
 
 struct CUstreamBatchMemOpParams_union
@@ -866,8 +886,8 @@ const CUstreamBatchMemOpParams = CUstreamBatchMemOpParams_v1
 @checked function cuStreamBatchMemOp_v2(stream, count, paramArray, flags)
     initialize_context()
     @gcsafe_ccall libcuda.cuStreamBatchMemOp_v2(stream::CUstream, count::Cuint,
-                                         paramArray::Ptr{CUstreamBatchMemOpParams},
-                                         flags::Cuint)::CUresult
+                                                paramArray::Ptr{CUstreamBatchMemOpParams},
+                                                flags::Cuint)::CUresult
 end
 
 @cenum CUstreamCaptureStatus_enum::UInt32 begin
@@ -882,11 +902,11 @@ const CUstreamCaptureStatus = CUstreamCaptureStatus_enum
                                             dependencies_out, numDependencies_out)
     initialize_context()
     @gcsafe_ccall libcuda.cuStreamGetCaptureInfo_v2(hStream::CUstream,
-                                             captureStatus_out::Ptr{CUstreamCaptureStatus},
-                                             id_out::Ptr{cuuint64_t},
-                                             graph_out::Ptr{CUgraph},
-                                             dependencies_out::Ptr{Ptr{CUgraphNode}},
-                                             numDependencies_out::Ptr{Csize_t})::CUresult
+                                                    captureStatus_out::Ptr{CUstreamCaptureStatus},
+                                                    id_out::Ptr{cuuint64_t},
+                                                    graph_out::Ptr{CUgraph},
+                                                    dependencies_out::Ptr{Ptr{CUgraphNode}},
+                                                    numDependencies_out::Ptr{Csize_t})::CUresult
 end
 
 mutable struct CUlib_st end
@@ -3107,27 +3127,28 @@ end
 
 @checked function cuDeviceGetLuid(luid, deviceNodeMask, dev)
     @gcsafe_ccall libcuda.cuDeviceGetLuid(luid::Cstring, deviceNodeMask::Ptr{Cuint},
-                                   dev::CUdevice)::CUresult
+                                          dev::CUdevice)::CUresult
 end
 
 @checked function cuDeviceGetTexture1DLinearMaxWidth(maxWidthInElements, format,
                                                      numChannels, dev)
     initialize_context()
     @gcsafe_ccall libcuda.cuDeviceGetTexture1DLinearMaxWidth(maxWidthInElements::Ptr{Csize_t},
-                                                      format::CUarray_format,
-                                                      numChannels::Cuint,
-                                                      dev::CUdevice)::CUresult
+                                                             format::CUarray_format,
+                                                             numChannels::Cuint,
+                                                             dev::CUdevice)::CUresult
 end
 
 @checked function cuDeviceGetAttribute(pi, attrib, dev)
     @gcsafe_ccall libcuda.cuDeviceGetAttribute(pi::Ptr{Cint}, attrib::CUdevice_attribute,
-                                        dev::CUdevice)::CUresult
+                                               dev::CUdevice)::CUresult
 end
 
 @checked function cuDeviceGetNvSciSyncAttributes(nvSciSyncAttrList, dev, flags)
     initialize_context()
     @gcsafe_ccall libcuda.cuDeviceGetNvSciSyncAttributes(nvSciSyncAttrList::Ptr{Cvoid},
-                                                  dev::CUdevice, flags::Cint)::CUresult
+                                                         dev::CUdevice,
+                                                         flags::Cint)::CUresult
 end
 
 @checked function cuDeviceSetMemPool(dev, pool)
@@ -3137,50 +3158,55 @@ end
 
 @checked function cuDeviceGetMemPool(pool, dev)
     initialize_context()
-    @gcsafe_ccall libcuda.cuDeviceGetMemPool(pool::Ptr{CUmemoryPool}, dev::CUdevice)::CUresult
+    @gcsafe_ccall libcuda.cuDeviceGetMemPool(pool::Ptr{CUmemoryPool},
+                                             dev::CUdevice)::CUresult
 end
 
 @checked function cuDeviceGetDefaultMemPool(pool_out, dev)
     initialize_context()
     @gcsafe_ccall libcuda.cuDeviceGetDefaultMemPool(pool_out::Ptr{CUmemoryPool},
-                                             dev::CUdevice)::CUresult
+                                                    dev::CUdevice)::CUresult
 end
 
 @checked function cuDeviceGetExecAffinitySupport(pi, type, dev)
     initialize_context()
-    @gcsafe_ccall libcuda.cuDeviceGetExecAffinitySupport(pi::Ptr{Cint}, type::CUexecAffinityType,
-                                                  dev::CUdevice)::CUresult
+    @gcsafe_ccall libcuda.cuDeviceGetExecAffinitySupport(pi::Ptr{Cint},
+                                                         type::CUexecAffinityType,
+                                                         dev::CUdevice)::CUresult
 end
 
 @checked function cuFlushGPUDirectRDMAWrites(target, scope)
     initialize_context()
     @gcsafe_ccall libcuda.cuFlushGPUDirectRDMAWrites(target::CUflushGPUDirectRDMAWritesTarget,
-                                              scope::CUflushGPUDirectRDMAWritesScope)::CUresult
+                                                     scope::CUflushGPUDirectRDMAWritesScope)::CUresult
 end
 
 @checked function cuDeviceGetProperties(prop, dev)
-    @gcsafe_ccall libcuda.cuDeviceGetProperties(prop::Ptr{CUdevprop}, dev::CUdevice)::CUresult
+    @gcsafe_ccall libcuda.cuDeviceGetProperties(prop::Ptr{CUdevprop},
+                                                dev::CUdevice)::CUresult
 end
 
 @checked function cuDeviceComputeCapability(major, minor, dev)
     @gcsafe_ccall libcuda.cuDeviceComputeCapability(major::Ptr{Cint}, minor::Ptr{Cint},
-                                             dev::CUdevice)::CUresult
+                                                    dev::CUdevice)::CUresult
 end
 
 @checked function cuDevicePrimaryCtxRetain(pctx, dev)
-    @gcsafe_ccall libcuda.cuDevicePrimaryCtxRetain(pctx::Ptr{CUcontext}, dev::CUdevice)::CUresult
+    @gcsafe_ccall libcuda.cuDevicePrimaryCtxRetain(pctx::Ptr{CUcontext},
+                                                   dev::CUdevice)::CUresult
 end
 
 @checked function cuDevicePrimaryCtxGetState(dev, flags, active)
     @gcsafe_ccall libcuda.cuDevicePrimaryCtxGetState(dev::CUdevice, flags::Ptr{Cuint},
-                                              active::Ptr{Cint})::CUresult
+                                                     active::Ptr{Cint})::CUresult
 end
 
 @checked function cuCtxCreate_v3(pctx, paramsArray, numParams, flags, dev)
     initialize_context()
     @gcsafe_ccall libcuda.cuCtxCreate_v3(pctx::Ptr{CUcontext},
-                                  paramsArray::Ptr{CUexecAffinityParam}, numParams::Cint,
-                                  flags::Cuint, dev::CUdevice)::CUresult
+                                         paramsArray::Ptr{CUexecAffinityParam},
+                                         numParams::Cint, flags::Cuint,
+                                         dev::CUdevice)::CUresult
 end
 
 @checked function cuCtxSetCurrent(ctx)
@@ -3253,7 +3279,7 @@ end
 @checked function cuCtxGetStreamPriorityRange(leastPriority, greatestPriority)
     initialize_context()
     @gcsafe_ccall libcuda.cuCtxGetStreamPriorityRange(leastPriority::Ptr{Cint},
-                                               greatestPriority::Ptr{Cint})::CUresult
+                                                      greatestPriority::Ptr{Cint})::CUresult
 end
 
 @checked function cuCtxResetPersistingL2Cache()
@@ -3264,7 +3290,7 @@ end
 @checked function cuCtxGetExecAffinity(pExecAffinity, type)
     initialize_context()
     @gcsafe_ccall libcuda.cuCtxGetExecAffinity(pExecAffinity::Ptr{CUexecAffinityParam},
-                                        type::CUexecAffinityType)::CUresult
+                                               type::CUexecAffinityType)::CUresult
 end
 
 @checked function cuCtxAttach(pctx, flags)
@@ -3284,20 +3310,21 @@ end
 
 @checked function cuModuleLoadData(_module, image)
     initialize_context()
-    @gcsafe_ccall libcuda.cuModuleLoadData(_module::Ptr{CUmodule}, image::Ptr{Cvoid})::CUresult
+    @gcsafe_ccall libcuda.cuModuleLoadData(_module::Ptr{CUmodule},
+                                           image::Ptr{Cvoid})::CUresult
 end
 
 @checked function cuModuleLoadDataEx(_module, image, numOptions, options, optionValues)
     initialize_context()
     @gcsafe_ccall libcuda.cuModuleLoadDataEx(_module::Ptr{CUmodule}, image::Ptr{Cvoid},
-                                      numOptions::Cuint, options::Ptr{CUjit_option},
-                                      optionValues::Ptr{Ptr{Cvoid}})::CUresult
+                                             numOptions::Cuint, options::Ptr{CUjit_option},
+                                             optionValues::Ptr{Ptr{Cvoid}})::CUresult
 end
 
 @checked function cuModuleLoadFatBinary(_module, fatCubin)
     initialize_context()
     @gcsafe_ccall libcuda.cuModuleLoadFatBinary(_module::Ptr{CUmodule},
-                                         fatCubin::Ptr{Cvoid})::CUresult
+                                                fatCubin::Ptr{Cvoid})::CUresult
 end
 
 @checked function cuModuleUnload(hmod)
@@ -3320,13 +3347,13 @@ end
 @checked function cuModuleGetFunction(hfunc, hmod, name)
     initialize_context()
     @gcsafe_ccall libcuda.cuModuleGetFunction(hfunc::Ptr{CUfunction}, hmod::CUmodule,
-                                       name::Cstring)::CUresult
+                                              name::Cstring)::CUresult
 end
 
 @checked function cuLinkComplete(state, cubinOut, sizeOut)
     initialize_context()
     @gcsafe_ccall libcuda.cuLinkComplete(state::CUlinkState, cubinOut::Ptr{Ptr{Cvoid}},
-                                  sizeOut::Ptr{Csize_t})::CUresult
+                                         sizeOut::Ptr{Csize_t})::CUresult
 end
 
 @checked function cuLinkDestroy(state)
@@ -3337,13 +3364,13 @@ end
 @checked function cuModuleGetTexRef(pTexRef, hmod, name)
     initialize_context()
     @gcsafe_ccall libcuda.cuModuleGetTexRef(pTexRef::Ptr{CUtexref}, hmod::CUmodule,
-                                     name::Cstring)::CUresult
+                                            name::Cstring)::CUresult
 end
 
 @checked function cuModuleGetSurfRef(pSurfRef, hmod, name)
     initialize_context()
     @gcsafe_ccall libcuda.cuModuleGetSurfRef(pSurfRef::Ptr{CUsurfref}, hmod::CUmodule,
-                                      name::Cstring)::CUresult
+                                             name::Cstring)::CUresult
 end
 
 @checked function cuLibraryLoadData(library, code, jitOptions, jitOptionsValues,
@@ -3351,12 +3378,12 @@ end
                                     numLibraryOptions)
     initialize_context()
     @gcsafe_ccall libcuda.cuLibraryLoadData(library::Ptr{CUlibrary}, code::Ptr{Cvoid},
-                                     jitOptions::Ptr{CUjit_option},
-                                     jitOptionsValues::Ptr{Ptr{Cvoid}},
-                                     numJitOptions::Cuint,
-                                     libraryOptions::Ptr{CUlibraryOption},
-                                     libraryOptionValues::Ptr{Ptr{Cvoid}},
-                                     numLibraryOptions::Cuint)::CUresult
+                                            jitOptions::Ptr{CUjit_option},
+                                            jitOptionsValues::Ptr{Ptr{Cvoid}},
+                                            numJitOptions::Cuint,
+                                            libraryOptions::Ptr{CUlibraryOption},
+                                            libraryOptionValues::Ptr{Ptr{Cvoid}},
+                                            numLibraryOptions::Cuint)::CUresult
 end
 
 @checked function cuLibraryLoadFromFile(library, fileName, jitOptions, jitOptionsValues,
@@ -3364,12 +3391,12 @@ end
                                         numLibraryOptions)
     initialize_context()
     @gcsafe_ccall libcuda.cuLibraryLoadFromFile(library::Ptr{CUlibrary}, fileName::Cstring,
-                                         jitOptions::Ptr{CUjit_option},
-                                         jitOptionsValues::Ptr{Ptr{Cvoid}},
-                                         numJitOptions::Cuint,
-                                         libraryOptions::Ptr{CUlibraryOption},
-                                         libraryOptionValues::Ptr{Ptr{Cvoid}},
-                                         numLibraryOptions::Cuint)::CUresult
+                                                jitOptions::Ptr{CUjit_option},
+                                                jitOptionsValues::Ptr{Ptr{Cvoid}},
+                                                numJitOptions::Cuint,
+                                                libraryOptions::Ptr{CUlibraryOption},
+                                                libraryOptionValues::Ptr{Ptr{Cvoid}},
+                                                numLibraryOptions::Cuint)::CUresult
 end
 
 @checked function cuLibraryUnload(library)
@@ -3380,53 +3407,56 @@ end
 @checked function cuLibraryGetKernel(pKernel, library, name)
     initialize_context()
     @gcsafe_ccall libcuda.cuLibraryGetKernel(pKernel::Ptr{CUkernel}, library::CUlibrary,
-                                      name::Cstring)::CUresult
+                                             name::Cstring)::CUresult
 end
 
 @checked function cuLibraryGetModule(pMod, library)
     initialize_context()
-    @gcsafe_ccall libcuda.cuLibraryGetModule(pMod::Ptr{CUmodule}, library::CUlibrary)::CUresult
+    @gcsafe_ccall libcuda.cuLibraryGetModule(pMod::Ptr{CUmodule},
+                                             library::CUlibrary)::CUresult
 end
 
 @checked function cuKernelGetFunction(pFunc, kernel)
     initialize_context()
-    @gcsafe_ccall libcuda.cuKernelGetFunction(pFunc::Ptr{CUfunction}, kernel::CUkernel)::CUresult
+    @gcsafe_ccall libcuda.cuKernelGetFunction(pFunc::Ptr{CUfunction},
+                                              kernel::CUkernel)::CUresult
 end
 
 @checked function cuLibraryGetGlobal(dptr, bytes, library, name)
     initialize_context()
     @gcsafe_ccall libcuda.cuLibraryGetGlobal(dptr::Ptr{CUdeviceptr}, bytes::Ptr{Csize_t},
-                                      library::CUlibrary, name::Cstring)::CUresult
+                                             library::CUlibrary, name::Cstring)::CUresult
 end
 
 @checked function cuLibraryGetManaged(dptr, bytes, library, name)
     initialize_context()
     @gcsafe_ccall libcuda.cuLibraryGetManaged(dptr::Ptr{CUdeviceptr}, bytes::Ptr{Csize_t},
-                                       library::CUlibrary, name::Cstring)::CUresult
+                                              library::CUlibrary, name::Cstring)::CUresult
 end
 
 @checked function cuLibraryGetUnifiedFunction(fptr, library, symbol)
     initialize_context()
-    @gcsafe_ccall libcuda.cuLibraryGetUnifiedFunction(fptr::Ptr{Ptr{Cvoid}}, library::CUlibrary,
-                                               symbol::Cstring)::CUresult
+    @gcsafe_ccall libcuda.cuLibraryGetUnifiedFunction(fptr::Ptr{Ptr{Cvoid}},
+                                                      library::CUlibrary,
+                                                      symbol::Cstring)::CUresult
 end
 
 @checked function cuKernelGetAttribute(pi, attrib, kernel, dev)
     initialize_context()
     @gcsafe_ccall libcuda.cuKernelGetAttribute(pi::Ptr{Cint}, attrib::CUfunction_attribute,
-                                        kernel::CUkernel, dev::CUdevice)::CUresult
+                                               kernel::CUkernel, dev::CUdevice)::CUresult
 end
 
 @checked function cuKernelSetAttribute(attrib, val, kernel, dev)
     initialize_context()
     @gcsafe_ccall libcuda.cuKernelSetAttribute(attrib::CUfunction_attribute, val::Cint,
-                                        kernel::CUkernel, dev::CUdevice)::CUresult
+                                               kernel::CUkernel, dev::CUdevice)::CUresult
 end
 
 @checked function cuKernelSetCacheConfig(kernel, config, dev)
     initialize_context()
     @gcsafe_ccall libcuda.cuKernelSetCacheConfig(kernel::CUkernel, config::CUfunc_cache,
-                                          dev::CUdevice)::CUresult
+                                                 dev::CUdevice)::CUresult
 end
 
 @checked function cuKernelGetName(name, hfunc)
@@ -3442,7 +3472,7 @@ end
 @checked function cuMemHostAlloc(pp, bytesize, Flags)
     initialize_context()
     @gcsafe_ccall libcuda.cuMemHostAlloc(pp::Ptr{Ptr{Cvoid}}, bytesize::Csize_t,
-                                  Flags::Cuint)::CUresult
+                                         Flags::Cuint)::CUresult
 end
 
 @checked function cuMemHostGetFlags(pFlags, p)
@@ -3453,36 +3483,37 @@ end
 @checked function cuMemAllocManaged(dptr, bytesize, flags)
     initialize_context()
     @gcsafe_ccall libcuda.cuMemAllocManaged(dptr::Ptr{CUdeviceptr}, bytesize::Csize_t,
-                                     flags::Cuint)::CUresult
+                                            flags::Cuint)::CUresult
 end
 
 @checked function cuDeviceGetByPCIBusId(dev, pciBusId)
     initialize_context()
-    @gcsafe_ccall libcuda.cuDeviceGetByPCIBusId(dev::Ptr{CUdevice}, pciBusId::Cstring)::CUresult
+    @gcsafe_ccall libcuda.cuDeviceGetByPCIBusId(dev::Ptr{CUdevice},
+                                                pciBusId::Cstring)::CUresult
 end
 
 @checked function cuDeviceGetPCIBusId(pciBusId, len, dev)
     initialize_context()
     @gcsafe_ccall libcuda.cuDeviceGetPCIBusId(pciBusId::Cstring, len::Cint,
-                                       dev::CUdevice)::CUresult
+                                              dev::CUdevice)::CUresult
 end
 
 @checked function cuIpcGetEventHandle(pHandle, event)
     initialize_context()
     @gcsafe_ccall libcuda.cuIpcGetEventHandle(pHandle::Ptr{CUipcEventHandle},
-                                       event::CUevent)::CUresult
+                                              event::CUevent)::CUresult
 end
 
 @checked function cuIpcOpenEventHandle(phEvent, handle)
     initialize_context()
     @gcsafe_ccall libcuda.cuIpcOpenEventHandle(phEvent::Ptr{CUevent},
-                                        handle::CUipcEventHandle)::CUresult
+                                               handle::CUipcEventHandle)::CUresult
 end
 
 @checked function cuIpcGetMemHandle(pHandle, dptr)
     initialize_context()
     @gcsafe_ccall libcuda.cuIpcGetMemHandle(pHandle::Ptr{CUipcMemHandle},
-                                     dptr::CUdeviceptr)::CUresult
+                                            dptr::CUdeviceptr)::CUresult
 end
 
 @checked function cuIpcCloseMemHandle(dptr)
@@ -3498,14 +3529,14 @@ end
 @checked function cuMemcpy(dst, src, ByteCount)
     initialize_context()
     @gcsafe_ccall libcuda.cuMemcpy(dst::CUdeviceptr, src::CUdeviceptr,
-                            ByteCount::Csize_t)::CUresult
+                                   ByteCount::Csize_t)::CUresult
 end
 
 @checked function cuMemcpyPeer(dstDevice, dstContext, srcDevice, srcContext, ByteCount)
     initialize_context()
     @gcsafe_ccall libcuda.cuMemcpyPeer(dstDevice::CUdeviceptr, dstContext::CUcontext,
-                                srcDevice::CUdeviceptr, srcContext::CUcontext,
-                                ByteCount::Csize_t)::CUresult
+                                       srcDevice::CUdeviceptr, srcContext::CUcontext,
+                                       ByteCount::Csize_t)::CUresult
 end
 
 @checked function cuMemcpy3DPeer(pCopy)
@@ -3515,92 +3546,93 @@ end
 
 @checked function cuMemcpyAsync(dst, src, ByteCount, hStream)
     initialize_context()
-    @gcsafe_ccall libcuda.cuMemcpyAsync(dst::CUdeviceptr, src::CUdeviceptr, ByteCount::Csize_t,
-                                 hStream::CUstream)::CUresult
+    @gcsafe_ccall libcuda.cuMemcpyAsync(dst::CUdeviceptr, src::CUdeviceptr,
+                                        ByteCount::Csize_t, hStream::CUstream)::CUresult
 end
 
 @checked function cuMemcpyPeerAsync(dstDevice, dstContext, srcDevice, srcContext, ByteCount,
                                     hStream)
     initialize_context()
     @gcsafe_ccall libcuda.cuMemcpyPeerAsync(dstDevice::CUdeviceptr, dstContext::CUcontext,
-                                     srcDevice::CUdeviceptr, srcContext::CUcontext,
-                                     ByteCount::Csize_t, hStream::CUstream)::CUresult
+                                            srcDevice::CUdeviceptr, srcContext::CUcontext,
+                                            ByteCount::Csize_t, hStream::CUstream)::CUresult
 end
 
 @checked function cuMemcpy3DPeerAsync(pCopy, hStream)
     initialize_context()
     @gcsafe_ccall libcuda.cuMemcpy3DPeerAsync(pCopy::Ptr{CUDA_MEMCPY3D_PEER},
-                                       hStream::CUstream)::CUresult
+                                              hStream::CUstream)::CUresult
 end
 
 @checked function cuMemsetD8Async(dstDevice, uc, N, hStream)
     initialize_context()
     @gcsafe_ccall libcuda.cuMemsetD8Async(dstDevice::CUdeviceptr, uc::Cuchar, N::Csize_t,
-                                   hStream::CUstream)::CUresult
+                                          hStream::CUstream)::CUresult
 end
 
 @checked function cuMemsetD16Async(dstDevice, us, N, hStream)
     initialize_context()
     @gcsafe_ccall libcuda.cuMemsetD16Async(dstDevice::CUdeviceptr, us::Cushort, N::Csize_t,
-                                    hStream::CUstream)::CUresult
+                                           hStream::CUstream)::CUresult
 end
 
 @checked function cuMemsetD32Async(dstDevice, ui, N, hStream)
     initialize_context()
     @gcsafe_ccall libcuda.cuMemsetD32Async(dstDevice::CUdeviceptr, ui::Cuint, N::Csize_t,
-                                    hStream::CUstream)::CUresult
+                                           hStream::CUstream)::CUresult
 end
 
 @checked function cuMemsetD2D8Async(dstDevice, dstPitch, uc, Width, Height, hStream)
     initialize_context()
-    @gcsafe_ccall libcuda.cuMemsetD2D8Async(dstDevice::CUdeviceptr, dstPitch::Csize_t, uc::Cuchar,
-                                     Width::Csize_t, Height::Csize_t,
-                                     hStream::CUstream)::CUresult
+    @gcsafe_ccall libcuda.cuMemsetD2D8Async(dstDevice::CUdeviceptr, dstPitch::Csize_t,
+                                            uc::Cuchar, Width::Csize_t, Height::Csize_t,
+                                            hStream::CUstream)::CUresult
 end
 
 @checked function cuMemsetD2D16Async(dstDevice, dstPitch, us, Width, Height, hStream)
     initialize_context()
     @gcsafe_ccall libcuda.cuMemsetD2D16Async(dstDevice::CUdeviceptr, dstPitch::Csize_t,
-                                      us::Cushort, Width::Csize_t, Height::Csize_t,
-                                      hStream::CUstream)::CUresult
+                                             us::Cushort, Width::Csize_t, Height::Csize_t,
+                                             hStream::CUstream)::CUresult
 end
 
 @checked function cuMemsetD2D32Async(dstDevice, dstPitch, ui, Width, Height, hStream)
     initialize_context()
-    @gcsafe_ccall libcuda.cuMemsetD2D32Async(dstDevice::CUdeviceptr, dstPitch::Csize_t, ui::Cuint,
-                                      Width::Csize_t, Height::Csize_t,
-                                      hStream::CUstream)::CUresult
+    @gcsafe_ccall libcuda.cuMemsetD2D32Async(dstDevice::CUdeviceptr, dstPitch::Csize_t,
+                                             ui::Cuint, Width::Csize_t, Height::Csize_t,
+                                             hStream::CUstream)::CUresult
 end
 
 @checked function cuArrayGetSparseProperties(sparseProperties, array)
     initialize_context()
     @gcsafe_ccall libcuda.cuArrayGetSparseProperties(sparseProperties::Ptr{CUDA_ARRAY_SPARSE_PROPERTIES},
-                                              array::CUarray)::CUresult
+                                                     array::CUarray)::CUresult
 end
 
 @checked function cuMipmappedArrayGetSparseProperties(sparseProperties, mipmap)
     initialize_context()
     @gcsafe_ccall libcuda.cuMipmappedArrayGetSparseProperties(sparseProperties::Ptr{CUDA_ARRAY_SPARSE_PROPERTIES},
-                                                       mipmap::CUmipmappedArray)::CUresult
+                                                              mipmap::CUmipmappedArray)::CUresult
 end
 
 @checked function cuArrayGetMemoryRequirements(memoryRequirements, array, device)
     initialize_context()
     @gcsafe_ccall libcuda.cuArrayGetMemoryRequirements(memoryRequirements::Ptr{CUDA_ARRAY_MEMORY_REQUIREMENTS},
-                                                array::CUarray, device::CUdevice)::CUresult
+                                                       array::CUarray,
+                                                       device::CUdevice)::CUresult
 end
 
 @checked function cuMipmappedArrayGetMemoryRequirements(memoryRequirements, mipmap, device)
     initialize_context()
     @gcsafe_ccall libcuda.cuMipmappedArrayGetMemoryRequirements(memoryRequirements::Ptr{CUDA_ARRAY_MEMORY_REQUIREMENTS},
-                                                         mipmap::CUmipmappedArray,
-                                                         device::CUdevice)::CUresult
+                                                                mipmap::CUmipmappedArray,
+                                                                device::CUdevice)::CUresult
 end
 
 @checked function cuArrayGetPlane(pPlaneArray, hArray, planeIdx)
     initialize_context()
     @gcsafe_ccall libcuda.cuArrayGetPlane(pPlaneArray::Ptr{CUarray}, hArray::CUarray,
-                                   planeIdx::Cuint)::CUresult
+                                          planeIdx::Cuint)::CUresult
 end
 
 @checked function cuArrayDestroy(hArray)
@@ -3611,15 +3643,15 @@ end
 @checked function cuMipmappedArrayCreate(pHandle, pMipmappedArrayDesc, numMipmapLevels)
     initialize_context()
     @gcsafe_ccall libcuda.cuMipmappedArrayCreate(pHandle::Ptr{CUmipmappedArray},
-                                          pMipmappedArrayDesc::Ptr{CUDA_ARRAY3D_DESCRIPTOR},
-                                          numMipmapLevels::Cuint)::CUresult
+                                                 pMipmappedArrayDesc::Ptr{CUDA_ARRAY3D_DESCRIPTOR},
+                                                 numMipmapLevels::Cuint)::CUresult
 end
 
 @checked function cuMipmappedArrayGetLevel(pLevelArray, hMipmappedArray, level)
     initialize_context()
     @gcsafe_ccall libcuda.cuMipmappedArrayGetLevel(pLevelArray::Ptr{CUarray},
-                                            hMipmappedArray::CUmipmappedArray,
-                                            level::Cuint)::CUresult
+                                                   hMipmappedArray::CUmipmappedArray,
+                                                   level::Cuint)::CUresult
 end
 
 @checked function cuMipmappedArrayDestroy(hMipmappedArray)
@@ -3629,17 +3661,17 @@ end
 
 @checked function cuMemGetHandleForAddressRange(handle, dptr, size, handleType, flags)
     initialize_context()
-    @gcsafe_ccall libcuda.cuMemGetHandleForAddressRange(handle::Ptr{Cvoid}, dptr::CUdeviceptr,
-                                                 size::Csize_t,
-                                                 handleType::CUmemRangeHandleType,
-                                                 flags::Culonglong)::CUresult
+    @gcsafe_ccall libcuda.cuMemGetHandleForAddressRange(handle::Ptr{Cvoid},
+                                                        dptr::CUdeviceptr, size::Csize_t,
+                                                        handleType::CUmemRangeHandleType,
+                                                        flags::Culonglong)::CUresult
 end
 
 @checked function cuMemAddressReserve(ptr, size, alignment, addr, flags)
     initialize_context()
     @gcsafe_ccall libcuda.cuMemAddressReserve(ptr::Ptr{CUdeviceptr}, size::Csize_t,
-                                       alignment::Csize_t, addr::CUdeviceptr,
-                                       flags::Culonglong)::CUresult
+                                              alignment::Csize_t, addr::CUdeviceptr,
+                                              flags::Culonglong)::CUresult
 end
 
 @checked function cuMemAddressFree(ptr, size)
@@ -3649,8 +3681,9 @@ end
 
 @checked function cuMemCreate(handle, size, prop, flags)
     initialize_context()
-    @gcsafe_ccall libcuda.cuMemCreate(handle::Ptr{CUmemGenericAllocationHandle}, size::Csize_t,
-                               prop::Ptr{CUmemAllocationProp}, flags::Culonglong)::CUresult
+    @gcsafe_ccall libcuda.cuMemCreate(handle::Ptr{CUmemGenericAllocationHandle},
+                                      size::Csize_t, prop::Ptr{CUmemAllocationProp},
+                                      flags::Culonglong)::CUresult
 end
 
 @checked function cuMemRelease(handle)
@@ -3661,14 +3694,14 @@ end
 @checked function cuMemMap(ptr, size, offset, handle, flags)
     initialize_context()
     @gcsafe_ccall libcuda.cuMemMap(ptr::CUdeviceptr, size::Csize_t, offset::Csize_t,
-                            handle::CUmemGenericAllocationHandle,
-                            flags::Culonglong)::CUresult
+                                   handle::CUmemGenericAllocationHandle,
+                                   flags::Culonglong)::CUresult
 end
 
 @checked function cuMemMapArrayAsync(mapInfoList, count, hStream)
     initialize_context()
     @gcsafe_ccall libcuda.cuMemMapArrayAsync(mapInfoList::Ptr{CUarrayMapInfo}, count::Cuint,
-                                      hStream::CUstream)::CUresult
+                                             hStream::CUstream)::CUresult
 end
 
 @checked function cuMemUnmap(ptr, size)
@@ -3679,47 +3712,49 @@ end
 @checked function cuMemSetAccess(ptr, size, desc, count)
     initialize_context()
     @gcsafe_ccall libcuda.cuMemSetAccess(ptr::CUdeviceptr, size::Csize_t,
-                                  desc::Ptr{CUmemAccessDesc}, count::Csize_t)::CUresult
+                                         desc::Ptr{CUmemAccessDesc},
+                                         count::Csize_t)::CUresult
 end
 
 @checked function cuMemGetAccess(flags, location, ptr)
     initialize_context()
-    @gcsafe_ccall libcuda.cuMemGetAccess(flags::Ptr{Culonglong}, location::Ptr{CUmemLocation},
-                                  ptr::CUdeviceptr)::CUresult
+    @gcsafe_ccall libcuda.cuMemGetAccess(flags::Ptr{Culonglong},
+                                         location::Ptr{CUmemLocation},
+                                         ptr::CUdeviceptr)::CUresult
 end
 
 @checked function cuMemExportToShareableHandle(shareableHandle, handle, handleType, flags)
     initialize_context()
     @gcsafe_ccall libcuda.cuMemExportToShareableHandle(shareableHandle::Ptr{Cvoid},
-                                                handle::CUmemGenericAllocationHandle,
-                                                handleType::CUmemAllocationHandleType,
-                                                flags::Culonglong)::CUresult
+                                                       handle::CUmemGenericAllocationHandle,
+                                                       handleType::CUmemAllocationHandleType,
+                                                       flags::Culonglong)::CUresult
 end
 
 @checked function cuMemImportFromShareableHandle(handle, osHandle, shHandleType)
     initialize_context()
     @gcsafe_ccall libcuda.cuMemImportFromShareableHandle(handle::Ptr{CUmemGenericAllocationHandle},
-                                                  osHandle::Ptr{Cvoid},
-                                                  shHandleType::CUmemAllocationHandleType)::CUresult
+                                                         osHandle::Ptr{Cvoid},
+                                                         shHandleType::CUmemAllocationHandleType)::CUresult
 end
 
 @checked function cuMemGetAllocationGranularity(granularity, prop, option)
     initialize_context()
     @gcsafe_ccall libcuda.cuMemGetAllocationGranularity(granularity::Ptr{Csize_t},
-                                                 prop::Ptr{CUmemAllocationProp},
-                                                 option::CUmemAllocationGranularity_flags)::CUresult
+                                                        prop::Ptr{CUmemAllocationProp},
+                                                        option::CUmemAllocationGranularity_flags)::CUresult
 end
 
 @checked function cuMemGetAllocationPropertiesFromHandle(prop, handle)
     initialize_context()
     @gcsafe_ccall libcuda.cuMemGetAllocationPropertiesFromHandle(prop::Ptr{CUmemAllocationProp},
-                                                          handle::CUmemGenericAllocationHandle)::CUresult
+                                                                 handle::CUmemGenericAllocationHandle)::CUresult
 end
 
 @checked function cuMemRetainAllocationHandle(handle, addr)
     initialize_context()
     @gcsafe_ccall libcuda.cuMemRetainAllocationHandle(handle::Ptr{CUmemGenericAllocationHandle},
-                                               addr::Ptr{Cvoid})::CUresult
+                                                      addr::Ptr{Cvoid})::CUresult
 end
 
 @checked function cuMemFreeAsync(dptr, hStream)
@@ -3730,42 +3765,46 @@ end
 @checked function cuMemAllocAsync(dptr, bytesize, hStream)
     initialize_context()
     @gcsafe_ccall libcuda.cuMemAllocAsync(dptr::Ptr{CUdeviceptr}, bytesize::Csize_t,
-                                   hStream::CUstream)::CUresult
+                                          hStream::CUstream)::CUresult
 end
 
 @checked function cuMemPoolTrimTo(pool, minBytesToKeep)
     initialize_context()
-    @gcsafe_ccall libcuda.cuMemPoolTrimTo(pool::CUmemoryPool, minBytesToKeep::Csize_t)::CUresult
+    @gcsafe_ccall libcuda.cuMemPoolTrimTo(pool::CUmemoryPool,
+                                          minBytesToKeep::Csize_t)::CUresult
 end
 
 @checked function cuMemPoolSetAttribute(pool, attr, value)
     initialize_context()
-    @gcsafe_ccall libcuda.cuMemPoolSetAttribute(pool::CUmemoryPool, attr::CUmemPool_attribute,
-                                         value::Ptr{Cvoid})::CUresult
+    @gcsafe_ccall libcuda.cuMemPoolSetAttribute(pool::CUmemoryPool,
+                                                attr::CUmemPool_attribute,
+                                                value::Ptr{Cvoid})::CUresult
 end
 
 @checked function cuMemPoolGetAttribute(pool, attr, value)
     initialize_context()
-    @gcsafe_ccall libcuda.cuMemPoolGetAttribute(pool::CUmemoryPool, attr::CUmemPool_attribute,
-                                         value::Ptr{Cvoid})::CUresult
+    @gcsafe_ccall libcuda.cuMemPoolGetAttribute(pool::CUmemoryPool,
+                                                attr::CUmemPool_attribute,
+                                                value::Ptr{Cvoid})::CUresult
 end
 
 @checked function cuMemPoolSetAccess(pool, map, count)
     initialize_context()
     @gcsafe_ccall libcuda.cuMemPoolSetAccess(pool::CUmemoryPool, map::Ptr{CUmemAccessDesc},
-                                      count::Csize_t)::CUresult
+                                             count::Csize_t)::CUresult
 end
 
 @checked function cuMemPoolGetAccess(flags, memPool, location)
     initialize_context()
-    @gcsafe_ccall libcuda.cuMemPoolGetAccess(flags::Ptr{CUmemAccess_flags}, memPool::CUmemoryPool,
-                                      location::Ptr{CUmemLocation})::CUresult
+    @gcsafe_ccall libcuda.cuMemPoolGetAccess(flags::Ptr{CUmemAccess_flags},
+                                             memPool::CUmemoryPool,
+                                             location::Ptr{CUmemLocation})::CUresult
 end
 
 @checked function cuMemPoolCreate(pool, poolProps)
     initialize_context()
     @gcsafe_ccall libcuda.cuMemPoolCreate(pool::Ptr{CUmemoryPool},
-                                   poolProps::Ptr{CUmemPoolProps})::CUresult
+                                          poolProps::Ptr{CUmemPoolProps})::CUresult
 end
 
 @checked function cuMemPoolDestroy(pool)
@@ -3776,136 +3815,147 @@ end
 @checked function cuMemAllocFromPoolAsync(dptr, bytesize, pool, hStream)
     initialize_context()
     @gcsafe_ccall libcuda.cuMemAllocFromPoolAsync(dptr::Ptr{CUdeviceptr}, bytesize::Csize_t,
-                                           pool::CUmemoryPool, hStream::CUstream)::CUresult
+                                                  pool::CUmemoryPool,
+                                                  hStream::CUstream)::CUresult
 end
 
 @checked function cuMemPoolExportToShareableHandle(handle_out, pool, handleType, flags)
     initialize_context()
     @gcsafe_ccall libcuda.cuMemPoolExportToShareableHandle(handle_out::Ptr{Cvoid},
-                                                    pool::CUmemoryPool,
-                                                    handleType::CUmemAllocationHandleType,
-                                                    flags::Culonglong)::CUresult
+                                                           pool::CUmemoryPool,
+                                                           handleType::CUmemAllocationHandleType,
+                                                           flags::Culonglong)::CUresult
 end
 
 @checked function cuMemPoolImportFromShareableHandle(pool_out, handle, handleType, flags)
     initialize_context()
     @gcsafe_ccall libcuda.cuMemPoolImportFromShareableHandle(pool_out::Ptr{CUmemoryPool},
-                                                      handle::Ptr{Cvoid},
-                                                      handleType::CUmemAllocationHandleType,
-                                                      flags::Culonglong)::CUresult
+                                                             handle::Ptr{Cvoid},
+                                                             handleType::CUmemAllocationHandleType,
+                                                             flags::Culonglong)::CUresult
 end
 
 @checked function cuMemPoolExportPointer(shareData_out, ptr)
     initialize_context()
     @gcsafe_ccall libcuda.cuMemPoolExportPointer(shareData_out::Ptr{CUmemPoolPtrExportData},
-                                          ptr::CUdeviceptr)::CUresult
+                                                 ptr::CUdeviceptr)::CUresult
 end
 
 @checked function cuMemPoolImportPointer(ptr_out, pool, shareData)
     initialize_context()
-    @gcsafe_ccall libcuda.cuMemPoolImportPointer(ptr_out::Ptr{CUdeviceptr}, pool::CUmemoryPool,
-                                          shareData::Ptr{CUmemPoolPtrExportData})::CUresult
+    @gcsafe_ccall libcuda.cuMemPoolImportPointer(ptr_out::Ptr{CUdeviceptr},
+                                                 pool::CUmemoryPool,
+                                                 shareData::Ptr{CUmemPoolPtrExportData})::CUresult
 end
 
 @checked function cuMulticastCreate(mcHandle, prop)
     initialize_context()
     @gcsafe_ccall libcuda.cuMulticastCreate(mcHandle::Ptr{CUmemGenericAllocationHandle},
-                                     prop::Ptr{CUmulticastObjectProp})::CUresult
+                                            prop::Ptr{CUmulticastObjectProp})::CUresult
 end
 
 @checked function cuMulticastAddDevice(mcHandle, dev)
     initialize_context()
     @gcsafe_ccall libcuda.cuMulticastAddDevice(mcHandle::CUmemGenericAllocationHandle,
-                                        dev::CUdevice)::CUresult
+                                               dev::CUdevice)::CUresult
 end
 
 @checked function cuMulticastBindMem(mcHandle, mcOffset, memHandle, memOffset, size, flags)
     initialize_context()
     @gcsafe_ccall libcuda.cuMulticastBindMem(mcHandle::CUmemGenericAllocationHandle,
-                                      mcOffset::Csize_t,
-                                      memHandle::CUmemGenericAllocationHandle,
-                                      memOffset::Csize_t, size::Csize_t,
-                                      flags::Culonglong)::CUresult
+                                             mcOffset::Csize_t,
+                                             memHandle::CUmemGenericAllocationHandle,
+                                             memOffset::Csize_t, size::Csize_t,
+                                             flags::Culonglong)::CUresult
 end
 
 @checked function cuMulticastBindAddr(mcHandle, mcOffset, memptr, size, flags)
     initialize_context()
     @gcsafe_ccall libcuda.cuMulticastBindAddr(mcHandle::CUmemGenericAllocationHandle,
-                                       mcOffset::Csize_t, memptr::CUdeviceptr,
-                                       size::Csize_t, flags::Culonglong)::CUresult
+                                              mcOffset::Csize_t, memptr::CUdeviceptr,
+                                              size::Csize_t, flags::Culonglong)::CUresult
 end
 
 @checked function cuMulticastUnbind(mcHandle, dev, mcOffset, size)
     initialize_context()
-    @gcsafe_ccall libcuda.cuMulticastUnbind(mcHandle::CUmemGenericAllocationHandle, dev::CUdevice,
-                                     mcOffset::Csize_t, size::Csize_t)::CUresult
+    @gcsafe_ccall libcuda.cuMulticastUnbind(mcHandle::CUmemGenericAllocationHandle,
+                                            dev::CUdevice, mcOffset::Csize_t,
+                                            size::Csize_t)::CUresult
 end
 
 @checked function cuMulticastGetGranularity(granularity, prop, option)
     initialize_context()
     @gcsafe_ccall libcuda.cuMulticastGetGranularity(granularity::Ptr{Csize_t},
-                                             prop::Ptr{CUmulticastObjectProp},
-                                             option::CUmulticastGranularity_flags)::CUresult
+                                                    prop::Ptr{CUmulticastObjectProp},
+                                                    option::CUmulticastGranularity_flags)::CUresult
 end
 
 @checked function cuPointerGetAttribute(data, attribute, ptr)
     initialize_context()
-    @gcsafe_ccall libcuda.cuPointerGetAttribute(data::Ptr{Cvoid}, attribute::CUpointer_attribute,
-                                         ptr::CUdeviceptr)::CUresult
+    @gcsafe_ccall libcuda.cuPointerGetAttribute(data::Ptr{Cvoid},
+                                                attribute::CUpointer_attribute,
+                                                ptr::CUdeviceptr)::CUresult
 end
 
 @checked function cuMemPrefetchAsync(devPtr, count, dstDevice, hStream)
     initialize_context()
     @gcsafe_ccall libcuda.cuMemPrefetchAsync(devPtr::CUdeviceptr, count::Csize_t,
-                                      dstDevice::CUdevice, hStream::CUstream)::CUresult
+                                             dstDevice::CUdevice,
+                                             hStream::CUstream)::CUresult
 end
 
 @checked function cuMemPrefetchAsync_v2(devPtr, count, location, flags, hStream)
     initialize_context()
     @gcsafe_ccall libcuda.cuMemPrefetchAsync_v2(devPtr::CUdeviceptr, count::Csize_t,
-                                         location::CUmemLocation, flags::Cuint,
-                                         hStream::CUstream)::CUresult
+                                                location::CUmemLocation, flags::Cuint,
+                                                hStream::CUstream)::CUresult
 end
 
 @checked function cuMemAdvise(devPtr, count, advice, device)
     initialize_context()
-    @gcsafe_ccall libcuda.cuMemAdvise(devPtr::CUdeviceptr, count::Csize_t, advice::CUmem_advise,
-                               device::CUdevice)::CUresult
+    @gcsafe_ccall libcuda.cuMemAdvise(devPtr::CUdeviceptr, count::Csize_t,
+                                      advice::CUmem_advise, device::CUdevice)::CUresult
 end
 
 @checked function cuMemAdvise_v2(devPtr, count, advice, location)
     initialize_context()
-    @gcsafe_ccall libcuda.cuMemAdvise_v2(devPtr::CUdeviceptr, count::Csize_t, advice::CUmem_advise,
-                                  location::CUmemLocation)::CUresult
+    @gcsafe_ccall libcuda.cuMemAdvise_v2(devPtr::CUdeviceptr, count::Csize_t,
+                                         advice::CUmem_advise,
+                                         location::CUmemLocation)::CUresult
 end
 
 @checked function cuMemRangeGetAttribute(data, dataSize, attribute, devPtr, count)
     initialize_context()
     @gcsafe_ccall libcuda.cuMemRangeGetAttribute(data::Ptr{Cvoid}, dataSize::Csize_t,
-                                          attribute::CUmem_range_attribute,
-                                          devPtr::CUdeviceptr, count::Csize_t)::CUresult
+                                                 attribute::CUmem_range_attribute,
+                                                 devPtr::CUdeviceptr,
+                                                 count::Csize_t)::CUresult
 end
 
 @checked function cuMemRangeGetAttributes(data, dataSizes, attributes, numAttributes,
                                           devPtr, count)
     initialize_context()
-    @gcsafe_ccall libcuda.cuMemRangeGetAttributes(data::Ptr{Ptr{Cvoid}}, dataSizes::Ptr{Csize_t},
-                                           attributes::Ptr{CUmem_range_attribute},
-                                           numAttributes::Csize_t, devPtr::CUdeviceptr,
-                                           count::Csize_t)::CUresult
+    @gcsafe_ccall libcuda.cuMemRangeGetAttributes(data::Ptr{Ptr{Cvoid}},
+                                                  dataSizes::Ptr{Csize_t},
+                                                  attributes::Ptr{CUmem_range_attribute},
+                                                  numAttributes::Csize_t,
+                                                  devPtr::CUdeviceptr,
+                                                  count::Csize_t)::CUresult
 end
 
 @checked function cuPointerSetAttribute(value, attribute, ptr)
     initialize_context()
-    @gcsafe_ccall libcuda.cuPointerSetAttribute(value::Ptr{Cvoid}, attribute::CUpointer_attribute,
-                                         ptr::CUdeviceptr)::CUresult
+    @gcsafe_ccall libcuda.cuPointerSetAttribute(value::Ptr{Cvoid},
+                                                attribute::CUpointer_attribute,
+                                                ptr::CUdeviceptr)::CUresult
 end
 
 @checked function cuPointerGetAttributes(numAttributes, attributes, data, ptr)
     initialize_context()
     @gcsafe_ccall libcuda.cuPointerGetAttributes(numAttributes::Cuint,
-                                          attributes::Ptr{CUpointer_attribute},
-                                          data::Ptr{Ptr{Cvoid}}, ptr::CUdeviceptr)::CUresult
+                                                 attributes::Ptr{CUpointer_attribute},
+                                                 data::Ptr{Ptr{Cvoid}},
+                                                 ptr::CUdeviceptr)::CUresult
 end
 
 @checked function cuStreamCreate(phStream, Flags)
@@ -3916,12 +3966,13 @@ end
 @checked function cuStreamCreateWithPriority(phStream, flags, priority)
     initialize_context()
     @gcsafe_ccall libcuda.cuStreamCreateWithPriority(phStream::Ptr{CUstream}, flags::Cuint,
-                                              priority::Cint)::CUresult
+                                                     priority::Cint)::CUresult
 end
 
 @checked function cuStreamGetPriority(hStream, priority)
     initialize_context()
-    @gcsafe_ccall libcuda.cuStreamGetPriority(hStream::CUstream, priority::Ptr{Cint})::CUresult
+    @gcsafe_ccall libcuda.cuStreamGetPriority(hStream::CUstream,
+                                              priority::Ptr{Cint})::CUresult
 end
 
 @checked function cuStreamGetFlags(hStream, flags)
@@ -3931,7 +3982,8 @@ end
 
 @checked function cuStreamGetId(hStream, streamId)
     initialize_context()
-    @gcsafe_ccall libcuda.cuStreamGetId(hStream::CUstream, streamId::Ptr{Culonglong})::CUresult
+    @gcsafe_ccall libcuda.cuStreamGetId(hStream::CUstream,
+                                        streamId::Ptr{Culonglong})::CUresult
 end
 
 @checked function cuStreamGetCtx(hStream, pctx)
@@ -3942,23 +3994,23 @@ end
 @checked function cuStreamWaitEvent(hStream, hEvent, Flags)
     initialize_context()
     @gcsafe_ccall libcuda.cuStreamWaitEvent(hStream::CUstream, hEvent::CUevent,
-                                     Flags::Cuint)::CUresult
+                                            Flags::Cuint)::CUresult
 end
 
 @checked function cuStreamAddCallback(hStream, callback, userData, flags)
     initialize_context()
     @gcsafe_ccall libcuda.cuStreamAddCallback(hStream::CUstream, callback::CUstreamCallback,
-                                       userData::Ptr{Cvoid}, flags::Cuint)::CUresult
+                                              userData::Ptr{Cvoid}, flags::Cuint)::CUresult
 end
 
 @checked function cuStreamBeginCaptureToGraph(hStream, hGraph, dependencies, dependencyData,
                                               numDependencies, mode)
     initialize_context()
     @gcsafe_ccall libcuda.cuStreamBeginCaptureToGraph(hStream::CUstream, hGraph::CUgraph,
-                                               dependencies::Ptr{CUgraphNode},
-                                               dependencyData::Ptr{CUgraphEdgeData},
-                                               numDependencies::Csize_t,
-                                               mode::CUstreamCaptureMode)::CUresult
+                                                      dependencies::Ptr{CUgraphNode},
+                                                      dependencyData::Ptr{CUgraphEdgeData},
+                                                      numDependencies::Csize_t,
+                                                      mode::CUstreamCaptureMode)::CUresult
 end
 
 @checked function cuThreadExchangeStreamCaptureMode(mode)
@@ -3968,13 +4020,14 @@ end
 
 @checked function cuStreamEndCapture(hStream, phGraph)
     initialize_context()
-    @gcsafe_ccall libcuda.cuStreamEndCapture(hStream::CUstream, phGraph::Ptr{CUgraph})::CUresult
+    @gcsafe_ccall libcuda.cuStreamEndCapture(hStream::CUstream,
+                                             phGraph::Ptr{CUgraph})::CUresult
 end
 
 @checked function cuStreamIsCapturing(hStream, captureStatus)
     initialize_context()
     @gcsafe_ccall libcuda.cuStreamIsCapturing(hStream::CUstream,
-                                       captureStatus::Ptr{CUstreamCaptureStatus})::CUresult
+                                              captureStatus::Ptr{CUstreamCaptureStatus})::CUresult
 end
 
 @checked function cuStreamGetCaptureInfo_v3(hStream, captureStatus_out, id_out, graph_out,
@@ -3982,21 +4035,21 @@ end
                                             numDependencies_out)
     initialize_context()
     @gcsafe_ccall libcuda.cuStreamGetCaptureInfo_v3(hStream::CUstream,
-                                             captureStatus_out::Ptr{CUstreamCaptureStatus},
-                                             id_out::Ptr{cuuint64_t},
-                                             graph_out::Ptr{CUgraph},
-                                             dependencies_out::Ptr{Ptr{CUgraphNode}},
-                                             edgeData_out::Ptr{Ptr{CUgraphEdgeData}},
-                                             numDependencies_out::Ptr{Csize_t})::CUresult
+                                                    captureStatus_out::Ptr{CUstreamCaptureStatus},
+                                                    id_out::Ptr{cuuint64_t},
+                                                    graph_out::Ptr{CUgraph},
+                                                    dependencies_out::Ptr{Ptr{CUgraphNode}},
+                                                    edgeData_out::Ptr{Ptr{CUgraphEdgeData}},
+                                                    numDependencies_out::Ptr{Csize_t})::CUresult
 end
 
 @checked function cuStreamUpdateCaptureDependencies(hStream, dependencies, numDependencies,
                                                     flags)
     initialize_context()
     @gcsafe_ccall libcuda.cuStreamUpdateCaptureDependencies(hStream::CUstream,
-                                                     dependencies::Ptr{CUgraphNode},
-                                                     numDependencies::Csize_t,
-                                                     flags::Cuint)::CUresult
+                                                            dependencies::Ptr{CUgraphNode},
+                                                            numDependencies::Csize_t,
+                                                            flags::Cuint)::CUresult
 end
 
 @checked function cuStreamUpdateCaptureDependencies_v2(hStream, dependencies,
@@ -4004,16 +4057,16 @@ end
                                                        flags)
     initialize_context()
     @gcsafe_ccall libcuda.cuStreamUpdateCaptureDependencies_v2(hStream::CUstream,
-                                                        dependencies::Ptr{CUgraphNode},
-                                                        dependencyData::Ptr{CUgraphEdgeData},
-                                                        numDependencies::Csize_t,
-                                                        flags::Cuint)::CUresult
+                                                               dependencies::Ptr{CUgraphNode},
+                                                               dependencyData::Ptr{CUgraphEdgeData},
+                                                               numDependencies::Csize_t,
+                                                               flags::Cuint)::CUresult
 end
 
 @checked function cuStreamAttachMemAsync(hStream, dptr, length, flags)
     initialize_context()
     @gcsafe_ccall libcuda.cuStreamAttachMemAsync(hStream::CUstream, dptr::CUdeviceptr,
-                                          length::Csize_t, flags::Cuint)::CUresult
+                                                 length::Csize_t, flags::Cuint)::CUresult
 end
 
 @checked function cuStreamQuery(hStream)
@@ -4034,13 +4087,13 @@ end
 @checked function cuStreamGetAttribute(hStream, attr, value_out)
     initialize_context()
     @gcsafe_ccall libcuda.cuStreamGetAttribute(hStream::CUstream, attr::CUstreamAttrID,
-                                        value_out::Ptr{CUstreamAttrValue})::CUresult
+                                               value_out::Ptr{CUstreamAttrValue})::CUresult
 end
 
 @checked function cuStreamSetAttribute(hStream, attr, value)
     initialize_context()
     @gcsafe_ccall libcuda.cuStreamSetAttribute(hStream::CUstream, attr::CUstreamAttrID,
-                                        value::Ptr{CUstreamAttrValue})::CUresult
+                                               value::Ptr{CUstreamAttrValue})::CUresult
 end
 
 @checked function cuEventCreate(phEvent, Flags)
@@ -4056,7 +4109,7 @@ end
 @checked function cuEventRecordWithFlags(hEvent, hStream, flags)
     initialize_context()
     @gcsafe_ccall libcuda.cuEventRecordWithFlags(hEvent::CUevent, hStream::CUstream,
-                                          flags::Cuint)::CUresult
+                                                 flags::Cuint)::CUresult
 end
 
 @checked function cuEventQuery(hEvent)
@@ -4072,27 +4125,27 @@ end
 @checked function cuEventElapsedTime(pMilliseconds, hStart, hEnd)
     initialize_context()
     @gcsafe_ccall libcuda.cuEventElapsedTime(pMilliseconds::Ptr{Cfloat}, hStart::CUevent,
-                                      hEnd::CUevent)::CUresult
+                                             hEnd::CUevent)::CUresult
 end
 
 @checked function cuImportExternalMemory(extMem_out, memHandleDesc)
     initialize_context()
     @gcsafe_ccall libcuda.cuImportExternalMemory(extMem_out::Ptr{CUexternalMemory},
-                                          memHandleDesc::Ptr{CUDA_EXTERNAL_MEMORY_HANDLE_DESC})::CUresult
+                                                 memHandleDesc::Ptr{CUDA_EXTERNAL_MEMORY_HANDLE_DESC})::CUresult
 end
 
 @checked function cuExternalMemoryGetMappedBuffer(devPtr, extMem, bufferDesc)
     initialize_context()
     @gcsafe_ccall libcuda.cuExternalMemoryGetMappedBuffer(devPtr::Ptr{CUdeviceptr},
-                                                   extMem::CUexternalMemory,
-                                                   bufferDesc::Ptr{CUDA_EXTERNAL_MEMORY_BUFFER_DESC})::CUresult
+                                                          extMem::CUexternalMemory,
+                                                          bufferDesc::Ptr{CUDA_EXTERNAL_MEMORY_BUFFER_DESC})::CUresult
 end
 
 @checked function cuExternalMemoryGetMappedMipmappedArray(mipmap, extMem, mipmapDesc)
     initialize_context()
     @gcsafe_ccall libcuda.cuExternalMemoryGetMappedMipmappedArray(mipmap::Ptr{CUmipmappedArray},
-                                                           extMem::CUexternalMemory,
-                                                           mipmapDesc::Ptr{CUDA_EXTERNAL_MEMORY_MIPMAPPED_ARRAY_DESC})::CUresult
+                                                                  extMem::CUexternalMemory,
+                                                                  mipmapDesc::Ptr{CUDA_EXTERNAL_MEMORY_MIPMAPPED_ARRAY_DESC})::CUresult
 end
 
 @checked function cuDestroyExternalMemory(extMem)
@@ -4103,25 +4156,25 @@ end
 @checked function cuImportExternalSemaphore(extSem_out, semHandleDesc)
     initialize_context()
     @gcsafe_ccall libcuda.cuImportExternalSemaphore(extSem_out::Ptr{CUexternalSemaphore},
-                                             semHandleDesc::Ptr{CUDA_EXTERNAL_SEMAPHORE_HANDLE_DESC})::CUresult
+                                                    semHandleDesc::Ptr{CUDA_EXTERNAL_SEMAPHORE_HANDLE_DESC})::CUresult
 end
 
 @checked function cuSignalExternalSemaphoresAsync(extSemArray, paramsArray, numExtSems,
                                                   stream)
     initialize_context()
     @gcsafe_ccall libcuda.cuSignalExternalSemaphoresAsync(extSemArray::Ptr{CUexternalSemaphore},
-                                                   paramsArray::Ptr{CUDA_EXTERNAL_SEMAPHORE_SIGNAL_PARAMS},
-                                                   numExtSems::Cuint,
-                                                   stream::CUstream)::CUresult
+                                                          paramsArray::Ptr{CUDA_EXTERNAL_SEMAPHORE_SIGNAL_PARAMS},
+                                                          numExtSems::Cuint,
+                                                          stream::CUstream)::CUresult
 end
 
 @checked function cuWaitExternalSemaphoresAsync(extSemArray, paramsArray, numExtSems,
                                                 stream)
     initialize_context()
     @gcsafe_ccall libcuda.cuWaitExternalSemaphoresAsync(extSemArray::Ptr{CUexternalSemaphore},
-                                                 paramsArray::Ptr{CUDA_EXTERNAL_SEMAPHORE_WAIT_PARAMS},
-                                                 numExtSems::Cuint,
-                                                 stream::CUstream)::CUresult
+                                                        paramsArray::Ptr{CUDA_EXTERNAL_SEMAPHORE_WAIT_PARAMS},
+                                                        numExtSems::Cuint,
+                                                        stream::CUstream)::CUresult
 end
 
 @checked function cuDestroyExternalSemaphore(extSem)
@@ -4132,24 +4185,26 @@ end
 @checked function cuFuncGetAttribute(pi, attrib, hfunc)
     initialize_context()
     @gcsafe_ccall libcuda.cuFuncGetAttribute(pi::Ptr{Cint}, attrib::CUfunction_attribute,
-                                      hfunc::CUfunction)::CUresult
+                                             hfunc::CUfunction)::CUresult
 end
 
 @checked function cuFuncSetAttribute(hfunc, attrib, value)
     initialize_context()
-    @gcsafe_ccall libcuda.cuFuncSetAttribute(hfunc::CUfunction, attrib::CUfunction_attribute,
-                                      value::Cint)::CUresult
+    @gcsafe_ccall libcuda.cuFuncSetAttribute(hfunc::CUfunction,
+                                             attrib::CUfunction_attribute,
+                                             value::Cint)::CUresult
 end
 
 @checked function cuFuncSetCacheConfig(hfunc, config)
     initialize_context()
-    @gcsafe_ccall libcuda.cuFuncSetCacheConfig(hfunc::CUfunction, config::CUfunc_cache)::CUresult
+    @gcsafe_ccall libcuda.cuFuncSetCacheConfig(hfunc::CUfunction,
+                                               config::CUfunc_cache)::CUresult
 end
 
 @checked function cuFuncSetSharedMemConfig(hfunc, config)
     initialize_context()
     @gcsafe_ccall libcuda.cuFuncSetSharedMemConfig(hfunc::CUfunction,
-                                            config::CUsharedconfig)::CUresult
+                                                   config::CUsharedconfig)::CUresult
 end
 
 @checked function cuFuncGetModule(hmod, hfunc)
@@ -4166,17 +4221,18 @@ end
                                  blockDimZ, sharedMemBytes, hStream, kernelParams, extra)
     initialize_context()
     @gcsafe_ccall libcuda.cuLaunchKernel(f::CUfunction, gridDimX::Cuint, gridDimY::Cuint,
-                                  gridDimZ::Cuint, blockDimX::Cuint, blockDimY::Cuint,
-                                  blockDimZ::Cuint, sharedMemBytes::Cuint,
-                                  hStream::CUstream, kernelParams::Ptr{Ptr{Cvoid}},
-                                  extra::Ptr{Ptr{Cvoid}})::CUresult
+                                         gridDimZ::Cuint, blockDimX::Cuint,
+                                         blockDimY::Cuint, blockDimZ::Cuint,
+                                         sharedMemBytes::Cuint, hStream::CUstream,
+                                         kernelParams::Ptr{Ptr{Cvoid}},
+                                         extra::Ptr{Ptr{Cvoid}})::CUresult
 end
 
 @checked function cuLaunchKernelEx(config, f, kernelParams, extra)
     initialize_context()
     @gcsafe_ccall libcuda.cuLaunchKernelEx(config::Ptr{CUlaunchConfig}, f::CUfunction,
-                                    kernelParams::Ptr{Ptr{Cvoid}},
-                                    extra::Ptr{Ptr{Cvoid}})::CUresult
+                                           kernelParams::Ptr{Ptr{Cvoid}},
+                                           extra::Ptr{Ptr{Cvoid}})::CUresult
 end
 
 @checked function cuLaunchCooperativeKernel(f, gridDimX, gridDimY, gridDimZ, blockDimX,
@@ -4184,30 +4240,30 @@ end
                                             kernelParams)
     initialize_context()
     @gcsafe_ccall libcuda.cuLaunchCooperativeKernel(f::CUfunction, gridDimX::Cuint,
-                                             gridDimY::Cuint, gridDimZ::Cuint,
-                                             blockDimX::Cuint, blockDimY::Cuint,
-                                             blockDimZ::Cuint, sharedMemBytes::Cuint,
-                                             hStream::CUstream,
-                                             kernelParams::Ptr{Ptr{Cvoid}})::CUresult
+                                                    gridDimY::Cuint, gridDimZ::Cuint,
+                                                    blockDimX::Cuint, blockDimY::Cuint,
+                                                    blockDimZ::Cuint, sharedMemBytes::Cuint,
+                                                    hStream::CUstream,
+                                                    kernelParams::Ptr{Ptr{Cvoid}})::CUresult
 end
 
 @checked function cuLaunchCooperativeKernelMultiDevice(launchParamsList, numDevices, flags)
     initialize_context()
     @gcsafe_ccall libcuda.cuLaunchCooperativeKernelMultiDevice(launchParamsList::Ptr{CUDA_LAUNCH_PARAMS},
-                                                        numDevices::Cuint,
-                                                        flags::Cuint)::CUresult
+                                                               numDevices::Cuint,
+                                                               flags::Cuint)::CUresult
 end
 
 @checked function cuLaunchHostFunc(hStream, fn, userData)
     initialize_context()
     @gcsafe_ccall libcuda.cuLaunchHostFunc(hStream::CUstream, fn::CUhostFn,
-                                    userData::Ptr{Cvoid})::CUresult
+                                           userData::Ptr{Cvoid})::CUresult
 end
 
 @checked function cuFuncSetBlockShape(hfunc, x, y, z)
     initialize_context()
     @gcsafe_ccall libcuda.cuFuncSetBlockShape(hfunc::CUfunction, x::Cint, y::Cint,
-                                       z::Cint)::CUresult
+                                              z::Cint)::CUresult
 end
 
 @checked function cuFuncSetSharedSize(hfunc, bytes)
@@ -4222,18 +4278,20 @@ end
 
 @checked function cuParamSeti(hfunc, offset, value)
     initialize_context()
-    @gcsafe_ccall libcuda.cuParamSeti(hfunc::CUfunction, offset::Cint, value::Cuint)::CUresult
+    @gcsafe_ccall libcuda.cuParamSeti(hfunc::CUfunction, offset::Cint,
+                                      value::Cuint)::CUresult
 end
 
 @checked function cuParamSetf(hfunc, offset, value)
     initialize_context()
-    @gcsafe_ccall libcuda.cuParamSetf(hfunc::CUfunction, offset::Cint, value::Cfloat)::CUresult
+    @gcsafe_ccall libcuda.cuParamSetf(hfunc::CUfunction, offset::Cint,
+                                      value::Cfloat)::CUresult
 end
 
 @checked function cuParamSetv(hfunc, offset, ptr, numbytes)
     initialize_context()
     @gcsafe_ccall libcuda.cuParamSetv(hfunc::CUfunction, offset::Cint, ptr::Ptr{Cvoid},
-                               numbytes::Cuint)::CUresult
+                                      numbytes::Cuint)::CUresult
 end
 
 @checked function cuLaunch(f)
@@ -4244,19 +4302,19 @@ end
 @checked function cuLaunchGrid(f, grid_width, grid_height)
     initialize_context()
     @gcsafe_ccall libcuda.cuLaunchGrid(f::CUfunction, grid_width::Cint,
-                                grid_height::Cint)::CUresult
+                                       grid_height::Cint)::CUresult
 end
 
 @checked function cuLaunchGridAsync(f, grid_width, grid_height, hStream)
     initialize_context()
-    @gcsafe_ccall libcuda.cuLaunchGridAsync(f::CUfunction, grid_width::Cint, grid_height::Cint,
-                                     hStream::CUstream)::CUresult
+    @gcsafe_ccall libcuda.cuLaunchGridAsync(f::CUfunction, grid_width::Cint,
+                                            grid_height::Cint, hStream::CUstream)::CUresult
 end
 
 @checked function cuParamSetTexRef(hfunc, texunit, hTexRef)
     initialize_context()
     @gcsafe_ccall libcuda.cuParamSetTexRef(hfunc::CUfunction, texunit::Cint,
-                                    hTexRef::CUtexref)::CUresult
+                                           hTexRef::CUtexref)::CUresult
 end
 
 @checked function cuGraphCreate(phGraph, flags)
@@ -4267,232 +4325,241 @@ end
 @checked function cuGraphAddMemcpyNode(phGraphNode, hGraph, dependencies, numDependencies,
                                        copyParams, ctx)
     initialize_context()
-    @gcsafe_ccall libcuda.cuGraphAddMemcpyNode(phGraphNode::Ptr{CUgraphNode}, hGraph::CUgraph,
-                                        dependencies::Ptr{CUgraphNode},
-                                        numDependencies::Csize_t,
-                                        copyParams::Ptr{CUDA_MEMCPY3D},
-                                        ctx::CUcontext)::CUresult
+    @gcsafe_ccall libcuda.cuGraphAddMemcpyNode(phGraphNode::Ptr{CUgraphNode},
+                                               hGraph::CUgraph,
+                                               dependencies::Ptr{CUgraphNode},
+                                               numDependencies::Csize_t,
+                                               copyParams::Ptr{CUDA_MEMCPY3D},
+                                               ctx::CUcontext)::CUresult
 end
 
 @checked function cuGraphMemcpyNodeGetParams(hNode, nodeParams)
     initialize_context()
     @gcsafe_ccall libcuda.cuGraphMemcpyNodeGetParams(hNode::CUgraphNode,
-                                              nodeParams::Ptr{CUDA_MEMCPY3D})::CUresult
+                                                     nodeParams::Ptr{CUDA_MEMCPY3D})::CUresult
 end
 
 @checked function cuGraphMemcpyNodeSetParams(hNode, nodeParams)
     initialize_context()
     @gcsafe_ccall libcuda.cuGraphMemcpyNodeSetParams(hNode::CUgraphNode,
-                                              nodeParams::Ptr{CUDA_MEMCPY3D})::CUresult
+                                                     nodeParams::Ptr{CUDA_MEMCPY3D})::CUresult
 end
 
 @checked function cuGraphAddMemsetNode(phGraphNode, hGraph, dependencies, numDependencies,
                                        memsetParams, ctx)
     initialize_context()
-    @gcsafe_ccall libcuda.cuGraphAddMemsetNode(phGraphNode::Ptr{CUgraphNode}, hGraph::CUgraph,
-                                        dependencies::Ptr{CUgraphNode},
-                                        numDependencies::Csize_t,
-                                        memsetParams::Ptr{CUDA_MEMSET_NODE_PARAMS},
-                                        ctx::CUcontext)::CUresult
+    @gcsafe_ccall libcuda.cuGraphAddMemsetNode(phGraphNode::Ptr{CUgraphNode},
+                                               hGraph::CUgraph,
+                                               dependencies::Ptr{CUgraphNode},
+                                               numDependencies::Csize_t,
+                                               memsetParams::Ptr{CUDA_MEMSET_NODE_PARAMS},
+                                               ctx::CUcontext)::CUresult
 end
 
 @checked function cuGraphMemsetNodeGetParams(hNode, nodeParams)
     initialize_context()
     @gcsafe_ccall libcuda.cuGraphMemsetNodeGetParams(hNode::CUgraphNode,
-                                              nodeParams::Ptr{CUDA_MEMSET_NODE_PARAMS})::CUresult
+                                                     nodeParams::Ptr{CUDA_MEMSET_NODE_PARAMS})::CUresult
 end
 
 @checked function cuGraphMemsetNodeSetParams(hNode, nodeParams)
     initialize_context()
     @gcsafe_ccall libcuda.cuGraphMemsetNodeSetParams(hNode::CUgraphNode,
-                                              nodeParams::Ptr{CUDA_MEMSET_NODE_PARAMS})::CUresult
+                                                     nodeParams::Ptr{CUDA_MEMSET_NODE_PARAMS})::CUresult
 end
 
 @checked function cuGraphAddHostNode(phGraphNode, hGraph, dependencies, numDependencies,
                                      nodeParams)
     initialize_context()
     @gcsafe_ccall libcuda.cuGraphAddHostNode(phGraphNode::Ptr{CUgraphNode}, hGraph::CUgraph,
-                                      dependencies::Ptr{CUgraphNode},
-                                      numDependencies::Csize_t,
-                                      nodeParams::Ptr{CUDA_HOST_NODE_PARAMS})::CUresult
+                                             dependencies::Ptr{CUgraphNode},
+                                             numDependencies::Csize_t,
+                                             nodeParams::Ptr{CUDA_HOST_NODE_PARAMS})::CUresult
 end
 
 @checked function cuGraphHostNodeGetParams(hNode, nodeParams)
     initialize_context()
     @gcsafe_ccall libcuda.cuGraphHostNodeGetParams(hNode::CUgraphNode,
-                                            nodeParams::Ptr{CUDA_HOST_NODE_PARAMS})::CUresult
+                                                   nodeParams::Ptr{CUDA_HOST_NODE_PARAMS})::CUresult
 end
 
 @checked function cuGraphHostNodeSetParams(hNode, nodeParams)
     initialize_context()
     @gcsafe_ccall libcuda.cuGraphHostNodeSetParams(hNode::CUgraphNode,
-                                            nodeParams::Ptr{CUDA_HOST_NODE_PARAMS})::CUresult
+                                                   nodeParams::Ptr{CUDA_HOST_NODE_PARAMS})::CUresult
 end
 
 @checked function cuGraphAddChildGraphNode(phGraphNode, hGraph, dependencies,
                                            numDependencies, childGraph)
     initialize_context()
-    @gcsafe_ccall libcuda.cuGraphAddChildGraphNode(phGraphNode::Ptr{CUgraphNode}, hGraph::CUgraph,
-                                            dependencies::Ptr{CUgraphNode},
-                                            numDependencies::Csize_t,
-                                            childGraph::CUgraph)::CUresult
+    @gcsafe_ccall libcuda.cuGraphAddChildGraphNode(phGraphNode::Ptr{CUgraphNode},
+                                                   hGraph::CUgraph,
+                                                   dependencies::Ptr{CUgraphNode},
+                                                   numDependencies::Csize_t,
+                                                   childGraph::CUgraph)::CUresult
 end
 
 @checked function cuGraphChildGraphNodeGetGraph(hNode, phGraph)
     initialize_context()
     @gcsafe_ccall libcuda.cuGraphChildGraphNodeGetGraph(hNode::CUgraphNode,
-                                                 phGraph::Ptr{CUgraph})::CUresult
+                                                        phGraph::Ptr{CUgraph})::CUresult
 end
 
 @checked function cuGraphAddEmptyNode(phGraphNode, hGraph, dependencies, numDependencies)
     initialize_context()
-    @gcsafe_ccall libcuda.cuGraphAddEmptyNode(phGraphNode::Ptr{CUgraphNode}, hGraph::CUgraph,
-                                       dependencies::Ptr{CUgraphNode},
-                                       numDependencies::Csize_t)::CUresult
+    @gcsafe_ccall libcuda.cuGraphAddEmptyNode(phGraphNode::Ptr{CUgraphNode},
+                                              hGraph::CUgraph,
+                                              dependencies::Ptr{CUgraphNode},
+                                              numDependencies::Csize_t)::CUresult
 end
 
 @checked function cuGraphAddEventRecordNode(phGraphNode, hGraph, dependencies,
                                             numDependencies, event)
     initialize_context()
-    @gcsafe_ccall libcuda.cuGraphAddEventRecordNode(phGraphNode::Ptr{CUgraphNode}, hGraph::CUgraph,
-                                             dependencies::Ptr{CUgraphNode},
-                                             numDependencies::Csize_t,
-                                             event::CUevent)::CUresult
+    @gcsafe_ccall libcuda.cuGraphAddEventRecordNode(phGraphNode::Ptr{CUgraphNode},
+                                                    hGraph::CUgraph,
+                                                    dependencies::Ptr{CUgraphNode},
+                                                    numDependencies::Csize_t,
+                                                    event::CUevent)::CUresult
 end
 
 @checked function cuGraphEventRecordNodeGetEvent(hNode, event_out)
     initialize_context()
     @gcsafe_ccall libcuda.cuGraphEventRecordNodeGetEvent(hNode::CUgraphNode,
-                                                  event_out::Ptr{CUevent})::CUresult
+                                                         event_out::Ptr{CUevent})::CUresult
 end
 
 @checked function cuGraphEventRecordNodeSetEvent(hNode, event)
     initialize_context()
     @gcsafe_ccall libcuda.cuGraphEventRecordNodeSetEvent(hNode::CUgraphNode,
-                                                  event::CUevent)::CUresult
+                                                         event::CUevent)::CUresult
 end
 
 @checked function cuGraphAddEventWaitNode(phGraphNode, hGraph, dependencies,
                                           numDependencies, event)
     initialize_context()
-    @gcsafe_ccall libcuda.cuGraphAddEventWaitNode(phGraphNode::Ptr{CUgraphNode}, hGraph::CUgraph,
-                                           dependencies::Ptr{CUgraphNode},
-                                           numDependencies::Csize_t,
-                                           event::CUevent)::CUresult
+    @gcsafe_ccall libcuda.cuGraphAddEventWaitNode(phGraphNode::Ptr{CUgraphNode},
+                                                  hGraph::CUgraph,
+                                                  dependencies::Ptr{CUgraphNode},
+                                                  numDependencies::Csize_t,
+                                                  event::CUevent)::CUresult
 end
 
 @checked function cuGraphEventWaitNodeGetEvent(hNode, event_out)
     initialize_context()
     @gcsafe_ccall libcuda.cuGraphEventWaitNodeGetEvent(hNode::CUgraphNode,
-                                                event_out::Ptr{CUevent})::CUresult
+                                                       event_out::Ptr{CUevent})::CUresult
 end
 
 @checked function cuGraphEventWaitNodeSetEvent(hNode, event)
     initialize_context()
     @gcsafe_ccall libcuda.cuGraphEventWaitNodeSetEvent(hNode::CUgraphNode,
-                                                event::CUevent)::CUresult
+                                                       event::CUevent)::CUresult
 end
 
 @checked function cuGraphAddExternalSemaphoresSignalNode(phGraphNode, hGraph, dependencies,
                                                          numDependencies, nodeParams)
     initialize_context()
     @gcsafe_ccall libcuda.cuGraphAddExternalSemaphoresSignalNode(phGraphNode::Ptr{CUgraphNode},
-                                                          hGraph::CUgraph,
-                                                          dependencies::Ptr{CUgraphNode},
-                                                          numDependencies::Csize_t,
-                                                          nodeParams::Ptr{CUDA_EXT_SEM_SIGNAL_NODE_PARAMS})::CUresult
+                                                                 hGraph::CUgraph,
+                                                                 dependencies::Ptr{CUgraphNode},
+                                                                 numDependencies::Csize_t,
+                                                                 nodeParams::Ptr{CUDA_EXT_SEM_SIGNAL_NODE_PARAMS})::CUresult
 end
 
 @checked function cuGraphExternalSemaphoresSignalNodeGetParams(hNode, params_out)
     initialize_context()
     @gcsafe_ccall libcuda.cuGraphExternalSemaphoresSignalNodeGetParams(hNode::CUgraphNode,
-                                                                params_out::Ptr{CUDA_EXT_SEM_SIGNAL_NODE_PARAMS})::CUresult
+                                                                       params_out::Ptr{CUDA_EXT_SEM_SIGNAL_NODE_PARAMS})::CUresult
 end
 
 @checked function cuGraphExternalSemaphoresSignalNodeSetParams(hNode, nodeParams)
     initialize_context()
     @gcsafe_ccall libcuda.cuGraphExternalSemaphoresSignalNodeSetParams(hNode::CUgraphNode,
-                                                                nodeParams::Ptr{CUDA_EXT_SEM_SIGNAL_NODE_PARAMS})::CUresult
+                                                                       nodeParams::Ptr{CUDA_EXT_SEM_SIGNAL_NODE_PARAMS})::CUresult
 end
 
 @checked function cuGraphAddExternalSemaphoresWaitNode(phGraphNode, hGraph, dependencies,
                                                        numDependencies, nodeParams)
     initialize_context()
     @gcsafe_ccall libcuda.cuGraphAddExternalSemaphoresWaitNode(phGraphNode::Ptr{CUgraphNode},
-                                                        hGraph::CUgraph,
-                                                        dependencies::Ptr{CUgraphNode},
-                                                        numDependencies::Csize_t,
-                                                        nodeParams::Ptr{CUDA_EXT_SEM_WAIT_NODE_PARAMS})::CUresult
+                                                               hGraph::CUgraph,
+                                                               dependencies::Ptr{CUgraphNode},
+                                                               numDependencies::Csize_t,
+                                                               nodeParams::Ptr{CUDA_EXT_SEM_WAIT_NODE_PARAMS})::CUresult
 end
 
 @checked function cuGraphExternalSemaphoresWaitNodeGetParams(hNode, params_out)
     initialize_context()
     @gcsafe_ccall libcuda.cuGraphExternalSemaphoresWaitNodeGetParams(hNode::CUgraphNode,
-                                                              params_out::Ptr{CUDA_EXT_SEM_WAIT_NODE_PARAMS})::CUresult
+                                                                     params_out::Ptr{CUDA_EXT_SEM_WAIT_NODE_PARAMS})::CUresult
 end
 
 @checked function cuGraphExternalSemaphoresWaitNodeSetParams(hNode, nodeParams)
     initialize_context()
     @gcsafe_ccall libcuda.cuGraphExternalSemaphoresWaitNodeSetParams(hNode::CUgraphNode,
-                                                              nodeParams::Ptr{CUDA_EXT_SEM_WAIT_NODE_PARAMS})::CUresult
+                                                                     nodeParams::Ptr{CUDA_EXT_SEM_WAIT_NODE_PARAMS})::CUresult
 end
 
 @checked function cuGraphAddBatchMemOpNode(phGraphNode, hGraph, dependencies,
                                            numDependencies, nodeParams)
     initialize_context()
-    @gcsafe_ccall libcuda.cuGraphAddBatchMemOpNode(phGraphNode::Ptr{CUgraphNode}, hGraph::CUgraph,
-                                            dependencies::Ptr{CUgraphNode},
-                                            numDependencies::Csize_t,
-                                            nodeParams::Ptr{CUDA_BATCH_MEM_OP_NODE_PARAMS})::CUresult
+    @gcsafe_ccall libcuda.cuGraphAddBatchMemOpNode(phGraphNode::Ptr{CUgraphNode},
+                                                   hGraph::CUgraph,
+                                                   dependencies::Ptr{CUgraphNode},
+                                                   numDependencies::Csize_t,
+                                                   nodeParams::Ptr{CUDA_BATCH_MEM_OP_NODE_PARAMS})::CUresult
 end
 
 @checked function cuGraphBatchMemOpNodeGetParams(hNode, nodeParams_out)
     initialize_context()
     @gcsafe_ccall libcuda.cuGraphBatchMemOpNodeGetParams(hNode::CUgraphNode,
-                                                  nodeParams_out::Ptr{CUDA_BATCH_MEM_OP_NODE_PARAMS})::CUresult
+                                                         nodeParams_out::Ptr{CUDA_BATCH_MEM_OP_NODE_PARAMS})::CUresult
 end
 
 @checked function cuGraphBatchMemOpNodeSetParams(hNode, nodeParams)
     initialize_context()
     @gcsafe_ccall libcuda.cuGraphBatchMemOpNodeSetParams(hNode::CUgraphNode,
-                                                  nodeParams::Ptr{CUDA_BATCH_MEM_OP_NODE_PARAMS})::CUresult
+                                                         nodeParams::Ptr{CUDA_BATCH_MEM_OP_NODE_PARAMS})::CUresult
 end
 
 @checked function cuGraphExecBatchMemOpNodeSetParams(hGraphExec, hNode, nodeParams)
     initialize_context()
     @gcsafe_ccall libcuda.cuGraphExecBatchMemOpNodeSetParams(hGraphExec::CUgraphExec,
-                                                      hNode::CUgraphNode,
-                                                      nodeParams::Ptr{CUDA_BATCH_MEM_OP_NODE_PARAMS})::CUresult
+                                                             hNode::CUgraphNode,
+                                                             nodeParams::Ptr{CUDA_BATCH_MEM_OP_NODE_PARAMS})::CUresult
 end
 
 @checked function cuGraphAddMemAllocNode(phGraphNode, hGraph, dependencies, numDependencies,
                                          nodeParams)
     initialize_context()
-    @gcsafe_ccall libcuda.cuGraphAddMemAllocNode(phGraphNode::Ptr{CUgraphNode}, hGraph::CUgraph,
-                                          dependencies::Ptr{CUgraphNode},
-                                          numDependencies::Csize_t,
-                                          nodeParams::Ptr{CUDA_MEM_ALLOC_NODE_PARAMS})::CUresult
+    @gcsafe_ccall libcuda.cuGraphAddMemAllocNode(phGraphNode::Ptr{CUgraphNode},
+                                                 hGraph::CUgraph,
+                                                 dependencies::Ptr{CUgraphNode},
+                                                 numDependencies::Csize_t,
+                                                 nodeParams::Ptr{CUDA_MEM_ALLOC_NODE_PARAMS})::CUresult
 end
 
 @checked function cuGraphMemAllocNodeGetParams(hNode, params_out)
     initialize_context()
     @gcsafe_ccall libcuda.cuGraphMemAllocNodeGetParams(hNode::CUgraphNode,
-                                                params_out::Ptr{CUDA_MEM_ALLOC_NODE_PARAMS})::CUresult
+                                                       params_out::Ptr{CUDA_MEM_ALLOC_NODE_PARAMS})::CUresult
 end
 
 @checked function cuGraphAddMemFreeNode(phGraphNode, hGraph, dependencies, numDependencies,
                                         dptr)
     initialize_context()
-    @gcsafe_ccall libcuda.cuGraphAddMemFreeNode(phGraphNode::Ptr{CUgraphNode}, hGraph::CUgraph,
-                                         dependencies::Ptr{CUgraphNode},
-                                         numDependencies::Csize_t,
-                                         dptr::CUdeviceptr)::CUresult
+    @gcsafe_ccall libcuda.cuGraphAddMemFreeNode(phGraphNode::Ptr{CUgraphNode},
+                                                hGraph::CUgraph,
+                                                dependencies::Ptr{CUgraphNode},
+                                                numDependencies::Csize_t,
+                                                dptr::CUdeviceptr)::CUresult
 end
 
 @checked function cuGraphMemFreeNodeGetParams(hNode, dptr_out)
     initialize_context()
     @gcsafe_ccall libcuda.cuGraphMemFreeNodeGetParams(hNode::CUgraphNode,
-                                               dptr_out::Ptr{CUdeviceptr})::CUresult
+                                                      dptr_out::Ptr{CUdeviceptr})::CUresult
 end
 
 @checked function cuDeviceGraphMemTrim(device)
@@ -4503,121 +4570,124 @@ end
 @checked function cuDeviceGetGraphMemAttribute(device, attr, value)
     initialize_context()
     @gcsafe_ccall libcuda.cuDeviceGetGraphMemAttribute(device::CUdevice,
-                                                attr::CUgraphMem_attribute,
-                                                value::Ptr{Cvoid})::CUresult
+                                                       attr::CUgraphMem_attribute,
+                                                       value::Ptr{Cvoid})::CUresult
 end
 
 @checked function cuDeviceSetGraphMemAttribute(device, attr, value)
     initialize_context()
     @gcsafe_ccall libcuda.cuDeviceSetGraphMemAttribute(device::CUdevice,
-                                                attr::CUgraphMem_attribute,
-                                                value::Ptr{Cvoid})::CUresult
+                                                       attr::CUgraphMem_attribute,
+                                                       value::Ptr{Cvoid})::CUresult
 end
 
 @checked function cuGraphClone(phGraphClone, originalGraph)
     initialize_context()
     @gcsafe_ccall libcuda.cuGraphClone(phGraphClone::Ptr{CUgraph},
-                                originalGraph::CUgraph)::CUresult
+                                       originalGraph::CUgraph)::CUresult
 end
 
 @checked function cuGraphNodeFindInClone(phNode, hOriginalNode, hClonedGraph)
     initialize_context()
     @gcsafe_ccall libcuda.cuGraphNodeFindInClone(phNode::Ptr{CUgraphNode},
-                                          hOriginalNode::CUgraphNode,
-                                          hClonedGraph::CUgraph)::CUresult
+                                                 hOriginalNode::CUgraphNode,
+                                                 hClonedGraph::CUgraph)::CUresult
 end
 
 @checked function cuGraphNodeGetType(hNode, type)
     initialize_context()
     @gcsafe_ccall libcuda.cuGraphNodeGetType(hNode::CUgraphNode,
-                                      type::Ptr{CUgraphNodeType})::CUresult
+                                             type::Ptr{CUgraphNodeType})::CUresult
 end
 
 @checked function cuGraphGetNodes(hGraph, nodes, numNodes)
     initialize_context()
     @gcsafe_ccall libcuda.cuGraphGetNodes(hGraph::CUgraph, nodes::Ptr{CUgraphNode},
-                                   numNodes::Ptr{Csize_t})::CUresult
+                                          numNodes::Ptr{Csize_t})::CUresult
 end
 
 @checked function cuGraphGetRootNodes(hGraph, rootNodes, numRootNodes)
     initialize_context()
     @gcsafe_ccall libcuda.cuGraphGetRootNodes(hGraph::CUgraph, rootNodes::Ptr{CUgraphNode},
-                                       numRootNodes::Ptr{Csize_t})::CUresult
+                                              numRootNodes::Ptr{Csize_t})::CUresult
 end
 
 @checked function cuGraphGetEdges(hGraph, from, to, numEdges)
     initialize_context()
     @gcsafe_ccall libcuda.cuGraphGetEdges(hGraph::CUgraph, from::Ptr{CUgraphNode},
-                                   to::Ptr{CUgraphNode}, numEdges::Ptr{Csize_t})::CUresult
+                                          to::Ptr{CUgraphNode},
+                                          numEdges::Ptr{Csize_t})::CUresult
 end
 
 @checked function cuGraphGetEdges_v2(hGraph, from, to, edgeData, numEdges)
     initialize_context()
     @gcsafe_ccall libcuda.cuGraphGetEdges_v2(hGraph::CUgraph, from::Ptr{CUgraphNode},
-                                      to::Ptr{CUgraphNode}, edgeData::Ptr{CUgraphEdgeData},
-                                      numEdges::Ptr{Csize_t})::CUresult
+                                             to::Ptr{CUgraphNode},
+                                             edgeData::Ptr{CUgraphEdgeData},
+                                             numEdges::Ptr{Csize_t})::CUresult
 end
 
 @checked function cuGraphNodeGetDependencies(hNode, dependencies, numDependencies)
     initialize_context()
     @gcsafe_ccall libcuda.cuGraphNodeGetDependencies(hNode::CUgraphNode,
-                                              dependencies::Ptr{CUgraphNode},
-                                              numDependencies::Ptr{Csize_t})::CUresult
+                                                     dependencies::Ptr{CUgraphNode},
+                                                     numDependencies::Ptr{Csize_t})::CUresult
 end
 
 @checked function cuGraphNodeGetDependencies_v2(hNode, dependencies, edgeData,
                                                 numDependencies)
     initialize_context()
     @gcsafe_ccall libcuda.cuGraphNodeGetDependencies_v2(hNode::CUgraphNode,
-                                                 dependencies::Ptr{CUgraphNode},
-                                                 edgeData::Ptr{CUgraphEdgeData},
-                                                 numDependencies::Ptr{Csize_t})::CUresult
+                                                        dependencies::Ptr{CUgraphNode},
+                                                        edgeData::Ptr{CUgraphEdgeData},
+                                                        numDependencies::Ptr{Csize_t})::CUresult
 end
 
 @checked function cuGraphNodeGetDependentNodes(hNode, dependentNodes, numDependentNodes)
     initialize_context()
     @gcsafe_ccall libcuda.cuGraphNodeGetDependentNodes(hNode::CUgraphNode,
-                                                dependentNodes::Ptr{CUgraphNode},
-                                                numDependentNodes::Ptr{Csize_t})::CUresult
+                                                       dependentNodes::Ptr{CUgraphNode},
+                                                       numDependentNodes::Ptr{Csize_t})::CUresult
 end
 
 @checked function cuGraphNodeGetDependentNodes_v2(hNode, dependentNodes, edgeData,
                                                   numDependentNodes)
     initialize_context()
     @gcsafe_ccall libcuda.cuGraphNodeGetDependentNodes_v2(hNode::CUgraphNode,
-                                                   dependentNodes::Ptr{CUgraphNode},
-                                                   edgeData::Ptr{CUgraphEdgeData},
-                                                   numDependentNodes::Ptr{Csize_t})::CUresult
+                                                          dependentNodes::Ptr{CUgraphNode},
+                                                          edgeData::Ptr{CUgraphEdgeData},
+                                                          numDependentNodes::Ptr{Csize_t})::CUresult
 end
 
 @checked function cuGraphAddDependencies(hGraph, from, to, numDependencies)
     initialize_context()
     @gcsafe_ccall libcuda.cuGraphAddDependencies(hGraph::CUgraph, from::Ptr{CUgraphNode},
-                                          to::Ptr{CUgraphNode},
-                                          numDependencies::Csize_t)::CUresult
+                                                 to::Ptr{CUgraphNode},
+                                                 numDependencies::Csize_t)::CUresult
 end
 
 @checked function cuGraphAddDependencies_v2(hGraph, from, to, edgeData, numDependencies)
     initialize_context()
     @gcsafe_ccall libcuda.cuGraphAddDependencies_v2(hGraph::CUgraph, from::Ptr{CUgraphNode},
-                                             to::Ptr{CUgraphNode},
-                                             edgeData::Ptr{CUgraphEdgeData},
-                                             numDependencies::Csize_t)::CUresult
+                                                    to::Ptr{CUgraphNode},
+                                                    edgeData::Ptr{CUgraphEdgeData},
+                                                    numDependencies::Csize_t)::CUresult
 end
 
 @checked function cuGraphRemoveDependencies(hGraph, from, to, numDependencies)
     initialize_context()
     @gcsafe_ccall libcuda.cuGraphRemoveDependencies(hGraph::CUgraph, from::Ptr{CUgraphNode},
-                                             to::Ptr{CUgraphNode},
-                                             numDependencies::Csize_t)::CUresult
+                                                    to::Ptr{CUgraphNode},
+                                                    numDependencies::Csize_t)::CUresult
 end
 
 @checked function cuGraphRemoveDependencies_v2(hGraph, from, to, edgeData, numDependencies)
     initialize_context()
-    @gcsafe_ccall libcuda.cuGraphRemoveDependencies_v2(hGraph::CUgraph, from::Ptr{CUgraphNode},
-                                                to::Ptr{CUgraphNode},
-                                                edgeData::Ptr{CUgraphEdgeData},
-                                                numDependencies::Csize_t)::CUresult
+    @gcsafe_ccall libcuda.cuGraphRemoveDependencies_v2(hGraph::CUgraph,
+                                                       from::Ptr{CUgraphNode},
+                                                       to::Ptr{CUgraphNode},
+                                                       edgeData::Ptr{CUgraphEdgeData},
+                                                       numDependencies::Csize_t)::CUresult
 end
 
 @checked function cuGraphDestroyNode(hNode)
@@ -4628,95 +4698,98 @@ end
 @checked function cuGraphInstantiateWithParams(phGraphExec, hGraph, instantiateParams)
     initialize_context()
     @gcsafe_ccall libcuda.cuGraphInstantiateWithParams(phGraphExec::Ptr{CUgraphExec},
-                                                hGraph::CUgraph,
-                                                instantiateParams::Ptr{CUDA_GRAPH_INSTANTIATE_PARAMS})::CUresult
+                                                       hGraph::CUgraph,
+                                                       instantiateParams::Ptr{CUDA_GRAPH_INSTANTIATE_PARAMS})::CUresult
 end
 
 @checked function cuGraphExecGetFlags(hGraphExec, flags)
     initialize_context()
     @gcsafe_ccall libcuda.cuGraphExecGetFlags(hGraphExec::CUgraphExec,
-                                       flags::Ptr{cuuint64_t})::CUresult
+                                              flags::Ptr{cuuint64_t})::CUresult
 end
 
 @checked function cuGraphExecMemcpyNodeSetParams(hGraphExec, hNode, copyParams, ctx)
     initialize_context()
     @gcsafe_ccall libcuda.cuGraphExecMemcpyNodeSetParams(hGraphExec::CUgraphExec,
-                                                  hNode::CUgraphNode,
-                                                  copyParams::Ptr{CUDA_MEMCPY3D},
-                                                  ctx::CUcontext)::CUresult
+                                                         hNode::CUgraphNode,
+                                                         copyParams::Ptr{CUDA_MEMCPY3D},
+                                                         ctx::CUcontext)::CUresult
 end
 
 @checked function cuGraphExecMemsetNodeSetParams(hGraphExec, hNode, memsetParams, ctx)
     initialize_context()
     @gcsafe_ccall libcuda.cuGraphExecMemsetNodeSetParams(hGraphExec::CUgraphExec,
-                                                  hNode::CUgraphNode,
-                                                  memsetParams::Ptr{CUDA_MEMSET_NODE_PARAMS},
-                                                  ctx::CUcontext)::CUresult
+                                                         hNode::CUgraphNode,
+                                                         memsetParams::Ptr{CUDA_MEMSET_NODE_PARAMS},
+                                                         ctx::CUcontext)::CUresult
 end
 
 @checked function cuGraphExecHostNodeSetParams(hGraphExec, hNode, nodeParams)
     initialize_context()
-    @gcsafe_ccall libcuda.cuGraphExecHostNodeSetParams(hGraphExec::CUgraphExec, hNode::CUgraphNode,
-                                                nodeParams::Ptr{CUDA_HOST_NODE_PARAMS})::CUresult
+    @gcsafe_ccall libcuda.cuGraphExecHostNodeSetParams(hGraphExec::CUgraphExec,
+                                                       hNode::CUgraphNode,
+                                                       nodeParams::Ptr{CUDA_HOST_NODE_PARAMS})::CUresult
 end
 
 @checked function cuGraphExecChildGraphNodeSetParams(hGraphExec, hNode, childGraph)
     initialize_context()
     @gcsafe_ccall libcuda.cuGraphExecChildGraphNodeSetParams(hGraphExec::CUgraphExec,
-                                                      hNode::CUgraphNode,
-                                                      childGraph::CUgraph)::CUresult
+                                                             hNode::CUgraphNode,
+                                                             childGraph::CUgraph)::CUresult
 end
 
 @checked function cuGraphExecEventRecordNodeSetEvent(hGraphExec, hNode, event)
     initialize_context()
     @gcsafe_ccall libcuda.cuGraphExecEventRecordNodeSetEvent(hGraphExec::CUgraphExec,
-                                                      hNode::CUgraphNode,
-                                                      event::CUevent)::CUresult
+                                                             hNode::CUgraphNode,
+                                                             event::CUevent)::CUresult
 end
 
 @checked function cuGraphExecEventWaitNodeSetEvent(hGraphExec, hNode, event)
     initialize_context()
     @gcsafe_ccall libcuda.cuGraphExecEventWaitNodeSetEvent(hGraphExec::CUgraphExec,
-                                                    hNode::CUgraphNode,
-                                                    event::CUevent)::CUresult
+                                                           hNode::CUgraphNode,
+                                                           event::CUevent)::CUresult
 end
 
 @checked function cuGraphExecExternalSemaphoresSignalNodeSetParams(hGraphExec, hNode,
                                                                    nodeParams)
     initialize_context()
     @gcsafe_ccall libcuda.cuGraphExecExternalSemaphoresSignalNodeSetParams(hGraphExec::CUgraphExec,
-                                                                    hNode::CUgraphNode,
-                                                                    nodeParams::Ptr{CUDA_EXT_SEM_SIGNAL_NODE_PARAMS})::CUresult
+                                                                           hNode::CUgraphNode,
+                                                                           nodeParams::Ptr{CUDA_EXT_SEM_SIGNAL_NODE_PARAMS})::CUresult
 end
 
 @checked function cuGraphExecExternalSemaphoresWaitNodeSetParams(hGraphExec, hNode,
                                                                  nodeParams)
     initialize_context()
     @gcsafe_ccall libcuda.cuGraphExecExternalSemaphoresWaitNodeSetParams(hGraphExec::CUgraphExec,
-                                                                  hNode::CUgraphNode,
-                                                                  nodeParams::Ptr{CUDA_EXT_SEM_WAIT_NODE_PARAMS})::CUresult
+                                                                         hNode::CUgraphNode,
+                                                                         nodeParams::Ptr{CUDA_EXT_SEM_WAIT_NODE_PARAMS})::CUresult
 end
 
 @checked function cuGraphNodeSetEnabled(hGraphExec, hNode, isEnabled)
     initialize_context()
     @gcsafe_ccall libcuda.cuGraphNodeSetEnabled(hGraphExec::CUgraphExec, hNode::CUgraphNode,
-                                         isEnabled::Cuint)::CUresult
+                                                isEnabled::Cuint)::CUresult
 end
 
 @checked function cuGraphNodeGetEnabled(hGraphExec, hNode, isEnabled)
     initialize_context()
     @gcsafe_ccall libcuda.cuGraphNodeGetEnabled(hGraphExec::CUgraphExec, hNode::CUgraphNode,
-                                         isEnabled::Ptr{Cuint})::CUresult
+                                                isEnabled::Ptr{Cuint})::CUresult
 end
 
 @checked function cuGraphUpload(hGraphExec, hStream)
     initialize_context()
-    @gcsafe_ccall libcuda.cuGraphUpload(hGraphExec::CUgraphExec, hStream::CUstream)::CUresult
+    @gcsafe_ccall libcuda.cuGraphUpload(hGraphExec::CUgraphExec,
+                                        hStream::CUstream)::CUresult
 end
 
 @checked function cuGraphLaunch(hGraphExec, hStream)
     initialize_context()
-    @gcsafe_ccall libcuda.cuGraphLaunch(hGraphExec::CUgraphExec, hStream::CUstream)::CUresult
+    @gcsafe_ccall libcuda.cuGraphLaunch(hGraphExec::CUgraphExec,
+                                        hStream::CUstream)::CUresult
 end
 
 @checked function cuGraphExecDestroy(hGraphExec)
@@ -4732,34 +4805,34 @@ end
 @checked function cuGraphKernelNodeCopyAttributes(dst, src)
     initialize_context()
     @gcsafe_ccall libcuda.cuGraphKernelNodeCopyAttributes(dst::CUgraphNode,
-                                                   src::CUgraphNode)::CUresult
+                                                          src::CUgraphNode)::CUresult
 end
 
 @checked function cuGraphKernelNodeGetAttribute(hNode, attr, value_out)
     initialize_context()
     @gcsafe_ccall libcuda.cuGraphKernelNodeGetAttribute(hNode::CUgraphNode,
-                                                 attr::CUkernelNodeAttrID,
-                                                 value_out::Ptr{CUkernelNodeAttrValue})::CUresult
+                                                        attr::CUkernelNodeAttrID,
+                                                        value_out::Ptr{CUkernelNodeAttrValue})::CUresult
 end
 
 @checked function cuGraphKernelNodeSetAttribute(hNode, attr, value)
     initialize_context()
     @gcsafe_ccall libcuda.cuGraphKernelNodeSetAttribute(hNode::CUgraphNode,
-                                                 attr::CUkernelNodeAttrID,
-                                                 value::Ptr{CUkernelNodeAttrValue})::CUresult
+                                                        attr::CUkernelNodeAttrID,
+                                                        value::Ptr{CUkernelNodeAttrValue})::CUresult
 end
 
 @checked function cuGraphDebugDotPrint(hGraph, path, flags)
     initialize_context()
     @gcsafe_ccall libcuda.cuGraphDebugDotPrint(hGraph::CUgraph, path::Cstring,
-                                        flags::Cuint)::CUresult
+                                               flags::Cuint)::CUresult
 end
 
 @checked function cuUserObjectCreate(object_out, ptr, destroy, initialRefcount, flags)
     initialize_context()
     @gcsafe_ccall libcuda.cuUserObjectCreate(object_out::Ptr{CUuserObject}, ptr::Ptr{Cvoid},
-                                      destroy::CUhostFn, initialRefcount::Cuint,
-                                      flags::Cuint)::CUresult
+                                             destroy::CUhostFn, initialRefcount::Cuint,
+                                             flags::Cuint)::CUresult
 end
 
 @checked function cuUserObjectRetain(object, count)
@@ -4775,61 +4848,63 @@ end
 @checked function cuGraphRetainUserObject(graph, object, count, flags)
     initialize_context()
     @gcsafe_ccall libcuda.cuGraphRetainUserObject(graph::CUgraph, object::CUuserObject,
-                                           count::Cuint, flags::Cuint)::CUresult
+                                                  count::Cuint, flags::Cuint)::CUresult
 end
 
 @checked function cuGraphReleaseUserObject(graph, object, count)
     initialize_context()
     @gcsafe_ccall libcuda.cuGraphReleaseUserObject(graph::CUgraph, object::CUuserObject,
-                                            count::Cuint)::CUresult
+                                                   count::Cuint)::CUresult
 end
 
 @checked function cuGraphAddNode(phGraphNode, hGraph, dependencies, numDependencies,
                                  nodeParams)
     initialize_context()
     @gcsafe_ccall libcuda.cuGraphAddNode(phGraphNode::Ptr{CUgraphNode}, hGraph::CUgraph,
-                                  dependencies::Ptr{CUgraphNode}, numDependencies::Csize_t,
-                                  nodeParams::Ptr{CUgraphNodeParams})::CUresult
+                                         dependencies::Ptr{CUgraphNode},
+                                         numDependencies::Csize_t,
+                                         nodeParams::Ptr{CUgraphNodeParams})::CUresult
 end
 
 @checked function cuGraphAddNode_v2(phGraphNode, hGraph, dependencies, dependencyData,
                                     numDependencies, nodeParams)
     initialize_context()
     @gcsafe_ccall libcuda.cuGraphAddNode_v2(phGraphNode::Ptr{CUgraphNode}, hGraph::CUgraph,
-                                     dependencies::Ptr{CUgraphNode},
-                                     dependencyData::Ptr{CUgraphEdgeData},
-                                     numDependencies::Csize_t,
-                                     nodeParams::Ptr{CUgraphNodeParams})::CUresult
+                                            dependencies::Ptr{CUgraphNode},
+                                            dependencyData::Ptr{CUgraphEdgeData},
+                                            numDependencies::Csize_t,
+                                            nodeParams::Ptr{CUgraphNodeParams})::CUresult
 end
 
 @checked function cuGraphNodeSetParams(hNode, nodeParams)
     initialize_context()
     @gcsafe_ccall libcuda.cuGraphNodeSetParams(hNode::CUgraphNode,
-                                        nodeParams::Ptr{CUgraphNodeParams})::CUresult
+                                               nodeParams::Ptr{CUgraphNodeParams})::CUresult
 end
 
 @checked function cuGraphExecNodeSetParams(hGraphExec, hNode, nodeParams)
     initialize_context()
-    @gcsafe_ccall libcuda.cuGraphExecNodeSetParams(hGraphExec::CUgraphExec, hNode::CUgraphNode,
-                                            nodeParams::Ptr{CUgraphNodeParams})::CUresult
+    @gcsafe_ccall libcuda.cuGraphExecNodeSetParams(hGraphExec::CUgraphExec,
+                                                   hNode::CUgraphNode,
+                                                   nodeParams::Ptr{CUgraphNodeParams})::CUresult
 end
 
 @checked function cuGraphConditionalHandleCreate(pHandle_out, hGraph, ctx,
                                                  defaultLaunchValue, flags)
     initialize_context()
     @gcsafe_ccall libcuda.cuGraphConditionalHandleCreate(pHandle_out::Ptr{CUgraphConditionalHandle},
-                                                  hGraph::CUgraph, ctx::CUcontext,
-                                                  defaultLaunchValue::Cuint,
-                                                  flags::Cuint)::CUresult
+                                                         hGraph::CUgraph, ctx::CUcontext,
+                                                         defaultLaunchValue::Cuint,
+                                                         flags::Cuint)::CUresult
 end
 
 @checked function cuOccupancyMaxActiveBlocksPerMultiprocessor(numBlocks, func, blockSize,
                                                               dynamicSMemSize)
     initialize_context()
     @gcsafe_ccall libcuda.cuOccupancyMaxActiveBlocksPerMultiprocessor(numBlocks::Ptr{Cint},
-                                                               func::CUfunction,
-                                                               blockSize::Cint,
-                                                               dynamicSMemSize::Csize_t)::CUresult
+                                                                      func::CUfunction,
+                                                                      blockSize::Cint,
+                                                                      dynamicSMemSize::Csize_t)::CUresult
 end
 
 @checked function cuOccupancyMaxActiveBlocksPerMultiprocessorWithFlags(numBlocks, func,
@@ -4838,10 +4913,10 @@ end
                                                                        flags)
     initialize_context()
     @gcsafe_ccall libcuda.cuOccupancyMaxActiveBlocksPerMultiprocessorWithFlags(numBlocks::Ptr{Cint},
-                                                                        func::CUfunction,
-                                                                        blockSize::Cint,
-                                                                        dynamicSMemSize::Csize_t,
-                                                                        flags::Cuint)::CUresult
+                                                                               func::CUfunction,
+                                                                               blockSize::Cint,
+                                                                               dynamicSMemSize::Csize_t,
+                                                                               flags::Cuint)::CUresult
 end
 
 @checked function cuOccupancyMaxPotentialBlockSize(minGridSize, blockSize, func,
@@ -4849,10 +4924,11 @@ end
                                                    dynamicSMemSize, blockSizeLimit)
     initialize_context()
     @gcsafe_ccall libcuda.cuOccupancyMaxPotentialBlockSize(minGridSize::Ptr{Cint},
-                                                    blockSize::Ptr{Cint}, func::CUfunction,
-                                                    blockSizeToDynamicSMemSize::CUoccupancyB2DSize,
-                                                    dynamicSMemSize::Csize_t,
-                                                    blockSizeLimit::Cint)::CUresult
+                                                           blockSize::Ptr{Cint},
+                                                           func::CUfunction,
+                                                           blockSizeToDynamicSMemSize::CUoccupancyB2DSize,
+                                                           dynamicSMemSize::Csize_t,
+                                                           blockSizeLimit::Cint)::CUresult
 end
 
 @checked function cuOccupancyMaxPotentialBlockSizeWithFlags(minGridSize, blockSize, func,
@@ -4861,94 +4937,98 @@ end
                                                             flags)
     initialize_context()
     @gcsafe_ccall libcuda.cuOccupancyMaxPotentialBlockSizeWithFlags(minGridSize::Ptr{Cint},
-                                                             blockSize::Ptr{Cint},
-                                                             func::CUfunction,
-                                                             blockSizeToDynamicSMemSize::CUoccupancyB2DSize,
-                                                             dynamicSMemSize::Csize_t,
-                                                             blockSizeLimit::Cint,
-                                                             flags::Cuint)::CUresult
+                                                                    blockSize::Ptr{Cint},
+                                                                    func::CUfunction,
+                                                                    blockSizeToDynamicSMemSize::CUoccupancyB2DSize,
+                                                                    dynamicSMemSize::Csize_t,
+                                                                    blockSizeLimit::Cint,
+                                                                    flags::Cuint)::CUresult
 end
 
 @checked function cuOccupancyAvailableDynamicSMemPerBlock(dynamicSmemSize, func, numBlocks,
                                                           blockSize)
     initialize_context()
     @gcsafe_ccall libcuda.cuOccupancyAvailableDynamicSMemPerBlock(dynamicSmemSize::Ptr{Csize_t},
-                                                           func::CUfunction,
-                                                           numBlocks::Cint,
-                                                           blockSize::Cint)::CUresult
+                                                                  func::CUfunction,
+                                                                  numBlocks::Cint,
+                                                                  blockSize::Cint)::CUresult
 end
 
 @checked function cuOccupancyMaxPotentialClusterSize(clusterSize, func, config)
     initialize_context()
     @gcsafe_ccall libcuda.cuOccupancyMaxPotentialClusterSize(clusterSize::Ptr{Cint},
-                                                      func::CUfunction,
-                                                      config::Ptr{CUlaunchConfig})::CUresult
+                                                             func::CUfunction,
+                                                             config::Ptr{CUlaunchConfig})::CUresult
 end
 
 @checked function cuOccupancyMaxActiveClusters(numClusters, func, config)
     initialize_context()
-    @gcsafe_ccall libcuda.cuOccupancyMaxActiveClusters(numClusters::Ptr{Cint}, func::CUfunction,
-                                                config::Ptr{CUlaunchConfig})::CUresult
+    @gcsafe_ccall libcuda.cuOccupancyMaxActiveClusters(numClusters::Ptr{Cint},
+                                                       func::CUfunction,
+                                                       config::Ptr{CUlaunchConfig})::CUresult
 end
 
 @checked function cuTexRefSetArray(hTexRef, hArray, Flags)
     initialize_context()
     @gcsafe_ccall libcuda.cuTexRefSetArray(hTexRef::CUtexref, hArray::CUarray,
-                                    Flags::Cuint)::CUresult
+                                           Flags::Cuint)::CUresult
 end
 
 @checked function cuTexRefSetMipmappedArray(hTexRef, hMipmappedArray, Flags)
     initialize_context()
     @gcsafe_ccall libcuda.cuTexRefSetMipmappedArray(hTexRef::CUtexref,
-                                             hMipmappedArray::CUmipmappedArray,
-                                             Flags::Cuint)::CUresult
+                                                    hMipmappedArray::CUmipmappedArray,
+                                                    Flags::Cuint)::CUresult
 end
 
 @checked function cuTexRefSetFormat(hTexRef, fmt, NumPackedComponents)
     initialize_context()
     @gcsafe_ccall libcuda.cuTexRefSetFormat(hTexRef::CUtexref, fmt::CUarray_format,
-                                     NumPackedComponents::Cint)::CUresult
+                                            NumPackedComponents::Cint)::CUresult
 end
 
 @checked function cuTexRefSetAddressMode(hTexRef, dim, am)
     initialize_context()
     @gcsafe_ccall libcuda.cuTexRefSetAddressMode(hTexRef::CUtexref, dim::Cint,
-                                          am::CUaddress_mode)::CUresult
+                                                 am::CUaddress_mode)::CUresult
 end
 
 @checked function cuTexRefSetFilterMode(hTexRef, fm)
     initialize_context()
-    @gcsafe_ccall libcuda.cuTexRefSetFilterMode(hTexRef::CUtexref, fm::CUfilter_mode)::CUresult
+    @gcsafe_ccall libcuda.cuTexRefSetFilterMode(hTexRef::CUtexref,
+                                                fm::CUfilter_mode)::CUresult
 end
 
 @checked function cuTexRefSetMipmapFilterMode(hTexRef, fm)
     initialize_context()
     @gcsafe_ccall libcuda.cuTexRefSetMipmapFilterMode(hTexRef::CUtexref,
-                                               fm::CUfilter_mode)::CUresult
+                                                      fm::CUfilter_mode)::CUresult
 end
 
 @checked function cuTexRefSetMipmapLevelBias(hTexRef, bias)
     initialize_context()
-    @gcsafe_ccall libcuda.cuTexRefSetMipmapLevelBias(hTexRef::CUtexref, bias::Cfloat)::CUresult
+    @gcsafe_ccall libcuda.cuTexRefSetMipmapLevelBias(hTexRef::CUtexref,
+                                                     bias::Cfloat)::CUresult
 end
 
 @checked function cuTexRefSetMipmapLevelClamp(hTexRef, minMipmapLevelClamp,
                                               maxMipmapLevelClamp)
     initialize_context()
     @gcsafe_ccall libcuda.cuTexRefSetMipmapLevelClamp(hTexRef::CUtexref,
-                                               minMipmapLevelClamp::Cfloat,
-                                               maxMipmapLevelClamp::Cfloat)::CUresult
+                                                      minMipmapLevelClamp::Cfloat,
+                                                      maxMipmapLevelClamp::Cfloat)::CUresult
 end
 
 @checked function cuTexRefSetMaxAnisotropy(hTexRef, maxAniso)
     initialize_context()
-    @gcsafe_ccall libcuda.cuTexRefSetMaxAnisotropy(hTexRef::CUtexref, maxAniso::Cuint)::CUresult
+    @gcsafe_ccall libcuda.cuTexRefSetMaxAnisotropy(hTexRef::CUtexref,
+                                                   maxAniso::Cuint)::CUresult
 end
 
 @checked function cuTexRefSetBorderColor(hTexRef, pBorderColor)
     initialize_context()
     @gcsafe_ccall libcuda.cuTexRefSetBorderColor(hTexRef::CUtexref,
-                                          pBorderColor::Ptr{Cfloat})::CUresult
+                                                 pBorderColor::Ptr{Cfloat})::CUresult
 end
 
 @checked function cuTexRefSetFlags(hTexRef, Flags)
@@ -4958,63 +5038,65 @@ end
 
 @checked function cuTexRefGetArray(phArray, hTexRef)
     initialize_context()
-    @gcsafe_ccall libcuda.cuTexRefGetArray(phArray::Ptr{CUarray}, hTexRef::CUtexref)::CUresult
+    @gcsafe_ccall libcuda.cuTexRefGetArray(phArray::Ptr{CUarray},
+                                           hTexRef::CUtexref)::CUresult
 end
 
 @checked function cuTexRefGetMipmappedArray(phMipmappedArray, hTexRef)
     initialize_context()
     @gcsafe_ccall libcuda.cuTexRefGetMipmappedArray(phMipmappedArray::Ptr{CUmipmappedArray},
-                                             hTexRef::CUtexref)::CUresult
+                                                    hTexRef::CUtexref)::CUresult
 end
 
 @checked function cuTexRefGetAddressMode(pam, hTexRef, dim)
     initialize_context()
-    @gcsafe_ccall libcuda.cuTexRefGetAddressMode(pam::Ptr{CUaddress_mode}, hTexRef::CUtexref,
-                                          dim::Cint)::CUresult
+    @gcsafe_ccall libcuda.cuTexRefGetAddressMode(pam::Ptr{CUaddress_mode},
+                                                 hTexRef::CUtexref, dim::Cint)::CUresult
 end
 
 @checked function cuTexRefGetFilterMode(pfm, hTexRef)
     initialize_context()
     @gcsafe_ccall libcuda.cuTexRefGetFilterMode(pfm::Ptr{CUfilter_mode},
-                                         hTexRef::CUtexref)::CUresult
+                                                hTexRef::CUtexref)::CUresult
 end
 
 @checked function cuTexRefGetFormat(pFormat, pNumChannels, hTexRef)
     initialize_context()
-    @gcsafe_ccall libcuda.cuTexRefGetFormat(pFormat::Ptr{CUarray_format}, pNumChannels::Ptr{Cint},
-                                     hTexRef::CUtexref)::CUresult
+    @gcsafe_ccall libcuda.cuTexRefGetFormat(pFormat::Ptr{CUarray_format},
+                                            pNumChannels::Ptr{Cint},
+                                            hTexRef::CUtexref)::CUresult
 end
 
 @checked function cuTexRefGetMipmapFilterMode(pfm, hTexRef)
     initialize_context()
     @gcsafe_ccall libcuda.cuTexRefGetMipmapFilterMode(pfm::Ptr{CUfilter_mode},
-                                               hTexRef::CUtexref)::CUresult
+                                                      hTexRef::CUtexref)::CUresult
 end
 
 @checked function cuTexRefGetMipmapLevelBias(pbias, hTexRef)
     initialize_context()
     @gcsafe_ccall libcuda.cuTexRefGetMipmapLevelBias(pbias::Ptr{Cfloat},
-                                              hTexRef::CUtexref)::CUresult
+                                                     hTexRef::CUtexref)::CUresult
 end
 
 @checked function cuTexRefGetMipmapLevelClamp(pminMipmapLevelClamp, pmaxMipmapLevelClamp,
                                               hTexRef)
     initialize_context()
     @gcsafe_ccall libcuda.cuTexRefGetMipmapLevelClamp(pminMipmapLevelClamp::Ptr{Cfloat},
-                                               pmaxMipmapLevelClamp::Ptr{Cfloat},
-                                               hTexRef::CUtexref)::CUresult
+                                                      pmaxMipmapLevelClamp::Ptr{Cfloat},
+                                                      hTexRef::CUtexref)::CUresult
 end
 
 @checked function cuTexRefGetMaxAnisotropy(pmaxAniso, hTexRef)
     initialize_context()
     @gcsafe_ccall libcuda.cuTexRefGetMaxAnisotropy(pmaxAniso::Ptr{Cint},
-                                            hTexRef::CUtexref)::CUresult
+                                                   hTexRef::CUtexref)::CUresult
 end
 
 @checked function cuTexRefGetBorderColor(pBorderColor, hTexRef)
     initialize_context()
     @gcsafe_ccall libcuda.cuTexRefGetBorderColor(pBorderColor::Ptr{Cfloat},
-                                          hTexRef::CUtexref)::CUresult
+                                                 hTexRef::CUtexref)::CUresult
 end
 
 @checked function cuTexRefGetFlags(pFlags, hTexRef)
@@ -5035,20 +5117,21 @@ end
 @checked function cuSurfRefSetArray(hSurfRef, hArray, Flags)
     initialize_context()
     @gcsafe_ccall libcuda.cuSurfRefSetArray(hSurfRef::CUsurfref, hArray::CUarray,
-                                     Flags::Cuint)::CUresult
+                                            Flags::Cuint)::CUresult
 end
 
 @checked function cuSurfRefGetArray(phArray, hSurfRef)
     initialize_context()
-    @gcsafe_ccall libcuda.cuSurfRefGetArray(phArray::Ptr{CUarray}, hSurfRef::CUsurfref)::CUresult
+    @gcsafe_ccall libcuda.cuSurfRefGetArray(phArray::Ptr{CUarray},
+                                            hSurfRef::CUsurfref)::CUresult
 end
 
 @checked function cuTexObjectCreate(pTexObject, pResDesc, pTexDesc, pResViewDesc)
     initialize_context()
     @gcsafe_ccall libcuda.cuTexObjectCreate(pTexObject::Ptr{CUtexObject},
-                                     pResDesc::Ptr{CUDA_RESOURCE_DESC},
-                                     pTexDesc::Ptr{CUDA_TEXTURE_DESC},
-                                     pResViewDesc::Ptr{CUDA_RESOURCE_VIEW_DESC})::CUresult
+                                            pResDesc::Ptr{CUDA_RESOURCE_DESC},
+                                            pTexDesc::Ptr{CUDA_TEXTURE_DESC},
+                                            pResViewDesc::Ptr{CUDA_RESOURCE_VIEW_DESC})::CUresult
 end
 
 @checked function cuTexObjectDestroy(texObject)
@@ -5059,25 +5142,25 @@ end
 @checked function cuTexObjectGetResourceDesc(pResDesc, texObject)
     initialize_context()
     @gcsafe_ccall libcuda.cuTexObjectGetResourceDesc(pResDesc::Ptr{CUDA_RESOURCE_DESC},
-                                              texObject::CUtexObject)::CUresult
+                                                     texObject::CUtexObject)::CUresult
 end
 
 @checked function cuTexObjectGetTextureDesc(pTexDesc, texObject)
     initialize_context()
     @gcsafe_ccall libcuda.cuTexObjectGetTextureDesc(pTexDesc::Ptr{CUDA_TEXTURE_DESC},
-                                             texObject::CUtexObject)::CUresult
+                                                    texObject::CUtexObject)::CUresult
 end
 
 @checked function cuTexObjectGetResourceViewDesc(pResViewDesc, texObject)
     initialize_context()
     @gcsafe_ccall libcuda.cuTexObjectGetResourceViewDesc(pResViewDesc::Ptr{CUDA_RESOURCE_VIEW_DESC},
-                                                  texObject::CUtexObject)::CUresult
+                                                         texObject::CUtexObject)::CUresult
 end
 
 @checked function cuSurfObjectCreate(pSurfObject, pResDesc)
     initialize_context()
     @gcsafe_ccall libcuda.cuSurfObjectCreate(pSurfObject::Ptr{CUsurfObject},
-                                      pResDesc::Ptr{CUDA_RESOURCE_DESC})::CUresult
+                                             pResDesc::Ptr{CUDA_RESOURCE_DESC})::CUresult
 end
 
 @checked function cuSurfObjectDestroy(surfObject)
@@ -5088,7 +5171,7 @@ end
 @checked function cuSurfObjectGetResourceDesc(pResDesc, surfObject)
     initialize_context()
     @gcsafe_ccall libcuda.cuSurfObjectGetResourceDesc(pResDesc::Ptr{CUDA_RESOURCE_DESC},
-                                               surfObject::CUsurfObject)::CUresult
+                                                      surfObject::CUsurfObject)::CUresult
 end
 
 @checked function cuTensorMapEncodeTiled(tensorMap, tensorDataType, tensorRank,
@@ -5097,16 +5180,17 @@ end
                                          oobFill)
     initialize_context()
     @gcsafe_ccall libcuda.cuTensorMapEncodeTiled(tensorMap::Ptr{CUtensorMap},
-                                          tensorDataType::CUtensorMapDataType,
-                                          tensorRank::cuuint32_t, globalAddress::Ptr{Cvoid},
-                                          globalDim::Ptr{cuuint64_t},
-                                          globalStrides::Ptr{cuuint64_t},
-                                          boxDim::Ptr{cuuint32_t},
-                                          elementStrides::Ptr{cuuint32_t},
-                                          interleave::CUtensorMapInterleave,
-                                          swizzle::CUtensorMapSwizzle,
-                                          l2Promotion::CUtensorMapL2promotion,
-                                          oobFill::CUtensorMapFloatOOBfill)::CUresult
+                                                 tensorDataType::CUtensorMapDataType,
+                                                 tensorRank::cuuint32_t,
+                                                 globalAddress::Ptr{Cvoid},
+                                                 globalDim::Ptr{cuuint64_t},
+                                                 globalStrides::Ptr{cuuint64_t},
+                                                 boxDim::Ptr{cuuint32_t},
+                                                 elementStrides::Ptr{cuuint32_t},
+                                                 interleave::CUtensorMapInterleave,
+                                                 swizzle::CUtensorMapSwizzle,
+                                                 l2Promotion::CUtensorMapL2promotion,
+                                                 oobFill::CUtensorMapFloatOOBfill)::CUresult
 end
 
 @checked function cuTensorMapEncodeIm2col(tensorMap, tensorDataType, tensorRank,
@@ -5116,37 +5200,38 @@ end
                                           interleave, swizzle, l2Promotion, oobFill)
     initialize_context()
     @gcsafe_ccall libcuda.cuTensorMapEncodeIm2col(tensorMap::Ptr{CUtensorMap},
-                                           tensorDataType::CUtensorMapDataType,
-                                           tensorRank::cuuint32_t,
-                                           globalAddress::Ptr{Cvoid},
-                                           globalDim::Ptr{cuuint64_t},
-                                           globalStrides::Ptr{cuuint64_t},
-                                           pixelBoxLowerCorner::Ptr{Cint},
-                                           pixelBoxUpperCorner::Ptr{Cint},
-                                           channelsPerPixel::cuuint32_t,
-                                           pixelsPerColumn::cuuint32_t,
-                                           elementStrides::Ptr{cuuint32_t},
-                                           interleave::CUtensorMapInterleave,
-                                           swizzle::CUtensorMapSwizzle,
-                                           l2Promotion::CUtensorMapL2promotion,
-                                           oobFill::CUtensorMapFloatOOBfill)::CUresult
+                                                  tensorDataType::CUtensorMapDataType,
+                                                  tensorRank::cuuint32_t,
+                                                  globalAddress::Ptr{Cvoid},
+                                                  globalDim::Ptr{cuuint64_t},
+                                                  globalStrides::Ptr{cuuint64_t},
+                                                  pixelBoxLowerCorner::Ptr{Cint},
+                                                  pixelBoxUpperCorner::Ptr{Cint},
+                                                  channelsPerPixel::cuuint32_t,
+                                                  pixelsPerColumn::cuuint32_t,
+                                                  elementStrides::Ptr{cuuint32_t},
+                                                  interleave::CUtensorMapInterleave,
+                                                  swizzle::CUtensorMapSwizzle,
+                                                  l2Promotion::CUtensorMapL2promotion,
+                                                  oobFill::CUtensorMapFloatOOBfill)::CUresult
 end
 
 @checked function cuTensorMapReplaceAddress(tensorMap, globalAddress)
     initialize_context()
     @gcsafe_ccall libcuda.cuTensorMapReplaceAddress(tensorMap::Ptr{CUtensorMap},
-                                             globalAddress::Ptr{Cvoid})::CUresult
+                                                    globalAddress::Ptr{Cvoid})::CUresult
 end
 
 @checked function cuDeviceCanAccessPeer(canAccessPeer, dev, peerDev)
     initialize_context()
     @gcsafe_ccall libcuda.cuDeviceCanAccessPeer(canAccessPeer::Ptr{Cint}, dev::CUdevice,
-                                         peerDev::CUdevice)::CUresult
+                                                peerDev::CUdevice)::CUresult
 end
 
 @checked function cuCtxEnablePeerAccess(peerContext, Flags)
     initialize_context()
-    @gcsafe_ccall libcuda.cuCtxEnablePeerAccess(peerContext::CUcontext, Flags::Cuint)::CUresult
+    @gcsafe_ccall libcuda.cuCtxEnablePeerAccess(peerContext::CUcontext,
+                                                Flags::Cuint)::CUresult
 end
 
 @checked function cuCtxDisablePeerAccess(peerContext)
@@ -5156,9 +5241,10 @@ end
 
 @checked function cuDeviceGetP2PAttribute(value, attrib, srcDevice, dstDevice)
     initialize_context()
-    @gcsafe_ccall libcuda.cuDeviceGetP2PAttribute(value::Ptr{Cint}, attrib::CUdevice_P2PAttribute,
-                                           srcDevice::CUdevice,
-                                           dstDevice::CUdevice)::CUresult
+    @gcsafe_ccall libcuda.cuDeviceGetP2PAttribute(value::Ptr{Cint},
+                                                  attrib::CUdevice_P2PAttribute,
+                                                  srcDevice::CUdevice,
+                                                  dstDevice::CUdevice)::CUresult
 end
 
 @checked function cuGraphicsUnregisterResource(resource)
@@ -5170,28 +5256,29 @@ end
                                                       mipLevel)
     initialize_context()
     @gcsafe_ccall libcuda.cuGraphicsSubResourceGetMappedArray(pArray::Ptr{CUarray},
-                                                       resource::CUgraphicsResource,
-                                                       arrayIndex::Cuint,
-                                                       mipLevel::Cuint)::CUresult
+                                                              resource::CUgraphicsResource,
+                                                              arrayIndex::Cuint,
+                                                              mipLevel::Cuint)::CUresult
 end
 
 @checked function cuGraphicsResourceGetMappedMipmappedArray(pMipmappedArray, resource)
     initialize_context()
     @gcsafe_ccall libcuda.cuGraphicsResourceGetMappedMipmappedArray(pMipmappedArray::Ptr{CUmipmappedArray},
-                                                             resource::CUgraphicsResource)::CUresult
+                                                                    resource::CUgraphicsResource)::CUresult
 end
 
 @checked function cuGraphicsMapResources(count, resources, hStream)
     initialize_context()
-    @gcsafe_ccall libcuda.cuGraphicsMapResources(count::Cuint, resources::Ptr{CUgraphicsResource},
-                                          hStream::CUstream)::CUresult
+    @gcsafe_ccall libcuda.cuGraphicsMapResources(count::Cuint,
+                                                 resources::Ptr{CUgraphicsResource},
+                                                 hStream::CUstream)::CUresult
 end
 
 @checked function cuGraphicsUnmapResources(count, resources, hStream)
     initialize_context()
     @gcsafe_ccall libcuda.cuGraphicsUnmapResources(count::Cuint,
-                                            resources::Ptr{CUgraphicsResource},
-                                            hStream::CUstream)::CUresult
+                                                   resources::Ptr{CUgraphicsResource},
+                                                   hStream::CUstream)::CUresult
 end
 
 @cenum CUcoredumpSettings_enum::UInt32 begin
@@ -5208,52 +5295,55 @@ const CUcoredumpSettings = CUcoredumpSettings_enum
 
 @checked function cuCoredumpGetAttribute(attrib, value, size)
     initialize_context()
-    @gcsafe_ccall libcuda.cuCoredumpGetAttribute(attrib::CUcoredumpSettings, value::Ptr{Cvoid},
-                                          size::Ptr{Csize_t})::CUresult
+    @gcsafe_ccall libcuda.cuCoredumpGetAttribute(attrib::CUcoredumpSettings,
+                                                 value::Ptr{Cvoid},
+                                                 size::Ptr{Csize_t})::CUresult
 end
 
 @checked function cuCoredumpGetAttributeGlobal(attrib, value, size)
     initialize_context()
     @gcsafe_ccall libcuda.cuCoredumpGetAttributeGlobal(attrib::CUcoredumpSettings,
-                                                value::Ptr{Cvoid},
-                                                size::Ptr{Csize_t})::CUresult
+                                                       value::Ptr{Cvoid},
+                                                       size::Ptr{Csize_t})::CUresult
 end
 
 @checked function cuCoredumpSetAttribute(attrib, value, size)
     initialize_context()
-    @gcsafe_ccall libcuda.cuCoredumpSetAttribute(attrib::CUcoredumpSettings, value::Ptr{Cvoid},
-                                          size::Ptr{Csize_t})::CUresult
+    @gcsafe_ccall libcuda.cuCoredumpSetAttribute(attrib::CUcoredumpSettings,
+                                                 value::Ptr{Cvoid},
+                                                 size::Ptr{Csize_t})::CUresult
 end
 
 @checked function cuCoredumpSetAttributeGlobal(attrib, value, size)
     initialize_context()
     @gcsafe_ccall libcuda.cuCoredumpSetAttributeGlobal(attrib::CUcoredumpSettings,
-                                                value::Ptr{Cvoid},
-                                                size::Ptr{Csize_t})::CUresult
+                                                       value::Ptr{Cvoid},
+                                                       size::Ptr{Csize_t})::CUresult
 end
 
 @checked function cuGetExportTable(ppExportTable, pExportTableId)
     initialize_context()
     @gcsafe_ccall libcuda.cuGetExportTable(ppExportTable::Ptr{Ptr{Cvoid}},
-                                    pExportTableId::Ptr{CUuuid})::CUresult
+                                           pExportTableId::Ptr{CUuuid})::CUresult
 end
 
 @checked function cuGLCtxCreate_v2(pCtx, Flags, device)
     initialize_context()
     @gcsafe_ccall libcuda.cuGLCtxCreate_v2(pCtx::Ptr{CUcontext}, Flags::Cuint,
-                                    device::CUdevice)::CUresult
+                                           device::CUdevice)::CUresult
 end
 
 @checked function cuGLMapBufferObject_v2(dptr, size, buffer)
     initialize_context()
     @gcsafe_ccall libcuda.cuGLMapBufferObject_v2(dptr::Ptr{CUdeviceptr}, size::Ptr{Csize_t},
-                                          buffer::GLuint)::CUresult
+                                                 buffer::GLuint)::CUresult
 end
 
 @checked function cuGLMapBufferObjectAsync_v2(dptr, size, buffer, hStream)
     initialize_context()
-    @gcsafe_ccall libcuda.cuGLMapBufferObjectAsync_v2(dptr::Ptr{CUdeviceptr}, size::Ptr{Csize_t},
-                                               buffer::GLuint, hStream::CUstream)::CUresult
+    @gcsafe_ccall libcuda.cuGLMapBufferObjectAsync_v2(dptr::Ptr{CUdeviceptr},
+                                                      size::Ptr{Csize_t}, buffer::GLuint,
+                                                      hStream::CUstream)::CUresult
 end
 
 @cenum CUGLDeviceList_enum::UInt32 begin
@@ -5268,21 +5358,22 @@ const CUGLDeviceList = CUGLDeviceList_enum
                                     deviceList)
     initialize_context()
     @gcsafe_ccall libcuda.cuGLGetDevices_v2(pCudaDeviceCount::Ptr{Cuint},
-                                     pCudaDevices::Ptr{CUdevice}, cudaDeviceCount::Cuint,
-                                     deviceList::CUGLDeviceList)::CUresult
+                                            pCudaDevices::Ptr{CUdevice},
+                                            cudaDeviceCount::Cuint,
+                                            deviceList::CUGLDeviceList)::CUresult
 end
 
 @checked function cuGraphicsGLRegisterBuffer(pCudaResource, buffer, Flags)
     initialize_context()
     @gcsafe_ccall libcuda.cuGraphicsGLRegisterBuffer(pCudaResource::Ptr{CUgraphicsResource},
-                                              buffer::GLuint, Flags::Cuint)::CUresult
+                                                     buffer::GLuint, Flags::Cuint)::CUresult
 end
 
 @checked function cuGraphicsGLRegisterImage(pCudaResource, image, target, Flags)
     initialize_context()
     @gcsafe_ccall libcuda.cuGraphicsGLRegisterImage(pCudaResource::Ptr{CUgraphicsResource},
-                                             image::GLuint, target::GLenum,
-                                             Flags::Cuint)::CUresult
+                                                    image::GLuint, target::GLenum,
+                                                    Flags::Cuint)::CUresult
 end
 
 @cenum CUGLmap_flags_enum::UInt32 begin
@@ -5315,12 +5406,14 @@ end
 
 @checked function cuGLSetBufferObjectMapFlags(buffer, Flags)
     initialize_context()
-    @gcsafe_ccall libcuda.cuGLSetBufferObjectMapFlags(buffer::GLuint, Flags::Cuint)::CUresult
+    @gcsafe_ccall libcuda.cuGLSetBufferObjectMapFlags(buffer::GLuint,
+                                                      Flags::Cuint)::CUresult
 end
 
 @checked function cuGLUnmapBufferObjectAsync(buffer, hStream)
     initialize_context()
-    @gcsafe_ccall libcuda.cuGLUnmapBufferObjectAsync(buffer::GLuint, hStream::CUstream)::CUresult
+    @gcsafe_ccall libcuda.cuGLUnmapBufferObjectAsync(buffer::GLuint,
+                                                     hStream::CUstream)::CUresult
 end
 
 @cenum CUoutput_mode_enum::UInt32 begin
@@ -5333,7 +5426,7 @@ const CUoutput_mode = CUoutput_mode_enum
 @checked function cuProfilerInitialize(configFile, outputFile, outputMode)
     initialize_context()
     @gcsafe_ccall libcuda.cuProfilerInitialize(configFile::Cstring, outputFile::Cstring,
-                                        outputMode::CUoutput_mode)::CUresult
+                                               outputMode::CUoutput_mode)::CUresult
 end
 
 @checked function cuProfilerStart()

--- a/lib/cudadrv/libcuda.jl
+++ b/lib/cudadrv/libcuda.jl
@@ -144,7 +144,7 @@ end
 const CUresult = cudaError_enum
 
 @checked function cuDeviceTotalMem_v2(bytes, dev)
-    @ccall libcuda.cuDeviceTotalMem_v2(bytes::Ptr{Csize_t}, dev::CUdevice)::CUresult
+    @gcsafe_ccall libcuda.cuDeviceTotalMem_v2(bytes::Ptr{Csize_t}, dev::CUdevice)::CUresult
 end
 
 mutable struct CUctx_st end
@@ -152,7 +152,7 @@ mutable struct CUctx_st end
 const CUcontext = Ptr{CUctx_st}
 
 @checked function cuCtxCreate_v2(pctx, flags, dev)
-    @ccall libcuda.cuCtxCreate_v2(pctx::Ptr{CUcontext}, flags::Cuint,
+    @gcsafe_ccall libcuda.cuCtxCreate_v2(pctx::Ptr{CUcontext}, flags::Cuint,
                                   dev::CUdevice)::CUresult
 end
 
@@ -162,64 +162,64 @@ const CUmodule = Ptr{CUmod_st}
 
 @checked function cuModuleGetGlobal_v2(dptr, bytes, hmod, name)
     initialize_context()
-    @ccall libcuda.cuModuleGetGlobal_v2(dptr::Ptr{CUdeviceptr}, bytes::Ptr{Csize_t},
+    @gcsafe_ccall libcuda.cuModuleGetGlobal_v2(dptr::Ptr{CUdeviceptr}, bytes::Ptr{Csize_t},
                                         hmod::CUmodule, name::Cstring)::CUresult
 end
 
 @checked function cuMemGetInfo_v2(free, total)
     initialize_context()
-    @ccall libcuda.cuMemGetInfo_v2(free::Ptr{Csize_t}, total::Ptr{Csize_t})::CUresult
+    @gcsafe_ccall libcuda.cuMemGetInfo_v2(free::Ptr{Csize_t}, total::Ptr{Csize_t})::CUresult
 end
 
 @checked function cuMemAlloc_v2(dptr, bytesize)
     initialize_context()
-    @ccall libcuda.cuMemAlloc_v2(dptr::Ptr{CUdeviceptr}, bytesize::Csize_t)::CUresult
+    @gcsafe_ccall libcuda.cuMemAlloc_v2(dptr::Ptr{CUdeviceptr}, bytesize::Csize_t)::CUresult
 end
 
 @checked function cuMemAllocPitch_v2(dptr, pPitch, WidthInBytes, Height, ElementSizeBytes)
     initialize_context()
-    @ccall libcuda.cuMemAllocPitch_v2(dptr::Ptr{CUdeviceptr}, pPitch::Ptr{Csize_t},
+    @gcsafe_ccall libcuda.cuMemAllocPitch_v2(dptr::Ptr{CUdeviceptr}, pPitch::Ptr{Csize_t},
                                       WidthInBytes::Csize_t, Height::Csize_t,
                                       ElementSizeBytes::Cuint)::CUresult
 end
 
 @checked function cuMemFree_v2(dptr)
     initialize_context()
-    @ccall libcuda.cuMemFree_v2(dptr::CUdeviceptr)::CUresult
+    @gcsafe_ccall libcuda.cuMemFree_v2(dptr::CUdeviceptr)::CUresult
 end
 
 @checked function cuMemGetAddressRange_v2(pbase, psize, dptr)
     initialize_context()
-    @ccall libcuda.cuMemGetAddressRange_v2(pbase::Ptr{CUdeviceptr}, psize::Ptr{Csize_t},
+    @gcsafe_ccall libcuda.cuMemGetAddressRange_v2(pbase::Ptr{CUdeviceptr}, psize::Ptr{Csize_t},
                                            dptr::CUdeviceptr)::CUresult
 end
 
 @checked function cuMemAllocHost_v2(pp, bytesize)
     initialize_context()
-    @ccall libcuda.cuMemAllocHost_v2(pp::Ptr{Ptr{Cvoid}}, bytesize::Csize_t)::CUresult
+    @gcsafe_ccall libcuda.cuMemAllocHost_v2(pp::Ptr{Ptr{Cvoid}}, bytesize::Csize_t)::CUresult
 end
 
 @checked function cuMemHostGetDevicePointer_v2(pdptr, p, Flags)
     initialize_context()
-    @ccall libcuda.cuMemHostGetDevicePointer_v2(pdptr::Ptr{CUdeviceptr}, p::Ptr{Cvoid},
+    @gcsafe_ccall libcuda.cuMemHostGetDevicePointer_v2(pdptr::Ptr{CUdeviceptr}, p::Ptr{Cvoid},
                                                 Flags::Cuint)::CUresult
 end
 
 @checked function cuMemcpyHtoD_v2(dstDevice, srcHost, ByteCount)
     initialize_context()
-    @ccall libcuda.cuMemcpyHtoD_v2(dstDevice::CUdeviceptr, srcHost::Ptr{Cvoid},
+    @gcsafe_ccall libcuda.cuMemcpyHtoD_v2(dstDevice::CUdeviceptr, srcHost::Ptr{Cvoid},
                                    ByteCount::Csize_t)::CUresult
 end
 
 @checked function cuMemcpyDtoH_v2(dstHost, srcDevice, ByteCount)
     initialize_context()
-    @ccall libcuda.cuMemcpyDtoH_v2(dstHost::Ptr{Cvoid}, srcDevice::CUdeviceptr,
+    @gcsafe_ccall libcuda.cuMemcpyDtoH_v2(dstHost::Ptr{Cvoid}, srcDevice::CUdeviceptr,
                                    ByteCount::Csize_t)::CUresult
 end
 
 @checked function cuMemcpyDtoD_v2(dstDevice, srcDevice, ByteCount)
     initialize_context()
-    @ccall libcuda.cuMemcpyDtoD_v2(dstDevice::CUdeviceptr, srcDevice::CUdeviceptr,
+    @gcsafe_ccall libcuda.cuMemcpyDtoD_v2(dstDevice::CUdeviceptr, srcDevice::CUdeviceptr,
                                    ByteCount::Csize_t)::CUresult
 end
 
@@ -227,44 +227,44 @@ mutable struct CUarray_st end
 
 @checked function cuMemcpyDtoA_v2(dstArray, dstOffset, srcDevice, ByteCount)
     initialize_context()
-    @ccall libcuda.cuMemcpyDtoA_v2(dstArray::CUarray, dstOffset::Csize_t,
+    @gcsafe_ccall libcuda.cuMemcpyDtoA_v2(dstArray::CUarray, dstOffset::Csize_t,
                                    srcDevice::CUdeviceptr, ByteCount::Csize_t)::CUresult
 end
 
 @checked function cuMemcpyAtoD_v2(dstDevice, srcArray, srcOffset, ByteCount)
     initialize_context()
-    @ccall libcuda.cuMemcpyAtoD_v2(dstDevice::CUdeviceptr, srcArray::CUarray,
+    @gcsafe_ccall libcuda.cuMemcpyAtoD_v2(dstDevice::CUdeviceptr, srcArray::CUarray,
                                    srcOffset::Csize_t, ByteCount::Csize_t)::CUresult
 end
 
 @checked function cuMemcpyHtoA_v2(dstArray, dstOffset, srcHost, ByteCount)
     initialize_context()
-    @ccall libcuda.cuMemcpyHtoA_v2(dstArray::CUarray, dstOffset::Csize_t,
+    @gcsafe_ccall libcuda.cuMemcpyHtoA_v2(dstArray::CUarray, dstOffset::Csize_t,
                                    srcHost::Ptr{Cvoid}, ByteCount::Csize_t)::CUresult
 end
 
 @checked function cuMemcpyAtoH_v2(dstHost, srcArray, srcOffset, ByteCount)
     initialize_context()
-    @ccall libcuda.cuMemcpyAtoH_v2(dstHost::Ptr{Cvoid}, srcArray::CUarray,
+    @gcsafe_ccall libcuda.cuMemcpyAtoH_v2(dstHost::Ptr{Cvoid}, srcArray::CUarray,
                                    srcOffset::Csize_t, ByteCount::Csize_t)::CUresult
 end
 
 @checked function cuMemcpyAtoA_v2(dstArray, dstOffset, srcArray, srcOffset, ByteCount)
     initialize_context()
-    @ccall libcuda.cuMemcpyAtoA_v2(dstArray::CUarray, dstOffset::Csize_t, srcArray::CUarray,
+    @gcsafe_ccall libcuda.cuMemcpyAtoA_v2(dstArray::CUarray, dstOffset::Csize_t, srcArray::CUarray,
                                    srcOffset::Csize_t, ByteCount::Csize_t)::CUresult
 end
 
 @checked function cuMemcpyHtoAAsync_v2(dstArray, dstOffset, srcHost, ByteCount, hStream)
     initialize_context()
-    @ccall libcuda.cuMemcpyHtoAAsync_v2(dstArray::CUarray, dstOffset::Csize_t,
+    @gcsafe_ccall libcuda.cuMemcpyHtoAAsync_v2(dstArray::CUarray, dstOffset::Csize_t,
                                         srcHost::Ptr{Cvoid}, ByteCount::Csize_t,
                                         hStream::CUstream)::CUresult
 end
 
 @checked function cuMemcpyAtoHAsync_v2(dstHost, srcArray, srcOffset, ByteCount, hStream)
     initialize_context()
-    @ccall libcuda.cuMemcpyAtoHAsync_v2(dstHost::Ptr{Cvoid}, srcArray::CUarray,
+    @gcsafe_ccall libcuda.cuMemcpyAtoHAsync_v2(dstHost::Ptr{Cvoid}, srcArray::CUarray,
                                         srcOffset::Csize_t, ByteCount::Csize_t,
                                         hStream::CUstream)::CUresult
 end
@@ -303,12 +303,12 @@ const CUDA_MEMCPY2D = CUDA_MEMCPY2D_v2
 
 @checked function cuMemcpy2D_v2(pCopy)
     initialize_context()
-    @ccall libcuda.cuMemcpy2D_v2(pCopy::Ptr{CUDA_MEMCPY2D})::CUresult
+    @gcsafe_ccall libcuda.cuMemcpy2D_v2(pCopy::Ptr{CUDA_MEMCPY2D})::CUresult
 end
 
 @checked function cuMemcpy2DUnaligned_v2(pCopy)
     initialize_context()
-    @ccall libcuda.cuMemcpy2DUnaligned_v2(pCopy::Ptr{CUDA_MEMCPY2D})::CUresult
+    @gcsafe_ccall libcuda.cuMemcpy2DUnaligned_v2(pCopy::Ptr{CUDA_MEMCPY2D})::CUresult
 end
 
 struct CUDA_MEMCPY3D_st
@@ -345,69 +345,69 @@ const CUDA_MEMCPY3D = CUDA_MEMCPY3D_v2
 
 @checked function cuMemcpy3D_v2(pCopy)
     initialize_context()
-    @ccall libcuda.cuMemcpy3D_v2(pCopy::Ptr{CUDA_MEMCPY3D})::CUresult
+    @gcsafe_ccall libcuda.cuMemcpy3D_v2(pCopy::Ptr{CUDA_MEMCPY3D})::CUresult
 end
 
 @checked function cuMemcpyHtoDAsync_v2(dstDevice, srcHost, ByteCount, hStream)
     initialize_context()
-    @ccall libcuda.cuMemcpyHtoDAsync_v2(dstDevice::CUdeviceptr, srcHost::Ptr{Cvoid},
+    @gcsafe_ccall libcuda.cuMemcpyHtoDAsync_v2(dstDevice::CUdeviceptr, srcHost::Ptr{Cvoid},
                                         ByteCount::Csize_t, hStream::CUstream)::CUresult
 end
 
 @checked function cuMemcpyDtoHAsync_v2(dstHost, srcDevice, ByteCount, hStream)
     initialize_context()
-    @ccall libcuda.cuMemcpyDtoHAsync_v2(dstHost::Ptr{Cvoid}, srcDevice::CUdeviceptr,
+    @gcsafe_ccall libcuda.cuMemcpyDtoHAsync_v2(dstHost::Ptr{Cvoid}, srcDevice::CUdeviceptr,
                                         ByteCount::Csize_t, hStream::CUstream)::CUresult
 end
 
 @checked function cuMemcpyDtoDAsync_v2(dstDevice, srcDevice, ByteCount, hStream)
     initialize_context()
-    @ccall libcuda.cuMemcpyDtoDAsync_v2(dstDevice::CUdeviceptr, srcDevice::CUdeviceptr,
+    @gcsafe_ccall libcuda.cuMemcpyDtoDAsync_v2(dstDevice::CUdeviceptr, srcDevice::CUdeviceptr,
                                         ByteCount::Csize_t, hStream::CUstream)::CUresult
 end
 
 @checked function cuMemcpy2DAsync_v2(pCopy, hStream)
     initialize_context()
-    @ccall libcuda.cuMemcpy2DAsync_v2(pCopy::Ptr{CUDA_MEMCPY2D},
+    @gcsafe_ccall libcuda.cuMemcpy2DAsync_v2(pCopy::Ptr{CUDA_MEMCPY2D},
                                       hStream::CUstream)::CUresult
 end
 
 @checked function cuMemcpy3DAsync_v2(pCopy, hStream)
     initialize_context()
-    @ccall libcuda.cuMemcpy3DAsync_v2(pCopy::Ptr{CUDA_MEMCPY3D},
+    @gcsafe_ccall libcuda.cuMemcpy3DAsync_v2(pCopy::Ptr{CUDA_MEMCPY3D},
                                       hStream::CUstream)::CUresult
 end
 
 @checked function cuMemsetD8_v2(dstDevice, uc, N)
     initialize_context()
-    @ccall libcuda.cuMemsetD8_v2(dstDevice::CUdeviceptr, uc::Cuchar, N::Csize_t)::CUresult
+    @gcsafe_ccall libcuda.cuMemsetD8_v2(dstDevice::CUdeviceptr, uc::Cuchar, N::Csize_t)::CUresult
 end
 
 @checked function cuMemsetD16_v2(dstDevice, us, N)
     initialize_context()
-    @ccall libcuda.cuMemsetD16_v2(dstDevice::CUdeviceptr, us::Cushort, N::Csize_t)::CUresult
+    @gcsafe_ccall libcuda.cuMemsetD16_v2(dstDevice::CUdeviceptr, us::Cushort, N::Csize_t)::CUresult
 end
 
 @checked function cuMemsetD32_v2(dstDevice, ui, N)
     initialize_context()
-    @ccall libcuda.cuMemsetD32_v2(dstDevice::CUdeviceptr, ui::Cuint, N::Csize_t)::CUresult
+    @gcsafe_ccall libcuda.cuMemsetD32_v2(dstDevice::CUdeviceptr, ui::Cuint, N::Csize_t)::CUresult
 end
 
 @checked function cuMemsetD2D8_v2(dstDevice, dstPitch, uc, Width, Height)
     initialize_context()
-    @ccall libcuda.cuMemsetD2D8_v2(dstDevice::CUdeviceptr, dstPitch::Csize_t, uc::Cuchar,
+    @gcsafe_ccall libcuda.cuMemsetD2D8_v2(dstDevice::CUdeviceptr, dstPitch::Csize_t, uc::Cuchar,
                                    Width::Csize_t, Height::Csize_t)::CUresult
 end
 
 @checked function cuMemsetD2D16_v2(dstDevice, dstPitch, us, Width, Height)
     initialize_context()
-    @ccall libcuda.cuMemsetD2D16_v2(dstDevice::CUdeviceptr, dstPitch::Csize_t, us::Cushort,
+    @gcsafe_ccall libcuda.cuMemsetD2D16_v2(dstDevice::CUdeviceptr, dstPitch::Csize_t, us::Cushort,
                                     Width::Csize_t, Height::Csize_t)::CUresult
 end
 
 @checked function cuMemsetD2D32_v2(dstDevice, dstPitch, ui, Width, Height)
     initialize_context()
-    @ccall libcuda.cuMemsetD2D32_v2(dstDevice::CUdeviceptr, dstPitch::Csize_t, ui::Cuint,
+    @gcsafe_ccall libcuda.cuMemsetD2D32_v2(dstDevice::CUdeviceptr, dstPitch::Csize_t, ui::Cuint,
                                     Width::Csize_t, Height::Csize_t)::CUresult
 end
 
@@ -464,13 +464,13 @@ const CUDA_ARRAY_DESCRIPTOR = CUDA_ARRAY_DESCRIPTOR_v2
 
 @checked function cuArrayCreate_v2(pHandle, pAllocateArray)
     initialize_context()
-    @ccall libcuda.cuArrayCreate_v2(pHandle::Ptr{CUarray},
+    @gcsafe_ccall libcuda.cuArrayCreate_v2(pHandle::Ptr{CUarray},
                                     pAllocateArray::Ptr{CUDA_ARRAY_DESCRIPTOR})::CUresult
 end
 
 @checked function cuArrayGetDescriptor_v2(pArrayDescriptor, hArray)
     initialize_context()
-    @ccall libcuda.cuArrayGetDescriptor_v2(pArrayDescriptor::Ptr{CUDA_ARRAY_DESCRIPTOR},
+    @gcsafe_ccall libcuda.cuArrayGetDescriptor_v2(pArrayDescriptor::Ptr{CUDA_ARRAY_DESCRIPTOR},
                                            hArray::CUarray)::CUresult
 end
 
@@ -489,13 +489,13 @@ const CUDA_ARRAY3D_DESCRIPTOR = CUDA_ARRAY3D_DESCRIPTOR_v2
 
 @checked function cuArray3DCreate_v2(pHandle, pAllocateArray)
     initialize_context()
-    @ccall libcuda.cuArray3DCreate_v2(pHandle::Ptr{CUarray},
+    @gcsafe_ccall libcuda.cuArray3DCreate_v2(pHandle::Ptr{CUarray},
                                       pAllocateArray::Ptr{CUDA_ARRAY3D_DESCRIPTOR})::CUresult
 end
 
 @checked function cuArray3DGetDescriptor_v2(pArrayDescriptor, hArray)
     initialize_context()
-    @ccall libcuda.cuArray3DGetDescriptor_v2(pArrayDescriptor::Ptr{CUDA_ARRAY3D_DESCRIPTOR},
+    @gcsafe_ccall libcuda.cuArray3DGetDescriptor_v2(pArrayDescriptor::Ptr{CUDA_ARRAY3D_DESCRIPTOR},
                                              hArray::CUarray)::CUresult
 end
 
@@ -505,13 +505,13 @@ const CUtexref = Ptr{CUtexref_st}
 
 @checked function cuTexRefSetAddress_v2(ByteOffset, hTexRef, dptr, bytes)
     initialize_context()
-    @ccall libcuda.cuTexRefSetAddress_v2(ByteOffset::Ptr{Csize_t}, hTexRef::CUtexref,
+    @gcsafe_ccall libcuda.cuTexRefSetAddress_v2(ByteOffset::Ptr{Csize_t}, hTexRef::CUtexref,
                                          dptr::CUdeviceptr, bytes::Csize_t)::CUresult
 end
 
 @checked function cuTexRefGetAddress_v2(pdptr, hTexRef)
     initialize_context()
-    @ccall libcuda.cuTexRefGetAddress_v2(pdptr::Ptr{CUdeviceptr},
+    @gcsafe_ccall libcuda.cuTexRefGetAddress_v2(pdptr::Ptr{CUdeviceptr},
                                          hTexRef::CUtexref)::CUresult
 end
 
@@ -521,26 +521,26 @@ const CUgraphicsResource = Ptr{CUgraphicsResource_st}
 
 @checked function cuGraphicsResourceGetMappedPointer_v2(pDevPtr, pSize, resource)
     initialize_context()
-    @ccall libcuda.cuGraphicsResourceGetMappedPointer_v2(pDevPtr::Ptr{CUdeviceptr},
+    @gcsafe_ccall libcuda.cuGraphicsResourceGetMappedPointer_v2(pDevPtr::Ptr{CUdeviceptr},
                                                          pSize::Ptr{Csize_t},
                                                          resource::CUgraphicsResource)::CUresult
 end
 
 @checked function cuCtxDestroy_v2(ctx)
-    @ccall libcuda.cuCtxDestroy_v2(ctx::CUcontext)::CUresult
+    @gcsafe_ccall libcuda.cuCtxDestroy_v2(ctx::CUcontext)::CUresult
 end
 
 @checked function cuCtxPopCurrent_v2(pctx)
-    @ccall libcuda.cuCtxPopCurrent_v2(pctx::Ptr{CUcontext})::CUresult
+    @gcsafe_ccall libcuda.cuCtxPopCurrent_v2(pctx::Ptr{CUcontext})::CUresult
 end
 
 @checked function cuCtxPushCurrent_v2(ctx)
-    @ccall libcuda.cuCtxPushCurrent_v2(ctx::CUcontext)::CUresult
+    @gcsafe_ccall libcuda.cuCtxPushCurrent_v2(ctx::CUcontext)::CUresult
 end
 
 @checked function cuStreamDestroy_v2(hStream)
     initialize_context()
-    @ccall libcuda.cuStreamDestroy_v2(hStream::CUstream)::CUresult
+    @gcsafe_ccall libcuda.cuStreamDestroy_v2(hStream::CUstream)::CUresult
 end
 
 mutable struct CUevent_st end
@@ -549,12 +549,12 @@ const CUevent = Ptr{CUevent_st}
 
 @checked function cuEventDestroy_v2(hEvent)
     initialize_context()
-    @ccall libcuda.cuEventDestroy_v2(hEvent::CUevent)::CUresult
+    @gcsafe_ccall libcuda.cuEventDestroy_v2(hEvent::CUevent)::CUresult
 end
 
 @checked function cuTexRefSetAddress2D_v3(hTexRef, desc, dptr, Pitch)
     initialize_context()
-    @ccall libcuda.cuTexRefSetAddress2D_v3(hTexRef::CUtexref,
+    @gcsafe_ccall libcuda.cuTexRefSetAddress2D_v3(hTexRef::CUtexref,
                                            desc::Ptr{CUDA_ARRAY_DESCRIPTOR},
                                            dptr::CUdeviceptr, Pitch::Csize_t)::CUresult
 end
@@ -603,7 +603,7 @@ const CUlinkState = Ptr{CUlinkState_st}
 
 @checked function cuLinkCreate_v2(numOptions, options, optionValues, stateOut)
     initialize_context()
-    @ccall libcuda.cuLinkCreate_v2(numOptions::Cuint, options::Ptr{CUjit_option},
+    @gcsafe_ccall libcuda.cuLinkCreate_v2(numOptions::Cuint, options::Ptr{CUjit_option},
                                    optionValues::Ptr{Ptr{Cvoid}},
                                    stateOut::Ptr{CUlinkState})::CUresult
 end
@@ -623,7 +623,7 @@ const CUjitInputType = CUjitInputType_enum
 @checked function cuLinkAddData_v2(state, type, data, size, name, numOptions, options,
                                    optionValues)
     initialize_context()
-    @ccall libcuda.cuLinkAddData_v2(state::CUlinkState, type::CUjitInputType,
+    @gcsafe_ccall libcuda.cuLinkAddData_v2(state::CUlinkState, type::CUjitInputType,
                                     data::Ptr{Cvoid}, size::Csize_t, name::Cstring,
                                     numOptions::Cuint, options::Ptr{CUjit_option},
                                     optionValues::Ptr{Ptr{Cvoid}})::CUresult
@@ -631,20 +631,20 @@ end
 
 @checked function cuLinkAddFile_v2(state, type, path, numOptions, options, optionValues)
     initialize_context()
-    @ccall libcuda.cuLinkAddFile_v2(state::CUlinkState, type::CUjitInputType, path::Cstring,
+    @gcsafe_ccall libcuda.cuLinkAddFile_v2(state::CUlinkState, type::CUjitInputType, path::Cstring,
                                     numOptions::Cuint, options::Ptr{CUjit_option},
                                     optionValues::Ptr{Ptr{Cvoid}})::CUresult
 end
 
 @checked function cuMemHostRegister_v2(p, bytesize, Flags)
     initialize_context()
-    @ccall libcuda.cuMemHostRegister_v2(p::Ptr{Cvoid}, bytesize::Csize_t,
+    @gcsafe_ccall libcuda.cuMemHostRegister_v2(p::Ptr{Cvoid}, bytesize::Csize_t,
                                         Flags::Cuint)::CUresult
 end
 
 @checked function cuGraphicsResourceSetMapFlags_v2(resource, flags)
     initialize_context()
-    @ccall libcuda.cuGraphicsResourceSetMapFlags_v2(resource::CUgraphicsResource,
+    @gcsafe_ccall libcuda.cuGraphicsResourceSetMapFlags_v2(resource::CUgraphicsResource,
                                                     flags::Cuint)::CUresult
 end
 
@@ -658,20 +658,20 @@ const CUstreamCaptureMode = CUstreamCaptureMode_enum
 
 @checked function cuStreamBeginCapture_v2(hStream, mode)
     initialize_context()
-    @ccall libcuda.cuStreamBeginCapture_v2(hStream::CUstream,
+    @gcsafe_ccall libcuda.cuStreamBeginCapture_v2(hStream::CUstream,
                                            mode::CUstreamCaptureMode)::CUresult
 end
 
 @checked function cuDevicePrimaryCtxRelease_v2(dev)
-    @ccall libcuda.cuDevicePrimaryCtxRelease_v2(dev::CUdevice)::CUresult
+    @gcsafe_ccall libcuda.cuDevicePrimaryCtxRelease_v2(dev::CUdevice)::CUresult
 end
 
 @checked function cuDevicePrimaryCtxReset_v2(dev)
-    @ccall libcuda.cuDevicePrimaryCtxReset_v2(dev::CUdevice)::CUresult
+    @gcsafe_ccall libcuda.cuDevicePrimaryCtxReset_v2(dev::CUdevice)::CUresult
 end
 
 @checked function cuDevicePrimaryCtxSetFlags_v2(dev, flags)
-    @ccall libcuda.cuDevicePrimaryCtxSetFlags_v2(dev::CUdevice, flags::Cuint)::CUresult
+    @gcsafe_ccall libcuda.cuDevicePrimaryCtxSetFlags_v2(dev::CUdevice, flags::Cuint)::CUresult
 end
 
 struct CUipcMemHandle_st
@@ -684,7 +684,7 @@ const CUipcMemHandle = CUipcMemHandle_v1
 
 @checked function cuIpcOpenMemHandle_v2(pdptr, handle, Flags)
     initialize_context()
-    @ccall libcuda.cuIpcOpenMemHandle_v2(pdptr::Ptr{CUdeviceptr}, handle::CUipcMemHandle,
+    @gcsafe_ccall libcuda.cuIpcOpenMemHandle_v2(pdptr::Ptr{CUdeviceptr}, handle::CUipcMemHandle,
                                          Flags::Cuint)::CUresult
 end
 
@@ -698,7 +698,7 @@ const CUgraph = Ptr{CUgraph_st}
 
 @checked function cuGraphInstantiateWithFlags(phGraphExec, hGraph, flags)
     initialize_context()
-    @ccall libcuda.cuGraphInstantiateWithFlags(phGraphExec::Ptr{CUgraphExec},
+    @gcsafe_ccall libcuda.cuGraphInstantiateWithFlags(phGraphExec::Ptr{CUgraphExec},
                                                hGraph::CUgraph, flags::Culonglong)::CUresult
 end
 
@@ -732,7 +732,7 @@ const CUgraphExecUpdateResultInfo = CUgraphExecUpdateResultInfo_v1
 
 @checked function cuGraphExecUpdate_v2(hGraphExec, hGraph, resultInfo)
     initialize_context()
-    @ccall libcuda.cuGraphExecUpdate_v2(hGraphExec::CUgraphExec, hGraph::CUgraph,
+    @gcsafe_ccall libcuda.cuGraphExecUpdate_v2(hGraphExec::CUgraphExec, hGraph::CUgraph,
                                         resultInfo::Ptr{CUgraphExecUpdateResultInfo})::CUresult
 end
 
@@ -748,7 +748,7 @@ const CUdriverProcAddressQueryResult = CUdriverProcAddressQueryResult_enum
 
 @checked function cuGetProcAddress_v2(symbol, pfn, cudaVersion, flags, symbolStatus)
     initialize_context()
-    @ccall libcuda.cuGetProcAddress_v2(symbol::Cstring, pfn::Ptr{Ptr{Cvoid}},
+    @gcsafe_ccall libcuda.cuGetProcAddress_v2(symbol::Cstring, pfn::Ptr{Ptr{Cvoid}},
                                        cudaVersion::Cint, flags::cuuint64_t,
                                        symbolStatus::Ptr{CUdriverProcAddressQueryResult})::CUresult
 end
@@ -783,7 +783,7 @@ const CUDA_KERNEL_NODE_PARAMS = CUDA_KERNEL_NODE_PARAMS_v2
 @checked function cuGraphAddKernelNode_v2(phGraphNode, hGraph, dependencies,
                                           numDependencies, nodeParams)
     initialize_context()
-    @ccall libcuda.cuGraphAddKernelNode_v2(phGraphNode::Ptr{CUgraphNode}, hGraph::CUgraph,
+    @gcsafe_ccall libcuda.cuGraphAddKernelNode_v2(phGraphNode::Ptr{CUgraphNode}, hGraph::CUgraph,
                                            dependencies::Ptr{CUgraphNode},
                                            numDependencies::Csize_t,
                                            nodeParams::Ptr{CUDA_KERNEL_NODE_PARAMS})::CUresult
@@ -791,19 +791,19 @@ end
 
 @checked function cuGraphKernelNodeGetParams_v2(hNode, nodeParams)
     initialize_context()
-    @ccall libcuda.cuGraphKernelNodeGetParams_v2(hNode::CUgraphNode,
+    @gcsafe_ccall libcuda.cuGraphKernelNodeGetParams_v2(hNode::CUgraphNode,
                                                  nodeParams::Ptr{CUDA_KERNEL_NODE_PARAMS})::CUresult
 end
 
 @checked function cuGraphKernelNodeSetParams_v2(hNode, nodeParams)
     initialize_context()
-    @ccall libcuda.cuGraphKernelNodeSetParams_v2(hNode::CUgraphNode,
+    @gcsafe_ccall libcuda.cuGraphKernelNodeSetParams_v2(hNode::CUgraphNode,
                                                  nodeParams::Ptr{CUDA_KERNEL_NODE_PARAMS})::CUresult
 end
 
 @checked function cuGraphExecKernelNodeSetParams_v2(hGraphExec, hNode, nodeParams)
     initialize_context()
-    @ccall libcuda.cuGraphExecKernelNodeSetParams_v2(hGraphExec::CUgraphExec,
+    @gcsafe_ccall libcuda.cuGraphExecKernelNodeSetParams_v2(hGraphExec::CUgraphExec,
                                                      hNode::CUgraphNode,
                                                      nodeParams::Ptr{CUDA_KERNEL_NODE_PARAMS})::CUresult
 end
@@ -812,25 +812,25 @@ const cuuint32_t = UInt32
 
 @checked function cuStreamWriteValue32_v2(stream, addr, value, flags)
     initialize_context()
-    @ccall libcuda.cuStreamWriteValue32_v2(stream::CUstream, addr::CUdeviceptr,
+    @gcsafe_ccall libcuda.cuStreamWriteValue32_v2(stream::CUstream, addr::CUdeviceptr,
                                            value::cuuint32_t, flags::Cuint)::CUresult
 end
 
 @checked function cuStreamWaitValue32_v2(stream, addr, value, flags)
     initialize_context()
-    @ccall libcuda.cuStreamWaitValue32_v2(stream::CUstream, addr::CUdeviceptr,
+    @gcsafe_ccall libcuda.cuStreamWaitValue32_v2(stream::CUstream, addr::CUdeviceptr,
                                           value::cuuint32_t, flags::Cuint)::CUresult
 end
 
 @checked function cuStreamWriteValue64_v2(stream, addr, value, flags)
     initialize_context()
-    @ccall libcuda.cuStreamWriteValue64_v2(stream::CUstream, addr::CUdeviceptr,
+    @gcsafe_ccall libcuda.cuStreamWriteValue64_v2(stream::CUstream, addr::CUdeviceptr,
                                            value::cuuint64_t, flags::Cuint)::CUresult
 end
 
 @checked function cuStreamWaitValue64_v2(stream, addr, value, flags)
     initialize_context()
-    @ccall libcuda.cuStreamWaitValue64_v2(stream::CUstream, addr::CUdeviceptr,
+    @gcsafe_ccall libcuda.cuStreamWaitValue64_v2(stream::CUstream, addr::CUdeviceptr,
                                           value::cuuint64_t, flags::Cuint)::CUresult
 end
 
@@ -865,7 +865,7 @@ const CUstreamBatchMemOpParams = CUstreamBatchMemOpParams_v1
 
 @checked function cuStreamBatchMemOp_v2(stream, count, paramArray, flags)
     initialize_context()
-    @ccall libcuda.cuStreamBatchMemOp_v2(stream::CUstream, count::Cuint,
+    @gcsafe_ccall libcuda.cuStreamBatchMemOp_v2(stream::CUstream, count::Cuint,
                                          paramArray::Ptr{CUstreamBatchMemOpParams},
                                          flags::Cuint)::CUresult
 end
@@ -881,7 +881,7 @@ const CUstreamCaptureStatus = CUstreamCaptureStatus_enum
 @checked function cuStreamGetCaptureInfo_v2(hStream, captureStatus_out, id_out, graph_out,
                                             dependencies_out, numDependencies_out)
     initialize_context()
-    @ccall libcuda.cuStreamGetCaptureInfo_v2(hStream::CUstream,
+    @gcsafe_ccall libcuda.cuStreamGetCaptureInfo_v2(hStream::CUstream,
                                              captureStatus_out::Ptr{CUstreamCaptureStatus},
                                              id_out::Ptr{cuuint64_t},
                                              graph_out::Ptr{CUgraph},
@@ -3070,239 +3070,239 @@ end
 const CUdeviceNumaConfig = CUdeviceNumaConfig_enum
 
 @checked function cuGetErrorString(error, pStr)
-    @ccall libcuda.cuGetErrorString(error::CUresult, pStr::Ptr{Cstring})::CUresult
+    @gcsafe_ccall libcuda.cuGetErrorString(error::CUresult, pStr::Ptr{Cstring})::CUresult
 end
 
 @checked function cuGetErrorName(error, pStr)
-    @ccall libcuda.cuGetErrorName(error::CUresult, pStr::Ptr{Cstring})::CUresult
+    @gcsafe_ccall libcuda.cuGetErrorName(error::CUresult, pStr::Ptr{Cstring})::CUresult
 end
 
 @checked function cuInit(Flags)
-    @ccall libcuda.cuInit(Flags::Cuint)::CUresult
+    @gcsafe_ccall libcuda.cuInit(Flags::Cuint)::CUresult
 end
 
 @checked function cuDriverGetVersion(driverVersion)
-    @ccall libcuda.cuDriverGetVersion(driverVersion::Ptr{Cint})::CUresult
+    @gcsafe_ccall libcuda.cuDriverGetVersion(driverVersion::Ptr{Cint})::CUresult
 end
 
 @checked function cuDeviceGet(device, ordinal)
-    @ccall libcuda.cuDeviceGet(device::Ptr{CUdevice}, ordinal::Cint)::CUresult
+    @gcsafe_ccall libcuda.cuDeviceGet(device::Ptr{CUdevice}, ordinal::Cint)::CUresult
 end
 
 @checked function cuDeviceGetCount(count)
-    @ccall libcuda.cuDeviceGetCount(count::Ptr{Cint})::CUresult
+    @gcsafe_ccall libcuda.cuDeviceGetCount(count::Ptr{Cint})::CUresult
 end
 
 @checked function cuDeviceGetName(name, len, dev)
-    @ccall libcuda.cuDeviceGetName(name::Cstring, len::Cint, dev::CUdevice)::CUresult
+    @gcsafe_ccall libcuda.cuDeviceGetName(name::Cstring, len::Cint, dev::CUdevice)::CUresult
 end
 
 @checked function cuDeviceGetUuid(uuid, dev)
-    @ccall libcuda.cuDeviceGetUuid(uuid::Ptr{CUuuid}, dev::CUdevice)::CUresult
+    @gcsafe_ccall libcuda.cuDeviceGetUuid(uuid::Ptr{CUuuid}, dev::CUdevice)::CUresult
 end
 
 @checked function cuDeviceGetUuid_v2(uuid, dev)
-    @ccall libcuda.cuDeviceGetUuid_v2(uuid::Ptr{CUuuid}, dev::CUdevice)::CUresult
+    @gcsafe_ccall libcuda.cuDeviceGetUuid_v2(uuid::Ptr{CUuuid}, dev::CUdevice)::CUresult
 end
 
 @checked function cuDeviceGetLuid(luid, deviceNodeMask, dev)
-    @ccall libcuda.cuDeviceGetLuid(luid::Cstring, deviceNodeMask::Ptr{Cuint},
+    @gcsafe_ccall libcuda.cuDeviceGetLuid(luid::Cstring, deviceNodeMask::Ptr{Cuint},
                                    dev::CUdevice)::CUresult
 end
 
 @checked function cuDeviceGetTexture1DLinearMaxWidth(maxWidthInElements, format,
                                                      numChannels, dev)
     initialize_context()
-    @ccall libcuda.cuDeviceGetTexture1DLinearMaxWidth(maxWidthInElements::Ptr{Csize_t},
+    @gcsafe_ccall libcuda.cuDeviceGetTexture1DLinearMaxWidth(maxWidthInElements::Ptr{Csize_t},
                                                       format::CUarray_format,
                                                       numChannels::Cuint,
                                                       dev::CUdevice)::CUresult
 end
 
 @checked function cuDeviceGetAttribute(pi, attrib, dev)
-    @ccall libcuda.cuDeviceGetAttribute(pi::Ptr{Cint}, attrib::CUdevice_attribute,
+    @gcsafe_ccall libcuda.cuDeviceGetAttribute(pi::Ptr{Cint}, attrib::CUdevice_attribute,
                                         dev::CUdevice)::CUresult
 end
 
 @checked function cuDeviceGetNvSciSyncAttributes(nvSciSyncAttrList, dev, flags)
     initialize_context()
-    @ccall libcuda.cuDeviceGetNvSciSyncAttributes(nvSciSyncAttrList::Ptr{Cvoid},
+    @gcsafe_ccall libcuda.cuDeviceGetNvSciSyncAttributes(nvSciSyncAttrList::Ptr{Cvoid},
                                                   dev::CUdevice, flags::Cint)::CUresult
 end
 
 @checked function cuDeviceSetMemPool(dev, pool)
     initialize_context()
-    @ccall libcuda.cuDeviceSetMemPool(dev::CUdevice, pool::CUmemoryPool)::CUresult
+    @gcsafe_ccall libcuda.cuDeviceSetMemPool(dev::CUdevice, pool::CUmemoryPool)::CUresult
 end
 
 @checked function cuDeviceGetMemPool(pool, dev)
     initialize_context()
-    @ccall libcuda.cuDeviceGetMemPool(pool::Ptr{CUmemoryPool}, dev::CUdevice)::CUresult
+    @gcsafe_ccall libcuda.cuDeviceGetMemPool(pool::Ptr{CUmemoryPool}, dev::CUdevice)::CUresult
 end
 
 @checked function cuDeviceGetDefaultMemPool(pool_out, dev)
     initialize_context()
-    @ccall libcuda.cuDeviceGetDefaultMemPool(pool_out::Ptr{CUmemoryPool},
+    @gcsafe_ccall libcuda.cuDeviceGetDefaultMemPool(pool_out::Ptr{CUmemoryPool},
                                              dev::CUdevice)::CUresult
 end
 
 @checked function cuDeviceGetExecAffinitySupport(pi, type, dev)
     initialize_context()
-    @ccall libcuda.cuDeviceGetExecAffinitySupport(pi::Ptr{Cint}, type::CUexecAffinityType,
+    @gcsafe_ccall libcuda.cuDeviceGetExecAffinitySupport(pi::Ptr{Cint}, type::CUexecAffinityType,
                                                   dev::CUdevice)::CUresult
 end
 
 @checked function cuFlushGPUDirectRDMAWrites(target, scope)
     initialize_context()
-    @ccall libcuda.cuFlushGPUDirectRDMAWrites(target::CUflushGPUDirectRDMAWritesTarget,
+    @gcsafe_ccall libcuda.cuFlushGPUDirectRDMAWrites(target::CUflushGPUDirectRDMAWritesTarget,
                                               scope::CUflushGPUDirectRDMAWritesScope)::CUresult
 end
 
 @checked function cuDeviceGetProperties(prop, dev)
-    @ccall libcuda.cuDeviceGetProperties(prop::Ptr{CUdevprop}, dev::CUdevice)::CUresult
+    @gcsafe_ccall libcuda.cuDeviceGetProperties(prop::Ptr{CUdevprop}, dev::CUdevice)::CUresult
 end
 
 @checked function cuDeviceComputeCapability(major, minor, dev)
-    @ccall libcuda.cuDeviceComputeCapability(major::Ptr{Cint}, minor::Ptr{Cint},
+    @gcsafe_ccall libcuda.cuDeviceComputeCapability(major::Ptr{Cint}, minor::Ptr{Cint},
                                              dev::CUdevice)::CUresult
 end
 
 @checked function cuDevicePrimaryCtxRetain(pctx, dev)
-    @ccall libcuda.cuDevicePrimaryCtxRetain(pctx::Ptr{CUcontext}, dev::CUdevice)::CUresult
+    @gcsafe_ccall libcuda.cuDevicePrimaryCtxRetain(pctx::Ptr{CUcontext}, dev::CUdevice)::CUresult
 end
 
 @checked function cuDevicePrimaryCtxGetState(dev, flags, active)
-    @ccall libcuda.cuDevicePrimaryCtxGetState(dev::CUdevice, flags::Ptr{Cuint},
+    @gcsafe_ccall libcuda.cuDevicePrimaryCtxGetState(dev::CUdevice, flags::Ptr{Cuint},
                                               active::Ptr{Cint})::CUresult
 end
 
 @checked function cuCtxCreate_v3(pctx, paramsArray, numParams, flags, dev)
     initialize_context()
-    @ccall libcuda.cuCtxCreate_v3(pctx::Ptr{CUcontext},
+    @gcsafe_ccall libcuda.cuCtxCreate_v3(pctx::Ptr{CUcontext},
                                   paramsArray::Ptr{CUexecAffinityParam}, numParams::Cint,
                                   flags::Cuint, dev::CUdevice)::CUresult
 end
 
 @checked function cuCtxSetCurrent(ctx)
-    @ccall libcuda.cuCtxSetCurrent(ctx::CUcontext)::CUresult
+    @gcsafe_ccall libcuda.cuCtxSetCurrent(ctx::CUcontext)::CUresult
 end
 
 @checked function cuCtxGetCurrent(pctx)
-    @ccall libcuda.cuCtxGetCurrent(pctx::Ptr{CUcontext})::CUresult
+    @gcsafe_ccall libcuda.cuCtxGetCurrent(pctx::Ptr{CUcontext})::CUresult
 end
 
 @checked function cuCtxGetDevice(device)
-    @ccall libcuda.cuCtxGetDevice(device::Ptr{CUdevice})::CUresult
+    @gcsafe_ccall libcuda.cuCtxGetDevice(device::Ptr{CUdevice})::CUresult
 end
 
 @checked function cuCtxGetFlags(flags)
     initialize_context()
-    @ccall libcuda.cuCtxGetFlags(flags::Ptr{Cuint})::CUresult
+    @gcsafe_ccall libcuda.cuCtxGetFlags(flags::Ptr{Cuint})::CUresult
 end
 
 @checked function cuCtxSetFlags(flags)
     initialize_context()
-    @ccall libcuda.cuCtxSetFlags(flags::Cuint)::CUresult
+    @gcsafe_ccall libcuda.cuCtxSetFlags(flags::Cuint)::CUresult
 end
 
 @checked function cuCtxGetId(ctx, ctxId)
     initialize_context()
-    @ccall libcuda.cuCtxGetId(ctx::CUcontext, ctxId::Ptr{Culonglong})::CUresult
+    @gcsafe_ccall libcuda.cuCtxGetId(ctx::CUcontext, ctxId::Ptr{Culonglong})::CUresult
 end
 
 @checked function cuCtxSynchronize()
     initialize_context()
-    @ccall libcuda.cuCtxSynchronize()::CUresult
+    @gcsafe_ccall libcuda.cuCtxSynchronize()::CUresult
 end
 
 @checked function cuCtxSetLimit(limit, value)
     initialize_context()
-    @ccall libcuda.cuCtxSetLimit(limit::CUlimit, value::Csize_t)::CUresult
+    @gcsafe_ccall libcuda.cuCtxSetLimit(limit::CUlimit, value::Csize_t)::CUresult
 end
 
 @checked function cuCtxGetLimit(pvalue, limit)
     initialize_context()
-    @ccall libcuda.cuCtxGetLimit(pvalue::Ptr{Csize_t}, limit::CUlimit)::CUresult
+    @gcsafe_ccall libcuda.cuCtxGetLimit(pvalue::Ptr{Csize_t}, limit::CUlimit)::CUresult
 end
 
 @checked function cuCtxGetCacheConfig(pconfig)
     initialize_context()
-    @ccall libcuda.cuCtxGetCacheConfig(pconfig::Ptr{CUfunc_cache})::CUresult
+    @gcsafe_ccall libcuda.cuCtxGetCacheConfig(pconfig::Ptr{CUfunc_cache})::CUresult
 end
 
 @checked function cuCtxSetCacheConfig(config)
     initialize_context()
-    @ccall libcuda.cuCtxSetCacheConfig(config::CUfunc_cache)::CUresult
+    @gcsafe_ccall libcuda.cuCtxSetCacheConfig(config::CUfunc_cache)::CUresult
 end
 
 @checked function cuCtxGetSharedMemConfig(pConfig)
     initialize_context()
-    @ccall libcuda.cuCtxGetSharedMemConfig(pConfig::Ptr{CUsharedconfig})::CUresult
+    @gcsafe_ccall libcuda.cuCtxGetSharedMemConfig(pConfig::Ptr{CUsharedconfig})::CUresult
 end
 
 @checked function cuCtxSetSharedMemConfig(config)
     initialize_context()
-    @ccall libcuda.cuCtxSetSharedMemConfig(config::CUsharedconfig)::CUresult
+    @gcsafe_ccall libcuda.cuCtxSetSharedMemConfig(config::CUsharedconfig)::CUresult
 end
 
 @checked function cuCtxGetApiVersion(ctx, version)
     initialize_context()
-    @ccall libcuda.cuCtxGetApiVersion(ctx::CUcontext, version::Ptr{Cuint})::CUresult
+    @gcsafe_ccall libcuda.cuCtxGetApiVersion(ctx::CUcontext, version::Ptr{Cuint})::CUresult
 end
 
 @checked function cuCtxGetStreamPriorityRange(leastPriority, greatestPriority)
     initialize_context()
-    @ccall libcuda.cuCtxGetStreamPriorityRange(leastPriority::Ptr{Cint},
+    @gcsafe_ccall libcuda.cuCtxGetStreamPriorityRange(leastPriority::Ptr{Cint},
                                                greatestPriority::Ptr{Cint})::CUresult
 end
 
 @checked function cuCtxResetPersistingL2Cache()
     initialize_context()
-    @ccall libcuda.cuCtxResetPersistingL2Cache()::CUresult
+    @gcsafe_ccall libcuda.cuCtxResetPersistingL2Cache()::CUresult
 end
 
 @checked function cuCtxGetExecAffinity(pExecAffinity, type)
     initialize_context()
-    @ccall libcuda.cuCtxGetExecAffinity(pExecAffinity::Ptr{CUexecAffinityParam},
+    @gcsafe_ccall libcuda.cuCtxGetExecAffinity(pExecAffinity::Ptr{CUexecAffinityParam},
                                         type::CUexecAffinityType)::CUresult
 end
 
 @checked function cuCtxAttach(pctx, flags)
     initialize_context()
-    @ccall libcuda.cuCtxAttach(pctx::Ptr{CUcontext}, flags::Cuint)::CUresult
+    @gcsafe_ccall libcuda.cuCtxAttach(pctx::Ptr{CUcontext}, flags::Cuint)::CUresult
 end
 
 @checked function cuCtxDetach(ctx)
     initialize_context()
-    @ccall libcuda.cuCtxDetach(ctx::CUcontext)::CUresult
+    @gcsafe_ccall libcuda.cuCtxDetach(ctx::CUcontext)::CUresult
 end
 
 @checked function cuModuleLoad(_module, fname)
     initialize_context()
-    @ccall libcuda.cuModuleLoad(_module::Ptr{CUmodule}, fname::Cstring)::CUresult
+    @gcsafe_ccall libcuda.cuModuleLoad(_module::Ptr{CUmodule}, fname::Cstring)::CUresult
 end
 
 @checked function cuModuleLoadData(_module, image)
     initialize_context()
-    @ccall libcuda.cuModuleLoadData(_module::Ptr{CUmodule}, image::Ptr{Cvoid})::CUresult
+    @gcsafe_ccall libcuda.cuModuleLoadData(_module::Ptr{CUmodule}, image::Ptr{Cvoid})::CUresult
 end
 
 @checked function cuModuleLoadDataEx(_module, image, numOptions, options, optionValues)
     initialize_context()
-    @ccall libcuda.cuModuleLoadDataEx(_module::Ptr{CUmodule}, image::Ptr{Cvoid},
+    @gcsafe_ccall libcuda.cuModuleLoadDataEx(_module::Ptr{CUmodule}, image::Ptr{Cvoid},
                                       numOptions::Cuint, options::Ptr{CUjit_option},
                                       optionValues::Ptr{Ptr{Cvoid}})::CUresult
 end
 
 @checked function cuModuleLoadFatBinary(_module, fatCubin)
     initialize_context()
-    @ccall libcuda.cuModuleLoadFatBinary(_module::Ptr{CUmodule},
+    @gcsafe_ccall libcuda.cuModuleLoadFatBinary(_module::Ptr{CUmodule},
                                          fatCubin::Ptr{Cvoid})::CUresult
 end
 
 @checked function cuModuleUnload(hmod)
     initialize_context()
-    @ccall libcuda.cuModuleUnload(hmod::CUmodule)::CUresult
+    @gcsafe_ccall libcuda.cuModuleUnload(hmod::CUmodule)::CUresult
 end
 
 @cenum CUmoduleLoadingMode_enum::UInt32 begin
@@ -3314,35 +3314,35 @@ const CUmoduleLoadingMode = CUmoduleLoadingMode_enum
 
 @checked function cuModuleGetLoadingMode(mode)
     initialize_context()
-    @ccall libcuda.cuModuleGetLoadingMode(mode::Ptr{CUmoduleLoadingMode})::CUresult
+    @gcsafe_ccall libcuda.cuModuleGetLoadingMode(mode::Ptr{CUmoduleLoadingMode})::CUresult
 end
 
 @checked function cuModuleGetFunction(hfunc, hmod, name)
     initialize_context()
-    @ccall libcuda.cuModuleGetFunction(hfunc::Ptr{CUfunction}, hmod::CUmodule,
+    @gcsafe_ccall libcuda.cuModuleGetFunction(hfunc::Ptr{CUfunction}, hmod::CUmodule,
                                        name::Cstring)::CUresult
 end
 
 @checked function cuLinkComplete(state, cubinOut, sizeOut)
     initialize_context()
-    @ccall libcuda.cuLinkComplete(state::CUlinkState, cubinOut::Ptr{Ptr{Cvoid}},
+    @gcsafe_ccall libcuda.cuLinkComplete(state::CUlinkState, cubinOut::Ptr{Ptr{Cvoid}},
                                   sizeOut::Ptr{Csize_t})::CUresult
 end
 
 @checked function cuLinkDestroy(state)
     initialize_context()
-    @ccall libcuda.cuLinkDestroy(state::CUlinkState)::CUresult
+    @gcsafe_ccall libcuda.cuLinkDestroy(state::CUlinkState)::CUresult
 end
 
 @checked function cuModuleGetTexRef(pTexRef, hmod, name)
     initialize_context()
-    @ccall libcuda.cuModuleGetTexRef(pTexRef::Ptr{CUtexref}, hmod::CUmodule,
+    @gcsafe_ccall libcuda.cuModuleGetTexRef(pTexRef::Ptr{CUtexref}, hmod::CUmodule,
                                      name::Cstring)::CUresult
 end
 
 @checked function cuModuleGetSurfRef(pSurfRef, hmod, name)
     initialize_context()
-    @ccall libcuda.cuModuleGetSurfRef(pSurfRef::Ptr{CUsurfref}, hmod::CUmodule,
+    @gcsafe_ccall libcuda.cuModuleGetSurfRef(pSurfRef::Ptr{CUsurfref}, hmod::CUmodule,
                                       name::Cstring)::CUresult
 end
 
@@ -3350,7 +3350,7 @@ end
                                     numJitOptions, libraryOptions, libraryOptionValues,
                                     numLibraryOptions)
     initialize_context()
-    @ccall libcuda.cuLibraryLoadData(library::Ptr{CUlibrary}, code::Ptr{Cvoid},
+    @gcsafe_ccall libcuda.cuLibraryLoadData(library::Ptr{CUlibrary}, code::Ptr{Cvoid},
                                      jitOptions::Ptr{CUjit_option},
                                      jitOptionsValues::Ptr{Ptr{Cvoid}},
                                      numJitOptions::Cuint,
@@ -3363,7 +3363,7 @@ end
                                         numJitOptions, libraryOptions, libraryOptionValues,
                                         numLibraryOptions)
     initialize_context()
-    @ccall libcuda.cuLibraryLoadFromFile(library::Ptr{CUlibrary}, fileName::Cstring,
+    @gcsafe_ccall libcuda.cuLibraryLoadFromFile(library::Ptr{CUlibrary}, fileName::Cstring,
                                          jitOptions::Ptr{CUjit_option},
                                          jitOptionsValues::Ptr{Ptr{Cvoid}},
                                          numJitOptions::Cuint,
@@ -3374,262 +3374,262 @@ end
 
 @checked function cuLibraryUnload(library)
     initialize_context()
-    @ccall libcuda.cuLibraryUnload(library::CUlibrary)::CUresult
+    @gcsafe_ccall libcuda.cuLibraryUnload(library::CUlibrary)::CUresult
 end
 
 @checked function cuLibraryGetKernel(pKernel, library, name)
     initialize_context()
-    @ccall libcuda.cuLibraryGetKernel(pKernel::Ptr{CUkernel}, library::CUlibrary,
+    @gcsafe_ccall libcuda.cuLibraryGetKernel(pKernel::Ptr{CUkernel}, library::CUlibrary,
                                       name::Cstring)::CUresult
 end
 
 @checked function cuLibraryGetModule(pMod, library)
     initialize_context()
-    @ccall libcuda.cuLibraryGetModule(pMod::Ptr{CUmodule}, library::CUlibrary)::CUresult
+    @gcsafe_ccall libcuda.cuLibraryGetModule(pMod::Ptr{CUmodule}, library::CUlibrary)::CUresult
 end
 
 @checked function cuKernelGetFunction(pFunc, kernel)
     initialize_context()
-    @ccall libcuda.cuKernelGetFunction(pFunc::Ptr{CUfunction}, kernel::CUkernel)::CUresult
+    @gcsafe_ccall libcuda.cuKernelGetFunction(pFunc::Ptr{CUfunction}, kernel::CUkernel)::CUresult
 end
 
 @checked function cuLibraryGetGlobal(dptr, bytes, library, name)
     initialize_context()
-    @ccall libcuda.cuLibraryGetGlobal(dptr::Ptr{CUdeviceptr}, bytes::Ptr{Csize_t},
+    @gcsafe_ccall libcuda.cuLibraryGetGlobal(dptr::Ptr{CUdeviceptr}, bytes::Ptr{Csize_t},
                                       library::CUlibrary, name::Cstring)::CUresult
 end
 
 @checked function cuLibraryGetManaged(dptr, bytes, library, name)
     initialize_context()
-    @ccall libcuda.cuLibraryGetManaged(dptr::Ptr{CUdeviceptr}, bytes::Ptr{Csize_t},
+    @gcsafe_ccall libcuda.cuLibraryGetManaged(dptr::Ptr{CUdeviceptr}, bytes::Ptr{Csize_t},
                                        library::CUlibrary, name::Cstring)::CUresult
 end
 
 @checked function cuLibraryGetUnifiedFunction(fptr, library, symbol)
     initialize_context()
-    @ccall libcuda.cuLibraryGetUnifiedFunction(fptr::Ptr{Ptr{Cvoid}}, library::CUlibrary,
+    @gcsafe_ccall libcuda.cuLibraryGetUnifiedFunction(fptr::Ptr{Ptr{Cvoid}}, library::CUlibrary,
                                                symbol::Cstring)::CUresult
 end
 
 @checked function cuKernelGetAttribute(pi, attrib, kernel, dev)
     initialize_context()
-    @ccall libcuda.cuKernelGetAttribute(pi::Ptr{Cint}, attrib::CUfunction_attribute,
+    @gcsafe_ccall libcuda.cuKernelGetAttribute(pi::Ptr{Cint}, attrib::CUfunction_attribute,
                                         kernel::CUkernel, dev::CUdevice)::CUresult
 end
 
 @checked function cuKernelSetAttribute(attrib, val, kernel, dev)
     initialize_context()
-    @ccall libcuda.cuKernelSetAttribute(attrib::CUfunction_attribute, val::Cint,
+    @gcsafe_ccall libcuda.cuKernelSetAttribute(attrib::CUfunction_attribute, val::Cint,
                                         kernel::CUkernel, dev::CUdevice)::CUresult
 end
 
 @checked function cuKernelSetCacheConfig(kernel, config, dev)
     initialize_context()
-    @ccall libcuda.cuKernelSetCacheConfig(kernel::CUkernel, config::CUfunc_cache,
+    @gcsafe_ccall libcuda.cuKernelSetCacheConfig(kernel::CUkernel, config::CUfunc_cache,
                                           dev::CUdevice)::CUresult
 end
 
 @checked function cuKernelGetName(name, hfunc)
     initialize_context()
-    @ccall libcuda.cuKernelGetName(name::Ptr{Cstring}, hfunc::CUkernel)::CUresult
+    @gcsafe_ccall libcuda.cuKernelGetName(name::Ptr{Cstring}, hfunc::CUkernel)::CUresult
 end
 
 @checked function cuMemFreeHost(p)
     initialize_context()
-    @ccall libcuda.cuMemFreeHost(p::Ptr{Cvoid})::CUresult
+    @gcsafe_ccall libcuda.cuMemFreeHost(p::Ptr{Cvoid})::CUresult
 end
 
 @checked function cuMemHostAlloc(pp, bytesize, Flags)
     initialize_context()
-    @ccall libcuda.cuMemHostAlloc(pp::Ptr{Ptr{Cvoid}}, bytesize::Csize_t,
+    @gcsafe_ccall libcuda.cuMemHostAlloc(pp::Ptr{Ptr{Cvoid}}, bytesize::Csize_t,
                                   Flags::Cuint)::CUresult
 end
 
 @checked function cuMemHostGetFlags(pFlags, p)
     initialize_context()
-    @ccall libcuda.cuMemHostGetFlags(pFlags::Ptr{Cuint}, p::Ptr{Cvoid})::CUresult
+    @gcsafe_ccall libcuda.cuMemHostGetFlags(pFlags::Ptr{Cuint}, p::Ptr{Cvoid})::CUresult
 end
 
 @checked function cuMemAllocManaged(dptr, bytesize, flags)
     initialize_context()
-    @ccall libcuda.cuMemAllocManaged(dptr::Ptr{CUdeviceptr}, bytesize::Csize_t,
+    @gcsafe_ccall libcuda.cuMemAllocManaged(dptr::Ptr{CUdeviceptr}, bytesize::Csize_t,
                                      flags::Cuint)::CUresult
 end
 
 @checked function cuDeviceGetByPCIBusId(dev, pciBusId)
     initialize_context()
-    @ccall libcuda.cuDeviceGetByPCIBusId(dev::Ptr{CUdevice}, pciBusId::Cstring)::CUresult
+    @gcsafe_ccall libcuda.cuDeviceGetByPCIBusId(dev::Ptr{CUdevice}, pciBusId::Cstring)::CUresult
 end
 
 @checked function cuDeviceGetPCIBusId(pciBusId, len, dev)
     initialize_context()
-    @ccall libcuda.cuDeviceGetPCIBusId(pciBusId::Cstring, len::Cint,
+    @gcsafe_ccall libcuda.cuDeviceGetPCIBusId(pciBusId::Cstring, len::Cint,
                                        dev::CUdevice)::CUresult
 end
 
 @checked function cuIpcGetEventHandle(pHandle, event)
     initialize_context()
-    @ccall libcuda.cuIpcGetEventHandle(pHandle::Ptr{CUipcEventHandle},
+    @gcsafe_ccall libcuda.cuIpcGetEventHandle(pHandle::Ptr{CUipcEventHandle},
                                        event::CUevent)::CUresult
 end
 
 @checked function cuIpcOpenEventHandle(phEvent, handle)
     initialize_context()
-    @ccall libcuda.cuIpcOpenEventHandle(phEvent::Ptr{CUevent},
+    @gcsafe_ccall libcuda.cuIpcOpenEventHandle(phEvent::Ptr{CUevent},
                                         handle::CUipcEventHandle)::CUresult
 end
 
 @checked function cuIpcGetMemHandle(pHandle, dptr)
     initialize_context()
-    @ccall libcuda.cuIpcGetMemHandle(pHandle::Ptr{CUipcMemHandle},
+    @gcsafe_ccall libcuda.cuIpcGetMemHandle(pHandle::Ptr{CUipcMemHandle},
                                      dptr::CUdeviceptr)::CUresult
 end
 
 @checked function cuIpcCloseMemHandle(dptr)
     initialize_context()
-    @ccall libcuda.cuIpcCloseMemHandle(dptr::CUdeviceptr)::CUresult
+    @gcsafe_ccall libcuda.cuIpcCloseMemHandle(dptr::CUdeviceptr)::CUresult
 end
 
 @checked function cuMemHostUnregister(p)
     initialize_context()
-    @ccall libcuda.cuMemHostUnregister(p::Ptr{Cvoid})::CUresult
+    @gcsafe_ccall libcuda.cuMemHostUnregister(p::Ptr{Cvoid})::CUresult
 end
 
 @checked function cuMemcpy(dst, src, ByteCount)
     initialize_context()
-    @ccall libcuda.cuMemcpy(dst::CUdeviceptr, src::CUdeviceptr,
+    @gcsafe_ccall libcuda.cuMemcpy(dst::CUdeviceptr, src::CUdeviceptr,
                             ByteCount::Csize_t)::CUresult
 end
 
 @checked function cuMemcpyPeer(dstDevice, dstContext, srcDevice, srcContext, ByteCount)
     initialize_context()
-    @ccall libcuda.cuMemcpyPeer(dstDevice::CUdeviceptr, dstContext::CUcontext,
+    @gcsafe_ccall libcuda.cuMemcpyPeer(dstDevice::CUdeviceptr, dstContext::CUcontext,
                                 srcDevice::CUdeviceptr, srcContext::CUcontext,
                                 ByteCount::Csize_t)::CUresult
 end
 
 @checked function cuMemcpy3DPeer(pCopy)
     initialize_context()
-    @ccall libcuda.cuMemcpy3DPeer(pCopy::Ptr{CUDA_MEMCPY3D_PEER})::CUresult
+    @gcsafe_ccall libcuda.cuMemcpy3DPeer(pCopy::Ptr{CUDA_MEMCPY3D_PEER})::CUresult
 end
 
 @checked function cuMemcpyAsync(dst, src, ByteCount, hStream)
     initialize_context()
-    @ccall libcuda.cuMemcpyAsync(dst::CUdeviceptr, src::CUdeviceptr, ByteCount::Csize_t,
+    @gcsafe_ccall libcuda.cuMemcpyAsync(dst::CUdeviceptr, src::CUdeviceptr, ByteCount::Csize_t,
                                  hStream::CUstream)::CUresult
 end
 
 @checked function cuMemcpyPeerAsync(dstDevice, dstContext, srcDevice, srcContext, ByteCount,
                                     hStream)
     initialize_context()
-    @ccall libcuda.cuMemcpyPeerAsync(dstDevice::CUdeviceptr, dstContext::CUcontext,
+    @gcsafe_ccall libcuda.cuMemcpyPeerAsync(dstDevice::CUdeviceptr, dstContext::CUcontext,
                                      srcDevice::CUdeviceptr, srcContext::CUcontext,
                                      ByteCount::Csize_t, hStream::CUstream)::CUresult
 end
 
 @checked function cuMemcpy3DPeerAsync(pCopy, hStream)
     initialize_context()
-    @ccall libcuda.cuMemcpy3DPeerAsync(pCopy::Ptr{CUDA_MEMCPY3D_PEER},
+    @gcsafe_ccall libcuda.cuMemcpy3DPeerAsync(pCopy::Ptr{CUDA_MEMCPY3D_PEER},
                                        hStream::CUstream)::CUresult
 end
 
 @checked function cuMemsetD8Async(dstDevice, uc, N, hStream)
     initialize_context()
-    @ccall libcuda.cuMemsetD8Async(dstDevice::CUdeviceptr, uc::Cuchar, N::Csize_t,
+    @gcsafe_ccall libcuda.cuMemsetD8Async(dstDevice::CUdeviceptr, uc::Cuchar, N::Csize_t,
                                    hStream::CUstream)::CUresult
 end
 
 @checked function cuMemsetD16Async(dstDevice, us, N, hStream)
     initialize_context()
-    @ccall libcuda.cuMemsetD16Async(dstDevice::CUdeviceptr, us::Cushort, N::Csize_t,
+    @gcsafe_ccall libcuda.cuMemsetD16Async(dstDevice::CUdeviceptr, us::Cushort, N::Csize_t,
                                     hStream::CUstream)::CUresult
 end
 
 @checked function cuMemsetD32Async(dstDevice, ui, N, hStream)
     initialize_context()
-    @ccall libcuda.cuMemsetD32Async(dstDevice::CUdeviceptr, ui::Cuint, N::Csize_t,
+    @gcsafe_ccall libcuda.cuMemsetD32Async(dstDevice::CUdeviceptr, ui::Cuint, N::Csize_t,
                                     hStream::CUstream)::CUresult
 end
 
 @checked function cuMemsetD2D8Async(dstDevice, dstPitch, uc, Width, Height, hStream)
     initialize_context()
-    @ccall libcuda.cuMemsetD2D8Async(dstDevice::CUdeviceptr, dstPitch::Csize_t, uc::Cuchar,
+    @gcsafe_ccall libcuda.cuMemsetD2D8Async(dstDevice::CUdeviceptr, dstPitch::Csize_t, uc::Cuchar,
                                      Width::Csize_t, Height::Csize_t,
                                      hStream::CUstream)::CUresult
 end
 
 @checked function cuMemsetD2D16Async(dstDevice, dstPitch, us, Width, Height, hStream)
     initialize_context()
-    @ccall libcuda.cuMemsetD2D16Async(dstDevice::CUdeviceptr, dstPitch::Csize_t,
+    @gcsafe_ccall libcuda.cuMemsetD2D16Async(dstDevice::CUdeviceptr, dstPitch::Csize_t,
                                       us::Cushort, Width::Csize_t, Height::Csize_t,
                                       hStream::CUstream)::CUresult
 end
 
 @checked function cuMemsetD2D32Async(dstDevice, dstPitch, ui, Width, Height, hStream)
     initialize_context()
-    @ccall libcuda.cuMemsetD2D32Async(dstDevice::CUdeviceptr, dstPitch::Csize_t, ui::Cuint,
+    @gcsafe_ccall libcuda.cuMemsetD2D32Async(dstDevice::CUdeviceptr, dstPitch::Csize_t, ui::Cuint,
                                       Width::Csize_t, Height::Csize_t,
                                       hStream::CUstream)::CUresult
 end
 
 @checked function cuArrayGetSparseProperties(sparseProperties, array)
     initialize_context()
-    @ccall libcuda.cuArrayGetSparseProperties(sparseProperties::Ptr{CUDA_ARRAY_SPARSE_PROPERTIES},
+    @gcsafe_ccall libcuda.cuArrayGetSparseProperties(sparseProperties::Ptr{CUDA_ARRAY_SPARSE_PROPERTIES},
                                               array::CUarray)::CUresult
 end
 
 @checked function cuMipmappedArrayGetSparseProperties(sparseProperties, mipmap)
     initialize_context()
-    @ccall libcuda.cuMipmappedArrayGetSparseProperties(sparseProperties::Ptr{CUDA_ARRAY_SPARSE_PROPERTIES},
+    @gcsafe_ccall libcuda.cuMipmappedArrayGetSparseProperties(sparseProperties::Ptr{CUDA_ARRAY_SPARSE_PROPERTIES},
                                                        mipmap::CUmipmappedArray)::CUresult
 end
 
 @checked function cuArrayGetMemoryRequirements(memoryRequirements, array, device)
     initialize_context()
-    @ccall libcuda.cuArrayGetMemoryRequirements(memoryRequirements::Ptr{CUDA_ARRAY_MEMORY_REQUIREMENTS},
+    @gcsafe_ccall libcuda.cuArrayGetMemoryRequirements(memoryRequirements::Ptr{CUDA_ARRAY_MEMORY_REQUIREMENTS},
                                                 array::CUarray, device::CUdevice)::CUresult
 end
 
 @checked function cuMipmappedArrayGetMemoryRequirements(memoryRequirements, mipmap, device)
     initialize_context()
-    @ccall libcuda.cuMipmappedArrayGetMemoryRequirements(memoryRequirements::Ptr{CUDA_ARRAY_MEMORY_REQUIREMENTS},
+    @gcsafe_ccall libcuda.cuMipmappedArrayGetMemoryRequirements(memoryRequirements::Ptr{CUDA_ARRAY_MEMORY_REQUIREMENTS},
                                                          mipmap::CUmipmappedArray,
                                                          device::CUdevice)::CUresult
 end
 
 @checked function cuArrayGetPlane(pPlaneArray, hArray, planeIdx)
     initialize_context()
-    @ccall libcuda.cuArrayGetPlane(pPlaneArray::Ptr{CUarray}, hArray::CUarray,
+    @gcsafe_ccall libcuda.cuArrayGetPlane(pPlaneArray::Ptr{CUarray}, hArray::CUarray,
                                    planeIdx::Cuint)::CUresult
 end
 
 @checked function cuArrayDestroy(hArray)
     initialize_context()
-    @ccall libcuda.cuArrayDestroy(hArray::CUarray)::CUresult
+    @gcsafe_ccall libcuda.cuArrayDestroy(hArray::CUarray)::CUresult
 end
 
 @checked function cuMipmappedArrayCreate(pHandle, pMipmappedArrayDesc, numMipmapLevels)
     initialize_context()
-    @ccall libcuda.cuMipmappedArrayCreate(pHandle::Ptr{CUmipmappedArray},
+    @gcsafe_ccall libcuda.cuMipmappedArrayCreate(pHandle::Ptr{CUmipmappedArray},
                                           pMipmappedArrayDesc::Ptr{CUDA_ARRAY3D_DESCRIPTOR},
                                           numMipmapLevels::Cuint)::CUresult
 end
 
 @checked function cuMipmappedArrayGetLevel(pLevelArray, hMipmappedArray, level)
     initialize_context()
-    @ccall libcuda.cuMipmappedArrayGetLevel(pLevelArray::Ptr{CUarray},
+    @gcsafe_ccall libcuda.cuMipmappedArrayGetLevel(pLevelArray::Ptr{CUarray},
                                             hMipmappedArray::CUmipmappedArray,
                                             level::Cuint)::CUresult
 end
 
 @checked function cuMipmappedArrayDestroy(hMipmappedArray)
     initialize_context()
-    @ccall libcuda.cuMipmappedArrayDestroy(hMipmappedArray::CUmipmappedArray)::CUresult
+    @gcsafe_ccall libcuda.cuMipmappedArrayDestroy(hMipmappedArray::CUmipmappedArray)::CUresult
 end
 
 @checked function cuMemGetHandleForAddressRange(handle, dptr, size, handleType, flags)
     initialize_context()
-    @ccall libcuda.cuMemGetHandleForAddressRange(handle::Ptr{Cvoid}, dptr::CUdeviceptr,
+    @gcsafe_ccall libcuda.cuMemGetHandleForAddressRange(handle::Ptr{Cvoid}, dptr::CUdeviceptr,
                                                  size::Csize_t,
                                                  handleType::CUmemRangeHandleType,
                                                  flags::Culonglong)::CUresult
@@ -3637,60 +3637,60 @@ end
 
 @checked function cuMemAddressReserve(ptr, size, alignment, addr, flags)
     initialize_context()
-    @ccall libcuda.cuMemAddressReserve(ptr::Ptr{CUdeviceptr}, size::Csize_t,
+    @gcsafe_ccall libcuda.cuMemAddressReserve(ptr::Ptr{CUdeviceptr}, size::Csize_t,
                                        alignment::Csize_t, addr::CUdeviceptr,
                                        flags::Culonglong)::CUresult
 end
 
 @checked function cuMemAddressFree(ptr, size)
     initialize_context()
-    @ccall libcuda.cuMemAddressFree(ptr::CUdeviceptr, size::Csize_t)::CUresult
+    @gcsafe_ccall libcuda.cuMemAddressFree(ptr::CUdeviceptr, size::Csize_t)::CUresult
 end
 
 @checked function cuMemCreate(handle, size, prop, flags)
     initialize_context()
-    @ccall libcuda.cuMemCreate(handle::Ptr{CUmemGenericAllocationHandle}, size::Csize_t,
+    @gcsafe_ccall libcuda.cuMemCreate(handle::Ptr{CUmemGenericAllocationHandle}, size::Csize_t,
                                prop::Ptr{CUmemAllocationProp}, flags::Culonglong)::CUresult
 end
 
 @checked function cuMemRelease(handle)
     initialize_context()
-    @ccall libcuda.cuMemRelease(handle::CUmemGenericAllocationHandle)::CUresult
+    @gcsafe_ccall libcuda.cuMemRelease(handle::CUmemGenericAllocationHandle)::CUresult
 end
 
 @checked function cuMemMap(ptr, size, offset, handle, flags)
     initialize_context()
-    @ccall libcuda.cuMemMap(ptr::CUdeviceptr, size::Csize_t, offset::Csize_t,
+    @gcsafe_ccall libcuda.cuMemMap(ptr::CUdeviceptr, size::Csize_t, offset::Csize_t,
                             handle::CUmemGenericAllocationHandle,
                             flags::Culonglong)::CUresult
 end
 
 @checked function cuMemMapArrayAsync(mapInfoList, count, hStream)
     initialize_context()
-    @ccall libcuda.cuMemMapArrayAsync(mapInfoList::Ptr{CUarrayMapInfo}, count::Cuint,
+    @gcsafe_ccall libcuda.cuMemMapArrayAsync(mapInfoList::Ptr{CUarrayMapInfo}, count::Cuint,
                                       hStream::CUstream)::CUresult
 end
 
 @checked function cuMemUnmap(ptr, size)
     initialize_context()
-    @ccall libcuda.cuMemUnmap(ptr::CUdeviceptr, size::Csize_t)::CUresult
+    @gcsafe_ccall libcuda.cuMemUnmap(ptr::CUdeviceptr, size::Csize_t)::CUresult
 end
 
 @checked function cuMemSetAccess(ptr, size, desc, count)
     initialize_context()
-    @ccall libcuda.cuMemSetAccess(ptr::CUdeviceptr, size::Csize_t,
+    @gcsafe_ccall libcuda.cuMemSetAccess(ptr::CUdeviceptr, size::Csize_t,
                                   desc::Ptr{CUmemAccessDesc}, count::Csize_t)::CUresult
 end
 
 @checked function cuMemGetAccess(flags, location, ptr)
     initialize_context()
-    @ccall libcuda.cuMemGetAccess(flags::Ptr{Culonglong}, location::Ptr{CUmemLocation},
+    @gcsafe_ccall libcuda.cuMemGetAccess(flags::Ptr{Culonglong}, location::Ptr{CUmemLocation},
                                   ptr::CUdeviceptr)::CUresult
 end
 
 @checked function cuMemExportToShareableHandle(shareableHandle, handle, handleType, flags)
     initialize_context()
-    @ccall libcuda.cuMemExportToShareableHandle(shareableHandle::Ptr{Cvoid},
+    @gcsafe_ccall libcuda.cuMemExportToShareableHandle(shareableHandle::Ptr{Cvoid},
                                                 handle::CUmemGenericAllocationHandle,
                                                 handleType::CUmemAllocationHandleType,
                                                 flags::Culonglong)::CUresult
@@ -3698,90 +3698,90 @@ end
 
 @checked function cuMemImportFromShareableHandle(handle, osHandle, shHandleType)
     initialize_context()
-    @ccall libcuda.cuMemImportFromShareableHandle(handle::Ptr{CUmemGenericAllocationHandle},
+    @gcsafe_ccall libcuda.cuMemImportFromShareableHandle(handle::Ptr{CUmemGenericAllocationHandle},
                                                   osHandle::Ptr{Cvoid},
                                                   shHandleType::CUmemAllocationHandleType)::CUresult
 end
 
 @checked function cuMemGetAllocationGranularity(granularity, prop, option)
     initialize_context()
-    @ccall libcuda.cuMemGetAllocationGranularity(granularity::Ptr{Csize_t},
+    @gcsafe_ccall libcuda.cuMemGetAllocationGranularity(granularity::Ptr{Csize_t},
                                                  prop::Ptr{CUmemAllocationProp},
                                                  option::CUmemAllocationGranularity_flags)::CUresult
 end
 
 @checked function cuMemGetAllocationPropertiesFromHandle(prop, handle)
     initialize_context()
-    @ccall libcuda.cuMemGetAllocationPropertiesFromHandle(prop::Ptr{CUmemAllocationProp},
+    @gcsafe_ccall libcuda.cuMemGetAllocationPropertiesFromHandle(prop::Ptr{CUmemAllocationProp},
                                                           handle::CUmemGenericAllocationHandle)::CUresult
 end
 
 @checked function cuMemRetainAllocationHandle(handle, addr)
     initialize_context()
-    @ccall libcuda.cuMemRetainAllocationHandle(handle::Ptr{CUmemGenericAllocationHandle},
+    @gcsafe_ccall libcuda.cuMemRetainAllocationHandle(handle::Ptr{CUmemGenericAllocationHandle},
                                                addr::Ptr{Cvoid})::CUresult
 end
 
 @checked function cuMemFreeAsync(dptr, hStream)
     initialize_context()
-    @ccall libcuda.cuMemFreeAsync(dptr::CUdeviceptr, hStream::CUstream)::CUresult
+    @gcsafe_ccall libcuda.cuMemFreeAsync(dptr::CUdeviceptr, hStream::CUstream)::CUresult
 end
 
 @checked function cuMemAllocAsync(dptr, bytesize, hStream)
     initialize_context()
-    @ccall libcuda.cuMemAllocAsync(dptr::Ptr{CUdeviceptr}, bytesize::Csize_t,
+    @gcsafe_ccall libcuda.cuMemAllocAsync(dptr::Ptr{CUdeviceptr}, bytesize::Csize_t,
                                    hStream::CUstream)::CUresult
 end
 
 @checked function cuMemPoolTrimTo(pool, minBytesToKeep)
     initialize_context()
-    @ccall libcuda.cuMemPoolTrimTo(pool::CUmemoryPool, minBytesToKeep::Csize_t)::CUresult
+    @gcsafe_ccall libcuda.cuMemPoolTrimTo(pool::CUmemoryPool, minBytesToKeep::Csize_t)::CUresult
 end
 
 @checked function cuMemPoolSetAttribute(pool, attr, value)
     initialize_context()
-    @ccall libcuda.cuMemPoolSetAttribute(pool::CUmemoryPool, attr::CUmemPool_attribute,
+    @gcsafe_ccall libcuda.cuMemPoolSetAttribute(pool::CUmemoryPool, attr::CUmemPool_attribute,
                                          value::Ptr{Cvoid})::CUresult
 end
 
 @checked function cuMemPoolGetAttribute(pool, attr, value)
     initialize_context()
-    @ccall libcuda.cuMemPoolGetAttribute(pool::CUmemoryPool, attr::CUmemPool_attribute,
+    @gcsafe_ccall libcuda.cuMemPoolGetAttribute(pool::CUmemoryPool, attr::CUmemPool_attribute,
                                          value::Ptr{Cvoid})::CUresult
 end
 
 @checked function cuMemPoolSetAccess(pool, map, count)
     initialize_context()
-    @ccall libcuda.cuMemPoolSetAccess(pool::CUmemoryPool, map::Ptr{CUmemAccessDesc},
+    @gcsafe_ccall libcuda.cuMemPoolSetAccess(pool::CUmemoryPool, map::Ptr{CUmemAccessDesc},
                                       count::Csize_t)::CUresult
 end
 
 @checked function cuMemPoolGetAccess(flags, memPool, location)
     initialize_context()
-    @ccall libcuda.cuMemPoolGetAccess(flags::Ptr{CUmemAccess_flags}, memPool::CUmemoryPool,
+    @gcsafe_ccall libcuda.cuMemPoolGetAccess(flags::Ptr{CUmemAccess_flags}, memPool::CUmemoryPool,
                                       location::Ptr{CUmemLocation})::CUresult
 end
 
 @checked function cuMemPoolCreate(pool, poolProps)
     initialize_context()
-    @ccall libcuda.cuMemPoolCreate(pool::Ptr{CUmemoryPool},
+    @gcsafe_ccall libcuda.cuMemPoolCreate(pool::Ptr{CUmemoryPool},
                                    poolProps::Ptr{CUmemPoolProps})::CUresult
 end
 
 @checked function cuMemPoolDestroy(pool)
     initialize_context()
-    @ccall libcuda.cuMemPoolDestroy(pool::CUmemoryPool)::CUresult
+    @gcsafe_ccall libcuda.cuMemPoolDestroy(pool::CUmemoryPool)::CUresult
 end
 
 @checked function cuMemAllocFromPoolAsync(dptr, bytesize, pool, hStream)
     initialize_context()
-    @ccall libcuda.cuMemAllocFromPoolAsync(dptr::Ptr{CUdeviceptr}, bytesize::Csize_t,
+    @gcsafe_ccall libcuda.cuMemAllocFromPoolAsync(dptr::Ptr{CUdeviceptr}, bytesize::Csize_t,
                                            pool::CUmemoryPool, hStream::CUstream)::CUresult
 end
 
 @checked function cuMemPoolExportToShareableHandle(handle_out, pool, handleType, flags)
     initialize_context()
-    @ccall libcuda.cuMemPoolExportToShareableHandle(handle_out::Ptr{Cvoid},
+    @gcsafe_ccall libcuda.cuMemPoolExportToShareableHandle(handle_out::Ptr{Cvoid},
                                                     pool::CUmemoryPool,
                                                     handleType::CUmemAllocationHandleType,
                                                     flags::Culonglong)::CUresult
@@ -3789,7 +3789,7 @@ end
 
 @checked function cuMemPoolImportFromShareableHandle(pool_out, handle, handleType, flags)
     initialize_context()
-    @ccall libcuda.cuMemPoolImportFromShareableHandle(pool_out::Ptr{CUmemoryPool},
+    @gcsafe_ccall libcuda.cuMemPoolImportFromShareableHandle(pool_out::Ptr{CUmemoryPool},
                                                       handle::Ptr{Cvoid},
                                                       handleType::CUmemAllocationHandleType,
                                                       flags::Culonglong)::CUresult
@@ -3797,31 +3797,31 @@ end
 
 @checked function cuMemPoolExportPointer(shareData_out, ptr)
     initialize_context()
-    @ccall libcuda.cuMemPoolExportPointer(shareData_out::Ptr{CUmemPoolPtrExportData},
+    @gcsafe_ccall libcuda.cuMemPoolExportPointer(shareData_out::Ptr{CUmemPoolPtrExportData},
                                           ptr::CUdeviceptr)::CUresult
 end
 
 @checked function cuMemPoolImportPointer(ptr_out, pool, shareData)
     initialize_context()
-    @ccall libcuda.cuMemPoolImportPointer(ptr_out::Ptr{CUdeviceptr}, pool::CUmemoryPool,
+    @gcsafe_ccall libcuda.cuMemPoolImportPointer(ptr_out::Ptr{CUdeviceptr}, pool::CUmemoryPool,
                                           shareData::Ptr{CUmemPoolPtrExportData})::CUresult
 end
 
 @checked function cuMulticastCreate(mcHandle, prop)
     initialize_context()
-    @ccall libcuda.cuMulticastCreate(mcHandle::Ptr{CUmemGenericAllocationHandle},
+    @gcsafe_ccall libcuda.cuMulticastCreate(mcHandle::Ptr{CUmemGenericAllocationHandle},
                                      prop::Ptr{CUmulticastObjectProp})::CUresult
 end
 
 @checked function cuMulticastAddDevice(mcHandle, dev)
     initialize_context()
-    @ccall libcuda.cuMulticastAddDevice(mcHandle::CUmemGenericAllocationHandle,
+    @gcsafe_ccall libcuda.cuMulticastAddDevice(mcHandle::CUmemGenericAllocationHandle,
                                         dev::CUdevice)::CUresult
 end
 
 @checked function cuMulticastBindMem(mcHandle, mcOffset, memHandle, memOffset, size, flags)
     initialize_context()
-    @ccall libcuda.cuMulticastBindMem(mcHandle::CUmemGenericAllocationHandle,
+    @gcsafe_ccall libcuda.cuMulticastBindMem(mcHandle::CUmemGenericAllocationHandle,
                                       mcOffset::Csize_t,
                                       memHandle::CUmemGenericAllocationHandle,
                                       memOffset::Csize_t, size::Csize_t,
@@ -3830,58 +3830,58 @@ end
 
 @checked function cuMulticastBindAddr(mcHandle, mcOffset, memptr, size, flags)
     initialize_context()
-    @ccall libcuda.cuMulticastBindAddr(mcHandle::CUmemGenericAllocationHandle,
+    @gcsafe_ccall libcuda.cuMulticastBindAddr(mcHandle::CUmemGenericAllocationHandle,
                                        mcOffset::Csize_t, memptr::CUdeviceptr,
                                        size::Csize_t, flags::Culonglong)::CUresult
 end
 
 @checked function cuMulticastUnbind(mcHandle, dev, mcOffset, size)
     initialize_context()
-    @ccall libcuda.cuMulticastUnbind(mcHandle::CUmemGenericAllocationHandle, dev::CUdevice,
+    @gcsafe_ccall libcuda.cuMulticastUnbind(mcHandle::CUmemGenericAllocationHandle, dev::CUdevice,
                                      mcOffset::Csize_t, size::Csize_t)::CUresult
 end
 
 @checked function cuMulticastGetGranularity(granularity, prop, option)
     initialize_context()
-    @ccall libcuda.cuMulticastGetGranularity(granularity::Ptr{Csize_t},
+    @gcsafe_ccall libcuda.cuMulticastGetGranularity(granularity::Ptr{Csize_t},
                                              prop::Ptr{CUmulticastObjectProp},
                                              option::CUmulticastGranularity_flags)::CUresult
 end
 
 @checked function cuPointerGetAttribute(data, attribute, ptr)
     initialize_context()
-    @ccall libcuda.cuPointerGetAttribute(data::Ptr{Cvoid}, attribute::CUpointer_attribute,
+    @gcsafe_ccall libcuda.cuPointerGetAttribute(data::Ptr{Cvoid}, attribute::CUpointer_attribute,
                                          ptr::CUdeviceptr)::CUresult
 end
 
 @checked function cuMemPrefetchAsync(devPtr, count, dstDevice, hStream)
     initialize_context()
-    @ccall libcuda.cuMemPrefetchAsync(devPtr::CUdeviceptr, count::Csize_t,
+    @gcsafe_ccall libcuda.cuMemPrefetchAsync(devPtr::CUdeviceptr, count::Csize_t,
                                       dstDevice::CUdevice, hStream::CUstream)::CUresult
 end
 
 @checked function cuMemPrefetchAsync_v2(devPtr, count, location, flags, hStream)
     initialize_context()
-    @ccall libcuda.cuMemPrefetchAsync_v2(devPtr::CUdeviceptr, count::Csize_t,
+    @gcsafe_ccall libcuda.cuMemPrefetchAsync_v2(devPtr::CUdeviceptr, count::Csize_t,
                                          location::CUmemLocation, flags::Cuint,
                                          hStream::CUstream)::CUresult
 end
 
 @checked function cuMemAdvise(devPtr, count, advice, device)
     initialize_context()
-    @ccall libcuda.cuMemAdvise(devPtr::CUdeviceptr, count::Csize_t, advice::CUmem_advise,
+    @gcsafe_ccall libcuda.cuMemAdvise(devPtr::CUdeviceptr, count::Csize_t, advice::CUmem_advise,
                                device::CUdevice)::CUresult
 end
 
 @checked function cuMemAdvise_v2(devPtr, count, advice, location)
     initialize_context()
-    @ccall libcuda.cuMemAdvise_v2(devPtr::CUdeviceptr, count::Csize_t, advice::CUmem_advise,
+    @gcsafe_ccall libcuda.cuMemAdvise_v2(devPtr::CUdeviceptr, count::Csize_t, advice::CUmem_advise,
                                   location::CUmemLocation)::CUresult
 end
 
 @checked function cuMemRangeGetAttribute(data, dataSize, attribute, devPtr, count)
     initialize_context()
-    @ccall libcuda.cuMemRangeGetAttribute(data::Ptr{Cvoid}, dataSize::Csize_t,
+    @gcsafe_ccall libcuda.cuMemRangeGetAttribute(data::Ptr{Cvoid}, dataSize::Csize_t,
                                           attribute::CUmem_range_attribute,
                                           devPtr::CUdeviceptr, count::Csize_t)::CUresult
 end
@@ -3889,7 +3889,7 @@ end
 @checked function cuMemRangeGetAttributes(data, dataSizes, attributes, numAttributes,
                                           devPtr, count)
     initialize_context()
-    @ccall libcuda.cuMemRangeGetAttributes(data::Ptr{Ptr{Cvoid}}, dataSizes::Ptr{Csize_t},
+    @gcsafe_ccall libcuda.cuMemRangeGetAttributes(data::Ptr{Ptr{Cvoid}}, dataSizes::Ptr{Csize_t},
                                            attributes::Ptr{CUmem_range_attribute},
                                            numAttributes::Csize_t, devPtr::CUdeviceptr,
                                            count::Csize_t)::CUresult
@@ -3897,64 +3897,64 @@ end
 
 @checked function cuPointerSetAttribute(value, attribute, ptr)
     initialize_context()
-    @ccall libcuda.cuPointerSetAttribute(value::Ptr{Cvoid}, attribute::CUpointer_attribute,
+    @gcsafe_ccall libcuda.cuPointerSetAttribute(value::Ptr{Cvoid}, attribute::CUpointer_attribute,
                                          ptr::CUdeviceptr)::CUresult
 end
 
 @checked function cuPointerGetAttributes(numAttributes, attributes, data, ptr)
     initialize_context()
-    @ccall libcuda.cuPointerGetAttributes(numAttributes::Cuint,
+    @gcsafe_ccall libcuda.cuPointerGetAttributes(numAttributes::Cuint,
                                           attributes::Ptr{CUpointer_attribute},
                                           data::Ptr{Ptr{Cvoid}}, ptr::CUdeviceptr)::CUresult
 end
 
 @checked function cuStreamCreate(phStream, Flags)
     initialize_context()
-    @ccall libcuda.cuStreamCreate(phStream::Ptr{CUstream}, Flags::Cuint)::CUresult
+    @gcsafe_ccall libcuda.cuStreamCreate(phStream::Ptr{CUstream}, Flags::Cuint)::CUresult
 end
 
 @checked function cuStreamCreateWithPriority(phStream, flags, priority)
     initialize_context()
-    @ccall libcuda.cuStreamCreateWithPriority(phStream::Ptr{CUstream}, flags::Cuint,
+    @gcsafe_ccall libcuda.cuStreamCreateWithPriority(phStream::Ptr{CUstream}, flags::Cuint,
                                               priority::Cint)::CUresult
 end
 
 @checked function cuStreamGetPriority(hStream, priority)
     initialize_context()
-    @ccall libcuda.cuStreamGetPriority(hStream::CUstream, priority::Ptr{Cint})::CUresult
+    @gcsafe_ccall libcuda.cuStreamGetPriority(hStream::CUstream, priority::Ptr{Cint})::CUresult
 end
 
 @checked function cuStreamGetFlags(hStream, flags)
     initialize_context()
-    @ccall libcuda.cuStreamGetFlags(hStream::CUstream, flags::Ptr{Cuint})::CUresult
+    @gcsafe_ccall libcuda.cuStreamGetFlags(hStream::CUstream, flags::Ptr{Cuint})::CUresult
 end
 
 @checked function cuStreamGetId(hStream, streamId)
     initialize_context()
-    @ccall libcuda.cuStreamGetId(hStream::CUstream, streamId::Ptr{Culonglong})::CUresult
+    @gcsafe_ccall libcuda.cuStreamGetId(hStream::CUstream, streamId::Ptr{Culonglong})::CUresult
 end
 
 @checked function cuStreamGetCtx(hStream, pctx)
     initialize_context()
-    @ccall libcuda.cuStreamGetCtx(hStream::CUstream, pctx::Ptr{CUcontext})::CUresult
+    @gcsafe_ccall libcuda.cuStreamGetCtx(hStream::CUstream, pctx::Ptr{CUcontext})::CUresult
 end
 
 @checked function cuStreamWaitEvent(hStream, hEvent, Flags)
     initialize_context()
-    @ccall libcuda.cuStreamWaitEvent(hStream::CUstream, hEvent::CUevent,
+    @gcsafe_ccall libcuda.cuStreamWaitEvent(hStream::CUstream, hEvent::CUevent,
                                      Flags::Cuint)::CUresult
 end
 
 @checked function cuStreamAddCallback(hStream, callback, userData, flags)
     initialize_context()
-    @ccall libcuda.cuStreamAddCallback(hStream::CUstream, callback::CUstreamCallback,
+    @gcsafe_ccall libcuda.cuStreamAddCallback(hStream::CUstream, callback::CUstreamCallback,
                                        userData::Ptr{Cvoid}, flags::Cuint)::CUresult
 end
 
 @checked function cuStreamBeginCaptureToGraph(hStream, hGraph, dependencies, dependencyData,
                                               numDependencies, mode)
     initialize_context()
-    @ccall libcuda.cuStreamBeginCaptureToGraph(hStream::CUstream, hGraph::CUgraph,
+    @gcsafe_ccall libcuda.cuStreamBeginCaptureToGraph(hStream::CUstream, hGraph::CUgraph,
                                                dependencies::Ptr{CUgraphNode},
                                                dependencyData::Ptr{CUgraphEdgeData},
                                                numDependencies::Csize_t,
@@ -3963,17 +3963,17 @@ end
 
 @checked function cuThreadExchangeStreamCaptureMode(mode)
     initialize_context()
-    @ccall libcuda.cuThreadExchangeStreamCaptureMode(mode::Ptr{CUstreamCaptureMode})::CUresult
+    @gcsafe_ccall libcuda.cuThreadExchangeStreamCaptureMode(mode::Ptr{CUstreamCaptureMode})::CUresult
 end
 
 @checked function cuStreamEndCapture(hStream, phGraph)
     initialize_context()
-    @ccall libcuda.cuStreamEndCapture(hStream::CUstream, phGraph::Ptr{CUgraph})::CUresult
+    @gcsafe_ccall libcuda.cuStreamEndCapture(hStream::CUstream, phGraph::Ptr{CUgraph})::CUresult
 end
 
 @checked function cuStreamIsCapturing(hStream, captureStatus)
     initialize_context()
-    @ccall libcuda.cuStreamIsCapturing(hStream::CUstream,
+    @gcsafe_ccall libcuda.cuStreamIsCapturing(hStream::CUstream,
                                        captureStatus::Ptr{CUstreamCaptureStatus})::CUresult
 end
 
@@ -3981,7 +3981,7 @@ end
                                             dependencies_out, edgeData_out,
                                             numDependencies_out)
     initialize_context()
-    @ccall libcuda.cuStreamGetCaptureInfo_v3(hStream::CUstream,
+    @gcsafe_ccall libcuda.cuStreamGetCaptureInfo_v3(hStream::CUstream,
                                              captureStatus_out::Ptr{CUstreamCaptureStatus},
                                              id_out::Ptr{cuuint64_t},
                                              graph_out::Ptr{CUgraph},
@@ -3993,7 +3993,7 @@ end
 @checked function cuStreamUpdateCaptureDependencies(hStream, dependencies, numDependencies,
                                                     flags)
     initialize_context()
-    @ccall libcuda.cuStreamUpdateCaptureDependencies(hStream::CUstream,
+    @gcsafe_ccall libcuda.cuStreamUpdateCaptureDependencies(hStream::CUstream,
                                                      dependencies::Ptr{CUgraphNode},
                                                      numDependencies::Csize_t,
                                                      flags::Cuint)::CUresult
@@ -4003,7 +4003,7 @@ end
                                                        dependencyData, numDependencies,
                                                        flags)
     initialize_context()
-    @ccall libcuda.cuStreamUpdateCaptureDependencies_v2(hStream::CUstream,
+    @gcsafe_ccall libcuda.cuStreamUpdateCaptureDependencies_v2(hStream::CUstream,
                                                         dependencies::Ptr{CUgraphNode},
                                                         dependencyData::Ptr{CUgraphEdgeData},
                                                         numDependencies::Csize_t,
@@ -4012,104 +4012,104 @@ end
 
 @checked function cuStreamAttachMemAsync(hStream, dptr, length, flags)
     initialize_context()
-    @ccall libcuda.cuStreamAttachMemAsync(hStream::CUstream, dptr::CUdeviceptr,
+    @gcsafe_ccall libcuda.cuStreamAttachMemAsync(hStream::CUstream, dptr::CUdeviceptr,
                                           length::Csize_t, flags::Cuint)::CUresult
 end
 
 @checked function cuStreamQuery(hStream)
     initialize_context()
-    @ccall libcuda.cuStreamQuery(hStream::CUstream)::CUresult
+    @gcsafe_ccall libcuda.cuStreamQuery(hStream::CUstream)::CUresult
 end
 
 @checked function cuStreamSynchronize(hStream)
     initialize_context()
-    @ccall libcuda.cuStreamSynchronize(hStream::CUstream)::CUresult
+    @gcsafe_ccall libcuda.cuStreamSynchronize(hStream::CUstream)::CUresult
 end
 
 @checked function cuStreamCopyAttributes(dst, src)
     initialize_context()
-    @ccall libcuda.cuStreamCopyAttributes(dst::CUstream, src::CUstream)::CUresult
+    @gcsafe_ccall libcuda.cuStreamCopyAttributes(dst::CUstream, src::CUstream)::CUresult
 end
 
 @checked function cuStreamGetAttribute(hStream, attr, value_out)
     initialize_context()
-    @ccall libcuda.cuStreamGetAttribute(hStream::CUstream, attr::CUstreamAttrID,
+    @gcsafe_ccall libcuda.cuStreamGetAttribute(hStream::CUstream, attr::CUstreamAttrID,
                                         value_out::Ptr{CUstreamAttrValue})::CUresult
 end
 
 @checked function cuStreamSetAttribute(hStream, attr, value)
     initialize_context()
-    @ccall libcuda.cuStreamSetAttribute(hStream::CUstream, attr::CUstreamAttrID,
+    @gcsafe_ccall libcuda.cuStreamSetAttribute(hStream::CUstream, attr::CUstreamAttrID,
                                         value::Ptr{CUstreamAttrValue})::CUresult
 end
 
 @checked function cuEventCreate(phEvent, Flags)
     initialize_context()
-    @ccall libcuda.cuEventCreate(phEvent::Ptr{CUevent}, Flags::Cuint)::CUresult
+    @gcsafe_ccall libcuda.cuEventCreate(phEvent::Ptr{CUevent}, Flags::Cuint)::CUresult
 end
 
 @checked function cuEventRecord(hEvent, hStream)
     initialize_context()
-    @ccall libcuda.cuEventRecord(hEvent::CUevent, hStream::CUstream)::CUresult
+    @gcsafe_ccall libcuda.cuEventRecord(hEvent::CUevent, hStream::CUstream)::CUresult
 end
 
 @checked function cuEventRecordWithFlags(hEvent, hStream, flags)
     initialize_context()
-    @ccall libcuda.cuEventRecordWithFlags(hEvent::CUevent, hStream::CUstream,
+    @gcsafe_ccall libcuda.cuEventRecordWithFlags(hEvent::CUevent, hStream::CUstream,
                                           flags::Cuint)::CUresult
 end
 
 @checked function cuEventQuery(hEvent)
     initialize_context()
-    @ccall libcuda.cuEventQuery(hEvent::CUevent)::CUresult
+    @gcsafe_ccall libcuda.cuEventQuery(hEvent::CUevent)::CUresult
 end
 
 @checked function cuEventSynchronize(hEvent)
     initialize_context()
-    @ccall libcuda.cuEventSynchronize(hEvent::CUevent)::CUresult
+    @gcsafe_ccall libcuda.cuEventSynchronize(hEvent::CUevent)::CUresult
 end
 
 @checked function cuEventElapsedTime(pMilliseconds, hStart, hEnd)
     initialize_context()
-    @ccall libcuda.cuEventElapsedTime(pMilliseconds::Ptr{Cfloat}, hStart::CUevent,
+    @gcsafe_ccall libcuda.cuEventElapsedTime(pMilliseconds::Ptr{Cfloat}, hStart::CUevent,
                                       hEnd::CUevent)::CUresult
 end
 
 @checked function cuImportExternalMemory(extMem_out, memHandleDesc)
     initialize_context()
-    @ccall libcuda.cuImportExternalMemory(extMem_out::Ptr{CUexternalMemory},
+    @gcsafe_ccall libcuda.cuImportExternalMemory(extMem_out::Ptr{CUexternalMemory},
                                           memHandleDesc::Ptr{CUDA_EXTERNAL_MEMORY_HANDLE_DESC})::CUresult
 end
 
 @checked function cuExternalMemoryGetMappedBuffer(devPtr, extMem, bufferDesc)
     initialize_context()
-    @ccall libcuda.cuExternalMemoryGetMappedBuffer(devPtr::Ptr{CUdeviceptr},
+    @gcsafe_ccall libcuda.cuExternalMemoryGetMappedBuffer(devPtr::Ptr{CUdeviceptr},
                                                    extMem::CUexternalMemory,
                                                    bufferDesc::Ptr{CUDA_EXTERNAL_MEMORY_BUFFER_DESC})::CUresult
 end
 
 @checked function cuExternalMemoryGetMappedMipmappedArray(mipmap, extMem, mipmapDesc)
     initialize_context()
-    @ccall libcuda.cuExternalMemoryGetMappedMipmappedArray(mipmap::Ptr{CUmipmappedArray},
+    @gcsafe_ccall libcuda.cuExternalMemoryGetMappedMipmappedArray(mipmap::Ptr{CUmipmappedArray},
                                                            extMem::CUexternalMemory,
                                                            mipmapDesc::Ptr{CUDA_EXTERNAL_MEMORY_MIPMAPPED_ARRAY_DESC})::CUresult
 end
 
 @checked function cuDestroyExternalMemory(extMem)
     initialize_context()
-    @ccall libcuda.cuDestroyExternalMemory(extMem::CUexternalMemory)::CUresult
+    @gcsafe_ccall libcuda.cuDestroyExternalMemory(extMem::CUexternalMemory)::CUresult
 end
 
 @checked function cuImportExternalSemaphore(extSem_out, semHandleDesc)
     initialize_context()
-    @ccall libcuda.cuImportExternalSemaphore(extSem_out::Ptr{CUexternalSemaphore},
+    @gcsafe_ccall libcuda.cuImportExternalSemaphore(extSem_out::Ptr{CUexternalSemaphore},
                                              semHandleDesc::Ptr{CUDA_EXTERNAL_SEMAPHORE_HANDLE_DESC})::CUresult
 end
 
 @checked function cuSignalExternalSemaphoresAsync(extSemArray, paramsArray, numExtSems,
                                                   stream)
     initialize_context()
-    @ccall libcuda.cuSignalExternalSemaphoresAsync(extSemArray::Ptr{CUexternalSemaphore},
+    @gcsafe_ccall libcuda.cuSignalExternalSemaphoresAsync(extSemArray::Ptr{CUexternalSemaphore},
                                                    paramsArray::Ptr{CUDA_EXTERNAL_SEMAPHORE_SIGNAL_PARAMS},
                                                    numExtSems::Cuint,
                                                    stream::CUstream)::CUresult
@@ -4118,7 +4118,7 @@ end
 @checked function cuWaitExternalSemaphoresAsync(extSemArray, paramsArray, numExtSems,
                                                 stream)
     initialize_context()
-    @ccall libcuda.cuWaitExternalSemaphoresAsync(extSemArray::Ptr{CUexternalSemaphore},
+    @gcsafe_ccall libcuda.cuWaitExternalSemaphoresAsync(extSemArray::Ptr{CUexternalSemaphore},
                                                  paramsArray::Ptr{CUDA_EXTERNAL_SEMAPHORE_WAIT_PARAMS},
                                                  numExtSems::Cuint,
                                                  stream::CUstream)::CUresult
@@ -4126,46 +4126,46 @@ end
 
 @checked function cuDestroyExternalSemaphore(extSem)
     initialize_context()
-    @ccall libcuda.cuDestroyExternalSemaphore(extSem::CUexternalSemaphore)::CUresult
+    @gcsafe_ccall libcuda.cuDestroyExternalSemaphore(extSem::CUexternalSemaphore)::CUresult
 end
 
 @checked function cuFuncGetAttribute(pi, attrib, hfunc)
     initialize_context()
-    @ccall libcuda.cuFuncGetAttribute(pi::Ptr{Cint}, attrib::CUfunction_attribute,
+    @gcsafe_ccall libcuda.cuFuncGetAttribute(pi::Ptr{Cint}, attrib::CUfunction_attribute,
                                       hfunc::CUfunction)::CUresult
 end
 
 @checked function cuFuncSetAttribute(hfunc, attrib, value)
     initialize_context()
-    @ccall libcuda.cuFuncSetAttribute(hfunc::CUfunction, attrib::CUfunction_attribute,
+    @gcsafe_ccall libcuda.cuFuncSetAttribute(hfunc::CUfunction, attrib::CUfunction_attribute,
                                       value::Cint)::CUresult
 end
 
 @checked function cuFuncSetCacheConfig(hfunc, config)
     initialize_context()
-    @ccall libcuda.cuFuncSetCacheConfig(hfunc::CUfunction, config::CUfunc_cache)::CUresult
+    @gcsafe_ccall libcuda.cuFuncSetCacheConfig(hfunc::CUfunction, config::CUfunc_cache)::CUresult
 end
 
 @checked function cuFuncSetSharedMemConfig(hfunc, config)
     initialize_context()
-    @ccall libcuda.cuFuncSetSharedMemConfig(hfunc::CUfunction,
+    @gcsafe_ccall libcuda.cuFuncSetSharedMemConfig(hfunc::CUfunction,
                                             config::CUsharedconfig)::CUresult
 end
 
 @checked function cuFuncGetModule(hmod, hfunc)
     initialize_context()
-    @ccall libcuda.cuFuncGetModule(hmod::Ptr{CUmodule}, hfunc::CUfunction)::CUresult
+    @gcsafe_ccall libcuda.cuFuncGetModule(hmod::Ptr{CUmodule}, hfunc::CUfunction)::CUresult
 end
 
 @checked function cuFuncGetName(name, hfunc)
     initialize_context()
-    @ccall libcuda.cuFuncGetName(name::Ptr{Cstring}, hfunc::CUfunction)::CUresult
+    @gcsafe_ccall libcuda.cuFuncGetName(name::Ptr{Cstring}, hfunc::CUfunction)::CUresult
 end
 
 @checked function cuLaunchKernel(f, gridDimX, gridDimY, gridDimZ, blockDimX, blockDimY,
                                  blockDimZ, sharedMemBytes, hStream, kernelParams, extra)
     initialize_context()
-    @ccall libcuda.cuLaunchKernel(f::CUfunction, gridDimX::Cuint, gridDimY::Cuint,
+    @gcsafe_ccall libcuda.cuLaunchKernel(f::CUfunction, gridDimX::Cuint, gridDimY::Cuint,
                                   gridDimZ::Cuint, blockDimX::Cuint, blockDimY::Cuint,
                                   blockDimZ::Cuint, sharedMemBytes::Cuint,
                                   hStream::CUstream, kernelParams::Ptr{Ptr{Cvoid}},
@@ -4174,7 +4174,7 @@ end
 
 @checked function cuLaunchKernelEx(config, f, kernelParams, extra)
     initialize_context()
-    @ccall libcuda.cuLaunchKernelEx(config::Ptr{CUlaunchConfig}, f::CUfunction,
+    @gcsafe_ccall libcuda.cuLaunchKernelEx(config::Ptr{CUlaunchConfig}, f::CUfunction,
                                     kernelParams::Ptr{Ptr{Cvoid}},
                                     extra::Ptr{Ptr{Cvoid}})::CUresult
 end
@@ -4183,7 +4183,7 @@ end
                                             blockDimY, blockDimZ, sharedMemBytes, hStream,
                                             kernelParams)
     initialize_context()
-    @ccall libcuda.cuLaunchCooperativeKernel(f::CUfunction, gridDimX::Cuint,
+    @gcsafe_ccall libcuda.cuLaunchCooperativeKernel(f::CUfunction, gridDimX::Cuint,
                                              gridDimY::Cuint, gridDimZ::Cuint,
                                              blockDimX::Cuint, blockDimY::Cuint,
                                              blockDimZ::Cuint, sharedMemBytes::Cuint,
@@ -4193,81 +4193,81 @@ end
 
 @checked function cuLaunchCooperativeKernelMultiDevice(launchParamsList, numDevices, flags)
     initialize_context()
-    @ccall libcuda.cuLaunchCooperativeKernelMultiDevice(launchParamsList::Ptr{CUDA_LAUNCH_PARAMS},
+    @gcsafe_ccall libcuda.cuLaunchCooperativeKernelMultiDevice(launchParamsList::Ptr{CUDA_LAUNCH_PARAMS},
                                                         numDevices::Cuint,
                                                         flags::Cuint)::CUresult
 end
 
 @checked function cuLaunchHostFunc(hStream, fn, userData)
     initialize_context()
-    @ccall libcuda.cuLaunchHostFunc(hStream::CUstream, fn::CUhostFn,
+    @gcsafe_ccall libcuda.cuLaunchHostFunc(hStream::CUstream, fn::CUhostFn,
                                     userData::Ptr{Cvoid})::CUresult
 end
 
 @checked function cuFuncSetBlockShape(hfunc, x, y, z)
     initialize_context()
-    @ccall libcuda.cuFuncSetBlockShape(hfunc::CUfunction, x::Cint, y::Cint,
+    @gcsafe_ccall libcuda.cuFuncSetBlockShape(hfunc::CUfunction, x::Cint, y::Cint,
                                        z::Cint)::CUresult
 end
 
 @checked function cuFuncSetSharedSize(hfunc, bytes)
     initialize_context()
-    @ccall libcuda.cuFuncSetSharedSize(hfunc::CUfunction, bytes::Cuint)::CUresult
+    @gcsafe_ccall libcuda.cuFuncSetSharedSize(hfunc::CUfunction, bytes::Cuint)::CUresult
 end
 
 @checked function cuParamSetSize(hfunc, numbytes)
     initialize_context()
-    @ccall libcuda.cuParamSetSize(hfunc::CUfunction, numbytes::Cuint)::CUresult
+    @gcsafe_ccall libcuda.cuParamSetSize(hfunc::CUfunction, numbytes::Cuint)::CUresult
 end
 
 @checked function cuParamSeti(hfunc, offset, value)
     initialize_context()
-    @ccall libcuda.cuParamSeti(hfunc::CUfunction, offset::Cint, value::Cuint)::CUresult
+    @gcsafe_ccall libcuda.cuParamSeti(hfunc::CUfunction, offset::Cint, value::Cuint)::CUresult
 end
 
 @checked function cuParamSetf(hfunc, offset, value)
     initialize_context()
-    @ccall libcuda.cuParamSetf(hfunc::CUfunction, offset::Cint, value::Cfloat)::CUresult
+    @gcsafe_ccall libcuda.cuParamSetf(hfunc::CUfunction, offset::Cint, value::Cfloat)::CUresult
 end
 
 @checked function cuParamSetv(hfunc, offset, ptr, numbytes)
     initialize_context()
-    @ccall libcuda.cuParamSetv(hfunc::CUfunction, offset::Cint, ptr::Ptr{Cvoid},
+    @gcsafe_ccall libcuda.cuParamSetv(hfunc::CUfunction, offset::Cint, ptr::Ptr{Cvoid},
                                numbytes::Cuint)::CUresult
 end
 
 @checked function cuLaunch(f)
     initialize_context()
-    @ccall libcuda.cuLaunch(f::CUfunction)::CUresult
+    @gcsafe_ccall libcuda.cuLaunch(f::CUfunction)::CUresult
 end
 
 @checked function cuLaunchGrid(f, grid_width, grid_height)
     initialize_context()
-    @ccall libcuda.cuLaunchGrid(f::CUfunction, grid_width::Cint,
+    @gcsafe_ccall libcuda.cuLaunchGrid(f::CUfunction, grid_width::Cint,
                                 grid_height::Cint)::CUresult
 end
 
 @checked function cuLaunchGridAsync(f, grid_width, grid_height, hStream)
     initialize_context()
-    @ccall libcuda.cuLaunchGridAsync(f::CUfunction, grid_width::Cint, grid_height::Cint,
+    @gcsafe_ccall libcuda.cuLaunchGridAsync(f::CUfunction, grid_width::Cint, grid_height::Cint,
                                      hStream::CUstream)::CUresult
 end
 
 @checked function cuParamSetTexRef(hfunc, texunit, hTexRef)
     initialize_context()
-    @ccall libcuda.cuParamSetTexRef(hfunc::CUfunction, texunit::Cint,
+    @gcsafe_ccall libcuda.cuParamSetTexRef(hfunc::CUfunction, texunit::Cint,
                                     hTexRef::CUtexref)::CUresult
 end
 
 @checked function cuGraphCreate(phGraph, flags)
     initialize_context()
-    @ccall libcuda.cuGraphCreate(phGraph::Ptr{CUgraph}, flags::Cuint)::CUresult
+    @gcsafe_ccall libcuda.cuGraphCreate(phGraph::Ptr{CUgraph}, flags::Cuint)::CUresult
 end
 
 @checked function cuGraphAddMemcpyNode(phGraphNode, hGraph, dependencies, numDependencies,
                                        copyParams, ctx)
     initialize_context()
-    @ccall libcuda.cuGraphAddMemcpyNode(phGraphNode::Ptr{CUgraphNode}, hGraph::CUgraph,
+    @gcsafe_ccall libcuda.cuGraphAddMemcpyNode(phGraphNode::Ptr{CUgraphNode}, hGraph::CUgraph,
                                         dependencies::Ptr{CUgraphNode},
                                         numDependencies::Csize_t,
                                         copyParams::Ptr{CUDA_MEMCPY3D},
@@ -4276,20 +4276,20 @@ end
 
 @checked function cuGraphMemcpyNodeGetParams(hNode, nodeParams)
     initialize_context()
-    @ccall libcuda.cuGraphMemcpyNodeGetParams(hNode::CUgraphNode,
+    @gcsafe_ccall libcuda.cuGraphMemcpyNodeGetParams(hNode::CUgraphNode,
                                               nodeParams::Ptr{CUDA_MEMCPY3D})::CUresult
 end
 
 @checked function cuGraphMemcpyNodeSetParams(hNode, nodeParams)
     initialize_context()
-    @ccall libcuda.cuGraphMemcpyNodeSetParams(hNode::CUgraphNode,
+    @gcsafe_ccall libcuda.cuGraphMemcpyNodeSetParams(hNode::CUgraphNode,
                                               nodeParams::Ptr{CUDA_MEMCPY3D})::CUresult
 end
 
 @checked function cuGraphAddMemsetNode(phGraphNode, hGraph, dependencies, numDependencies,
                                        memsetParams, ctx)
     initialize_context()
-    @ccall libcuda.cuGraphAddMemsetNode(phGraphNode::Ptr{CUgraphNode}, hGraph::CUgraph,
+    @gcsafe_ccall libcuda.cuGraphAddMemsetNode(phGraphNode::Ptr{CUgraphNode}, hGraph::CUgraph,
                                         dependencies::Ptr{CUgraphNode},
                                         numDependencies::Csize_t,
                                         memsetParams::Ptr{CUDA_MEMSET_NODE_PARAMS},
@@ -4298,20 +4298,20 @@ end
 
 @checked function cuGraphMemsetNodeGetParams(hNode, nodeParams)
     initialize_context()
-    @ccall libcuda.cuGraphMemsetNodeGetParams(hNode::CUgraphNode,
+    @gcsafe_ccall libcuda.cuGraphMemsetNodeGetParams(hNode::CUgraphNode,
                                               nodeParams::Ptr{CUDA_MEMSET_NODE_PARAMS})::CUresult
 end
 
 @checked function cuGraphMemsetNodeSetParams(hNode, nodeParams)
     initialize_context()
-    @ccall libcuda.cuGraphMemsetNodeSetParams(hNode::CUgraphNode,
+    @gcsafe_ccall libcuda.cuGraphMemsetNodeSetParams(hNode::CUgraphNode,
                                               nodeParams::Ptr{CUDA_MEMSET_NODE_PARAMS})::CUresult
 end
 
 @checked function cuGraphAddHostNode(phGraphNode, hGraph, dependencies, numDependencies,
                                      nodeParams)
     initialize_context()
-    @ccall libcuda.cuGraphAddHostNode(phGraphNode::Ptr{CUgraphNode}, hGraph::CUgraph,
+    @gcsafe_ccall libcuda.cuGraphAddHostNode(phGraphNode::Ptr{CUgraphNode}, hGraph::CUgraph,
                                       dependencies::Ptr{CUgraphNode},
                                       numDependencies::Csize_t,
                                       nodeParams::Ptr{CUDA_HOST_NODE_PARAMS})::CUresult
@@ -4319,20 +4319,20 @@ end
 
 @checked function cuGraphHostNodeGetParams(hNode, nodeParams)
     initialize_context()
-    @ccall libcuda.cuGraphHostNodeGetParams(hNode::CUgraphNode,
+    @gcsafe_ccall libcuda.cuGraphHostNodeGetParams(hNode::CUgraphNode,
                                             nodeParams::Ptr{CUDA_HOST_NODE_PARAMS})::CUresult
 end
 
 @checked function cuGraphHostNodeSetParams(hNode, nodeParams)
     initialize_context()
-    @ccall libcuda.cuGraphHostNodeSetParams(hNode::CUgraphNode,
+    @gcsafe_ccall libcuda.cuGraphHostNodeSetParams(hNode::CUgraphNode,
                                             nodeParams::Ptr{CUDA_HOST_NODE_PARAMS})::CUresult
 end
 
 @checked function cuGraphAddChildGraphNode(phGraphNode, hGraph, dependencies,
                                            numDependencies, childGraph)
     initialize_context()
-    @ccall libcuda.cuGraphAddChildGraphNode(phGraphNode::Ptr{CUgraphNode}, hGraph::CUgraph,
+    @gcsafe_ccall libcuda.cuGraphAddChildGraphNode(phGraphNode::Ptr{CUgraphNode}, hGraph::CUgraph,
                                             dependencies::Ptr{CUgraphNode},
                                             numDependencies::Csize_t,
                                             childGraph::CUgraph)::CUresult
@@ -4340,13 +4340,13 @@ end
 
 @checked function cuGraphChildGraphNodeGetGraph(hNode, phGraph)
     initialize_context()
-    @ccall libcuda.cuGraphChildGraphNodeGetGraph(hNode::CUgraphNode,
+    @gcsafe_ccall libcuda.cuGraphChildGraphNodeGetGraph(hNode::CUgraphNode,
                                                  phGraph::Ptr{CUgraph})::CUresult
 end
 
 @checked function cuGraphAddEmptyNode(phGraphNode, hGraph, dependencies, numDependencies)
     initialize_context()
-    @ccall libcuda.cuGraphAddEmptyNode(phGraphNode::Ptr{CUgraphNode}, hGraph::CUgraph,
+    @gcsafe_ccall libcuda.cuGraphAddEmptyNode(phGraphNode::Ptr{CUgraphNode}, hGraph::CUgraph,
                                        dependencies::Ptr{CUgraphNode},
                                        numDependencies::Csize_t)::CUresult
 end
@@ -4354,7 +4354,7 @@ end
 @checked function cuGraphAddEventRecordNode(phGraphNode, hGraph, dependencies,
                                             numDependencies, event)
     initialize_context()
-    @ccall libcuda.cuGraphAddEventRecordNode(phGraphNode::Ptr{CUgraphNode}, hGraph::CUgraph,
+    @gcsafe_ccall libcuda.cuGraphAddEventRecordNode(phGraphNode::Ptr{CUgraphNode}, hGraph::CUgraph,
                                              dependencies::Ptr{CUgraphNode},
                                              numDependencies::Csize_t,
                                              event::CUevent)::CUresult
@@ -4362,20 +4362,20 @@ end
 
 @checked function cuGraphEventRecordNodeGetEvent(hNode, event_out)
     initialize_context()
-    @ccall libcuda.cuGraphEventRecordNodeGetEvent(hNode::CUgraphNode,
+    @gcsafe_ccall libcuda.cuGraphEventRecordNodeGetEvent(hNode::CUgraphNode,
                                                   event_out::Ptr{CUevent})::CUresult
 end
 
 @checked function cuGraphEventRecordNodeSetEvent(hNode, event)
     initialize_context()
-    @ccall libcuda.cuGraphEventRecordNodeSetEvent(hNode::CUgraphNode,
+    @gcsafe_ccall libcuda.cuGraphEventRecordNodeSetEvent(hNode::CUgraphNode,
                                                   event::CUevent)::CUresult
 end
 
 @checked function cuGraphAddEventWaitNode(phGraphNode, hGraph, dependencies,
                                           numDependencies, event)
     initialize_context()
-    @ccall libcuda.cuGraphAddEventWaitNode(phGraphNode::Ptr{CUgraphNode}, hGraph::CUgraph,
+    @gcsafe_ccall libcuda.cuGraphAddEventWaitNode(phGraphNode::Ptr{CUgraphNode}, hGraph::CUgraph,
                                            dependencies::Ptr{CUgraphNode},
                                            numDependencies::Csize_t,
                                            event::CUevent)::CUresult
@@ -4383,20 +4383,20 @@ end
 
 @checked function cuGraphEventWaitNodeGetEvent(hNode, event_out)
     initialize_context()
-    @ccall libcuda.cuGraphEventWaitNodeGetEvent(hNode::CUgraphNode,
+    @gcsafe_ccall libcuda.cuGraphEventWaitNodeGetEvent(hNode::CUgraphNode,
                                                 event_out::Ptr{CUevent})::CUresult
 end
 
 @checked function cuGraphEventWaitNodeSetEvent(hNode, event)
     initialize_context()
-    @ccall libcuda.cuGraphEventWaitNodeSetEvent(hNode::CUgraphNode,
+    @gcsafe_ccall libcuda.cuGraphEventWaitNodeSetEvent(hNode::CUgraphNode,
                                                 event::CUevent)::CUresult
 end
 
 @checked function cuGraphAddExternalSemaphoresSignalNode(phGraphNode, hGraph, dependencies,
                                                          numDependencies, nodeParams)
     initialize_context()
-    @ccall libcuda.cuGraphAddExternalSemaphoresSignalNode(phGraphNode::Ptr{CUgraphNode},
+    @gcsafe_ccall libcuda.cuGraphAddExternalSemaphoresSignalNode(phGraphNode::Ptr{CUgraphNode},
                                                           hGraph::CUgraph,
                                                           dependencies::Ptr{CUgraphNode},
                                                           numDependencies::Csize_t,
@@ -4405,20 +4405,20 @@ end
 
 @checked function cuGraphExternalSemaphoresSignalNodeGetParams(hNode, params_out)
     initialize_context()
-    @ccall libcuda.cuGraphExternalSemaphoresSignalNodeGetParams(hNode::CUgraphNode,
+    @gcsafe_ccall libcuda.cuGraphExternalSemaphoresSignalNodeGetParams(hNode::CUgraphNode,
                                                                 params_out::Ptr{CUDA_EXT_SEM_SIGNAL_NODE_PARAMS})::CUresult
 end
 
 @checked function cuGraphExternalSemaphoresSignalNodeSetParams(hNode, nodeParams)
     initialize_context()
-    @ccall libcuda.cuGraphExternalSemaphoresSignalNodeSetParams(hNode::CUgraphNode,
+    @gcsafe_ccall libcuda.cuGraphExternalSemaphoresSignalNodeSetParams(hNode::CUgraphNode,
                                                                 nodeParams::Ptr{CUDA_EXT_SEM_SIGNAL_NODE_PARAMS})::CUresult
 end
 
 @checked function cuGraphAddExternalSemaphoresWaitNode(phGraphNode, hGraph, dependencies,
                                                        numDependencies, nodeParams)
     initialize_context()
-    @ccall libcuda.cuGraphAddExternalSemaphoresWaitNode(phGraphNode::Ptr{CUgraphNode},
+    @gcsafe_ccall libcuda.cuGraphAddExternalSemaphoresWaitNode(phGraphNode::Ptr{CUgraphNode},
                                                         hGraph::CUgraph,
                                                         dependencies::Ptr{CUgraphNode},
                                                         numDependencies::Csize_t,
@@ -4427,20 +4427,20 @@ end
 
 @checked function cuGraphExternalSemaphoresWaitNodeGetParams(hNode, params_out)
     initialize_context()
-    @ccall libcuda.cuGraphExternalSemaphoresWaitNodeGetParams(hNode::CUgraphNode,
+    @gcsafe_ccall libcuda.cuGraphExternalSemaphoresWaitNodeGetParams(hNode::CUgraphNode,
                                                               params_out::Ptr{CUDA_EXT_SEM_WAIT_NODE_PARAMS})::CUresult
 end
 
 @checked function cuGraphExternalSemaphoresWaitNodeSetParams(hNode, nodeParams)
     initialize_context()
-    @ccall libcuda.cuGraphExternalSemaphoresWaitNodeSetParams(hNode::CUgraphNode,
+    @gcsafe_ccall libcuda.cuGraphExternalSemaphoresWaitNodeSetParams(hNode::CUgraphNode,
                                                               nodeParams::Ptr{CUDA_EXT_SEM_WAIT_NODE_PARAMS})::CUresult
 end
 
 @checked function cuGraphAddBatchMemOpNode(phGraphNode, hGraph, dependencies,
                                            numDependencies, nodeParams)
     initialize_context()
-    @ccall libcuda.cuGraphAddBatchMemOpNode(phGraphNode::Ptr{CUgraphNode}, hGraph::CUgraph,
+    @gcsafe_ccall libcuda.cuGraphAddBatchMemOpNode(phGraphNode::Ptr{CUgraphNode}, hGraph::CUgraph,
                                             dependencies::Ptr{CUgraphNode},
                                             numDependencies::Csize_t,
                                             nodeParams::Ptr{CUDA_BATCH_MEM_OP_NODE_PARAMS})::CUresult
@@ -4448,19 +4448,19 @@ end
 
 @checked function cuGraphBatchMemOpNodeGetParams(hNode, nodeParams_out)
     initialize_context()
-    @ccall libcuda.cuGraphBatchMemOpNodeGetParams(hNode::CUgraphNode,
+    @gcsafe_ccall libcuda.cuGraphBatchMemOpNodeGetParams(hNode::CUgraphNode,
                                                   nodeParams_out::Ptr{CUDA_BATCH_MEM_OP_NODE_PARAMS})::CUresult
 end
 
 @checked function cuGraphBatchMemOpNodeSetParams(hNode, nodeParams)
     initialize_context()
-    @ccall libcuda.cuGraphBatchMemOpNodeSetParams(hNode::CUgraphNode,
+    @gcsafe_ccall libcuda.cuGraphBatchMemOpNodeSetParams(hNode::CUgraphNode,
                                                   nodeParams::Ptr{CUDA_BATCH_MEM_OP_NODE_PARAMS})::CUresult
 end
 
 @checked function cuGraphExecBatchMemOpNodeSetParams(hGraphExec, hNode, nodeParams)
     initialize_context()
-    @ccall libcuda.cuGraphExecBatchMemOpNodeSetParams(hGraphExec::CUgraphExec,
+    @gcsafe_ccall libcuda.cuGraphExecBatchMemOpNodeSetParams(hGraphExec::CUgraphExec,
                                                       hNode::CUgraphNode,
                                                       nodeParams::Ptr{CUDA_BATCH_MEM_OP_NODE_PARAMS})::CUresult
 end
@@ -4468,7 +4468,7 @@ end
 @checked function cuGraphAddMemAllocNode(phGraphNode, hGraph, dependencies, numDependencies,
                                          nodeParams)
     initialize_context()
-    @ccall libcuda.cuGraphAddMemAllocNode(phGraphNode::Ptr{CUgraphNode}, hGraph::CUgraph,
+    @gcsafe_ccall libcuda.cuGraphAddMemAllocNode(phGraphNode::Ptr{CUgraphNode}, hGraph::CUgraph,
                                           dependencies::Ptr{CUgraphNode},
                                           numDependencies::Csize_t,
                                           nodeParams::Ptr{CUDA_MEM_ALLOC_NODE_PARAMS})::CUresult
@@ -4476,14 +4476,14 @@ end
 
 @checked function cuGraphMemAllocNodeGetParams(hNode, params_out)
     initialize_context()
-    @ccall libcuda.cuGraphMemAllocNodeGetParams(hNode::CUgraphNode,
+    @gcsafe_ccall libcuda.cuGraphMemAllocNodeGetParams(hNode::CUgraphNode,
                                                 params_out::Ptr{CUDA_MEM_ALLOC_NODE_PARAMS})::CUresult
 end
 
 @checked function cuGraphAddMemFreeNode(phGraphNode, hGraph, dependencies, numDependencies,
                                         dptr)
     initialize_context()
-    @ccall libcuda.cuGraphAddMemFreeNode(phGraphNode::Ptr{CUgraphNode}, hGraph::CUgraph,
+    @gcsafe_ccall libcuda.cuGraphAddMemFreeNode(phGraphNode::Ptr{CUgraphNode}, hGraph::CUgraph,
                                          dependencies::Ptr{CUgraphNode},
                                          numDependencies::Csize_t,
                                          dptr::CUdeviceptr)::CUresult
@@ -4491,76 +4491,76 @@ end
 
 @checked function cuGraphMemFreeNodeGetParams(hNode, dptr_out)
     initialize_context()
-    @ccall libcuda.cuGraphMemFreeNodeGetParams(hNode::CUgraphNode,
+    @gcsafe_ccall libcuda.cuGraphMemFreeNodeGetParams(hNode::CUgraphNode,
                                                dptr_out::Ptr{CUdeviceptr})::CUresult
 end
 
 @checked function cuDeviceGraphMemTrim(device)
     initialize_context()
-    @ccall libcuda.cuDeviceGraphMemTrim(device::CUdevice)::CUresult
+    @gcsafe_ccall libcuda.cuDeviceGraphMemTrim(device::CUdevice)::CUresult
 end
 
 @checked function cuDeviceGetGraphMemAttribute(device, attr, value)
     initialize_context()
-    @ccall libcuda.cuDeviceGetGraphMemAttribute(device::CUdevice,
+    @gcsafe_ccall libcuda.cuDeviceGetGraphMemAttribute(device::CUdevice,
                                                 attr::CUgraphMem_attribute,
                                                 value::Ptr{Cvoid})::CUresult
 end
 
 @checked function cuDeviceSetGraphMemAttribute(device, attr, value)
     initialize_context()
-    @ccall libcuda.cuDeviceSetGraphMemAttribute(device::CUdevice,
+    @gcsafe_ccall libcuda.cuDeviceSetGraphMemAttribute(device::CUdevice,
                                                 attr::CUgraphMem_attribute,
                                                 value::Ptr{Cvoid})::CUresult
 end
 
 @checked function cuGraphClone(phGraphClone, originalGraph)
     initialize_context()
-    @ccall libcuda.cuGraphClone(phGraphClone::Ptr{CUgraph},
+    @gcsafe_ccall libcuda.cuGraphClone(phGraphClone::Ptr{CUgraph},
                                 originalGraph::CUgraph)::CUresult
 end
 
 @checked function cuGraphNodeFindInClone(phNode, hOriginalNode, hClonedGraph)
     initialize_context()
-    @ccall libcuda.cuGraphNodeFindInClone(phNode::Ptr{CUgraphNode},
+    @gcsafe_ccall libcuda.cuGraphNodeFindInClone(phNode::Ptr{CUgraphNode},
                                           hOriginalNode::CUgraphNode,
                                           hClonedGraph::CUgraph)::CUresult
 end
 
 @checked function cuGraphNodeGetType(hNode, type)
     initialize_context()
-    @ccall libcuda.cuGraphNodeGetType(hNode::CUgraphNode,
+    @gcsafe_ccall libcuda.cuGraphNodeGetType(hNode::CUgraphNode,
                                       type::Ptr{CUgraphNodeType})::CUresult
 end
 
 @checked function cuGraphGetNodes(hGraph, nodes, numNodes)
     initialize_context()
-    @ccall libcuda.cuGraphGetNodes(hGraph::CUgraph, nodes::Ptr{CUgraphNode},
+    @gcsafe_ccall libcuda.cuGraphGetNodes(hGraph::CUgraph, nodes::Ptr{CUgraphNode},
                                    numNodes::Ptr{Csize_t})::CUresult
 end
 
 @checked function cuGraphGetRootNodes(hGraph, rootNodes, numRootNodes)
     initialize_context()
-    @ccall libcuda.cuGraphGetRootNodes(hGraph::CUgraph, rootNodes::Ptr{CUgraphNode},
+    @gcsafe_ccall libcuda.cuGraphGetRootNodes(hGraph::CUgraph, rootNodes::Ptr{CUgraphNode},
                                        numRootNodes::Ptr{Csize_t})::CUresult
 end
 
 @checked function cuGraphGetEdges(hGraph, from, to, numEdges)
     initialize_context()
-    @ccall libcuda.cuGraphGetEdges(hGraph::CUgraph, from::Ptr{CUgraphNode},
+    @gcsafe_ccall libcuda.cuGraphGetEdges(hGraph::CUgraph, from::Ptr{CUgraphNode},
                                    to::Ptr{CUgraphNode}, numEdges::Ptr{Csize_t})::CUresult
 end
 
 @checked function cuGraphGetEdges_v2(hGraph, from, to, edgeData, numEdges)
     initialize_context()
-    @ccall libcuda.cuGraphGetEdges_v2(hGraph::CUgraph, from::Ptr{CUgraphNode},
+    @gcsafe_ccall libcuda.cuGraphGetEdges_v2(hGraph::CUgraph, from::Ptr{CUgraphNode},
                                       to::Ptr{CUgraphNode}, edgeData::Ptr{CUgraphEdgeData},
                                       numEdges::Ptr{Csize_t})::CUresult
 end
 
 @checked function cuGraphNodeGetDependencies(hNode, dependencies, numDependencies)
     initialize_context()
-    @ccall libcuda.cuGraphNodeGetDependencies(hNode::CUgraphNode,
+    @gcsafe_ccall libcuda.cuGraphNodeGetDependencies(hNode::CUgraphNode,
                                               dependencies::Ptr{CUgraphNode},
                                               numDependencies::Ptr{Csize_t})::CUresult
 end
@@ -4568,7 +4568,7 @@ end
 @checked function cuGraphNodeGetDependencies_v2(hNode, dependencies, edgeData,
                                                 numDependencies)
     initialize_context()
-    @ccall libcuda.cuGraphNodeGetDependencies_v2(hNode::CUgraphNode,
+    @gcsafe_ccall libcuda.cuGraphNodeGetDependencies_v2(hNode::CUgraphNode,
                                                  dependencies::Ptr{CUgraphNode},
                                                  edgeData::Ptr{CUgraphEdgeData},
                                                  numDependencies::Ptr{Csize_t})::CUresult
@@ -4576,7 +4576,7 @@ end
 
 @checked function cuGraphNodeGetDependentNodes(hNode, dependentNodes, numDependentNodes)
     initialize_context()
-    @ccall libcuda.cuGraphNodeGetDependentNodes(hNode::CUgraphNode,
+    @gcsafe_ccall libcuda.cuGraphNodeGetDependentNodes(hNode::CUgraphNode,
                                                 dependentNodes::Ptr{CUgraphNode},
                                                 numDependentNodes::Ptr{Csize_t})::CUresult
 end
@@ -4584,7 +4584,7 @@ end
 @checked function cuGraphNodeGetDependentNodes_v2(hNode, dependentNodes, edgeData,
                                                   numDependentNodes)
     initialize_context()
-    @ccall libcuda.cuGraphNodeGetDependentNodes_v2(hNode::CUgraphNode,
+    @gcsafe_ccall libcuda.cuGraphNodeGetDependentNodes_v2(hNode::CUgraphNode,
                                                    dependentNodes::Ptr{CUgraphNode},
                                                    edgeData::Ptr{CUgraphEdgeData},
                                                    numDependentNodes::Ptr{Csize_t})::CUresult
@@ -4592,14 +4592,14 @@ end
 
 @checked function cuGraphAddDependencies(hGraph, from, to, numDependencies)
     initialize_context()
-    @ccall libcuda.cuGraphAddDependencies(hGraph::CUgraph, from::Ptr{CUgraphNode},
+    @gcsafe_ccall libcuda.cuGraphAddDependencies(hGraph::CUgraph, from::Ptr{CUgraphNode},
                                           to::Ptr{CUgraphNode},
                                           numDependencies::Csize_t)::CUresult
 end
 
 @checked function cuGraphAddDependencies_v2(hGraph, from, to, edgeData, numDependencies)
     initialize_context()
-    @ccall libcuda.cuGraphAddDependencies_v2(hGraph::CUgraph, from::Ptr{CUgraphNode},
+    @gcsafe_ccall libcuda.cuGraphAddDependencies_v2(hGraph::CUgraph, from::Ptr{CUgraphNode},
                                              to::Ptr{CUgraphNode},
                                              edgeData::Ptr{CUgraphEdgeData},
                                              numDependencies::Csize_t)::CUresult
@@ -4607,14 +4607,14 @@ end
 
 @checked function cuGraphRemoveDependencies(hGraph, from, to, numDependencies)
     initialize_context()
-    @ccall libcuda.cuGraphRemoveDependencies(hGraph::CUgraph, from::Ptr{CUgraphNode},
+    @gcsafe_ccall libcuda.cuGraphRemoveDependencies(hGraph::CUgraph, from::Ptr{CUgraphNode},
                                              to::Ptr{CUgraphNode},
                                              numDependencies::Csize_t)::CUresult
 end
 
 @checked function cuGraphRemoveDependencies_v2(hGraph, from, to, edgeData, numDependencies)
     initialize_context()
-    @ccall libcuda.cuGraphRemoveDependencies_v2(hGraph::CUgraph, from::Ptr{CUgraphNode},
+    @gcsafe_ccall libcuda.cuGraphRemoveDependencies_v2(hGraph::CUgraph, from::Ptr{CUgraphNode},
                                                 to::Ptr{CUgraphNode},
                                                 edgeData::Ptr{CUgraphEdgeData},
                                                 numDependencies::Csize_t)::CUresult
@@ -4622,25 +4622,25 @@ end
 
 @checked function cuGraphDestroyNode(hNode)
     initialize_context()
-    @ccall libcuda.cuGraphDestroyNode(hNode::CUgraphNode)::CUresult
+    @gcsafe_ccall libcuda.cuGraphDestroyNode(hNode::CUgraphNode)::CUresult
 end
 
 @checked function cuGraphInstantiateWithParams(phGraphExec, hGraph, instantiateParams)
     initialize_context()
-    @ccall libcuda.cuGraphInstantiateWithParams(phGraphExec::Ptr{CUgraphExec},
+    @gcsafe_ccall libcuda.cuGraphInstantiateWithParams(phGraphExec::Ptr{CUgraphExec},
                                                 hGraph::CUgraph,
                                                 instantiateParams::Ptr{CUDA_GRAPH_INSTANTIATE_PARAMS})::CUresult
 end
 
 @checked function cuGraphExecGetFlags(hGraphExec, flags)
     initialize_context()
-    @ccall libcuda.cuGraphExecGetFlags(hGraphExec::CUgraphExec,
+    @gcsafe_ccall libcuda.cuGraphExecGetFlags(hGraphExec::CUgraphExec,
                                        flags::Ptr{cuuint64_t})::CUresult
 end
 
 @checked function cuGraphExecMemcpyNodeSetParams(hGraphExec, hNode, copyParams, ctx)
     initialize_context()
-    @ccall libcuda.cuGraphExecMemcpyNodeSetParams(hGraphExec::CUgraphExec,
+    @gcsafe_ccall libcuda.cuGraphExecMemcpyNodeSetParams(hGraphExec::CUgraphExec,
                                                   hNode::CUgraphNode,
                                                   copyParams::Ptr{CUDA_MEMCPY3D},
                                                   ctx::CUcontext)::CUresult
@@ -4648,7 +4648,7 @@ end
 
 @checked function cuGraphExecMemsetNodeSetParams(hGraphExec, hNode, memsetParams, ctx)
     initialize_context()
-    @ccall libcuda.cuGraphExecMemsetNodeSetParams(hGraphExec::CUgraphExec,
+    @gcsafe_ccall libcuda.cuGraphExecMemsetNodeSetParams(hGraphExec::CUgraphExec,
                                                   hNode::CUgraphNode,
                                                   memsetParams::Ptr{CUDA_MEMSET_NODE_PARAMS},
                                                   ctx::CUcontext)::CUresult
@@ -4656,27 +4656,27 @@ end
 
 @checked function cuGraphExecHostNodeSetParams(hGraphExec, hNode, nodeParams)
     initialize_context()
-    @ccall libcuda.cuGraphExecHostNodeSetParams(hGraphExec::CUgraphExec, hNode::CUgraphNode,
+    @gcsafe_ccall libcuda.cuGraphExecHostNodeSetParams(hGraphExec::CUgraphExec, hNode::CUgraphNode,
                                                 nodeParams::Ptr{CUDA_HOST_NODE_PARAMS})::CUresult
 end
 
 @checked function cuGraphExecChildGraphNodeSetParams(hGraphExec, hNode, childGraph)
     initialize_context()
-    @ccall libcuda.cuGraphExecChildGraphNodeSetParams(hGraphExec::CUgraphExec,
+    @gcsafe_ccall libcuda.cuGraphExecChildGraphNodeSetParams(hGraphExec::CUgraphExec,
                                                       hNode::CUgraphNode,
                                                       childGraph::CUgraph)::CUresult
 end
 
 @checked function cuGraphExecEventRecordNodeSetEvent(hGraphExec, hNode, event)
     initialize_context()
-    @ccall libcuda.cuGraphExecEventRecordNodeSetEvent(hGraphExec::CUgraphExec,
+    @gcsafe_ccall libcuda.cuGraphExecEventRecordNodeSetEvent(hGraphExec::CUgraphExec,
                                                       hNode::CUgraphNode,
                                                       event::CUevent)::CUresult
 end
 
 @checked function cuGraphExecEventWaitNodeSetEvent(hGraphExec, hNode, event)
     initialize_context()
-    @ccall libcuda.cuGraphExecEventWaitNodeSetEvent(hGraphExec::CUgraphExec,
+    @gcsafe_ccall libcuda.cuGraphExecEventWaitNodeSetEvent(hGraphExec::CUgraphExec,
                                                     hNode::CUgraphNode,
                                                     event::CUevent)::CUresult
 end
@@ -4684,7 +4684,7 @@ end
 @checked function cuGraphExecExternalSemaphoresSignalNodeSetParams(hGraphExec, hNode,
                                                                    nodeParams)
     initialize_context()
-    @ccall libcuda.cuGraphExecExternalSemaphoresSignalNodeSetParams(hGraphExec::CUgraphExec,
+    @gcsafe_ccall libcuda.cuGraphExecExternalSemaphoresSignalNodeSetParams(hGraphExec::CUgraphExec,
                                                                     hNode::CUgraphNode,
                                                                     nodeParams::Ptr{CUDA_EXT_SEM_SIGNAL_NODE_PARAMS})::CUresult
 end
@@ -4692,102 +4692,102 @@ end
 @checked function cuGraphExecExternalSemaphoresWaitNodeSetParams(hGraphExec, hNode,
                                                                  nodeParams)
     initialize_context()
-    @ccall libcuda.cuGraphExecExternalSemaphoresWaitNodeSetParams(hGraphExec::CUgraphExec,
+    @gcsafe_ccall libcuda.cuGraphExecExternalSemaphoresWaitNodeSetParams(hGraphExec::CUgraphExec,
                                                                   hNode::CUgraphNode,
                                                                   nodeParams::Ptr{CUDA_EXT_SEM_WAIT_NODE_PARAMS})::CUresult
 end
 
 @checked function cuGraphNodeSetEnabled(hGraphExec, hNode, isEnabled)
     initialize_context()
-    @ccall libcuda.cuGraphNodeSetEnabled(hGraphExec::CUgraphExec, hNode::CUgraphNode,
+    @gcsafe_ccall libcuda.cuGraphNodeSetEnabled(hGraphExec::CUgraphExec, hNode::CUgraphNode,
                                          isEnabled::Cuint)::CUresult
 end
 
 @checked function cuGraphNodeGetEnabled(hGraphExec, hNode, isEnabled)
     initialize_context()
-    @ccall libcuda.cuGraphNodeGetEnabled(hGraphExec::CUgraphExec, hNode::CUgraphNode,
+    @gcsafe_ccall libcuda.cuGraphNodeGetEnabled(hGraphExec::CUgraphExec, hNode::CUgraphNode,
                                          isEnabled::Ptr{Cuint})::CUresult
 end
 
 @checked function cuGraphUpload(hGraphExec, hStream)
     initialize_context()
-    @ccall libcuda.cuGraphUpload(hGraphExec::CUgraphExec, hStream::CUstream)::CUresult
+    @gcsafe_ccall libcuda.cuGraphUpload(hGraphExec::CUgraphExec, hStream::CUstream)::CUresult
 end
 
 @checked function cuGraphLaunch(hGraphExec, hStream)
     initialize_context()
-    @ccall libcuda.cuGraphLaunch(hGraphExec::CUgraphExec, hStream::CUstream)::CUresult
+    @gcsafe_ccall libcuda.cuGraphLaunch(hGraphExec::CUgraphExec, hStream::CUstream)::CUresult
 end
 
 @checked function cuGraphExecDestroy(hGraphExec)
     initialize_context()
-    @ccall libcuda.cuGraphExecDestroy(hGraphExec::CUgraphExec)::CUresult
+    @gcsafe_ccall libcuda.cuGraphExecDestroy(hGraphExec::CUgraphExec)::CUresult
 end
 
 @checked function cuGraphDestroy(hGraph)
     initialize_context()
-    @ccall libcuda.cuGraphDestroy(hGraph::CUgraph)::CUresult
+    @gcsafe_ccall libcuda.cuGraphDestroy(hGraph::CUgraph)::CUresult
 end
 
 @checked function cuGraphKernelNodeCopyAttributes(dst, src)
     initialize_context()
-    @ccall libcuda.cuGraphKernelNodeCopyAttributes(dst::CUgraphNode,
+    @gcsafe_ccall libcuda.cuGraphKernelNodeCopyAttributes(dst::CUgraphNode,
                                                    src::CUgraphNode)::CUresult
 end
 
 @checked function cuGraphKernelNodeGetAttribute(hNode, attr, value_out)
     initialize_context()
-    @ccall libcuda.cuGraphKernelNodeGetAttribute(hNode::CUgraphNode,
+    @gcsafe_ccall libcuda.cuGraphKernelNodeGetAttribute(hNode::CUgraphNode,
                                                  attr::CUkernelNodeAttrID,
                                                  value_out::Ptr{CUkernelNodeAttrValue})::CUresult
 end
 
 @checked function cuGraphKernelNodeSetAttribute(hNode, attr, value)
     initialize_context()
-    @ccall libcuda.cuGraphKernelNodeSetAttribute(hNode::CUgraphNode,
+    @gcsafe_ccall libcuda.cuGraphKernelNodeSetAttribute(hNode::CUgraphNode,
                                                  attr::CUkernelNodeAttrID,
                                                  value::Ptr{CUkernelNodeAttrValue})::CUresult
 end
 
 @checked function cuGraphDebugDotPrint(hGraph, path, flags)
     initialize_context()
-    @ccall libcuda.cuGraphDebugDotPrint(hGraph::CUgraph, path::Cstring,
+    @gcsafe_ccall libcuda.cuGraphDebugDotPrint(hGraph::CUgraph, path::Cstring,
                                         flags::Cuint)::CUresult
 end
 
 @checked function cuUserObjectCreate(object_out, ptr, destroy, initialRefcount, flags)
     initialize_context()
-    @ccall libcuda.cuUserObjectCreate(object_out::Ptr{CUuserObject}, ptr::Ptr{Cvoid},
+    @gcsafe_ccall libcuda.cuUserObjectCreate(object_out::Ptr{CUuserObject}, ptr::Ptr{Cvoid},
                                       destroy::CUhostFn, initialRefcount::Cuint,
                                       flags::Cuint)::CUresult
 end
 
 @checked function cuUserObjectRetain(object, count)
     initialize_context()
-    @ccall libcuda.cuUserObjectRetain(object::CUuserObject, count::Cuint)::CUresult
+    @gcsafe_ccall libcuda.cuUserObjectRetain(object::CUuserObject, count::Cuint)::CUresult
 end
 
 @checked function cuUserObjectRelease(object, count)
     initialize_context()
-    @ccall libcuda.cuUserObjectRelease(object::CUuserObject, count::Cuint)::CUresult
+    @gcsafe_ccall libcuda.cuUserObjectRelease(object::CUuserObject, count::Cuint)::CUresult
 end
 
 @checked function cuGraphRetainUserObject(graph, object, count, flags)
     initialize_context()
-    @ccall libcuda.cuGraphRetainUserObject(graph::CUgraph, object::CUuserObject,
+    @gcsafe_ccall libcuda.cuGraphRetainUserObject(graph::CUgraph, object::CUuserObject,
                                            count::Cuint, flags::Cuint)::CUresult
 end
 
 @checked function cuGraphReleaseUserObject(graph, object, count)
     initialize_context()
-    @ccall libcuda.cuGraphReleaseUserObject(graph::CUgraph, object::CUuserObject,
+    @gcsafe_ccall libcuda.cuGraphReleaseUserObject(graph::CUgraph, object::CUuserObject,
                                             count::Cuint)::CUresult
 end
 
 @checked function cuGraphAddNode(phGraphNode, hGraph, dependencies, numDependencies,
                                  nodeParams)
     initialize_context()
-    @ccall libcuda.cuGraphAddNode(phGraphNode::Ptr{CUgraphNode}, hGraph::CUgraph,
+    @gcsafe_ccall libcuda.cuGraphAddNode(phGraphNode::Ptr{CUgraphNode}, hGraph::CUgraph,
                                   dependencies::Ptr{CUgraphNode}, numDependencies::Csize_t,
                                   nodeParams::Ptr{CUgraphNodeParams})::CUresult
 end
@@ -4795,7 +4795,7 @@ end
 @checked function cuGraphAddNode_v2(phGraphNode, hGraph, dependencies, dependencyData,
                                     numDependencies, nodeParams)
     initialize_context()
-    @ccall libcuda.cuGraphAddNode_v2(phGraphNode::Ptr{CUgraphNode}, hGraph::CUgraph,
+    @gcsafe_ccall libcuda.cuGraphAddNode_v2(phGraphNode::Ptr{CUgraphNode}, hGraph::CUgraph,
                                      dependencies::Ptr{CUgraphNode},
                                      dependencyData::Ptr{CUgraphEdgeData},
                                      numDependencies::Csize_t,
@@ -4804,20 +4804,20 @@ end
 
 @checked function cuGraphNodeSetParams(hNode, nodeParams)
     initialize_context()
-    @ccall libcuda.cuGraphNodeSetParams(hNode::CUgraphNode,
+    @gcsafe_ccall libcuda.cuGraphNodeSetParams(hNode::CUgraphNode,
                                         nodeParams::Ptr{CUgraphNodeParams})::CUresult
 end
 
 @checked function cuGraphExecNodeSetParams(hGraphExec, hNode, nodeParams)
     initialize_context()
-    @ccall libcuda.cuGraphExecNodeSetParams(hGraphExec::CUgraphExec, hNode::CUgraphNode,
+    @gcsafe_ccall libcuda.cuGraphExecNodeSetParams(hGraphExec::CUgraphExec, hNode::CUgraphNode,
                                             nodeParams::Ptr{CUgraphNodeParams})::CUresult
 end
 
 @checked function cuGraphConditionalHandleCreate(pHandle_out, hGraph, ctx,
                                                  defaultLaunchValue, flags)
     initialize_context()
-    @ccall libcuda.cuGraphConditionalHandleCreate(pHandle_out::Ptr{CUgraphConditionalHandle},
+    @gcsafe_ccall libcuda.cuGraphConditionalHandleCreate(pHandle_out::Ptr{CUgraphConditionalHandle},
                                                   hGraph::CUgraph, ctx::CUcontext,
                                                   defaultLaunchValue::Cuint,
                                                   flags::Cuint)::CUresult
@@ -4826,7 +4826,7 @@ end
 @checked function cuOccupancyMaxActiveBlocksPerMultiprocessor(numBlocks, func, blockSize,
                                                               dynamicSMemSize)
     initialize_context()
-    @ccall libcuda.cuOccupancyMaxActiveBlocksPerMultiprocessor(numBlocks::Ptr{Cint},
+    @gcsafe_ccall libcuda.cuOccupancyMaxActiveBlocksPerMultiprocessor(numBlocks::Ptr{Cint},
                                                                func::CUfunction,
                                                                blockSize::Cint,
                                                                dynamicSMemSize::Csize_t)::CUresult
@@ -4837,7 +4837,7 @@ end
                                                                        dynamicSMemSize,
                                                                        flags)
     initialize_context()
-    @ccall libcuda.cuOccupancyMaxActiveBlocksPerMultiprocessorWithFlags(numBlocks::Ptr{Cint},
+    @gcsafe_ccall libcuda.cuOccupancyMaxActiveBlocksPerMultiprocessorWithFlags(numBlocks::Ptr{Cint},
                                                                         func::CUfunction,
                                                                         blockSize::Cint,
                                                                         dynamicSMemSize::Csize_t,
@@ -4848,30 +4848,11 @@ end
                                                    blockSizeToDynamicSMemSize,
                                                    dynamicSMemSize, blockSizeLimit)
     initialize_context()
-    # Until https://github.com/JuliaLang/julia/pull/49933
-    # do this manually. There seems to be a lock taken inside that can lead to deadlocks
-    _minGridSize = Base.cconvert(Ptr{Cint}, minGridSize)
-    _blockSize = Base.cconvert(Ptr{Cint}, blockSize)
-    _func = Base.cconvert(CUfunction, func)
-    _blockSizeToDynamicSMemSize = Base.cconvert(CUoccupancyB2DSize, blockSizeToDynamicSMemSize)
-    _dynamicSMemSize = Base.cconvert(Csize_t, dynamicSMemSize)
-    _blockSizeLimit =  Base.cconvert(Cint, blockSizeLimit)
-    GC.@preserve _minGridSize _blockSize _func _blockSizeToDynamicSMemSize _dynamicSMemSize _blockSizeLimit begin
-        __minGridSize = Base.unsafe_convert(Ptr{Cint}, _minGridSize)
-        __blockSize = Base.unsafe_convert(Ptr{Cint}, _blockSize)
-        __func = Base.unsafe_convert(CUfunction, _func)
-        __blockSizeToDynamicSMemSize = Base.unsafe_convert(CUoccupancyB2DSize, _blockSizeToDynamicSMemSize)
-        __dynamicSMemSize = Base.unsafe_convert(Csize_t, _dynamicSMemSize)
-        __blockSizeLimit = Base.unsafe_convert(Cint, _blockSizeLimit)
-        gc_state = @ccall(jl_gc_safe_enter()::Int8)
-        result   = @ccall libcuda.cuOccupancyMaxPotentialBlockSize( __minGridSize::Ptr{Cint},
-                                                                    __blockSize::Ptr{Cint}, __func::CUfunction,
-                                                                    __blockSizeToDynamicSMemSize::CUoccupancyB2DSize,
-                                                                    __dynamicSMemSize::Csize_t,
-                                                                    __blockSizeLimit::Cint)::CUresult
-        @ccall(jl_gc_safe_leave(gc_state::Int8)::Cvoid)
-    end
-    return result
+    @gcsafe_ccall libcuda.cuOccupancyMaxPotentialBlockSize(minGridSize::Ptr{Cint},
+                                                    blockSize::Ptr{Cint}, func::CUfunction,
+                                                    blockSizeToDynamicSMemSize::CUoccupancyB2DSize,
+                                                    dynamicSMemSize::Csize_t,
+                                                    blockSizeLimit::Cint)::CUresult
 end
 
 @checked function cuOccupancyMaxPotentialBlockSizeWithFlags(minGridSize, blockSize, func,
@@ -4879,7 +4860,7 @@ end
                                                             dynamicSMemSize, blockSizeLimit,
                                                             flags)
     initialize_context()
-    @ccall libcuda.cuOccupancyMaxPotentialBlockSizeWithFlags(minGridSize::Ptr{Cint},
+    @gcsafe_ccall libcuda.cuOccupancyMaxPotentialBlockSizeWithFlags(minGridSize::Ptr{Cint},
                                                              blockSize::Ptr{Cint},
                                                              func::CUfunction,
                                                              blockSizeToDynamicSMemSize::CUoccupancyB2DSize,
@@ -4891,7 +4872,7 @@ end
 @checked function cuOccupancyAvailableDynamicSMemPerBlock(dynamicSmemSize, func, numBlocks,
                                                           blockSize)
     initialize_context()
-    @ccall libcuda.cuOccupancyAvailableDynamicSMemPerBlock(dynamicSmemSize::Ptr{Csize_t},
+    @gcsafe_ccall libcuda.cuOccupancyAvailableDynamicSMemPerBlock(dynamicSmemSize::Ptr{Csize_t},
                                                            func::CUfunction,
                                                            numBlocks::Cint,
                                                            blockSize::Cint)::CUresult
@@ -4899,172 +4880,172 @@ end
 
 @checked function cuOccupancyMaxPotentialClusterSize(clusterSize, func, config)
     initialize_context()
-    @ccall libcuda.cuOccupancyMaxPotentialClusterSize(clusterSize::Ptr{Cint},
+    @gcsafe_ccall libcuda.cuOccupancyMaxPotentialClusterSize(clusterSize::Ptr{Cint},
                                                       func::CUfunction,
                                                       config::Ptr{CUlaunchConfig})::CUresult
 end
 
 @checked function cuOccupancyMaxActiveClusters(numClusters, func, config)
     initialize_context()
-    @ccall libcuda.cuOccupancyMaxActiveClusters(numClusters::Ptr{Cint}, func::CUfunction,
+    @gcsafe_ccall libcuda.cuOccupancyMaxActiveClusters(numClusters::Ptr{Cint}, func::CUfunction,
                                                 config::Ptr{CUlaunchConfig})::CUresult
 end
 
 @checked function cuTexRefSetArray(hTexRef, hArray, Flags)
     initialize_context()
-    @ccall libcuda.cuTexRefSetArray(hTexRef::CUtexref, hArray::CUarray,
+    @gcsafe_ccall libcuda.cuTexRefSetArray(hTexRef::CUtexref, hArray::CUarray,
                                     Flags::Cuint)::CUresult
 end
 
 @checked function cuTexRefSetMipmappedArray(hTexRef, hMipmappedArray, Flags)
     initialize_context()
-    @ccall libcuda.cuTexRefSetMipmappedArray(hTexRef::CUtexref,
+    @gcsafe_ccall libcuda.cuTexRefSetMipmappedArray(hTexRef::CUtexref,
                                              hMipmappedArray::CUmipmappedArray,
                                              Flags::Cuint)::CUresult
 end
 
 @checked function cuTexRefSetFormat(hTexRef, fmt, NumPackedComponents)
     initialize_context()
-    @ccall libcuda.cuTexRefSetFormat(hTexRef::CUtexref, fmt::CUarray_format,
+    @gcsafe_ccall libcuda.cuTexRefSetFormat(hTexRef::CUtexref, fmt::CUarray_format,
                                      NumPackedComponents::Cint)::CUresult
 end
 
 @checked function cuTexRefSetAddressMode(hTexRef, dim, am)
     initialize_context()
-    @ccall libcuda.cuTexRefSetAddressMode(hTexRef::CUtexref, dim::Cint,
+    @gcsafe_ccall libcuda.cuTexRefSetAddressMode(hTexRef::CUtexref, dim::Cint,
                                           am::CUaddress_mode)::CUresult
 end
 
 @checked function cuTexRefSetFilterMode(hTexRef, fm)
     initialize_context()
-    @ccall libcuda.cuTexRefSetFilterMode(hTexRef::CUtexref, fm::CUfilter_mode)::CUresult
+    @gcsafe_ccall libcuda.cuTexRefSetFilterMode(hTexRef::CUtexref, fm::CUfilter_mode)::CUresult
 end
 
 @checked function cuTexRefSetMipmapFilterMode(hTexRef, fm)
     initialize_context()
-    @ccall libcuda.cuTexRefSetMipmapFilterMode(hTexRef::CUtexref,
+    @gcsafe_ccall libcuda.cuTexRefSetMipmapFilterMode(hTexRef::CUtexref,
                                                fm::CUfilter_mode)::CUresult
 end
 
 @checked function cuTexRefSetMipmapLevelBias(hTexRef, bias)
     initialize_context()
-    @ccall libcuda.cuTexRefSetMipmapLevelBias(hTexRef::CUtexref, bias::Cfloat)::CUresult
+    @gcsafe_ccall libcuda.cuTexRefSetMipmapLevelBias(hTexRef::CUtexref, bias::Cfloat)::CUresult
 end
 
 @checked function cuTexRefSetMipmapLevelClamp(hTexRef, minMipmapLevelClamp,
                                               maxMipmapLevelClamp)
     initialize_context()
-    @ccall libcuda.cuTexRefSetMipmapLevelClamp(hTexRef::CUtexref,
+    @gcsafe_ccall libcuda.cuTexRefSetMipmapLevelClamp(hTexRef::CUtexref,
                                                minMipmapLevelClamp::Cfloat,
                                                maxMipmapLevelClamp::Cfloat)::CUresult
 end
 
 @checked function cuTexRefSetMaxAnisotropy(hTexRef, maxAniso)
     initialize_context()
-    @ccall libcuda.cuTexRefSetMaxAnisotropy(hTexRef::CUtexref, maxAniso::Cuint)::CUresult
+    @gcsafe_ccall libcuda.cuTexRefSetMaxAnisotropy(hTexRef::CUtexref, maxAniso::Cuint)::CUresult
 end
 
 @checked function cuTexRefSetBorderColor(hTexRef, pBorderColor)
     initialize_context()
-    @ccall libcuda.cuTexRefSetBorderColor(hTexRef::CUtexref,
+    @gcsafe_ccall libcuda.cuTexRefSetBorderColor(hTexRef::CUtexref,
                                           pBorderColor::Ptr{Cfloat})::CUresult
 end
 
 @checked function cuTexRefSetFlags(hTexRef, Flags)
     initialize_context()
-    @ccall libcuda.cuTexRefSetFlags(hTexRef::CUtexref, Flags::Cuint)::CUresult
+    @gcsafe_ccall libcuda.cuTexRefSetFlags(hTexRef::CUtexref, Flags::Cuint)::CUresult
 end
 
 @checked function cuTexRefGetArray(phArray, hTexRef)
     initialize_context()
-    @ccall libcuda.cuTexRefGetArray(phArray::Ptr{CUarray}, hTexRef::CUtexref)::CUresult
+    @gcsafe_ccall libcuda.cuTexRefGetArray(phArray::Ptr{CUarray}, hTexRef::CUtexref)::CUresult
 end
 
 @checked function cuTexRefGetMipmappedArray(phMipmappedArray, hTexRef)
     initialize_context()
-    @ccall libcuda.cuTexRefGetMipmappedArray(phMipmappedArray::Ptr{CUmipmappedArray},
+    @gcsafe_ccall libcuda.cuTexRefGetMipmappedArray(phMipmappedArray::Ptr{CUmipmappedArray},
                                              hTexRef::CUtexref)::CUresult
 end
 
 @checked function cuTexRefGetAddressMode(pam, hTexRef, dim)
     initialize_context()
-    @ccall libcuda.cuTexRefGetAddressMode(pam::Ptr{CUaddress_mode}, hTexRef::CUtexref,
+    @gcsafe_ccall libcuda.cuTexRefGetAddressMode(pam::Ptr{CUaddress_mode}, hTexRef::CUtexref,
                                           dim::Cint)::CUresult
 end
 
 @checked function cuTexRefGetFilterMode(pfm, hTexRef)
     initialize_context()
-    @ccall libcuda.cuTexRefGetFilterMode(pfm::Ptr{CUfilter_mode},
+    @gcsafe_ccall libcuda.cuTexRefGetFilterMode(pfm::Ptr{CUfilter_mode},
                                          hTexRef::CUtexref)::CUresult
 end
 
 @checked function cuTexRefGetFormat(pFormat, pNumChannels, hTexRef)
     initialize_context()
-    @ccall libcuda.cuTexRefGetFormat(pFormat::Ptr{CUarray_format}, pNumChannels::Ptr{Cint},
+    @gcsafe_ccall libcuda.cuTexRefGetFormat(pFormat::Ptr{CUarray_format}, pNumChannels::Ptr{Cint},
                                      hTexRef::CUtexref)::CUresult
 end
 
 @checked function cuTexRefGetMipmapFilterMode(pfm, hTexRef)
     initialize_context()
-    @ccall libcuda.cuTexRefGetMipmapFilterMode(pfm::Ptr{CUfilter_mode},
+    @gcsafe_ccall libcuda.cuTexRefGetMipmapFilterMode(pfm::Ptr{CUfilter_mode},
                                                hTexRef::CUtexref)::CUresult
 end
 
 @checked function cuTexRefGetMipmapLevelBias(pbias, hTexRef)
     initialize_context()
-    @ccall libcuda.cuTexRefGetMipmapLevelBias(pbias::Ptr{Cfloat},
+    @gcsafe_ccall libcuda.cuTexRefGetMipmapLevelBias(pbias::Ptr{Cfloat},
                                               hTexRef::CUtexref)::CUresult
 end
 
 @checked function cuTexRefGetMipmapLevelClamp(pminMipmapLevelClamp, pmaxMipmapLevelClamp,
                                               hTexRef)
     initialize_context()
-    @ccall libcuda.cuTexRefGetMipmapLevelClamp(pminMipmapLevelClamp::Ptr{Cfloat},
+    @gcsafe_ccall libcuda.cuTexRefGetMipmapLevelClamp(pminMipmapLevelClamp::Ptr{Cfloat},
                                                pmaxMipmapLevelClamp::Ptr{Cfloat},
                                                hTexRef::CUtexref)::CUresult
 end
 
 @checked function cuTexRefGetMaxAnisotropy(pmaxAniso, hTexRef)
     initialize_context()
-    @ccall libcuda.cuTexRefGetMaxAnisotropy(pmaxAniso::Ptr{Cint},
+    @gcsafe_ccall libcuda.cuTexRefGetMaxAnisotropy(pmaxAniso::Ptr{Cint},
                                             hTexRef::CUtexref)::CUresult
 end
 
 @checked function cuTexRefGetBorderColor(pBorderColor, hTexRef)
     initialize_context()
-    @ccall libcuda.cuTexRefGetBorderColor(pBorderColor::Ptr{Cfloat},
+    @gcsafe_ccall libcuda.cuTexRefGetBorderColor(pBorderColor::Ptr{Cfloat},
                                           hTexRef::CUtexref)::CUresult
 end
 
 @checked function cuTexRefGetFlags(pFlags, hTexRef)
     initialize_context()
-    @ccall libcuda.cuTexRefGetFlags(pFlags::Ptr{Cuint}, hTexRef::CUtexref)::CUresult
+    @gcsafe_ccall libcuda.cuTexRefGetFlags(pFlags::Ptr{Cuint}, hTexRef::CUtexref)::CUresult
 end
 
 @checked function cuTexRefCreate(pTexRef)
     initialize_context()
-    @ccall libcuda.cuTexRefCreate(pTexRef::Ptr{CUtexref})::CUresult
+    @gcsafe_ccall libcuda.cuTexRefCreate(pTexRef::Ptr{CUtexref})::CUresult
 end
 
 @checked function cuTexRefDestroy(hTexRef)
     initialize_context()
-    @ccall libcuda.cuTexRefDestroy(hTexRef::CUtexref)::CUresult
+    @gcsafe_ccall libcuda.cuTexRefDestroy(hTexRef::CUtexref)::CUresult
 end
 
 @checked function cuSurfRefSetArray(hSurfRef, hArray, Flags)
     initialize_context()
-    @ccall libcuda.cuSurfRefSetArray(hSurfRef::CUsurfref, hArray::CUarray,
+    @gcsafe_ccall libcuda.cuSurfRefSetArray(hSurfRef::CUsurfref, hArray::CUarray,
                                      Flags::Cuint)::CUresult
 end
 
 @checked function cuSurfRefGetArray(phArray, hSurfRef)
     initialize_context()
-    @ccall libcuda.cuSurfRefGetArray(phArray::Ptr{CUarray}, hSurfRef::CUsurfref)::CUresult
+    @gcsafe_ccall libcuda.cuSurfRefGetArray(phArray::Ptr{CUarray}, hSurfRef::CUsurfref)::CUresult
 end
 
 @checked function cuTexObjectCreate(pTexObject, pResDesc, pTexDesc, pResViewDesc)
     initialize_context()
-    @ccall libcuda.cuTexObjectCreate(pTexObject::Ptr{CUtexObject},
+    @gcsafe_ccall libcuda.cuTexObjectCreate(pTexObject::Ptr{CUtexObject},
                                      pResDesc::Ptr{CUDA_RESOURCE_DESC},
                                      pTexDesc::Ptr{CUDA_TEXTURE_DESC},
                                      pResViewDesc::Ptr{CUDA_RESOURCE_VIEW_DESC})::CUresult
@@ -5072,41 +5053,41 @@ end
 
 @checked function cuTexObjectDestroy(texObject)
     initialize_context()
-    @ccall libcuda.cuTexObjectDestroy(texObject::CUtexObject)::CUresult
+    @gcsafe_ccall libcuda.cuTexObjectDestroy(texObject::CUtexObject)::CUresult
 end
 
 @checked function cuTexObjectGetResourceDesc(pResDesc, texObject)
     initialize_context()
-    @ccall libcuda.cuTexObjectGetResourceDesc(pResDesc::Ptr{CUDA_RESOURCE_DESC},
+    @gcsafe_ccall libcuda.cuTexObjectGetResourceDesc(pResDesc::Ptr{CUDA_RESOURCE_DESC},
                                               texObject::CUtexObject)::CUresult
 end
 
 @checked function cuTexObjectGetTextureDesc(pTexDesc, texObject)
     initialize_context()
-    @ccall libcuda.cuTexObjectGetTextureDesc(pTexDesc::Ptr{CUDA_TEXTURE_DESC},
+    @gcsafe_ccall libcuda.cuTexObjectGetTextureDesc(pTexDesc::Ptr{CUDA_TEXTURE_DESC},
                                              texObject::CUtexObject)::CUresult
 end
 
 @checked function cuTexObjectGetResourceViewDesc(pResViewDesc, texObject)
     initialize_context()
-    @ccall libcuda.cuTexObjectGetResourceViewDesc(pResViewDesc::Ptr{CUDA_RESOURCE_VIEW_DESC},
+    @gcsafe_ccall libcuda.cuTexObjectGetResourceViewDesc(pResViewDesc::Ptr{CUDA_RESOURCE_VIEW_DESC},
                                                   texObject::CUtexObject)::CUresult
 end
 
 @checked function cuSurfObjectCreate(pSurfObject, pResDesc)
     initialize_context()
-    @ccall libcuda.cuSurfObjectCreate(pSurfObject::Ptr{CUsurfObject},
+    @gcsafe_ccall libcuda.cuSurfObjectCreate(pSurfObject::Ptr{CUsurfObject},
                                       pResDesc::Ptr{CUDA_RESOURCE_DESC})::CUresult
 end
 
 @checked function cuSurfObjectDestroy(surfObject)
     initialize_context()
-    @ccall libcuda.cuSurfObjectDestroy(surfObject::CUsurfObject)::CUresult
+    @gcsafe_ccall libcuda.cuSurfObjectDestroy(surfObject::CUsurfObject)::CUresult
 end
 
 @checked function cuSurfObjectGetResourceDesc(pResDesc, surfObject)
     initialize_context()
-    @ccall libcuda.cuSurfObjectGetResourceDesc(pResDesc::Ptr{CUDA_RESOURCE_DESC},
+    @gcsafe_ccall libcuda.cuSurfObjectGetResourceDesc(pResDesc::Ptr{CUDA_RESOURCE_DESC},
                                                surfObject::CUsurfObject)::CUresult
 end
 
@@ -5115,7 +5096,7 @@ end
                                          elementStrides, interleave, swizzle, l2Promotion,
                                          oobFill)
     initialize_context()
-    @ccall libcuda.cuTensorMapEncodeTiled(tensorMap::Ptr{CUtensorMap},
+    @gcsafe_ccall libcuda.cuTensorMapEncodeTiled(tensorMap::Ptr{CUtensorMap},
                                           tensorDataType::CUtensorMapDataType,
                                           tensorRank::cuuint32_t, globalAddress::Ptr{Cvoid},
                                           globalDim::Ptr{cuuint64_t},
@@ -5134,7 +5115,7 @@ end
                                           channelsPerPixel, pixelsPerColumn, elementStrides,
                                           interleave, swizzle, l2Promotion, oobFill)
     initialize_context()
-    @ccall libcuda.cuTensorMapEncodeIm2col(tensorMap::Ptr{CUtensorMap},
+    @gcsafe_ccall libcuda.cuTensorMapEncodeIm2col(tensorMap::Ptr{CUtensorMap},
                                            tensorDataType::CUtensorMapDataType,
                                            tensorRank::cuuint32_t,
                                            globalAddress::Ptr{Cvoid},
@@ -5153,42 +5134,42 @@ end
 
 @checked function cuTensorMapReplaceAddress(tensorMap, globalAddress)
     initialize_context()
-    @ccall libcuda.cuTensorMapReplaceAddress(tensorMap::Ptr{CUtensorMap},
+    @gcsafe_ccall libcuda.cuTensorMapReplaceAddress(tensorMap::Ptr{CUtensorMap},
                                              globalAddress::Ptr{Cvoid})::CUresult
 end
 
 @checked function cuDeviceCanAccessPeer(canAccessPeer, dev, peerDev)
     initialize_context()
-    @ccall libcuda.cuDeviceCanAccessPeer(canAccessPeer::Ptr{Cint}, dev::CUdevice,
+    @gcsafe_ccall libcuda.cuDeviceCanAccessPeer(canAccessPeer::Ptr{Cint}, dev::CUdevice,
                                          peerDev::CUdevice)::CUresult
 end
 
 @checked function cuCtxEnablePeerAccess(peerContext, Flags)
     initialize_context()
-    @ccall libcuda.cuCtxEnablePeerAccess(peerContext::CUcontext, Flags::Cuint)::CUresult
+    @gcsafe_ccall libcuda.cuCtxEnablePeerAccess(peerContext::CUcontext, Flags::Cuint)::CUresult
 end
 
 @checked function cuCtxDisablePeerAccess(peerContext)
     initialize_context()
-    @ccall libcuda.cuCtxDisablePeerAccess(peerContext::CUcontext)::CUresult
+    @gcsafe_ccall libcuda.cuCtxDisablePeerAccess(peerContext::CUcontext)::CUresult
 end
 
 @checked function cuDeviceGetP2PAttribute(value, attrib, srcDevice, dstDevice)
     initialize_context()
-    @ccall libcuda.cuDeviceGetP2PAttribute(value::Ptr{Cint}, attrib::CUdevice_P2PAttribute,
+    @gcsafe_ccall libcuda.cuDeviceGetP2PAttribute(value::Ptr{Cint}, attrib::CUdevice_P2PAttribute,
                                            srcDevice::CUdevice,
                                            dstDevice::CUdevice)::CUresult
 end
 
 @checked function cuGraphicsUnregisterResource(resource)
     initialize_context()
-    @ccall libcuda.cuGraphicsUnregisterResource(resource::CUgraphicsResource)::CUresult
+    @gcsafe_ccall libcuda.cuGraphicsUnregisterResource(resource::CUgraphicsResource)::CUresult
 end
 
 @checked function cuGraphicsSubResourceGetMappedArray(pArray, resource, arrayIndex,
                                                       mipLevel)
     initialize_context()
-    @ccall libcuda.cuGraphicsSubResourceGetMappedArray(pArray::Ptr{CUarray},
+    @gcsafe_ccall libcuda.cuGraphicsSubResourceGetMappedArray(pArray::Ptr{CUarray},
                                                        resource::CUgraphicsResource,
                                                        arrayIndex::Cuint,
                                                        mipLevel::Cuint)::CUresult
@@ -5196,19 +5177,19 @@ end
 
 @checked function cuGraphicsResourceGetMappedMipmappedArray(pMipmappedArray, resource)
     initialize_context()
-    @ccall libcuda.cuGraphicsResourceGetMappedMipmappedArray(pMipmappedArray::Ptr{CUmipmappedArray},
+    @gcsafe_ccall libcuda.cuGraphicsResourceGetMappedMipmappedArray(pMipmappedArray::Ptr{CUmipmappedArray},
                                                              resource::CUgraphicsResource)::CUresult
 end
 
 @checked function cuGraphicsMapResources(count, resources, hStream)
     initialize_context()
-    @ccall libcuda.cuGraphicsMapResources(count::Cuint, resources::Ptr{CUgraphicsResource},
+    @gcsafe_ccall libcuda.cuGraphicsMapResources(count::Cuint, resources::Ptr{CUgraphicsResource},
                                           hStream::CUstream)::CUresult
 end
 
 @checked function cuGraphicsUnmapResources(count, resources, hStream)
     initialize_context()
-    @ccall libcuda.cuGraphicsUnmapResources(count::Cuint,
+    @gcsafe_ccall libcuda.cuGraphicsUnmapResources(count::Cuint,
                                             resources::Ptr{CUgraphicsResource},
                                             hStream::CUstream)::CUresult
 end
@@ -5227,51 +5208,51 @@ const CUcoredumpSettings = CUcoredumpSettings_enum
 
 @checked function cuCoredumpGetAttribute(attrib, value, size)
     initialize_context()
-    @ccall libcuda.cuCoredumpGetAttribute(attrib::CUcoredumpSettings, value::Ptr{Cvoid},
+    @gcsafe_ccall libcuda.cuCoredumpGetAttribute(attrib::CUcoredumpSettings, value::Ptr{Cvoid},
                                           size::Ptr{Csize_t})::CUresult
 end
 
 @checked function cuCoredumpGetAttributeGlobal(attrib, value, size)
     initialize_context()
-    @ccall libcuda.cuCoredumpGetAttributeGlobal(attrib::CUcoredumpSettings,
+    @gcsafe_ccall libcuda.cuCoredumpGetAttributeGlobal(attrib::CUcoredumpSettings,
                                                 value::Ptr{Cvoid},
                                                 size::Ptr{Csize_t})::CUresult
 end
 
 @checked function cuCoredumpSetAttribute(attrib, value, size)
     initialize_context()
-    @ccall libcuda.cuCoredumpSetAttribute(attrib::CUcoredumpSettings, value::Ptr{Cvoid},
+    @gcsafe_ccall libcuda.cuCoredumpSetAttribute(attrib::CUcoredumpSettings, value::Ptr{Cvoid},
                                           size::Ptr{Csize_t})::CUresult
 end
 
 @checked function cuCoredumpSetAttributeGlobal(attrib, value, size)
     initialize_context()
-    @ccall libcuda.cuCoredumpSetAttributeGlobal(attrib::CUcoredumpSettings,
+    @gcsafe_ccall libcuda.cuCoredumpSetAttributeGlobal(attrib::CUcoredumpSettings,
                                                 value::Ptr{Cvoid},
                                                 size::Ptr{Csize_t})::CUresult
 end
 
 @checked function cuGetExportTable(ppExportTable, pExportTableId)
     initialize_context()
-    @ccall libcuda.cuGetExportTable(ppExportTable::Ptr{Ptr{Cvoid}},
+    @gcsafe_ccall libcuda.cuGetExportTable(ppExportTable::Ptr{Ptr{Cvoid}},
                                     pExportTableId::Ptr{CUuuid})::CUresult
 end
 
 @checked function cuGLCtxCreate_v2(pCtx, Flags, device)
     initialize_context()
-    @ccall libcuda.cuGLCtxCreate_v2(pCtx::Ptr{CUcontext}, Flags::Cuint,
+    @gcsafe_ccall libcuda.cuGLCtxCreate_v2(pCtx::Ptr{CUcontext}, Flags::Cuint,
                                     device::CUdevice)::CUresult
 end
 
 @checked function cuGLMapBufferObject_v2(dptr, size, buffer)
     initialize_context()
-    @ccall libcuda.cuGLMapBufferObject_v2(dptr::Ptr{CUdeviceptr}, size::Ptr{Csize_t},
+    @gcsafe_ccall libcuda.cuGLMapBufferObject_v2(dptr::Ptr{CUdeviceptr}, size::Ptr{Csize_t},
                                           buffer::GLuint)::CUresult
 end
 
 @checked function cuGLMapBufferObjectAsync_v2(dptr, size, buffer, hStream)
     initialize_context()
-    @ccall libcuda.cuGLMapBufferObjectAsync_v2(dptr::Ptr{CUdeviceptr}, size::Ptr{Csize_t},
+    @gcsafe_ccall libcuda.cuGLMapBufferObjectAsync_v2(dptr::Ptr{CUdeviceptr}, size::Ptr{Csize_t},
                                                buffer::GLuint, hStream::CUstream)::CUresult
 end
 
@@ -5286,20 +5267,20 @@ const CUGLDeviceList = CUGLDeviceList_enum
 @checked function cuGLGetDevices_v2(pCudaDeviceCount, pCudaDevices, cudaDeviceCount,
                                     deviceList)
     initialize_context()
-    @ccall libcuda.cuGLGetDevices_v2(pCudaDeviceCount::Ptr{Cuint},
+    @gcsafe_ccall libcuda.cuGLGetDevices_v2(pCudaDeviceCount::Ptr{Cuint},
                                      pCudaDevices::Ptr{CUdevice}, cudaDeviceCount::Cuint,
                                      deviceList::CUGLDeviceList)::CUresult
 end
 
 @checked function cuGraphicsGLRegisterBuffer(pCudaResource, buffer, Flags)
     initialize_context()
-    @ccall libcuda.cuGraphicsGLRegisterBuffer(pCudaResource::Ptr{CUgraphicsResource},
+    @gcsafe_ccall libcuda.cuGraphicsGLRegisterBuffer(pCudaResource::Ptr{CUgraphicsResource},
                                               buffer::GLuint, Flags::Cuint)::CUresult
 end
 
 @checked function cuGraphicsGLRegisterImage(pCudaResource, image, target, Flags)
     initialize_context()
-    @ccall libcuda.cuGraphicsGLRegisterImage(pCudaResource::Ptr{CUgraphicsResource},
+    @gcsafe_ccall libcuda.cuGraphicsGLRegisterImage(pCudaResource::Ptr{CUgraphicsResource},
                                              image::GLuint, target::GLenum,
                                              Flags::Cuint)::CUresult
 end
@@ -5314,32 +5295,32 @@ const CUGLmap_flags = CUGLmap_flags_enum
 
 @checked function cuGLInit()
     initialize_context()
-    @ccall libcuda.cuGLInit()::CUresult
+    @gcsafe_ccall libcuda.cuGLInit()::CUresult
 end
 
 @checked function cuGLRegisterBufferObject(buffer)
     initialize_context()
-    @ccall libcuda.cuGLRegisterBufferObject(buffer::GLuint)::CUresult
+    @gcsafe_ccall libcuda.cuGLRegisterBufferObject(buffer::GLuint)::CUresult
 end
 
 @checked function cuGLUnmapBufferObject(buffer)
     initialize_context()
-    @ccall libcuda.cuGLUnmapBufferObject(buffer::GLuint)::CUresult
+    @gcsafe_ccall libcuda.cuGLUnmapBufferObject(buffer::GLuint)::CUresult
 end
 
 @checked function cuGLUnregisterBufferObject(buffer)
     initialize_context()
-    @ccall libcuda.cuGLUnregisterBufferObject(buffer::GLuint)::CUresult
+    @gcsafe_ccall libcuda.cuGLUnregisterBufferObject(buffer::GLuint)::CUresult
 end
 
 @checked function cuGLSetBufferObjectMapFlags(buffer, Flags)
     initialize_context()
-    @ccall libcuda.cuGLSetBufferObjectMapFlags(buffer::GLuint, Flags::Cuint)::CUresult
+    @gcsafe_ccall libcuda.cuGLSetBufferObjectMapFlags(buffer::GLuint, Flags::Cuint)::CUresult
 end
 
 @checked function cuGLUnmapBufferObjectAsync(buffer, hStream)
     initialize_context()
-    @ccall libcuda.cuGLUnmapBufferObjectAsync(buffer::GLuint, hStream::CUstream)::CUresult
+    @gcsafe_ccall libcuda.cuGLUnmapBufferObjectAsync(buffer::GLuint, hStream::CUstream)::CUresult
 end
 
 @cenum CUoutput_mode_enum::UInt32 begin
@@ -5351,18 +5332,18 @@ const CUoutput_mode = CUoutput_mode_enum
 
 @checked function cuProfilerInitialize(configFile, outputFile, outputMode)
     initialize_context()
-    @ccall libcuda.cuProfilerInitialize(configFile::Cstring, outputFile::Cstring,
+    @gcsafe_ccall libcuda.cuProfilerInitialize(configFile::Cstring, outputFile::Cstring,
                                         outputMode::CUoutput_mode)::CUresult
 end
 
 @checked function cuProfilerStart()
     initialize_context()
-    @ccall libcuda.cuProfilerStart()::CUresult
+    @gcsafe_ccall libcuda.cuProfilerStart()::CUresult
 end
 
 @checked function cuProfilerStop()
     initialize_context()
-    @ccall libcuda.cuProfilerStop()::CUresult
+    @gcsafe_ccall libcuda.cuProfilerStop()::CUresult
 end
 
 struct var"##Ctag#276"

--- a/lib/cudadrv/occupancy.jl
+++ b/lib/cudadrv/occupancy.jl
@@ -36,7 +36,13 @@ end
 # HACK: callback function for `launch_configuration` on platforms without support for
 #       trampolines as used by `@cfunction` (JuliaLang/julia#27174, JuliaLang/julia#32154)
 _shmem_cb = nothing
-_shmem_cint_cb(x::Cint) = Cint(something(_shmem_cb)(x))
+function _shmem_cint_cb(x::Cint)
+    # see @gcsafe_ccall documentation
+    @static if VERSION < v"1.9"
+        GC.safepoint()
+    end
+    Cint(something(_shmem_cb)(x))
+end
 _shmem_cb_lock = Threads.ReentrantLock()
 
 """
@@ -58,7 +64,13 @@ function launch_configuration(fun::CuFunction; shmem::Union{Integer,Base.Callabl
     if isa(shmem, Integer)
         cuOccupancyMaxPotentialBlockSize(blocks_ref, threads_ref, fun, C_NULL, shmem, max_threads)
     elseif Sys.ARCH == :x86 || Sys.ARCH == :x86_64
-        shmem_cint = threads -> Cint(shmem(threads))
+        function shmem_cint(threads)
+            # see @gcsafe_ccall documentation
+            @static if VERSION < v"1.9"
+                GC.safepoint()
+            end
+            Cint(shmem(threads))
+        end
         cb = @cfunction($shmem_cint, Cint, (Cint,))
         cuOccupancyMaxPotentialBlockSize(blocks_ref, threads_ref, fun, cb, 0, max_threads)
     else

--- a/lib/cudadrv/occupancy.jl
+++ b/lib/cudadrv/occupancy.jl
@@ -36,11 +36,7 @@ end
 # HACK: callback function for `launch_configuration` on platforms without support for
 #       trampolines as used by `@cfunction` (JuliaLang/julia#27174, JuliaLang/julia#32154)
 _shmem_cb = nothing
-function _shmem_cint_cb(x::Cint)
-    # see @gcsafe_ccall documentation
-    @static if VERSION < v"1.9"
-        GC.safepoint()
-    end
+@gcunsafe_callback function _shmem_cint_cb(x::Cint)
     Cint(something(_shmem_cb)(x))
 end
 _shmem_cb_lock = Threads.ReentrantLock()
@@ -64,11 +60,7 @@ function launch_configuration(fun::CuFunction; shmem::Union{Integer,Base.Callabl
     if isa(shmem, Integer)
         cuOccupancyMaxPotentialBlockSize(blocks_ref, threads_ref, fun, C_NULL, shmem, max_threads)
     elseif Sys.ARCH == :x86 || Sys.ARCH == :x86_64
-        function shmem_cint(threads)
-            # see @gcsafe_ccall documentation
-            @static if VERSION < v"1.9"
-                GC.safepoint()
-            end
+        @gcunsafe_callback function shmem_cint(threads)
             Cint(shmem(threads))
         end
         cb = @cfunction($shmem_cint, Cint, (Cint,))

--- a/lib/cudnn/Project.toml
+++ b/lib/cudnn/Project.toml
@@ -1,7 +1,7 @@
 name = "cuDNN"
 uuid = "02a925ec-e4fe-4b08-9a7e-0d78e3d38ccd"
 authors = ["Tim Besard <tim.besard@gmail.com>"]
-version = "1.3.0"
+version = "1.3.1"
 
 [deps]
 CEnum = "fa961155-64e5-5f13-b03f-caf6b980ea82"
@@ -11,7 +11,7 @@ CUDNN_jll = "62b44479-cb7b-5706-934f-f13b2eb2e645"
 
 [compat]
 CEnum = "0.2, 0.3, 0.4, 0.5"
-CUDA = "~5.1, ~5.2"
+CUDA = "~5.3"
 CUDA_Runtime_Discovery = "0.2"
 CUDNN_jll = "~8.9"
 julia = "1.8"

--- a/lib/cudnn/src/cuDNN.jl
+++ b/lib/cudnn/src/cuDNN.jl
@@ -138,6 +138,11 @@ function log_message(sev, udata, dbg_ptr, ptr)
 end
 
 function _log_message(sev, dbg, str)
+    # see @gcsafe_ccall documentation
+    @static if VERSION < v"1.9"
+        GC.safepoint()
+    end
+
     lines = split(str, '\0')
     msg = join(lines, '\n')
     if sev == CUDNN_SEV_INFO

--- a/lib/cudnn/src/cuDNN.jl
+++ b/lib/cudnn/src/cuDNN.jl
@@ -137,12 +137,7 @@ function log_message(sev, udata, dbg_ptr, ptr)
     return
 end
 
-function _log_message(sev, dbg, str)
-    # see @gcsafe_ccall documentation
-    @static if VERSION < v"1.9"
-        GC.safepoint()
-    end
-
+@gcunsafe_callback function _log_message(sev, dbg, str)
     lines = split(str, '\0')
     msg = join(lines, '\n')
     if sev == CUDNN_SEV_INFO

--- a/lib/cudnn/src/libcudnn.jl
+++ b/lib/cudnn/src/libcudnn.jl
@@ -33,15 +33,15 @@ mutable struct cudnnContext end
 const cudnnHandle_t = Ptr{cudnnContext}
 
 function cudnnGetVersion()
-    @ccall libcudnn.cudnnGetVersion()::Csize_t
+    @gcsafe_ccall libcudnn.cudnnGetVersion()::Csize_t
 end
 
 function cudnnGetMaxDeviceVersion()
-    @ccall libcudnn.cudnnGetMaxDeviceVersion()::Csize_t
+    @gcsafe_ccall libcudnn.cudnnGetMaxDeviceVersion()::Csize_t
 end
 
 function cudnnGetCudartVersion()
-    @ccall libcudnn.cudnnGetCudartVersion()::Csize_t
+    @gcsafe_ccall libcudnn.cudnnGetCudartVersion()::Csize_t
 end
 
 @cenum cudnnStatus_t::UInt32 begin
@@ -63,7 +63,7 @@ end
 end
 
 function cudnnGetErrorString(status)
-    @ccall libcudnn.cudnnGetErrorString(status::cudnnStatus_t)::Cstring
+    @gcsafe_ccall libcudnn.cudnnGetErrorString(status::cudnnStatus_t)::Cstring
 end
 
 mutable struct cudnnRuntimeTag_t end
@@ -76,37 +76,37 @@ end
 
 @checked function cudnnQueryRuntimeError(handle, rstatus, mode, tag)
     initialize_context()
-    @ccall libcudnn.cudnnQueryRuntimeError(handle::cudnnHandle_t,
-                                           rstatus::Ptr{cudnnStatus_t},
-                                           mode::cudnnErrQueryMode_t,
-                                           tag::Ptr{cudnnRuntimeTag_t})::cudnnStatus_t
+    @gcsafe_ccall libcudnn.cudnnQueryRuntimeError(handle::cudnnHandle_t,
+                                                  rstatus::Ptr{cudnnStatus_t},
+                                                  mode::cudnnErrQueryMode_t,
+                                                  tag::Ptr{cudnnRuntimeTag_t})::cudnnStatus_t
 end
 
 @checked function cudnnGetProperty(type, value)
-    @ccall libcudnn.cudnnGetProperty(type::libraryPropertyType,
-                                     value::Ptr{Cint})::cudnnStatus_t
+    @gcsafe_ccall libcudnn.cudnnGetProperty(type::libraryPropertyType,
+                                            value::Ptr{Cint})::cudnnStatus_t
 end
 
 @checked function cudnnCreate(handle)
     initialize_context()
-    @ccall libcudnn.cudnnCreate(handle::Ptr{cudnnHandle_t})::cudnnStatus_t
+    @gcsafe_ccall libcudnn.cudnnCreate(handle::Ptr{cudnnHandle_t})::cudnnStatus_t
 end
 
 @checked function cudnnDestroy(handle)
     initialize_context()
-    @ccall libcudnn.cudnnDestroy(handle::cudnnHandle_t)::cudnnStatus_t
+    @gcsafe_ccall libcudnn.cudnnDestroy(handle::cudnnHandle_t)::cudnnStatus_t
 end
 
 @checked function cudnnSetStream(handle, streamId)
     initialize_context()
-    @ccall libcudnn.cudnnSetStream(handle::cudnnHandle_t,
-                                   streamId::cudaStream_t)::cudnnStatus_t
+    @gcsafe_ccall libcudnn.cudnnSetStream(handle::cudnnHandle_t,
+                                          streamId::cudaStream_t)::cudnnStatus_t
 end
 
 @checked function cudnnGetStream(handle, streamId)
     initialize_context()
-    @ccall libcudnn.cudnnGetStream(handle::cudnnHandle_t,
-                                   streamId::Ptr{cudaStream_t})::cudnnStatus_t
+    @gcsafe_ccall libcudnn.cudnnGetStream(handle::cudnnHandle_t,
+                                          streamId::Ptr{cudaStream_t})::cudnnStatus_t
 end
 
 mutable struct cudnnTensorStruct end
@@ -186,7 +186,7 @@ end
 
 @checked function cudnnCreateTensorDescriptor(tensorDesc)
     initialize_context()
-    @ccall libcudnn.cudnnCreateTensorDescriptor(tensorDesc::Ptr{cudnnTensorDescriptor_t})::cudnnStatus_t
+    @gcsafe_ccall libcudnn.cudnnCreateTensorDescriptor(tensorDesc::Ptr{cudnnTensorDescriptor_t})::cudnnStatus_t
 end
 
 @cenum cudnnTensorFormat_t::UInt32 begin
@@ -197,68 +197,73 @@ end
 
 @checked function cudnnSetTensor4dDescriptor(tensorDesc, format, dataType, n, c, h, w)
     initialize_context()
-    @ccall libcudnn.cudnnSetTensor4dDescriptor(tensorDesc::cudnnTensorDescriptor_t,
-                                               format::cudnnTensorFormat_t,
-                                               dataType::cudnnDataType_t, n::Cint, c::Cint,
-                                               h::Cint, w::Cint)::cudnnStatus_t
+    @gcsafe_ccall libcudnn.cudnnSetTensor4dDescriptor(tensorDesc::cudnnTensorDescriptor_t,
+                                                      format::cudnnTensorFormat_t,
+                                                      dataType::cudnnDataType_t, n::Cint,
+                                                      c::Cint, h::Cint,
+                                                      w::Cint)::cudnnStatus_t
 end
 
 @checked function cudnnSetTensor4dDescriptorEx(tensorDesc, dataType, n, c, h, w, nStride,
                                                cStride, hStride, wStride)
     initialize_context()
-    @ccall libcudnn.cudnnSetTensor4dDescriptorEx(tensorDesc::cudnnTensorDescriptor_t,
-                                                 dataType::cudnnDataType_t, n::Cint,
-                                                 c::Cint, h::Cint, w::Cint, nStride::Cint,
-                                                 cStride::Cint, hStride::Cint,
-                                                 wStride::Cint)::cudnnStatus_t
+    @gcsafe_ccall libcudnn.cudnnSetTensor4dDescriptorEx(tensorDesc::cudnnTensorDescriptor_t,
+                                                        dataType::cudnnDataType_t, n::Cint,
+                                                        c::Cint, h::Cint, w::Cint,
+                                                        nStride::Cint, cStride::Cint,
+                                                        hStride::Cint,
+                                                        wStride::Cint)::cudnnStatus_t
 end
 
 @checked function cudnnGetTensor4dDescriptor(tensorDesc, dataType, n, c, h, w, nStride,
                                              cStride, hStride, wStride)
     initialize_context()
-    @ccall libcudnn.cudnnGetTensor4dDescriptor(tensorDesc::cudnnTensorDescriptor_t,
-                                               dataType::Ptr{cudnnDataType_t}, n::Ptr{Cint},
-                                               c::Ptr{Cint}, h::Ptr{Cint}, w::Ptr{Cint},
-                                               nStride::Ptr{Cint}, cStride::Ptr{Cint},
-                                               hStride::Ptr{Cint},
-                                               wStride::Ptr{Cint})::cudnnStatus_t
+    @gcsafe_ccall libcudnn.cudnnGetTensor4dDescriptor(tensorDesc::cudnnTensorDescriptor_t,
+                                                      dataType::Ptr{cudnnDataType_t},
+                                                      n::Ptr{Cint}, c::Ptr{Cint},
+                                                      h::Ptr{Cint}, w::Ptr{Cint},
+                                                      nStride::Ptr{Cint},
+                                                      cStride::Ptr{Cint},
+                                                      hStride::Ptr{Cint},
+                                                      wStride::Ptr{Cint})::cudnnStatus_t
 end
 
 @checked function cudnnSetTensorNdDescriptor(tensorDesc, dataType, nbDims, dimA, strideA)
     initialize_context()
-    @ccall libcudnn.cudnnSetTensorNdDescriptor(tensorDesc::cudnnTensorDescriptor_t,
-                                               dataType::cudnnDataType_t, nbDims::Cint,
-                                               dimA::Ptr{Cint},
-                                               strideA::Ptr{Cint})::cudnnStatus_t
+    @gcsafe_ccall libcudnn.cudnnSetTensorNdDescriptor(tensorDesc::cudnnTensorDescriptor_t,
+                                                      dataType::cudnnDataType_t,
+                                                      nbDims::Cint, dimA::Ptr{Cint},
+                                                      strideA::Ptr{Cint})::cudnnStatus_t
 end
 
 @checked function cudnnSetTensorNdDescriptorEx(tensorDesc, format, dataType, nbDims, dimA)
     initialize_context()
-    @ccall libcudnn.cudnnSetTensorNdDescriptorEx(tensorDesc::cudnnTensorDescriptor_t,
-                                                 format::cudnnTensorFormat_t,
-                                                 dataType::cudnnDataType_t, nbDims::Cint,
-                                                 dimA::Ptr{Cint})::cudnnStatus_t
+    @gcsafe_ccall libcudnn.cudnnSetTensorNdDescriptorEx(tensorDesc::cudnnTensorDescriptor_t,
+                                                        format::cudnnTensorFormat_t,
+                                                        dataType::cudnnDataType_t,
+                                                        nbDims::Cint,
+                                                        dimA::Ptr{Cint})::cudnnStatus_t
 end
 
 @checked function cudnnGetTensorNdDescriptor(tensorDesc, nbDimsRequested, dataType, nbDims,
                                              dimA, strideA)
     initialize_context()
-    @ccall libcudnn.cudnnGetTensorNdDescriptor(tensorDesc::cudnnTensorDescriptor_t,
-                                               nbDimsRequested::Cint,
-                                               dataType::Ptr{cudnnDataType_t},
-                                               nbDims::Ptr{Cint}, dimA::Ptr{Cint},
-                                               strideA::Ptr{Cint})::cudnnStatus_t
+    @gcsafe_ccall libcudnn.cudnnGetTensorNdDescriptor(tensorDesc::cudnnTensorDescriptor_t,
+                                                      nbDimsRequested::Cint,
+                                                      dataType::Ptr{cudnnDataType_t},
+                                                      nbDims::Ptr{Cint}, dimA::Ptr{Cint},
+                                                      strideA::Ptr{Cint})::cudnnStatus_t
 end
 
 @checked function cudnnGetTensorSizeInBytes(tensorDesc, size)
     initialize_context()
-    @ccall libcudnn.cudnnGetTensorSizeInBytes(tensorDesc::cudnnTensorDescriptor_t,
-                                              size::Ptr{Csize_t})::cudnnStatus_t
+    @gcsafe_ccall libcudnn.cudnnGetTensorSizeInBytes(tensorDesc::cudnnTensorDescriptor_t,
+                                                     size::Ptr{Csize_t})::cudnnStatus_t
 end
 
 @checked function cudnnDestroyTensorDescriptor(tensorDesc)
     initialize_context()
-    @ccall libcudnn.cudnnDestroyTensorDescriptor(tensorDesc::cudnnTensorDescriptor_t)::cudnnStatus_t
+    @gcsafe_ccall libcudnn.cudnnDestroyTensorDescriptor(tensorDesc::cudnnTensorDescriptor_t)::cudnnStatus_t
 end
 
 @cenum cudnnFoldingDirection_t::UInt32 begin
@@ -268,73 +273,74 @@ end
 
 @checked function cudnnInitTransformDest(transformDesc, srcDesc, destDesc, destSizeInBytes)
     initialize_context()
-    @ccall libcudnn.cudnnInitTransformDest(transformDesc::cudnnTensorTransformDescriptor_t,
-                                           srcDesc::cudnnTensorDescriptor_t,
-                                           destDesc::cudnnTensorDescriptor_t,
-                                           destSizeInBytes::Ptr{Csize_t})::cudnnStatus_t
+    @gcsafe_ccall libcudnn.cudnnInitTransformDest(transformDesc::cudnnTensorTransformDescriptor_t,
+                                                  srcDesc::cudnnTensorDescriptor_t,
+                                                  destDesc::cudnnTensorDescriptor_t,
+                                                  destSizeInBytes::Ptr{Csize_t})::cudnnStatus_t
 end
 
 @checked function cudnnCreateTensorTransformDescriptor(transformDesc)
     initialize_context()
-    @ccall libcudnn.cudnnCreateTensorTransformDescriptor(transformDesc::Ptr{cudnnTensorTransformDescriptor_t})::cudnnStatus_t
+    @gcsafe_ccall libcudnn.cudnnCreateTensorTransformDescriptor(transformDesc::Ptr{cudnnTensorTransformDescriptor_t})::cudnnStatus_t
 end
 
 @checked function cudnnSetTensorTransformDescriptor(transformDesc, nbDims, destFormat,
                                                     padBeforeA, padAfterA, foldA, direction)
     initialize_context()
-    @ccall libcudnn.cudnnSetTensorTransformDescriptor(transformDesc::cudnnTensorTransformDescriptor_t,
-                                                      nbDims::UInt32,
-                                                      destFormat::cudnnTensorFormat_t,
-                                                      padBeforeA::Ptr{Int32},
-                                                      padAfterA::Ptr{Int32},
-                                                      foldA::Ptr{UInt32},
-                                                      direction::cudnnFoldingDirection_t)::cudnnStatus_t
+    @gcsafe_ccall libcudnn.cudnnSetTensorTransformDescriptor(transformDesc::cudnnTensorTransformDescriptor_t,
+                                                             nbDims::UInt32,
+                                                             destFormat::cudnnTensorFormat_t,
+                                                             padBeforeA::Ptr{Int32},
+                                                             padAfterA::Ptr{Int32},
+                                                             foldA::Ptr{UInt32},
+                                                             direction::cudnnFoldingDirection_t)::cudnnStatus_t
 end
 
 @checked function cudnnGetTensorTransformDescriptor(transformDesc, nbDimsRequested,
                                                     destFormat, padBeforeA, padAfterA,
                                                     foldA, direction)
     initialize_context()
-    @ccall libcudnn.cudnnGetTensorTransformDescriptor(transformDesc::cudnnTensorTransformDescriptor_t,
-                                                      nbDimsRequested::UInt32,
-                                                      destFormat::Ptr{cudnnTensorFormat_t},
-                                                      padBeforeA::Ptr{Int32},
-                                                      padAfterA::Ptr{Int32},
-                                                      foldA::Ptr{UInt32},
-                                                      direction::Ptr{cudnnFoldingDirection_t})::cudnnStatus_t
+    @gcsafe_ccall libcudnn.cudnnGetTensorTransformDescriptor(transformDesc::cudnnTensorTransformDescriptor_t,
+                                                             nbDimsRequested::UInt32,
+                                                             destFormat::Ptr{cudnnTensorFormat_t},
+                                                             padBeforeA::Ptr{Int32},
+                                                             padAfterA::Ptr{Int32},
+                                                             foldA::Ptr{UInt32},
+                                                             direction::Ptr{cudnnFoldingDirection_t})::cudnnStatus_t
 end
 
 @checked function cudnnDestroyTensorTransformDescriptor(transformDesc)
     initialize_context()
-    @ccall libcudnn.cudnnDestroyTensorTransformDescriptor(transformDesc::cudnnTensorTransformDescriptor_t)::cudnnStatus_t
+    @gcsafe_ccall libcudnn.cudnnDestroyTensorTransformDescriptor(transformDesc::cudnnTensorTransformDescriptor_t)::cudnnStatus_t
 end
 
 @checked function cudnnTransformTensor(handle, alpha, xDesc, x, beta, yDesc, y)
     initialize_context()
-    @ccall libcudnn.cudnnTransformTensor(handle::cudnnHandle_t, alpha::Ptr{Cvoid},
-                                         xDesc::cudnnTensorDescriptor_t, x::Ptr{Cvoid},
-                                         beta::Ptr{Cvoid}, yDesc::cudnnTensorDescriptor_t,
-                                         y::Ptr{Cvoid})::cudnnStatus_t
+    @gcsafe_ccall libcudnn.cudnnTransformTensor(handle::cudnnHandle_t, alpha::Ptr{Cvoid},
+                                                xDesc::cudnnTensorDescriptor_t,
+                                                x::Ptr{Cvoid}, beta::Ptr{Cvoid},
+                                                yDesc::cudnnTensorDescriptor_t,
+                                                y::Ptr{Cvoid})::cudnnStatus_t
 end
 
 @checked function cudnnTransformTensorEx(handle, transDesc, alpha, srcDesc, srcData, beta,
                                          destDesc, destData)
     initialize_context()
-    @ccall libcudnn.cudnnTransformTensorEx(handle::cudnnHandle_t,
-                                           transDesc::cudnnTensorTransformDescriptor_t,
-                                           alpha::Ptr{Cvoid},
-                                           srcDesc::cudnnTensorDescriptor_t,
-                                           srcData::Ptr{Cvoid}, beta::Ptr{Cvoid},
-                                           destDesc::cudnnTensorDescriptor_t,
-                                           destData::Ptr{Cvoid})::cudnnStatus_t
+    @gcsafe_ccall libcudnn.cudnnTransformTensorEx(handle::cudnnHandle_t,
+                                                  transDesc::cudnnTensorTransformDescriptor_t,
+                                                  alpha::Ptr{Cvoid},
+                                                  srcDesc::cudnnTensorDescriptor_t,
+                                                  srcData::Ptr{Cvoid}, beta::Ptr{Cvoid},
+                                                  destDesc::cudnnTensorDescriptor_t,
+                                                  destData::Ptr{Cvoid})::cudnnStatus_t
 end
 
 @checked function cudnnAddTensor(handle, alpha, aDesc, A, beta, cDesc, C)
     initialize_context()
-    @ccall libcudnn.cudnnAddTensor(handle::cudnnHandle_t, alpha::Ptr{Cvoid},
-                                   aDesc::cudnnTensorDescriptor_t, A::CuPtr{Cvoid},
-                                   beta::Ptr{Cvoid}, cDesc::cudnnTensorDescriptor_t,
-                                   C::CuPtr{Cvoid})::cudnnStatus_t
+    @gcsafe_ccall libcudnn.cudnnAddTensor(handle::cudnnHandle_t, alpha::Ptr{Cvoid},
+                                          aDesc::cudnnTensorDescriptor_t, A::CuPtr{Cvoid},
+                                          beta::Ptr{Cvoid}, cDesc::cudnnTensorDescriptor_t,
+                                          C::CuPtr{Cvoid})::cudnnStatus_t
 end
 
 @cenum cudnnOpTensorOp_t::UInt32 begin
@@ -348,42 +354,42 @@ end
 
 @checked function cudnnCreateOpTensorDescriptor(opTensorDesc)
     initialize_context()
-    @ccall libcudnn.cudnnCreateOpTensorDescriptor(opTensorDesc::Ptr{cudnnOpTensorDescriptor_t})::cudnnStatus_t
+    @gcsafe_ccall libcudnn.cudnnCreateOpTensorDescriptor(opTensorDesc::Ptr{cudnnOpTensorDescriptor_t})::cudnnStatus_t
 end
 
 @checked function cudnnSetOpTensorDescriptor(opTensorDesc, opTensorOp, opTensorCompType,
                                              opTensorNanOpt)
     initialize_context()
-    @ccall libcudnn.cudnnSetOpTensorDescriptor(opTensorDesc::cudnnOpTensorDescriptor_t,
-                                               opTensorOp::cudnnOpTensorOp_t,
-                                               opTensorCompType::cudnnDataType_t,
-                                               opTensorNanOpt::cudnnNanPropagation_t)::cudnnStatus_t
+    @gcsafe_ccall libcudnn.cudnnSetOpTensorDescriptor(opTensorDesc::cudnnOpTensorDescriptor_t,
+                                                      opTensorOp::cudnnOpTensorOp_t,
+                                                      opTensorCompType::cudnnDataType_t,
+                                                      opTensorNanOpt::cudnnNanPropagation_t)::cudnnStatus_t
 end
 
 @checked function cudnnGetOpTensorDescriptor(opTensorDesc, opTensorOp, opTensorCompType,
                                              opTensorNanOpt)
     initialize_context()
-    @ccall libcudnn.cudnnGetOpTensorDescriptor(opTensorDesc::cudnnOpTensorDescriptor_t,
-                                               opTensorOp::Ptr{cudnnOpTensorOp_t},
-                                               opTensorCompType::Ptr{cudnnDataType_t},
-                                               opTensorNanOpt::Ptr{cudnnNanPropagation_t})::cudnnStatus_t
+    @gcsafe_ccall libcudnn.cudnnGetOpTensorDescriptor(opTensorDesc::cudnnOpTensorDescriptor_t,
+                                                      opTensorOp::Ptr{cudnnOpTensorOp_t},
+                                                      opTensorCompType::Ptr{cudnnDataType_t},
+                                                      opTensorNanOpt::Ptr{cudnnNanPropagation_t})::cudnnStatus_t
 end
 
 @checked function cudnnDestroyOpTensorDescriptor(opTensorDesc)
     initialize_context()
-    @ccall libcudnn.cudnnDestroyOpTensorDescriptor(opTensorDesc::cudnnOpTensorDescriptor_t)::cudnnStatus_t
+    @gcsafe_ccall libcudnn.cudnnDestroyOpTensorDescriptor(opTensorDesc::cudnnOpTensorDescriptor_t)::cudnnStatus_t
 end
 
 @checked function cudnnOpTensor(handle, opTensorDesc, alpha1, aDesc, A, alpha2, bDesc, B,
                                 beta, cDesc, C)
     initialize_context()
-    @ccall libcudnn.cudnnOpTensor(handle::cudnnHandle_t,
-                                  opTensorDesc::cudnnOpTensorDescriptor_t,
-                                  alpha1::Ptr{Cvoid}, aDesc::cudnnTensorDescriptor_t,
-                                  A::CuPtr{Cvoid}, alpha2::Ptr{Cvoid},
-                                  bDesc::cudnnTensorDescriptor_t, B::CuPtr{Cvoid},
-                                  beta::Ptr{Cvoid}, cDesc::cudnnTensorDescriptor_t,
-                                  C::CuPtr{Cvoid})::cudnnStatus_t
+    @gcsafe_ccall libcudnn.cudnnOpTensor(handle::cudnnHandle_t,
+                                         opTensorDesc::cudnnOpTensorDescriptor_t,
+                                         alpha1::Ptr{Cvoid}, aDesc::cudnnTensorDescriptor_t,
+                                         A::CuPtr{Cvoid}, alpha2::Ptr{Cvoid},
+                                         bDesc::cudnnTensorDescriptor_t, B::CuPtr{Cvoid},
+                                         beta::Ptr{Cvoid}, cDesc::cudnnTensorDescriptor_t,
+                                         C::CuPtr{Cvoid})::cudnnStatus_t
 end
 
 @cenum cudnnReduceTensorOp_t::UInt32 begin
@@ -412,7 +418,7 @@ end
 
 @checked function cudnnCreateReduceTensorDescriptor(reduceTensorDesc)
     initialize_context()
-    @ccall libcudnn.cudnnCreateReduceTensorDescriptor(reduceTensorDesc::Ptr{cudnnReduceTensorDescriptor_t})::cudnnStatus_t
+    @gcsafe_ccall libcudnn.cudnnCreateReduceTensorDescriptor(reduceTensorDesc::Ptr{cudnnReduceTensorDescriptor_t})::cudnnStatus_t
 end
 
 @checked function cudnnSetReduceTensorDescriptor(reduceTensorDesc, reduceTensorOp,
@@ -420,12 +426,12 @@ end
                                                  reduceTensorIndices,
                                                  reduceTensorIndicesType)
     initialize_context()
-    @ccall libcudnn.cudnnSetReduceTensorDescriptor(reduceTensorDesc::cudnnReduceTensorDescriptor_t,
-                                                   reduceTensorOp::cudnnReduceTensorOp_t,
-                                                   reduceTensorCompType::cudnnDataType_t,
-                                                   reduceTensorNanOpt::cudnnNanPropagation_t,
-                                                   reduceTensorIndices::cudnnReduceTensorIndices_t,
-                                                   reduceTensorIndicesType::cudnnIndicesType_t)::cudnnStatus_t
+    @gcsafe_ccall libcudnn.cudnnSetReduceTensorDescriptor(reduceTensorDesc::cudnnReduceTensorDescriptor_t,
+                                                          reduceTensorOp::cudnnReduceTensorOp_t,
+                                                          reduceTensorCompType::cudnnDataType_t,
+                                                          reduceTensorNanOpt::cudnnNanPropagation_t,
+                                                          reduceTensorIndices::cudnnReduceTensorIndices_t,
+                                                          reduceTensorIndicesType::cudnnIndicesType_t)::cudnnStatus_t
 end
 
 @checked function cudnnGetReduceTensorDescriptor(reduceTensorDesc, reduceTensorOp,
@@ -433,128 +439,136 @@ end
                                                  reduceTensorIndices,
                                                  reduceTensorIndicesType)
     initialize_context()
-    @ccall libcudnn.cudnnGetReduceTensorDescriptor(reduceTensorDesc::cudnnReduceTensorDescriptor_t,
-                                                   reduceTensorOp::Ptr{cudnnReduceTensorOp_t},
-                                                   reduceTensorCompType::Ptr{cudnnDataType_t},
-                                                   reduceTensorNanOpt::Ptr{cudnnNanPropagation_t},
-                                                   reduceTensorIndices::Ptr{cudnnReduceTensorIndices_t},
-                                                   reduceTensorIndicesType::Ptr{cudnnIndicesType_t})::cudnnStatus_t
+    @gcsafe_ccall libcudnn.cudnnGetReduceTensorDescriptor(reduceTensorDesc::cudnnReduceTensorDescriptor_t,
+                                                          reduceTensorOp::Ptr{cudnnReduceTensorOp_t},
+                                                          reduceTensorCompType::Ptr{cudnnDataType_t},
+                                                          reduceTensorNanOpt::Ptr{cudnnNanPropagation_t},
+                                                          reduceTensorIndices::Ptr{cudnnReduceTensorIndices_t},
+                                                          reduceTensorIndicesType::Ptr{cudnnIndicesType_t})::cudnnStatus_t
 end
 
 @checked function cudnnDestroyReduceTensorDescriptor(reduceTensorDesc)
     initialize_context()
-    @ccall libcudnn.cudnnDestroyReduceTensorDescriptor(reduceTensorDesc::cudnnReduceTensorDescriptor_t)::cudnnStatus_t
+    @gcsafe_ccall libcudnn.cudnnDestroyReduceTensorDescriptor(reduceTensorDesc::cudnnReduceTensorDescriptor_t)::cudnnStatus_t
 end
 
 @checked function cudnnGetReductionIndicesSize(handle, reduceTensorDesc, aDesc, cDesc,
                                                sizeInBytes)
     initialize_context()
-    @ccall libcudnn.cudnnGetReductionIndicesSize(handle::cudnnHandle_t,
-                                                 reduceTensorDesc::cudnnReduceTensorDescriptor_t,
-                                                 aDesc::cudnnTensorDescriptor_t,
-                                                 cDesc::cudnnTensorDescriptor_t,
-                                                 sizeInBytes::Ptr{Csize_t})::cudnnStatus_t
+    @gcsafe_ccall libcudnn.cudnnGetReductionIndicesSize(handle::cudnnHandle_t,
+                                                        reduceTensorDesc::cudnnReduceTensorDescriptor_t,
+                                                        aDesc::cudnnTensorDescriptor_t,
+                                                        cDesc::cudnnTensorDescriptor_t,
+                                                        sizeInBytes::Ptr{Csize_t})::cudnnStatus_t
 end
 
 @checked function cudnnGetReductionWorkspaceSize(handle, reduceTensorDesc, aDesc, cDesc,
                                                  sizeInBytes)
     initialize_context()
-    @ccall libcudnn.cudnnGetReductionWorkspaceSize(handle::cudnnHandle_t,
-                                                   reduceTensorDesc::cudnnReduceTensorDescriptor_t,
-                                                   aDesc::cudnnTensorDescriptor_t,
-                                                   cDesc::cudnnTensorDescriptor_t,
-                                                   sizeInBytes::Ref{Csize_t})::cudnnStatus_t
+    @gcsafe_ccall libcudnn.cudnnGetReductionWorkspaceSize(handle::cudnnHandle_t,
+                                                          reduceTensorDesc::cudnnReduceTensorDescriptor_t,
+                                                          aDesc::cudnnTensorDescriptor_t,
+                                                          cDesc::cudnnTensorDescriptor_t,
+                                                          sizeInBytes::Ref{Csize_t})::cudnnStatus_t
 end
 
 @checked function cudnnReduceTensor(handle, reduceTensorDesc, indices, indicesSizeInBytes,
                                     workspace, workspaceSizeInBytes, alpha, aDesc, A, beta,
                                     cDesc, C)
     initialize_context()
-    @ccall libcudnn.cudnnReduceTensor(handle::cudnnHandle_t,
-                                      reduceTensorDesc::cudnnReduceTensorDescriptor_t,
-                                      indices::Ptr{Cvoid}, indicesSizeInBytes::Csize_t,
-                                      workspace::CuPtr{Cvoid},
-                                      workspaceSizeInBytes::Csize_t, alpha::Ptr{Cvoid},
-                                      aDesc::cudnnTensorDescriptor_t, A::CuPtr{Cvoid},
-                                      beta::Ptr{Cvoid}, cDesc::cudnnTensorDescriptor_t,
-                                      C::CuPtr{Cvoid})::cudnnStatus_t
+    @gcsafe_ccall libcudnn.cudnnReduceTensor(handle::cudnnHandle_t,
+                                             reduceTensorDesc::cudnnReduceTensorDescriptor_t,
+                                             indices::Ptr{Cvoid},
+                                             indicesSizeInBytes::Csize_t,
+                                             workspace::CuPtr{Cvoid},
+                                             workspaceSizeInBytes::Csize_t,
+                                             alpha::Ptr{Cvoid},
+                                             aDesc::cudnnTensorDescriptor_t,
+                                             A::CuPtr{Cvoid}, beta::Ptr{Cvoid},
+                                             cDesc::cudnnTensorDescriptor_t,
+                                             C::CuPtr{Cvoid})::cudnnStatus_t
 end
 
 @checked function cudnnSetTensor(handle, yDesc, y, valuePtr)
     initialize_context()
-    @ccall libcudnn.cudnnSetTensor(handle::cudnnHandle_t, yDesc::cudnnTensorDescriptor_t,
-                                   y::CuPtr{Cvoid}, valuePtr::Ptr{Cvoid})::cudnnStatus_t
+    @gcsafe_ccall libcudnn.cudnnSetTensor(handle::cudnnHandle_t,
+                                          yDesc::cudnnTensorDescriptor_t, y::CuPtr{Cvoid},
+                                          valuePtr::Ptr{Cvoid})::cudnnStatus_t
 end
 
 @checked function cudnnScaleTensor(handle, yDesc, y, alpha)
     initialize_context()
-    @ccall libcudnn.cudnnScaleTensor(handle::cudnnHandle_t, yDesc::cudnnTensorDescriptor_t,
-                                     y::CuPtr{Cvoid}, alpha::Ptr{Cvoid})::cudnnStatus_t
+    @gcsafe_ccall libcudnn.cudnnScaleTensor(handle::cudnnHandle_t,
+                                            yDesc::cudnnTensorDescriptor_t, y::CuPtr{Cvoid},
+                                            alpha::Ptr{Cvoid})::cudnnStatus_t
 end
 
 @checked function cudnnCreateFilterDescriptor(filterDesc)
     initialize_context()
-    @ccall libcudnn.cudnnCreateFilterDescriptor(filterDesc::Ptr{cudnnFilterDescriptor_t})::cudnnStatus_t
+    @gcsafe_ccall libcudnn.cudnnCreateFilterDescriptor(filterDesc::Ptr{cudnnFilterDescriptor_t})::cudnnStatus_t
 end
 
 @checked function cudnnSetFilter4dDescriptor(filterDesc, dataType, format, k, c, h, w)
     initialize_context()
-    @ccall libcudnn.cudnnSetFilter4dDescriptor(filterDesc::cudnnFilterDescriptor_t,
-                                               dataType::cudnnDataType_t,
-                                               format::cudnnTensorFormat_t, k::Cint,
-                                               c::Cint, h::Cint, w::Cint)::cudnnStatus_t
+    @gcsafe_ccall libcudnn.cudnnSetFilter4dDescriptor(filterDesc::cudnnFilterDescriptor_t,
+                                                      dataType::cudnnDataType_t,
+                                                      format::cudnnTensorFormat_t, k::Cint,
+                                                      c::Cint, h::Cint,
+                                                      w::Cint)::cudnnStatus_t
 end
 
 @checked function cudnnGetFilter4dDescriptor(filterDesc, dataType, format, k, c, h, w)
     initialize_context()
-    @ccall libcudnn.cudnnGetFilter4dDescriptor(filterDesc::cudnnFilterDescriptor_t,
-                                               dataType::Ptr{cudnnDataType_t},
-                                               format::Ptr{cudnnTensorFormat_t},
-                                               k::Ptr{Cint}, c::Ptr{Cint}, h::Ptr{Cint},
-                                               w::Ptr{Cint})::cudnnStatus_t
+    @gcsafe_ccall libcudnn.cudnnGetFilter4dDescriptor(filterDesc::cudnnFilterDescriptor_t,
+                                                      dataType::Ptr{cudnnDataType_t},
+                                                      format::Ptr{cudnnTensorFormat_t},
+                                                      k::Ptr{Cint}, c::Ptr{Cint},
+                                                      h::Ptr{Cint},
+                                                      w::Ptr{Cint})::cudnnStatus_t
 end
 
 @checked function cudnnSetFilterNdDescriptor(filterDesc, dataType, format, nbDims,
                                              filterDimA)
     initialize_context()
-    @ccall libcudnn.cudnnSetFilterNdDescriptor(filterDesc::cudnnFilterDescriptor_t,
-                                               dataType::cudnnDataType_t,
-                                               format::cudnnTensorFormat_t, nbDims::Cint,
-                                               filterDimA::Ptr{Cint})::cudnnStatus_t
+    @gcsafe_ccall libcudnn.cudnnSetFilterNdDescriptor(filterDesc::cudnnFilterDescriptor_t,
+                                                      dataType::cudnnDataType_t,
+                                                      format::cudnnTensorFormat_t,
+                                                      nbDims::Cint,
+                                                      filterDimA::Ptr{Cint})::cudnnStatus_t
 end
 
 @checked function cudnnGetFilterNdDescriptor(filterDesc, nbDimsRequested, dataType, format,
                                              nbDims, filterDimA)
     initialize_context()
-    @ccall libcudnn.cudnnGetFilterNdDescriptor(filterDesc::cudnnFilterDescriptor_t,
-                                               nbDimsRequested::Cint,
-                                               dataType::Ptr{cudnnDataType_t},
-                                               format::Ptr{cudnnTensorFormat_t},
-                                               nbDims::Ptr{Cint},
-                                               filterDimA::Ptr{Cint})::cudnnStatus_t
+    @gcsafe_ccall libcudnn.cudnnGetFilterNdDescriptor(filterDesc::cudnnFilterDescriptor_t,
+                                                      nbDimsRequested::Cint,
+                                                      dataType::Ptr{cudnnDataType_t},
+                                                      format::Ptr{cudnnTensorFormat_t},
+                                                      nbDims::Ptr{Cint},
+                                                      filterDimA::Ptr{Cint})::cudnnStatus_t
 end
 
 @checked function cudnnGetFilterSizeInBytes(filterDesc, size)
     initialize_context()
-    @ccall libcudnn.cudnnGetFilterSizeInBytes(filterDesc::cudnnFilterDescriptor_t,
-                                              size::Ptr{Csize_t})::cudnnStatus_t
+    @gcsafe_ccall libcudnn.cudnnGetFilterSizeInBytes(filterDesc::cudnnFilterDescriptor_t,
+                                                     size::Ptr{Csize_t})::cudnnStatus_t
 end
 
 @checked function cudnnTransformFilter(handle, transDesc, alpha, srcDesc, srcData, beta,
                                        destDesc, destData)
     initialize_context()
-    @ccall libcudnn.cudnnTransformFilter(handle::cudnnHandle_t,
-                                         transDesc::cudnnTensorTransformDescriptor_t,
-                                         alpha::Ptr{Cvoid},
-                                         srcDesc::cudnnFilterDescriptor_t,
-                                         srcData::CuPtr{Cvoid}, beta::Ptr{Cvoid},
-                                         destDesc::cudnnFilterDescriptor_t,
-                                         destData::CuPtr{Cvoid})::cudnnStatus_t
+    @gcsafe_ccall libcudnn.cudnnTransformFilter(handle::cudnnHandle_t,
+                                                transDesc::cudnnTensorTransformDescriptor_t,
+                                                alpha::Ptr{Cvoid},
+                                                srcDesc::cudnnFilterDescriptor_t,
+                                                srcData::CuPtr{Cvoid}, beta::Ptr{Cvoid},
+                                                destDesc::cudnnFilterDescriptor_t,
+                                                destData::CuPtr{Cvoid})::cudnnStatus_t
 end
 
 @checked function cudnnDestroyFilterDescriptor(filterDesc)
     initialize_context()
-    @ccall libcudnn.cudnnDestroyFilterDescriptor(filterDesc::cudnnFilterDescriptor_t)::cudnnStatus_t
+    @gcsafe_ccall libcudnn.cudnnDestroyFilterDescriptor(filterDesc::cudnnFilterDescriptor_t)::cudnnStatus_t
 end
 
 @cenum cudnnSoftmaxAlgorithm_t::UInt32 begin
@@ -570,12 +584,13 @@ end
 
 @checked function cudnnSoftmaxForward(handle, algo, mode, alpha, xDesc, x, beta, yDesc, y)
     initialize_context()
-    @ccall libcudnn.cudnnSoftmaxForward(handle::cudnnHandle_t,
-                                        algo::cudnnSoftmaxAlgorithm_t,
-                                        mode::cudnnSoftmaxMode_t, alpha::Ptr{Cvoid},
-                                        xDesc::cudnnTensorDescriptor_t, x::CuPtr{Cvoid},
-                                        beta::Ptr{Cvoid}, yDesc::cudnnTensorDescriptor_t,
-                                        y::CuPtr{Cvoid})::cudnnStatus_t
+    @gcsafe_ccall libcudnn.cudnnSoftmaxForward(handle::cudnnHandle_t,
+                                               algo::cudnnSoftmaxAlgorithm_t,
+                                               mode::cudnnSoftmaxMode_t, alpha::Ptr{Cvoid},
+                                               xDesc::cudnnTensorDescriptor_t,
+                                               x::CuPtr{Cvoid}, beta::Ptr{Cvoid},
+                                               yDesc::cudnnTensorDescriptor_t,
+                                               y::CuPtr{Cvoid})::cudnnStatus_t
 end
 
 @cenum cudnnPoolingMode_t::UInt32 begin
@@ -587,7 +602,7 @@ end
 
 @checked function cudnnCreatePoolingDescriptor(poolingDesc)
     initialize_context()
-    @ccall libcudnn.cudnnCreatePoolingDescriptor(poolingDesc::Ptr{cudnnPoolingDescriptor_t})::cudnnStatus_t
+    @gcsafe_ccall libcudnn.cudnnCreatePoolingDescriptor(poolingDesc::Ptr{cudnnPoolingDescriptor_t})::cudnnStatus_t
 end
 
 @checked function cudnnSetPooling2dDescriptor(poolingDesc, mode, maxpoolingNanOpt,
@@ -595,14 +610,15 @@ end
                                               horizontalPadding, verticalStride,
                                               horizontalStride)
     initialize_context()
-    @ccall libcudnn.cudnnSetPooling2dDescriptor(poolingDesc::cudnnPoolingDescriptor_t,
-                                                mode::cudnnPoolingMode_t,
-                                                maxpoolingNanOpt::cudnnNanPropagation_t,
-                                                windowHeight::Cint, windowWidth::Cint,
-                                                verticalPadding::Cint,
-                                                horizontalPadding::Cint,
-                                                verticalStride::Cint,
-                                                horizontalStride::Cint)::cudnnStatus_t
+    @gcsafe_ccall libcudnn.cudnnSetPooling2dDescriptor(poolingDesc::cudnnPoolingDescriptor_t,
+                                                       mode::cudnnPoolingMode_t,
+                                                       maxpoolingNanOpt::cudnnNanPropagation_t,
+                                                       windowHeight::Cint,
+                                                       windowWidth::Cint,
+                                                       verticalPadding::Cint,
+                                                       horizontalPadding::Cint,
+                                                       verticalStride::Cint,
+                                                       horizontalStride::Cint)::cudnnStatus_t
 end
 
 @checked function cudnnGetPooling2dDescriptor(poolingDesc, mode, maxpoolingNanOpt,
@@ -610,73 +626,75 @@ end
                                               horizontalPadding, verticalStride,
                                               horizontalStride)
     initialize_context()
-    @ccall libcudnn.cudnnGetPooling2dDescriptor(poolingDesc::cudnnPoolingDescriptor_t,
-                                                mode::Ptr{cudnnPoolingMode_t},
-                                                maxpoolingNanOpt::Ptr{cudnnNanPropagation_t},
-                                                windowHeight::Ptr{Cint},
-                                                windowWidth::Ptr{Cint},
-                                                verticalPadding::Ptr{Cint},
-                                                horizontalPadding::Ptr{Cint},
-                                                verticalStride::Ptr{Cint},
-                                                horizontalStride::Ptr{Cint})::cudnnStatus_t
+    @gcsafe_ccall libcudnn.cudnnGetPooling2dDescriptor(poolingDesc::cudnnPoolingDescriptor_t,
+                                                       mode::Ptr{cudnnPoolingMode_t},
+                                                       maxpoolingNanOpt::Ptr{cudnnNanPropagation_t},
+                                                       windowHeight::Ptr{Cint},
+                                                       windowWidth::Ptr{Cint},
+                                                       verticalPadding::Ptr{Cint},
+                                                       horizontalPadding::Ptr{Cint},
+                                                       verticalStride::Ptr{Cint},
+                                                       horizontalStride::Ptr{Cint})::cudnnStatus_t
 end
 
 @checked function cudnnSetPoolingNdDescriptor(poolingDesc, mode, maxpoolingNanOpt, nbDims,
                                               windowDimA, paddingA, strideA)
     initialize_context()
-    @ccall libcudnn.cudnnSetPoolingNdDescriptor(poolingDesc::cudnnPoolingDescriptor_t,
-                                                mode::cudnnPoolingMode_t,
-                                                maxpoolingNanOpt::cudnnNanPropagation_t,
-                                                nbDims::Cint, windowDimA::Ptr{Cint},
-                                                paddingA::Ptr{Cint},
-                                                strideA::Ptr{Cint})::cudnnStatus_t
+    @gcsafe_ccall libcudnn.cudnnSetPoolingNdDescriptor(poolingDesc::cudnnPoolingDescriptor_t,
+                                                       mode::cudnnPoolingMode_t,
+                                                       maxpoolingNanOpt::cudnnNanPropagation_t,
+                                                       nbDims::Cint, windowDimA::Ptr{Cint},
+                                                       paddingA::Ptr{Cint},
+                                                       strideA::Ptr{Cint})::cudnnStatus_t
 end
 
 @checked function cudnnGetPoolingNdDescriptor(poolingDesc, nbDimsRequested, mode,
                                               maxpoolingNanOpt, nbDims, windowDimA,
                                               paddingA, strideA)
     initialize_context()
-    @ccall libcudnn.cudnnGetPoolingNdDescriptor(poolingDesc::cudnnPoolingDescriptor_t,
-                                                nbDimsRequested::Cint,
-                                                mode::Ptr{cudnnPoolingMode_t},
-                                                maxpoolingNanOpt::Ptr{cudnnNanPropagation_t},
-                                                nbDims::Ptr{Cint}, windowDimA::Ptr{Cint},
-                                                paddingA::Ptr{Cint},
-                                                strideA::Ptr{Cint})::cudnnStatus_t
+    @gcsafe_ccall libcudnn.cudnnGetPoolingNdDescriptor(poolingDesc::cudnnPoolingDescriptor_t,
+                                                       nbDimsRequested::Cint,
+                                                       mode::Ptr{cudnnPoolingMode_t},
+                                                       maxpoolingNanOpt::Ptr{cudnnNanPropagation_t},
+                                                       nbDims::Ptr{Cint},
+                                                       windowDimA::Ptr{Cint},
+                                                       paddingA::Ptr{Cint},
+                                                       strideA::Ptr{Cint})::cudnnStatus_t
 end
 
 @checked function cudnnGetPoolingNdForwardOutputDim(poolingDesc, inputTensorDesc, nbDims,
                                                     outputTensorDimA)
     initialize_context()
-    @ccall libcudnn.cudnnGetPoolingNdForwardOutputDim(poolingDesc::cudnnPoolingDescriptor_t,
-                                                      inputTensorDesc::cudnnTensorDescriptor_t,
-                                                      nbDims::Cint,
-                                                      outputTensorDimA::Ptr{Cint})::cudnnStatus_t
+    @gcsafe_ccall libcudnn.cudnnGetPoolingNdForwardOutputDim(poolingDesc::cudnnPoolingDescriptor_t,
+                                                             inputTensorDesc::cudnnTensorDescriptor_t,
+                                                             nbDims::Cint,
+                                                             outputTensorDimA::Ptr{Cint})::cudnnStatus_t
 end
 
 @checked function cudnnGetPooling2dForwardOutputDim(poolingDesc, inputTensorDesc, n, c, h,
                                                     w)
     initialize_context()
-    @ccall libcudnn.cudnnGetPooling2dForwardOutputDim(poolingDesc::cudnnPoolingDescriptor_t,
-                                                      inputTensorDesc::cudnnTensorDescriptor_t,
-                                                      n::Ptr{Cint}, c::Ptr{Cint},
-                                                      h::Ptr{Cint},
-                                                      w::Ptr{Cint})::cudnnStatus_t
+    @gcsafe_ccall libcudnn.cudnnGetPooling2dForwardOutputDim(poolingDesc::cudnnPoolingDescriptor_t,
+                                                             inputTensorDesc::cudnnTensorDescriptor_t,
+                                                             n::Ptr{Cint}, c::Ptr{Cint},
+                                                             h::Ptr{Cint},
+                                                             w::Ptr{Cint})::cudnnStatus_t
 end
 
 @checked function cudnnDestroyPoolingDescriptor(poolingDesc)
     initialize_context()
-    @ccall libcudnn.cudnnDestroyPoolingDescriptor(poolingDesc::cudnnPoolingDescriptor_t)::cudnnStatus_t
+    @gcsafe_ccall libcudnn.cudnnDestroyPoolingDescriptor(poolingDesc::cudnnPoolingDescriptor_t)::cudnnStatus_t
 end
 
 @checked function cudnnPoolingForward(handle, poolingDesc, alpha, xDesc, x, beta, yDesc, y)
     initialize_context()
-    @ccall libcudnn.cudnnPoolingForward(handle::cudnnHandle_t,
-                                        poolingDesc::cudnnPoolingDescriptor_t,
-                                        alpha::Ptr{Cvoid}, xDesc::cudnnTensorDescriptor_t,
-                                        x::CuPtr{Cvoid}, beta::Ptr{Cvoid},
-                                        yDesc::cudnnTensorDescriptor_t,
-                                        y::CuPtr{Cvoid})::cudnnStatus_t
+    @gcsafe_ccall libcudnn.cudnnPoolingForward(handle::cudnnHandle_t,
+                                               poolingDesc::cudnnPoolingDescriptor_t,
+                                               alpha::Ptr{Cvoid},
+                                               xDesc::cudnnTensorDescriptor_t,
+                                               x::CuPtr{Cvoid}, beta::Ptr{Cvoid},
+                                               yDesc::cudnnTensorDescriptor_t,
+                                               y::CuPtr{Cvoid})::cudnnStatus_t
 end
 
 @cenum cudnnActivationMode_t::UInt32 begin
@@ -691,56 +709,57 @@ end
 
 @checked function cudnnCreateActivationDescriptor(activationDesc)
     initialize_context()
-    @ccall libcudnn.cudnnCreateActivationDescriptor(activationDesc::Ptr{cudnnActivationDescriptor_t})::cudnnStatus_t
+    @gcsafe_ccall libcudnn.cudnnCreateActivationDescriptor(activationDesc::Ptr{cudnnActivationDescriptor_t})::cudnnStatus_t
 end
 
 @checked function cudnnSetActivationDescriptor(activationDesc, mode, reluNanOpt, coef)
     initialize_context()
-    @ccall libcudnn.cudnnSetActivationDescriptor(activationDesc::cudnnActivationDescriptor_t,
-                                                 mode::cudnnActivationMode_t,
-                                                 reluNanOpt::cudnnNanPropagation_t,
-                                                 coef::Cdouble)::cudnnStatus_t
+    @gcsafe_ccall libcudnn.cudnnSetActivationDescriptor(activationDesc::cudnnActivationDescriptor_t,
+                                                        mode::cudnnActivationMode_t,
+                                                        reluNanOpt::cudnnNanPropagation_t,
+                                                        coef::Cdouble)::cudnnStatus_t
 end
 
 @checked function cudnnGetActivationDescriptor(activationDesc, mode, reluNanOpt, coef)
     initialize_context()
-    @ccall libcudnn.cudnnGetActivationDescriptor(activationDesc::cudnnActivationDescriptor_t,
-                                                 mode::Ptr{cudnnActivationMode_t},
-                                                 reluNanOpt::Ptr{cudnnNanPropagation_t},
-                                                 coef::Ptr{Cdouble})::cudnnStatus_t
+    @gcsafe_ccall libcudnn.cudnnGetActivationDescriptor(activationDesc::cudnnActivationDescriptor_t,
+                                                        mode::Ptr{cudnnActivationMode_t},
+                                                        reluNanOpt::Ptr{cudnnNanPropagation_t},
+                                                        coef::Ptr{Cdouble})::cudnnStatus_t
 end
 
 @checked function cudnnSetActivationDescriptorSwishBeta(activationDesc, swish_beta)
     initialize_context()
-    @ccall libcudnn.cudnnSetActivationDescriptorSwishBeta(activationDesc::cudnnActivationDescriptor_t,
-                                                          swish_beta::Cdouble)::cudnnStatus_t
+    @gcsafe_ccall libcudnn.cudnnSetActivationDescriptorSwishBeta(activationDesc::cudnnActivationDescriptor_t,
+                                                                 swish_beta::Cdouble)::cudnnStatus_t
 end
 
 @checked function cudnnGetActivationDescriptorSwishBeta(activationDesc, swish_beta)
     initialize_context()
-    @ccall libcudnn.cudnnGetActivationDescriptorSwishBeta(activationDesc::cudnnActivationDescriptor_t,
-                                                          swish_beta::Ptr{Cdouble})::cudnnStatus_t
+    @gcsafe_ccall libcudnn.cudnnGetActivationDescriptorSwishBeta(activationDesc::cudnnActivationDescriptor_t,
+                                                                 swish_beta::Ptr{Cdouble})::cudnnStatus_t
 end
 
 @checked function cudnnDestroyActivationDescriptor(activationDesc)
     initialize_context()
-    @ccall libcudnn.cudnnDestroyActivationDescriptor(activationDesc::cudnnActivationDescriptor_t)::cudnnStatus_t
+    @gcsafe_ccall libcudnn.cudnnDestroyActivationDescriptor(activationDesc::cudnnActivationDescriptor_t)::cudnnStatus_t
 end
 
 @checked function cudnnActivationForward(handle, activationDesc, alpha, xDesc, x, beta,
                                          yDesc, y)
     initialize_context()
-    @ccall libcudnn.cudnnActivationForward(handle::cudnnHandle_t,
-                                           activationDesc::cudnnActivationDescriptor_t,
-                                           alpha::Ptr{Cvoid},
-                                           xDesc::cudnnTensorDescriptor_t, x::CuPtr{Cvoid},
-                                           beta::Ptr{Cvoid}, yDesc::cudnnTensorDescriptor_t,
-                                           y::CuPtr{Cvoid})::cudnnStatus_t
+    @gcsafe_ccall libcudnn.cudnnActivationForward(handle::cudnnHandle_t,
+                                                  activationDesc::cudnnActivationDescriptor_t,
+                                                  alpha::Ptr{Cvoid},
+                                                  xDesc::cudnnTensorDescriptor_t,
+                                                  x::CuPtr{Cvoid}, beta::Ptr{Cvoid},
+                                                  yDesc::cudnnTensorDescriptor_t,
+                                                  y::CuPtr{Cvoid})::cudnnStatus_t
 end
 
 @checked function cudnnCreateLRNDescriptor(normDesc)
     initialize_context()
-    @ccall libcudnn.cudnnCreateLRNDescriptor(normDesc::Ptr{cudnnLRNDescriptor_t})::cudnnStatus_t
+    @gcsafe_ccall libcudnn.cudnnCreateLRNDescriptor(normDesc::Ptr{cudnnLRNDescriptor_t})::cudnnStatus_t
 end
 
 @cenum cudnnLRNMode_t::UInt32 begin
@@ -749,33 +768,36 @@ end
 
 @checked function cudnnSetLRNDescriptor(normDesc, lrnN, lrnAlpha, lrnBeta, lrnK)
     initialize_context()
-    @ccall libcudnn.cudnnSetLRNDescriptor(normDesc::cudnnLRNDescriptor_t, lrnN::Cuint,
-                                          lrnAlpha::Cdouble, lrnBeta::Cdouble,
-                                          lrnK::Cdouble)::cudnnStatus_t
+    @gcsafe_ccall libcudnn.cudnnSetLRNDescriptor(normDesc::cudnnLRNDescriptor_t,
+                                                 lrnN::Cuint, lrnAlpha::Cdouble,
+                                                 lrnBeta::Cdouble,
+                                                 lrnK::Cdouble)::cudnnStatus_t
 end
 
 @checked function cudnnGetLRNDescriptor(normDesc, lrnN, lrnAlpha, lrnBeta, lrnK)
     initialize_context()
-    @ccall libcudnn.cudnnGetLRNDescriptor(normDesc::cudnnLRNDescriptor_t, lrnN::Ptr{Cuint},
-                                          lrnAlpha::Ptr{Cdouble}, lrnBeta::Ptr{Cdouble},
-                                          lrnK::Ptr{Cdouble})::cudnnStatus_t
+    @gcsafe_ccall libcudnn.cudnnGetLRNDescriptor(normDesc::cudnnLRNDescriptor_t,
+                                                 lrnN::Ptr{Cuint}, lrnAlpha::Ptr{Cdouble},
+                                                 lrnBeta::Ptr{Cdouble},
+                                                 lrnK::Ptr{Cdouble})::cudnnStatus_t
 end
 
 @checked function cudnnDestroyLRNDescriptor(lrnDesc)
     initialize_context()
-    @ccall libcudnn.cudnnDestroyLRNDescriptor(lrnDesc::cudnnLRNDescriptor_t)::cudnnStatus_t
+    @gcsafe_ccall libcudnn.cudnnDestroyLRNDescriptor(lrnDesc::cudnnLRNDescriptor_t)::cudnnStatus_t
 end
 
 @checked function cudnnLRNCrossChannelForward(handle, normDesc, lrnMode, alpha, xDesc, x,
                                               beta, yDesc, y)
     initialize_context()
-    @ccall libcudnn.cudnnLRNCrossChannelForward(handle::cudnnHandle_t,
-                                                normDesc::cudnnLRNDescriptor_t,
-                                                lrnMode::cudnnLRNMode_t, alpha::Ptr{Cvoid},
-                                                xDesc::cudnnTensorDescriptor_t,
-                                                x::CuPtr{Cvoid}, beta::Ptr{Cvoid},
-                                                yDesc::cudnnTensorDescriptor_t,
-                                                y::CuPtr{Cvoid})::cudnnStatus_t
+    @gcsafe_ccall libcudnn.cudnnLRNCrossChannelForward(handle::cudnnHandle_t,
+                                                       normDesc::cudnnLRNDescriptor_t,
+                                                       lrnMode::cudnnLRNMode_t,
+                                                       alpha::Ptr{Cvoid},
+                                                       xDesc::cudnnTensorDescriptor_t,
+                                                       x::CuPtr{Cvoid}, beta::Ptr{Cvoid},
+                                                       yDesc::cudnnTensorDescriptor_t,
+                                                       y::CuPtr{Cvoid})::cudnnStatus_t
 end
 
 @cenum cudnnDivNormMode_t::UInt32 begin
@@ -785,16 +807,18 @@ end
 @checked function cudnnDivisiveNormalizationForward(handle, normDesc, mode, alpha, xDesc, x,
                                                     means, temp, temp2, beta, yDesc, y)
     initialize_context()
-    @ccall libcudnn.cudnnDivisiveNormalizationForward(handle::cudnnHandle_t,
-                                                      normDesc::cudnnLRNDescriptor_t,
-                                                      mode::cudnnDivNormMode_t,
-                                                      alpha::Ptr{Cvoid},
-                                                      xDesc::cudnnTensorDescriptor_t,
-                                                      x::CuPtr{Cvoid}, means::CuPtr{Cvoid},
-                                                      temp::CuPtr{Cvoid},
-                                                      temp2::CuPtr{Cvoid}, beta::Ptr{Cvoid},
-                                                      yDesc::cudnnTensorDescriptor_t,
-                                                      y::CuPtr{Cvoid})::cudnnStatus_t
+    @gcsafe_ccall libcudnn.cudnnDivisiveNormalizationForward(handle::cudnnHandle_t,
+                                                             normDesc::cudnnLRNDescriptor_t,
+                                                             mode::cudnnDivNormMode_t,
+                                                             alpha::Ptr{Cvoid},
+                                                             xDesc::cudnnTensorDescriptor_t,
+                                                             x::CuPtr{Cvoid},
+                                                             means::CuPtr{Cvoid},
+                                                             temp::CuPtr{Cvoid},
+                                                             temp2::CuPtr{Cvoid},
+                                                             beta::Ptr{Cvoid},
+                                                             yDesc::cudnnTensorDescriptor_t,
+                                                             y::CuPtr{Cvoid})::cudnnStatus_t
 end
 
 @cenum cudnnBatchNormMode_t::UInt32 begin
@@ -805,9 +829,9 @@ end
 
 @checked function cudnnDeriveBNTensorDescriptor(derivedBnDesc, xDesc, mode)
     initialize_context()
-    @ccall libcudnn.cudnnDeriveBNTensorDescriptor(derivedBnDesc::cudnnTensorDescriptor_t,
-                                                  xDesc::cudnnTensorDescriptor_t,
-                                                  mode::cudnnBatchNormMode_t)::cudnnStatus_t
+    @gcsafe_ccall libcudnn.cudnnDeriveBNTensorDescriptor(derivedBnDesc::cudnnTensorDescriptor_t,
+                                                         xDesc::cudnnTensorDescriptor_t,
+                                                         mode::cudnnBatchNormMode_t)::cudnnStatus_t
 end
 
 @cenum cudnnBatchNormOps_t::UInt32 begin
@@ -822,20 +846,20 @@ end
                                                           bnBias, estimatedMean,
                                                           estimatedVariance, epsilon)
     initialize_context()
-    @ccall libcudnn.cudnnBatchNormalizationForwardInference(handle::cudnnHandle_t,
-                                                            mode::cudnnBatchNormMode_t,
-                                                            alpha::Ptr{Cvoid},
-                                                            beta::Ptr{Cvoid},
-                                                            xDesc::cudnnTensorDescriptor_t,
-                                                            x::CuPtr{Cvoid},
-                                                            yDesc::cudnnTensorDescriptor_t,
-                                                            y::CuPtr{Cvoid},
-                                                            bnScaleBiasMeanVarDesc::cudnnTensorDescriptor_t,
-                                                            bnScale::CuPtr{Cvoid},
-                                                            bnBias::CuPtr{Cvoid},
-                                                            estimatedMean::CuPtr{Cvoid},
-                                                            estimatedVariance::CuPtr{Cvoid},
-                                                            epsilon::Cdouble)::cudnnStatus_t
+    @gcsafe_ccall libcudnn.cudnnBatchNormalizationForwardInference(handle::cudnnHandle_t,
+                                                                   mode::cudnnBatchNormMode_t,
+                                                                   alpha::Ptr{Cvoid},
+                                                                   beta::Ptr{Cvoid},
+                                                                   xDesc::cudnnTensorDescriptor_t,
+                                                                   x::CuPtr{Cvoid},
+                                                                   yDesc::cudnnTensorDescriptor_t,
+                                                                   y::CuPtr{Cvoid},
+                                                                   bnScaleBiasMeanVarDesc::cudnnTensorDescriptor_t,
+                                                                   bnScale::CuPtr{Cvoid},
+                                                                   bnBias::CuPtr{Cvoid},
+                                                                   estimatedMean::CuPtr{Cvoid},
+                                                                   estimatedVariance::CuPtr{Cvoid},
+                                                                   epsilon::Cdouble)::cudnnStatus_t
 end
 
 @cenum cudnnNormMode_t::UInt32 begin
@@ -852,11 +876,11 @@ end
                                                   derivedNormMeanVarDesc, xDesc, mode,
                                                   groupCnt)
     initialize_context()
-    @ccall libcudnn.cudnnDeriveNormTensorDescriptor(derivedNormScaleBiasDesc::cudnnTensorDescriptor_t,
-                                                    derivedNormMeanVarDesc::cudnnTensorDescriptor_t,
-                                                    xDesc::cudnnTensorDescriptor_t,
-                                                    mode::cudnnNormMode_t,
-                                                    groupCnt::Cint)::cudnnStatus_t
+    @gcsafe_ccall libcudnn.cudnnDeriveNormTensorDescriptor(derivedNormScaleBiasDesc::cudnnTensorDescriptor_t,
+                                                           derivedNormMeanVarDesc::cudnnTensorDescriptor_t,
+                                                           xDesc::cudnnTensorDescriptor_t,
+                                                           mode::cudnnNormMode_t,
+                                                           groupCnt::Cint)::cudnnStatus_t
 end
 
 @cenum cudnnNormOps_t::UInt32 begin
@@ -872,25 +896,27 @@ end
                                                      zDesc, z, activationDesc, yDesc, y,
                                                      epsilon, groupCnt)
     initialize_context()
-    @ccall libcudnn.cudnnNormalizationForwardInference(handle::cudnnHandle_t,
-                                                       mode::cudnnNormMode_t,
-                                                       normOps::cudnnNormOps_t,
-                                                       algo::cudnnNormAlgo_t,
-                                                       alpha::Ptr{Cvoid}, beta::Ptr{Cvoid},
-                                                       xDesc::cudnnTensorDescriptor_t,
-                                                       x::CuPtr{Cvoid},
-                                                       normScaleBiasDesc::cudnnTensorDescriptor_t,
-                                                       normScale::CuPtr{Cvoid},
-                                                       normBias::CuPtr{Cvoid},
-                                                       normMeanVarDesc::cudnnTensorDescriptor_t,
-                                                       estimatedMean::CuPtr{Cvoid},
-                                                       estimatedVariance::CuPtr{Cvoid},
-                                                       zDesc::cudnnTensorDescriptor_t,
-                                                       z::CuPtr{Cvoid},
-                                                       activationDesc::cudnnActivationDescriptor_t,
-                                                       yDesc::cudnnTensorDescriptor_t,
-                                                       y::CuPtr{Cvoid}, epsilon::Cdouble,
-                                                       groupCnt::Cint)::cudnnStatus_t
+    @gcsafe_ccall libcudnn.cudnnNormalizationForwardInference(handle::cudnnHandle_t,
+                                                              mode::cudnnNormMode_t,
+                                                              normOps::cudnnNormOps_t,
+                                                              algo::cudnnNormAlgo_t,
+                                                              alpha::Ptr{Cvoid},
+                                                              beta::Ptr{Cvoid},
+                                                              xDesc::cudnnTensorDescriptor_t,
+                                                              x::CuPtr{Cvoid},
+                                                              normScaleBiasDesc::cudnnTensorDescriptor_t,
+                                                              normScale::CuPtr{Cvoid},
+                                                              normBias::CuPtr{Cvoid},
+                                                              normMeanVarDesc::cudnnTensorDescriptor_t,
+                                                              estimatedMean::CuPtr{Cvoid},
+                                                              estimatedVariance::CuPtr{Cvoid},
+                                                              zDesc::cudnnTensorDescriptor_t,
+                                                              z::CuPtr{Cvoid},
+                                                              activationDesc::cudnnActivationDescriptor_t,
+                                                              yDesc::cudnnTensorDescriptor_t,
+                                                              y::CuPtr{Cvoid},
+                                                              epsilon::Cdouble,
+                                                              groupCnt::Cint)::cudnnStatus_t
 end
 
 @cenum cudnnSamplerType_t::UInt32 begin
@@ -899,43 +925,43 @@ end
 
 @checked function cudnnCreateSpatialTransformerDescriptor(stDesc)
     initialize_context()
-    @ccall libcudnn.cudnnCreateSpatialTransformerDescriptor(stDesc::Ptr{cudnnSpatialTransformerDescriptor_t})::cudnnStatus_t
+    @gcsafe_ccall libcudnn.cudnnCreateSpatialTransformerDescriptor(stDesc::Ptr{cudnnSpatialTransformerDescriptor_t})::cudnnStatus_t
 end
 
 @checked function cudnnSetSpatialTransformerNdDescriptor(stDesc, samplerType, dataType,
                                                          nbDims, dimA)
     initialize_context()
-    @ccall libcudnn.cudnnSetSpatialTransformerNdDescriptor(stDesc::cudnnSpatialTransformerDescriptor_t,
-                                                           samplerType::cudnnSamplerType_t,
-                                                           dataType::cudnnDataType_t,
-                                                           nbDims::Cint,
-                                                           dimA::Ptr{Cint})::cudnnStatus_t
+    @gcsafe_ccall libcudnn.cudnnSetSpatialTransformerNdDescriptor(stDesc::cudnnSpatialTransformerDescriptor_t,
+                                                                  samplerType::cudnnSamplerType_t,
+                                                                  dataType::cudnnDataType_t,
+                                                                  nbDims::Cint,
+                                                                  dimA::Ptr{Cint})::cudnnStatus_t
 end
 
 @checked function cudnnDestroySpatialTransformerDescriptor(stDesc)
     initialize_context()
-    @ccall libcudnn.cudnnDestroySpatialTransformerDescriptor(stDesc::cudnnSpatialTransformerDescriptor_t)::cudnnStatus_t
+    @gcsafe_ccall libcudnn.cudnnDestroySpatialTransformerDescriptor(stDesc::cudnnSpatialTransformerDescriptor_t)::cudnnStatus_t
 end
 
 @checked function cudnnSpatialTfGridGeneratorForward(handle, stDesc, theta, grid)
     initialize_context()
-    @ccall libcudnn.cudnnSpatialTfGridGeneratorForward(handle::cudnnHandle_t,
-                                                       stDesc::cudnnSpatialTransformerDescriptor_t,
-                                                       theta::CuPtr{Cvoid},
-                                                       grid::CuPtr{Cvoid})::cudnnStatus_t
+    @gcsafe_ccall libcudnn.cudnnSpatialTfGridGeneratorForward(handle::cudnnHandle_t,
+                                                              stDesc::cudnnSpatialTransformerDescriptor_t,
+                                                              theta::CuPtr{Cvoid},
+                                                              grid::CuPtr{Cvoid})::cudnnStatus_t
 end
 
 @checked function cudnnSpatialTfSamplerForward(handle, stDesc, alpha, xDesc, x, grid, beta,
                                                yDesc, y)
     initialize_context()
-    @ccall libcudnn.cudnnSpatialTfSamplerForward(handle::cudnnHandle_t,
-                                                 stDesc::cudnnSpatialTransformerDescriptor_t,
-                                                 alpha::Ptr{Cvoid},
-                                                 xDesc::cudnnTensorDescriptor_t,
-                                                 x::CuPtr{Cvoid}, grid::CuPtr{Cvoid},
-                                                 beta::Ptr{Cvoid},
-                                                 yDesc::cudnnTensorDescriptor_t,
-                                                 y::CuPtr{Cvoid})::cudnnStatus_t
+    @gcsafe_ccall libcudnn.cudnnSpatialTfSamplerForward(handle::cudnnHandle_t,
+                                                        stDesc::cudnnSpatialTransformerDescriptor_t,
+                                                        alpha::Ptr{Cvoid},
+                                                        xDesc::cudnnTensorDescriptor_t,
+                                                        x::CuPtr{Cvoid}, grid::CuPtr{Cvoid},
+                                                        beta::Ptr{Cvoid},
+                                                        yDesc::cudnnTensorDescriptor_t,
+                                                        y::CuPtr{Cvoid})::cudnnStatus_t
 end
 
 mutable struct cudnnDropoutStruct end
@@ -944,63 +970,66 @@ const cudnnDropoutDescriptor_t = Ptr{cudnnDropoutStruct}
 
 @checked function cudnnCreateDropoutDescriptor(dropoutDesc)
     initialize_context()
-    @ccall libcudnn.cudnnCreateDropoutDescriptor(dropoutDesc::Ptr{cudnnDropoutDescriptor_t})::cudnnStatus_t
+    @gcsafe_ccall libcudnn.cudnnCreateDropoutDescriptor(dropoutDesc::Ptr{cudnnDropoutDescriptor_t})::cudnnStatus_t
 end
 
 @checked function cudnnDestroyDropoutDescriptor(dropoutDesc)
     initialize_context()
-    @ccall libcudnn.cudnnDestroyDropoutDescriptor(dropoutDesc::cudnnDropoutDescriptor_t)::cudnnStatus_t
+    @gcsafe_ccall libcudnn.cudnnDestroyDropoutDescriptor(dropoutDesc::cudnnDropoutDescriptor_t)::cudnnStatus_t
 end
 
 @checked function cudnnDropoutGetStatesSize(handle, sizeInBytes)
     initialize_context()
-    @ccall libcudnn.cudnnDropoutGetStatesSize(handle::cudnnHandle_t,
-                                              sizeInBytes::Ptr{Csize_t})::cudnnStatus_t
+    @gcsafe_ccall libcudnn.cudnnDropoutGetStatesSize(handle::cudnnHandle_t,
+                                                     sizeInBytes::Ptr{Csize_t})::cudnnStatus_t
 end
 
 @checked function cudnnDropoutGetReserveSpaceSize(xdesc, sizeInBytes)
     initialize_context()
-    @ccall libcudnn.cudnnDropoutGetReserveSpaceSize(xdesc::cudnnTensorDescriptor_t,
-                                                    sizeInBytes::Ref{Csize_t})::cudnnStatus_t
+    @gcsafe_ccall libcudnn.cudnnDropoutGetReserveSpaceSize(xdesc::cudnnTensorDescriptor_t,
+                                                           sizeInBytes::Ref{Csize_t})::cudnnStatus_t
 end
 
 @checked function cudnnSetDropoutDescriptor(dropoutDesc, handle, dropout, states,
                                             stateSizeInBytes, seed)
     initialize_context()
-    @ccall libcudnn.cudnnSetDropoutDescriptor(dropoutDesc::cudnnDropoutDescriptor_t,
-                                              handle::cudnnHandle_t, dropout::Cfloat,
-                                              states::CuPtr{Cvoid},
-                                              stateSizeInBytes::Csize_t,
-                                              seed::Culonglong)::cudnnStatus_t
+    @gcsafe_ccall libcudnn.cudnnSetDropoutDescriptor(dropoutDesc::cudnnDropoutDescriptor_t,
+                                                     handle::cudnnHandle_t, dropout::Cfloat,
+                                                     states::CuPtr{Cvoid},
+                                                     stateSizeInBytes::Csize_t,
+                                                     seed::Culonglong)::cudnnStatus_t
 end
 
 @checked function cudnnRestoreDropoutDescriptor(dropoutDesc, handle, dropout, states,
                                                 stateSizeInBytes, seed)
     initialize_context()
-    @ccall libcudnn.cudnnRestoreDropoutDescriptor(dropoutDesc::cudnnDropoutDescriptor_t,
-                                                  handle::cudnnHandle_t, dropout::Cfloat,
-                                                  states::CuPtr{Cvoid},
-                                                  stateSizeInBytes::Csize_t,
-                                                  seed::Culonglong)::cudnnStatus_t
+    @gcsafe_ccall libcudnn.cudnnRestoreDropoutDescriptor(dropoutDesc::cudnnDropoutDescriptor_t,
+                                                         handle::cudnnHandle_t,
+                                                         dropout::Cfloat,
+                                                         states::CuPtr{Cvoid},
+                                                         stateSizeInBytes::Csize_t,
+                                                         seed::Culonglong)::cudnnStatus_t
 end
 
 @checked function cudnnGetDropoutDescriptor(dropoutDesc, handle, dropout, states, seed)
     initialize_context()
-    @ccall libcudnn.cudnnGetDropoutDescriptor(dropoutDesc::cudnnDropoutDescriptor_t,
-                                              handle::cudnnHandle_t, dropout::Ptr{Cfloat},
-                                              states::Ptr{CuPtr{Cvoid}},
-                                              seed::Ptr{Culonglong})::cudnnStatus_t
+    @gcsafe_ccall libcudnn.cudnnGetDropoutDescriptor(dropoutDesc::cudnnDropoutDescriptor_t,
+                                                     handle::cudnnHandle_t,
+                                                     dropout::Ptr{Cfloat},
+                                                     states::Ptr{CuPtr{Cvoid}},
+                                                     seed::Ptr{Culonglong})::cudnnStatus_t
 end
 
 @checked function cudnnDropoutForward(handle, dropoutDesc, xdesc, x, ydesc, y, reserveSpace,
                                       reserveSpaceSizeInBytes)
     initialize_context()
-    @ccall libcudnn.cudnnDropoutForward(handle::cudnnHandle_t,
-                                        dropoutDesc::cudnnDropoutDescriptor_t,
-                                        xdesc::cudnnTensorDescriptor_t, x::CuPtr{Cvoid},
-                                        ydesc::cudnnTensorDescriptor_t, y::CuPtr{Cvoid},
-                                        reserveSpace::CuPtr{Cvoid},
-                                        reserveSpaceSizeInBytes::Csize_t)::cudnnStatus_t
+    @gcsafe_ccall libcudnn.cudnnDropoutForward(handle::cudnnHandle_t,
+                                               dropoutDesc::cudnnDropoutDescriptor_t,
+                                               xdesc::cudnnTensorDescriptor_t,
+                                               x::CuPtr{Cvoid},
+                                               ydesc::cudnnTensorDescriptor_t,
+                                               y::CuPtr{Cvoid}, reserveSpace::CuPtr{Cvoid},
+                                               reserveSpaceSizeInBytes::Csize_t)::cudnnStatus_t
 end
 
 mutable struct cudnnAlgorithmStruct end
@@ -1105,81 +1134,82 @@ const cudnnAlgorithm_t = cudnnAlgorithmUnionStruct
 
 @checked function cudnnCreateAlgorithmDescriptor(algoDesc)
     initialize_context()
-    @ccall libcudnn.cudnnCreateAlgorithmDescriptor(algoDesc::Ptr{cudnnAlgorithmDescriptor_t})::cudnnStatus_t
+    @gcsafe_ccall libcudnn.cudnnCreateAlgorithmDescriptor(algoDesc::Ptr{cudnnAlgorithmDescriptor_t})::cudnnStatus_t
 end
 
 @checked function cudnnSetAlgorithmDescriptor(algoDesc, algorithm)
     initialize_context()
-    @ccall libcudnn.cudnnSetAlgorithmDescriptor(algoDesc::cudnnAlgorithmDescriptor_t,
-                                                algorithm::cudnnAlgorithm_t)::cudnnStatus_t
+    @gcsafe_ccall libcudnn.cudnnSetAlgorithmDescriptor(algoDesc::cudnnAlgorithmDescriptor_t,
+                                                       algorithm::cudnnAlgorithm_t)::cudnnStatus_t
 end
 
 @checked function cudnnGetAlgorithmDescriptor(algoDesc, algorithm)
     initialize_context()
-    @ccall libcudnn.cudnnGetAlgorithmDescriptor(algoDesc::cudnnAlgorithmDescriptor_t,
-                                                algorithm::Ptr{cudnnAlgorithm_t})::cudnnStatus_t
+    @gcsafe_ccall libcudnn.cudnnGetAlgorithmDescriptor(algoDesc::cudnnAlgorithmDescriptor_t,
+                                                       algorithm::Ptr{cudnnAlgorithm_t})::cudnnStatus_t
 end
 
 @checked function cudnnCopyAlgorithmDescriptor(src, dest)
     initialize_context()
-    @ccall libcudnn.cudnnCopyAlgorithmDescriptor(src::cudnnAlgorithmDescriptor_t,
-                                                 dest::cudnnAlgorithmDescriptor_t)::cudnnStatus_t
+    @gcsafe_ccall libcudnn.cudnnCopyAlgorithmDescriptor(src::cudnnAlgorithmDescriptor_t,
+                                                        dest::cudnnAlgorithmDescriptor_t)::cudnnStatus_t
 end
 
 @checked function cudnnDestroyAlgorithmDescriptor(algoDesc)
     initialize_context()
-    @ccall libcudnn.cudnnDestroyAlgorithmDescriptor(algoDesc::cudnnAlgorithmDescriptor_t)::cudnnStatus_t
+    @gcsafe_ccall libcudnn.cudnnDestroyAlgorithmDescriptor(algoDesc::cudnnAlgorithmDescriptor_t)::cudnnStatus_t
 end
 
 @checked function cudnnCreateAlgorithmPerformance(algoPerf, numberToCreate)
     initialize_context()
-    @ccall libcudnn.cudnnCreateAlgorithmPerformance(algoPerf::Ptr{cudnnAlgorithmPerformance_t},
-                                                    numberToCreate::Cint)::cudnnStatus_t
+    @gcsafe_ccall libcudnn.cudnnCreateAlgorithmPerformance(algoPerf::Ptr{cudnnAlgorithmPerformance_t},
+                                                           numberToCreate::Cint)::cudnnStatus_t
 end
 
 @checked function cudnnSetAlgorithmPerformance(algoPerf, algoDesc, status, time, memory)
     initialize_context()
-    @ccall libcudnn.cudnnSetAlgorithmPerformance(algoPerf::cudnnAlgorithmPerformance_t,
-                                                 algoDesc::cudnnAlgorithmDescriptor_t,
-                                                 status::cudnnStatus_t, time::Cfloat,
-                                                 memory::Csize_t)::cudnnStatus_t
+    @gcsafe_ccall libcudnn.cudnnSetAlgorithmPerformance(algoPerf::cudnnAlgorithmPerformance_t,
+                                                        algoDesc::cudnnAlgorithmDescriptor_t,
+                                                        status::cudnnStatus_t, time::Cfloat,
+                                                        memory::Csize_t)::cudnnStatus_t
 end
 
 @checked function cudnnGetAlgorithmPerformance(algoPerf, algoDesc, status, time, memory)
     initialize_context()
-    @ccall libcudnn.cudnnGetAlgorithmPerformance(algoPerf::cudnnAlgorithmPerformance_t,
-                                                 algoDesc::Ptr{cudnnAlgorithmDescriptor_t},
-                                                 status::Ptr{cudnnStatus_t},
-                                                 time::Ptr{Cfloat},
-                                                 memory::Ptr{Csize_t})::cudnnStatus_t
+    @gcsafe_ccall libcudnn.cudnnGetAlgorithmPerformance(algoPerf::cudnnAlgorithmPerformance_t,
+                                                        algoDesc::Ptr{cudnnAlgorithmDescriptor_t},
+                                                        status::Ptr{cudnnStatus_t},
+                                                        time::Ptr{Cfloat},
+                                                        memory::Ptr{Csize_t})::cudnnStatus_t
 end
 
 @checked function cudnnDestroyAlgorithmPerformance(algoPerf, numberToDestroy)
     initialize_context()
-    @ccall libcudnn.cudnnDestroyAlgorithmPerformance(algoPerf::Ptr{cudnnAlgorithmPerformance_t},
-                                                     numberToDestroy::Cint)::cudnnStatus_t
+    @gcsafe_ccall libcudnn.cudnnDestroyAlgorithmPerformance(algoPerf::Ptr{cudnnAlgorithmPerformance_t},
+                                                            numberToDestroy::Cint)::cudnnStatus_t
 end
 
 @checked function cudnnGetAlgorithmSpaceSize(handle, algoDesc, algoSpaceSizeInBytes)
     initialize_context()
-    @ccall libcudnn.cudnnGetAlgorithmSpaceSize(handle::cudnnHandle_t,
-                                               algoDesc::cudnnAlgorithmDescriptor_t,
-                                               algoSpaceSizeInBytes::Ptr{Csize_t})::cudnnStatus_t
+    @gcsafe_ccall libcudnn.cudnnGetAlgorithmSpaceSize(handle::cudnnHandle_t,
+                                                      algoDesc::cudnnAlgorithmDescriptor_t,
+                                                      algoSpaceSizeInBytes::Ptr{Csize_t})::cudnnStatus_t
 end
 
 @checked function cudnnSaveAlgorithm(handle, algoDesc, algoSpace, algoSpaceSizeInBytes)
     initialize_context()
-    @ccall libcudnn.cudnnSaveAlgorithm(handle::cudnnHandle_t,
-                                       algoDesc::cudnnAlgorithmDescriptor_t,
-                                       algoSpace::Ptr{Cvoid},
-                                       algoSpaceSizeInBytes::Csize_t)::cudnnStatus_t
+    @gcsafe_ccall libcudnn.cudnnSaveAlgorithm(handle::cudnnHandle_t,
+                                              algoDesc::cudnnAlgorithmDescriptor_t,
+                                              algoSpace::Ptr{Cvoid},
+                                              algoSpaceSizeInBytes::Csize_t)::cudnnStatus_t
 end
 
 @checked function cudnnRestoreAlgorithm(handle, algoSpace, algoSpaceSizeInBytes, algoDesc)
     initialize_context()
-    @ccall libcudnn.cudnnRestoreAlgorithm(handle::cudnnHandle_t, algoSpace::Ptr{Cvoid},
-                                          algoSpaceSizeInBytes::Csize_t,
-                                          algoDesc::cudnnAlgorithmDescriptor_t)::cudnnStatus_t
+    @gcsafe_ccall libcudnn.cudnnRestoreAlgorithm(handle::cudnnHandle_t,
+                                                 algoSpace::Ptr{Cvoid},
+                                                 algoSpaceSizeInBytes::Csize_t,
+                                                 algoDesc::cudnnAlgorithmDescriptor_t)::cudnnStatus_t
 end
 
 @cenum cudnnSeverity_t::UInt32 begin
@@ -1209,92 +1239,101 @@ const cudnnDebug_t = cudnnDebugStruct
 const cudnnCallback_t = Ptr{Cvoid}
 
 @checked function cudnnSetCallback(mask, udata, fptr)
-    @ccall libcudnn.cudnnSetCallback(mask::Cuint, udata::Ptr{Cvoid},
-                                     fptr::cudnnCallback_t)::cudnnStatus_t
+    @gcsafe_ccall libcudnn.cudnnSetCallback(mask::Cuint, udata::Ptr{Cvoid},
+                                            fptr::cudnnCallback_t)::cudnnStatus_t
 end
 
 @checked function cudnnGetCallback(mask, udata, fptr)
-    @ccall libcudnn.cudnnGetCallback(mask::Ptr{Cuint}, udata::Ptr{Ptr{Cvoid}},
-                                     fptr::Ptr{cudnnCallback_t})::cudnnStatus_t
+    @gcsafe_ccall libcudnn.cudnnGetCallback(mask::Ptr{Cuint}, udata::Ptr{Ptr{Cvoid}},
+                                            fptr::Ptr{cudnnCallback_t})::cudnnStatus_t
 end
 
 @checked function cudnnOpsInferVersionCheck()
     initialize_context()
-    @ccall libcudnn.cudnnOpsInferVersionCheck()::cudnnStatus_t
+    @gcsafe_ccall libcudnn.cudnnOpsInferVersionCheck()::cudnnStatus_t
 end
 
 @checked function cudnnSoftmaxBackward(handle, algo, mode, alpha, yDesc, y, dyDesc, dy,
                                        beta, dxDesc, dx)
     initialize_context()
-    @ccall libcudnn.cudnnSoftmaxBackward(handle::cudnnHandle_t,
-                                         algo::cudnnSoftmaxAlgorithm_t,
-                                         mode::cudnnSoftmaxMode_t, alpha::Ptr{Cvoid},
-                                         yDesc::cudnnTensorDescriptor_t, y::CuPtr{Cvoid},
-                                         dyDesc::cudnnTensorDescriptor_t, dy::CuPtr{Cvoid},
-                                         beta::Ptr{Cvoid}, dxDesc::cudnnTensorDescriptor_t,
-                                         dx::CuPtr{Cvoid})::cudnnStatus_t
+    @gcsafe_ccall libcudnn.cudnnSoftmaxBackward(handle::cudnnHandle_t,
+                                                algo::cudnnSoftmaxAlgorithm_t,
+                                                mode::cudnnSoftmaxMode_t, alpha::Ptr{Cvoid},
+                                                yDesc::cudnnTensorDescriptor_t,
+                                                y::CuPtr{Cvoid},
+                                                dyDesc::cudnnTensorDescriptor_t,
+                                                dy::CuPtr{Cvoid}, beta::Ptr{Cvoid},
+                                                dxDesc::cudnnTensorDescriptor_t,
+                                                dx::CuPtr{Cvoid})::cudnnStatus_t
 end
 
 @checked function cudnnPoolingBackward(handle, poolingDesc, alpha, yDesc, y, dyDesc, dy,
                                        xDesc, x, beta, dxDesc, dx)
     initialize_context()
-    @ccall libcudnn.cudnnPoolingBackward(handle::cudnnHandle_t,
-                                         poolingDesc::cudnnPoolingDescriptor_t,
-                                         alpha::Ptr{Cvoid}, yDesc::cudnnTensorDescriptor_t,
-                                         y::CuPtr{Cvoid}, dyDesc::cudnnTensorDescriptor_t,
-                                         dy::CuPtr{Cvoid}, xDesc::cudnnTensorDescriptor_t,
-                                         x::CuPtr{Cvoid}, beta::Ptr{Cvoid},
-                                         dxDesc::cudnnTensorDescriptor_t,
-                                         dx::CuPtr{Cvoid})::cudnnStatus_t
+    @gcsafe_ccall libcudnn.cudnnPoolingBackward(handle::cudnnHandle_t,
+                                                poolingDesc::cudnnPoolingDescriptor_t,
+                                                alpha::Ptr{Cvoid},
+                                                yDesc::cudnnTensorDescriptor_t,
+                                                y::CuPtr{Cvoid},
+                                                dyDesc::cudnnTensorDescriptor_t,
+                                                dy::CuPtr{Cvoid},
+                                                xDesc::cudnnTensorDescriptor_t,
+                                                x::CuPtr{Cvoid}, beta::Ptr{Cvoid},
+                                                dxDesc::cudnnTensorDescriptor_t,
+                                                dx::CuPtr{Cvoid})::cudnnStatus_t
 end
 
 @checked function cudnnActivationBackward(handle, activationDesc, alpha, yDesc, y, dyDesc,
                                           dy, xDesc, x, beta, dxDesc, dx)
     initialize_context()
-    @ccall libcudnn.cudnnActivationBackward(handle::cudnnHandle_t,
-                                            activationDesc::cudnnActivationDescriptor_t,
-                                            alpha::Ptr{Cvoid},
-                                            yDesc::cudnnTensorDescriptor_t, y::CuPtr{Cvoid},
-                                            dyDesc::cudnnTensorDescriptor_t,
-                                            dy::CuPtr{Cvoid},
-                                            xDesc::cudnnTensorDescriptor_t, x::CuPtr{Cvoid},
-                                            beta::Ptr{Cvoid},
-                                            dxDesc::cudnnTensorDescriptor_t,
-                                            dx::CuPtr{Cvoid})::cudnnStatus_t
+    @gcsafe_ccall libcudnn.cudnnActivationBackward(handle::cudnnHandle_t,
+                                                   activationDesc::cudnnActivationDescriptor_t,
+                                                   alpha::Ptr{Cvoid},
+                                                   yDesc::cudnnTensorDescriptor_t,
+                                                   y::CuPtr{Cvoid},
+                                                   dyDesc::cudnnTensorDescriptor_t,
+                                                   dy::CuPtr{Cvoid},
+                                                   xDesc::cudnnTensorDescriptor_t,
+                                                   x::CuPtr{Cvoid}, beta::Ptr{Cvoid},
+                                                   dxDesc::cudnnTensorDescriptor_t,
+                                                   dx::CuPtr{Cvoid})::cudnnStatus_t
 end
 
 @checked function cudnnLRNCrossChannelBackward(handle, normDesc, lrnMode, alpha, yDesc, y,
                                                dyDesc, dy, xDesc, x, beta, dxDesc, dx)
     initialize_context()
-    @ccall libcudnn.cudnnLRNCrossChannelBackward(handle::cudnnHandle_t,
-                                                 normDesc::cudnnLRNDescriptor_t,
-                                                 lrnMode::cudnnLRNMode_t, alpha::Ptr{Cvoid},
-                                                 yDesc::cudnnTensorDescriptor_t,
-                                                 y::CuPtr{Cvoid},
-                                                 dyDesc::cudnnTensorDescriptor_t,
-                                                 dy::CuPtr{Cvoid},
-                                                 xDesc::cudnnTensorDescriptor_t,
-                                                 x::CuPtr{Cvoid}, beta::Ptr{Cvoid},
-                                                 dxDesc::cudnnTensorDescriptor_t,
-                                                 dx::CuPtr{Cvoid})::cudnnStatus_t
+    @gcsafe_ccall libcudnn.cudnnLRNCrossChannelBackward(handle::cudnnHandle_t,
+                                                        normDesc::cudnnLRNDescriptor_t,
+                                                        lrnMode::cudnnLRNMode_t,
+                                                        alpha::Ptr{Cvoid},
+                                                        yDesc::cudnnTensorDescriptor_t,
+                                                        y::CuPtr{Cvoid},
+                                                        dyDesc::cudnnTensorDescriptor_t,
+                                                        dy::CuPtr{Cvoid},
+                                                        xDesc::cudnnTensorDescriptor_t,
+                                                        x::CuPtr{Cvoid}, beta::Ptr{Cvoid},
+                                                        dxDesc::cudnnTensorDescriptor_t,
+                                                        dx::CuPtr{Cvoid})::cudnnStatus_t
 end
 
 @checked function cudnnDivisiveNormalizationBackward(handle, normDesc, mode, alpha, xDesc,
                                                      x, means, dy, temp, temp2, beta,
                                                      dXdMeansDesc, dx, dMeans)
     initialize_context()
-    @ccall libcudnn.cudnnDivisiveNormalizationBackward(handle::cudnnHandle_t,
-                                                       normDesc::cudnnLRNDescriptor_t,
-                                                       mode::cudnnDivNormMode_t,
-                                                       alpha::Ptr{Cvoid},
-                                                       xDesc::cudnnTensorDescriptor_t,
-                                                       x::CuPtr{Cvoid}, means::CuPtr{Cvoid},
-                                                       dy::CuPtr{Cvoid}, temp::CuPtr{Cvoid},
-                                                       temp2::CuPtr{Cvoid},
-                                                       beta::Ptr{Cvoid},
-                                                       dXdMeansDesc::cudnnTensorDescriptor_t,
-                                                       dx::CuPtr{Cvoid},
-                                                       dMeans::CuPtr{Cvoid})::cudnnStatus_t
+    @gcsafe_ccall libcudnn.cudnnDivisiveNormalizationBackward(handle::cudnnHandle_t,
+                                                              normDesc::cudnnLRNDescriptor_t,
+                                                              mode::cudnnDivNormMode_t,
+                                                              alpha::Ptr{Cvoid},
+                                                              xDesc::cudnnTensorDescriptor_t,
+                                                              x::CuPtr{Cvoid},
+                                                              means::CuPtr{Cvoid},
+                                                              dy::CuPtr{Cvoid},
+                                                              temp::CuPtr{Cvoid},
+                                                              temp2::CuPtr{Cvoid},
+                                                              beta::Ptr{Cvoid},
+                                                              dXdMeansDesc::cudnnTensorDescriptor_t,
+                                                              dx::CuPtr{Cvoid},
+                                                              dMeans::CuPtr{Cvoid})::cudnnStatus_t
 end
 
 @checked function cudnnGetBatchNormalizationForwardTrainingExWorkspaceSize(handle, mode,
@@ -1304,15 +1343,15 @@ end
                                                                            activationDesc,
                                                                            sizeInBytes)
     initialize_context()
-    @ccall libcudnn.cudnnGetBatchNormalizationForwardTrainingExWorkspaceSize(handle::cudnnHandle_t,
-                                                                             mode::cudnnBatchNormMode_t,
-                                                                             bnOps::cudnnBatchNormOps_t,
-                                                                             xDesc::cudnnTensorDescriptor_t,
-                                                                             zDesc::cudnnTensorDescriptor_t,
-                                                                             yDesc::cudnnTensorDescriptor_t,
-                                                                             bnScaleBiasMeanVarDesc::cudnnTensorDescriptor_t,
-                                                                             activationDesc::cudnnActivationDescriptor_t,
-                                                                             sizeInBytes::Ref{Csize_t})::cudnnStatus_t
+    @gcsafe_ccall libcudnn.cudnnGetBatchNormalizationForwardTrainingExWorkspaceSize(handle::cudnnHandle_t,
+                                                                                    mode::cudnnBatchNormMode_t,
+                                                                                    bnOps::cudnnBatchNormOps_t,
+                                                                                    xDesc::cudnnTensorDescriptor_t,
+                                                                                    zDesc::cudnnTensorDescriptor_t,
+                                                                                    yDesc::cudnnTensorDescriptor_t,
+                                                                                    bnScaleBiasMeanVarDesc::cudnnTensorDescriptor_t,
+                                                                                    activationDesc::cudnnActivationDescriptor_t,
+                                                                                    sizeInBytes::Ref{Csize_t})::cudnnStatus_t
 end
 
 @checked function cudnnGetBatchNormalizationBackwardExWorkspaceSize(handle, mode, bnOps,
@@ -1322,29 +1361,29 @@ end
                                                                     activationDesc,
                                                                     sizeInBytes)
     initialize_context()
-    @ccall libcudnn.cudnnGetBatchNormalizationBackwardExWorkspaceSize(handle::cudnnHandle_t,
-                                                                      mode::cudnnBatchNormMode_t,
-                                                                      bnOps::cudnnBatchNormOps_t,
-                                                                      xDesc::cudnnTensorDescriptor_t,
-                                                                      yDesc::cudnnTensorDescriptor_t,
-                                                                      dyDesc::cudnnTensorDescriptor_t,
-                                                                      dzDesc::cudnnTensorDescriptor_t,
-                                                                      dxDesc::cudnnTensorDescriptor_t,
-                                                                      dBnScaleBiasDesc::cudnnTensorDescriptor_t,
-                                                                      activationDesc::cudnnActivationDescriptor_t,
-                                                                      sizeInBytes::Ref{Csize_t})::cudnnStatus_t
+    @gcsafe_ccall libcudnn.cudnnGetBatchNormalizationBackwardExWorkspaceSize(handle::cudnnHandle_t,
+                                                                             mode::cudnnBatchNormMode_t,
+                                                                             bnOps::cudnnBatchNormOps_t,
+                                                                             xDesc::cudnnTensorDescriptor_t,
+                                                                             yDesc::cudnnTensorDescriptor_t,
+                                                                             dyDesc::cudnnTensorDescriptor_t,
+                                                                             dzDesc::cudnnTensorDescriptor_t,
+                                                                             dxDesc::cudnnTensorDescriptor_t,
+                                                                             dBnScaleBiasDesc::cudnnTensorDescriptor_t,
+                                                                             activationDesc::cudnnActivationDescriptor_t,
+                                                                             sizeInBytes::Ref{Csize_t})::cudnnStatus_t
 end
 
 @checked function cudnnGetBatchNormalizationTrainingExReserveSpaceSize(handle, mode, bnOps,
                                                                        activationDesc,
                                                                        xDesc, sizeInBytes)
     initialize_context()
-    @ccall libcudnn.cudnnGetBatchNormalizationTrainingExReserveSpaceSize(handle::cudnnHandle_t,
-                                                                         mode::cudnnBatchNormMode_t,
-                                                                         bnOps::cudnnBatchNormOps_t,
-                                                                         activationDesc::cudnnActivationDescriptor_t,
-                                                                         xDesc::cudnnTensorDescriptor_t,
-                                                                         sizeInBytes::Ref{Csize_t})::cudnnStatus_t
+    @gcsafe_ccall libcudnn.cudnnGetBatchNormalizationTrainingExReserveSpaceSize(handle::cudnnHandle_t,
+                                                                                mode::cudnnBatchNormMode_t,
+                                                                                bnOps::cudnnBatchNormOps_t,
+                                                                                activationDesc::cudnnActivationDescriptor_t,
+                                                                                xDesc::cudnnTensorDescriptor_t,
+                                                                                sizeInBytes::Ref{Csize_t})::cudnnStatus_t
 end
 
 @checked function cudnnBatchNormalizationForwardTraining(handle, mode, alpha, beta, xDesc,
@@ -1356,23 +1395,23 @@ end
                                                          resultSaveMean,
                                                          resultSaveInvVariance)
     initialize_context()
-    @ccall libcudnn.cudnnBatchNormalizationForwardTraining(handle::cudnnHandle_t,
-                                                           mode::cudnnBatchNormMode_t,
-                                                           alpha::Ptr{Cvoid},
-                                                           beta::Ptr{Cvoid},
-                                                           xDesc::cudnnTensorDescriptor_t,
-                                                           x::CuPtr{Cvoid},
-                                                           yDesc::cudnnTensorDescriptor_t,
-                                                           y::CuPtr{Cvoid},
-                                                           bnScaleBiasMeanVarDesc::cudnnTensorDescriptor_t,
-                                                           bnScale::CuPtr{Cvoid},
-                                                           bnBias::CuPtr{Cvoid},
-                                                           exponentialAverageFactor::Cdouble,
-                                                           resultRunningMean::CuPtr{Cvoid},
-                                                           resultRunningVariance::CuPtr{Cvoid},
-                                                           epsilon::Cdouble,
-                                                           resultSaveMean::CuPtr{Cvoid},
-                                                           resultSaveInvVariance::CuPtr{Cvoid})::cudnnStatus_t
+    @gcsafe_ccall libcudnn.cudnnBatchNormalizationForwardTraining(handle::cudnnHandle_t,
+                                                                  mode::cudnnBatchNormMode_t,
+                                                                  alpha::Ptr{Cvoid},
+                                                                  beta::Ptr{Cvoid},
+                                                                  xDesc::cudnnTensorDescriptor_t,
+                                                                  x::CuPtr{Cvoid},
+                                                                  yDesc::cudnnTensorDescriptor_t,
+                                                                  y::CuPtr{Cvoid},
+                                                                  bnScaleBiasMeanVarDesc::cudnnTensorDescriptor_t,
+                                                                  bnScale::CuPtr{Cvoid},
+                                                                  bnBias::CuPtr{Cvoid},
+                                                                  exponentialAverageFactor::Cdouble,
+                                                                  resultRunningMean::CuPtr{Cvoid},
+                                                                  resultRunningVariance::CuPtr{Cvoid},
+                                                                  epsilon::Cdouble,
+                                                                  resultSaveMean::CuPtr{Cvoid},
+                                                                  resultSaveInvVariance::CuPtr{Cvoid})::cudnnStatus_t
 end
 
 @checked function cudnnBatchNormalizationForwardTrainingEx(handle, mode, bnOps, alpha, beta,
@@ -1389,31 +1428,31 @@ end
                                                            reserveSpace,
                                                            reserveSpaceSizeInBytes)
     initialize_context()
-    @ccall libcudnn.cudnnBatchNormalizationForwardTrainingEx(handle::cudnnHandle_t,
-                                                             mode::cudnnBatchNormMode_t,
-                                                             bnOps::cudnnBatchNormOps_t,
-                                                             alpha::Ptr{Cvoid},
-                                                             beta::Ptr{Cvoid},
-                                                             xDesc::cudnnTensorDescriptor_t,
-                                                             xData::CuPtr{Cvoid},
-                                                             zDesc::cudnnTensorDescriptor_t,
-                                                             zData::CuPtr{Cvoid},
-                                                             yDesc::cudnnTensorDescriptor_t,
-                                                             yData::CuPtr{Cvoid},
-                                                             bnScaleBiasMeanVarDesc::cudnnTensorDescriptor_t,
-                                                             bnScale::CuPtr{Cvoid},
-                                                             bnBias::CuPtr{Cvoid},
-                                                             exponentialAverageFactor::Cdouble,
-                                                             resultRunningMean::CuPtr{Cvoid},
-                                                             resultRunningVariance::CuPtr{Cvoid},
-                                                             epsilon::Cdouble,
-                                                             resultSaveMean::CuPtr{Cvoid},
-                                                             resultSaveInvVariance::CuPtr{Cvoid},
-                                                             activationDesc::cudnnActivationDescriptor_t,
-                                                             workspace::CuPtr{Cvoid},
-                                                             workSpaceSizeInBytes::Csize_t,
-                                                             reserveSpace::CuPtr{Cvoid},
-                                                             reserveSpaceSizeInBytes::Csize_t)::cudnnStatus_t
+    @gcsafe_ccall libcudnn.cudnnBatchNormalizationForwardTrainingEx(handle::cudnnHandle_t,
+                                                                    mode::cudnnBatchNormMode_t,
+                                                                    bnOps::cudnnBatchNormOps_t,
+                                                                    alpha::Ptr{Cvoid},
+                                                                    beta::Ptr{Cvoid},
+                                                                    xDesc::cudnnTensorDescriptor_t,
+                                                                    xData::CuPtr{Cvoid},
+                                                                    zDesc::cudnnTensorDescriptor_t,
+                                                                    zData::CuPtr{Cvoid},
+                                                                    yDesc::cudnnTensorDescriptor_t,
+                                                                    yData::CuPtr{Cvoid},
+                                                                    bnScaleBiasMeanVarDesc::cudnnTensorDescriptor_t,
+                                                                    bnScale::CuPtr{Cvoid},
+                                                                    bnBias::CuPtr{Cvoid},
+                                                                    exponentialAverageFactor::Cdouble,
+                                                                    resultRunningMean::CuPtr{Cvoid},
+                                                                    resultRunningVariance::CuPtr{Cvoid},
+                                                                    epsilon::Cdouble,
+                                                                    resultSaveMean::CuPtr{Cvoid},
+                                                                    resultSaveInvVariance::CuPtr{Cvoid},
+                                                                    activationDesc::cudnnActivationDescriptor_t,
+                                                                    workspace::CuPtr{Cvoid},
+                                                                    workSpaceSizeInBytes::Csize_t,
+                                                                    reserveSpace::CuPtr{Cvoid},
+                                                                    reserveSpaceSizeInBytes::Csize_t)::cudnnStatus_t
 end
 
 @checked function cudnnBatchNormalizationBackward(handle, mode, alphaDataDiff, betaDataDiff,
@@ -1422,25 +1461,25 @@ end
                                                   bnScale, dBnScaleResult, dBnBiasResult,
                                                   epsilon, savedMean, savedInvVariance)
     initialize_context()
-    @ccall libcudnn.cudnnBatchNormalizationBackward(handle::cudnnHandle_t,
-                                                    mode::cudnnBatchNormMode_t,
-                                                    alphaDataDiff::Ptr{Cvoid},
-                                                    betaDataDiff::Ptr{Cvoid},
-                                                    alphaParamDiff::Ptr{Cvoid},
-                                                    betaParamDiff::Ptr{Cvoid},
-                                                    xDesc::cudnnTensorDescriptor_t,
-                                                    x::CuPtr{Cvoid},
-                                                    dyDesc::cudnnTensorDescriptor_t,
-                                                    dy::CuPtr{Cvoid},
-                                                    dxDesc::cudnnTensorDescriptor_t,
-                                                    dx::CuPtr{Cvoid},
-                                                    dBnScaleBiasDesc::cudnnTensorDescriptor_t,
-                                                    bnScale::CuPtr{Cvoid},
-                                                    dBnScaleResult::CuPtr{Cvoid},
-                                                    dBnBiasResult::CuPtr{Cvoid},
-                                                    epsilon::Cdouble,
-                                                    savedMean::CuPtr{Cvoid},
-                                                    savedInvVariance::CuPtr{Cvoid})::cudnnStatus_t
+    @gcsafe_ccall libcudnn.cudnnBatchNormalizationBackward(handle::cudnnHandle_t,
+                                                           mode::cudnnBatchNormMode_t,
+                                                           alphaDataDiff::Ptr{Cvoid},
+                                                           betaDataDiff::Ptr{Cvoid},
+                                                           alphaParamDiff::Ptr{Cvoid},
+                                                           betaParamDiff::Ptr{Cvoid},
+                                                           xDesc::cudnnTensorDescriptor_t,
+                                                           x::CuPtr{Cvoid},
+                                                           dyDesc::cudnnTensorDescriptor_t,
+                                                           dy::CuPtr{Cvoid},
+                                                           dxDesc::cudnnTensorDescriptor_t,
+                                                           dx::CuPtr{Cvoid},
+                                                           dBnScaleBiasDesc::cudnnTensorDescriptor_t,
+                                                           bnScale::CuPtr{Cvoid},
+                                                           dBnScaleResult::CuPtr{Cvoid},
+                                                           dBnBiasResult::CuPtr{Cvoid},
+                                                           epsilon::Cdouble,
+                                                           savedMean::CuPtr{Cvoid},
+                                                           savedInvVariance::CuPtr{Cvoid})::cudnnStatus_t
 end
 
 @checked function cudnnBatchNormalizationBackwardEx(handle, mode, bnOps, alphaDataDiff,
@@ -1454,36 +1493,36 @@ end
                                                     workSpace, workSpaceSizeInBytes,
                                                     reserveSpace, reserveSpaceSizeInBytes)
     initialize_context()
-    @ccall libcudnn.cudnnBatchNormalizationBackwardEx(handle::cudnnHandle_t,
-                                                      mode::cudnnBatchNormMode_t,
-                                                      bnOps::cudnnBatchNormOps_t,
-                                                      alphaDataDiff::Ptr{Cvoid},
-                                                      betaDataDiff::Ptr{Cvoid},
-                                                      alphaParamDiff::Ptr{Cvoid},
-                                                      betaParamDiff::Ptr{Cvoid},
-                                                      xDesc::cudnnTensorDescriptor_t,
-                                                      xData::CuPtr{Cvoid},
-                                                      yDesc::cudnnTensorDescriptor_t,
-                                                      yData::CuPtr{Cvoid},
-                                                      dyDesc::cudnnTensorDescriptor_t,
-                                                      dyData::CuPtr{Cvoid},
-                                                      dzDesc::cudnnTensorDescriptor_t,
-                                                      dzData::CuPtr{Cvoid},
-                                                      dxDesc::cudnnTensorDescriptor_t,
-                                                      dxData::CuPtr{Cvoid},
-                                                      dBnScaleBiasDesc::cudnnTensorDescriptor_t,
-                                                      bnScaleData::CuPtr{Cvoid},
-                                                      bnBiasData::CuPtr{Cvoid},
-                                                      dBnScaleData::CuPtr{Cvoid},
-                                                      dBnBiasData::CuPtr{Cvoid},
-                                                      epsilon::Cdouble,
-                                                      savedMean::CuPtr{Cvoid},
-                                                      savedInvVariance::CuPtr{Cvoid},
-                                                      activationDesc::cudnnActivationDescriptor_t,
-                                                      workSpace::CuPtr{Cvoid},
-                                                      workSpaceSizeInBytes::Csize_t,
-                                                      reserveSpace::CuPtr{Cvoid},
-                                                      reserveSpaceSizeInBytes::Csize_t)::cudnnStatus_t
+    @gcsafe_ccall libcudnn.cudnnBatchNormalizationBackwardEx(handle::cudnnHandle_t,
+                                                             mode::cudnnBatchNormMode_t,
+                                                             bnOps::cudnnBatchNormOps_t,
+                                                             alphaDataDiff::Ptr{Cvoid},
+                                                             betaDataDiff::Ptr{Cvoid},
+                                                             alphaParamDiff::Ptr{Cvoid},
+                                                             betaParamDiff::Ptr{Cvoid},
+                                                             xDesc::cudnnTensorDescriptor_t,
+                                                             xData::CuPtr{Cvoid},
+                                                             yDesc::cudnnTensorDescriptor_t,
+                                                             yData::CuPtr{Cvoid},
+                                                             dyDesc::cudnnTensorDescriptor_t,
+                                                             dyData::CuPtr{Cvoid},
+                                                             dzDesc::cudnnTensorDescriptor_t,
+                                                             dzData::CuPtr{Cvoid},
+                                                             dxDesc::cudnnTensorDescriptor_t,
+                                                             dxData::CuPtr{Cvoid},
+                                                             dBnScaleBiasDesc::cudnnTensorDescriptor_t,
+                                                             bnScaleData::CuPtr{Cvoid},
+                                                             bnBiasData::CuPtr{Cvoid},
+                                                             dBnScaleData::CuPtr{Cvoid},
+                                                             dBnBiasData::CuPtr{Cvoid},
+                                                             epsilon::Cdouble,
+                                                             savedMean::CuPtr{Cvoid},
+                                                             savedInvVariance::CuPtr{Cvoid},
+                                                             activationDesc::cudnnActivationDescriptor_t,
+                                                             workSpace::CuPtr{Cvoid},
+                                                             workSpaceSizeInBytes::Csize_t,
+                                                             reserveSpace::CuPtr{Cvoid},
+                                                             reserveSpaceSizeInBytes::Csize_t)::cudnnStatus_t
 end
 
 @checked function cudnnGetNormalizationForwardTrainingWorkspaceSize(handle, mode, normOps,
@@ -1494,18 +1533,18 @@ end
                                                                     normMeanVarDesc,
                                                                     sizeInBytes, groupCnt)
     initialize_context()
-    @ccall libcudnn.cudnnGetNormalizationForwardTrainingWorkspaceSize(handle::cudnnHandle_t,
-                                                                      mode::cudnnNormMode_t,
-                                                                      normOps::cudnnNormOps_t,
-                                                                      algo::cudnnNormAlgo_t,
-                                                                      xDesc::cudnnTensorDescriptor_t,
-                                                                      zDesc::cudnnTensorDescriptor_t,
-                                                                      yDesc::cudnnTensorDescriptor_t,
-                                                                      normScaleBiasDesc::cudnnTensorDescriptor_t,
-                                                                      activationDesc::cudnnActivationDescriptor_t,
-                                                                      normMeanVarDesc::cudnnTensorDescriptor_t,
-                                                                      sizeInBytes::Ref{Csize_t},
-                                                                      groupCnt::Cint)::cudnnStatus_t
+    @gcsafe_ccall libcudnn.cudnnGetNormalizationForwardTrainingWorkspaceSize(handle::cudnnHandle_t,
+                                                                             mode::cudnnNormMode_t,
+                                                                             normOps::cudnnNormOps_t,
+                                                                             algo::cudnnNormAlgo_t,
+                                                                             xDesc::cudnnTensorDescriptor_t,
+                                                                             zDesc::cudnnTensorDescriptor_t,
+                                                                             yDesc::cudnnTensorDescriptor_t,
+                                                                             normScaleBiasDesc::cudnnTensorDescriptor_t,
+                                                                             activationDesc::cudnnActivationDescriptor_t,
+                                                                             normMeanVarDesc::cudnnTensorDescriptor_t,
+                                                                             sizeInBytes::Ref{Csize_t},
+                                                                             groupCnt::Cint)::cudnnStatus_t
 end
 
 @checked function cudnnGetNormalizationBackwardWorkspaceSize(handle, mode, normOps, algo,
@@ -1515,34 +1554,34 @@ end
                                                              normMeanVarDesc, sizeInBytes,
                                                              groupCnt)
     initialize_context()
-    @ccall libcudnn.cudnnGetNormalizationBackwardWorkspaceSize(handle::cudnnHandle_t,
-                                                               mode::cudnnNormMode_t,
-                                                               normOps::cudnnNormOps_t,
-                                                               algo::cudnnNormAlgo_t,
-                                                               xDesc::cudnnTensorDescriptor_t,
-                                                               yDesc::cudnnTensorDescriptor_t,
-                                                               dyDesc::cudnnTensorDescriptor_t,
-                                                               dzDesc::cudnnTensorDescriptor_t,
-                                                               dxDesc::cudnnTensorDescriptor_t,
-                                                               dNormScaleBiasDesc::cudnnTensorDescriptor_t,
-                                                               activationDesc::cudnnActivationDescriptor_t,
-                                                               normMeanVarDesc::cudnnTensorDescriptor_t,
-                                                               sizeInBytes::Ref{Csize_t},
-                                                               groupCnt::Cint)::cudnnStatus_t
+    @gcsafe_ccall libcudnn.cudnnGetNormalizationBackwardWorkspaceSize(handle::cudnnHandle_t,
+                                                                      mode::cudnnNormMode_t,
+                                                                      normOps::cudnnNormOps_t,
+                                                                      algo::cudnnNormAlgo_t,
+                                                                      xDesc::cudnnTensorDescriptor_t,
+                                                                      yDesc::cudnnTensorDescriptor_t,
+                                                                      dyDesc::cudnnTensorDescriptor_t,
+                                                                      dzDesc::cudnnTensorDescriptor_t,
+                                                                      dxDesc::cudnnTensorDescriptor_t,
+                                                                      dNormScaleBiasDesc::cudnnTensorDescriptor_t,
+                                                                      activationDesc::cudnnActivationDescriptor_t,
+                                                                      normMeanVarDesc::cudnnTensorDescriptor_t,
+                                                                      sizeInBytes::Ref{Csize_t},
+                                                                      groupCnt::Cint)::cudnnStatus_t
 end
 
 @checked function cudnnGetNormalizationTrainingReserveSpaceSize(handle, mode, normOps, algo,
                                                                 activationDesc, xDesc,
                                                                 sizeInBytes, groupCnt)
     initialize_context()
-    @ccall libcudnn.cudnnGetNormalizationTrainingReserveSpaceSize(handle::cudnnHandle_t,
-                                                                  mode::cudnnNormMode_t,
-                                                                  normOps::cudnnNormOps_t,
-                                                                  algo::cudnnNormAlgo_t,
-                                                                  activationDesc::cudnnActivationDescriptor_t,
-                                                                  xDesc::cudnnTensorDescriptor_t,
-                                                                  sizeInBytes::Ref{Csize_t},
-                                                                  groupCnt::Cint)::cudnnStatus_t
+    @gcsafe_ccall libcudnn.cudnnGetNormalizationTrainingReserveSpaceSize(handle::cudnnHandle_t,
+                                                                         mode::cudnnNormMode_t,
+                                                                         normOps::cudnnNormOps_t,
+                                                                         algo::cudnnNormAlgo_t,
+                                                                         activationDesc::cudnnActivationDescriptor_t,
+                                                                         xDesc::cudnnTensorDescriptor_t,
+                                                                         sizeInBytes::Ref{Csize_t},
+                                                                         groupCnt::Cint)::cudnnStatus_t
 end
 
 @checked function cudnnNormalizationForwardTraining(handle, mode, normOps, algo, alpha,
@@ -1557,33 +1596,34 @@ end
                                                     reserveSpace, reserveSpaceSizeInBytes,
                                                     groupCnt)
     initialize_context()
-    @ccall libcudnn.cudnnNormalizationForwardTraining(handle::cudnnHandle_t,
-                                                      mode::cudnnNormMode_t,
-                                                      normOps::cudnnNormOps_t,
-                                                      algo::cudnnNormAlgo_t,
-                                                      alpha::Ptr{Cvoid}, beta::Ptr{Cvoid},
-                                                      xDesc::cudnnTensorDescriptor_t,
-                                                      xData::CuPtr{Cvoid},
-                                                      normScaleBiasDesc::cudnnTensorDescriptor_t,
-                                                      normScale::CuPtr{Cvoid},
-                                                      normBias::CuPtr{Cvoid},
-                                                      exponentialAverageFactor::Cdouble,
-                                                      normMeanVarDesc::cudnnTensorDescriptor_t,
-                                                      resultRunningMean::CuPtr{Cvoid},
-                                                      resultRunningVariance::CuPtr{Cvoid},
-                                                      epsilon::Cdouble,
-                                                      resultSaveMean::CuPtr{Cvoid},
-                                                      resultSaveInvVariance::CuPtr{Cvoid},
-                                                      activationDesc::cudnnActivationDescriptor_t,
-                                                      zDesc::cudnnTensorDescriptor_t,
-                                                      zData::CuPtr{Cvoid},
-                                                      yDesc::cudnnTensorDescriptor_t,
-                                                      yData::CuPtr{Cvoid},
-                                                      workspace::CuPtr{Cvoid},
-                                                      workSpaceSizeInBytes::Csize_t,
-                                                      reserveSpace::CuPtr{Cvoid},
-                                                      reserveSpaceSizeInBytes::Csize_t,
-                                                      groupCnt::Cint)::cudnnStatus_t
+    @gcsafe_ccall libcudnn.cudnnNormalizationForwardTraining(handle::cudnnHandle_t,
+                                                             mode::cudnnNormMode_t,
+                                                             normOps::cudnnNormOps_t,
+                                                             algo::cudnnNormAlgo_t,
+                                                             alpha::Ptr{Cvoid},
+                                                             beta::Ptr{Cvoid},
+                                                             xDesc::cudnnTensorDescriptor_t,
+                                                             xData::CuPtr{Cvoid},
+                                                             normScaleBiasDesc::cudnnTensorDescriptor_t,
+                                                             normScale::CuPtr{Cvoid},
+                                                             normBias::CuPtr{Cvoid},
+                                                             exponentialAverageFactor::Cdouble,
+                                                             normMeanVarDesc::cudnnTensorDescriptor_t,
+                                                             resultRunningMean::CuPtr{Cvoid},
+                                                             resultRunningVariance::CuPtr{Cvoid},
+                                                             epsilon::Cdouble,
+                                                             resultSaveMean::CuPtr{Cvoid},
+                                                             resultSaveInvVariance::CuPtr{Cvoid},
+                                                             activationDesc::cudnnActivationDescriptor_t,
+                                                             zDesc::cudnnTensorDescriptor_t,
+                                                             zData::CuPtr{Cvoid},
+                                                             yDesc::cudnnTensorDescriptor_t,
+                                                             yData::CuPtr{Cvoid},
+                                                             workspace::CuPtr{Cvoid},
+                                                             workSpaceSizeInBytes::Csize_t,
+                                                             reserveSpace::CuPtr{Cvoid},
+                                                             reserveSpaceSizeInBytes::Csize_t,
+                                                             groupCnt::Cint)::cudnnStatus_t
 end
 
 @checked function cudnnNormalizationBackward(handle, mode, normOps, algo, alphaDataDiff,
@@ -1597,79 +1637,84 @@ end
                                              workSpaceSizeInBytes, reserveSpace,
                                              reserveSpaceSizeInBytes, groupCnt)
     initialize_context()
-    @ccall libcudnn.cudnnNormalizationBackward(handle::cudnnHandle_t, mode::cudnnNormMode_t,
-                                               normOps::cudnnNormOps_t,
-                                               algo::cudnnNormAlgo_t,
-                                               alphaDataDiff::Ptr{Cvoid},
-                                               betaDataDiff::Ptr{Cvoid},
-                                               alphaParamDiff::Ptr{Cvoid},
-                                               betaParamDiff::Ptr{Cvoid},
-                                               xDesc::cudnnTensorDescriptor_t,
-                                               xData::CuPtr{Cvoid},
-                                               yDesc::cudnnTensorDescriptor_t,
-                                               yData::CuPtr{Cvoid},
-                                               dyDesc::cudnnTensorDescriptor_t,
-                                               dyData::CuPtr{Cvoid},
-                                               dzDesc::cudnnTensorDescriptor_t,
-                                               dzData::CuPtr{Cvoid},
-                                               dxDesc::cudnnTensorDescriptor_t,
-                                               dxData::CuPtr{Cvoid},
-                                               dNormScaleBiasDesc::cudnnTensorDescriptor_t,
-                                               normScaleData::CuPtr{Cvoid},
-                                               normBiasData::CuPtr{Cvoid},
-                                               dNormScaleData::CuPtr{Cvoid},
-                                               dNormBiasData::CuPtr{Cvoid},
-                                               epsilon::Cdouble,
-                                               normMeanVarDesc::cudnnTensorDescriptor_t,
-                                               savedMean::CuPtr{Cvoid},
-                                               savedInvVariance::CuPtr{Cvoid},
-                                               activationDesc::cudnnActivationDescriptor_t,
-                                               workSpace::CuPtr{Cvoid},
-                                               workSpaceSizeInBytes::Csize_t,
-                                               reserveSpace::CuPtr{Cvoid},
-                                               reserveSpaceSizeInBytes::Csize_t,
-                                               groupCnt::Cint)::cudnnStatus_t
+    @gcsafe_ccall libcudnn.cudnnNormalizationBackward(handle::cudnnHandle_t,
+                                                      mode::cudnnNormMode_t,
+                                                      normOps::cudnnNormOps_t,
+                                                      algo::cudnnNormAlgo_t,
+                                                      alphaDataDiff::Ptr{Cvoid},
+                                                      betaDataDiff::Ptr{Cvoid},
+                                                      alphaParamDiff::Ptr{Cvoid},
+                                                      betaParamDiff::Ptr{Cvoid},
+                                                      xDesc::cudnnTensorDescriptor_t,
+                                                      xData::CuPtr{Cvoid},
+                                                      yDesc::cudnnTensorDescriptor_t,
+                                                      yData::CuPtr{Cvoid},
+                                                      dyDesc::cudnnTensorDescriptor_t,
+                                                      dyData::CuPtr{Cvoid},
+                                                      dzDesc::cudnnTensorDescriptor_t,
+                                                      dzData::CuPtr{Cvoid},
+                                                      dxDesc::cudnnTensorDescriptor_t,
+                                                      dxData::CuPtr{Cvoid},
+                                                      dNormScaleBiasDesc::cudnnTensorDescriptor_t,
+                                                      normScaleData::CuPtr{Cvoid},
+                                                      normBiasData::CuPtr{Cvoid},
+                                                      dNormScaleData::CuPtr{Cvoid},
+                                                      dNormBiasData::CuPtr{Cvoid},
+                                                      epsilon::Cdouble,
+                                                      normMeanVarDesc::cudnnTensorDescriptor_t,
+                                                      savedMean::CuPtr{Cvoid},
+                                                      savedInvVariance::CuPtr{Cvoid},
+                                                      activationDesc::cudnnActivationDescriptor_t,
+                                                      workSpace::CuPtr{Cvoid},
+                                                      workSpaceSizeInBytes::Csize_t,
+                                                      reserveSpace::CuPtr{Cvoid},
+                                                      reserveSpaceSizeInBytes::Csize_t,
+                                                      groupCnt::Cint)::cudnnStatus_t
 end
 
 @checked function cudnnSpatialTfGridGeneratorBackward(handle, stDesc, dgrid, dtheta)
     initialize_context()
-    @ccall libcudnn.cudnnSpatialTfGridGeneratorBackward(handle::cudnnHandle_t,
-                                                        stDesc::cudnnSpatialTransformerDescriptor_t,
-                                                        dgrid::CuPtr{Cvoid},
-                                                        dtheta::CuPtr{Cvoid})::cudnnStatus_t
+    @gcsafe_ccall libcudnn.cudnnSpatialTfGridGeneratorBackward(handle::cudnnHandle_t,
+                                                               stDesc::cudnnSpatialTransformerDescriptor_t,
+                                                               dgrid::CuPtr{Cvoid},
+                                                               dtheta::CuPtr{Cvoid})::cudnnStatus_t
 end
 
 @checked function cudnnSpatialTfSamplerBackward(handle, stDesc, alpha, xDesc, x, beta,
                                                 dxDesc, dx, alphaDgrid, dyDesc, dy, grid,
                                                 betaDgrid, dgrid)
     initialize_context()
-    @ccall libcudnn.cudnnSpatialTfSamplerBackward(handle::cudnnHandle_t,
-                                                  stDesc::cudnnSpatialTransformerDescriptor_t,
-                                                  alpha::Ptr{Cvoid},
-                                                  xDesc::cudnnTensorDescriptor_t,
-                                                  x::CuPtr{Cvoid}, beta::Ptr{Cvoid},
-                                                  dxDesc::cudnnTensorDescriptor_t,
-                                                  dx::CuPtr{Cvoid}, alphaDgrid::Ptr{Cvoid},
-                                                  dyDesc::cudnnTensorDescriptor_t,
-                                                  dy::CuPtr{Cvoid}, grid::CuPtr{Cvoid},
-                                                  betaDgrid::Ptr{Cvoid},
-                                                  dgrid::CuPtr{Cvoid})::cudnnStatus_t
+    @gcsafe_ccall libcudnn.cudnnSpatialTfSamplerBackward(handle::cudnnHandle_t,
+                                                         stDesc::cudnnSpatialTransformerDescriptor_t,
+                                                         alpha::Ptr{Cvoid},
+                                                         xDesc::cudnnTensorDescriptor_t,
+                                                         x::CuPtr{Cvoid}, beta::Ptr{Cvoid},
+                                                         dxDesc::cudnnTensorDescriptor_t,
+                                                         dx::CuPtr{Cvoid},
+                                                         alphaDgrid::Ptr{Cvoid},
+                                                         dyDesc::cudnnTensorDescriptor_t,
+                                                         dy::CuPtr{Cvoid},
+                                                         grid::CuPtr{Cvoid},
+                                                         betaDgrid::Ptr{Cvoid},
+                                                         dgrid::CuPtr{Cvoid})::cudnnStatus_t
 end
 
 @checked function cudnnDropoutBackward(handle, dropoutDesc, dydesc, dy, dxdesc, dx,
                                        reserveSpace, reserveSpaceSizeInBytes)
     initialize_context()
-    @ccall libcudnn.cudnnDropoutBackward(handle::cudnnHandle_t,
-                                         dropoutDesc::cudnnDropoutDescriptor_t,
-                                         dydesc::cudnnTensorDescriptor_t, dy::CuPtr{Cvoid},
-                                         dxdesc::cudnnTensorDescriptor_t, dx::CuPtr{Cvoid},
-                                         reserveSpace::CuPtr{Cvoid},
-                                         reserveSpaceSizeInBytes::Csize_t)::cudnnStatus_t
+    @gcsafe_ccall libcudnn.cudnnDropoutBackward(handle::cudnnHandle_t,
+                                                dropoutDesc::cudnnDropoutDescriptor_t,
+                                                dydesc::cudnnTensorDescriptor_t,
+                                                dy::CuPtr{Cvoid},
+                                                dxdesc::cudnnTensorDescriptor_t,
+                                                dx::CuPtr{Cvoid},
+                                                reserveSpace::CuPtr{Cvoid},
+                                                reserveSpaceSizeInBytes::Csize_t)::cudnnStatus_t
 end
 
 @checked function cudnnOpsTrainVersionCheck()
     initialize_context()
-    @ccall libcudnn.cudnnOpsTrainVersionCheck()::cudnnStatus_t
+    @gcsafe_ccall libcudnn.cudnnOpsTrainVersionCheck()::cudnnStatus_t
 end
 
 @cenum cudnnForwardMode_t::UInt32 begin
@@ -1728,12 +1773,12 @@ const cudnnRNNDataDescriptor_t = Ptr{cudnnRNNDataStruct}
 
 @checked function cudnnCreateRNNDescriptor(rnnDesc)
     initialize_context()
-    @ccall libcudnn.cudnnCreateRNNDescriptor(rnnDesc::Ptr{cudnnRNNDescriptor_t})::cudnnStatus_t
+    @gcsafe_ccall libcudnn.cudnnCreateRNNDescriptor(rnnDesc::Ptr{cudnnRNNDescriptor_t})::cudnnStatus_t
 end
 
 @checked function cudnnDestroyRNNDescriptor(rnnDesc)
     initialize_context()
-    @ccall libcudnn.cudnnDestroyRNNDescriptor(rnnDesc::cudnnRNNDescriptor_t)::cudnnStatus_t
+    @gcsafe_ccall libcudnn.cudnnDestroyRNNDescriptor(rnnDesc::cudnnRNNDescriptor_t)::cudnnStatus_t
 end
 
 @checked function cudnnSetRNNDescriptor_v8(rnnDesc, algo, cellMode, biasMode, dirMode,
@@ -1741,18 +1786,19 @@ end
                                            inputSize, hiddenSize, projSize, numLayers,
                                            dropoutDesc, auxFlags)
     initialize_context()
-    @ccall libcudnn.cudnnSetRNNDescriptor_v8(rnnDesc::cudnnRNNDescriptor_t,
-                                             algo::cudnnRNNAlgo_t, cellMode::cudnnRNNMode_t,
-                                             biasMode::cudnnRNNBiasMode_t,
-                                             dirMode::cudnnDirectionMode_t,
-                                             inputMode::cudnnRNNInputMode_t,
-                                             dataType::cudnnDataType_t,
-                                             mathPrec::cudnnDataType_t,
-                                             mathType::cudnnMathType_t, inputSize::Int32,
-                                             hiddenSize::Int32, projSize::Int32,
-                                             numLayers::Int32,
-                                             dropoutDesc::cudnnDropoutDescriptor_t,
-                                             auxFlags::UInt32)::cudnnStatus_t
+    @gcsafe_ccall libcudnn.cudnnSetRNNDescriptor_v8(rnnDesc::cudnnRNNDescriptor_t,
+                                                    algo::cudnnRNNAlgo_t,
+                                                    cellMode::cudnnRNNMode_t,
+                                                    biasMode::cudnnRNNBiasMode_t,
+                                                    dirMode::cudnnDirectionMode_t,
+                                                    inputMode::cudnnRNNInputMode_t,
+                                                    dataType::cudnnDataType_t,
+                                                    mathPrec::cudnnDataType_t,
+                                                    mathType::cudnnMathType_t,
+                                                    inputSize::Int32, hiddenSize::Int32,
+                                                    projSize::Int32, numLayers::Int32,
+                                                    dropoutDesc::cudnnDropoutDescriptor_t,
+                                                    auxFlags::UInt32)::cudnnStatus_t
 end
 
 @checked function cudnnGetRNNDescriptor_v8(rnnDesc, algo, cellMode, biasMode, dirMode,
@@ -1760,304 +1806,320 @@ end
                                            inputSize, hiddenSize, projSize, numLayers,
                                            dropoutDesc, auxFlags)
     initialize_context()
-    @ccall libcudnn.cudnnGetRNNDescriptor_v8(rnnDesc::cudnnRNNDescriptor_t,
-                                             algo::Ref{cudnnRNNAlgo_t},
-                                             cellMode::Ref{cudnnRNNMode_t},
-                                             biasMode::Ref{cudnnRNNBiasMode_t},
-                                             dirMode::Ref{cudnnDirectionMode_t},
-                                             inputMode::Ref{cudnnRNNInputMode_t},
-                                             dataType::Ref{cudnnDataType_t},
-                                             mathPrec::Ref{cudnnDataType_t},
-                                             mathType::Ref{cudnnMathType_t},
-                                             inputSize::Ref{Int32}, hiddenSize::Ref{Int32},
-                                             projSize::Ref{Int32}, numLayers::Ref{Int32},
-                                             dropoutDesc::Ref{cudnnDropoutDescriptor_t},
-                                             auxFlags::Ref{UInt32})::cudnnStatus_t
+    @gcsafe_ccall libcudnn.cudnnGetRNNDescriptor_v8(rnnDesc::cudnnRNNDescriptor_t,
+                                                    algo::Ref{cudnnRNNAlgo_t},
+                                                    cellMode::Ref{cudnnRNNMode_t},
+                                                    biasMode::Ref{cudnnRNNBiasMode_t},
+                                                    dirMode::Ref{cudnnDirectionMode_t},
+                                                    inputMode::Ref{cudnnRNNInputMode_t},
+                                                    dataType::Ref{cudnnDataType_t},
+                                                    mathPrec::Ref{cudnnDataType_t},
+                                                    mathType::Ref{cudnnMathType_t},
+                                                    inputSize::Ref{Int32},
+                                                    hiddenSize::Ref{Int32},
+                                                    projSize::Ref{Int32},
+                                                    numLayers::Ref{Int32},
+                                                    dropoutDesc::Ref{cudnnDropoutDescriptor_t},
+                                                    auxFlags::Ref{UInt32})::cudnnStatus_t
 end
 
 @checked function cudnnSetRNNDescriptor_v6(handle, rnnDesc, hiddenSize, numLayers,
                                            dropoutDesc, inputMode, direction, cellMode,
                                            algo, mathPrec)
     initialize_context()
-    @ccall libcudnn.cudnnSetRNNDescriptor_v6(handle::cudnnHandle_t,
-                                             rnnDesc::cudnnRNNDescriptor_t,
-                                             hiddenSize::Cint, numLayers::Cint,
-                                             dropoutDesc::cudnnDropoutDescriptor_t,
-                                             inputMode::cudnnRNNInputMode_t,
-                                             direction::cudnnDirectionMode_t,
-                                             cellMode::cudnnRNNMode_t, algo::cudnnRNNAlgo_t,
-                                             mathPrec::cudnnDataType_t)::cudnnStatus_t
+    @gcsafe_ccall libcudnn.cudnnSetRNNDescriptor_v6(handle::cudnnHandle_t,
+                                                    rnnDesc::cudnnRNNDescriptor_t,
+                                                    hiddenSize::Cint, numLayers::Cint,
+                                                    dropoutDesc::cudnnDropoutDescriptor_t,
+                                                    inputMode::cudnnRNNInputMode_t,
+                                                    direction::cudnnDirectionMode_t,
+                                                    cellMode::cudnnRNNMode_t,
+                                                    algo::cudnnRNNAlgo_t,
+                                                    mathPrec::cudnnDataType_t)::cudnnStatus_t
 end
 
 @checked function cudnnGetRNNDescriptor_v6(handle, rnnDesc, hiddenSize, numLayers,
                                            dropoutDesc, inputMode, direction, cellMode,
                                            algo, mathPrec)
     initialize_context()
-    @ccall libcudnn.cudnnGetRNNDescriptor_v6(handle::cudnnHandle_t,
-                                             rnnDesc::cudnnRNNDescriptor_t,
-                                             hiddenSize::Ref{Cint}, numLayers::Ref{Cint},
-                                             dropoutDesc::Ref{cudnnDropoutDescriptor_t},
-                                             inputMode::Ref{cudnnRNNInputMode_t},
-                                             direction::Ref{cudnnDirectionMode_t},
-                                             cellMode::Ref{cudnnRNNMode_t},
-                                             algo::Ref{cudnnRNNAlgo_t},
-                                             mathPrec::Ref{cudnnDataType_t})::cudnnStatus_t
+    @gcsafe_ccall libcudnn.cudnnGetRNNDescriptor_v6(handle::cudnnHandle_t,
+                                                    rnnDesc::cudnnRNNDescriptor_t,
+                                                    hiddenSize::Ref{Cint},
+                                                    numLayers::Ref{Cint},
+                                                    dropoutDesc::Ref{cudnnDropoutDescriptor_t},
+                                                    inputMode::Ref{cudnnRNNInputMode_t},
+                                                    direction::Ref{cudnnDirectionMode_t},
+                                                    cellMode::Ref{cudnnRNNMode_t},
+                                                    algo::Ref{cudnnRNNAlgo_t},
+                                                    mathPrec::Ref{cudnnDataType_t})::cudnnStatus_t
 end
 
 @checked function cudnnSetRNNMatrixMathType(rnnDesc, mType)
     initialize_context()
-    @ccall libcudnn.cudnnSetRNNMatrixMathType(rnnDesc::cudnnRNNDescriptor_t,
-                                              mType::cudnnMathType_t)::cudnnStatus_t
+    @gcsafe_ccall libcudnn.cudnnSetRNNMatrixMathType(rnnDesc::cudnnRNNDescriptor_t,
+                                                     mType::cudnnMathType_t)::cudnnStatus_t
 end
 
 @checked function cudnnGetRNNMatrixMathType(rnnDesc, mType)
     initialize_context()
-    @ccall libcudnn.cudnnGetRNNMatrixMathType(rnnDesc::cudnnRNNDescriptor_t,
-                                              mType::Ptr{cudnnMathType_t})::cudnnStatus_t
+    @gcsafe_ccall libcudnn.cudnnGetRNNMatrixMathType(rnnDesc::cudnnRNNDescriptor_t,
+                                                     mType::Ptr{cudnnMathType_t})::cudnnStatus_t
 end
 
 @checked function cudnnSetRNNBiasMode(rnnDesc, biasMode)
     initialize_context()
-    @ccall libcudnn.cudnnSetRNNBiasMode(rnnDesc::cudnnRNNDescriptor_t,
-                                        biasMode::cudnnRNNBiasMode_t)::cudnnStatus_t
+    @gcsafe_ccall libcudnn.cudnnSetRNNBiasMode(rnnDesc::cudnnRNNDescriptor_t,
+                                               biasMode::cudnnRNNBiasMode_t)::cudnnStatus_t
 end
 
 @checked function cudnnGetRNNBiasMode(rnnDesc, biasMode)
     initialize_context()
-    @ccall libcudnn.cudnnGetRNNBiasMode(rnnDesc::cudnnRNNDescriptor_t,
-                                        biasMode::Ptr{cudnnRNNBiasMode_t})::cudnnStatus_t
+    @gcsafe_ccall libcudnn.cudnnGetRNNBiasMode(rnnDesc::cudnnRNNDescriptor_t,
+                                               biasMode::Ptr{cudnnRNNBiasMode_t})::cudnnStatus_t
 end
 
 @checked function cudnnRNNSetClip_v8(rnnDesc, clipMode, clipNanOpt, lclip, rclip)
     initialize_context()
-    @ccall libcudnn.cudnnRNNSetClip_v8(rnnDesc::cudnnRNNDescriptor_t,
-                                       clipMode::cudnnRNNClipMode_t,
-                                       clipNanOpt::cudnnNanPropagation_t, lclip::Cdouble,
-                                       rclip::Cdouble)::cudnnStatus_t
+    @gcsafe_ccall libcudnn.cudnnRNNSetClip_v8(rnnDesc::cudnnRNNDescriptor_t,
+                                              clipMode::cudnnRNNClipMode_t,
+                                              clipNanOpt::cudnnNanPropagation_t,
+                                              lclip::Cdouble, rclip::Cdouble)::cudnnStatus_t
 end
 
 @checked function cudnnRNNGetClip_v8(rnnDesc, clipMode, clipNanOpt, lclip, rclip)
     initialize_context()
-    @ccall libcudnn.cudnnRNNGetClip_v8(rnnDesc::cudnnRNNDescriptor_t,
-                                       clipMode::Ref{cudnnRNNClipMode_t},
-                                       clipNanOpt::Ref{cudnnNanPropagation_t},
-                                       lclip::Ref{Cdouble},
-                                       rclip::Ref{Cdouble})::cudnnStatus_t
+    @gcsafe_ccall libcudnn.cudnnRNNGetClip_v8(rnnDesc::cudnnRNNDescriptor_t,
+                                              clipMode::Ref{cudnnRNNClipMode_t},
+                                              clipNanOpt::Ref{cudnnNanPropagation_t},
+                                              lclip::Ref{Cdouble},
+                                              rclip::Ref{Cdouble})::cudnnStatus_t
 end
 
 @checked function cudnnRNNSetClip(handle, rnnDesc, clipMode, clipNanOpt, lclip, rclip)
     initialize_context()
-    @ccall libcudnn.cudnnRNNSetClip(handle::cudnnHandle_t, rnnDesc::cudnnRNNDescriptor_t,
-                                    clipMode::cudnnRNNClipMode_t,
-                                    clipNanOpt::cudnnNanPropagation_t, lclip::Cdouble,
-                                    rclip::Cdouble)::cudnnStatus_t
+    @gcsafe_ccall libcudnn.cudnnRNNSetClip(handle::cudnnHandle_t,
+                                           rnnDesc::cudnnRNNDescriptor_t,
+                                           clipMode::cudnnRNNClipMode_t,
+                                           clipNanOpt::cudnnNanPropagation_t,
+                                           lclip::Cdouble, rclip::Cdouble)::cudnnStatus_t
 end
 
 @checked function cudnnRNNGetClip(handle, rnnDesc, clipMode, clipNanOpt, lclip, rclip)
     initialize_context()
-    @ccall libcudnn.cudnnRNNGetClip(handle::cudnnHandle_t, rnnDesc::cudnnRNNDescriptor_t,
-                                    clipMode::Ptr{cudnnRNNClipMode_t},
-                                    clipNanOpt::Ptr{cudnnNanPropagation_t},
-                                    lclip::Ptr{Cdouble}, rclip::Ptr{Cdouble})::cudnnStatus_t
+    @gcsafe_ccall libcudnn.cudnnRNNGetClip(handle::cudnnHandle_t,
+                                           rnnDesc::cudnnRNNDescriptor_t,
+                                           clipMode::Ptr{cudnnRNNClipMode_t},
+                                           clipNanOpt::Ptr{cudnnNanPropagation_t},
+                                           lclip::Ptr{Cdouble},
+                                           rclip::Ptr{Cdouble})::cudnnStatus_t
 end
 
 @checked function cudnnSetRNNProjectionLayers(handle, rnnDesc, recProjSize, outProjSize)
     initialize_context()
-    @ccall libcudnn.cudnnSetRNNProjectionLayers(handle::cudnnHandle_t,
-                                                rnnDesc::cudnnRNNDescriptor_t,
-                                                recProjSize::Cint,
-                                                outProjSize::Cint)::cudnnStatus_t
+    @gcsafe_ccall libcudnn.cudnnSetRNNProjectionLayers(handle::cudnnHandle_t,
+                                                       rnnDesc::cudnnRNNDescriptor_t,
+                                                       recProjSize::Cint,
+                                                       outProjSize::Cint)::cudnnStatus_t
 end
 
 @checked function cudnnGetRNNProjectionLayers(handle, rnnDesc, recProjSize, outProjSize)
     initialize_context()
-    @ccall libcudnn.cudnnGetRNNProjectionLayers(handle::cudnnHandle_t,
-                                                rnnDesc::cudnnRNNDescriptor_t,
-                                                recProjSize::Ptr{Cint},
-                                                outProjSize::Ptr{Cint})::cudnnStatus_t
+    @gcsafe_ccall libcudnn.cudnnGetRNNProjectionLayers(handle::cudnnHandle_t,
+                                                       rnnDesc::cudnnRNNDescriptor_t,
+                                                       recProjSize::Ptr{Cint},
+                                                       outProjSize::Ptr{Cint})::cudnnStatus_t
 end
 
 @checked function cudnnCreatePersistentRNNPlan(rnnDesc, minibatch, dataType, plan)
     initialize_context()
-    @ccall libcudnn.cudnnCreatePersistentRNNPlan(rnnDesc::cudnnRNNDescriptor_t,
-                                                 minibatch::Cint, dataType::cudnnDataType_t,
-                                                 plan::Ptr{cudnnPersistentRNNPlan_t})::cudnnStatus_t
+    @gcsafe_ccall libcudnn.cudnnCreatePersistentRNNPlan(rnnDesc::cudnnRNNDescriptor_t,
+                                                        minibatch::Cint,
+                                                        dataType::cudnnDataType_t,
+                                                        plan::Ptr{cudnnPersistentRNNPlan_t})::cudnnStatus_t
 end
 
 @checked function cudnnDestroyPersistentRNNPlan(plan)
     initialize_context()
-    @ccall libcudnn.cudnnDestroyPersistentRNNPlan(plan::cudnnPersistentRNNPlan_t)::cudnnStatus_t
+    @gcsafe_ccall libcudnn.cudnnDestroyPersistentRNNPlan(plan::cudnnPersistentRNNPlan_t)::cudnnStatus_t
 end
 
 @checked function cudnnSetPersistentRNNPlan(rnnDesc, plan)
     initialize_context()
-    @ccall libcudnn.cudnnSetPersistentRNNPlan(rnnDesc::cudnnRNNDescriptor_t,
-                                              plan::cudnnPersistentRNNPlan_t)::cudnnStatus_t
+    @gcsafe_ccall libcudnn.cudnnSetPersistentRNNPlan(rnnDesc::cudnnRNNDescriptor_t,
+                                                     plan::cudnnPersistentRNNPlan_t)::cudnnStatus_t
 end
 
 @checked function cudnnBuildRNNDynamic(handle, rnnDesc, miniBatch)
     initialize_context()
-    @ccall libcudnn.cudnnBuildRNNDynamic(handle::cudnnHandle_t,
-                                         rnnDesc::cudnnRNNDescriptor_t,
-                                         miniBatch::Cint)::cudnnStatus_t
+    @gcsafe_ccall libcudnn.cudnnBuildRNNDynamic(handle::cudnnHandle_t,
+                                                rnnDesc::cudnnRNNDescriptor_t,
+                                                miniBatch::Cint)::cudnnStatus_t
 end
 
 @checked function cudnnGetRNNWorkspaceSize(handle, rnnDesc, seqLength, xDesc, sizeInBytes)
     initialize_context()
-    @ccall libcudnn.cudnnGetRNNWorkspaceSize(handle::cudnnHandle_t,
-                                             rnnDesc::cudnnRNNDescriptor_t, seqLength::Cint,
-                                             xDesc::Ptr{cudnnTensorDescriptor_t},
-                                             sizeInBytes::Ref{Csize_t})::cudnnStatus_t
+    @gcsafe_ccall libcudnn.cudnnGetRNNWorkspaceSize(handle::cudnnHandle_t,
+                                                    rnnDesc::cudnnRNNDescriptor_t,
+                                                    seqLength::Cint,
+                                                    xDesc::Ptr{cudnnTensorDescriptor_t},
+                                                    sizeInBytes::Ref{Csize_t})::cudnnStatus_t
 end
 
 @checked function cudnnGetRNNTrainingReserveSize(handle, rnnDesc, seqLength, xDesc,
                                                  sizeInBytes)
     initialize_context()
-    @ccall libcudnn.cudnnGetRNNTrainingReserveSize(handle::cudnnHandle_t,
-                                                   rnnDesc::cudnnRNNDescriptor_t,
-                                                   seqLength::Cint,
-                                                   xDesc::Ptr{cudnnTensorDescriptor_t},
-                                                   sizeInBytes::Ref{Csize_t})::cudnnStatus_t
+    @gcsafe_ccall libcudnn.cudnnGetRNNTrainingReserveSize(handle::cudnnHandle_t,
+                                                          rnnDesc::cudnnRNNDescriptor_t,
+                                                          seqLength::Cint,
+                                                          xDesc::Ptr{cudnnTensorDescriptor_t},
+                                                          sizeInBytes::Ref{Csize_t})::cudnnStatus_t
 end
 
 @checked function cudnnGetRNNTempSpaceSizes(handle, rnnDesc, fwdMode, xDesc, workSpaceSize,
                                             reserveSpaceSize)
     initialize_context()
-    @ccall libcudnn.cudnnGetRNNTempSpaceSizes(handle::cudnnHandle_t,
-                                              rnnDesc::cudnnRNNDescriptor_t,
-                                              fwdMode::cudnnForwardMode_t,
-                                              xDesc::cudnnRNNDataDescriptor_t,
-                                              workSpaceSize::Ref{Csize_t},
-                                              reserveSpaceSize::Ref{Csize_t})::cudnnStatus_t
+    @gcsafe_ccall libcudnn.cudnnGetRNNTempSpaceSizes(handle::cudnnHandle_t,
+                                                     rnnDesc::cudnnRNNDescriptor_t,
+                                                     fwdMode::cudnnForwardMode_t,
+                                                     xDesc::cudnnRNNDataDescriptor_t,
+                                                     workSpaceSize::Ref{Csize_t},
+                                                     reserveSpaceSize::Ref{Csize_t})::cudnnStatus_t
 end
 
 @checked function cudnnGetRNNParamsSize(handle, rnnDesc, xDesc, sizeInBytes, dataType)
     initialize_context()
-    @ccall libcudnn.cudnnGetRNNParamsSize(handle::cudnnHandle_t,
-                                          rnnDesc::cudnnRNNDescriptor_t,
-                                          xDesc::cudnnTensorDescriptor_t,
-                                          sizeInBytes::Ref{Csize_t},
-                                          dataType::cudnnDataType_t)::cudnnStatus_t
+    @gcsafe_ccall libcudnn.cudnnGetRNNParamsSize(handle::cudnnHandle_t,
+                                                 rnnDesc::cudnnRNNDescriptor_t,
+                                                 xDesc::cudnnTensorDescriptor_t,
+                                                 sizeInBytes::Ref{Csize_t},
+                                                 dataType::cudnnDataType_t)::cudnnStatus_t
 end
 
 @checked function cudnnGetRNNWeightSpaceSize(handle, rnnDesc, weightSpaceSize)
     initialize_context()
-    @ccall libcudnn.cudnnGetRNNWeightSpaceSize(handle::cudnnHandle_t,
-                                               rnnDesc::cudnnRNNDescriptor_t,
-                                               weightSpaceSize::Ref{Csize_t})::cudnnStatus_t
+    @gcsafe_ccall libcudnn.cudnnGetRNNWeightSpaceSize(handle::cudnnHandle_t,
+                                                      rnnDesc::cudnnRNNDescriptor_t,
+                                                      weightSpaceSize::Ref{Csize_t})::cudnnStatus_t
 end
 
 @checked function cudnnGetRNNLinLayerMatrixParams(handle, rnnDesc, pseudoLayer, xDesc,
                                                   wDesc, w, linLayerID, linLayerMatDesc,
                                                   linLayerMat)
     initialize_context()
-    @ccall libcudnn.cudnnGetRNNLinLayerMatrixParams(handle::cudnnHandle_t,
-                                                    rnnDesc::cudnnRNNDescriptor_t,
-                                                    pseudoLayer::Cint,
-                                                    xDesc::cudnnTensorDescriptor_t,
-                                                    wDesc::cudnnFilterDescriptor_t,
-                                                    w::CuPtr{Cvoid}, linLayerID::Cint,
-                                                    linLayerMatDesc::cudnnFilterDescriptor_t,
-                                                    linLayerMat::Ptr{Ptr{Cvoid}})::cudnnStatus_t
+    @gcsafe_ccall libcudnn.cudnnGetRNNLinLayerMatrixParams(handle::cudnnHandle_t,
+                                                           rnnDesc::cudnnRNNDescriptor_t,
+                                                           pseudoLayer::Cint,
+                                                           xDesc::cudnnTensorDescriptor_t,
+                                                           wDesc::cudnnFilterDescriptor_t,
+                                                           w::CuPtr{Cvoid},
+                                                           linLayerID::Cint,
+                                                           linLayerMatDesc::cudnnFilterDescriptor_t,
+                                                           linLayerMat::Ptr{Ptr{Cvoid}})::cudnnStatus_t
 end
 
 @checked function cudnnGetRNNLinLayerBiasParams(handle, rnnDesc, pseudoLayer, xDesc, wDesc,
                                                 w, linLayerID, linLayerBiasDesc,
                                                 linLayerBias)
     initialize_context()
-    @ccall libcudnn.cudnnGetRNNLinLayerBiasParams(handle::cudnnHandle_t,
-                                                  rnnDesc::cudnnRNNDescriptor_t,
-                                                  pseudoLayer::Cint,
-                                                  xDesc::cudnnTensorDescriptor_t,
-                                                  wDesc::cudnnFilterDescriptor_t,
-                                                  w::CuPtr{Cvoid}, linLayerID::Cint,
-                                                  linLayerBiasDesc::cudnnFilterDescriptor_t,
-                                                  linLayerBias::Ptr{Ptr{Cvoid}})::cudnnStatus_t
+    @gcsafe_ccall libcudnn.cudnnGetRNNLinLayerBiasParams(handle::cudnnHandle_t,
+                                                         rnnDesc::cudnnRNNDescriptor_t,
+                                                         pseudoLayer::Cint,
+                                                         xDesc::cudnnTensorDescriptor_t,
+                                                         wDesc::cudnnFilterDescriptor_t,
+                                                         w::CuPtr{Cvoid}, linLayerID::Cint,
+                                                         linLayerBiasDesc::cudnnFilterDescriptor_t,
+                                                         linLayerBias::Ptr{Ptr{Cvoid}})::cudnnStatus_t
 end
 
 @checked function cudnnGetRNNWeightParams(handle, rnnDesc, pseudoLayer, weightSpaceSize,
                                           weightSpace, linLayerID, mDesc, mAddr, bDesc,
                                           bAddr)
     initialize_context()
-    @ccall libcudnn.cudnnGetRNNWeightParams(handle::cudnnHandle_t,
-                                            rnnDesc::cudnnRNNDescriptor_t,
-                                            pseudoLayer::Int32, weightSpaceSize::Csize_t,
-                                            weightSpace::CuPtr{Cvoid}, linLayerID::Int32,
-                                            mDesc::cudnnTensorDescriptor_t,
-                                            mAddr::Ptr{CuPtr{Cvoid}},
-                                            bDesc::cudnnTensorDescriptor_t,
-                                            bAddr::Ptr{CuPtr{Cvoid}})::cudnnStatus_t
+    @gcsafe_ccall libcudnn.cudnnGetRNNWeightParams(handle::cudnnHandle_t,
+                                                   rnnDesc::cudnnRNNDescriptor_t,
+                                                   pseudoLayer::Int32,
+                                                   weightSpaceSize::Csize_t,
+                                                   weightSpace::CuPtr{Cvoid},
+                                                   linLayerID::Int32,
+                                                   mDesc::cudnnTensorDescriptor_t,
+                                                   mAddr::Ptr{CuPtr{Cvoid}},
+                                                   bDesc::cudnnTensorDescriptor_t,
+                                                   bAddr::Ptr{CuPtr{Cvoid}})::cudnnStatus_t
 end
 
 @checked function cudnnRNNForwardInference(handle, rnnDesc, seqLength, xDesc, x, hxDesc, hx,
                                            cxDesc, cx, wDesc, w, yDesc, y, hyDesc, hy,
                                            cyDesc, cy, workSpace, workSpaceSizeInBytes)
     initialize_context()
-    @ccall libcudnn.cudnnRNNForwardInference(handle::cudnnHandle_t,
-                                             rnnDesc::cudnnRNNDescriptor_t, seqLength::Cint,
-                                             xDesc::Ptr{cudnnTensorDescriptor_t},
-                                             x::CuPtr{Cvoid},
-                                             hxDesc::cudnnTensorDescriptor_t,
-                                             hx::CuPtr{Cvoid},
-                                             cxDesc::cudnnTensorDescriptor_t,
-                                             cx::CuPtr{Cvoid},
-                                             wDesc::cudnnFilterDescriptor_t,
-                                             w::CuPtr{Cvoid},
-                                             yDesc::Ptr{cudnnTensorDescriptor_t},
-                                             y::CuPtr{Cvoid},
-                                             hyDesc::cudnnTensorDescriptor_t,
-                                             hy::CuPtr{Cvoid},
-                                             cyDesc::cudnnTensorDescriptor_t,
-                                             cy::CuPtr{Cvoid}, workSpace::CuPtr{Cvoid},
-                                             workSpaceSizeInBytes::Csize_t)::cudnnStatus_t
+    @gcsafe_ccall libcudnn.cudnnRNNForwardInference(handle::cudnnHandle_t,
+                                                    rnnDesc::cudnnRNNDescriptor_t,
+                                                    seqLength::Cint,
+                                                    xDesc::Ptr{cudnnTensorDescriptor_t},
+                                                    x::CuPtr{Cvoid},
+                                                    hxDesc::cudnnTensorDescriptor_t,
+                                                    hx::CuPtr{Cvoid},
+                                                    cxDesc::cudnnTensorDescriptor_t,
+                                                    cx::CuPtr{Cvoid},
+                                                    wDesc::cudnnFilterDescriptor_t,
+                                                    w::CuPtr{Cvoid},
+                                                    yDesc::Ptr{cudnnTensorDescriptor_t},
+                                                    y::CuPtr{Cvoid},
+                                                    hyDesc::cudnnTensorDescriptor_t,
+                                                    hy::CuPtr{Cvoid},
+                                                    cyDesc::cudnnTensorDescriptor_t,
+                                                    cy::CuPtr{Cvoid},
+                                                    workSpace::CuPtr{Cvoid},
+                                                    workSpaceSizeInBytes::Csize_t)::cudnnStatus_t
 end
 
 @checked function cudnnSetRNNPaddingMode(rnnDesc, paddingMode)
     initialize_context()
-    @ccall libcudnn.cudnnSetRNNPaddingMode(rnnDesc::cudnnRNNDescriptor_t,
-                                           paddingMode::Cuint)::cudnnStatus_t
+    @gcsafe_ccall libcudnn.cudnnSetRNNPaddingMode(rnnDesc::cudnnRNNDescriptor_t,
+                                                  paddingMode::Cuint)::cudnnStatus_t
 end
 
 @checked function cudnnGetRNNPaddingMode(rnnDesc, paddingMode)
     initialize_context()
-    @ccall libcudnn.cudnnGetRNNPaddingMode(rnnDesc::cudnnRNNDescriptor_t,
-                                           paddingMode::Ptr{Cuint})::cudnnStatus_t
+    @gcsafe_ccall libcudnn.cudnnGetRNNPaddingMode(rnnDesc::cudnnRNNDescriptor_t,
+                                                  paddingMode::Ptr{Cuint})::cudnnStatus_t
 end
 
 @checked function cudnnCreateRNNDataDescriptor(rnnDataDesc)
     initialize_context()
-    @ccall libcudnn.cudnnCreateRNNDataDescriptor(rnnDataDesc::Ptr{cudnnRNNDataDescriptor_t})::cudnnStatus_t
+    @gcsafe_ccall libcudnn.cudnnCreateRNNDataDescriptor(rnnDataDesc::Ptr{cudnnRNNDataDescriptor_t})::cudnnStatus_t
 end
 
 @checked function cudnnDestroyRNNDataDescriptor(rnnDataDesc)
     initialize_context()
-    @ccall libcudnn.cudnnDestroyRNNDataDescriptor(rnnDataDesc::cudnnRNNDataDescriptor_t)::cudnnStatus_t
+    @gcsafe_ccall libcudnn.cudnnDestroyRNNDataDescriptor(rnnDataDesc::cudnnRNNDataDescriptor_t)::cudnnStatus_t
 end
 
 @checked function cudnnSetRNNDataDescriptor(rnnDataDesc, dataType, layout, maxSeqLength,
                                             batchSize, vectorSize, seqLengthArray,
                                             paddingFill)
     initialize_context()
-    @ccall libcudnn.cudnnSetRNNDataDescriptor(rnnDataDesc::cudnnRNNDataDescriptor_t,
-                                              dataType::cudnnDataType_t,
-                                              layout::cudnnRNNDataLayout_t,
-                                              maxSeqLength::Cint, batchSize::Cint,
-                                              vectorSize::Cint, seqLengthArray::Ptr{Cint},
-                                              paddingFill::Ptr{Cvoid})::cudnnStatus_t
+    @gcsafe_ccall libcudnn.cudnnSetRNNDataDescriptor(rnnDataDesc::cudnnRNNDataDescriptor_t,
+                                                     dataType::cudnnDataType_t,
+                                                     layout::cudnnRNNDataLayout_t,
+                                                     maxSeqLength::Cint, batchSize::Cint,
+                                                     vectorSize::Cint,
+                                                     seqLengthArray::Ptr{Cint},
+                                                     paddingFill::Ptr{Cvoid})::cudnnStatus_t
 end
 
 @checked function cudnnGetRNNDataDescriptor(rnnDataDesc, dataType, layout, maxSeqLength,
                                             batchSize, vectorSize, arrayLengthRequested,
                                             seqLengthArray, paddingFill)
     initialize_context()
-    @ccall libcudnn.cudnnGetRNNDataDescriptor(rnnDataDesc::cudnnRNNDataDescriptor_t,
-                                              dataType::Ptr{cudnnDataType_t},
-                                              layout::Ptr{cudnnRNNDataLayout_t},
-                                              maxSeqLength::Ptr{Cint}, batchSize::Ptr{Cint},
-                                              vectorSize::Ptr{Cint},
-                                              arrayLengthRequested::Cint,
-                                              seqLengthArray::Ptr{Cint},
-                                              paddingFill::Ptr{Cvoid})::cudnnStatus_t
+    @gcsafe_ccall libcudnn.cudnnGetRNNDataDescriptor(rnnDataDesc::cudnnRNNDataDescriptor_t,
+                                                     dataType::Ptr{cudnnDataType_t},
+                                                     layout::Ptr{cudnnRNNDataLayout_t},
+                                                     maxSeqLength::Ptr{Cint},
+                                                     batchSize::Ptr{Cint},
+                                                     vectorSize::Ptr{Cint},
+                                                     arrayLengthRequested::Cint,
+                                                     seqLengthArray::Ptr{Cint},
+                                                     paddingFill::Ptr{Cvoid})::cudnnStatus_t
 end
 
 @checked function cudnnRNNForwardInferenceEx(handle, rnnDesc, xDesc, x, hxDesc, hx, cxDesc,
@@ -2065,32 +2127,32 @@ end
                                              kDesc, keys, cDesc, cAttn, iDesc, iAttn, qDesc,
                                              queries, workSpace, workSpaceSizeInBytes)
     initialize_context()
-    @ccall libcudnn.cudnnRNNForwardInferenceEx(handle::cudnnHandle_t,
-                                               rnnDesc::cudnnRNNDescriptor_t,
-                                               xDesc::cudnnRNNDataDescriptor_t,
-                                               x::CuPtr{Cvoid},
-                                               hxDesc::cudnnTensorDescriptor_t,
-                                               hx::CuPtr{Cvoid},
-                                               cxDesc::cudnnTensorDescriptor_t,
-                                               cx::CuPtr{Cvoid},
-                                               wDesc::cudnnFilterDescriptor_t,
-                                               w::CuPtr{Cvoid},
-                                               yDesc::cudnnRNNDataDescriptor_t,
-                                               y::CuPtr{Cvoid},
-                                               hyDesc::cudnnTensorDescriptor_t,
-                                               hy::CuPtr{Cvoid},
-                                               cyDesc::cudnnTensorDescriptor_t,
-                                               cy::CuPtr{Cvoid},
-                                               kDesc::cudnnRNNDataDescriptor_t,
-                                               keys::Ptr{Cvoid},
-                                               cDesc::cudnnRNNDataDescriptor_t,
-                                               cAttn::Ptr{Cvoid},
-                                               iDesc::cudnnRNNDataDescriptor_t,
-                                               iAttn::Ptr{Cvoid},
-                                               qDesc::cudnnRNNDataDescriptor_t,
-                                               queries::CuPtr{Cvoid},
-                                               workSpace::CuPtr{Cvoid},
-                                               workSpaceSizeInBytes::Csize_t)::cudnnStatus_t
+    @gcsafe_ccall libcudnn.cudnnRNNForwardInferenceEx(handle::cudnnHandle_t,
+                                                      rnnDesc::cudnnRNNDescriptor_t,
+                                                      xDesc::cudnnRNNDataDescriptor_t,
+                                                      x::CuPtr{Cvoid},
+                                                      hxDesc::cudnnTensorDescriptor_t,
+                                                      hx::CuPtr{Cvoid},
+                                                      cxDesc::cudnnTensorDescriptor_t,
+                                                      cx::CuPtr{Cvoid},
+                                                      wDesc::cudnnFilterDescriptor_t,
+                                                      w::CuPtr{Cvoid},
+                                                      yDesc::cudnnRNNDataDescriptor_t,
+                                                      y::CuPtr{Cvoid},
+                                                      hyDesc::cudnnTensorDescriptor_t,
+                                                      hy::CuPtr{Cvoid},
+                                                      cyDesc::cudnnTensorDescriptor_t,
+                                                      cy::CuPtr{Cvoid},
+                                                      kDesc::cudnnRNNDataDescriptor_t,
+                                                      keys::Ptr{Cvoid},
+                                                      cDesc::cudnnRNNDataDescriptor_t,
+                                                      cAttn::Ptr{Cvoid},
+                                                      iDesc::cudnnRNNDataDescriptor_t,
+                                                      iAttn::Ptr{Cvoid},
+                                                      qDesc::cudnnRNNDataDescriptor_t,
+                                                      queries::CuPtr{Cvoid},
+                                                      workSpace::CuPtr{Cvoid},
+                                                      workSpaceSizeInBytes::Csize_t)::cudnnStatus_t
 end
 
 @checked function cudnnRNNForward(handle, rnnDesc, fwdMode, devSeqLengths, xDesc, x, yDesc,
@@ -2098,32 +2160,34 @@ end
                                   weightSpace, workSpaceSize, workSpace, reserveSpaceSize,
                                   reserveSpace)
     initialize_context()
-    @ccall libcudnn.cudnnRNNForward(handle::cudnnHandle_t, rnnDesc::cudnnRNNDescriptor_t,
-                                    fwdMode::cudnnForwardMode_t,
-                                    devSeqLengths::CuPtr{Int32},
-                                    xDesc::cudnnRNNDataDescriptor_t, x::CuPtr{Cvoid},
-                                    yDesc::cudnnRNNDataDescriptor_t, y::CuPtr{Cvoid},
-                                    hDesc::cudnnTensorDescriptor_t, hx::CuPtr{Cvoid},
-                                    hy::CuPtr{Cvoid}, cDesc::cudnnTensorDescriptor_t,
-                                    cx::CuPtr{Cvoid}, cy::CuPtr{Cvoid},
-                                    weightSpaceSize::Csize_t, weightSpace::CuPtr{Cvoid},
-                                    workSpaceSize::Csize_t, workSpace::CuPtr{Cvoid},
-                                    reserveSpaceSize::Csize_t,
-                                    reserveSpace::CuPtr{Cvoid})::cudnnStatus_t
+    @gcsafe_ccall libcudnn.cudnnRNNForward(handle::cudnnHandle_t,
+                                           rnnDesc::cudnnRNNDescriptor_t,
+                                           fwdMode::cudnnForwardMode_t,
+                                           devSeqLengths::CuPtr{Int32},
+                                           xDesc::cudnnRNNDataDescriptor_t, x::CuPtr{Cvoid},
+                                           yDesc::cudnnRNNDataDescriptor_t, y::CuPtr{Cvoid},
+                                           hDesc::cudnnTensorDescriptor_t, hx::CuPtr{Cvoid},
+                                           hy::CuPtr{Cvoid}, cDesc::cudnnTensorDescriptor_t,
+                                           cx::CuPtr{Cvoid}, cy::CuPtr{Cvoid},
+                                           weightSpaceSize::Csize_t,
+                                           weightSpace::CuPtr{Cvoid},
+                                           workSpaceSize::Csize_t, workSpace::CuPtr{Cvoid},
+                                           reserveSpaceSize::Csize_t,
+                                           reserveSpace::CuPtr{Cvoid})::cudnnStatus_t
 end
 
 @checked function cudnnSetRNNAlgorithmDescriptor(handle, rnnDesc, algoDesc)
     initialize_context()
-    @ccall libcudnn.cudnnSetRNNAlgorithmDescriptor(handle::cudnnHandle_t,
-                                                   rnnDesc::cudnnRNNDescriptor_t,
-                                                   algoDesc::cudnnAlgorithmDescriptor_t)::cudnnStatus_t
+    @gcsafe_ccall libcudnn.cudnnSetRNNAlgorithmDescriptor(handle::cudnnHandle_t,
+                                                          rnnDesc::cudnnRNNDescriptor_t,
+                                                          algoDesc::cudnnAlgorithmDescriptor_t)::cudnnStatus_t
 end
 
 @checked function cudnnGetRNNForwardInferenceAlgorithmMaxCount(handle, rnnDesc, count)
     initialize_context()
-    @ccall libcudnn.cudnnGetRNNForwardInferenceAlgorithmMaxCount(handle::cudnnHandle_t,
-                                                                 rnnDesc::cudnnRNNDescriptor_t,
-                                                                 count::Ptr{Cint})::cudnnStatus_t
+    @gcsafe_ccall libcudnn.cudnnGetRNNForwardInferenceAlgorithmMaxCount(handle::cudnnHandle_t,
+                                                                        rnnDesc::cudnnRNNDescriptor_t,
+                                                                        count::Ptr{Cint})::cudnnStatus_t
 end
 
 @checked function cudnnFindRNNForwardInferenceAlgorithmEx(handle, rnnDesc, seqLength, xDesc,
@@ -2134,29 +2198,29 @@ end
                                                           returnedAlgoCount, perfResults,
                                                           workspace, workSpaceSizeInBytes)
     initialize_context()
-    @ccall libcudnn.cudnnFindRNNForwardInferenceAlgorithmEx(handle::cudnnHandle_t,
-                                                            rnnDesc::cudnnRNNDescriptor_t,
-                                                            seqLength::Cint,
-                                                            xDesc::Ptr{cudnnTensorDescriptor_t},
-                                                            x::CuPtr{Cvoid},
-                                                            hxDesc::cudnnTensorDescriptor_t,
-                                                            hx::CuPtr{Cvoid},
-                                                            cxDesc::cudnnTensorDescriptor_t,
-                                                            cx::CuPtr{Cvoid},
-                                                            wDesc::cudnnFilterDescriptor_t,
-                                                            w::CuPtr{Cvoid},
-                                                            yDesc::Ptr{cudnnTensorDescriptor_t},
-                                                            y::CuPtr{Cvoid},
-                                                            hyDesc::cudnnTensorDescriptor_t,
-                                                            hy::CuPtr{Cvoid},
-                                                            cyDesc::cudnnTensorDescriptor_t,
-                                                            cy::CuPtr{Cvoid},
-                                                            findIntensity::Cfloat,
-                                                            requestedAlgoCount::Cint,
-                                                            returnedAlgoCount::Ptr{Cint},
-                                                            perfResults::Ptr{cudnnAlgorithmPerformance_t},
-                                                            workspace::CuPtr{Cvoid},
-                                                            workSpaceSizeInBytes::Csize_t)::cudnnStatus_t
+    @gcsafe_ccall libcudnn.cudnnFindRNNForwardInferenceAlgorithmEx(handle::cudnnHandle_t,
+                                                                   rnnDesc::cudnnRNNDescriptor_t,
+                                                                   seqLength::Cint,
+                                                                   xDesc::Ptr{cudnnTensorDescriptor_t},
+                                                                   x::CuPtr{Cvoid},
+                                                                   hxDesc::cudnnTensorDescriptor_t,
+                                                                   hx::CuPtr{Cvoid},
+                                                                   cxDesc::cudnnTensorDescriptor_t,
+                                                                   cx::CuPtr{Cvoid},
+                                                                   wDesc::cudnnFilterDescriptor_t,
+                                                                   w::CuPtr{Cvoid},
+                                                                   yDesc::Ptr{cudnnTensorDescriptor_t},
+                                                                   y::CuPtr{Cvoid},
+                                                                   hyDesc::cudnnTensorDescriptor_t,
+                                                                   hy::CuPtr{Cvoid},
+                                                                   cyDesc::cudnnTensorDescriptor_t,
+                                                                   cy::CuPtr{Cvoid},
+                                                                   findIntensity::Cfloat,
+                                                                   requestedAlgoCount::Cint,
+                                                                   returnedAlgoCount::Ptr{Cint},
+                                                                   perfResults::Ptr{cudnnAlgorithmPerformance_t},
+                                                                   workspace::CuPtr{Cvoid},
+                                                                   workSpaceSizeInBytes::Csize_t)::cudnnStatus_t
 end
 
 @cenum cudnnSeqDataAxis_t::UInt32 begin
@@ -2172,24 +2236,24 @@ const cudnnSeqDataDescriptor_t = Ptr{cudnnSeqDataStruct}
 
 @checked function cudnnCreateSeqDataDescriptor(seqDataDesc)
     initialize_context()
-    @ccall libcudnn.cudnnCreateSeqDataDescriptor(seqDataDesc::Ptr{cudnnSeqDataDescriptor_t})::cudnnStatus_t
+    @gcsafe_ccall libcudnn.cudnnCreateSeqDataDescriptor(seqDataDesc::Ptr{cudnnSeqDataDescriptor_t})::cudnnStatus_t
 end
 
 @checked function cudnnDestroySeqDataDescriptor(seqDataDesc)
     initialize_context()
-    @ccall libcudnn.cudnnDestroySeqDataDescriptor(seqDataDesc::cudnnSeqDataDescriptor_t)::cudnnStatus_t
+    @gcsafe_ccall libcudnn.cudnnDestroySeqDataDescriptor(seqDataDesc::cudnnSeqDataDescriptor_t)::cudnnStatus_t
 end
 
 @checked function cudnnSetSeqDataDescriptor(seqDataDesc, dataType, nbDims, dimA, axes,
                                             seqLengthArraySize, seqLengthArray, paddingFill)
     initialize_context()
-    @ccall libcudnn.cudnnSetSeqDataDescriptor(seqDataDesc::cudnnSeqDataDescriptor_t,
-                                              dataType::cudnnDataType_t, nbDims::Cint,
-                                              dimA::Ptr{Cint},
-                                              axes::Ptr{cudnnSeqDataAxis_t},
-                                              seqLengthArraySize::Csize_t,
-                                              seqLengthArray::Ptr{Cint},
-                                              paddingFill::Ptr{Cvoid})::cudnnStatus_t
+    @gcsafe_ccall libcudnn.cudnnSetSeqDataDescriptor(seqDataDesc::cudnnSeqDataDescriptor_t,
+                                                     dataType::cudnnDataType_t,
+                                                     nbDims::Cint, dimA::Ptr{Cint},
+                                                     axes::Ptr{cudnnSeqDataAxis_t},
+                                                     seqLengthArraySize::Csize_t,
+                                                     seqLengthArray::Ptr{Cint},
+                                                     paddingFill::Ptr{Cvoid})::cudnnStatus_t
 end
 
 @checked function cudnnGetSeqDataDescriptor(seqDataDesc, dataType, nbDims, nbDimsRequested,
@@ -2197,15 +2261,15 @@ end
                                             seqLengthSizeRequested, seqLengthArray,
                                             paddingFill)
     initialize_context()
-    @ccall libcudnn.cudnnGetSeqDataDescriptor(seqDataDesc::cudnnSeqDataDescriptor_t,
-                                              dataType::Ptr{cudnnDataType_t},
-                                              nbDims::Ptr{Cint}, nbDimsRequested::Cint,
-                                              dimA::Ptr{Cint},
-                                              axes::Ptr{cudnnSeqDataAxis_t},
-                                              seqLengthArraySize::Ptr{Csize_t},
-                                              seqLengthSizeRequested::Csize_t,
-                                              seqLengthArray::Ptr{Cint},
-                                              paddingFill::Ptr{Cvoid})::cudnnStatus_t
+    @gcsafe_ccall libcudnn.cudnnGetSeqDataDescriptor(seqDataDesc::cudnnSeqDataDescriptor_t,
+                                                     dataType::Ptr{cudnnDataType_t},
+                                                     nbDims::Ptr{Cint},
+                                                     nbDimsRequested::Cint, dimA::Ptr{Cint},
+                                                     axes::Ptr{cudnnSeqDataAxis_t},
+                                                     seqLengthArraySize::Ptr{Csize_t},
+                                                     seqLengthSizeRequested::Csize_t,
+                                                     seqLengthArray::Ptr{Cint},
+                                                     paddingFill::Ptr{Cvoid})::cudnnStatus_t
 end
 
 const cudnnAttnQueryMap_t = Cuint
@@ -2216,12 +2280,12 @@ const cudnnAttnDescriptor_t = Ptr{cudnnAttnStruct}
 
 @checked function cudnnCreateAttnDescriptor(attnDesc)
     initialize_context()
-    @ccall libcudnn.cudnnCreateAttnDescriptor(attnDesc::Ptr{cudnnAttnDescriptor_t})::cudnnStatus_t
+    @gcsafe_ccall libcudnn.cudnnCreateAttnDescriptor(attnDesc::Ptr{cudnnAttnDescriptor_t})::cudnnStatus_t
 end
 
 @checked function cudnnDestroyAttnDescriptor(attnDesc)
     initialize_context()
-    @ccall libcudnn.cudnnDestroyAttnDescriptor(attnDesc::cudnnAttnDescriptor_t)::cudnnStatus_t
+    @gcsafe_ccall libcudnn.cudnnDestroyAttnDescriptor(attnDesc::cudnnAttnDescriptor_t)::cudnnStatus_t
 end
 
 @checked function cudnnSetAttnDescriptor(attnDesc, attnMode, nHeads, smScaler, dataType,
@@ -2230,19 +2294,20 @@ end
                                          kProjSize, vProjSize, oProjSize, qoMaxSeqLength,
                                          kvMaxSeqLength, maxBatchSize, maxBeamSize)
     initialize_context()
-    @ccall libcudnn.cudnnSetAttnDescriptor(attnDesc::cudnnAttnDescriptor_t, attnMode::Cuint,
-                                           nHeads::Cint, smScaler::Cdouble,
-                                           dataType::cudnnDataType_t,
-                                           computePrec::cudnnDataType_t,
-                                           mathType::cudnnMathType_t,
-                                           attnDropoutDesc::cudnnDropoutDescriptor_t,
-                                           postDropoutDesc::cudnnDropoutDescriptor_t,
-                                           qSize::Cint, kSize::Cint, vSize::Cint,
-                                           qProjSize::Cint, kProjSize::Cint,
-                                           vProjSize::Cint, oProjSize::Cint,
-                                           qoMaxSeqLength::Cint, kvMaxSeqLength::Cint,
-                                           maxBatchSize::Cint,
-                                           maxBeamSize::Cint)::cudnnStatus_t
+    @gcsafe_ccall libcudnn.cudnnSetAttnDescriptor(attnDesc::cudnnAttnDescriptor_t,
+                                                  attnMode::Cuint, nHeads::Cint,
+                                                  smScaler::Cdouble,
+                                                  dataType::cudnnDataType_t,
+                                                  computePrec::cudnnDataType_t,
+                                                  mathType::cudnnMathType_t,
+                                                  attnDropoutDesc::cudnnDropoutDescriptor_t,
+                                                  postDropoutDesc::cudnnDropoutDescriptor_t,
+                                                  qSize::Cint, kSize::Cint, vSize::Cint,
+                                                  qProjSize::Cint, kProjSize::Cint,
+                                                  vProjSize::Cint, oProjSize::Cint,
+                                                  qoMaxSeqLength::Cint,
+                                                  kvMaxSeqLength::Cint, maxBatchSize::Cint,
+                                                  maxBeamSize::Cint)::cudnnStatus_t
 end
 
 @checked function cudnnGetAttnDescriptor(attnDesc, attnMode, nHeads, smScaler, dataType,
@@ -2251,32 +2316,34 @@ end
                                          kProjSize, vProjSize, oProjSize, qoMaxSeqLength,
                                          kvMaxSeqLength, maxBatchSize, maxBeamSize)
     initialize_context()
-    @ccall libcudnn.cudnnGetAttnDescriptor(attnDesc::cudnnAttnDescriptor_t,
-                                           attnMode::Ptr{Cuint}, nHeads::Ptr{Cint},
-                                           smScaler::Ptr{Cdouble},
-                                           dataType::Ptr{cudnnDataType_t},
-                                           computePrec::Ptr{cudnnDataType_t},
-                                           mathType::Ptr{cudnnMathType_t},
-                                           attnDropoutDesc::Ptr{cudnnDropoutDescriptor_t},
-                                           postDropoutDesc::Ptr{cudnnDropoutDescriptor_t},
-                                           qSize::Ptr{Cint}, kSize::Ptr{Cint},
-                                           vSize::Ptr{Cint}, qProjSize::Ptr{Cint},
-                                           kProjSize::Ptr{Cint}, vProjSize::Ptr{Cint},
-                                           oProjSize::Ptr{Cint}, qoMaxSeqLength::Ptr{Cint},
-                                           kvMaxSeqLength::Ptr{Cint},
-                                           maxBatchSize::Ptr{Cint},
-                                           maxBeamSize::Ptr{Cint})::cudnnStatus_t
+    @gcsafe_ccall libcudnn.cudnnGetAttnDescriptor(attnDesc::cudnnAttnDescriptor_t,
+                                                  attnMode::Ptr{Cuint}, nHeads::Ptr{Cint},
+                                                  smScaler::Ptr{Cdouble},
+                                                  dataType::Ptr{cudnnDataType_t},
+                                                  computePrec::Ptr{cudnnDataType_t},
+                                                  mathType::Ptr{cudnnMathType_t},
+                                                  attnDropoutDesc::Ptr{cudnnDropoutDescriptor_t},
+                                                  postDropoutDesc::Ptr{cudnnDropoutDescriptor_t},
+                                                  qSize::Ptr{Cint}, kSize::Ptr{Cint},
+                                                  vSize::Ptr{Cint}, qProjSize::Ptr{Cint},
+                                                  kProjSize::Ptr{Cint},
+                                                  vProjSize::Ptr{Cint},
+                                                  oProjSize::Ptr{Cint},
+                                                  qoMaxSeqLength::Ptr{Cint},
+                                                  kvMaxSeqLength::Ptr{Cint},
+                                                  maxBatchSize::Ptr{Cint},
+                                                  maxBeamSize::Ptr{Cint})::cudnnStatus_t
 end
 
 @checked function cudnnGetMultiHeadAttnBuffers(handle, attnDesc, weightSizeInBytes,
                                                workSpaceSizeInBytes,
                                                reserveSpaceSizeInBytes)
     initialize_context()
-    @ccall libcudnn.cudnnGetMultiHeadAttnBuffers(handle::cudnnHandle_t,
-                                                 attnDesc::cudnnAttnDescriptor_t,
-                                                 weightSizeInBytes::Ptr{Csize_t},
-                                                 workSpaceSizeInBytes::Ptr{Csize_t},
-                                                 reserveSpaceSizeInBytes::Ptr{Csize_t})::cudnnStatus_t
+    @gcsafe_ccall libcudnn.cudnnGetMultiHeadAttnBuffers(handle::cudnnHandle_t,
+                                                        attnDesc::cudnnAttnDescriptor_t,
+                                                        weightSizeInBytes::Ptr{Csize_t},
+                                                        workSpaceSizeInBytes::Ptr{Csize_t},
+                                                        reserveSpaceSizeInBytes::Ptr{Csize_t})::cudnnStatus_t
 end
 
 @cenum cudnnMultiHeadAttnWeightKind_t::UInt32 begin
@@ -2293,13 +2360,13 @@ end
 @checked function cudnnGetMultiHeadAttnWeights(handle, attnDesc, wKind, weightSizeInBytes,
                                                weights, wDesc, wAddr)
     initialize_context()
-    @ccall libcudnn.cudnnGetMultiHeadAttnWeights(handle::cudnnHandle_t,
-                                                 attnDesc::cudnnAttnDescriptor_t,
-                                                 wKind::cudnnMultiHeadAttnWeightKind_t,
-                                                 weightSizeInBytes::Csize_t,
-                                                 weights::CuPtr{Cvoid},
-                                                 wDesc::cudnnTensorDescriptor_t,
-                                                 wAddr::CuPtr{Ptr{Cvoid}})::cudnnStatus_t
+    @gcsafe_ccall libcudnn.cudnnGetMultiHeadAttnWeights(handle::cudnnHandle_t,
+                                                        attnDesc::cudnnAttnDescriptor_t,
+                                                        wKind::cudnnMultiHeadAttnWeightKind_t,
+                                                        weightSizeInBytes::Csize_t,
+                                                        weights::CuPtr{Cvoid},
+                                                        wDesc::cudnnTensorDescriptor_t,
+                                                        wAddr::CuPtr{Ptr{Cvoid}})::cudnnStatus_t
 end
 
 @checked function cudnnMultiHeadAttnForward(handle, attnDesc, currIdx, loWinIdx, hiWinIdx,
@@ -2309,31 +2376,32 @@ end
                                             workSpaceSizeInBytes, workSpace,
                                             reserveSpaceSizeInBytes, reserveSpace)
     initialize_context()
-    @ccall libcudnn.cudnnMultiHeadAttnForward(handle::cudnnHandle_t,
-                                              attnDesc::cudnnAttnDescriptor_t,
-                                              currIdx::Cint, loWinIdx::Ptr{Cint},
-                                              hiWinIdx::Ptr{Cint},
-                                              devSeqLengthsQO::CuPtr{Cint},
-                                              devSeqLengthsKV::CuPtr{Cint},
-                                              qDesc::cudnnSeqDataDescriptor_t,
-                                              queries::CuPtr{Cvoid},
-                                              residuals::CuPtr{Cvoid},
-                                              kDesc::cudnnSeqDataDescriptor_t,
-                                              keys::CuPtr{Cvoid},
-                                              vDesc::cudnnSeqDataDescriptor_t,
-                                              values::CuPtr{Cvoid},
-                                              oDesc::cudnnSeqDataDescriptor_t,
-                                              out::CuPtr{Cvoid}, weightSizeInBytes::Csize_t,
-                                              weights::CuPtr{Cvoid},
-                                              workSpaceSizeInBytes::Csize_t,
-                                              workSpace::CuPtr{Cvoid},
-                                              reserveSpaceSizeInBytes::Csize_t,
-                                              reserveSpace::CuPtr{Cvoid})::cudnnStatus_t
+    @gcsafe_ccall libcudnn.cudnnMultiHeadAttnForward(handle::cudnnHandle_t,
+                                                     attnDesc::cudnnAttnDescriptor_t,
+                                                     currIdx::Cint, loWinIdx::Ptr{Cint},
+                                                     hiWinIdx::Ptr{Cint},
+                                                     devSeqLengthsQO::CuPtr{Cint},
+                                                     devSeqLengthsKV::CuPtr{Cint},
+                                                     qDesc::cudnnSeqDataDescriptor_t,
+                                                     queries::CuPtr{Cvoid},
+                                                     residuals::CuPtr{Cvoid},
+                                                     kDesc::cudnnSeqDataDescriptor_t,
+                                                     keys::CuPtr{Cvoid},
+                                                     vDesc::cudnnSeqDataDescriptor_t,
+                                                     values::CuPtr{Cvoid},
+                                                     oDesc::cudnnSeqDataDescriptor_t,
+                                                     out::CuPtr{Cvoid},
+                                                     weightSizeInBytes::Csize_t,
+                                                     weights::CuPtr{Cvoid},
+                                                     workSpaceSizeInBytes::Csize_t,
+                                                     workSpace::CuPtr{Cvoid},
+                                                     reserveSpaceSizeInBytes::Csize_t,
+                                                     reserveSpace::CuPtr{Cvoid})::cudnnStatus_t
 end
 
 @checked function cudnnAdvInferVersionCheck()
     initialize_context()
-    @ccall libcudnn.cudnnAdvInferVersionCheck()::cudnnStatus_t
+    @gcsafe_ccall libcudnn.cudnnAdvInferVersionCheck()::cudnnStatus_t
 end
 
 @cenum cudnnWgradMode_t::UInt32 begin
@@ -2346,24 +2414,27 @@ end
                                           cyDesc, cy, workSpace, workSpaceSizeInBytes,
                                           reserveSpace, reserveSpaceSizeInBytes)
     initialize_context()
-    @ccall libcudnn.cudnnRNNForwardTraining(handle::cudnnHandle_t,
-                                            rnnDesc::cudnnRNNDescriptor_t, seqLength::Cint,
-                                            xDesc::Ptr{cudnnTensorDescriptor_t},
-                                            x::CuPtr{Cvoid},
-                                            hxDesc::cudnnTensorDescriptor_t,
-                                            hx::CuPtr{Cvoid},
-                                            cxDesc::cudnnTensorDescriptor_t,
-                                            cx::CuPtr{Cvoid},
-                                            wDesc::cudnnFilterDescriptor_t, w::CuPtr{Cvoid},
-                                            yDesc::Ptr{cudnnTensorDescriptor_t},
-                                            y::CuPtr{Cvoid},
-                                            hyDesc::cudnnTensorDescriptor_t,
-                                            hy::CuPtr{Cvoid},
-                                            cyDesc::cudnnTensorDescriptor_t,
-                                            cy::CuPtr{Cvoid}, workSpace::CuPtr{Cvoid},
-                                            workSpaceSizeInBytes::Csize_t,
-                                            reserveSpace::CuPtr{Cvoid},
-                                            reserveSpaceSizeInBytes::Csize_t)::cudnnStatus_t
+    @gcsafe_ccall libcudnn.cudnnRNNForwardTraining(handle::cudnnHandle_t,
+                                                   rnnDesc::cudnnRNNDescriptor_t,
+                                                   seqLength::Cint,
+                                                   xDesc::Ptr{cudnnTensorDescriptor_t},
+                                                   x::CuPtr{Cvoid},
+                                                   hxDesc::cudnnTensorDescriptor_t,
+                                                   hx::CuPtr{Cvoid},
+                                                   cxDesc::cudnnTensorDescriptor_t,
+                                                   cx::CuPtr{Cvoid},
+                                                   wDesc::cudnnFilterDescriptor_t,
+                                                   w::CuPtr{Cvoid},
+                                                   yDesc::Ptr{cudnnTensorDescriptor_t},
+                                                   y::CuPtr{Cvoid},
+                                                   hyDesc::cudnnTensorDescriptor_t,
+                                                   hy::CuPtr{Cvoid},
+                                                   cyDesc::cudnnTensorDescriptor_t,
+                                                   cy::CuPtr{Cvoid},
+                                                   workSpace::CuPtr{Cvoid},
+                                                   workSpaceSizeInBytes::Csize_t,
+                                                   reserveSpace::CuPtr{Cvoid},
+                                                   reserveSpaceSizeInBytes::Csize_t)::cudnnStatus_t
 end
 
 @checked function cudnnRNNBackwardData(handle, rnnDesc, seqLength, yDesc, y, dyDesc, dy,
@@ -2372,26 +2443,32 @@ end
                                        workSpace, workSpaceSizeInBytes, reserveSpace,
                                        reserveSpaceSizeInBytes)
     initialize_context()
-    @ccall libcudnn.cudnnRNNBackwardData(handle::cudnnHandle_t,
-                                         rnnDesc::cudnnRNNDescriptor_t, seqLength::Cint,
-                                         yDesc::Ptr{cudnnTensorDescriptor_t},
-                                         y::CuPtr{Cvoid},
-                                         dyDesc::Ptr{cudnnTensorDescriptor_t},
-                                         dy::CuPtr{Cvoid}, dhyDesc::cudnnTensorDescriptor_t,
-                                         dhy::CuPtr{Cvoid},
-                                         dcyDesc::cudnnTensorDescriptor_t,
-                                         dcy::CuPtr{Cvoid}, wDesc::cudnnFilterDescriptor_t,
-                                         w::CuPtr{Cvoid}, hxDesc::cudnnTensorDescriptor_t,
-                                         hx::CuPtr{Cvoid}, cxDesc::cudnnTensorDescriptor_t,
-                                         cx::CuPtr{Cvoid},
-                                         dxDesc::Ptr{cudnnTensorDescriptor_t},
-                                         dx::CuPtr{Cvoid}, dhxDesc::cudnnTensorDescriptor_t,
-                                         dhx::CuPtr{Cvoid},
-                                         dcxDesc::cudnnTensorDescriptor_t,
-                                         dcx::CuPtr{Cvoid}, workSpace::CuPtr{Cvoid},
-                                         workSpaceSizeInBytes::Csize_t,
-                                         reserveSpace::CuPtr{Cvoid},
-                                         reserveSpaceSizeInBytes::Csize_t)::cudnnStatus_t
+    @gcsafe_ccall libcudnn.cudnnRNNBackwardData(handle::cudnnHandle_t,
+                                                rnnDesc::cudnnRNNDescriptor_t,
+                                                seqLength::Cint,
+                                                yDesc::Ptr{cudnnTensorDescriptor_t},
+                                                y::CuPtr{Cvoid},
+                                                dyDesc::Ptr{cudnnTensorDescriptor_t},
+                                                dy::CuPtr{Cvoid},
+                                                dhyDesc::cudnnTensorDescriptor_t,
+                                                dhy::CuPtr{Cvoid},
+                                                dcyDesc::cudnnTensorDescriptor_t,
+                                                dcy::CuPtr{Cvoid},
+                                                wDesc::cudnnFilterDescriptor_t,
+                                                w::CuPtr{Cvoid},
+                                                hxDesc::cudnnTensorDescriptor_t,
+                                                hx::CuPtr{Cvoid},
+                                                cxDesc::cudnnTensorDescriptor_t,
+                                                cx::CuPtr{Cvoid},
+                                                dxDesc::Ptr{cudnnTensorDescriptor_t},
+                                                dx::CuPtr{Cvoid},
+                                                dhxDesc::cudnnTensorDescriptor_t,
+                                                dhx::CuPtr{Cvoid},
+                                                dcxDesc::cudnnTensorDescriptor_t,
+                                                dcx::CuPtr{Cvoid}, workSpace::CuPtr{Cvoid},
+                                                workSpaceSizeInBytes::Csize_t,
+                                                reserveSpace::CuPtr{Cvoid},
+                                                reserveSpaceSizeInBytes::Csize_t)::cudnnStatus_t
 end
 
 @checked function cudnnRNNBackwardData_v8(handle, rnnDesc, devSeqLengths, yDesc, y, dy,
@@ -2399,41 +2476,45 @@ end
                                           dcx, weightSpaceSize, weightSpace, workSpaceSize,
                                           workSpace, reserveSpaceSize, reserveSpace)
     initialize_context()
-    @ccall libcudnn.cudnnRNNBackwardData_v8(handle::cudnnHandle_t,
-                                            rnnDesc::cudnnRNNDescriptor_t,
-                                            devSeqLengths::CuPtr{Int32},
-                                            yDesc::cudnnRNNDataDescriptor_t,
-                                            y::CuPtr{Cvoid}, dy::CuPtr{Cvoid},
-                                            xDesc::cudnnRNNDataDescriptor_t,
-                                            dx::CuPtr{Cvoid},
-                                            hDesc::cudnnTensorDescriptor_t,
-                                            hx::CuPtr{Cvoid}, dhy::CuPtr{Cvoid},
-                                            dhx::CuPtr{Cvoid},
-                                            cDesc::cudnnTensorDescriptor_t,
-                                            cx::CuPtr{Cvoid}, dcy::CuPtr{Cvoid},
-                                            dcx::CuPtr{Cvoid}, weightSpaceSize::Csize_t,
-                                            weightSpace::CuPtr{Cvoid},
-                                            workSpaceSize::Csize_t, workSpace::CuPtr{Cvoid},
-                                            reserveSpaceSize::Csize_t,
-                                            reserveSpace::CuPtr{Cvoid})::cudnnStatus_t
+    @gcsafe_ccall libcudnn.cudnnRNNBackwardData_v8(handle::cudnnHandle_t,
+                                                   rnnDesc::cudnnRNNDescriptor_t,
+                                                   devSeqLengths::CuPtr{Int32},
+                                                   yDesc::cudnnRNNDataDescriptor_t,
+                                                   y::CuPtr{Cvoid}, dy::CuPtr{Cvoid},
+                                                   xDesc::cudnnRNNDataDescriptor_t,
+                                                   dx::CuPtr{Cvoid},
+                                                   hDesc::cudnnTensorDescriptor_t,
+                                                   hx::CuPtr{Cvoid}, dhy::CuPtr{Cvoid},
+                                                   dhx::CuPtr{Cvoid},
+                                                   cDesc::cudnnTensorDescriptor_t,
+                                                   cx::CuPtr{Cvoid}, dcy::CuPtr{Cvoid},
+                                                   dcx::CuPtr{Cvoid},
+                                                   weightSpaceSize::Csize_t,
+                                                   weightSpace::CuPtr{Cvoid},
+                                                   workSpaceSize::Csize_t,
+                                                   workSpace::CuPtr{Cvoid},
+                                                   reserveSpaceSize::Csize_t,
+                                                   reserveSpace::CuPtr{Cvoid})::cudnnStatus_t
 end
 
 @checked function cudnnRNNBackwardWeights(handle, rnnDesc, seqLength, xDesc, x, hxDesc, hx,
                                           yDesc, y, workSpace, workSpaceSizeInBytes, dwDesc,
                                           dw, reserveSpace, reserveSpaceSizeInBytes)
     initialize_context()
-    @ccall libcudnn.cudnnRNNBackwardWeights(handle::cudnnHandle_t,
-                                            rnnDesc::cudnnRNNDescriptor_t, seqLength::Cint,
-                                            xDesc::Ptr{cudnnTensorDescriptor_t},
-                                            x::CuPtr{Cvoid},
-                                            hxDesc::cudnnTensorDescriptor_t,
-                                            hx::CuPtr{Cvoid},
-                                            yDesc::Ptr{cudnnTensorDescriptor_t},
-                                            y::CuPtr{Cvoid}, workSpace::CuPtr{Cvoid},
-                                            workSpaceSizeInBytes::Csize_t,
-                                            dwDesc::cudnnFilterDescriptor_t,
-                                            dw::CuPtr{Cvoid}, reserveSpace::CuPtr{Cvoid},
-                                            reserveSpaceSizeInBytes::Csize_t)::cudnnStatus_t
+    @gcsafe_ccall libcudnn.cudnnRNNBackwardWeights(handle::cudnnHandle_t,
+                                                   rnnDesc::cudnnRNNDescriptor_t,
+                                                   seqLength::Cint,
+                                                   xDesc::Ptr{cudnnTensorDescriptor_t},
+                                                   x::CuPtr{Cvoid},
+                                                   hxDesc::cudnnTensorDescriptor_t,
+                                                   hx::CuPtr{Cvoid},
+                                                   yDesc::Ptr{cudnnTensorDescriptor_t},
+                                                   y::CuPtr{Cvoid}, workSpace::CuPtr{Cvoid},
+                                                   workSpaceSizeInBytes::Csize_t,
+                                                   dwDesc::cudnnFilterDescriptor_t,
+                                                   dw::CuPtr{Cvoid},
+                                                   reserveSpace::CuPtr{Cvoid},
+                                                   reserveSpaceSizeInBytes::Csize_t)::cudnnStatus_t
 end
 
 @checked function cudnnRNNBackwardWeights_v8(handle, rnnDesc, addGrad, devSeqLengths, xDesc,
@@ -2441,21 +2522,22 @@ end
                                              dweightSpace, workSpaceSize, workSpace,
                                              reserveSpaceSize, reserveSpace)
     initialize_context()
-    @ccall libcudnn.cudnnRNNBackwardWeights_v8(handle::cudnnHandle_t,
-                                               rnnDesc::cudnnRNNDescriptor_t,
-                                               addGrad::cudnnWgradMode_t,
-                                               devSeqLengths::CuPtr{Int32},
-                                               xDesc::cudnnRNNDataDescriptor_t,
-                                               x::CuPtr{Cvoid},
-                                               hDesc::cudnnTensorDescriptor_t,
-                                               hx::CuPtr{Cvoid},
-                                               yDesc::cudnnRNNDataDescriptor_t,
-                                               y::CuPtr{Cvoid}, weightSpaceSize::Csize_t,
-                                               dweightSpace::CuPtr{Cvoid},
-                                               workSpaceSize::Csize_t,
-                                               workSpace::CuPtr{Cvoid},
-                                               reserveSpaceSize::Csize_t,
-                                               reserveSpace::CuPtr{Cvoid})::cudnnStatus_t
+    @gcsafe_ccall libcudnn.cudnnRNNBackwardWeights_v8(handle::cudnnHandle_t,
+                                                      rnnDesc::cudnnRNNDescriptor_t,
+                                                      addGrad::cudnnWgradMode_t,
+                                                      devSeqLengths::CuPtr{Int32},
+                                                      xDesc::cudnnRNNDataDescriptor_t,
+                                                      x::CuPtr{Cvoid},
+                                                      hDesc::cudnnTensorDescriptor_t,
+                                                      hx::CuPtr{Cvoid},
+                                                      yDesc::cudnnRNNDataDescriptor_t,
+                                                      y::CuPtr{Cvoid},
+                                                      weightSpaceSize::Csize_t,
+                                                      dweightSpace::CuPtr{Cvoid},
+                                                      workSpaceSize::Csize_t,
+                                                      workSpace::CuPtr{Cvoid},
+                                                      reserveSpaceSize::Csize_t,
+                                                      reserveSpace::CuPtr{Cvoid})::cudnnStatus_t
 end
 
 @checked function cudnnRNNForwardTrainingEx(handle, rnnDesc, xDesc, x, hxDesc, hx, cxDesc,
@@ -2464,34 +2546,34 @@ end
                                             queries, workSpace, workSpaceSizeInBytes,
                                             reserveSpace, reserveSpaceSizeInBytes)
     initialize_context()
-    @ccall libcudnn.cudnnRNNForwardTrainingEx(handle::cudnnHandle_t,
-                                              rnnDesc::cudnnRNNDescriptor_t,
-                                              xDesc::cudnnRNNDataDescriptor_t,
-                                              x::CuPtr{Cvoid},
-                                              hxDesc::cudnnTensorDescriptor_t,
-                                              hx::CuPtr{Cvoid},
-                                              cxDesc::cudnnTensorDescriptor_t,
-                                              cx::CuPtr{Cvoid},
-                                              wDesc::cudnnFilterDescriptor_t,
-                                              w::CuPtr{Cvoid},
-                                              yDesc::cudnnRNNDataDescriptor_t,
-                                              y::CuPtr{Cvoid},
-                                              hyDesc::cudnnTensorDescriptor_t,
-                                              hy::CuPtr{Cvoid},
-                                              cyDesc::cudnnTensorDescriptor_t,
-                                              cy::CuPtr{Cvoid},
-                                              kDesc::cudnnRNNDataDescriptor_t,
-                                              keys::CuPtr{Cvoid},
-                                              cDesc::cudnnRNNDataDescriptor_t,
-                                              cAttn::CuPtr{Cvoid},
-                                              iDesc::cudnnRNNDataDescriptor_t,
-                                              iAttn::CuPtr{Cvoid},
-                                              qDesc::cudnnRNNDataDescriptor_t,
-                                              queries::CuPtr{Cvoid},
-                                              workSpace::CuPtr{Cvoid},
-                                              workSpaceSizeInBytes::Csize_t,
-                                              reserveSpace::CuPtr{Cvoid},
-                                              reserveSpaceSizeInBytes::Csize_t)::cudnnStatus_t
+    @gcsafe_ccall libcudnn.cudnnRNNForwardTrainingEx(handle::cudnnHandle_t,
+                                                     rnnDesc::cudnnRNNDescriptor_t,
+                                                     xDesc::cudnnRNNDataDescriptor_t,
+                                                     x::CuPtr{Cvoid},
+                                                     hxDesc::cudnnTensorDescriptor_t,
+                                                     hx::CuPtr{Cvoid},
+                                                     cxDesc::cudnnTensorDescriptor_t,
+                                                     cx::CuPtr{Cvoid},
+                                                     wDesc::cudnnFilterDescriptor_t,
+                                                     w::CuPtr{Cvoid},
+                                                     yDesc::cudnnRNNDataDescriptor_t,
+                                                     y::CuPtr{Cvoid},
+                                                     hyDesc::cudnnTensorDescriptor_t,
+                                                     hy::CuPtr{Cvoid},
+                                                     cyDesc::cudnnTensorDescriptor_t,
+                                                     cy::CuPtr{Cvoid},
+                                                     kDesc::cudnnRNNDataDescriptor_t,
+                                                     keys::CuPtr{Cvoid},
+                                                     cDesc::cudnnRNNDataDescriptor_t,
+                                                     cAttn::CuPtr{Cvoid},
+                                                     iDesc::cudnnRNNDataDescriptor_t,
+                                                     iAttn::CuPtr{Cvoid},
+                                                     qDesc::cudnnRNNDataDescriptor_t,
+                                                     queries::CuPtr{Cvoid},
+                                                     workSpace::CuPtr{Cvoid},
+                                                     workSpaceSizeInBytes::Csize_t,
+                                                     reserveSpace::CuPtr{Cvoid},
+                                                     reserveSpaceSizeInBytes::Csize_t)::cudnnStatus_t
 end
 
 @checked function cudnnRNNBackwardDataEx(handle, rnnDesc, yDesc, y, dyDesc, dy, dcDesc,
@@ -2501,58 +2583,63 @@ end
                                          workSpaceSizeInBytes, reserveSpace,
                                          reserveSpaceSizeInBytes)
     initialize_context()
-    @ccall libcudnn.cudnnRNNBackwardDataEx(handle::cudnnHandle_t,
-                                           rnnDesc::cudnnRNNDescriptor_t,
-                                           yDesc::cudnnRNNDataDescriptor_t, y::CuPtr{Cvoid},
-                                           dyDesc::cudnnRNNDataDescriptor_t,
-                                           dy::CuPtr{Cvoid},
-                                           dcDesc::cudnnRNNDataDescriptor_t,
-                                           dcAttn::CuPtr{Cvoid},
-                                           dhyDesc::cudnnTensorDescriptor_t,
-                                           dhy::CuPtr{Cvoid},
-                                           dcyDesc::cudnnTensorDescriptor_t,
-                                           dcy::CuPtr{Cvoid},
-                                           wDesc::cudnnFilterDescriptor_t, w::CuPtr{Cvoid},
-                                           hxDesc::cudnnTensorDescriptor_t,
-                                           hx::CuPtr{Cvoid},
-                                           cxDesc::cudnnTensorDescriptor_t,
-                                           cx::CuPtr{Cvoid},
-                                           dxDesc::cudnnRNNDataDescriptor_t,
-                                           dx::CuPtr{Cvoid},
-                                           dhxDesc::cudnnTensorDescriptor_t,
-                                           dhx::Ptr{Cvoid},
-                                           dcxDesc::cudnnTensorDescriptor_t,
-                                           dcx::CuPtr{Cvoid},
-                                           dkDesc::cudnnRNNDataDescriptor_t,
-                                           dkeys::Ptr{Cvoid}, workSpace::CuPtr{Cvoid},
-                                           workSpaceSizeInBytes::Csize_t,
-                                           reserveSpace::CuPtr{Cvoid},
-                                           reserveSpaceSizeInBytes::Csize_t)::cudnnStatus_t
+    @gcsafe_ccall libcudnn.cudnnRNNBackwardDataEx(handle::cudnnHandle_t,
+                                                  rnnDesc::cudnnRNNDescriptor_t,
+                                                  yDesc::cudnnRNNDataDescriptor_t,
+                                                  y::CuPtr{Cvoid},
+                                                  dyDesc::cudnnRNNDataDescriptor_t,
+                                                  dy::CuPtr{Cvoid},
+                                                  dcDesc::cudnnRNNDataDescriptor_t,
+                                                  dcAttn::CuPtr{Cvoid},
+                                                  dhyDesc::cudnnTensorDescriptor_t,
+                                                  dhy::CuPtr{Cvoid},
+                                                  dcyDesc::cudnnTensorDescriptor_t,
+                                                  dcy::CuPtr{Cvoid},
+                                                  wDesc::cudnnFilterDescriptor_t,
+                                                  w::CuPtr{Cvoid},
+                                                  hxDesc::cudnnTensorDescriptor_t,
+                                                  hx::CuPtr{Cvoid},
+                                                  cxDesc::cudnnTensorDescriptor_t,
+                                                  cx::CuPtr{Cvoid},
+                                                  dxDesc::cudnnRNNDataDescriptor_t,
+                                                  dx::CuPtr{Cvoid},
+                                                  dhxDesc::cudnnTensorDescriptor_t,
+                                                  dhx::Ptr{Cvoid},
+                                                  dcxDesc::cudnnTensorDescriptor_t,
+                                                  dcx::CuPtr{Cvoid},
+                                                  dkDesc::cudnnRNNDataDescriptor_t,
+                                                  dkeys::Ptr{Cvoid},
+                                                  workSpace::CuPtr{Cvoid},
+                                                  workSpaceSizeInBytes::Csize_t,
+                                                  reserveSpace::CuPtr{Cvoid},
+                                                  reserveSpaceSizeInBytes::Csize_t)::cudnnStatus_t
 end
 
 @checked function cudnnRNNBackwardWeightsEx(handle, rnnDesc, xDesc, x, hxDesc, hx, yDesc, y,
                                             workSpace, workSpaceSizeInBytes, dwDesc, dw,
                                             reserveSpace, reserveSpaceSizeInBytes)
     initialize_context()
-    @ccall libcudnn.cudnnRNNBackwardWeightsEx(handle::cudnnHandle_t,
-                                              rnnDesc::cudnnRNNDescriptor_t,
-                                              xDesc::cudnnRNNDataDescriptor_t,
-                                              x::CuPtr{Cvoid},
-                                              hxDesc::cudnnTensorDescriptor_t,
-                                              hx::CuPtr{Cvoid},
-                                              yDesc::cudnnRNNDataDescriptor_t,
-                                              y::CuPtr{Cvoid}, workSpace::CuPtr{Cvoid},
-                                              workSpaceSizeInBytes::Csize_t,
-                                              dwDesc::cudnnFilterDescriptor_t,
-                                              dw::CuPtr{Cvoid}, reserveSpace::CuPtr{Cvoid},
-                                              reserveSpaceSizeInBytes::Csize_t)::cudnnStatus_t
+    @gcsafe_ccall libcudnn.cudnnRNNBackwardWeightsEx(handle::cudnnHandle_t,
+                                                     rnnDesc::cudnnRNNDescriptor_t,
+                                                     xDesc::cudnnRNNDataDescriptor_t,
+                                                     x::CuPtr{Cvoid},
+                                                     hxDesc::cudnnTensorDescriptor_t,
+                                                     hx::CuPtr{Cvoid},
+                                                     yDesc::cudnnRNNDataDescriptor_t,
+                                                     y::CuPtr{Cvoid},
+                                                     workSpace::CuPtr{Cvoid},
+                                                     workSpaceSizeInBytes::Csize_t,
+                                                     dwDesc::cudnnFilterDescriptor_t,
+                                                     dw::CuPtr{Cvoid},
+                                                     reserveSpace::CuPtr{Cvoid},
+                                                     reserveSpaceSizeInBytes::Csize_t)::cudnnStatus_t
 end
 
 @checked function cudnnGetRNNForwardTrainingAlgorithmMaxCount(handle, rnnDesc, count)
     initialize_context()
-    @ccall libcudnn.cudnnGetRNNForwardTrainingAlgorithmMaxCount(handle::cudnnHandle_t,
-                                                                rnnDesc::cudnnRNNDescriptor_t,
-                                                                count::Ptr{Cint})::cudnnStatus_t
+    @gcsafe_ccall libcudnn.cudnnGetRNNForwardTrainingAlgorithmMaxCount(handle::cudnnHandle_t,
+                                                                       rnnDesc::cudnnRNNDescriptor_t,
+                                                                       count::Ptr{Cint})::cudnnStatus_t
 end
 
 @checked function cudnnFindRNNForwardTrainingAlgorithmEx(handle, rnnDesc, seqLength, xDesc,
@@ -2565,38 +2652,38 @@ end
                                                          reserveSpace,
                                                          reserveSpaceSizeInBytes)
     initialize_context()
-    @ccall libcudnn.cudnnFindRNNForwardTrainingAlgorithmEx(handle::cudnnHandle_t,
-                                                           rnnDesc::cudnnRNNDescriptor_t,
-                                                           seqLength::Cint,
-                                                           xDesc::Ptr{cudnnTensorDescriptor_t},
-                                                           x::CuPtr{Cvoid},
-                                                           hxDesc::cudnnTensorDescriptor_t,
-                                                           hx::CuPtr{Cvoid},
-                                                           cxDesc::cudnnTensorDescriptor_t,
-                                                           cx::CuPtr{Cvoid},
-                                                           wDesc::cudnnFilterDescriptor_t,
-                                                           w::CuPtr{Cvoid},
-                                                           yDesc::Ptr{cudnnTensorDescriptor_t},
-                                                           y::CuPtr{Cvoid},
-                                                           hyDesc::cudnnTensorDescriptor_t,
-                                                           hy::CuPtr{Cvoid},
-                                                           cyDesc::cudnnTensorDescriptor_t,
-                                                           cy::CuPtr{Cvoid},
-                                                           findIntensity::Cfloat,
-                                                           requestedAlgoCount::Cint,
-                                                           returnedAlgoCount::Ptr{Cint},
-                                                           perfResults::Ptr{cudnnAlgorithmPerformance_t},
-                                                           workspace::CuPtr{Cvoid},
-                                                           workSpaceSizeInBytes::Csize_t,
-                                                           reserveSpace::CuPtr{Cvoid},
-                                                           reserveSpaceSizeInBytes::Csize_t)::cudnnStatus_t
+    @gcsafe_ccall libcudnn.cudnnFindRNNForwardTrainingAlgorithmEx(handle::cudnnHandle_t,
+                                                                  rnnDesc::cudnnRNNDescriptor_t,
+                                                                  seqLength::Cint,
+                                                                  xDesc::Ptr{cudnnTensorDescriptor_t},
+                                                                  x::CuPtr{Cvoid},
+                                                                  hxDesc::cudnnTensorDescriptor_t,
+                                                                  hx::CuPtr{Cvoid},
+                                                                  cxDesc::cudnnTensorDescriptor_t,
+                                                                  cx::CuPtr{Cvoid},
+                                                                  wDesc::cudnnFilterDescriptor_t,
+                                                                  w::CuPtr{Cvoid},
+                                                                  yDesc::Ptr{cudnnTensorDescriptor_t},
+                                                                  y::CuPtr{Cvoid},
+                                                                  hyDesc::cudnnTensorDescriptor_t,
+                                                                  hy::CuPtr{Cvoid},
+                                                                  cyDesc::cudnnTensorDescriptor_t,
+                                                                  cy::CuPtr{Cvoid},
+                                                                  findIntensity::Cfloat,
+                                                                  requestedAlgoCount::Cint,
+                                                                  returnedAlgoCount::Ptr{Cint},
+                                                                  perfResults::Ptr{cudnnAlgorithmPerformance_t},
+                                                                  workspace::CuPtr{Cvoid},
+                                                                  workSpaceSizeInBytes::Csize_t,
+                                                                  reserveSpace::CuPtr{Cvoid},
+                                                                  reserveSpaceSizeInBytes::Csize_t)::cudnnStatus_t
 end
 
 @checked function cudnnGetRNNBackwardDataAlgorithmMaxCount(handle, rnnDesc, count)
     initialize_context()
-    @ccall libcudnn.cudnnGetRNNBackwardDataAlgorithmMaxCount(handle::cudnnHandle_t,
-                                                             rnnDesc::cudnnRNNDescriptor_t,
-                                                             count::Ptr{Cint})::cudnnStatus_t
+    @gcsafe_ccall libcudnn.cudnnGetRNNBackwardDataAlgorithmMaxCount(handle::cudnnHandle_t,
+                                                                    rnnDesc::cudnnRNNDescriptor_t,
+                                                                    count::Ptr{Cint})::cudnnStatus_t
 end
 
 @checked function cudnnFindRNNBackwardDataAlgorithmEx(handle, rnnDesc, seqLength, yDesc, y,
@@ -2609,44 +2696,44 @@ end
                                                       workSpaceSizeInBytes, reserveSpace,
                                                       reserveSpaceSizeInBytes)
     initialize_context()
-    @ccall libcudnn.cudnnFindRNNBackwardDataAlgorithmEx(handle::cudnnHandle_t,
-                                                        rnnDesc::cudnnRNNDescriptor_t,
-                                                        seqLength::Cint,
-                                                        yDesc::Ptr{cudnnTensorDescriptor_t},
-                                                        y::CuPtr{Cvoid},
-                                                        dyDesc::Ptr{cudnnTensorDescriptor_t},
-                                                        dy::CuPtr{Cvoid},
-                                                        dhyDesc::cudnnTensorDescriptor_t,
-                                                        dhy::CuPtr{Cvoid},
-                                                        dcyDesc::cudnnTensorDescriptor_t,
-                                                        dcy::CuPtr{Cvoid},
-                                                        wDesc::cudnnFilterDescriptor_t,
-                                                        w::CuPtr{Cvoid},
-                                                        hxDesc::cudnnTensorDescriptor_t,
-                                                        hx::CuPtr{Cvoid},
-                                                        cxDesc::cudnnTensorDescriptor_t,
-                                                        cx::CuPtr{Cvoid},
-                                                        dxDesc::Ptr{cudnnTensorDescriptor_t},
-                                                        dx::CuPtr{Cvoid},
-                                                        dhxDesc::cudnnTensorDescriptor_t,
-                                                        dhx::CuPtr{Cvoid},
-                                                        dcxDesc::cudnnTensorDescriptor_t,
-                                                        dcx::CuPtr{Cvoid},
-                                                        findIntensity::Cfloat,
-                                                        requestedAlgoCount::Cint,
-                                                        returnedAlgoCount::Ptr{Cint},
-                                                        perfResults::Ptr{cudnnAlgorithmPerformance_t},
-                                                        workspace::CuPtr{Cvoid},
-                                                        workSpaceSizeInBytes::Csize_t,
-                                                        reserveSpace::CuPtr{Cvoid},
-                                                        reserveSpaceSizeInBytes::Csize_t)::cudnnStatus_t
+    @gcsafe_ccall libcudnn.cudnnFindRNNBackwardDataAlgorithmEx(handle::cudnnHandle_t,
+                                                               rnnDesc::cudnnRNNDescriptor_t,
+                                                               seqLength::Cint,
+                                                               yDesc::Ptr{cudnnTensorDescriptor_t},
+                                                               y::CuPtr{Cvoid},
+                                                               dyDesc::Ptr{cudnnTensorDescriptor_t},
+                                                               dy::CuPtr{Cvoid},
+                                                               dhyDesc::cudnnTensorDescriptor_t,
+                                                               dhy::CuPtr{Cvoid},
+                                                               dcyDesc::cudnnTensorDescriptor_t,
+                                                               dcy::CuPtr{Cvoid},
+                                                               wDesc::cudnnFilterDescriptor_t,
+                                                               w::CuPtr{Cvoid},
+                                                               hxDesc::cudnnTensorDescriptor_t,
+                                                               hx::CuPtr{Cvoid},
+                                                               cxDesc::cudnnTensorDescriptor_t,
+                                                               cx::CuPtr{Cvoid},
+                                                               dxDesc::Ptr{cudnnTensorDescriptor_t},
+                                                               dx::CuPtr{Cvoid},
+                                                               dhxDesc::cudnnTensorDescriptor_t,
+                                                               dhx::CuPtr{Cvoid},
+                                                               dcxDesc::cudnnTensorDescriptor_t,
+                                                               dcx::CuPtr{Cvoid},
+                                                               findIntensity::Cfloat,
+                                                               requestedAlgoCount::Cint,
+                                                               returnedAlgoCount::Ptr{Cint},
+                                                               perfResults::Ptr{cudnnAlgorithmPerformance_t},
+                                                               workspace::CuPtr{Cvoid},
+                                                               workSpaceSizeInBytes::Csize_t,
+                                                               reserveSpace::CuPtr{Cvoid},
+                                                               reserveSpaceSizeInBytes::Csize_t)::cudnnStatus_t
 end
 
 @checked function cudnnGetRNNBackwardWeightsAlgorithmMaxCount(handle, rnnDesc, count)
     initialize_context()
-    @ccall libcudnn.cudnnGetRNNBackwardWeightsAlgorithmMaxCount(handle::cudnnHandle_t,
-                                                                rnnDesc::cudnnRNNDescriptor_t,
-                                                                count::Ptr{Cint})::cudnnStatus_t
+    @gcsafe_ccall libcudnn.cudnnGetRNNBackwardWeightsAlgorithmMaxCount(handle::cudnnHandle_t,
+                                                                       rnnDesc::cudnnRNNDescriptor_t,
+                                                                       count::Ptr{Cint})::cudnnStatus_t
 end
 
 @checked function cudnnFindRNNBackwardWeightsAlgorithmEx(handle, rnnDesc, seqLength, xDesc,
@@ -2657,25 +2744,25 @@ end
                                                          dwDesc, dw, reserveSpace,
                                                          reserveSpaceSizeInBytes)
     initialize_context()
-    @ccall libcudnn.cudnnFindRNNBackwardWeightsAlgorithmEx(handle::cudnnHandle_t,
-                                                           rnnDesc::cudnnRNNDescriptor_t,
-                                                           seqLength::Cint,
-                                                           xDesc::Ptr{cudnnTensorDescriptor_t},
-                                                           x::CuPtr{Cvoid},
-                                                           hxDesc::cudnnTensorDescriptor_t,
-                                                           hx::CuPtr{Cvoid},
-                                                           yDesc::Ptr{cudnnTensorDescriptor_t},
-                                                           y::CuPtr{Cvoid},
-                                                           findIntensity::Cfloat,
-                                                           requestedAlgoCount::Cint,
-                                                           returnedAlgoCount::Ptr{Cint},
-                                                           perfResults::Ptr{cudnnAlgorithmPerformance_t},
-                                                           workspace::CuPtr{Cvoid},
-                                                           workSpaceSizeInBytes::Csize_t,
-                                                           dwDesc::cudnnFilterDescriptor_t,
-                                                           dw::CuPtr{Cvoid},
-                                                           reserveSpace::CuPtr{Cvoid},
-                                                           reserveSpaceSizeInBytes::Csize_t)::cudnnStatus_t
+    @gcsafe_ccall libcudnn.cudnnFindRNNBackwardWeightsAlgorithmEx(handle::cudnnHandle_t,
+                                                                  rnnDesc::cudnnRNNDescriptor_t,
+                                                                  seqLength::Cint,
+                                                                  xDesc::Ptr{cudnnTensorDescriptor_t},
+                                                                  x::CuPtr{Cvoid},
+                                                                  hxDesc::cudnnTensorDescriptor_t,
+                                                                  hx::CuPtr{Cvoid},
+                                                                  yDesc::Ptr{cudnnTensorDescriptor_t},
+                                                                  y::CuPtr{Cvoid},
+                                                                  findIntensity::Cfloat,
+                                                                  requestedAlgoCount::Cint,
+                                                                  returnedAlgoCount::Ptr{Cint},
+                                                                  perfResults::Ptr{cudnnAlgorithmPerformance_t},
+                                                                  workspace::CuPtr{Cvoid},
+                                                                  workSpaceSizeInBytes::Csize_t,
+                                                                  dwDesc::cudnnFilterDescriptor_t,
+                                                                  dw::CuPtr{Cvoid},
+                                                                  reserveSpace::CuPtr{Cvoid},
+                                                                  reserveSpaceSizeInBytes::Csize_t)::cudnnStatus_t
 end
 
 @checked function cudnnMultiHeadAttnBackwardData(handle, attnDesc, loWinIdx, hiWinIdx,
@@ -2686,27 +2773,29 @@ end
                                                  workSpaceSizeInBytes, workSpace,
                                                  reserveSpaceSizeInBytes, reserveSpace)
     initialize_context()
-    @ccall libcudnn.cudnnMultiHeadAttnBackwardData(handle::cudnnHandle_t,
-                                                   attnDesc::cudnnAttnDescriptor_t,
-                                                   loWinIdx::Ptr{Cint}, hiWinIdx::Ptr{Cint},
-                                                   devSeqLengthsDQDO::CuPtr{Cint},
-                                                   devSeqLengthsDKDV::CuPtr{Cint},
-                                                   doDesc::cudnnSeqDataDescriptor_t,
-                                                   dout::CuPtr{Cvoid},
-                                                   dqDesc::cudnnSeqDataDescriptor_t,
-                                                   dqueries::CuPtr{Cvoid},
-                                                   queries::CuPtr{Cvoid},
-                                                   dkDesc::cudnnSeqDataDescriptor_t,
-                                                   dkeys::CuPtr{Cvoid}, keys::CuPtr{Cvoid},
-                                                   dvDesc::cudnnSeqDataDescriptor_t,
-                                                   dvalues::CuPtr{Cvoid},
-                                                   values::CuPtr{Cvoid},
-                                                   weightSizeInBytes::Csize_t,
-                                                   weights::CuPtr{Cvoid},
-                                                   workSpaceSizeInBytes::Csize_t,
-                                                   workSpace::CuPtr{Cvoid},
-                                                   reserveSpaceSizeInBytes::Csize_t,
-                                                   reserveSpace::CuPtr{Cvoid})::cudnnStatus_t
+    @gcsafe_ccall libcudnn.cudnnMultiHeadAttnBackwardData(handle::cudnnHandle_t,
+                                                          attnDesc::cudnnAttnDescriptor_t,
+                                                          loWinIdx::Ptr{Cint},
+                                                          hiWinIdx::Ptr{Cint},
+                                                          devSeqLengthsDQDO::CuPtr{Cint},
+                                                          devSeqLengthsDKDV::CuPtr{Cint},
+                                                          doDesc::cudnnSeqDataDescriptor_t,
+                                                          dout::CuPtr{Cvoid},
+                                                          dqDesc::cudnnSeqDataDescriptor_t,
+                                                          dqueries::CuPtr{Cvoid},
+                                                          queries::CuPtr{Cvoid},
+                                                          dkDesc::cudnnSeqDataDescriptor_t,
+                                                          dkeys::CuPtr{Cvoid},
+                                                          keys::CuPtr{Cvoid},
+                                                          dvDesc::cudnnSeqDataDescriptor_t,
+                                                          dvalues::CuPtr{Cvoid},
+                                                          values::CuPtr{Cvoid},
+                                                          weightSizeInBytes::Csize_t,
+                                                          weights::CuPtr{Cvoid},
+                                                          workSpaceSizeInBytes::Csize_t,
+                                                          workSpace::CuPtr{Cvoid},
+                                                          reserveSpaceSizeInBytes::Csize_t,
+                                                          reserveSpace::CuPtr{Cvoid})::cudnnStatus_t
 end
 
 @checked function cudnnMultiHeadAttnBackwardWeights(handle, attnDesc, addGrad, qDesc,
@@ -2716,24 +2805,24 @@ end
                                                     workSpace, reserveSpaceSizeInBytes,
                                                     reserveSpace)
     initialize_context()
-    @ccall libcudnn.cudnnMultiHeadAttnBackwardWeights(handle::cudnnHandle_t,
-                                                      attnDesc::cudnnAttnDescriptor_t,
-                                                      addGrad::cudnnWgradMode_t,
-                                                      qDesc::cudnnSeqDataDescriptor_t,
-                                                      queries::CuPtr{Cvoid},
-                                                      kDesc::cudnnSeqDataDescriptor_t,
-                                                      keys::CuPtr{Cvoid},
-                                                      vDesc::cudnnSeqDataDescriptor_t,
-                                                      values::CuPtr{Cvoid},
-                                                      doDesc::cudnnSeqDataDescriptor_t,
-                                                      dout::CuPtr{Cvoid},
-                                                      weightSizeInBytes::Csize_t,
-                                                      weights::CuPtr{Cvoid},
-                                                      dweights::CuPtr{Cvoid},
-                                                      workSpaceSizeInBytes::Csize_t,
-                                                      workSpace::CuPtr{Cvoid},
-                                                      reserveSpaceSizeInBytes::Csize_t,
-                                                      reserveSpace::CuPtr{Cvoid})::cudnnStatus_t
+    @gcsafe_ccall libcudnn.cudnnMultiHeadAttnBackwardWeights(handle::cudnnHandle_t,
+                                                             attnDesc::cudnnAttnDescriptor_t,
+                                                             addGrad::cudnnWgradMode_t,
+                                                             qDesc::cudnnSeqDataDescriptor_t,
+                                                             queries::CuPtr{Cvoid},
+                                                             kDesc::cudnnSeqDataDescriptor_t,
+                                                             keys::CuPtr{Cvoid},
+                                                             vDesc::cudnnSeqDataDescriptor_t,
+                                                             values::CuPtr{Cvoid},
+                                                             doDesc::cudnnSeqDataDescriptor_t,
+                                                             dout::CuPtr{Cvoid},
+                                                             weightSizeInBytes::Csize_t,
+                                                             weights::CuPtr{Cvoid},
+                                                             dweights::CuPtr{Cvoid},
+                                                             workSpaceSizeInBytes::Csize_t,
+                                                             workSpace::CuPtr{Cvoid},
+                                                             reserveSpaceSizeInBytes::Csize_t,
+                                                             reserveSpace::CuPtr{Cvoid})::cudnnStatus_t
 end
 
 @cenum cudnnLossNormalizationMode_t::UInt32 begin
@@ -2743,119 +2832,123 @@ end
 
 @checked function cudnnCreateCTCLossDescriptor(ctcLossDesc)
     initialize_context()
-    @ccall libcudnn.cudnnCreateCTCLossDescriptor(ctcLossDesc::Ptr{cudnnCTCLossDescriptor_t})::cudnnStatus_t
+    @gcsafe_ccall libcudnn.cudnnCreateCTCLossDescriptor(ctcLossDesc::Ptr{cudnnCTCLossDescriptor_t})::cudnnStatus_t
 end
 
 @checked function cudnnSetCTCLossDescriptor(ctcLossDesc, compType)
     initialize_context()
-    @ccall libcudnn.cudnnSetCTCLossDescriptor(ctcLossDesc::cudnnCTCLossDescriptor_t,
-                                              compType::cudnnDataType_t)::cudnnStatus_t
+    @gcsafe_ccall libcudnn.cudnnSetCTCLossDescriptor(ctcLossDesc::cudnnCTCLossDescriptor_t,
+                                                     compType::cudnnDataType_t)::cudnnStatus_t
 end
 
 @checked function cudnnSetCTCLossDescriptorEx(ctcLossDesc, compType, normMode, gradMode)
     initialize_context()
-    @ccall libcudnn.cudnnSetCTCLossDescriptorEx(ctcLossDesc::cudnnCTCLossDescriptor_t,
-                                                compType::cudnnDataType_t,
-                                                normMode::cudnnLossNormalizationMode_t,
-                                                gradMode::cudnnNanPropagation_t)::cudnnStatus_t
+    @gcsafe_ccall libcudnn.cudnnSetCTCLossDescriptorEx(ctcLossDesc::cudnnCTCLossDescriptor_t,
+                                                       compType::cudnnDataType_t,
+                                                       normMode::cudnnLossNormalizationMode_t,
+                                                       gradMode::cudnnNanPropagation_t)::cudnnStatus_t
 end
 
 @checked function cudnnSetCTCLossDescriptor_v8(ctcLossDesc, compType, normMode, gradMode,
                                                maxLabelLength)
     initialize_context()
-    @ccall libcudnn.cudnnSetCTCLossDescriptor_v8(ctcLossDesc::cudnnCTCLossDescriptor_t,
-                                                 compType::cudnnDataType_t,
-                                                 normMode::cudnnLossNormalizationMode_t,
-                                                 gradMode::cudnnNanPropagation_t,
-                                                 maxLabelLength::Cint)::cudnnStatus_t
+    @gcsafe_ccall libcudnn.cudnnSetCTCLossDescriptor_v8(ctcLossDesc::cudnnCTCLossDescriptor_t,
+                                                        compType::cudnnDataType_t,
+                                                        normMode::cudnnLossNormalizationMode_t,
+                                                        gradMode::cudnnNanPropagation_t,
+                                                        maxLabelLength::Cint)::cudnnStatus_t
 end
 
 @checked function cudnnGetCTCLossDescriptor(ctcLossDesc, compType)
     initialize_context()
-    @ccall libcudnn.cudnnGetCTCLossDescriptor(ctcLossDesc::cudnnCTCLossDescriptor_t,
-                                              compType::Ptr{cudnnDataType_t})::cudnnStatus_t
+    @gcsafe_ccall libcudnn.cudnnGetCTCLossDescriptor(ctcLossDesc::cudnnCTCLossDescriptor_t,
+                                                     compType::Ptr{cudnnDataType_t})::cudnnStatus_t
 end
 
 @checked function cudnnGetCTCLossDescriptorEx(ctcLossDesc, compType, normMode, gradMode)
     initialize_context()
-    @ccall libcudnn.cudnnGetCTCLossDescriptorEx(ctcLossDesc::cudnnCTCLossDescriptor_t,
-                                                compType::Ptr{cudnnDataType_t},
-                                                normMode::Ptr{cudnnLossNormalizationMode_t},
-                                                gradMode::Ptr{cudnnNanPropagation_t})::cudnnStatus_t
+    @gcsafe_ccall libcudnn.cudnnGetCTCLossDescriptorEx(ctcLossDesc::cudnnCTCLossDescriptor_t,
+                                                       compType::Ptr{cudnnDataType_t},
+                                                       normMode::Ptr{cudnnLossNormalizationMode_t},
+                                                       gradMode::Ptr{cudnnNanPropagation_t})::cudnnStatus_t
 end
 
 @checked function cudnnGetCTCLossDescriptor_v8(ctcLossDesc, compType, normMode, gradMode,
                                                maxLabelLength)
     initialize_context()
-    @ccall libcudnn.cudnnGetCTCLossDescriptor_v8(ctcLossDesc::cudnnCTCLossDescriptor_t,
-                                                 compType::Ref{cudnnDataType_t},
-                                                 normMode::Ref{cudnnLossNormalizationMode_t},
-                                                 gradMode::Ref{cudnnNanPropagation_t},
-                                                 maxLabelLength::Ref{Cint})::cudnnStatus_t
+    @gcsafe_ccall libcudnn.cudnnGetCTCLossDescriptor_v8(ctcLossDesc::cudnnCTCLossDescriptor_t,
+                                                        compType::Ref{cudnnDataType_t},
+                                                        normMode::Ref{cudnnLossNormalizationMode_t},
+                                                        gradMode::Ref{cudnnNanPropagation_t},
+                                                        maxLabelLength::Ref{Cint})::cudnnStatus_t
 end
 
 @checked function cudnnDestroyCTCLossDescriptor(ctcLossDesc)
     initialize_context()
-    @ccall libcudnn.cudnnDestroyCTCLossDescriptor(ctcLossDesc::cudnnCTCLossDescriptor_t)::cudnnStatus_t
+    @gcsafe_ccall libcudnn.cudnnDestroyCTCLossDescriptor(ctcLossDesc::cudnnCTCLossDescriptor_t)::cudnnStatus_t
 end
 
 @checked function cudnnCTCLoss(handle, probsDesc, probs, hostLabels, hostLabelLengths,
                                hostInputLengths, costs, gradientsDesc, gradients, algo,
                                ctcLossDesc, workspace, workSpaceSizeInBytes)
     initialize_context()
-    @ccall libcudnn.cudnnCTCLoss(handle::cudnnHandle_t, probsDesc::cudnnTensorDescriptor_t,
-                                 probs::CuPtr{Cvoid}, hostLabels::Ptr{Cint},
-                                 hostLabelLengths::Ptr{Cint}, hostInputLengths::Ptr{Cint},
-                                 costs::CuPtr{Cvoid},
-                                 gradientsDesc::cudnnTensorDescriptor_t,
-                                 gradients::CuPtr{Cvoid}, algo::cudnnCTCLossAlgo_t,
-                                 ctcLossDesc::cudnnCTCLossDescriptor_t,
-                                 workspace::CuPtr{Cvoid},
-                                 workSpaceSizeInBytes::Csize_t)::cudnnStatus_t
+    @gcsafe_ccall libcudnn.cudnnCTCLoss(handle::cudnnHandle_t,
+                                        probsDesc::cudnnTensorDescriptor_t,
+                                        probs::CuPtr{Cvoid}, hostLabels::Ptr{Cint},
+                                        hostLabelLengths::Ptr{Cint},
+                                        hostInputLengths::Ptr{Cint}, costs::CuPtr{Cvoid},
+                                        gradientsDesc::cudnnTensorDescriptor_t,
+                                        gradients::CuPtr{Cvoid}, algo::cudnnCTCLossAlgo_t,
+                                        ctcLossDesc::cudnnCTCLossDescriptor_t,
+                                        workspace::CuPtr{Cvoid},
+                                        workSpaceSizeInBytes::Csize_t)::cudnnStatus_t
 end
 
 @checked function cudnnCTCLoss_v8(handle, algo, ctcLossDesc, probsDesc, probs, labels,
                                   labelLengths, inputLengths, costs, gradientsDesc,
                                   gradients, workSpaceSizeInBytes, workspace)
     initialize_context()
-    @ccall libcudnn.cudnnCTCLoss_v8(handle::cudnnHandle_t, algo::cudnnCTCLossAlgo_t,
-                                    ctcLossDesc::cudnnCTCLossDescriptor_t,
-                                    probsDesc::cudnnTensorDescriptor_t, probs::Ptr{Cvoid},
-                                    labels::CuPtr{Cint}, labelLengths::CuPtr{Cint},
-                                    inputLengths::CuPtr{Cint}, costs::Ptr{Cvoid},
-                                    gradientsDesc::cudnnTensorDescriptor_t,
-                                    gradients::Ptr{Cvoid}, workSpaceSizeInBytes::Csize_t,
-                                    workspace::CuPtr{Cvoid})::cudnnStatus_t
+    @gcsafe_ccall libcudnn.cudnnCTCLoss_v8(handle::cudnnHandle_t, algo::cudnnCTCLossAlgo_t,
+                                           ctcLossDesc::cudnnCTCLossDescriptor_t,
+                                           probsDesc::cudnnTensorDescriptor_t,
+                                           probs::Ptr{Cvoid}, labels::CuPtr{Cint},
+                                           labelLengths::CuPtr{Cint},
+                                           inputLengths::CuPtr{Cint}, costs::Ptr{Cvoid},
+                                           gradientsDesc::cudnnTensorDescriptor_t,
+                                           gradients::Ptr{Cvoid},
+                                           workSpaceSizeInBytes::Csize_t,
+                                           workspace::CuPtr{Cvoid})::cudnnStatus_t
 end
 
 @checked function cudnnGetCTCLossWorkspaceSize(handle, probsDesc, gradientsDesc, labels,
                                                labelLengths, inputLengths, algo,
                                                ctcLossDesc, sizeInBytes)
     initialize_context()
-    @ccall libcudnn.cudnnGetCTCLossWorkspaceSize(handle::cudnnHandle_t,
-                                                 probsDesc::cudnnTensorDescriptor_t,
-                                                 gradientsDesc::cudnnTensorDescriptor_t,
-                                                 labels::Ptr{Cint}, labelLengths::Ptr{Cint},
-                                                 inputLengths::Ptr{Cint},
-                                                 algo::cudnnCTCLossAlgo_t,
-                                                 ctcLossDesc::cudnnCTCLossDescriptor_t,
-                                                 sizeInBytes::Ref{Csize_t})::cudnnStatus_t
+    @gcsafe_ccall libcudnn.cudnnGetCTCLossWorkspaceSize(handle::cudnnHandle_t,
+                                                        probsDesc::cudnnTensorDescriptor_t,
+                                                        gradientsDesc::cudnnTensorDescriptor_t,
+                                                        labels::Ptr{Cint},
+                                                        labelLengths::Ptr{Cint},
+                                                        inputLengths::Ptr{Cint},
+                                                        algo::cudnnCTCLossAlgo_t,
+                                                        ctcLossDesc::cudnnCTCLossDescriptor_t,
+                                                        sizeInBytes::Ref{Csize_t})::cudnnStatus_t
 end
 
 @checked function cudnnGetCTCLossWorkspaceSize_v8(handle, algo, ctcLossDesc, probsDesc,
                                                   gradientsDesc, sizeInBytes)
     initialize_context()
-    @ccall libcudnn.cudnnGetCTCLossWorkspaceSize_v8(handle::cudnnHandle_t,
-                                                    algo::cudnnCTCLossAlgo_t,
-                                                    ctcLossDesc::cudnnCTCLossDescriptor_t,
-                                                    probsDesc::cudnnTensorDescriptor_t,
-                                                    gradientsDesc::cudnnTensorDescriptor_t,
-                                                    sizeInBytes::Ptr{Csize_t})::cudnnStatus_t
+    @gcsafe_ccall libcudnn.cudnnGetCTCLossWorkspaceSize_v8(handle::cudnnHandle_t,
+                                                           algo::cudnnCTCLossAlgo_t,
+                                                           ctcLossDesc::cudnnCTCLossDescriptor_t,
+                                                           probsDesc::cudnnTensorDescriptor_t,
+                                                           gradientsDesc::cudnnTensorDescriptor_t,
+                                                           sizeInBytes::Ptr{Csize_t})::cudnnStatus_t
 end
 
 @checked function cudnnAdvTrainVersionCheck()
     initialize_context()
-    @ccall libcudnn.cudnnAdvTrainVersionCheck()::cudnnStatus_t
+    @gcsafe_ccall libcudnn.cudnnAdvTrainVersionCheck()::cudnnStatus_t
 end
 
 mutable struct cudnnConvolutionStruct end
@@ -2886,123 +2979,127 @@ const cudnnConvolutionFwdAlgoPerf_t = cudnnConvolutionFwdAlgoPerfStruct
 
 @checked function cudnnCreateConvolutionDescriptor(convDesc)
     initialize_context()
-    @ccall libcudnn.cudnnCreateConvolutionDescriptor(convDesc::Ptr{cudnnConvolutionDescriptor_t})::cudnnStatus_t
+    @gcsafe_ccall libcudnn.cudnnCreateConvolutionDescriptor(convDesc::Ptr{cudnnConvolutionDescriptor_t})::cudnnStatus_t
 end
 
 @checked function cudnnDestroyConvolutionDescriptor(convDesc)
     initialize_context()
-    @ccall libcudnn.cudnnDestroyConvolutionDescriptor(convDesc::cudnnConvolutionDescriptor_t)::cudnnStatus_t
+    @gcsafe_ccall libcudnn.cudnnDestroyConvolutionDescriptor(convDesc::cudnnConvolutionDescriptor_t)::cudnnStatus_t
 end
 
 @checked function cudnnSetConvolutionMathType(convDesc, mathType)
     initialize_context()
-    @ccall libcudnn.cudnnSetConvolutionMathType(convDesc::cudnnConvolutionDescriptor_t,
-                                                mathType::cudnnMathType_t)::cudnnStatus_t
+    @gcsafe_ccall libcudnn.cudnnSetConvolutionMathType(convDesc::cudnnConvolutionDescriptor_t,
+                                                       mathType::cudnnMathType_t)::cudnnStatus_t
 end
 
 @checked function cudnnGetConvolutionMathType(convDesc, mathType)
     initialize_context()
-    @ccall libcudnn.cudnnGetConvolutionMathType(convDesc::cudnnConvolutionDescriptor_t,
-                                                mathType::Ptr{cudnnMathType_t})::cudnnStatus_t
+    @gcsafe_ccall libcudnn.cudnnGetConvolutionMathType(convDesc::cudnnConvolutionDescriptor_t,
+                                                       mathType::Ptr{cudnnMathType_t})::cudnnStatus_t
 end
 
 @checked function cudnnSetConvolutionGroupCount(convDesc, groupCount)
     initialize_context()
-    @ccall libcudnn.cudnnSetConvolutionGroupCount(convDesc::cudnnConvolutionDescriptor_t,
-                                                  groupCount::Cint)::cudnnStatus_t
+    @gcsafe_ccall libcudnn.cudnnSetConvolutionGroupCount(convDesc::cudnnConvolutionDescriptor_t,
+                                                         groupCount::Cint)::cudnnStatus_t
 end
 
 @checked function cudnnGetConvolutionGroupCount(convDesc, groupCount)
     initialize_context()
-    @ccall libcudnn.cudnnGetConvolutionGroupCount(convDesc::cudnnConvolutionDescriptor_t,
-                                                  groupCount::Ptr{Cint})::cudnnStatus_t
+    @gcsafe_ccall libcudnn.cudnnGetConvolutionGroupCount(convDesc::cudnnConvolutionDescriptor_t,
+                                                         groupCount::Ptr{Cint})::cudnnStatus_t
 end
 
 @checked function cudnnSetConvolutionReorderType(convDesc, reorderType)
     initialize_context()
-    @ccall libcudnn.cudnnSetConvolutionReorderType(convDesc::cudnnConvolutionDescriptor_t,
-                                                   reorderType::cudnnReorderType_t)::cudnnStatus_t
+    @gcsafe_ccall libcudnn.cudnnSetConvolutionReorderType(convDesc::cudnnConvolutionDescriptor_t,
+                                                          reorderType::cudnnReorderType_t)::cudnnStatus_t
 end
 
 @checked function cudnnGetConvolutionReorderType(convDesc, reorderType)
     initialize_context()
-    @ccall libcudnn.cudnnGetConvolutionReorderType(convDesc::cudnnConvolutionDescriptor_t,
-                                                   reorderType::Ptr{cudnnReorderType_t})::cudnnStatus_t
+    @gcsafe_ccall libcudnn.cudnnGetConvolutionReorderType(convDesc::cudnnConvolutionDescriptor_t,
+                                                          reorderType::Ptr{cudnnReorderType_t})::cudnnStatus_t
 end
 
 @checked function cudnnSetConvolution2dDescriptor(convDesc, pad_h, pad_w, u, v, dilation_h,
                                                   dilation_w, mode, computeType)
     initialize_context()
-    @ccall libcudnn.cudnnSetConvolution2dDescriptor(convDesc::cudnnConvolutionDescriptor_t,
-                                                    pad_h::Cint, pad_w::Cint, u::Cint,
-                                                    v::Cint, dilation_h::Cint,
-                                                    dilation_w::Cint,
-                                                    mode::cudnnConvolutionMode_t,
-                                                    computeType::cudnnDataType_t)::cudnnStatus_t
+    @gcsafe_ccall libcudnn.cudnnSetConvolution2dDescriptor(convDesc::cudnnConvolutionDescriptor_t,
+                                                           pad_h::Cint, pad_w::Cint,
+                                                           u::Cint, v::Cint,
+                                                           dilation_h::Cint,
+                                                           dilation_w::Cint,
+                                                           mode::cudnnConvolutionMode_t,
+                                                           computeType::cudnnDataType_t)::cudnnStatus_t
 end
 
 @checked function cudnnGetConvolution2dDescriptor(convDesc, pad_h, pad_w, u, v, dilation_h,
                                                   dilation_w, mode, computeType)
     initialize_context()
-    @ccall libcudnn.cudnnGetConvolution2dDescriptor(convDesc::cudnnConvolutionDescriptor_t,
-                                                    pad_h::Ptr{Cint}, pad_w::Ptr{Cint},
-                                                    u::Ptr{Cint}, v::Ptr{Cint},
-                                                    dilation_h::Ptr{Cint},
-                                                    dilation_w::Ptr{Cint},
-                                                    mode::Ptr{cudnnConvolutionMode_t},
-                                                    computeType::Ptr{cudnnDataType_t})::cudnnStatus_t
+    @gcsafe_ccall libcudnn.cudnnGetConvolution2dDescriptor(convDesc::cudnnConvolutionDescriptor_t,
+                                                           pad_h::Ptr{Cint},
+                                                           pad_w::Ptr{Cint}, u::Ptr{Cint},
+                                                           v::Ptr{Cint},
+                                                           dilation_h::Ptr{Cint},
+                                                           dilation_w::Ptr{Cint},
+                                                           mode::Ptr{cudnnConvolutionMode_t},
+                                                           computeType::Ptr{cudnnDataType_t})::cudnnStatus_t
 end
 
 @checked function cudnnSetConvolutionNdDescriptor(convDesc, arrayLength, padA,
                                                   filterStrideA, dilationA, mode,
                                                   computeType)
     initialize_context()
-    @ccall libcudnn.cudnnSetConvolutionNdDescriptor(convDesc::cudnnConvolutionDescriptor_t,
-                                                    arrayLength::Cint, padA::Ptr{Cint},
-                                                    filterStrideA::Ptr{Cint},
-                                                    dilationA::Ptr{Cint},
-                                                    mode::cudnnConvolutionMode_t,
-                                                    computeType::cudnnDataType_t)::cudnnStatus_t
+    @gcsafe_ccall libcudnn.cudnnSetConvolutionNdDescriptor(convDesc::cudnnConvolutionDescriptor_t,
+                                                           arrayLength::Cint,
+                                                           padA::Ptr{Cint},
+                                                           filterStrideA::Ptr{Cint},
+                                                           dilationA::Ptr{Cint},
+                                                           mode::cudnnConvolutionMode_t,
+                                                           computeType::cudnnDataType_t)::cudnnStatus_t
 end
 
 @checked function cudnnGetConvolutionNdDescriptor(convDesc, arrayLengthRequested,
                                                   arrayLength, padA, strideA, dilationA,
                                                   mode, computeType)
     initialize_context()
-    @ccall libcudnn.cudnnGetConvolutionNdDescriptor(convDesc::cudnnConvolutionDescriptor_t,
-                                                    arrayLengthRequested::Cint,
-                                                    arrayLength::Ptr{Cint}, padA::Ptr{Cint},
-                                                    strideA::Ptr{Cint},
-                                                    dilationA::Ptr{Cint},
-                                                    mode::Ptr{cudnnConvolutionMode_t},
-                                                    computeType::Ptr{cudnnDataType_t})::cudnnStatus_t
+    @gcsafe_ccall libcudnn.cudnnGetConvolutionNdDescriptor(convDesc::cudnnConvolutionDescriptor_t,
+                                                           arrayLengthRequested::Cint,
+                                                           arrayLength::Ptr{Cint},
+                                                           padA::Ptr{Cint},
+                                                           strideA::Ptr{Cint},
+                                                           dilationA::Ptr{Cint},
+                                                           mode::Ptr{cudnnConvolutionMode_t},
+                                                           computeType::Ptr{cudnnDataType_t})::cudnnStatus_t
 end
 
 @checked function cudnnGetConvolution2dForwardOutputDim(convDesc, inputTensorDesc,
                                                         filterDesc, n, c, h, w)
     initialize_context()
-    @ccall libcudnn.cudnnGetConvolution2dForwardOutputDim(convDesc::cudnnConvolutionDescriptor_t,
-                                                          inputTensorDesc::cudnnTensorDescriptor_t,
-                                                          filterDesc::cudnnFilterDescriptor_t,
-                                                          n::Ptr{Cint}, c::Ptr{Cint},
-                                                          h::Ptr{Cint},
-                                                          w::Ptr{Cint})::cudnnStatus_t
+    @gcsafe_ccall libcudnn.cudnnGetConvolution2dForwardOutputDim(convDesc::cudnnConvolutionDescriptor_t,
+                                                                 inputTensorDesc::cudnnTensorDescriptor_t,
+                                                                 filterDesc::cudnnFilterDescriptor_t,
+                                                                 n::Ptr{Cint}, c::Ptr{Cint},
+                                                                 h::Ptr{Cint},
+                                                                 w::Ptr{Cint})::cudnnStatus_t
 end
 
 @checked function cudnnGetConvolutionNdForwardOutputDim(convDesc, inputTensorDesc,
                                                         filterDesc, nbDims, tensorOuputDimA)
     initialize_context()
-    @ccall libcudnn.cudnnGetConvolutionNdForwardOutputDim(convDesc::cudnnConvolutionDescriptor_t,
-                                                          inputTensorDesc::cudnnTensorDescriptor_t,
-                                                          filterDesc::cudnnFilterDescriptor_t,
-                                                          nbDims::Cint,
-                                                          tensorOuputDimA::Ptr{Cint})::cudnnStatus_t
+    @gcsafe_ccall libcudnn.cudnnGetConvolutionNdForwardOutputDim(convDesc::cudnnConvolutionDescriptor_t,
+                                                                 inputTensorDesc::cudnnTensorDescriptor_t,
+                                                                 filterDesc::cudnnFilterDescriptor_t,
+                                                                 nbDims::Cint,
+                                                                 tensorOuputDimA::Ptr{Cint})::cudnnStatus_t
 end
 
 @checked function cudnnGetConvolutionForwardAlgorithmMaxCount(handle, count)
     initialize_context()
-    @ccall libcudnn.cudnnGetConvolutionForwardAlgorithmMaxCount(handle::cudnnHandle_t,
-                                                                count::Ptr{Cint})::cudnnStatus_t
+    @gcsafe_ccall libcudnn.cudnnGetConvolutionForwardAlgorithmMaxCount(handle::cudnnHandle_t,
+                                                                       count::Ptr{Cint})::cudnnStatus_t
 end
 
 @checked function cudnnGetConvolutionForwardAlgorithm_v7(handle, srcDesc, filterDesc,
@@ -3010,28 +3107,28 @@ end
                                                          requestedAlgoCount,
                                                          returnedAlgoCount, perfResults)
     initialize_context()
-    @ccall libcudnn.cudnnGetConvolutionForwardAlgorithm_v7(handle::cudnnHandle_t,
-                                                           srcDesc::cudnnTensorDescriptor_t,
-                                                           filterDesc::cudnnFilterDescriptor_t,
-                                                           convDesc::cudnnConvolutionDescriptor_t,
-                                                           destDesc::cudnnTensorDescriptor_t,
-                                                           requestedAlgoCount::Cint,
-                                                           returnedAlgoCount::Ptr{Cint},
-                                                           perfResults::Ptr{cudnnConvolutionFwdAlgoPerf_t})::cudnnStatus_t
+    @gcsafe_ccall libcudnn.cudnnGetConvolutionForwardAlgorithm_v7(handle::cudnnHandle_t,
+                                                                  srcDesc::cudnnTensorDescriptor_t,
+                                                                  filterDesc::cudnnFilterDescriptor_t,
+                                                                  convDesc::cudnnConvolutionDescriptor_t,
+                                                                  destDesc::cudnnTensorDescriptor_t,
+                                                                  requestedAlgoCount::Cint,
+                                                                  returnedAlgoCount::Ptr{Cint},
+                                                                  perfResults::Ptr{cudnnConvolutionFwdAlgoPerf_t})::cudnnStatus_t
 end
 
 @checked function cudnnFindConvolutionForwardAlgorithm(handle, xDesc, wDesc, convDesc,
                                                        yDesc, requestedAlgoCount,
                                                        returnedAlgoCount, perfResults)
     initialize_context()
-    @ccall libcudnn.cudnnFindConvolutionForwardAlgorithm(handle::cudnnHandle_t,
-                                                         xDesc::cudnnTensorDescriptor_t,
-                                                         wDesc::cudnnFilterDescriptor_t,
-                                                         convDesc::cudnnConvolutionDescriptor_t,
-                                                         yDesc::cudnnTensorDescriptor_t,
-                                                         requestedAlgoCount::Cint,
-                                                         returnedAlgoCount::Ptr{Cint},
-                                                         perfResults::Ptr{cudnnConvolutionFwdAlgoPerf_t})::cudnnStatus_t
+    @gcsafe_ccall libcudnn.cudnnFindConvolutionForwardAlgorithm(handle::cudnnHandle_t,
+                                                                xDesc::cudnnTensorDescriptor_t,
+                                                                wDesc::cudnnFilterDescriptor_t,
+                                                                convDesc::cudnnConvolutionDescriptor_t,
+                                                                yDesc::cudnnTensorDescriptor_t,
+                                                                requestedAlgoCount::Cint,
+                                                                returnedAlgoCount::Ptr{Cint},
+                                                                perfResults::Ptr{cudnnConvolutionFwdAlgoPerf_t})::cudnnStatus_t
 end
 
 @checked function cudnnFindConvolutionForwardAlgorithmEx(handle, xDesc, x, wDesc, w,
@@ -3040,66 +3137,71 @@ end
                                                          returnedAlgoCount, perfResults,
                                                          workSpace, workSpaceSizeInBytes)
     initialize_context()
-    @ccall libcudnn.cudnnFindConvolutionForwardAlgorithmEx(handle::cudnnHandle_t,
-                                                           xDesc::cudnnTensorDescriptor_t,
-                                                           x::CuPtr{Cvoid},
-                                                           wDesc::cudnnFilterDescriptor_t,
-                                                           w::CuPtr{Cvoid},
-                                                           convDesc::cudnnConvolutionDescriptor_t,
-                                                           yDesc::cudnnTensorDescriptor_t,
-                                                           y::CuPtr{Cvoid},
-                                                           requestedAlgoCount::Cint,
-                                                           returnedAlgoCount::Ptr{Cint},
-                                                           perfResults::Ptr{cudnnConvolutionFwdAlgoPerf_t},
-                                                           workSpace::CuPtr{Cvoid},
-                                                           workSpaceSizeInBytes::Csize_t)::cudnnStatus_t
+    @gcsafe_ccall libcudnn.cudnnFindConvolutionForwardAlgorithmEx(handle::cudnnHandle_t,
+                                                                  xDesc::cudnnTensorDescriptor_t,
+                                                                  x::CuPtr{Cvoid},
+                                                                  wDesc::cudnnFilterDescriptor_t,
+                                                                  w::CuPtr{Cvoid},
+                                                                  convDesc::cudnnConvolutionDescriptor_t,
+                                                                  yDesc::cudnnTensorDescriptor_t,
+                                                                  y::CuPtr{Cvoid},
+                                                                  requestedAlgoCount::Cint,
+                                                                  returnedAlgoCount::Ptr{Cint},
+                                                                  perfResults::Ptr{cudnnConvolutionFwdAlgoPerf_t},
+                                                                  workSpace::CuPtr{Cvoid},
+                                                                  workSpaceSizeInBytes::Csize_t)::cudnnStatus_t
 end
 
 @checked function cudnnIm2Col(handle, xDesc, x, wDesc, convDesc, colBuffer)
     initialize_context()
-    @ccall libcudnn.cudnnIm2Col(handle::cudnnHandle_t, xDesc::cudnnTensorDescriptor_t,
-                                x::CuPtr{Cvoid}, wDesc::cudnnFilterDescriptor_t,
-                                convDesc::cudnnConvolutionDescriptor_t,
-                                colBuffer::CuPtr{Cvoid})::cudnnStatus_t
+    @gcsafe_ccall libcudnn.cudnnIm2Col(handle::cudnnHandle_t,
+                                       xDesc::cudnnTensorDescriptor_t, x::CuPtr{Cvoid},
+                                       wDesc::cudnnFilterDescriptor_t,
+                                       convDesc::cudnnConvolutionDescriptor_t,
+                                       colBuffer::CuPtr{Cvoid})::cudnnStatus_t
 end
 
 @checked function cudnnReorderFilterAndBias(handle, filterDesc, reorderType, filterData,
                                             reorderedFilterData, reorderBias, biasData,
                                             reorderedBiasData)
     initialize_context()
-    @ccall libcudnn.cudnnReorderFilterAndBias(handle::cudnnHandle_t,
-                                              filterDesc::cudnnFilterDescriptor_t,
-                                              reorderType::cudnnReorderType_t,
-                                              filterData::CuPtr{Cvoid},
-                                              reorderedFilterData::CuPtr{Cvoid},
-                                              reorderBias::Cint, biasData::CuPtr{Cvoid},
-                                              reorderedBiasData::CuPtr{Cvoid})::cudnnStatus_t
+    @gcsafe_ccall libcudnn.cudnnReorderFilterAndBias(handle::cudnnHandle_t,
+                                                     filterDesc::cudnnFilterDescriptor_t,
+                                                     reorderType::cudnnReorderType_t,
+                                                     filterData::CuPtr{Cvoid},
+                                                     reorderedFilterData::CuPtr{Cvoid},
+                                                     reorderBias::Cint,
+                                                     biasData::CuPtr{Cvoid},
+                                                     reorderedBiasData::CuPtr{Cvoid})::cudnnStatus_t
 end
 
 @checked function cudnnGetConvolutionForwardWorkspaceSize(handle, xDesc, wDesc, convDesc,
                                                           yDesc, algo, sizeInBytes)
     initialize_context()
-    @ccall libcudnn.cudnnGetConvolutionForwardWorkspaceSize(handle::cudnnHandle_t,
-                                                            xDesc::cudnnTensorDescriptor_t,
-                                                            wDesc::cudnnFilterDescriptor_t,
-                                                            convDesc::cudnnConvolutionDescriptor_t,
-                                                            yDesc::cudnnTensorDescriptor_t,
-                                                            algo::cudnnConvolutionFwdAlgo_t,
-                                                            sizeInBytes::Ref{Csize_t})::cudnnStatus_t
+    @gcsafe_ccall libcudnn.cudnnGetConvolutionForwardWorkspaceSize(handle::cudnnHandle_t,
+                                                                   xDesc::cudnnTensorDescriptor_t,
+                                                                   wDesc::cudnnFilterDescriptor_t,
+                                                                   convDesc::cudnnConvolutionDescriptor_t,
+                                                                   yDesc::cudnnTensorDescriptor_t,
+                                                                   algo::cudnnConvolutionFwdAlgo_t,
+                                                                   sizeInBytes::Ref{Csize_t})::cudnnStatus_t
 end
 
 @checked function cudnnConvolutionForward(handle, alpha, xDesc, x, wDesc, w, convDesc, algo,
                                           workSpace, workSpaceSizeInBytes, beta, yDesc, y)
     initialize_context()
-    @ccall libcudnn.cudnnConvolutionForward(handle::cudnnHandle_t, alpha::Ptr{Cvoid},
-                                            xDesc::cudnnTensorDescriptor_t, x::CuPtr{Cvoid},
-                                            wDesc::cudnnFilterDescriptor_t, w::CuPtr{Cvoid},
-                                            convDesc::cudnnConvolutionDescriptor_t,
-                                            algo::cudnnConvolutionFwdAlgo_t,
-                                            workSpace::CuPtr{Cvoid},
-                                            workSpaceSizeInBytes::Csize_t, beta::Ptr{Cvoid},
-                                            yDesc::cudnnTensorDescriptor_t,
-                                            y::CuPtr{Cvoid})::cudnnStatus_t
+    @gcsafe_ccall libcudnn.cudnnConvolutionForward(handle::cudnnHandle_t, alpha::Ptr{Cvoid},
+                                                   xDesc::cudnnTensorDescriptor_t,
+                                                   x::CuPtr{Cvoid},
+                                                   wDesc::cudnnFilterDescriptor_t,
+                                                   w::CuPtr{Cvoid},
+                                                   convDesc::cudnnConvolutionDescriptor_t,
+                                                   algo::cudnnConvolutionFwdAlgo_t,
+                                                   workSpace::CuPtr{Cvoid},
+                                                   workSpaceSizeInBytes::Csize_t,
+                                                   beta::Ptr{Cvoid},
+                                                   yDesc::cudnnTensorDescriptor_t,
+                                                   y::CuPtr{Cvoid})::cudnnStatus_t
 end
 
 @checked function cudnnConvolutionBiasActivationForward(handle, alpha1, xDesc, x, wDesc, w,
@@ -3108,24 +3210,24 @@ end
                                                         z, biasDesc, bias, activationDesc,
                                                         yDesc, y)
     initialize_context()
-    @ccall libcudnn.cudnnConvolutionBiasActivationForward(handle::cudnnHandle_t,
-                                                          alpha1::Ptr{Cvoid},
-                                                          xDesc::cudnnTensorDescriptor_t,
-                                                          x::CuPtr{Cvoid},
-                                                          wDesc::cudnnFilterDescriptor_t,
-                                                          w::CuPtr{Cvoid},
-                                                          convDesc::cudnnConvolutionDescriptor_t,
-                                                          algo::cudnnConvolutionFwdAlgo_t,
-                                                          workSpace::CuPtr{Cvoid},
-                                                          workSpaceSizeInBytes::Csize_t,
-                                                          alpha2::Ptr{Cvoid},
-                                                          zDesc::cudnnTensorDescriptor_t,
-                                                          z::CuPtr{Cvoid},
-                                                          biasDesc::cudnnTensorDescriptor_t,
-                                                          bias::CuPtr{Cvoid},
-                                                          activationDesc::cudnnActivationDescriptor_t,
-                                                          yDesc::cudnnTensorDescriptor_t,
-                                                          y::CuPtr{Cvoid})::cudnnStatus_t
+    @gcsafe_ccall libcudnn.cudnnConvolutionBiasActivationForward(handle::cudnnHandle_t,
+                                                                 alpha1::Ptr{Cvoid},
+                                                                 xDesc::cudnnTensorDescriptor_t,
+                                                                 x::CuPtr{Cvoid},
+                                                                 wDesc::cudnnFilterDescriptor_t,
+                                                                 w::CuPtr{Cvoid},
+                                                                 convDesc::cudnnConvolutionDescriptor_t,
+                                                                 algo::cudnnConvolutionFwdAlgo_t,
+                                                                 workSpace::CuPtr{Cvoid},
+                                                                 workSpaceSizeInBytes::Csize_t,
+                                                                 alpha2::Ptr{Cvoid},
+                                                                 zDesc::cudnnTensorDescriptor_t,
+                                                                 z::CuPtr{Cvoid},
+                                                                 biasDesc::cudnnTensorDescriptor_t,
+                                                                 bias::CuPtr{Cvoid},
+                                                                 activationDesc::cudnnActivationDescriptor_t,
+                                                                 yDesc::cudnnTensorDescriptor_t,
+                                                                 y::CuPtr{Cvoid})::cudnnStatus_t
 end
 
 struct cudnnConvolutionBwdDataAlgoPerfStruct
@@ -3142,22 +3244,22 @@ const cudnnConvolutionBwdDataAlgoPerf_t = cudnnConvolutionBwdDataAlgoPerfStruct
 
 @checked function cudnnGetConvolutionBackwardDataAlgorithmMaxCount(handle, count)
     initialize_context()
-    @ccall libcudnn.cudnnGetConvolutionBackwardDataAlgorithmMaxCount(handle::cudnnHandle_t,
-                                                                     count::Ptr{Cint})::cudnnStatus_t
+    @gcsafe_ccall libcudnn.cudnnGetConvolutionBackwardDataAlgorithmMaxCount(handle::cudnnHandle_t,
+                                                                            count::Ptr{Cint})::cudnnStatus_t
 end
 
 @checked function cudnnFindConvolutionBackwardDataAlgorithm(handle, wDesc, dyDesc, convDesc,
                                                             dxDesc, requestedAlgoCount,
                                                             returnedAlgoCount, perfResults)
     initialize_context()
-    @ccall libcudnn.cudnnFindConvolutionBackwardDataAlgorithm(handle::cudnnHandle_t,
-                                                              wDesc::cudnnFilterDescriptor_t,
-                                                              dyDesc::cudnnTensorDescriptor_t,
-                                                              convDesc::cudnnConvolutionDescriptor_t,
-                                                              dxDesc::cudnnTensorDescriptor_t,
-                                                              requestedAlgoCount::Cint,
-                                                              returnedAlgoCount::Ptr{Cint},
-                                                              perfResults::Ptr{cudnnConvolutionBwdDataAlgoPerf_t})::cudnnStatus_t
+    @gcsafe_ccall libcudnn.cudnnFindConvolutionBackwardDataAlgorithm(handle::cudnnHandle_t,
+                                                                     wDesc::cudnnFilterDescriptor_t,
+                                                                     dyDesc::cudnnTensorDescriptor_t,
+                                                                     convDesc::cudnnConvolutionDescriptor_t,
+                                                                     dxDesc::cudnnTensorDescriptor_t,
+                                                                     requestedAlgoCount::Cint,
+                                                                     returnedAlgoCount::Ptr{Cint},
+                                                                     perfResults::Ptr{cudnnConvolutionBwdDataAlgoPerf_t})::cudnnStatus_t
 end
 
 @checked function cudnnFindConvolutionBackwardDataAlgorithmEx(handle, wDesc, w, dyDesc, dy,
@@ -3167,19 +3269,19 @@ end
                                                               perfResults, workSpace,
                                                               workSpaceSizeInBytes)
     initialize_context()
-    @ccall libcudnn.cudnnFindConvolutionBackwardDataAlgorithmEx(handle::cudnnHandle_t,
-                                                                wDesc::cudnnFilterDescriptor_t,
-                                                                w::CuPtr{Cvoid},
-                                                                dyDesc::cudnnTensorDescriptor_t,
-                                                                dy::CuPtr{Cvoid},
-                                                                convDesc::cudnnConvolutionDescriptor_t,
-                                                                dxDesc::cudnnTensorDescriptor_t,
-                                                                dx::CuPtr{Cvoid},
-                                                                requestedAlgoCount::Cint,
-                                                                returnedAlgoCount::Ptr{Cint},
-                                                                perfResults::Ptr{cudnnConvolutionBwdDataAlgoPerf_t},
-                                                                workSpace::CuPtr{Cvoid},
-                                                                workSpaceSizeInBytes::Csize_t)::cudnnStatus_t
+    @gcsafe_ccall libcudnn.cudnnFindConvolutionBackwardDataAlgorithmEx(handle::cudnnHandle_t,
+                                                                       wDesc::cudnnFilterDescriptor_t,
+                                                                       w::CuPtr{Cvoid},
+                                                                       dyDesc::cudnnTensorDescriptor_t,
+                                                                       dy::CuPtr{Cvoid},
+                                                                       convDesc::cudnnConvolutionDescriptor_t,
+                                                                       dxDesc::cudnnTensorDescriptor_t,
+                                                                       dx::CuPtr{Cvoid},
+                                                                       requestedAlgoCount::Cint,
+                                                                       returnedAlgoCount::Ptr{Cint},
+                                                                       perfResults::Ptr{cudnnConvolutionBwdDataAlgoPerf_t},
+                                                                       workSpace::CuPtr{Cvoid},
+                                                                       workSpaceSizeInBytes::Csize_t)::cudnnStatus_t
 end
 
 @checked function cudnnGetConvolutionBackwardDataAlgorithm_v7(handle, filterDesc, diffDesc,
@@ -3188,45 +3290,46 @@ end
                                                               returnedAlgoCount,
                                                               perfResults)
     initialize_context()
-    @ccall libcudnn.cudnnGetConvolutionBackwardDataAlgorithm_v7(handle::cudnnHandle_t,
-                                                                filterDesc::cudnnFilterDescriptor_t,
-                                                                diffDesc::cudnnTensorDescriptor_t,
-                                                                convDesc::cudnnConvolutionDescriptor_t,
-                                                                gradDesc::cudnnTensorDescriptor_t,
-                                                                requestedAlgoCount::Cint,
-                                                                returnedAlgoCount::Ptr{Cint},
-                                                                perfResults::Ptr{cudnnConvolutionBwdDataAlgoPerf_t})::cudnnStatus_t
+    @gcsafe_ccall libcudnn.cudnnGetConvolutionBackwardDataAlgorithm_v7(handle::cudnnHandle_t,
+                                                                       filterDesc::cudnnFilterDescriptor_t,
+                                                                       diffDesc::cudnnTensorDescriptor_t,
+                                                                       convDesc::cudnnConvolutionDescriptor_t,
+                                                                       gradDesc::cudnnTensorDescriptor_t,
+                                                                       requestedAlgoCount::Cint,
+                                                                       returnedAlgoCount::Ptr{Cint},
+                                                                       perfResults::Ptr{cudnnConvolutionBwdDataAlgoPerf_t})::cudnnStatus_t
 end
 
 @checked function cudnnGetConvolutionBackwardDataWorkspaceSize(handle, wDesc, dyDesc,
                                                                convDesc, dxDesc, algo,
                                                                sizeInBytes)
     initialize_context()
-    @ccall libcudnn.cudnnGetConvolutionBackwardDataWorkspaceSize(handle::cudnnHandle_t,
-                                                                 wDesc::cudnnFilterDescriptor_t,
-                                                                 dyDesc::cudnnTensorDescriptor_t,
-                                                                 convDesc::cudnnConvolutionDescriptor_t,
-                                                                 dxDesc::cudnnTensorDescriptor_t,
-                                                                 algo::cudnnConvolutionBwdDataAlgo_t,
-                                                                 sizeInBytes::Ref{Csize_t})::cudnnStatus_t
+    @gcsafe_ccall libcudnn.cudnnGetConvolutionBackwardDataWorkspaceSize(handle::cudnnHandle_t,
+                                                                        wDesc::cudnnFilterDescriptor_t,
+                                                                        dyDesc::cudnnTensorDescriptor_t,
+                                                                        convDesc::cudnnConvolutionDescriptor_t,
+                                                                        dxDesc::cudnnTensorDescriptor_t,
+                                                                        algo::cudnnConvolutionBwdDataAlgo_t,
+                                                                        sizeInBytes::Ref{Csize_t})::cudnnStatus_t
 end
 
 @checked function cudnnConvolutionBackwardData(handle, alpha, wDesc, w, dyDesc, dy,
                                                convDesc, algo, workSpace,
                                                workSpaceSizeInBytes, beta, dxDesc, dx)
     initialize_context()
-    @ccall libcudnn.cudnnConvolutionBackwardData(handle::cudnnHandle_t, alpha::Ptr{Cvoid},
-                                                 wDesc::cudnnFilterDescriptor_t,
-                                                 w::CuPtr{Cvoid},
-                                                 dyDesc::cudnnTensorDescriptor_t,
-                                                 dy::CuPtr{Cvoid},
-                                                 convDesc::cudnnConvolutionDescriptor_t,
-                                                 algo::cudnnConvolutionBwdDataAlgo_t,
-                                                 workSpace::CuPtr{Cvoid},
-                                                 workSpaceSizeInBytes::Csize_t,
-                                                 beta::Ptr{Cvoid},
-                                                 dxDesc::cudnnTensorDescriptor_t,
-                                                 dx::CuPtr{Cvoid})::cudnnStatus_t
+    @gcsafe_ccall libcudnn.cudnnConvolutionBackwardData(handle::cudnnHandle_t,
+                                                        alpha::Ptr{Cvoid},
+                                                        wDesc::cudnnFilterDescriptor_t,
+                                                        w::CuPtr{Cvoid},
+                                                        dyDesc::cudnnTensorDescriptor_t,
+                                                        dy::CuPtr{Cvoid},
+                                                        convDesc::cudnnConvolutionDescriptor_t,
+                                                        algo::cudnnConvolutionBwdDataAlgo_t,
+                                                        workSpace::CuPtr{Cvoid},
+                                                        workSpaceSizeInBytes::Csize_t,
+                                                        beta::Ptr{Cvoid},
+                                                        dxDesc::cudnnTensorDescriptor_t,
+                                                        dx::CuPtr{Cvoid})::cudnnStatus_t
 end
 
 @checked function cudnnGetFoldedConvBackwardDataDescriptors(handle, filterDesc, diffDesc,
@@ -3240,20 +3343,20 @@ end
                                                             gradFoldTransDesc,
                                                             gradUnfoldTransDesc)
     initialize_context()
-    @ccall libcudnn.cudnnGetFoldedConvBackwardDataDescriptors(handle::cudnnHandle_t,
-                                                              filterDesc::cudnnFilterDescriptor_t,
-                                                              diffDesc::cudnnTensorDescriptor_t,
-                                                              convDesc::cudnnConvolutionDescriptor_t,
-                                                              gradDesc::cudnnTensorDescriptor_t,
-                                                              transformFormat::cudnnTensorFormat_t,
-                                                              foldedFilterDesc::cudnnFilterDescriptor_t,
-                                                              paddedDiffDesc::cudnnTensorDescriptor_t,
-                                                              foldedConvDesc::cudnnConvolutionDescriptor_t,
-                                                              foldedGradDesc::cudnnTensorDescriptor_t,
-                                                              filterFoldTransDesc::cudnnTensorTransformDescriptor_t,
-                                                              diffPadTransDesc::cudnnTensorTransformDescriptor_t,
-                                                              gradFoldTransDesc::cudnnTensorTransformDescriptor_t,
-                                                              gradUnfoldTransDesc::cudnnTensorTransformDescriptor_t)::cudnnStatus_t
+    @gcsafe_ccall libcudnn.cudnnGetFoldedConvBackwardDataDescriptors(handle::cudnnHandle_t,
+                                                                     filterDesc::cudnnFilterDescriptor_t,
+                                                                     diffDesc::cudnnTensorDescriptor_t,
+                                                                     convDesc::cudnnConvolutionDescriptor_t,
+                                                                     gradDesc::cudnnTensorDescriptor_t,
+                                                                     transformFormat::cudnnTensorFormat_t,
+                                                                     foldedFilterDesc::cudnnFilterDescriptor_t,
+                                                                     paddedDiffDesc::cudnnTensorDescriptor_t,
+                                                                     foldedConvDesc::cudnnConvolutionDescriptor_t,
+                                                                     foldedGradDesc::cudnnTensorDescriptor_t,
+                                                                     filterFoldTransDesc::cudnnTensorTransformDescriptor_t,
+                                                                     diffPadTransDesc::cudnnTensorTransformDescriptor_t,
+                                                                     gradFoldTransDesc::cudnnTensorTransformDescriptor_t,
+                                                                     gradUnfoldTransDesc::cudnnTensorTransformDescriptor_t)::cudnnStatus_t
 end
 
 mutable struct cudnnFusedOpsConstParamStruct end
@@ -3359,7 +3462,7 @@ end
 
 @checked function cudnnCnnInferVersionCheck()
     initialize_context()
-    @ccall libcudnn.cudnnCnnInferVersionCheck()::cudnnStatus_t
+    @gcsafe_ccall libcudnn.cudnnCnnInferVersionCheck()::cudnnStatus_t
 end
 
 struct cudnnConvolutionBwdFilterAlgoPerfStruct
@@ -3376,8 +3479,8 @@ const cudnnConvolutionBwdFilterAlgoPerf_t = cudnnConvolutionBwdFilterAlgoPerfStr
 
 @checked function cudnnGetConvolutionBackwardFilterAlgorithmMaxCount(handle, count)
     initialize_context()
-    @ccall libcudnn.cudnnGetConvolutionBackwardFilterAlgorithmMaxCount(handle::cudnnHandle_t,
-                                                                       count::Ptr{Cint})::cudnnStatus_t
+    @gcsafe_ccall libcudnn.cudnnGetConvolutionBackwardFilterAlgorithmMaxCount(handle::cudnnHandle_t,
+                                                                              count::Ptr{Cint})::cudnnStatus_t
 end
 
 @checked function cudnnFindConvolutionBackwardFilterAlgorithm(handle, xDesc, dyDesc,
@@ -3386,14 +3489,14 @@ end
                                                               returnedAlgoCount,
                                                               perfResults)
     initialize_context()
-    @ccall libcudnn.cudnnFindConvolutionBackwardFilterAlgorithm(handle::cudnnHandle_t,
-                                                                xDesc::cudnnTensorDescriptor_t,
-                                                                dyDesc::cudnnTensorDescriptor_t,
-                                                                convDesc::cudnnConvolutionDescriptor_t,
-                                                                dwDesc::cudnnFilterDescriptor_t,
-                                                                requestedAlgoCount::Cint,
-                                                                returnedAlgoCount::Ptr{Cint},
-                                                                perfResults::Ptr{cudnnConvolutionBwdFilterAlgoPerf_t})::cudnnStatus_t
+    @gcsafe_ccall libcudnn.cudnnFindConvolutionBackwardFilterAlgorithm(handle::cudnnHandle_t,
+                                                                       xDesc::cudnnTensorDescriptor_t,
+                                                                       dyDesc::cudnnTensorDescriptor_t,
+                                                                       convDesc::cudnnConvolutionDescriptor_t,
+                                                                       dwDesc::cudnnFilterDescriptor_t,
+                                                                       requestedAlgoCount::Cint,
+                                                                       returnedAlgoCount::Ptr{Cint},
+                                                                       perfResults::Ptr{cudnnConvolutionBwdFilterAlgoPerf_t})::cudnnStatus_t
 end
 
 @checked function cudnnFindConvolutionBackwardFilterAlgorithmEx(handle, xDesc, x, dyDesc, y,
@@ -3403,19 +3506,19 @@ end
                                                                 perfResults, workSpace,
                                                                 workSpaceSizeInBytes)
     initialize_context()
-    @ccall libcudnn.cudnnFindConvolutionBackwardFilterAlgorithmEx(handle::cudnnHandle_t,
-                                                                  xDesc::cudnnTensorDescriptor_t,
-                                                                  x::CuPtr{Cvoid},
-                                                                  dyDesc::cudnnTensorDescriptor_t,
-                                                                  y::CuPtr{Cvoid},
-                                                                  convDesc::cudnnConvolutionDescriptor_t,
-                                                                  dwDesc::cudnnFilterDescriptor_t,
-                                                                  dw::CuPtr{Cvoid},
-                                                                  requestedAlgoCount::Cint,
-                                                                  returnedAlgoCount::Ptr{Cint},
-                                                                  perfResults::Ptr{cudnnConvolutionBwdFilterAlgoPerf_t},
-                                                                  workSpace::CuPtr{Cvoid},
-                                                                  workSpaceSizeInBytes::Csize_t)::cudnnStatus_t
+    @gcsafe_ccall libcudnn.cudnnFindConvolutionBackwardFilterAlgorithmEx(handle::cudnnHandle_t,
+                                                                         xDesc::cudnnTensorDescriptor_t,
+                                                                         x::CuPtr{Cvoid},
+                                                                         dyDesc::cudnnTensorDescriptor_t,
+                                                                         y::CuPtr{Cvoid},
+                                                                         convDesc::cudnnConvolutionDescriptor_t,
+                                                                         dwDesc::cudnnFilterDescriptor_t,
+                                                                         dw::CuPtr{Cvoid},
+                                                                         requestedAlgoCount::Cint,
+                                                                         returnedAlgoCount::Ptr{Cint},
+                                                                         perfResults::Ptr{cudnnConvolutionBwdFilterAlgoPerf_t},
+                                                                         workSpace::CuPtr{Cvoid},
+                                                                         workSpaceSizeInBytes::Csize_t)::cudnnStatus_t
 end
 
 @checked function cudnnGetConvolutionBackwardFilterAlgorithm_v7(handle, srcDesc, diffDesc,
@@ -3424,135 +3527,139 @@ end
                                                                 returnedAlgoCount,
                                                                 perfResults)
     initialize_context()
-    @ccall libcudnn.cudnnGetConvolutionBackwardFilterAlgorithm_v7(handle::cudnnHandle_t,
-                                                                  srcDesc::cudnnTensorDescriptor_t,
-                                                                  diffDesc::cudnnTensorDescriptor_t,
-                                                                  convDesc::cudnnConvolutionDescriptor_t,
-                                                                  gradDesc::cudnnFilterDescriptor_t,
-                                                                  requestedAlgoCount::Cint,
-                                                                  returnedAlgoCount::Ptr{Cint},
-                                                                  perfResults::Ptr{cudnnConvolutionBwdFilterAlgoPerf_t})::cudnnStatus_t
+    @gcsafe_ccall libcudnn.cudnnGetConvolutionBackwardFilterAlgorithm_v7(handle::cudnnHandle_t,
+                                                                         srcDesc::cudnnTensorDescriptor_t,
+                                                                         diffDesc::cudnnTensorDescriptor_t,
+                                                                         convDesc::cudnnConvolutionDescriptor_t,
+                                                                         gradDesc::cudnnFilterDescriptor_t,
+                                                                         requestedAlgoCount::Cint,
+                                                                         returnedAlgoCount::Ptr{Cint},
+                                                                         perfResults::Ptr{cudnnConvolutionBwdFilterAlgoPerf_t})::cudnnStatus_t
 end
 
 @checked function cudnnGetConvolutionBackwardFilterWorkspaceSize(handle, xDesc, dyDesc,
                                                                  convDesc, gradDesc, algo,
                                                                  sizeInBytes)
     initialize_context()
-    @ccall libcudnn.cudnnGetConvolutionBackwardFilterWorkspaceSize(handle::cudnnHandle_t,
-                                                                   xDesc::cudnnTensorDescriptor_t,
-                                                                   dyDesc::cudnnTensorDescriptor_t,
-                                                                   convDesc::cudnnConvolutionDescriptor_t,
-                                                                   gradDesc::cudnnFilterDescriptor_t,
-                                                                   algo::cudnnConvolutionBwdFilterAlgo_t,
-                                                                   sizeInBytes::Ref{Csize_t})::cudnnStatus_t
+    @gcsafe_ccall libcudnn.cudnnGetConvolutionBackwardFilterWorkspaceSize(handle::cudnnHandle_t,
+                                                                          xDesc::cudnnTensorDescriptor_t,
+                                                                          dyDesc::cudnnTensorDescriptor_t,
+                                                                          convDesc::cudnnConvolutionDescriptor_t,
+                                                                          gradDesc::cudnnFilterDescriptor_t,
+                                                                          algo::cudnnConvolutionBwdFilterAlgo_t,
+                                                                          sizeInBytes::Ref{Csize_t})::cudnnStatus_t
 end
 
 @checked function cudnnConvolutionBackwardFilter(handle, alpha, xDesc, x, dyDesc, dy,
                                                  convDesc, algo, workSpace,
                                                  workSpaceSizeInBytes, beta, dwDesc, dw)
     initialize_context()
-    @ccall libcudnn.cudnnConvolutionBackwardFilter(handle::cudnnHandle_t, alpha::Ptr{Cvoid},
-                                                   xDesc::cudnnTensorDescriptor_t,
-                                                   x::CuPtr{Cvoid},
-                                                   dyDesc::cudnnTensorDescriptor_t,
-                                                   dy::CuPtr{Cvoid},
-                                                   convDesc::cudnnConvolutionDescriptor_t,
-                                                   algo::cudnnConvolutionBwdFilterAlgo_t,
-                                                   workSpace::CuPtr{Cvoid},
-                                                   workSpaceSizeInBytes::Csize_t,
-                                                   beta::Ptr{Cvoid},
-                                                   dwDesc::cudnnFilterDescriptor_t,
-                                                   dw::CuPtr{Cvoid})::cudnnStatus_t
+    @gcsafe_ccall libcudnn.cudnnConvolutionBackwardFilter(handle::cudnnHandle_t,
+                                                          alpha::Ptr{Cvoid},
+                                                          xDesc::cudnnTensorDescriptor_t,
+                                                          x::CuPtr{Cvoid},
+                                                          dyDesc::cudnnTensorDescriptor_t,
+                                                          dy::CuPtr{Cvoid},
+                                                          convDesc::cudnnConvolutionDescriptor_t,
+                                                          algo::cudnnConvolutionBwdFilterAlgo_t,
+                                                          workSpace::CuPtr{Cvoid},
+                                                          workSpaceSizeInBytes::Csize_t,
+                                                          beta::Ptr{Cvoid},
+                                                          dwDesc::cudnnFilterDescriptor_t,
+                                                          dw::CuPtr{Cvoid})::cudnnStatus_t
 end
 
 @checked function cudnnConvolutionBackwardBias(handle, alpha, dyDesc, dy, beta, dbDesc, db)
     initialize_context()
-    @ccall libcudnn.cudnnConvolutionBackwardBias(handle::cudnnHandle_t, alpha::Ptr{Cvoid},
-                                                 dyDesc::cudnnTensorDescriptor_t,
-                                                 dy::CuPtr{Cvoid}, beta::Ptr{Cvoid},
-                                                 dbDesc::cudnnTensorDescriptor_t,
-                                                 db::CuPtr{Cvoid})::cudnnStatus_t
+    @gcsafe_ccall libcudnn.cudnnConvolutionBackwardBias(handle::cudnnHandle_t,
+                                                        alpha::Ptr{Cvoid},
+                                                        dyDesc::cudnnTensorDescriptor_t,
+                                                        dy::CuPtr{Cvoid}, beta::Ptr{Cvoid},
+                                                        dbDesc::cudnnTensorDescriptor_t,
+                                                        db::CuPtr{Cvoid})::cudnnStatus_t
 end
 
 @checked function cudnnCreateFusedOpsConstParamPack(constPack, ops)
     initialize_context()
-    @ccall libcudnn.cudnnCreateFusedOpsConstParamPack(constPack::Ptr{cudnnFusedOpsConstParamPack_t},
-                                                      ops::cudnnFusedOps_t)::cudnnStatus_t
+    @gcsafe_ccall libcudnn.cudnnCreateFusedOpsConstParamPack(constPack::Ptr{cudnnFusedOpsConstParamPack_t},
+                                                             ops::cudnnFusedOps_t)::cudnnStatus_t
 end
 
 @checked function cudnnDestroyFusedOpsConstParamPack(constPack)
     initialize_context()
-    @ccall libcudnn.cudnnDestroyFusedOpsConstParamPack(constPack::cudnnFusedOpsConstParamPack_t)::cudnnStatus_t
+    @gcsafe_ccall libcudnn.cudnnDestroyFusedOpsConstParamPack(constPack::cudnnFusedOpsConstParamPack_t)::cudnnStatus_t
 end
 
 @checked function cudnnSetFusedOpsConstParamPackAttribute(constPack, paramLabel, param)
     initialize_context()
-    @ccall libcudnn.cudnnSetFusedOpsConstParamPackAttribute(constPack::cudnnFusedOpsConstParamPack_t,
-                                                            paramLabel::cudnnFusedOpsConstParamLabel_t,
-                                                            param::Ptr{Cvoid})::cudnnStatus_t
+    @gcsafe_ccall libcudnn.cudnnSetFusedOpsConstParamPackAttribute(constPack::cudnnFusedOpsConstParamPack_t,
+                                                                   paramLabel::cudnnFusedOpsConstParamLabel_t,
+                                                                   param::Ptr{Cvoid})::cudnnStatus_t
 end
 
 @checked function cudnnGetFusedOpsConstParamPackAttribute(constPack, paramLabel, param,
                                                           isNULL)
     initialize_context()
-    @ccall libcudnn.cudnnGetFusedOpsConstParamPackAttribute(constPack::cudnnFusedOpsConstParamPack_t,
-                                                            paramLabel::cudnnFusedOpsConstParamLabel_t,
-                                                            param::Ptr{Cvoid},
-                                                            isNULL::Ptr{Cint})::cudnnStatus_t
+    @gcsafe_ccall libcudnn.cudnnGetFusedOpsConstParamPackAttribute(constPack::cudnnFusedOpsConstParamPack_t,
+                                                                   paramLabel::cudnnFusedOpsConstParamLabel_t,
+                                                                   param::Ptr{Cvoid},
+                                                                   isNULL::Ptr{Cint})::cudnnStatus_t
 end
 
 @checked function cudnnCreateFusedOpsVariantParamPack(varPack, ops)
     initialize_context()
-    @ccall libcudnn.cudnnCreateFusedOpsVariantParamPack(varPack::Ptr{cudnnFusedOpsVariantParamPack_t},
-                                                        ops::cudnnFusedOps_t)::cudnnStatus_t
+    @gcsafe_ccall libcudnn.cudnnCreateFusedOpsVariantParamPack(varPack::Ptr{cudnnFusedOpsVariantParamPack_t},
+                                                               ops::cudnnFusedOps_t)::cudnnStatus_t
 end
 
 @checked function cudnnDestroyFusedOpsVariantParamPack(varPack)
     initialize_context()
-    @ccall libcudnn.cudnnDestroyFusedOpsVariantParamPack(varPack::cudnnFusedOpsVariantParamPack_t)::cudnnStatus_t
+    @gcsafe_ccall libcudnn.cudnnDestroyFusedOpsVariantParamPack(varPack::cudnnFusedOpsVariantParamPack_t)::cudnnStatus_t
 end
 
 @checked function cudnnSetFusedOpsVariantParamPackAttribute(varPack, paramLabel, ptr)
     initialize_context()
-    @ccall libcudnn.cudnnSetFusedOpsVariantParamPackAttribute(varPack::cudnnFusedOpsVariantParamPack_t,
-                                                              paramLabel::cudnnFusedOpsVariantParamLabel_t,
-                                                              ptr::PtrOrCuPtr{Cvoid})::cudnnStatus_t
+    @gcsafe_ccall libcudnn.cudnnSetFusedOpsVariantParamPackAttribute(varPack::cudnnFusedOpsVariantParamPack_t,
+                                                                     paramLabel::cudnnFusedOpsVariantParamLabel_t,
+                                                                     ptr::PtrOrCuPtr{Cvoid})::cudnnStatus_t
 end
 
 @checked function cudnnGetFusedOpsVariantParamPackAttribute(varPack, paramLabel, ptr)
     initialize_context()
-    @ccall libcudnn.cudnnGetFusedOpsVariantParamPackAttribute(varPack::cudnnFusedOpsVariantParamPack_t,
-                                                              paramLabel::cudnnFusedOpsVariantParamLabel_t,
-                                                              ptr::PtrOrCuPtr{Cvoid})::cudnnStatus_t
+    @gcsafe_ccall libcudnn.cudnnGetFusedOpsVariantParamPackAttribute(varPack::cudnnFusedOpsVariantParamPack_t,
+                                                                     paramLabel::cudnnFusedOpsVariantParamLabel_t,
+                                                                     ptr::PtrOrCuPtr{Cvoid})::cudnnStatus_t
 end
 
 @checked function cudnnCreateFusedOpsPlan(plan, ops)
     initialize_context()
-    @ccall libcudnn.cudnnCreateFusedOpsPlan(plan::Ptr{cudnnFusedOpsPlan_t},
-                                            ops::cudnnFusedOps_t)::cudnnStatus_t
+    @gcsafe_ccall libcudnn.cudnnCreateFusedOpsPlan(plan::Ptr{cudnnFusedOpsPlan_t},
+                                                   ops::cudnnFusedOps_t)::cudnnStatus_t
 end
 
 @checked function cudnnDestroyFusedOpsPlan(plan)
     initialize_context()
-    @ccall libcudnn.cudnnDestroyFusedOpsPlan(plan::cudnnFusedOpsPlan_t)::cudnnStatus_t
+    @gcsafe_ccall libcudnn.cudnnDestroyFusedOpsPlan(plan::cudnnFusedOpsPlan_t)::cudnnStatus_t
 end
 
 @checked function cudnnMakeFusedOpsPlan(handle, plan, constPack, workspaceSizeInBytes)
     initialize_context()
-    @ccall libcudnn.cudnnMakeFusedOpsPlan(handle::cudnnHandle_t, plan::cudnnFusedOpsPlan_t,
-                                          constPack::cudnnFusedOpsConstParamPack_t,
-                                          workspaceSizeInBytes::Ptr{Csize_t})::cudnnStatus_t
+    @gcsafe_ccall libcudnn.cudnnMakeFusedOpsPlan(handle::cudnnHandle_t,
+                                                 plan::cudnnFusedOpsPlan_t,
+                                                 constPack::cudnnFusedOpsConstParamPack_t,
+                                                 workspaceSizeInBytes::Ptr{Csize_t})::cudnnStatus_t
 end
 
 @checked function cudnnFusedOpsExecute(handle, plan, varPack)
     initialize_context()
-    @ccall libcudnn.cudnnFusedOpsExecute(handle::cudnnHandle_t, plan::cudnnFusedOpsPlan_t,
-                                         varPack::cudnnFusedOpsVariantParamPack_t)::cudnnStatus_t
+    @gcsafe_ccall libcudnn.cudnnFusedOpsExecute(handle::cudnnHandle_t,
+                                                plan::cudnnFusedOpsPlan_t,
+                                                varPack::cudnnFusedOpsVariantParamPack_t)::cudnnStatus_t
 end
 
 @checked function cudnnCnnTrainVersionCheck()
     initialize_context()
-    @ccall libcudnn.cudnnCnnTrainVersionCheck()::cudnnStatus_t
+    @gcsafe_ccall libcudnn.cudnnCnnTrainVersionCheck()::cudnnStatus_t
 end
 
 const CUDNN_MAX_SM_MAJOR_NUMBER = 9

--- a/lib/cufft/libcufft.jl
+++ b/lib/cufft/libcufft.jl
@@ -76,211 +76,222 @@ const cufftHandle = Cint
 
 @checked function cufftPlan1d(plan, nx, type, batch)
     initialize_context()
-    @ccall libcufft.cufftPlan1d(plan::Ptr{cufftHandle}, nx::Cint, type::cufftType,
-                                batch::Cint)::cufftResult
+    @gcsafe_ccall libcufft.cufftPlan1d(plan::Ptr{cufftHandle}, nx::Cint, type::cufftType,
+                                       batch::Cint)::cufftResult
 end
 
 @checked function cufftPlan2d(plan, nx, ny, type)
     initialize_context()
-    @ccall libcufft.cufftPlan2d(plan::Ptr{cufftHandle}, nx::Cint, ny::Cint,
-                                type::cufftType)::cufftResult
+    @gcsafe_ccall libcufft.cufftPlan2d(plan::Ptr{cufftHandle}, nx::Cint, ny::Cint,
+                                       type::cufftType)::cufftResult
 end
 
 @checked function cufftPlan3d(plan, nx, ny, nz, type)
     initialize_context()
-    @ccall libcufft.cufftPlan3d(plan::Ptr{cufftHandle}, nx::Cint, ny::Cint, nz::Cint,
-                                type::cufftType)::cufftResult
+    @gcsafe_ccall libcufft.cufftPlan3d(plan::Ptr{cufftHandle}, nx::Cint, ny::Cint, nz::Cint,
+                                       type::cufftType)::cufftResult
 end
 
 @checked function cufftPlanMany(plan, rank, n, inembed, istride, idist, onembed, ostride,
                                 odist, type, batch)
     initialize_context()
-    @ccall libcufft.cufftPlanMany(plan::Ptr{cufftHandle}, rank::Cint, n::Ptr{Cint},
-                                  inembed::Ptr{Cint}, istride::Cint, idist::Cint,
-                                  onembed::Ptr{Cint}, ostride::Cint, odist::Cint,
-                                  type::cufftType, batch::Cint)::cufftResult
+    @gcsafe_ccall libcufft.cufftPlanMany(plan::Ptr{cufftHandle}, rank::Cint, n::Ptr{Cint},
+                                         inembed::Ptr{Cint}, istride::Cint, idist::Cint,
+                                         onembed::Ptr{Cint}, ostride::Cint, odist::Cint,
+                                         type::cufftType, batch::Cint)::cufftResult
 end
 
 @checked function cufftMakePlan1d(plan, nx, type, batch, workSize)
     initialize_context()
-    @ccall libcufft.cufftMakePlan1d(plan::cufftHandle, nx::Cint, type::cufftType,
-                                    batch::Cint, workSize::Ptr{Csize_t})::cufftResult
+    @gcsafe_ccall libcufft.cufftMakePlan1d(plan::cufftHandle, nx::Cint, type::cufftType,
+                                           batch::Cint, workSize::Ptr{Csize_t})::cufftResult
 end
 
 @checked function cufftMakePlan2d(plan, nx, ny, type, workSize)
     initialize_context()
-    @ccall libcufft.cufftMakePlan2d(plan::cufftHandle, nx::Cint, ny::Cint, type::cufftType,
-                                    workSize::Ptr{Csize_t})::cufftResult
+    @gcsafe_ccall libcufft.cufftMakePlan2d(plan::cufftHandle, nx::Cint, ny::Cint,
+                                           type::cufftType,
+                                           workSize::Ptr{Csize_t})::cufftResult
 end
 
 @checked function cufftMakePlan3d(plan, nx, ny, nz, type, workSize)
     initialize_context()
-    @ccall libcufft.cufftMakePlan3d(plan::cufftHandle, nx::Cint, ny::Cint, nz::Cint,
-                                    type::cufftType, workSize::Ptr{Csize_t})::cufftResult
+    @gcsafe_ccall libcufft.cufftMakePlan3d(plan::cufftHandle, nx::Cint, ny::Cint, nz::Cint,
+                                           type::cufftType,
+                                           workSize::Ptr{Csize_t})::cufftResult
 end
 
 @checked function cufftMakePlanMany(plan, rank, n, inembed, istride, idist, onembed,
                                     ostride, odist, type, batch, workSize)
     initialize_context()
-    @ccall libcufft.cufftMakePlanMany(plan::cufftHandle, rank::Cint, n::Ptr{Cint},
-                                      inembed::Ptr{Cint}, istride::Cint, idist::Cint,
-                                      onembed::Ptr{Cint}, ostride::Cint, odist::Cint,
-                                      type::cufftType, batch::Cint,
-                                      workSize::Ptr{Csize_t})::cufftResult
+    @gcsafe_ccall libcufft.cufftMakePlanMany(plan::cufftHandle, rank::Cint, n::Ptr{Cint},
+                                             inembed::Ptr{Cint}, istride::Cint, idist::Cint,
+                                             onembed::Ptr{Cint}, ostride::Cint, odist::Cint,
+                                             type::cufftType, batch::Cint,
+                                             workSize::Ptr{Csize_t})::cufftResult
 end
 
 @checked function cufftMakePlanMany64(plan, rank, n, inembed, istride, idist, onembed,
                                       ostride, odist, type, batch, workSize)
     initialize_context()
-    @ccall libcufft.cufftMakePlanMany64(plan::cufftHandle, rank::Cint, n::Ptr{Clonglong},
-                                        inembed::Ptr{Clonglong}, istride::Clonglong,
-                                        idist::Clonglong, onembed::Ptr{Clonglong},
-                                        ostride::Clonglong, odist::Clonglong,
-                                        type::cufftType, batch::Clonglong,
-                                        workSize::Ptr{Csize_t})::cufftResult
+    @gcsafe_ccall libcufft.cufftMakePlanMany64(plan::cufftHandle, rank::Cint,
+                                               n::Ptr{Clonglong}, inembed::Ptr{Clonglong},
+                                               istride::Clonglong, idist::Clonglong,
+                                               onembed::Ptr{Clonglong}, ostride::Clonglong,
+                                               odist::Clonglong, type::cufftType,
+                                               batch::Clonglong,
+                                               workSize::Ptr{Csize_t})::cufftResult
 end
 
 @checked function cufftGetSizeMany64(plan, rank, n, inembed, istride, idist, onembed,
                                      ostride, odist, type, batch, workSize)
     initialize_context()
-    @ccall libcufft.cufftGetSizeMany64(plan::cufftHandle, rank::Cint, n::Ptr{Clonglong},
-                                       inembed::Ptr{Clonglong}, istride::Clonglong,
-                                       idist::Clonglong, onembed::Ptr{Clonglong},
-                                       ostride::Clonglong, odist::Clonglong,
-                                       type::cufftType, batch::Clonglong,
-                                       workSize::Ptr{Csize_t})::cufftResult
+    @gcsafe_ccall libcufft.cufftGetSizeMany64(plan::cufftHandle, rank::Cint,
+                                              n::Ptr{Clonglong}, inembed::Ptr{Clonglong},
+                                              istride::Clonglong, idist::Clonglong,
+                                              onembed::Ptr{Clonglong}, ostride::Clonglong,
+                                              odist::Clonglong, type::cufftType,
+                                              batch::Clonglong,
+                                              workSize::Ptr{Csize_t})::cufftResult
 end
 
 @checked function cufftEstimate1d(nx, type, batch, workSize)
     initialize_context()
-    @ccall libcufft.cufftEstimate1d(nx::Cint, type::cufftType, batch::Cint,
-                                    workSize::Ptr{Csize_t})::cufftResult
+    @gcsafe_ccall libcufft.cufftEstimate1d(nx::Cint, type::cufftType, batch::Cint,
+                                           workSize::Ptr{Csize_t})::cufftResult
 end
 
 @checked function cufftEstimate2d(nx, ny, type, workSize)
     initialize_context()
-    @ccall libcufft.cufftEstimate2d(nx::Cint, ny::Cint, type::cufftType,
-                                    workSize::Ptr{Csize_t})::cufftResult
+    @gcsafe_ccall libcufft.cufftEstimate2d(nx::Cint, ny::Cint, type::cufftType,
+                                           workSize::Ptr{Csize_t})::cufftResult
 end
 
 @checked function cufftEstimate3d(nx, ny, nz, type, workSize)
     initialize_context()
-    @ccall libcufft.cufftEstimate3d(nx::Cint, ny::Cint, nz::Cint, type::cufftType,
-                                    workSize::Ptr{Csize_t})::cufftResult
+    @gcsafe_ccall libcufft.cufftEstimate3d(nx::Cint, ny::Cint, nz::Cint, type::cufftType,
+                                           workSize::Ptr{Csize_t})::cufftResult
 end
 
 @checked function cufftEstimateMany(rank, n, inembed, istride, idist, onembed, ostride,
                                     odist, type, batch, workSize)
     initialize_context()
-    @ccall libcufft.cufftEstimateMany(rank::Cint, n::Ptr{Cint}, inembed::Ptr{Cint},
-                                      istride::Cint, idist::Cint, onembed::Ptr{Cint},
-                                      ostride::Cint, odist::Cint, type::cufftType,
-                                      batch::Cint, workSize::Ptr{Csize_t})::cufftResult
+    @gcsafe_ccall libcufft.cufftEstimateMany(rank::Cint, n::Ptr{Cint}, inembed::Ptr{Cint},
+                                             istride::Cint, idist::Cint, onembed::Ptr{Cint},
+                                             ostride::Cint, odist::Cint, type::cufftType,
+                                             batch::Cint,
+                                             workSize::Ptr{Csize_t})::cufftResult
 end
 
 @checked function cufftCreate(handle)
     initialize_context()
-    @ccall libcufft.cufftCreate(handle::Ptr{cufftHandle})::cufftResult
+    @gcsafe_ccall libcufft.cufftCreate(handle::Ptr{cufftHandle})::cufftResult
 end
 
 @checked function cufftGetSize1d(handle, nx, type, batch, workSize)
     initialize_context()
-    @ccall libcufft.cufftGetSize1d(handle::cufftHandle, nx::Cint, type::cufftType,
-                                   batch::Cint, workSize::Ptr{Csize_t})::cufftResult
+    @gcsafe_ccall libcufft.cufftGetSize1d(handle::cufftHandle, nx::Cint, type::cufftType,
+                                          batch::Cint, workSize::Ptr{Csize_t})::cufftResult
 end
 
 @checked function cufftGetSize2d(handle, nx, ny, type, workSize)
     initialize_context()
-    @ccall libcufft.cufftGetSize2d(handle::cufftHandle, nx::Cint, ny::Cint, type::cufftType,
-                                   workSize::Ptr{Csize_t})::cufftResult
+    @gcsafe_ccall libcufft.cufftGetSize2d(handle::cufftHandle, nx::Cint, ny::Cint,
+                                          type::cufftType,
+                                          workSize::Ptr{Csize_t})::cufftResult
 end
 
 @checked function cufftGetSize3d(handle, nx, ny, nz, type, workSize)
     initialize_context()
-    @ccall libcufft.cufftGetSize3d(handle::cufftHandle, nx::Cint, ny::Cint, nz::Cint,
-                                   type::cufftType, workSize::Ptr{Csize_t})::cufftResult
+    @gcsafe_ccall libcufft.cufftGetSize3d(handle::cufftHandle, nx::Cint, ny::Cint, nz::Cint,
+                                          type::cufftType,
+                                          workSize::Ptr{Csize_t})::cufftResult
 end
 
 @checked function cufftGetSizeMany(handle, rank, n, inembed, istride, idist, onembed,
                                    ostride, odist, type, batch, workArea)
     initialize_context()
-    @ccall libcufft.cufftGetSizeMany(handle::cufftHandle, rank::Cint, n::Ptr{Cint},
-                                     inembed::Ptr{Cint}, istride::Cint, idist::Cint,
-                                     onembed::Ptr{Cint}, ostride::Cint, odist::Cint,
-                                     type::cufftType, batch::Cint,
-                                     workArea::Ptr{Csize_t})::cufftResult
+    @gcsafe_ccall libcufft.cufftGetSizeMany(handle::cufftHandle, rank::Cint, n::Ptr{Cint},
+                                            inembed::Ptr{Cint}, istride::Cint, idist::Cint,
+                                            onembed::Ptr{Cint}, ostride::Cint, odist::Cint,
+                                            type::cufftType, batch::Cint,
+                                            workArea::Ptr{Csize_t})::cufftResult
 end
 
 @checked function cufftGetSize(handle, workSize)
     initialize_context()
-    @ccall libcufft.cufftGetSize(handle::cufftHandle, workSize::Ptr{Csize_t})::cufftResult
+    @gcsafe_ccall libcufft.cufftGetSize(handle::cufftHandle,
+                                        workSize::Ptr{Csize_t})::cufftResult
 end
 
 @checked function cufftSetWorkArea(plan, workArea)
     initialize_context()
-    @ccall libcufft.cufftSetWorkArea(plan::cufftHandle, workArea::CuPtr{Cvoid})::cufftResult
+    @gcsafe_ccall libcufft.cufftSetWorkArea(plan::cufftHandle,
+                                            workArea::CuPtr{Cvoid})::cufftResult
 end
 
 @checked function cufftSetAutoAllocation(plan, autoAllocate)
     initialize_context()
-    @ccall libcufft.cufftSetAutoAllocation(plan::cufftHandle,
-                                           autoAllocate::Cint)::cufftResult
+    @gcsafe_ccall libcufft.cufftSetAutoAllocation(plan::cufftHandle,
+                                                  autoAllocate::Cint)::cufftResult
 end
 
 @checked function cufftExecC2C(plan, idata, odata, direction)
     initialize_context()
-    @ccall libcufft.cufftExecC2C(plan::cufftHandle, idata::CuPtr{cufftComplex},
-                                 odata::CuPtr{cufftComplex}, direction::Cint)::cufftResult
+    @gcsafe_ccall libcufft.cufftExecC2C(plan::cufftHandle, idata::CuPtr{cufftComplex},
+                                        odata::CuPtr{cufftComplex},
+                                        direction::Cint)::cufftResult
 end
 
 @checked function cufftExecR2C(plan, idata, odata)
     initialize_context()
-    @ccall libcufft.cufftExecR2C(plan::cufftHandle, idata::CuPtr{cufftReal},
-                                 odata::CuPtr{cufftComplex})::cufftResult
+    @gcsafe_ccall libcufft.cufftExecR2C(plan::cufftHandle, idata::CuPtr{cufftReal},
+                                        odata::CuPtr{cufftComplex})::cufftResult
 end
 
 @checked function cufftExecC2R(plan, idata, odata)
     initialize_context()
-    @ccall libcufft.cufftExecC2R(plan::cufftHandle, idata::CuPtr{cufftComplex},
-                                 odata::CuPtr{cufftReal})::cufftResult
+    @gcsafe_ccall libcufft.cufftExecC2R(plan::cufftHandle, idata::CuPtr{cufftComplex},
+                                        odata::CuPtr{cufftReal})::cufftResult
 end
 
 @checked function cufftExecZ2Z(plan, idata, odata, direction)
     initialize_context()
-    @ccall libcufft.cufftExecZ2Z(plan::cufftHandle, idata::CuPtr{cufftDoubleComplex},
-                                 odata::CuPtr{cufftDoubleComplex},
-                                 direction::Cint)::cufftResult
+    @gcsafe_ccall libcufft.cufftExecZ2Z(plan::cufftHandle, idata::CuPtr{cufftDoubleComplex},
+                                        odata::CuPtr{cufftDoubleComplex},
+                                        direction::Cint)::cufftResult
 end
 
 @checked function cufftExecD2Z(plan, idata, odata)
     initialize_context()
-    @ccall libcufft.cufftExecD2Z(plan::cufftHandle, idata::CuPtr{cufftDoubleReal},
-                                 odata::CuPtr{cufftDoubleComplex})::cufftResult
+    @gcsafe_ccall libcufft.cufftExecD2Z(plan::cufftHandle, idata::CuPtr{cufftDoubleReal},
+                                        odata::CuPtr{cufftDoubleComplex})::cufftResult
 end
 
 @checked function cufftExecZ2D(plan, idata, odata)
     initialize_context()
-    @ccall libcufft.cufftExecZ2D(plan::cufftHandle, idata::CuPtr{cufftDoubleComplex},
-                                 odata::CuPtr{cufftDoubleReal})::cufftResult
+    @gcsafe_ccall libcufft.cufftExecZ2D(plan::cufftHandle, idata::CuPtr{cufftDoubleComplex},
+                                        odata::CuPtr{cufftDoubleReal})::cufftResult
 end
 
 @checked function cufftSetStream(plan, stream)
     initialize_context()
-    @ccall libcufft.cufftSetStream(plan::cufftHandle, stream::cudaStream_t)::cufftResult
+    @gcsafe_ccall libcufft.cufftSetStream(plan::cufftHandle,
+                                          stream::cudaStream_t)::cufftResult
 end
 
 @checked function cufftDestroy(plan)
     initialize_context()
-    @ccall libcufft.cufftDestroy(plan::cufftHandle)::cufftResult
+    @gcsafe_ccall libcufft.cufftDestroy(plan::cufftHandle)::cufftResult
 end
 
 @checked function cufftGetVersion(version)
-    @ccall libcufft.cufftGetVersion(version::Ptr{Cint})::cufftResult
+    @gcsafe_ccall libcufft.cufftGetVersion(version::Ptr{Cint})::cufftResult
 end
 
 @checked function cufftGetProperty(type, value)
-    @ccall libcufft.cufftGetProperty(type::libraryPropertyType,
-                                     value::Ptr{Cint})::cufftResult
+    @gcsafe_ccall libcufft.cufftGetProperty(type::libraryPropertyType,
+                                            value::Ptr{Cint})::cufftResult
 end
 
 # Skipping MacroDefinition: CUFFTAPI __attribute__ ( ( visibility ( "default" ) ) )

--- a/lib/cupti/libcupti.jl
+++ b/lib/cupti/libcupti.jl
@@ -85,18 +85,18 @@ end
 end
 
 @checked function cuptiGetResultString(result, str)
-    @ccall libcupti.cuptiGetResultString(result::CUptiResult,
-                                         str::Ptr{Cstring})::CUptiResult
+    @gcsafe_ccall libcupti.cuptiGetResultString(result::CUptiResult,
+                                                str::Ptr{Cstring})::CUptiResult
 end
 
 @checked function cuptiGetErrorMessage(result, str)
     initialize_context()
-    @ccall libcupti.cuptiGetErrorMessage(result::CUptiResult,
-                                         str::Ptr{Cstring})::CUptiResult
+    @gcsafe_ccall libcupti.cuptiGetErrorMessage(result::CUptiResult,
+                                                str::Ptr{Cstring})::CUptiResult
 end
 
 @checked function cuptiGetVersion(version)
-    @ccall libcupti.cuptiGetVersion(version::Ptr{UInt32})::CUptiResult
+    @gcsafe_ccall libcupti.cuptiGetVersion(version::Ptr{UInt32})::CUptiResult
 end
 
 @cenum CUpti_ApiCallbackSite::UInt32 begin
@@ -281,53 +281,55 @@ const CUpti_DomainTable = Ptr{CUpti_CallbackDomain}
 
 @checked function cuptiSupportedDomains(domainCount, domainTable)
     initialize_context()
-    @ccall libcupti.cuptiSupportedDomains(domainCount::Ptr{Csize_t},
-                                          domainTable::Ptr{CUpti_DomainTable})::CUptiResult
+    @gcsafe_ccall libcupti.cuptiSupportedDomains(domainCount::Ptr{Csize_t},
+                                                 domainTable::Ptr{CUpti_DomainTable})::CUptiResult
 end
 
 @checked function cuptiSubscribe(subscriber, callback, userdata)
     initialize_context()
-    @ccall libcupti.cuptiSubscribe(subscriber::Ptr{CUpti_SubscriberHandle},
-                                   callback::CUpti_CallbackFunc,
-                                   userdata::Ptr{Cvoid})::CUptiResult
+    @gcsafe_ccall libcupti.cuptiSubscribe(subscriber::Ptr{CUpti_SubscriberHandle},
+                                          callback::CUpti_CallbackFunc,
+                                          userdata::Ptr{Cvoid})::CUptiResult
 end
 
 @checked function cuptiUnsubscribe(subscriber)
     initialize_context()
-    @ccall libcupti.cuptiUnsubscribe(subscriber::CUpti_SubscriberHandle)::CUptiResult
+    @gcsafe_ccall libcupti.cuptiUnsubscribe(subscriber::CUpti_SubscriberHandle)::CUptiResult
 end
 
 @checked function cuptiGetCallbackState(enable, subscriber, domain, cbid)
     initialize_context()
-    @ccall libcupti.cuptiGetCallbackState(enable::Ptr{UInt32},
-                                          subscriber::CUpti_SubscriberHandle,
-                                          domain::CUpti_CallbackDomain,
-                                          cbid::CUpti_CallbackId)::CUptiResult
+    @gcsafe_ccall libcupti.cuptiGetCallbackState(enable::Ptr{UInt32},
+                                                 subscriber::CUpti_SubscriberHandle,
+                                                 domain::CUpti_CallbackDomain,
+                                                 cbid::CUpti_CallbackId)::CUptiResult
 end
 
 @checked function cuptiEnableCallback(enable, subscriber, domain, cbid)
     initialize_context()
-    @ccall libcupti.cuptiEnableCallback(enable::UInt32, subscriber::CUpti_SubscriberHandle,
-                                        domain::CUpti_CallbackDomain,
-                                        cbid::CUpti_CallbackId)::CUptiResult
+    @gcsafe_ccall libcupti.cuptiEnableCallback(enable::UInt32,
+                                               subscriber::CUpti_SubscriberHandle,
+                                               domain::CUpti_CallbackDomain,
+                                               cbid::CUpti_CallbackId)::CUptiResult
 end
 
 @checked function cuptiEnableDomain(enable, subscriber, domain)
     initialize_context()
-    @ccall libcupti.cuptiEnableDomain(enable::UInt32, subscriber::CUpti_SubscriberHandle,
-                                      domain::CUpti_CallbackDomain)::CUptiResult
+    @gcsafe_ccall libcupti.cuptiEnableDomain(enable::UInt32,
+                                             subscriber::CUpti_SubscriberHandle,
+                                             domain::CUpti_CallbackDomain)::CUptiResult
 end
 
 @checked function cuptiEnableAllDomains(enable, subscriber)
     initialize_context()
-    @ccall libcupti.cuptiEnableAllDomains(enable::UInt32,
-                                          subscriber::CUpti_SubscriberHandle)::CUptiResult
+    @gcsafe_ccall libcupti.cuptiEnableAllDomains(enable::UInt32,
+                                                 subscriber::CUpti_SubscriberHandle)::CUptiResult
 end
 
 @checked function cuptiGetCallbackName(domain, cbid, name)
     initialize_context()
-    @ccall libcupti.cuptiGetCallbackName(domain::CUpti_CallbackDomain, cbid::UInt32,
-                                         name::Ptr{Cstring})::CUptiResult
+    @gcsafe_ccall libcupti.cuptiGetCallbackName(domain::CUpti_CallbackDomain, cbid::UInt32,
+                                                name::Ptr{Cstring})::CUptiResult
 end
 
 const CUpti_EventID = UInt32
@@ -442,201 +444,202 @@ end
 
 @checked function cuptiSetEventCollectionMode(context, mode)
     initialize_context()
-    @ccall libcupti.cuptiSetEventCollectionMode(context::CUcontext,
-                                                mode::CUpti_EventCollectionMode)::CUptiResult
+    @gcsafe_ccall libcupti.cuptiSetEventCollectionMode(context::CUcontext,
+                                                       mode::CUpti_EventCollectionMode)::CUptiResult
 end
 
 @checked function cuptiDeviceGetAttribute(device, attrib, valueSize, value)
     initialize_context()
-    @ccall libcupti.cuptiDeviceGetAttribute(device::CUdevice, attrib::CUpti_DeviceAttribute,
-                                            valueSize::Ptr{Csize_t},
-                                            value::Ptr{Cvoid})::CUptiResult
+    @gcsafe_ccall libcupti.cuptiDeviceGetAttribute(device::CUdevice,
+                                                   attrib::CUpti_DeviceAttribute,
+                                                   valueSize::Ptr{Csize_t},
+                                                   value::Ptr{Cvoid})::CUptiResult
 end
 
 @checked function cuptiDeviceGetNumEventDomains(device, numDomains)
     initialize_context()
-    @ccall libcupti.cuptiDeviceGetNumEventDomains(device::CUdevice,
-                                                  numDomains::Ptr{UInt32})::CUptiResult
+    @gcsafe_ccall libcupti.cuptiDeviceGetNumEventDomains(device::CUdevice,
+                                                         numDomains::Ptr{UInt32})::CUptiResult
 end
 
 @checked function cuptiDeviceEnumEventDomains(device, arraySizeBytes, domainArray)
     initialize_context()
-    @ccall libcupti.cuptiDeviceEnumEventDomains(device::CUdevice,
-                                                arraySizeBytes::Ptr{Csize_t},
-                                                domainArray::Ptr{CUpti_EventDomainID})::CUptiResult
+    @gcsafe_ccall libcupti.cuptiDeviceEnumEventDomains(device::CUdevice,
+                                                       arraySizeBytes::Ptr{Csize_t},
+                                                       domainArray::Ptr{CUpti_EventDomainID})::CUptiResult
 end
 
 @checked function cuptiDeviceGetEventDomainAttribute(device, eventDomain, attrib, valueSize,
                                                      value)
     initialize_context()
-    @ccall libcupti.cuptiDeviceGetEventDomainAttribute(device::CUdevice,
-                                                       eventDomain::CUpti_EventDomainID,
-                                                       attrib::CUpti_EventDomainAttribute,
-                                                       valueSize::Ptr{Csize_t},
-                                                       value::Ptr{Cvoid})::CUptiResult
+    @gcsafe_ccall libcupti.cuptiDeviceGetEventDomainAttribute(device::CUdevice,
+                                                              eventDomain::CUpti_EventDomainID,
+                                                              attrib::CUpti_EventDomainAttribute,
+                                                              valueSize::Ptr{Csize_t},
+                                                              value::Ptr{Cvoid})::CUptiResult
 end
 
 @checked function cuptiGetNumEventDomains(numDomains)
     initialize_context()
-    @ccall libcupti.cuptiGetNumEventDomains(numDomains::Ptr{UInt32})::CUptiResult
+    @gcsafe_ccall libcupti.cuptiGetNumEventDomains(numDomains::Ptr{UInt32})::CUptiResult
 end
 
 @checked function cuptiEnumEventDomains(arraySizeBytes, domainArray)
     initialize_context()
-    @ccall libcupti.cuptiEnumEventDomains(arraySizeBytes::Ptr{Csize_t},
-                                          domainArray::Ptr{CUpti_EventDomainID})::CUptiResult
+    @gcsafe_ccall libcupti.cuptiEnumEventDomains(arraySizeBytes::Ptr{Csize_t},
+                                                 domainArray::Ptr{CUpti_EventDomainID})::CUptiResult
 end
 
 @checked function cuptiEventDomainGetAttribute(eventDomain, attrib, valueSize, value)
     initialize_context()
-    @ccall libcupti.cuptiEventDomainGetAttribute(eventDomain::CUpti_EventDomainID,
-                                                 attrib::CUpti_EventDomainAttribute,
-                                                 valueSize::Ptr{Csize_t},
-                                                 value::Ptr{Cvoid})::CUptiResult
+    @gcsafe_ccall libcupti.cuptiEventDomainGetAttribute(eventDomain::CUpti_EventDomainID,
+                                                        attrib::CUpti_EventDomainAttribute,
+                                                        valueSize::Ptr{Csize_t},
+                                                        value::Ptr{Cvoid})::CUptiResult
 end
 
 @checked function cuptiEventDomainGetNumEvents(eventDomain, numEvents)
     initialize_context()
-    @ccall libcupti.cuptiEventDomainGetNumEvents(eventDomain::CUpti_EventDomainID,
-                                                 numEvents::Ptr{UInt32})::CUptiResult
+    @gcsafe_ccall libcupti.cuptiEventDomainGetNumEvents(eventDomain::CUpti_EventDomainID,
+                                                        numEvents::Ptr{UInt32})::CUptiResult
 end
 
 @checked function cuptiEventDomainEnumEvents(eventDomain, arraySizeBytes, eventArray)
     initialize_context()
-    @ccall libcupti.cuptiEventDomainEnumEvents(eventDomain::CUpti_EventDomainID,
-                                               arraySizeBytes::Ptr{Csize_t},
-                                               eventArray::Ptr{CUpti_EventID})::CUptiResult
+    @gcsafe_ccall libcupti.cuptiEventDomainEnumEvents(eventDomain::CUpti_EventDomainID,
+                                                      arraySizeBytes::Ptr{Csize_t},
+                                                      eventArray::Ptr{CUpti_EventID})::CUptiResult
 end
 
 @checked function cuptiEventGetAttribute(event, attrib, valueSize, value)
     initialize_context()
-    @ccall libcupti.cuptiEventGetAttribute(event::CUpti_EventID,
-                                           attrib::CUpti_EventAttribute,
-                                           valueSize::Ptr{Csize_t},
-                                           value::Ptr{Cvoid})::CUptiResult
+    @gcsafe_ccall libcupti.cuptiEventGetAttribute(event::CUpti_EventID,
+                                                  attrib::CUpti_EventAttribute,
+                                                  valueSize::Ptr{Csize_t},
+                                                  value::Ptr{Cvoid})::CUptiResult
 end
 
 @checked function cuptiEventGetIdFromName(device, eventName, event)
     initialize_context()
-    @ccall libcupti.cuptiEventGetIdFromName(device::CUdevice, eventName::Cstring,
-                                            event::Ptr{CUpti_EventID})::CUptiResult
+    @gcsafe_ccall libcupti.cuptiEventGetIdFromName(device::CUdevice, eventName::Cstring,
+                                                   event::Ptr{CUpti_EventID})::CUptiResult
 end
 
 @checked function cuptiEventGroupCreate(context, eventGroup, flags)
     initialize_context()
-    @ccall libcupti.cuptiEventGroupCreate(context::CUcontext,
-                                          eventGroup::Ptr{CUpti_EventGroup},
-                                          flags::UInt32)::CUptiResult
+    @gcsafe_ccall libcupti.cuptiEventGroupCreate(context::CUcontext,
+                                                 eventGroup::Ptr{CUpti_EventGroup},
+                                                 flags::UInt32)::CUptiResult
 end
 
 @checked function cuptiEventGroupDestroy(eventGroup)
     initialize_context()
-    @ccall libcupti.cuptiEventGroupDestroy(eventGroup::CUpti_EventGroup)::CUptiResult
+    @gcsafe_ccall libcupti.cuptiEventGroupDestroy(eventGroup::CUpti_EventGroup)::CUptiResult
 end
 
 @checked function cuptiEventGroupGetAttribute(eventGroup, attrib, valueSize, value)
     initialize_context()
-    @ccall libcupti.cuptiEventGroupGetAttribute(eventGroup::CUpti_EventGroup,
-                                                attrib::CUpti_EventGroupAttribute,
-                                                valueSize::Ptr{Csize_t},
-                                                value::Ptr{Cvoid})::CUptiResult
+    @gcsafe_ccall libcupti.cuptiEventGroupGetAttribute(eventGroup::CUpti_EventGroup,
+                                                       attrib::CUpti_EventGroupAttribute,
+                                                       valueSize::Ptr{Csize_t},
+                                                       value::Ptr{Cvoid})::CUptiResult
 end
 
 @checked function cuptiEventGroupSetAttribute(eventGroup, attrib, valueSize, value)
     initialize_context()
-    @ccall libcupti.cuptiEventGroupSetAttribute(eventGroup::CUpti_EventGroup,
-                                                attrib::CUpti_EventGroupAttribute,
-                                                valueSize::Csize_t,
-                                                value::Ptr{Cvoid})::CUptiResult
+    @gcsafe_ccall libcupti.cuptiEventGroupSetAttribute(eventGroup::CUpti_EventGroup,
+                                                       attrib::CUpti_EventGroupAttribute,
+                                                       valueSize::Csize_t,
+                                                       value::Ptr{Cvoid})::CUptiResult
 end
 
 @checked function cuptiEventGroupAddEvent(eventGroup, event)
     initialize_context()
-    @ccall libcupti.cuptiEventGroupAddEvent(eventGroup::CUpti_EventGroup,
-                                            event::CUpti_EventID)::CUptiResult
+    @gcsafe_ccall libcupti.cuptiEventGroupAddEvent(eventGroup::CUpti_EventGroup,
+                                                   event::CUpti_EventID)::CUptiResult
 end
 
 @checked function cuptiEventGroupRemoveEvent(eventGroup, event)
     initialize_context()
-    @ccall libcupti.cuptiEventGroupRemoveEvent(eventGroup::CUpti_EventGroup,
-                                               event::CUpti_EventID)::CUptiResult
+    @gcsafe_ccall libcupti.cuptiEventGroupRemoveEvent(eventGroup::CUpti_EventGroup,
+                                                      event::CUpti_EventID)::CUptiResult
 end
 
 @checked function cuptiEventGroupRemoveAllEvents(eventGroup)
     initialize_context()
-    @ccall libcupti.cuptiEventGroupRemoveAllEvents(eventGroup::CUpti_EventGroup)::CUptiResult
+    @gcsafe_ccall libcupti.cuptiEventGroupRemoveAllEvents(eventGroup::CUpti_EventGroup)::CUptiResult
 end
 
 @checked function cuptiEventGroupResetAllEvents(eventGroup)
     initialize_context()
-    @ccall libcupti.cuptiEventGroupResetAllEvents(eventGroup::CUpti_EventGroup)::CUptiResult
+    @gcsafe_ccall libcupti.cuptiEventGroupResetAllEvents(eventGroup::CUpti_EventGroup)::CUptiResult
 end
 
 @checked function cuptiEventGroupEnable(eventGroup)
     initialize_context()
-    @ccall libcupti.cuptiEventGroupEnable(eventGroup::CUpti_EventGroup)::CUptiResult
+    @gcsafe_ccall libcupti.cuptiEventGroupEnable(eventGroup::CUpti_EventGroup)::CUptiResult
 end
 
 @checked function cuptiEventGroupDisable(eventGroup)
     initialize_context()
-    @ccall libcupti.cuptiEventGroupDisable(eventGroup::CUpti_EventGroup)::CUptiResult
+    @gcsafe_ccall libcupti.cuptiEventGroupDisable(eventGroup::CUpti_EventGroup)::CUptiResult
 end
 
 @checked function cuptiEventGroupReadEvent(eventGroup, flags, event,
                                            eventValueBufferSizeBytes, eventValueBuffer)
     initialize_context()
-    @ccall libcupti.cuptiEventGroupReadEvent(eventGroup::CUpti_EventGroup,
-                                             flags::CUpti_ReadEventFlags,
-                                             event::CUpti_EventID,
-                                             eventValueBufferSizeBytes::Ptr{Csize_t},
-                                             eventValueBuffer::Ptr{UInt64})::CUptiResult
+    @gcsafe_ccall libcupti.cuptiEventGroupReadEvent(eventGroup::CUpti_EventGroup,
+                                                    flags::CUpti_ReadEventFlags,
+                                                    event::CUpti_EventID,
+                                                    eventValueBufferSizeBytes::Ptr{Csize_t},
+                                                    eventValueBuffer::Ptr{UInt64})::CUptiResult
 end
 
 @checked function cuptiEventGroupReadAllEvents(eventGroup, flags, eventValueBufferSizeBytes,
                                                eventValueBuffer, eventIdArraySizeBytes,
                                                eventIdArray, numEventIdsRead)
     initialize_context()
-    @ccall libcupti.cuptiEventGroupReadAllEvents(eventGroup::CUpti_EventGroup,
-                                                 flags::CUpti_ReadEventFlags,
-                                                 eventValueBufferSizeBytes::Ptr{Csize_t},
-                                                 eventValueBuffer::Ptr{UInt64},
-                                                 eventIdArraySizeBytes::Ptr{Csize_t},
-                                                 eventIdArray::Ptr{CUpti_EventID},
-                                                 numEventIdsRead::Ptr{Csize_t})::CUptiResult
+    @gcsafe_ccall libcupti.cuptiEventGroupReadAllEvents(eventGroup::CUpti_EventGroup,
+                                                        flags::CUpti_ReadEventFlags,
+                                                        eventValueBufferSizeBytes::Ptr{Csize_t},
+                                                        eventValueBuffer::Ptr{UInt64},
+                                                        eventIdArraySizeBytes::Ptr{Csize_t},
+                                                        eventIdArray::Ptr{CUpti_EventID},
+                                                        numEventIdsRead::Ptr{Csize_t})::CUptiResult
 end
 
 @checked function cuptiEventGroupSetsCreate(context, eventIdArraySizeBytes, eventIdArray,
                                             eventGroupPasses)
     initialize_context()
-    @ccall libcupti.cuptiEventGroupSetsCreate(context::CUcontext,
-                                              eventIdArraySizeBytes::Csize_t,
-                                              eventIdArray::Ptr{CUpti_EventID},
-                                              eventGroupPasses::Ptr{Ptr{CUpti_EventGroupSets}})::CUptiResult
+    @gcsafe_ccall libcupti.cuptiEventGroupSetsCreate(context::CUcontext,
+                                                     eventIdArraySizeBytes::Csize_t,
+                                                     eventIdArray::Ptr{CUpti_EventID},
+                                                     eventGroupPasses::Ptr{Ptr{CUpti_EventGroupSets}})::CUptiResult
 end
 
 @checked function cuptiEventGroupSetsDestroy(eventGroupSets)
     initialize_context()
-    @ccall libcupti.cuptiEventGroupSetsDestroy(eventGroupSets::Ptr{CUpti_EventGroupSets})::CUptiResult
+    @gcsafe_ccall libcupti.cuptiEventGroupSetsDestroy(eventGroupSets::Ptr{CUpti_EventGroupSets})::CUptiResult
 end
 
 @checked function cuptiEventGroupSetEnable(eventGroupSet)
     initialize_context()
-    @ccall libcupti.cuptiEventGroupSetEnable(eventGroupSet::Ptr{CUpti_EventGroupSet})::CUptiResult
+    @gcsafe_ccall libcupti.cuptiEventGroupSetEnable(eventGroupSet::Ptr{CUpti_EventGroupSet})::CUptiResult
 end
 
 @checked function cuptiEventGroupSetDisable(eventGroupSet)
     initialize_context()
-    @ccall libcupti.cuptiEventGroupSetDisable(eventGroupSet::Ptr{CUpti_EventGroupSet})::CUptiResult
+    @gcsafe_ccall libcupti.cuptiEventGroupSetDisable(eventGroupSet::Ptr{CUpti_EventGroupSet})::CUptiResult
 end
 
 @checked function cuptiEnableKernelReplayMode(context)
     initialize_context()
-    @ccall libcupti.cuptiEnableKernelReplayMode(context::CUcontext)::CUptiResult
+    @gcsafe_ccall libcupti.cuptiEnableKernelReplayMode(context::CUcontext)::CUptiResult
 end
 
 @checked function cuptiDisableKernelReplayMode(context)
     initialize_context()
-    @ccall libcupti.cuptiDisableKernelReplayMode(context::CUcontext)::CUptiResult
+    @gcsafe_ccall libcupti.cuptiDisableKernelReplayMode(context::CUcontext)::CUptiResult
 end
 
 # typedef void ( CUPTIAPI * CUpti_KernelReplayUpdateFunc ) ( const char * kernelName , int numReplaysDone , void * customData )
@@ -644,8 +647,8 @@ const CUpti_KernelReplayUpdateFunc = Ptr{Cvoid}
 
 @checked function cuptiKernelReplaySubscribeUpdate(updateFunc, customData)
     initialize_context()
-    @ccall libcupti.cuptiKernelReplaySubscribeUpdate(updateFunc::CUpti_KernelReplayUpdateFunc,
-                                                     customData::Ptr{Cvoid})::CUptiResult
+    @gcsafe_ccall libcupti.cuptiKernelReplaySubscribeUpdate(updateFunc::CUpti_KernelReplayUpdateFunc,
+                                                            customData::Ptr{Cvoid})::CUptiResult
 end
 
 const CUpti_MetricID = UInt32
@@ -750,93 +753,95 @@ end
 
 @checked function cuptiGetNumMetrics(numMetrics)
     initialize_context()
-    @ccall libcupti.cuptiGetNumMetrics(numMetrics::Ptr{UInt32})::CUptiResult
+    @gcsafe_ccall libcupti.cuptiGetNumMetrics(numMetrics::Ptr{UInt32})::CUptiResult
 end
 
 @checked function cuptiEnumMetrics(arraySizeBytes, metricArray)
     initialize_context()
-    @ccall libcupti.cuptiEnumMetrics(arraySizeBytes::Ptr{Csize_t},
-                                     metricArray::Ptr{CUpti_MetricID})::CUptiResult
+    @gcsafe_ccall libcupti.cuptiEnumMetrics(arraySizeBytes::Ptr{Csize_t},
+                                            metricArray::Ptr{CUpti_MetricID})::CUptiResult
 end
 
 @checked function cuptiDeviceGetNumMetrics(device, numMetrics)
     initialize_context()
-    @ccall libcupti.cuptiDeviceGetNumMetrics(device::CUdevice,
-                                             numMetrics::Ptr{UInt32})::CUptiResult
+    @gcsafe_ccall libcupti.cuptiDeviceGetNumMetrics(device::CUdevice,
+                                                    numMetrics::Ptr{UInt32})::CUptiResult
 end
 
 @checked function cuptiDeviceEnumMetrics(device, arraySizeBytes, metricArray)
     initialize_context()
-    @ccall libcupti.cuptiDeviceEnumMetrics(device::CUdevice, arraySizeBytes::Ptr{Csize_t},
-                                           metricArray::Ptr{CUpti_MetricID})::CUptiResult
+    @gcsafe_ccall libcupti.cuptiDeviceEnumMetrics(device::CUdevice,
+                                                  arraySizeBytes::Ptr{Csize_t},
+                                                  metricArray::Ptr{CUpti_MetricID})::CUptiResult
 end
 
 @checked function cuptiMetricGetAttribute(metric, attrib, valueSize, value)
     initialize_context()
-    @ccall libcupti.cuptiMetricGetAttribute(metric::CUpti_MetricID,
-                                            attrib::CUpti_MetricAttribute,
-                                            valueSize::Ptr{Csize_t},
-                                            value::Ptr{Cvoid})::CUptiResult
+    @gcsafe_ccall libcupti.cuptiMetricGetAttribute(metric::CUpti_MetricID,
+                                                   attrib::CUpti_MetricAttribute,
+                                                   valueSize::Ptr{Csize_t},
+                                                   value::Ptr{Cvoid})::CUptiResult
 end
 
 @checked function cuptiMetricGetIdFromName(device, metricName, metric)
     initialize_context()
-    @ccall libcupti.cuptiMetricGetIdFromName(device::CUdevice, metricName::Cstring,
-                                             metric::Ptr{CUpti_MetricID})::CUptiResult
+    @gcsafe_ccall libcupti.cuptiMetricGetIdFromName(device::CUdevice, metricName::Cstring,
+                                                    metric::Ptr{CUpti_MetricID})::CUptiResult
 end
 
 @checked function cuptiMetricGetNumEvents(metric, numEvents)
     initialize_context()
-    @ccall libcupti.cuptiMetricGetNumEvents(metric::CUpti_MetricID,
-                                            numEvents::Ptr{UInt32})::CUptiResult
+    @gcsafe_ccall libcupti.cuptiMetricGetNumEvents(metric::CUpti_MetricID,
+                                                   numEvents::Ptr{UInt32})::CUptiResult
 end
 
 @checked function cuptiMetricEnumEvents(metric, eventIdArraySizeBytes, eventIdArray)
     initialize_context()
-    @ccall libcupti.cuptiMetricEnumEvents(metric::CUpti_MetricID,
-                                          eventIdArraySizeBytes::Ptr{Csize_t},
-                                          eventIdArray::Ptr{CUpti_EventID})::CUptiResult
+    @gcsafe_ccall libcupti.cuptiMetricEnumEvents(metric::CUpti_MetricID,
+                                                 eventIdArraySizeBytes::Ptr{Csize_t},
+                                                 eventIdArray::Ptr{CUpti_EventID})::CUptiResult
 end
 
 @checked function cuptiMetricGetNumProperties(metric, numProp)
     initialize_context()
-    @ccall libcupti.cuptiMetricGetNumProperties(metric::CUpti_MetricID,
-                                                numProp::Ptr{UInt32})::CUptiResult
+    @gcsafe_ccall libcupti.cuptiMetricGetNumProperties(metric::CUpti_MetricID,
+                                                       numProp::Ptr{UInt32})::CUptiResult
 end
 
 @checked function cuptiMetricEnumProperties(metric, propIdArraySizeBytes, propIdArray)
     initialize_context()
-    @ccall libcupti.cuptiMetricEnumProperties(metric::CUpti_MetricID,
-                                              propIdArraySizeBytes::Ptr{Csize_t},
-                                              propIdArray::Ptr{CUpti_MetricPropertyID})::CUptiResult
+    @gcsafe_ccall libcupti.cuptiMetricEnumProperties(metric::CUpti_MetricID,
+                                                     propIdArraySizeBytes::Ptr{Csize_t},
+                                                     propIdArray::Ptr{CUpti_MetricPropertyID})::CUptiResult
 end
 
 @checked function cuptiMetricGetRequiredEventGroupSets(context, metric, eventGroupSets)
     initialize_context()
-    @ccall libcupti.cuptiMetricGetRequiredEventGroupSets(context::CUcontext,
-                                                         metric::CUpti_MetricID,
-                                                         eventGroupSets::Ptr{Ptr{CUpti_EventGroupSets}})::CUptiResult
+    @gcsafe_ccall libcupti.cuptiMetricGetRequiredEventGroupSets(context::CUcontext,
+                                                                metric::CUpti_MetricID,
+                                                                eventGroupSets::Ptr{Ptr{CUpti_EventGroupSets}})::CUptiResult
 end
 
 @checked function cuptiMetricCreateEventGroupSets(context, metricIdArraySizeBytes,
                                                   metricIdArray, eventGroupPasses)
     initialize_context()
-    @ccall libcupti.cuptiMetricCreateEventGroupSets(context::CUcontext,
-                                                    metricIdArraySizeBytes::Csize_t,
-                                                    metricIdArray::Ptr{CUpti_MetricID},
-                                                    eventGroupPasses::Ptr{Ptr{CUpti_EventGroupSets}})::CUptiResult
+    @gcsafe_ccall libcupti.cuptiMetricCreateEventGroupSets(context::CUcontext,
+                                                           metricIdArraySizeBytes::Csize_t,
+                                                           metricIdArray::Ptr{CUpti_MetricID},
+                                                           eventGroupPasses::Ptr{Ptr{CUpti_EventGroupSets}})::CUptiResult
 end
 
 @checked function cuptiMetricGetValue(device, metric, eventIdArraySizeBytes, eventIdArray,
                                       eventValueArraySizeBytes, eventValueArray,
                                       timeDuration, metricValue)
     initialize_context()
-    @ccall libcupti.cuptiMetricGetValue(device::CUdevice, metric::CUpti_MetricID,
-                                        eventIdArraySizeBytes::Csize_t,
-                                        eventIdArray::Ptr{CUpti_EventID},
-                                        eventValueArraySizeBytes::Csize_t,
-                                        eventValueArray::Ptr{UInt64}, timeDuration::UInt64,
-                                        metricValue::Ptr{CUpti_MetricValue})::CUptiResult
+    @gcsafe_ccall libcupti.cuptiMetricGetValue(device::CUdevice, metric::CUpti_MetricID,
+                                               eventIdArraySizeBytes::Csize_t,
+                                               eventIdArray::Ptr{CUpti_EventID},
+                                               eventValueArraySizeBytes::Csize_t,
+                                               eventValueArray::Ptr{UInt64},
+                                               timeDuration::UInt64,
+                                               metricValue::Ptr{CUpti_MetricValue})::CUptiResult
 end
 
 @checked function cuptiMetricGetValue2(metric, eventIdArraySizeBytes, eventIdArray,
@@ -844,16 +849,16 @@ end
                                        propIdArraySizeBytes, propIdArray,
                                        propValueArraySizeBytes, propValueArray, metricValue)
     initialize_context()
-    @ccall libcupti.cuptiMetricGetValue2(metric::CUpti_MetricID,
-                                         eventIdArraySizeBytes::Csize_t,
-                                         eventIdArray::Ptr{CUpti_EventID},
-                                         eventValueArraySizeBytes::Csize_t,
-                                         eventValueArray::Ptr{UInt64},
-                                         propIdArraySizeBytes::Csize_t,
-                                         propIdArray::Ptr{CUpti_MetricPropertyID},
-                                         propValueArraySizeBytes::Csize_t,
-                                         propValueArray::Ptr{UInt64},
-                                         metricValue::Ptr{CUpti_MetricValue})::CUptiResult
+    @gcsafe_ccall libcupti.cuptiMetricGetValue2(metric::CUpti_MetricID,
+                                                eventIdArraySizeBytes::Csize_t,
+                                                eventIdArray::Ptr{CUpti_EventID},
+                                                eventValueArraySizeBytes::Csize_t,
+                                                eventValueArray::Ptr{UInt64},
+                                                propIdArraySizeBytes::Csize_t,
+                                                propIdArray::Ptr{CUpti_MetricPropertyID},
+                                                propValueArraySizeBytes::Csize_t,
+                                                propValueArray::Ptr{UInt64},
+                                                metricValue::Ptr{CUpti_MetricValue})::CUptiResult
 end
 
 @cenum CUpti_ActivityKind::UInt32 begin
@@ -2470,87 +2475,90 @@ end
 
 @checked function cuptiGetTimestamp(timestamp)
     initialize_context()
-    @ccall libcupti.cuptiGetTimestamp(timestamp::Ptr{UInt64})::CUptiResult
+    @gcsafe_ccall libcupti.cuptiGetTimestamp(timestamp::Ptr{UInt64})::CUptiResult
 end
 
 @checked function cuptiGetContextId(context, contextId)
     initialize_context()
-    @ccall libcupti.cuptiGetContextId(context::CUcontext,
-                                      contextId::Ptr{UInt32})::CUptiResult
+    @gcsafe_ccall libcupti.cuptiGetContextId(context::CUcontext,
+                                             contextId::Ptr{UInt32})::CUptiResult
 end
 
 @checked function cuptiGetStreamId(context, stream, streamId)
     initialize_context()
-    @ccall libcupti.cuptiGetStreamId(context::CUcontext, stream::CUstream,
-                                     streamId::Ptr{UInt32})::CUptiResult
+    @gcsafe_ccall libcupti.cuptiGetStreamId(context::CUcontext, stream::CUstream,
+                                            streamId::Ptr{UInt32})::CUptiResult
 end
 
 @checked function cuptiGetStreamIdEx(context, stream, perThreadStream, streamId)
     initialize_context()
-    @ccall libcupti.cuptiGetStreamIdEx(context::CUcontext, stream::CUstream,
-                                       perThreadStream::UInt8,
-                                       streamId::Ptr{UInt32})::CUptiResult
+    @gcsafe_ccall libcupti.cuptiGetStreamIdEx(context::CUcontext, stream::CUstream,
+                                              perThreadStream::UInt8,
+                                              streamId::Ptr{UInt32})::CUptiResult
 end
 
 @checked function cuptiGetDeviceId(context, deviceId)
     initialize_context()
-    @ccall libcupti.cuptiGetDeviceId(context::CUcontext, deviceId::Ptr{UInt32})::CUptiResult
+    @gcsafe_ccall libcupti.cuptiGetDeviceId(context::CUcontext,
+                                            deviceId::Ptr{UInt32})::CUptiResult
 end
 
 @checked function cuptiGetGraphNodeId(node, nodeId)
     initialize_context()
-    @ccall libcupti.cuptiGetGraphNodeId(node::CUgraphNode, nodeId::Ptr{UInt64})::CUptiResult
+    @gcsafe_ccall libcupti.cuptiGetGraphNodeId(node::CUgraphNode,
+                                               nodeId::Ptr{UInt64})::CUptiResult
 end
 
 @checked function cuptiGetGraphId(graph, pId)
     initialize_context()
-    @ccall libcupti.cuptiGetGraphId(graph::CUgraph, pId::Ptr{UInt32})::CUptiResult
+    @gcsafe_ccall libcupti.cuptiGetGraphId(graph::CUgraph, pId::Ptr{UInt32})::CUptiResult
 end
 
 @checked function cuptiGetGraphExecId(graphExec, pId)
     initialize_context()
-    @ccall libcupti.cuptiGetGraphExecId(graphExec::CUgraphExec,
-                                        pId::Ptr{UInt32})::CUptiResult
+    @gcsafe_ccall libcupti.cuptiGetGraphExecId(graphExec::CUgraphExec,
+                                               pId::Ptr{UInt32})::CUptiResult
 end
 
 @checked function cuptiActivityEnable(kind)
     initialize_context()
-    @ccall libcupti.cuptiActivityEnable(kind::CUpti_ActivityKind)::CUptiResult
+    @gcsafe_ccall libcupti.cuptiActivityEnable(kind::CUpti_ActivityKind)::CUptiResult
 end
 
 @checked function cuptiActivityEnableAndDump(kind)
     initialize_context()
-    @ccall libcupti.cuptiActivityEnableAndDump(kind::CUpti_ActivityKind)::CUptiResult
+    @gcsafe_ccall libcupti.cuptiActivityEnableAndDump(kind::CUpti_ActivityKind)::CUptiResult
 end
 
 @checked function cuptiActivityDisable(kind)
     initialize_context()
-    @ccall libcupti.cuptiActivityDisable(kind::CUpti_ActivityKind)::CUptiResult
+    @gcsafe_ccall libcupti.cuptiActivityDisable(kind::CUpti_ActivityKind)::CUptiResult
 end
 
 @checked function cuptiActivityEnableContext(context, kind)
     initialize_context()
-    @ccall libcupti.cuptiActivityEnableContext(context::CUcontext,
-                                               kind::CUpti_ActivityKind)::CUptiResult
+    @gcsafe_ccall libcupti.cuptiActivityEnableContext(context::CUcontext,
+                                                      kind::CUpti_ActivityKind)::CUptiResult
 end
 
 @checked function cuptiActivityDisableContext(context, kind)
     initialize_context()
-    @ccall libcupti.cuptiActivityDisableContext(context::CUcontext,
-                                                kind::CUpti_ActivityKind)::CUptiResult
+    @gcsafe_ccall libcupti.cuptiActivityDisableContext(context::CUcontext,
+                                                       kind::CUpti_ActivityKind)::CUptiResult
 end
 
 @checked function cuptiActivityGetNumDroppedRecords(context, streamId, dropped)
     initialize_context()
-    @ccall libcupti.cuptiActivityGetNumDroppedRecords(context::CUcontext, streamId::UInt32,
-                                                      dropped::Ptr{Csize_t})::CUptiResult
+    @gcsafe_ccall libcupti.cuptiActivityGetNumDroppedRecords(context::CUcontext,
+                                                             streamId::UInt32,
+                                                             dropped::Ptr{Csize_t})::CUptiResult
 end
 
 @checked function cuptiActivityGetNextRecord(buffer, validBufferSizeBytes, record)
     initialize_context()
-    @ccall libcupti.cuptiActivityGetNextRecord(buffer::Ptr{UInt8},
-                                               validBufferSizeBytes::Csize_t,
-                                               record::Ptr{Ptr{CUpti_Activity}})::CUptiResult
+    @gcsafe_ccall libcupti.cuptiActivityGetNextRecord(buffer::Ptr{UInt8},
+                                                      validBufferSizeBytes::Csize_t,
+                                                      record::Ptr{Ptr{CUpti_Activity}})::CUptiResult
 end
 
 # typedef void ( CUPTIAPI * CUpti_BuffersCallbackRequestFunc ) ( uint8_t * * buffer , size_t * size , size_t * maxNumRecords )
@@ -2561,77 +2569,78 @@ const CUpti_BuffersCallbackCompleteFunc = Ptr{Cvoid}
 
 @checked function cuptiActivityRegisterCallbacks(funcBufferRequested, funcBufferCompleted)
     initialize_context()
-    @ccall libcupti.cuptiActivityRegisterCallbacks(funcBufferRequested::CUpti_BuffersCallbackRequestFunc,
-                                                   funcBufferCompleted::CUpti_BuffersCallbackCompleteFunc)::CUptiResult
+    @gcsafe_ccall libcupti.cuptiActivityRegisterCallbacks(funcBufferRequested::CUpti_BuffersCallbackRequestFunc,
+                                                          funcBufferCompleted::CUpti_BuffersCallbackCompleteFunc)::CUptiResult
 end
 
 @checked function cuptiActivityFlush(context, streamId, flag)
     initialize_context()
-    @ccall libcupti.cuptiActivityFlush(context::CUcontext, streamId::UInt32,
-                                       flag::UInt32)::CUptiResult
+    @gcsafe_ccall libcupti.cuptiActivityFlush(context::CUcontext, streamId::UInt32,
+                                              flag::UInt32)::CUptiResult
 end
 
 @checked function cuptiActivityFlushAll(flag)
     initialize_context()
-    @ccall libcupti.cuptiActivityFlushAll(flag::UInt32)::CUptiResult
+    @gcsafe_ccall libcupti.cuptiActivityFlushAll(flag::UInt32)::CUptiResult
 end
 
 @checked function cuptiActivityGetAttribute(attr, valueSize, value)
     initialize_context()
-    @ccall libcupti.cuptiActivityGetAttribute(attr::CUpti_ActivityAttribute,
-                                              valueSize::Ptr{Csize_t},
-                                              value::Ptr{Cvoid})::CUptiResult
+    @gcsafe_ccall libcupti.cuptiActivityGetAttribute(attr::CUpti_ActivityAttribute,
+                                                     valueSize::Ptr{Csize_t},
+                                                     value::Ptr{Cvoid})::CUptiResult
 end
 
 @checked function cuptiActivitySetAttribute(attr, valueSize, value)
     initialize_context()
-    @ccall libcupti.cuptiActivitySetAttribute(attr::CUpti_ActivityAttribute,
-                                              valueSize::Ptr{Csize_t},
-                                              value::Ptr{Cvoid})::CUptiResult
+    @gcsafe_ccall libcupti.cuptiActivitySetAttribute(attr::CUpti_ActivityAttribute,
+                                                     valueSize::Ptr{Csize_t},
+                                                     value::Ptr{Cvoid})::CUptiResult
 end
 
 @checked function cuptiActivityConfigureUnifiedMemoryCounter(config, count)
     initialize_context()
-    @ccall libcupti.cuptiActivityConfigureUnifiedMemoryCounter(config::Ptr{CUpti_ActivityUnifiedMemoryCounterConfig},
-                                                               count::UInt32)::CUptiResult
+    @gcsafe_ccall libcupti.cuptiActivityConfigureUnifiedMemoryCounter(config::Ptr{CUpti_ActivityUnifiedMemoryCounterConfig},
+                                                                      count::UInt32)::CUptiResult
 end
 
 @checked function cuptiGetAutoBoostState(context, state)
     initialize_context()
-    @ccall libcupti.cuptiGetAutoBoostState(context::CUcontext,
-                                           state::Ptr{CUpti_ActivityAutoBoostState})::CUptiResult
+    @gcsafe_ccall libcupti.cuptiGetAutoBoostState(context::CUcontext,
+                                                  state::Ptr{CUpti_ActivityAutoBoostState})::CUptiResult
 end
 
 @checked function cuptiActivityConfigurePCSampling(ctx, config)
     initialize_context()
-    @ccall libcupti.cuptiActivityConfigurePCSampling(ctx::CUcontext,
-                                                     config::Ptr{CUpti_ActivityPCSamplingConfig})::CUptiResult
+    @gcsafe_ccall libcupti.cuptiActivityConfigurePCSampling(ctx::CUcontext,
+                                                            config::Ptr{CUpti_ActivityPCSamplingConfig})::CUptiResult
 end
 
 @checked function cuptiGetLastError()
     initialize_context()
-    @ccall libcupti.cuptiGetLastError()::CUptiResult
+    @gcsafe_ccall libcupti.cuptiGetLastError()::CUptiResult
 end
 
 @checked function cuptiSetThreadIdType(type)
     initialize_context()
-    @ccall libcupti.cuptiSetThreadIdType(type::CUpti_ActivityThreadIdType)::CUptiResult
+    @gcsafe_ccall libcupti.cuptiSetThreadIdType(type::CUpti_ActivityThreadIdType)::CUptiResult
 end
 
 @checked function cuptiGetThreadIdType(type)
     initialize_context()
-    @ccall libcupti.cuptiGetThreadIdType(type::Ptr{CUpti_ActivityThreadIdType})::CUptiResult
+    @gcsafe_ccall libcupti.cuptiGetThreadIdType(type::Ptr{CUpti_ActivityThreadIdType})::CUptiResult
 end
 
 @checked function cuptiComputeCapabilitySupported(major, minor, support)
     initialize_context()
-    @ccall libcupti.cuptiComputeCapabilitySupported(major::Cint, minor::Cint,
-                                                    support::Ptr{Cint})::CUptiResult
+    @gcsafe_ccall libcupti.cuptiComputeCapabilitySupported(major::Cint, minor::Cint,
+                                                           support::Ptr{Cint})::CUptiResult
 end
 
 @checked function cuptiDeviceSupported(dev, support)
     initialize_context()
-    @ccall libcupti.cuptiDeviceSupported(dev::CUdevice, support::Ptr{Cint})::CUptiResult
+    @gcsafe_ccall libcupti.cuptiDeviceSupported(dev::CUdevice,
+                                                support::Ptr{Cint})::CUptiResult
 end
 
 @cenum CUpti_DeviceVirtualizationMode::UInt32 begin
@@ -2643,40 +2652,40 @@ end
 
 @checked function cuptiDeviceVirtualizationMode(dev, mode)
     initialize_context()
-    @ccall libcupti.cuptiDeviceVirtualizationMode(dev::CUdevice,
-                                                  mode::Ptr{CUpti_DeviceVirtualizationMode})::CUptiResult
+    @gcsafe_ccall libcupti.cuptiDeviceVirtualizationMode(dev::CUdevice,
+                                                         mode::Ptr{CUpti_DeviceVirtualizationMode})::CUptiResult
 end
 
 @checked function cuptiFinalize()
     initialize_context()
-    @ccall libcupti.cuptiFinalize()::CUptiResult
+    @gcsafe_ccall libcupti.cuptiFinalize()::CUptiResult
 end
 
 @checked function cuptiActivityPushExternalCorrelationId(kind, id)
     initialize_context()
-    @ccall libcupti.cuptiActivityPushExternalCorrelationId(kind::CUpti_ExternalCorrelationKind,
-                                                           id::UInt64)::CUptiResult
+    @gcsafe_ccall libcupti.cuptiActivityPushExternalCorrelationId(kind::CUpti_ExternalCorrelationKind,
+                                                                  id::UInt64)::CUptiResult
 end
 
 @checked function cuptiActivityPopExternalCorrelationId(kind, lastId)
     initialize_context()
-    @ccall libcupti.cuptiActivityPopExternalCorrelationId(kind::CUpti_ExternalCorrelationKind,
-                                                          lastId::Ptr{UInt64})::CUptiResult
+    @gcsafe_ccall libcupti.cuptiActivityPopExternalCorrelationId(kind::CUpti_ExternalCorrelationKind,
+                                                                 lastId::Ptr{UInt64})::CUptiResult
 end
 
 @checked function cuptiActivityEnableLatencyTimestamps(enable)
     initialize_context()
-    @ccall libcupti.cuptiActivityEnableLatencyTimestamps(enable::UInt8)::CUptiResult
+    @gcsafe_ccall libcupti.cuptiActivityEnableLatencyTimestamps(enable::UInt8)::CUptiResult
 end
 
 @checked function cuptiActivityFlushPeriod(time)
     initialize_context()
-    @ccall libcupti.cuptiActivityFlushPeriod(time::UInt32)::CUptiResult
+    @gcsafe_ccall libcupti.cuptiActivityFlushPeriod(time::UInt32)::CUptiResult
 end
 
 @checked function cuptiActivityEnableLaunchAttributes(enable)
     initialize_context()
-    @ccall libcupti.cuptiActivityEnableLaunchAttributes(enable::UInt8)::CUptiResult
+    @gcsafe_ccall libcupti.cuptiActivityEnableLaunchAttributes(enable::UInt8)::CUptiResult
 end
 
 # typedef uint64_t ( CUPTIAPI * CUpti_TimestampCallbackFunc ) ( void )
@@ -2684,12 +2693,12 @@ const CUpti_TimestampCallbackFunc = Ptr{Cvoid}
 
 @checked function cuptiActivityRegisterTimestampCallback(funcTimestamp)
     initialize_context()
-    @ccall libcupti.cuptiActivityRegisterTimestampCallback(funcTimestamp::CUpti_TimestampCallbackFunc)::CUptiResult
+    @gcsafe_ccall libcupti.cuptiActivityRegisterTimestampCallback(funcTimestamp::CUpti_TimestampCallbackFunc)::CUptiResult
 end
 
 @checked function cuptiActivityEnableDeviceGraph(enable)
     initialize_context()
-    @ccall libcupti.cuptiActivityEnableDeviceGraph(enable::UInt8)::CUptiResult
+    @gcsafe_ccall libcupti.cuptiActivityEnableDeviceGraph(enable::UInt8)::CUptiResult
 end
 
 struct CUpti_ActivityOverhead
@@ -5450,102 +5459,102 @@ end
 
 @checked function cuptiProfilerInitialize(pParams)
     initialize_context()
-    @ccall libcupti.cuptiProfilerInitialize(pParams::Ptr{CUpti_Profiler_Initialize_Params})::CUptiResult
+    @gcsafe_ccall libcupti.cuptiProfilerInitialize(pParams::Ptr{CUpti_Profiler_Initialize_Params})::CUptiResult
 end
 
 @checked function cuptiProfilerDeInitialize(pParams)
     initialize_context()
-    @ccall libcupti.cuptiProfilerDeInitialize(pParams::Ptr{CUpti_Profiler_DeInitialize_Params})::CUptiResult
+    @gcsafe_ccall libcupti.cuptiProfilerDeInitialize(pParams::Ptr{CUpti_Profiler_DeInitialize_Params})::CUptiResult
 end
 
 @checked function cuptiProfilerCounterDataImageCalculateSize(pParams)
     initialize_context()
-    @ccall libcupti.cuptiProfilerCounterDataImageCalculateSize(pParams::Ptr{CUpti_Profiler_CounterDataImage_CalculateSize_Params})::CUptiResult
+    @gcsafe_ccall libcupti.cuptiProfilerCounterDataImageCalculateSize(pParams::Ptr{CUpti_Profiler_CounterDataImage_CalculateSize_Params})::CUptiResult
 end
 
 @checked function cuptiProfilerCounterDataImageInitialize(pParams)
     initialize_context()
-    @ccall libcupti.cuptiProfilerCounterDataImageInitialize(pParams::Ptr{CUpti_Profiler_CounterDataImage_Initialize_Params})::CUptiResult
+    @gcsafe_ccall libcupti.cuptiProfilerCounterDataImageInitialize(pParams::Ptr{CUpti_Profiler_CounterDataImage_Initialize_Params})::CUptiResult
 end
 
 @checked function cuptiProfilerCounterDataImageCalculateScratchBufferSize(pParams)
     initialize_context()
-    @ccall libcupti.cuptiProfilerCounterDataImageCalculateScratchBufferSize(pParams::Ptr{CUpti_Profiler_CounterDataImage_CalculateScratchBufferSize_Params})::CUptiResult
+    @gcsafe_ccall libcupti.cuptiProfilerCounterDataImageCalculateScratchBufferSize(pParams::Ptr{CUpti_Profiler_CounterDataImage_CalculateScratchBufferSize_Params})::CUptiResult
 end
 
 @checked function cuptiProfilerCounterDataImageInitializeScratchBuffer(pParams)
     initialize_context()
-    @ccall libcupti.cuptiProfilerCounterDataImageInitializeScratchBuffer(pParams::Ptr{CUpti_Profiler_CounterDataImage_InitializeScratchBuffer_Params})::CUptiResult
+    @gcsafe_ccall libcupti.cuptiProfilerCounterDataImageInitializeScratchBuffer(pParams::Ptr{CUpti_Profiler_CounterDataImage_InitializeScratchBuffer_Params})::CUptiResult
 end
 
 @checked function cuptiProfilerBeginSession(pParams)
     initialize_context()
-    @ccall libcupti.cuptiProfilerBeginSession(pParams::Ptr{CUpti_Profiler_BeginSession_Params})::CUptiResult
+    @gcsafe_ccall libcupti.cuptiProfilerBeginSession(pParams::Ptr{CUpti_Profiler_BeginSession_Params})::CUptiResult
 end
 
 @checked function cuptiProfilerEndSession(pParams)
     initialize_context()
-    @ccall libcupti.cuptiProfilerEndSession(pParams::Ptr{CUpti_Profiler_EndSession_Params})::CUptiResult
+    @gcsafe_ccall libcupti.cuptiProfilerEndSession(pParams::Ptr{CUpti_Profiler_EndSession_Params})::CUptiResult
 end
 
 @checked function cuptiProfilerSetConfig(pParams)
     initialize_context()
-    @ccall libcupti.cuptiProfilerSetConfig(pParams::Ptr{CUpti_Profiler_SetConfig_Params})::CUptiResult
+    @gcsafe_ccall libcupti.cuptiProfilerSetConfig(pParams::Ptr{CUpti_Profiler_SetConfig_Params})::CUptiResult
 end
 
 @checked function cuptiProfilerUnsetConfig(pParams)
     initialize_context()
-    @ccall libcupti.cuptiProfilerUnsetConfig(pParams::Ptr{CUpti_Profiler_UnsetConfig_Params})::CUptiResult
+    @gcsafe_ccall libcupti.cuptiProfilerUnsetConfig(pParams::Ptr{CUpti_Profiler_UnsetConfig_Params})::CUptiResult
 end
 
 @checked function cuptiProfilerBeginPass(pParams)
     initialize_context()
-    @ccall libcupti.cuptiProfilerBeginPass(pParams::Ptr{CUpti_Profiler_BeginPass_Params})::CUptiResult
+    @gcsafe_ccall libcupti.cuptiProfilerBeginPass(pParams::Ptr{CUpti_Profiler_BeginPass_Params})::CUptiResult
 end
 
 @checked function cuptiProfilerEndPass(pParams)
     initialize_context()
-    @ccall libcupti.cuptiProfilerEndPass(pParams::Ptr{CUpti_Profiler_EndPass_Params})::CUptiResult
+    @gcsafe_ccall libcupti.cuptiProfilerEndPass(pParams::Ptr{CUpti_Profiler_EndPass_Params})::CUptiResult
 end
 
 @checked function cuptiProfilerEnableProfiling(pParams)
     initialize_context()
-    @ccall libcupti.cuptiProfilerEnableProfiling(pParams::Ptr{CUpti_Profiler_EnableProfiling_Params})::CUptiResult
+    @gcsafe_ccall libcupti.cuptiProfilerEnableProfiling(pParams::Ptr{CUpti_Profiler_EnableProfiling_Params})::CUptiResult
 end
 
 @checked function cuptiProfilerDisableProfiling(pParams)
     initialize_context()
-    @ccall libcupti.cuptiProfilerDisableProfiling(pParams::Ptr{CUpti_Profiler_DisableProfiling_Params})::CUptiResult
+    @gcsafe_ccall libcupti.cuptiProfilerDisableProfiling(pParams::Ptr{CUpti_Profiler_DisableProfiling_Params})::CUptiResult
 end
 
 @checked function cuptiProfilerIsPassCollected(pParams)
     initialize_context()
-    @ccall libcupti.cuptiProfilerIsPassCollected(pParams::Ptr{CUpti_Profiler_IsPassCollected_Params})::CUptiResult
+    @gcsafe_ccall libcupti.cuptiProfilerIsPassCollected(pParams::Ptr{CUpti_Profiler_IsPassCollected_Params})::CUptiResult
 end
 
 @checked function cuptiProfilerFlushCounterData(pParams)
     initialize_context()
-    @ccall libcupti.cuptiProfilerFlushCounterData(pParams::Ptr{CUpti_Profiler_FlushCounterData_Params})::CUptiResult
+    @gcsafe_ccall libcupti.cuptiProfilerFlushCounterData(pParams::Ptr{CUpti_Profiler_FlushCounterData_Params})::CUptiResult
 end
 
 @checked function cuptiProfilerPushRange(pParams)
     initialize_context()
-    @ccall libcupti.cuptiProfilerPushRange(pParams::Ptr{CUpti_Profiler_PushRange_Params})::CUptiResult
+    @gcsafe_ccall libcupti.cuptiProfilerPushRange(pParams::Ptr{CUpti_Profiler_PushRange_Params})::CUptiResult
 end
 
 @checked function cuptiProfilerPopRange(pParams)
     initialize_context()
-    @ccall libcupti.cuptiProfilerPopRange(pParams::Ptr{CUpti_Profiler_PopRange_Params})::CUptiResult
+    @gcsafe_ccall libcupti.cuptiProfilerPopRange(pParams::Ptr{CUpti_Profiler_PopRange_Params})::CUptiResult
 end
 
 @checked function cuptiProfilerGetCounterAvailability(pParams)
     initialize_context()
-    @ccall libcupti.cuptiProfilerGetCounterAvailability(pParams::Ptr{CUpti_Profiler_GetCounterAvailability_Params})::CUptiResult
+    @gcsafe_ccall libcupti.cuptiProfilerGetCounterAvailability(pParams::Ptr{CUpti_Profiler_GetCounterAvailability_Params})::CUptiResult
 end
 
 @checked function cuptiProfilerDeviceSupported(pParams)
     initialize_context()
-    @ccall libcupti.cuptiProfilerDeviceSupported(pParams::Ptr{CUpti_Profiler_DeviceSupported_Params})::CUptiResult
+    @gcsafe_ccall libcupti.cuptiProfilerDeviceSupported(pParams::Ptr{CUpti_Profiler_DeviceSupported_Params})::CUptiResult
 end
 
 struct var"##Ctag#533"

--- a/lib/curand/libcurand.jl
+++ b/lib/curand/libcurand.jl
@@ -141,181 +141,184 @@ const curandMethod_t = curandMethod
 
 @checked function curandCreateGenerator(generator, rng_type)
     initialize_context()
-    @ccall libcurand.curandCreateGenerator(generator::Ptr{curandGenerator_t},
-                                           rng_type::curandRngType_t)::curandStatus_t
+    @gcsafe_ccall libcurand.curandCreateGenerator(generator::Ptr{curandGenerator_t},
+                                                  rng_type::curandRngType_t)::curandStatus_t
 end
 
 @checked function curandCreateGeneratorHost(generator, rng_type)
     initialize_context()
-    @ccall libcurand.curandCreateGeneratorHost(generator::Ptr{curandGenerator_t},
-                                               rng_type::curandRngType_t)::curandStatus_t
+    @gcsafe_ccall libcurand.curandCreateGeneratorHost(generator::Ptr{curandGenerator_t},
+                                                      rng_type::curandRngType_t)::curandStatus_t
 end
 
 @checked function curandDestroyGenerator(generator)
     initialize_context()
-    @ccall libcurand.curandDestroyGenerator(generator::curandGenerator_t)::curandStatus_t
+    @gcsafe_ccall libcurand.curandDestroyGenerator(generator::curandGenerator_t)::curandStatus_t
 end
 
 @checked function curandGetVersion(version)
-    @ccall libcurand.curandGetVersion(version::Ptr{Cint})::curandStatus_t
+    @gcsafe_ccall libcurand.curandGetVersion(version::Ptr{Cint})::curandStatus_t
 end
 
 @checked function curandGetProperty(type, value)
-    @ccall libcurand.curandGetProperty(type::libraryPropertyType,
-                                       value::Ptr{Cint})::curandStatus_t
+    @gcsafe_ccall libcurand.curandGetProperty(type::libraryPropertyType,
+                                              value::Ptr{Cint})::curandStatus_t
 end
 
 @checked function curandSetStream(generator, stream)
     initialize_context()
-    @ccall libcurand.curandSetStream(generator::curandGenerator_t,
-                                     stream::cudaStream_t)::curandStatus_t
+    @gcsafe_ccall libcurand.curandSetStream(generator::curandGenerator_t,
+                                            stream::cudaStream_t)::curandStatus_t
 end
 
 @checked function curandSetPseudoRandomGeneratorSeed(generator, seed)
     initialize_context()
-    @ccall libcurand.curandSetPseudoRandomGeneratorSeed(generator::curandGenerator_t,
-                                                        seed::Culonglong)::curandStatus_t
+    @gcsafe_ccall libcurand.curandSetPseudoRandomGeneratorSeed(generator::curandGenerator_t,
+                                                               seed::Culonglong)::curandStatus_t
 end
 
 @checked function curandSetGeneratorOffset(generator, offset)
     initialize_context()
-    @ccall libcurand.curandSetGeneratorOffset(generator::curandGenerator_t,
-                                              offset::Culonglong)::curandStatus_t
+    @gcsafe_ccall libcurand.curandSetGeneratorOffset(generator::curandGenerator_t,
+                                                     offset::Culonglong)::curandStatus_t
 end
 
 @checked function curandSetGeneratorOrdering(generator, order)
     initialize_context()
-    @ccall libcurand.curandSetGeneratorOrdering(generator::curandGenerator_t,
-                                                order::curandOrdering_t)::curandStatus_t
+    @gcsafe_ccall libcurand.curandSetGeneratorOrdering(generator::curandGenerator_t,
+                                                       order::curandOrdering_t)::curandStatus_t
 end
 
 @checked function curandSetQuasiRandomGeneratorDimensions(generator, num_dimensions)
     initialize_context()
-    @ccall libcurand.curandSetQuasiRandomGeneratorDimensions(generator::curandGenerator_t,
-                                                             num_dimensions::Cuint)::curandStatus_t
+    @gcsafe_ccall libcurand.curandSetQuasiRandomGeneratorDimensions(generator::curandGenerator_t,
+                                                                    num_dimensions::Cuint)::curandStatus_t
 end
 
 @checked function curandGenerate(generator, outputPtr, num)
     initialize_context()
-    @ccall libcurand.curandGenerate(generator::curandGenerator_t, outputPtr::CuPtr{UInt32},
-                                    num::Csize_t)::curandStatus_t
+    @gcsafe_ccall libcurand.curandGenerate(generator::curandGenerator_t,
+                                           outputPtr::CuPtr{UInt32},
+                                           num::Csize_t)::curandStatus_t
 end
 
 @checked function curandGenerateLongLong(generator, outputPtr, num)
     initialize_context()
-    @ccall libcurand.curandGenerateLongLong(generator::curandGenerator_t,
-                                            outputPtr::CuPtr{Culonglong},
-                                            num::Csize_t)::curandStatus_t
+    @gcsafe_ccall libcurand.curandGenerateLongLong(generator::curandGenerator_t,
+                                                   outputPtr::CuPtr{Culonglong},
+                                                   num::Csize_t)::curandStatus_t
 end
 
 @checked function curandGenerateUniform(generator, outputPtr, num)
     initialize_context()
-    @ccall libcurand.curandGenerateUniform(generator::curandGenerator_t,
-                                           outputPtr::CuPtr{Cfloat},
-                                           num::Csize_t)::curandStatus_t
+    @gcsafe_ccall libcurand.curandGenerateUniform(generator::curandGenerator_t,
+                                                  outputPtr::CuPtr{Cfloat},
+                                                  num::Csize_t)::curandStatus_t
 end
 
 @checked function curandGenerateUniformDouble(generator, outputPtr, num)
     initialize_context()
-    @ccall libcurand.curandGenerateUniformDouble(generator::curandGenerator_t,
-                                                 outputPtr::CuPtr{Cdouble},
-                                                 num::Csize_t)::curandStatus_t
+    @gcsafe_ccall libcurand.curandGenerateUniformDouble(generator::curandGenerator_t,
+                                                        outputPtr::CuPtr{Cdouble},
+                                                        num::Csize_t)::curandStatus_t
 end
 
 @checked function curandGenerateNormal(generator, outputPtr, n, mean, stddev)
     initialize_context()
-    @ccall libcurand.curandGenerateNormal(generator::curandGenerator_t,
-                                          outputPtr::CuPtr{Cfloat}, n::Csize_t,
-                                          mean::Cfloat, stddev::Cfloat)::curandStatus_t
+    @gcsafe_ccall libcurand.curandGenerateNormal(generator::curandGenerator_t,
+                                                 outputPtr::CuPtr{Cfloat}, n::Csize_t,
+                                                 mean::Cfloat,
+                                                 stddev::Cfloat)::curandStatus_t
 end
 
 @checked function curandGenerateNormalDouble(generator, outputPtr, n, mean, stddev)
     initialize_context()
-    @ccall libcurand.curandGenerateNormalDouble(generator::curandGenerator_t,
-                                                outputPtr::CuPtr{Cdouble}, n::Csize_t,
-                                                mean::Cdouble,
-                                                stddev::Cdouble)::curandStatus_t
+    @gcsafe_ccall libcurand.curandGenerateNormalDouble(generator::curandGenerator_t,
+                                                       outputPtr::CuPtr{Cdouble},
+                                                       n::Csize_t, mean::Cdouble,
+                                                       stddev::Cdouble)::curandStatus_t
 end
 
 @checked function curandGenerateLogNormal(generator, outputPtr, n, mean, stddev)
     initialize_context()
-    @ccall libcurand.curandGenerateLogNormal(generator::curandGenerator_t,
-                                             outputPtr::CuPtr{Cfloat}, n::Csize_t,
-                                             mean::Cfloat, stddev::Cfloat)::curandStatus_t
+    @gcsafe_ccall libcurand.curandGenerateLogNormal(generator::curandGenerator_t,
+                                                    outputPtr::CuPtr{Cfloat}, n::Csize_t,
+                                                    mean::Cfloat,
+                                                    stddev::Cfloat)::curandStatus_t
 end
 
 @checked function curandGenerateLogNormalDouble(generator, outputPtr, n, mean, stddev)
     initialize_context()
-    @ccall libcurand.curandGenerateLogNormalDouble(generator::curandGenerator_t,
-                                                   outputPtr::CuPtr{Cdouble}, n::Csize_t,
-                                                   mean::Cdouble,
-                                                   stddev::Cdouble)::curandStatus_t
+    @gcsafe_ccall libcurand.curandGenerateLogNormalDouble(generator::curandGenerator_t,
+                                                          outputPtr::CuPtr{Cdouble},
+                                                          n::Csize_t, mean::Cdouble,
+                                                          stddev::Cdouble)::curandStatus_t
 end
 
 @checked function curandCreatePoissonDistribution(lambda, discrete_distribution)
     initialize_context()
-    @ccall libcurand.curandCreatePoissonDistribution(lambda::Cdouble,
-                                                     discrete_distribution::Ptr{curandDiscreteDistribution_t})::curandStatus_t
+    @gcsafe_ccall libcurand.curandCreatePoissonDistribution(lambda::Cdouble,
+                                                            discrete_distribution::Ptr{curandDiscreteDistribution_t})::curandStatus_t
 end
 
 @checked function curandDestroyDistribution(discrete_distribution)
     initialize_context()
-    @ccall libcurand.curandDestroyDistribution(discrete_distribution::curandDiscreteDistribution_t)::curandStatus_t
+    @gcsafe_ccall libcurand.curandDestroyDistribution(discrete_distribution::curandDiscreteDistribution_t)::curandStatus_t
 end
 
 @checked function curandGeneratePoisson(generator, outputPtr, n, lambda)
     initialize_context()
-    @ccall libcurand.curandGeneratePoisson(generator::curandGenerator_t,
-                                           outputPtr::CuPtr{UInt32}, n::Csize_t,
-                                           lambda::Cdouble)::curandStatus_t
+    @gcsafe_ccall libcurand.curandGeneratePoisson(generator::curandGenerator_t,
+                                                  outputPtr::CuPtr{UInt32}, n::Csize_t,
+                                                  lambda::Cdouble)::curandStatus_t
 end
 
 @checked function curandGeneratePoissonMethod(generator, outputPtr, n, lambda, method)
     initialize_context()
-    @ccall libcurand.curandGeneratePoissonMethod(generator::curandGenerator_t,
-                                                 outputPtr::CuPtr{UInt32}, n::Csize_t,
-                                                 lambda::Cdouble,
-                                                 method::curandMethod_t)::curandStatus_t
+    @gcsafe_ccall libcurand.curandGeneratePoissonMethod(generator::curandGenerator_t,
+                                                        outputPtr::CuPtr{UInt32},
+                                                        n::Csize_t, lambda::Cdouble,
+                                                        method::curandMethod_t)::curandStatus_t
 end
 
 @checked function curandGenerateBinomial(generator, outputPtr, num, n, p)
     initialize_context()
-    @ccall libcurand.curandGenerateBinomial(generator::curandGenerator_t,
-                                            outputPtr::CuPtr{UInt32}, num::Csize_t,
-                                            n::Cuint, p::Cdouble)::curandStatus_t
+    @gcsafe_ccall libcurand.curandGenerateBinomial(generator::curandGenerator_t,
+                                                   outputPtr::CuPtr{UInt32}, num::Csize_t,
+                                                   n::Cuint, p::Cdouble)::curandStatus_t
 end
 
 @checked function curandGenerateBinomialMethod(generator, outputPtr, num, n, p, method)
     initialize_context()
-    @ccall libcurand.curandGenerateBinomialMethod(generator::curandGenerator_t,
-                                                  outputPtr::CuPtr{UInt32}, num::Csize_t,
-                                                  n::Cuint, p::Cdouble,
-                                                  method::curandMethod_t)::curandStatus_t
+    @gcsafe_ccall libcurand.curandGenerateBinomialMethod(generator::curandGenerator_t,
+                                                         outputPtr::CuPtr{UInt32},
+                                                         num::Csize_t, n::Cuint, p::Cdouble,
+                                                         method::curandMethod_t)::curandStatus_t
 end
 
 @checked function curandGenerateSeeds(generator)
     initialize_context()
-    @ccall libcurand.curandGenerateSeeds(generator::curandGenerator_t)::curandStatus_t
+    @gcsafe_ccall libcurand.curandGenerateSeeds(generator::curandGenerator_t)::curandStatus_t
 end
 
 @checked function curandGetDirectionVectors32(vectors, set)
     initialize_context()
-    @ccall libcurand.curandGetDirectionVectors32(vectors::Ptr{Ptr{curandDirectionVectors32_t}},
-                                                 set::curandDirectionVectorSet_t)::curandStatus_t
+    @gcsafe_ccall libcurand.curandGetDirectionVectors32(vectors::Ptr{Ptr{curandDirectionVectors32_t}},
+                                                        set::curandDirectionVectorSet_t)::curandStatus_t
 end
 
 @checked function curandGetScrambleConstants32(constants)
     initialize_context()
-    @ccall libcurand.curandGetScrambleConstants32(constants::Ptr{Ptr{Cuint}})::curandStatus_t
+    @gcsafe_ccall libcurand.curandGetScrambleConstants32(constants::Ptr{Ptr{Cuint}})::curandStatus_t
 end
 
 @checked function curandGetDirectionVectors64(vectors, set)
     initialize_context()
-    @ccall libcurand.curandGetDirectionVectors64(vectors::Ptr{Ptr{curandDirectionVectors64_t}},
-                                                 set::curandDirectionVectorSet_t)::curandStatus_t
+    @gcsafe_ccall libcurand.curandGetDirectionVectors64(vectors::Ptr{Ptr{curandDirectionVectors64_t}},
+                                                        set::curandDirectionVectorSet_t)::curandStatus_t
 end
 
 @checked function curandGetScrambleConstants64(constants)
     initialize_context()
-    @ccall libcurand.curandGetScrambleConstants64(constants::Ptr{Ptr{Culonglong}})::curandStatus_t
+    @gcsafe_ccall libcurand.curandGetScrambleConstants64(constants::Ptr{Ptr{Culonglong}})::curandStatus_t
 end

--- a/lib/cusolver/libcusolver.jl
+++ b/lib/cusolver/libcusolver.jl
@@ -165,1944 +165,2217 @@ end
 end
 
 @checked function cusolverGetProperty(type, value)
-    @ccall libcusolver.cusolverGetProperty(type::libraryPropertyType,
-                                           value::Ptr{Cint})::cusolverStatus_t
+    @gcsafe_ccall libcusolver.cusolverGetProperty(type::libraryPropertyType,
+                                                  value::Ptr{Cint})::cusolverStatus_t
 end
 
 @checked function cusolverGetVersion(version)
-    @ccall libcusolver.cusolverGetVersion(version::Ptr{Cint})::cusolverStatus_t
+    @gcsafe_ccall libcusolver.cusolverGetVersion(version::Ptr{Cint})::cusolverStatus_t
 end
 
 @checked function cusolverDnCreate(handle)
     initialize_context()
-    @ccall libcusolver.cusolverDnCreate(handle::Ptr{cusolverDnHandle_t})::cusolverStatus_t
+    @gcsafe_ccall libcusolver.cusolverDnCreate(handle::Ptr{cusolverDnHandle_t})::cusolverStatus_t
 end
 
 @checked function cusolverDnDestroy(handle)
     initialize_context()
-    @ccall libcusolver.cusolverDnDestroy(handle::cusolverDnHandle_t)::cusolverStatus_t
+    @gcsafe_ccall libcusolver.cusolverDnDestroy(handle::cusolverDnHandle_t)::cusolverStatus_t
 end
 
 @checked function cusolverDnSetStream(handle, streamId)
     initialize_context()
-    @ccall libcusolver.cusolverDnSetStream(handle::cusolverDnHandle_t,
-                                           streamId::cudaStream_t)::cusolverStatus_t
+    @gcsafe_ccall libcusolver.cusolverDnSetStream(handle::cusolverDnHandle_t,
+                                                  streamId::cudaStream_t)::cusolverStatus_t
 end
 
 @checked function cusolverDnGetStream(handle, streamId)
     initialize_context()
-    @ccall libcusolver.cusolverDnGetStream(handle::cusolverDnHandle_t,
-                                           streamId::Ptr{cudaStream_t})::cusolverStatus_t
+    @gcsafe_ccall libcusolver.cusolverDnGetStream(handle::cusolverDnHandle_t,
+                                                  streamId::Ptr{cudaStream_t})::cusolverStatus_t
 end
 
 @checked function cusolverDnSetDeterministicMode(handle, mode)
     initialize_context()
-    @ccall libcusolver.cusolverDnSetDeterministicMode(handle::cusolverDnHandle_t,
-                                                      mode::cusolverDeterministicMode_t)::cusolverStatus_t
+    @gcsafe_ccall libcusolver.cusolverDnSetDeterministicMode(handle::cusolverDnHandle_t,
+                                                             mode::cusolverDeterministicMode_t)::cusolverStatus_t
 end
 
 @checked function cusolverDnGetDeterministicMode(handle, mode)
     initialize_context()
-    @ccall libcusolver.cusolverDnGetDeterministicMode(handle::cusolverDnHandle_t,
-                                                      mode::Ptr{cusolverDeterministicMode_t})::cusolverStatus_t
+    @gcsafe_ccall libcusolver.cusolverDnGetDeterministicMode(handle::cusolverDnHandle_t,
+                                                             mode::Ptr{cusolverDeterministicMode_t})::cusolverStatus_t
 end
 
 @checked function cusolverDnIRSParamsCreate(params_ptr)
     initialize_context()
-    @ccall libcusolver.cusolverDnIRSParamsCreate(params_ptr::Ptr{cusolverDnIRSParams_t})::cusolverStatus_t
+    @gcsafe_ccall libcusolver.cusolverDnIRSParamsCreate(params_ptr::Ptr{cusolverDnIRSParams_t})::cusolverStatus_t
 end
 
 @checked function cusolverDnIRSParamsDestroy(params)
     initialize_context()
-    @ccall libcusolver.cusolverDnIRSParamsDestroy(params::cusolverDnIRSParams_t)::cusolverStatus_t
+    @gcsafe_ccall libcusolver.cusolverDnIRSParamsDestroy(params::cusolverDnIRSParams_t)::cusolverStatus_t
 end
 
 @checked function cusolverDnIRSParamsSetRefinementSolver(params, refinement_solver)
     initialize_context()
-    @ccall libcusolver.cusolverDnIRSParamsSetRefinementSolver(params::cusolverDnIRSParams_t,
-                                                              refinement_solver::cusolverIRSRefinement_t)::cusolverStatus_t
+    @gcsafe_ccall libcusolver.cusolverDnIRSParamsSetRefinementSolver(params::cusolverDnIRSParams_t,
+                                                                     refinement_solver::cusolverIRSRefinement_t)::cusolverStatus_t
 end
 
 @checked function cusolverDnIRSParamsSetSolverMainPrecision(params, solver_main_precision)
     initialize_context()
-    @ccall libcusolver.cusolverDnIRSParamsSetSolverMainPrecision(params::cusolverDnIRSParams_t,
-                                                                 solver_main_precision::cusolverPrecType_t)::cusolverStatus_t
+    @gcsafe_ccall libcusolver.cusolverDnIRSParamsSetSolverMainPrecision(params::cusolverDnIRSParams_t,
+                                                                        solver_main_precision::cusolverPrecType_t)::cusolverStatus_t
 end
 
 @checked function cusolverDnIRSParamsSetSolverLowestPrecision(params,
                                                               solver_lowest_precision)
     initialize_context()
-    @ccall libcusolver.cusolverDnIRSParamsSetSolverLowestPrecision(params::cusolverDnIRSParams_t,
-                                                                   solver_lowest_precision::cusolverPrecType_t)::cusolverStatus_t
+    @gcsafe_ccall libcusolver.cusolverDnIRSParamsSetSolverLowestPrecision(params::cusolverDnIRSParams_t,
+                                                                          solver_lowest_precision::cusolverPrecType_t)::cusolverStatus_t
 end
 
 @checked function cusolverDnIRSParamsSetSolverPrecisions(params, solver_main_precision,
                                                          solver_lowest_precision)
     initialize_context()
-    @ccall libcusolver.cusolverDnIRSParamsSetSolverPrecisions(params::cusolverDnIRSParams_t,
-                                                              solver_main_precision::cusolverPrecType_t,
-                                                              solver_lowest_precision::cusolverPrecType_t)::cusolverStatus_t
+    @gcsafe_ccall libcusolver.cusolverDnIRSParamsSetSolverPrecisions(params::cusolverDnIRSParams_t,
+                                                                     solver_main_precision::cusolverPrecType_t,
+                                                                     solver_lowest_precision::cusolverPrecType_t)::cusolverStatus_t
 end
 
 @checked function cusolverDnIRSParamsSetTol(params, val)
     initialize_context()
-    @ccall libcusolver.cusolverDnIRSParamsSetTol(params::cusolverDnIRSParams_t,
-                                                 val::Cdouble)::cusolverStatus_t
+    @gcsafe_ccall libcusolver.cusolverDnIRSParamsSetTol(params::cusolverDnIRSParams_t,
+                                                        val::Cdouble)::cusolverStatus_t
 end
 
 @checked function cusolverDnIRSParamsSetTolInner(params, val)
     initialize_context()
-    @ccall libcusolver.cusolverDnIRSParamsSetTolInner(params::cusolverDnIRSParams_t,
-                                                      val::Cdouble)::cusolverStatus_t
+    @gcsafe_ccall libcusolver.cusolverDnIRSParamsSetTolInner(params::cusolverDnIRSParams_t,
+                                                             val::Cdouble)::cusolverStatus_t
 end
 
 @checked function cusolverDnIRSParamsSetMaxIters(params, maxiters)
     initialize_context()
-    @ccall libcusolver.cusolverDnIRSParamsSetMaxIters(params::cusolverDnIRSParams_t,
-                                                      maxiters::cusolver_int_t)::cusolverStatus_t
+    @gcsafe_ccall libcusolver.cusolverDnIRSParamsSetMaxIters(params::cusolverDnIRSParams_t,
+                                                             maxiters::cusolver_int_t)::cusolverStatus_t
 end
 
 @checked function cusolverDnIRSParamsSetMaxItersInner(params, maxiters_inner)
     initialize_context()
-    @ccall libcusolver.cusolverDnIRSParamsSetMaxItersInner(params::cusolverDnIRSParams_t,
-                                                           maxiters_inner::cusolver_int_t)::cusolverStatus_t
+    @gcsafe_ccall libcusolver.cusolverDnIRSParamsSetMaxItersInner(params::cusolverDnIRSParams_t,
+                                                                  maxiters_inner::cusolver_int_t)::cusolverStatus_t
 end
 
 @checked function cusolverDnIRSParamsGetMaxIters(params, maxiters)
     initialize_context()
-    @ccall libcusolver.cusolverDnIRSParamsGetMaxIters(params::cusolverDnIRSParams_t,
-                                                      maxiters::Ptr{cusolver_int_t})::cusolverStatus_t
+    @gcsafe_ccall libcusolver.cusolverDnIRSParamsGetMaxIters(params::cusolverDnIRSParams_t,
+                                                             maxiters::Ptr{cusolver_int_t})::cusolverStatus_t
 end
 
 @checked function cusolverDnIRSParamsEnableFallback(params)
     initialize_context()
-    @ccall libcusolver.cusolverDnIRSParamsEnableFallback(params::cusolverDnIRSParams_t)::cusolverStatus_t
+    @gcsafe_ccall libcusolver.cusolverDnIRSParamsEnableFallback(params::cusolverDnIRSParams_t)::cusolverStatus_t
 end
 
 @checked function cusolverDnIRSParamsDisableFallback(params)
     initialize_context()
-    @ccall libcusolver.cusolverDnIRSParamsDisableFallback(params::cusolverDnIRSParams_t)::cusolverStatus_t
+    @gcsafe_ccall libcusolver.cusolverDnIRSParamsDisableFallback(params::cusolverDnIRSParams_t)::cusolverStatus_t
 end
 
 @checked function cusolverDnIRSInfosDestroy(infos)
     initialize_context()
-    @ccall libcusolver.cusolverDnIRSInfosDestroy(infos::cusolverDnIRSInfos_t)::cusolverStatus_t
+    @gcsafe_ccall libcusolver.cusolverDnIRSInfosDestroy(infos::cusolverDnIRSInfos_t)::cusolverStatus_t
 end
 
 @checked function cusolverDnIRSInfosCreate(infos_ptr)
     initialize_context()
-    @ccall libcusolver.cusolverDnIRSInfosCreate(infos_ptr::Ptr{cusolverDnIRSInfos_t})::cusolverStatus_t
+    @gcsafe_ccall libcusolver.cusolverDnIRSInfosCreate(infos_ptr::Ptr{cusolverDnIRSInfos_t})::cusolverStatus_t
 end
 
 @checked function cusolverDnIRSInfosGetNiters(infos, niters)
     initialize_context()
-    @ccall libcusolver.cusolverDnIRSInfosGetNiters(infos::cusolverDnIRSInfos_t,
-                                                   niters::Ptr{cusolver_int_t})::cusolverStatus_t
+    @gcsafe_ccall libcusolver.cusolverDnIRSInfosGetNiters(infos::cusolverDnIRSInfos_t,
+                                                          niters::Ptr{cusolver_int_t})::cusolverStatus_t
 end
 
 @checked function cusolverDnIRSInfosGetOuterNiters(infos, outer_niters)
     initialize_context()
-    @ccall libcusolver.cusolverDnIRSInfosGetOuterNiters(infos::cusolverDnIRSInfos_t,
-                                                        outer_niters::Ptr{cusolver_int_t})::cusolverStatus_t
+    @gcsafe_ccall libcusolver.cusolverDnIRSInfosGetOuterNiters(infos::cusolverDnIRSInfos_t,
+                                                               outer_niters::Ptr{cusolver_int_t})::cusolverStatus_t
 end
 
 @checked function cusolverDnIRSInfosRequestResidual(infos)
     initialize_context()
-    @ccall libcusolver.cusolverDnIRSInfosRequestResidual(infos::cusolverDnIRSInfos_t)::cusolverStatus_t
+    @gcsafe_ccall libcusolver.cusolverDnIRSInfosRequestResidual(infos::cusolverDnIRSInfos_t)::cusolverStatus_t
 end
 
 @checked function cusolverDnIRSInfosGetResidualHistory(infos, residual_history)
     initialize_context()
-    @ccall libcusolver.cusolverDnIRSInfosGetResidualHistory(infos::cusolverDnIRSInfos_t,
-                                                            residual_history::Ptr{Ptr{Cvoid}})::cusolverStatus_t
+    @gcsafe_ccall libcusolver.cusolverDnIRSInfosGetResidualHistory(infos::cusolverDnIRSInfos_t,
+                                                                   residual_history::Ptr{Ptr{Cvoid}})::cusolverStatus_t
 end
 
 @checked function cusolverDnIRSInfosGetMaxIters(infos, maxiters)
     initialize_context()
-    @ccall libcusolver.cusolverDnIRSInfosGetMaxIters(infos::cusolverDnIRSInfos_t,
-                                                     maxiters::Ptr{cusolver_int_t})::cusolverStatus_t
+    @gcsafe_ccall libcusolver.cusolverDnIRSInfosGetMaxIters(infos::cusolverDnIRSInfos_t,
+                                                            maxiters::Ptr{cusolver_int_t})::cusolverStatus_t
 end
 
 @checked function cusolverDnZZgesv(handle, n, nrhs, dA, ldda, dipiv, dB, lddb, dX, lddx,
                                    dWorkspace, lwork_bytes, iter, d_info)
     initialize_context()
-    @ccall libcusolver.cusolverDnZZgesv(handle::cusolverDnHandle_t, n::cusolver_int_t,
-                                        nrhs::cusolver_int_t, dA::CuPtr{cuDoubleComplex},
-                                        ldda::cusolver_int_t, dipiv::CuPtr{cusolver_int_t},
-                                        dB::CuPtr{cuDoubleComplex}, lddb::cusolver_int_t,
-                                        dX::CuPtr{cuDoubleComplex}, lddx::cusolver_int_t,
-                                        dWorkspace::CuPtr{Cvoid}, lwork_bytes::Csize_t,
-                                        iter::Ptr{cusolver_int_t},
-                                        d_info::CuPtr{cusolver_int_t})::cusolverStatus_t
+    @gcsafe_ccall libcusolver.cusolverDnZZgesv(handle::cusolverDnHandle_t,
+                                               n::cusolver_int_t, nrhs::cusolver_int_t,
+                                               dA::CuPtr{cuDoubleComplex},
+                                               ldda::cusolver_int_t,
+                                               dipiv::CuPtr{cusolver_int_t},
+                                               dB::CuPtr{cuDoubleComplex},
+                                               lddb::cusolver_int_t,
+                                               dX::CuPtr{cuDoubleComplex},
+                                               lddx::cusolver_int_t,
+                                               dWorkspace::CuPtr{Cvoid},
+                                               lwork_bytes::Csize_t,
+                                               iter::Ptr{cusolver_int_t},
+                                               d_info::CuPtr{cusolver_int_t})::cusolverStatus_t
 end
 
 @checked function cusolverDnZCgesv(handle, n, nrhs, dA, ldda, dipiv, dB, lddb, dX, lddx,
                                    dWorkspace, lwork_bytes, iter, d_info)
     initialize_context()
-    @ccall libcusolver.cusolverDnZCgesv(handle::cusolverDnHandle_t, n::cusolver_int_t,
-                                        nrhs::cusolver_int_t, dA::CuPtr{cuDoubleComplex},
-                                        ldda::cusolver_int_t, dipiv::CuPtr{cusolver_int_t},
-                                        dB::CuPtr{cuDoubleComplex}, lddb::cusolver_int_t,
-                                        dX::CuPtr{cuDoubleComplex}, lddx::cusolver_int_t,
-                                        dWorkspace::CuPtr{Cvoid}, lwork_bytes::Csize_t,
-                                        iter::Ptr{cusolver_int_t},
-                                        d_info::CuPtr{cusolver_int_t})::cusolverStatus_t
+    @gcsafe_ccall libcusolver.cusolverDnZCgesv(handle::cusolverDnHandle_t,
+                                               n::cusolver_int_t, nrhs::cusolver_int_t,
+                                               dA::CuPtr{cuDoubleComplex},
+                                               ldda::cusolver_int_t,
+                                               dipiv::CuPtr{cusolver_int_t},
+                                               dB::CuPtr{cuDoubleComplex},
+                                               lddb::cusolver_int_t,
+                                               dX::CuPtr{cuDoubleComplex},
+                                               lddx::cusolver_int_t,
+                                               dWorkspace::CuPtr{Cvoid},
+                                               lwork_bytes::Csize_t,
+                                               iter::Ptr{cusolver_int_t},
+                                               d_info::CuPtr{cusolver_int_t})::cusolverStatus_t
 end
 
 @checked function cusolverDnZKgesv(handle, n, nrhs, dA, ldda, dipiv, dB, lddb, dX, lddx,
                                    dWorkspace, lwork_bytes, iter, d_info)
     initialize_context()
-    @ccall libcusolver.cusolverDnZKgesv(handle::cusolverDnHandle_t, n::cusolver_int_t,
-                                        nrhs::cusolver_int_t, dA::CuPtr{cuDoubleComplex},
-                                        ldda::cusolver_int_t, dipiv::CuPtr{cusolver_int_t},
-                                        dB::CuPtr{cuDoubleComplex}, lddb::cusolver_int_t,
-                                        dX::CuPtr{cuDoubleComplex}, lddx::cusolver_int_t,
-                                        dWorkspace::CuPtr{Cvoid}, lwork_bytes::Csize_t,
-                                        iter::Ptr{cusolver_int_t},
-                                        d_info::CuPtr{cusolver_int_t})::cusolverStatus_t
+    @gcsafe_ccall libcusolver.cusolverDnZKgesv(handle::cusolverDnHandle_t,
+                                               n::cusolver_int_t, nrhs::cusolver_int_t,
+                                               dA::CuPtr{cuDoubleComplex},
+                                               ldda::cusolver_int_t,
+                                               dipiv::CuPtr{cusolver_int_t},
+                                               dB::CuPtr{cuDoubleComplex},
+                                               lddb::cusolver_int_t,
+                                               dX::CuPtr{cuDoubleComplex},
+                                               lddx::cusolver_int_t,
+                                               dWorkspace::CuPtr{Cvoid},
+                                               lwork_bytes::Csize_t,
+                                               iter::Ptr{cusolver_int_t},
+                                               d_info::CuPtr{cusolver_int_t})::cusolverStatus_t
 end
 
 @checked function cusolverDnZEgesv(handle, n, nrhs, dA, ldda, dipiv, dB, lddb, dX, lddx,
                                    dWorkspace, lwork_bytes, iter, d_info)
     initialize_context()
-    @ccall libcusolver.cusolverDnZEgesv(handle::cusolverDnHandle_t, n::cusolver_int_t,
-                                        nrhs::cusolver_int_t, dA::CuPtr{cuDoubleComplex},
-                                        ldda::cusolver_int_t, dipiv::CuPtr{cusolver_int_t},
-                                        dB::CuPtr{cuDoubleComplex}, lddb::cusolver_int_t,
-                                        dX::CuPtr{cuDoubleComplex}, lddx::cusolver_int_t,
-                                        dWorkspace::CuPtr{Cvoid}, lwork_bytes::Csize_t,
-                                        iter::Ptr{cusolver_int_t},
-                                        d_info::CuPtr{cusolver_int_t})::cusolverStatus_t
+    @gcsafe_ccall libcusolver.cusolverDnZEgesv(handle::cusolverDnHandle_t,
+                                               n::cusolver_int_t, nrhs::cusolver_int_t,
+                                               dA::CuPtr{cuDoubleComplex},
+                                               ldda::cusolver_int_t,
+                                               dipiv::CuPtr{cusolver_int_t},
+                                               dB::CuPtr{cuDoubleComplex},
+                                               lddb::cusolver_int_t,
+                                               dX::CuPtr{cuDoubleComplex},
+                                               lddx::cusolver_int_t,
+                                               dWorkspace::CuPtr{Cvoid},
+                                               lwork_bytes::Csize_t,
+                                               iter::Ptr{cusolver_int_t},
+                                               d_info::CuPtr{cusolver_int_t})::cusolverStatus_t
 end
 
 @checked function cusolverDnZYgesv(handle, n, nrhs, dA, ldda, dipiv, dB, lddb, dX, lddx,
                                    dWorkspace, lwork_bytes, iter, d_info)
     initialize_context()
-    @ccall libcusolver.cusolverDnZYgesv(handle::cusolverDnHandle_t, n::cusolver_int_t,
-                                        nrhs::cusolver_int_t, dA::CuPtr{cuDoubleComplex},
-                                        ldda::cusolver_int_t, dipiv::CuPtr{cusolver_int_t},
-                                        dB::CuPtr{cuDoubleComplex}, lddb::cusolver_int_t,
-                                        dX::CuPtr{cuDoubleComplex}, lddx::cusolver_int_t,
-                                        dWorkspace::CuPtr{Cvoid}, lwork_bytes::Csize_t,
-                                        iter::Ptr{cusolver_int_t},
-                                        d_info::CuPtr{cusolver_int_t})::cusolverStatus_t
+    @gcsafe_ccall libcusolver.cusolverDnZYgesv(handle::cusolverDnHandle_t,
+                                               n::cusolver_int_t, nrhs::cusolver_int_t,
+                                               dA::CuPtr{cuDoubleComplex},
+                                               ldda::cusolver_int_t,
+                                               dipiv::CuPtr{cusolver_int_t},
+                                               dB::CuPtr{cuDoubleComplex},
+                                               lddb::cusolver_int_t,
+                                               dX::CuPtr{cuDoubleComplex},
+                                               lddx::cusolver_int_t,
+                                               dWorkspace::CuPtr{Cvoid},
+                                               lwork_bytes::Csize_t,
+                                               iter::Ptr{cusolver_int_t},
+                                               d_info::CuPtr{cusolver_int_t})::cusolverStatus_t
 end
 
 @checked function cusolverDnCCgesv(handle, n, nrhs, dA, ldda, dipiv, dB, lddb, dX, lddx,
                                    dWorkspace, lwork_bytes, iter, d_info)
     initialize_context()
-    @ccall libcusolver.cusolverDnCCgesv(handle::cusolverDnHandle_t, n::cusolver_int_t,
-                                        nrhs::cusolver_int_t, dA::CuPtr{cuComplex},
-                                        ldda::cusolver_int_t, dipiv::CuPtr{cusolver_int_t},
-                                        dB::CuPtr{cuComplex}, lddb::cusolver_int_t,
-                                        dX::CuPtr{cuComplex}, lddx::cusolver_int_t,
-                                        dWorkspace::CuPtr{Cvoid}, lwork_bytes::Csize_t,
-                                        iter::Ptr{cusolver_int_t},
-                                        d_info::CuPtr{cusolver_int_t})::cusolverStatus_t
+    @gcsafe_ccall libcusolver.cusolverDnCCgesv(handle::cusolverDnHandle_t,
+                                               n::cusolver_int_t, nrhs::cusolver_int_t,
+                                               dA::CuPtr{cuComplex}, ldda::cusolver_int_t,
+                                               dipiv::CuPtr{cusolver_int_t},
+                                               dB::CuPtr{cuComplex}, lddb::cusolver_int_t,
+                                               dX::CuPtr{cuComplex}, lddx::cusolver_int_t,
+                                               dWorkspace::CuPtr{Cvoid},
+                                               lwork_bytes::Csize_t,
+                                               iter::Ptr{cusolver_int_t},
+                                               d_info::CuPtr{cusolver_int_t})::cusolverStatus_t
 end
 
 @checked function cusolverDnCEgesv(handle, n, nrhs, dA, ldda, dipiv, dB, lddb, dX, lddx,
                                    dWorkspace, lwork_bytes, iter, d_info)
     initialize_context()
-    @ccall libcusolver.cusolverDnCEgesv(handle::cusolverDnHandle_t, n::cusolver_int_t,
-                                        nrhs::cusolver_int_t, dA::CuPtr{cuComplex},
-                                        ldda::cusolver_int_t, dipiv::CuPtr{cusolver_int_t},
-                                        dB::CuPtr{cuComplex}, lddb::cusolver_int_t,
-                                        dX::CuPtr{cuComplex}, lddx::cusolver_int_t,
-                                        dWorkspace::CuPtr{Cvoid}, lwork_bytes::Csize_t,
-                                        iter::Ptr{cusolver_int_t},
-                                        d_info::CuPtr{cusolver_int_t})::cusolverStatus_t
+    @gcsafe_ccall libcusolver.cusolverDnCEgesv(handle::cusolverDnHandle_t,
+                                               n::cusolver_int_t, nrhs::cusolver_int_t,
+                                               dA::CuPtr{cuComplex}, ldda::cusolver_int_t,
+                                               dipiv::CuPtr{cusolver_int_t},
+                                               dB::CuPtr{cuComplex}, lddb::cusolver_int_t,
+                                               dX::CuPtr{cuComplex}, lddx::cusolver_int_t,
+                                               dWorkspace::CuPtr{Cvoid},
+                                               lwork_bytes::Csize_t,
+                                               iter::Ptr{cusolver_int_t},
+                                               d_info::CuPtr{cusolver_int_t})::cusolverStatus_t
 end
 
 @checked function cusolverDnCKgesv(handle, n, nrhs, dA, ldda, dipiv, dB, lddb, dX, lddx,
                                    dWorkspace, lwork_bytes, iter, d_info)
     initialize_context()
-    @ccall libcusolver.cusolverDnCKgesv(handle::cusolverDnHandle_t, n::cusolver_int_t,
-                                        nrhs::cusolver_int_t, dA::CuPtr{cuComplex},
-                                        ldda::cusolver_int_t, dipiv::CuPtr{cusolver_int_t},
-                                        dB::CuPtr{cuComplex}, lddb::cusolver_int_t,
-                                        dX::CuPtr{cuComplex}, lddx::cusolver_int_t,
-                                        dWorkspace::CuPtr{Cvoid}, lwork_bytes::Csize_t,
-                                        iter::Ptr{cusolver_int_t},
-                                        d_info::CuPtr{cusolver_int_t})::cusolverStatus_t
+    @gcsafe_ccall libcusolver.cusolverDnCKgesv(handle::cusolverDnHandle_t,
+                                               n::cusolver_int_t, nrhs::cusolver_int_t,
+                                               dA::CuPtr{cuComplex}, ldda::cusolver_int_t,
+                                               dipiv::CuPtr{cusolver_int_t},
+                                               dB::CuPtr{cuComplex}, lddb::cusolver_int_t,
+                                               dX::CuPtr{cuComplex}, lddx::cusolver_int_t,
+                                               dWorkspace::CuPtr{Cvoid},
+                                               lwork_bytes::Csize_t,
+                                               iter::Ptr{cusolver_int_t},
+                                               d_info::CuPtr{cusolver_int_t})::cusolverStatus_t
 end
 
 @checked function cusolverDnCYgesv(handle, n, nrhs, dA, ldda, dipiv, dB, lddb, dX, lddx,
                                    dWorkspace, lwork_bytes, iter, d_info)
     initialize_context()
-    @ccall libcusolver.cusolverDnCYgesv(handle::cusolverDnHandle_t, n::cusolver_int_t,
-                                        nrhs::cusolver_int_t, dA::CuPtr{cuComplex},
-                                        ldda::cusolver_int_t, dipiv::CuPtr{cusolver_int_t},
-                                        dB::CuPtr{cuComplex}, lddb::cusolver_int_t,
-                                        dX::CuPtr{cuComplex}, lddx::cusolver_int_t,
-                                        dWorkspace::CuPtr{Cvoid}, lwork_bytes::Csize_t,
-                                        iter::Ptr{cusolver_int_t},
-                                        d_info::CuPtr{cusolver_int_t})::cusolverStatus_t
+    @gcsafe_ccall libcusolver.cusolverDnCYgesv(handle::cusolverDnHandle_t,
+                                               n::cusolver_int_t, nrhs::cusolver_int_t,
+                                               dA::CuPtr{cuComplex}, ldda::cusolver_int_t,
+                                               dipiv::CuPtr{cusolver_int_t},
+                                               dB::CuPtr{cuComplex}, lddb::cusolver_int_t,
+                                               dX::CuPtr{cuComplex}, lddx::cusolver_int_t,
+                                               dWorkspace::CuPtr{Cvoid},
+                                               lwork_bytes::Csize_t,
+                                               iter::Ptr{cusolver_int_t},
+                                               d_info::CuPtr{cusolver_int_t})::cusolverStatus_t
 end
 
 @checked function cusolverDnDDgesv(handle, n, nrhs, dA, ldda, dipiv, dB, lddb, dX, lddx,
                                    dWorkspace, lwork_bytes, iter, d_info)
     initialize_context()
-    @ccall libcusolver.cusolverDnDDgesv(handle::cusolverDnHandle_t, n::cusolver_int_t,
-                                        nrhs::cusolver_int_t, dA::CuPtr{Cdouble},
-                                        ldda::cusolver_int_t, dipiv::CuPtr{cusolver_int_t},
-                                        dB::CuPtr{Cdouble}, lddb::cusolver_int_t,
-                                        dX::CuPtr{Cdouble}, lddx::cusolver_int_t,
-                                        dWorkspace::CuPtr{Cvoid}, lwork_bytes::Csize_t,
-                                        iter::Ptr{cusolver_int_t},
-                                        d_info::CuPtr{cusolver_int_t})::cusolverStatus_t
+    @gcsafe_ccall libcusolver.cusolverDnDDgesv(handle::cusolverDnHandle_t,
+                                               n::cusolver_int_t, nrhs::cusolver_int_t,
+                                               dA::CuPtr{Cdouble}, ldda::cusolver_int_t,
+                                               dipiv::CuPtr{cusolver_int_t},
+                                               dB::CuPtr{Cdouble}, lddb::cusolver_int_t,
+                                               dX::CuPtr{Cdouble}, lddx::cusolver_int_t,
+                                               dWorkspace::CuPtr{Cvoid},
+                                               lwork_bytes::Csize_t,
+                                               iter::Ptr{cusolver_int_t},
+                                               d_info::CuPtr{cusolver_int_t})::cusolverStatus_t
 end
 
 @checked function cusolverDnDSgesv(handle, n, nrhs, dA, ldda, dipiv, dB, lddb, dX, lddx,
                                    dWorkspace, lwork_bytes, iter, d_info)
     initialize_context()
-    @ccall libcusolver.cusolverDnDSgesv(handle::cusolverDnHandle_t, n::cusolver_int_t,
-                                        nrhs::cusolver_int_t, dA::CuPtr{Cdouble},
-                                        ldda::cusolver_int_t, dipiv::CuPtr{cusolver_int_t},
-                                        dB::CuPtr{Cdouble}, lddb::cusolver_int_t,
-                                        dX::CuPtr{Cdouble}, lddx::cusolver_int_t,
-                                        dWorkspace::CuPtr{Cvoid}, lwork_bytes::Csize_t,
-                                        iter::Ptr{cusolver_int_t},
-                                        d_info::CuPtr{cusolver_int_t})::cusolverStatus_t
+    @gcsafe_ccall libcusolver.cusolverDnDSgesv(handle::cusolverDnHandle_t,
+                                               n::cusolver_int_t, nrhs::cusolver_int_t,
+                                               dA::CuPtr{Cdouble}, ldda::cusolver_int_t,
+                                               dipiv::CuPtr{cusolver_int_t},
+                                               dB::CuPtr{Cdouble}, lddb::cusolver_int_t,
+                                               dX::CuPtr{Cdouble}, lddx::cusolver_int_t,
+                                               dWorkspace::CuPtr{Cvoid},
+                                               lwork_bytes::Csize_t,
+                                               iter::Ptr{cusolver_int_t},
+                                               d_info::CuPtr{cusolver_int_t})::cusolverStatus_t
 end
 
 @checked function cusolverDnDHgesv(handle, n, nrhs, dA, ldda, dipiv, dB, lddb, dX, lddx,
                                    dWorkspace, lwork_bytes, iter, d_info)
     initialize_context()
-    @ccall libcusolver.cusolverDnDHgesv(handle::cusolverDnHandle_t, n::cusolver_int_t,
-                                        nrhs::cusolver_int_t, dA::CuPtr{Cdouble},
-                                        ldda::cusolver_int_t, dipiv::CuPtr{cusolver_int_t},
-                                        dB::CuPtr{Cdouble}, lddb::cusolver_int_t,
-                                        dX::CuPtr{Cdouble}, lddx::cusolver_int_t,
-                                        dWorkspace::CuPtr{Cvoid}, lwork_bytes::Csize_t,
-                                        iter::Ptr{cusolver_int_t},
-                                        d_info::CuPtr{cusolver_int_t})::cusolverStatus_t
+    @gcsafe_ccall libcusolver.cusolverDnDHgesv(handle::cusolverDnHandle_t,
+                                               n::cusolver_int_t, nrhs::cusolver_int_t,
+                                               dA::CuPtr{Cdouble}, ldda::cusolver_int_t,
+                                               dipiv::CuPtr{cusolver_int_t},
+                                               dB::CuPtr{Cdouble}, lddb::cusolver_int_t,
+                                               dX::CuPtr{Cdouble}, lddx::cusolver_int_t,
+                                               dWorkspace::CuPtr{Cvoid},
+                                               lwork_bytes::Csize_t,
+                                               iter::Ptr{cusolver_int_t},
+                                               d_info::CuPtr{cusolver_int_t})::cusolverStatus_t
 end
 
 @checked function cusolverDnDBgesv(handle, n, nrhs, dA, ldda, dipiv, dB, lddb, dX, lddx,
                                    dWorkspace, lwork_bytes, iter, d_info)
     initialize_context()
-    @ccall libcusolver.cusolverDnDBgesv(handle::cusolverDnHandle_t, n::cusolver_int_t,
-                                        nrhs::cusolver_int_t, dA::CuPtr{Cdouble},
-                                        ldda::cusolver_int_t, dipiv::CuPtr{cusolver_int_t},
-                                        dB::CuPtr{Cdouble}, lddb::cusolver_int_t,
-                                        dX::CuPtr{Cdouble}, lddx::cusolver_int_t,
-                                        dWorkspace::CuPtr{Cvoid}, lwork_bytes::Csize_t,
-                                        iter::Ptr{cusolver_int_t},
-                                        d_info::CuPtr{cusolver_int_t})::cusolverStatus_t
+    @gcsafe_ccall libcusolver.cusolverDnDBgesv(handle::cusolverDnHandle_t,
+                                               n::cusolver_int_t, nrhs::cusolver_int_t,
+                                               dA::CuPtr{Cdouble}, ldda::cusolver_int_t,
+                                               dipiv::CuPtr{cusolver_int_t},
+                                               dB::CuPtr{Cdouble}, lddb::cusolver_int_t,
+                                               dX::CuPtr{Cdouble}, lddx::cusolver_int_t,
+                                               dWorkspace::CuPtr{Cvoid},
+                                               lwork_bytes::Csize_t,
+                                               iter::Ptr{cusolver_int_t},
+                                               d_info::CuPtr{cusolver_int_t})::cusolverStatus_t
 end
 
 @checked function cusolverDnDXgesv(handle, n, nrhs, dA, ldda, dipiv, dB, lddb, dX, lddx,
                                    dWorkspace, lwork_bytes, iter, d_info)
     initialize_context()
-    @ccall libcusolver.cusolverDnDXgesv(handle::cusolverDnHandle_t, n::cusolver_int_t,
-                                        nrhs::cusolver_int_t, dA::CuPtr{Cdouble},
-                                        ldda::cusolver_int_t, dipiv::CuPtr{cusolver_int_t},
-                                        dB::CuPtr{Cdouble}, lddb::cusolver_int_t,
-                                        dX::CuPtr{Cdouble}, lddx::cusolver_int_t,
-                                        dWorkspace::CuPtr{Cvoid}, lwork_bytes::Csize_t,
-                                        iter::Ptr{cusolver_int_t},
-                                        d_info::CuPtr{cusolver_int_t})::cusolverStatus_t
+    @gcsafe_ccall libcusolver.cusolverDnDXgesv(handle::cusolverDnHandle_t,
+                                               n::cusolver_int_t, nrhs::cusolver_int_t,
+                                               dA::CuPtr{Cdouble}, ldda::cusolver_int_t,
+                                               dipiv::CuPtr{cusolver_int_t},
+                                               dB::CuPtr{Cdouble}, lddb::cusolver_int_t,
+                                               dX::CuPtr{Cdouble}, lddx::cusolver_int_t,
+                                               dWorkspace::CuPtr{Cvoid},
+                                               lwork_bytes::Csize_t,
+                                               iter::Ptr{cusolver_int_t},
+                                               d_info::CuPtr{cusolver_int_t})::cusolverStatus_t
 end
 
 @checked function cusolverDnSSgesv(handle, n, nrhs, dA, ldda, dipiv, dB, lddb, dX, lddx,
                                    dWorkspace, lwork_bytes, iter, d_info)
     initialize_context()
-    @ccall libcusolver.cusolverDnSSgesv(handle::cusolverDnHandle_t, n::cusolver_int_t,
-                                        nrhs::cusolver_int_t, dA::CuPtr{Cfloat},
-                                        ldda::cusolver_int_t, dipiv::CuPtr{cusolver_int_t},
-                                        dB::CuPtr{Cfloat}, lddb::cusolver_int_t,
-                                        dX::CuPtr{Cfloat}, lddx::cusolver_int_t,
-                                        dWorkspace::CuPtr{Cvoid}, lwork_bytes::Csize_t,
-                                        iter::Ptr{cusolver_int_t},
-                                        d_info::CuPtr{cusolver_int_t})::cusolverStatus_t
+    @gcsafe_ccall libcusolver.cusolverDnSSgesv(handle::cusolverDnHandle_t,
+                                               n::cusolver_int_t, nrhs::cusolver_int_t,
+                                               dA::CuPtr{Cfloat}, ldda::cusolver_int_t,
+                                               dipiv::CuPtr{cusolver_int_t},
+                                               dB::CuPtr{Cfloat}, lddb::cusolver_int_t,
+                                               dX::CuPtr{Cfloat}, lddx::cusolver_int_t,
+                                               dWorkspace::CuPtr{Cvoid},
+                                               lwork_bytes::Csize_t,
+                                               iter::Ptr{cusolver_int_t},
+                                               d_info::CuPtr{cusolver_int_t})::cusolverStatus_t
 end
 
 @checked function cusolverDnSHgesv(handle, n, nrhs, dA, ldda, dipiv, dB, lddb, dX, lddx,
                                    dWorkspace, lwork_bytes, iter, d_info)
     initialize_context()
-    @ccall libcusolver.cusolverDnSHgesv(handle::cusolverDnHandle_t, n::cusolver_int_t,
-                                        nrhs::cusolver_int_t, dA::CuPtr{Cfloat},
-                                        ldda::cusolver_int_t, dipiv::CuPtr{cusolver_int_t},
-                                        dB::CuPtr{Cfloat}, lddb::cusolver_int_t,
-                                        dX::CuPtr{Cfloat}, lddx::cusolver_int_t,
-                                        dWorkspace::CuPtr{Cvoid}, lwork_bytes::Csize_t,
-                                        iter::Ptr{cusolver_int_t},
-                                        d_info::CuPtr{cusolver_int_t})::cusolverStatus_t
+    @gcsafe_ccall libcusolver.cusolverDnSHgesv(handle::cusolverDnHandle_t,
+                                               n::cusolver_int_t, nrhs::cusolver_int_t,
+                                               dA::CuPtr{Cfloat}, ldda::cusolver_int_t,
+                                               dipiv::CuPtr{cusolver_int_t},
+                                               dB::CuPtr{Cfloat}, lddb::cusolver_int_t,
+                                               dX::CuPtr{Cfloat}, lddx::cusolver_int_t,
+                                               dWorkspace::CuPtr{Cvoid},
+                                               lwork_bytes::Csize_t,
+                                               iter::Ptr{cusolver_int_t},
+                                               d_info::CuPtr{cusolver_int_t})::cusolverStatus_t
 end
 
 @checked function cusolverDnSBgesv(handle, n, nrhs, dA, ldda, dipiv, dB, lddb, dX, lddx,
                                    dWorkspace, lwork_bytes, iter, d_info)
     initialize_context()
-    @ccall libcusolver.cusolverDnSBgesv(handle::cusolverDnHandle_t, n::cusolver_int_t,
-                                        nrhs::cusolver_int_t, dA::CuPtr{Cfloat},
-                                        ldda::cusolver_int_t, dipiv::CuPtr{cusolver_int_t},
-                                        dB::CuPtr{Cfloat}, lddb::cusolver_int_t,
-                                        dX::CuPtr{Cfloat}, lddx::cusolver_int_t,
-                                        dWorkspace::CuPtr{Cvoid}, lwork_bytes::Csize_t,
-                                        iter::Ptr{cusolver_int_t},
-                                        d_info::CuPtr{cusolver_int_t})::cusolverStatus_t
+    @gcsafe_ccall libcusolver.cusolverDnSBgesv(handle::cusolverDnHandle_t,
+                                               n::cusolver_int_t, nrhs::cusolver_int_t,
+                                               dA::CuPtr{Cfloat}, ldda::cusolver_int_t,
+                                               dipiv::CuPtr{cusolver_int_t},
+                                               dB::CuPtr{Cfloat}, lddb::cusolver_int_t,
+                                               dX::CuPtr{Cfloat}, lddx::cusolver_int_t,
+                                               dWorkspace::CuPtr{Cvoid},
+                                               lwork_bytes::Csize_t,
+                                               iter::Ptr{cusolver_int_t},
+                                               d_info::CuPtr{cusolver_int_t})::cusolverStatus_t
 end
 
 @checked function cusolverDnSXgesv(handle, n, nrhs, dA, ldda, dipiv, dB, lddb, dX, lddx,
                                    dWorkspace, lwork_bytes, iter, d_info)
     initialize_context()
-    @ccall libcusolver.cusolverDnSXgesv(handle::cusolverDnHandle_t, n::cusolver_int_t,
-                                        nrhs::cusolver_int_t, dA::CuPtr{Cfloat},
-                                        ldda::cusolver_int_t, dipiv::CuPtr{cusolver_int_t},
-                                        dB::CuPtr{Cfloat}, lddb::cusolver_int_t,
-                                        dX::CuPtr{Cfloat}, lddx::cusolver_int_t,
-                                        dWorkspace::CuPtr{Cvoid}, lwork_bytes::Csize_t,
-                                        iter::Ptr{cusolver_int_t},
-                                        d_info::CuPtr{cusolver_int_t})::cusolverStatus_t
+    @gcsafe_ccall libcusolver.cusolverDnSXgesv(handle::cusolverDnHandle_t,
+                                               n::cusolver_int_t, nrhs::cusolver_int_t,
+                                               dA::CuPtr{Cfloat}, ldda::cusolver_int_t,
+                                               dipiv::CuPtr{cusolver_int_t},
+                                               dB::CuPtr{Cfloat}, lddb::cusolver_int_t,
+                                               dX::CuPtr{Cfloat}, lddx::cusolver_int_t,
+                                               dWorkspace::CuPtr{Cvoid},
+                                               lwork_bytes::Csize_t,
+                                               iter::Ptr{cusolver_int_t},
+                                               d_info::CuPtr{cusolver_int_t})::cusolverStatus_t
 end
 
 @checked function cusolverDnZZgesv_bufferSize(handle, n, nrhs, dA, ldda, dipiv, dB, lddb,
                                               dX, lddx, dWorkspace, lwork_bytes)
     initialize_context()
-    @ccall libcusolver.cusolverDnZZgesv_bufferSize(handle::cusolverDnHandle_t,
-                                                   n::cusolver_int_t, nrhs::cusolver_int_t,
-                                                   dA::CuPtr{cuDoubleComplex},
-                                                   ldda::cusolver_int_t,
-                                                   dipiv::CuPtr{cusolver_int_t},
-                                                   dB::CuPtr{cuDoubleComplex},
-                                                   lddb::cusolver_int_t,
-                                                   dX::CuPtr{cuDoubleComplex},
-                                                   lddx::cusolver_int_t,
-                                                   dWorkspace::CuPtr{Cvoid},
-                                                   lwork_bytes::Ptr{Csize_t})::cusolverStatus_t
+    @gcsafe_ccall libcusolver.cusolverDnZZgesv_bufferSize(handle::cusolverDnHandle_t,
+                                                          n::cusolver_int_t,
+                                                          nrhs::cusolver_int_t,
+                                                          dA::CuPtr{cuDoubleComplex},
+                                                          ldda::cusolver_int_t,
+                                                          dipiv::CuPtr{cusolver_int_t},
+                                                          dB::CuPtr{cuDoubleComplex},
+                                                          lddb::cusolver_int_t,
+                                                          dX::CuPtr{cuDoubleComplex},
+                                                          lddx::cusolver_int_t,
+                                                          dWorkspace::CuPtr{Cvoid},
+                                                          lwork_bytes::Ptr{Csize_t})::cusolverStatus_t
 end
 
 @checked function cusolverDnZCgesv_bufferSize(handle, n, nrhs, dA, ldda, dipiv, dB, lddb,
                                               dX, lddx, dWorkspace, lwork_bytes)
     initialize_context()
-    @ccall libcusolver.cusolverDnZCgesv_bufferSize(handle::cusolverDnHandle_t,
-                                                   n::cusolver_int_t, nrhs::cusolver_int_t,
-                                                   dA::CuPtr{cuDoubleComplex},
-                                                   ldda::cusolver_int_t,
-                                                   dipiv::CuPtr{cusolver_int_t},
-                                                   dB::CuPtr{cuDoubleComplex},
-                                                   lddb::cusolver_int_t,
-                                                   dX::CuPtr{cuDoubleComplex},
-                                                   lddx::cusolver_int_t,
-                                                   dWorkspace::CuPtr{Cvoid},
-                                                   lwork_bytes::Ptr{Csize_t})::cusolverStatus_t
+    @gcsafe_ccall libcusolver.cusolverDnZCgesv_bufferSize(handle::cusolverDnHandle_t,
+                                                          n::cusolver_int_t,
+                                                          nrhs::cusolver_int_t,
+                                                          dA::CuPtr{cuDoubleComplex},
+                                                          ldda::cusolver_int_t,
+                                                          dipiv::CuPtr{cusolver_int_t},
+                                                          dB::CuPtr{cuDoubleComplex},
+                                                          lddb::cusolver_int_t,
+                                                          dX::CuPtr{cuDoubleComplex},
+                                                          lddx::cusolver_int_t,
+                                                          dWorkspace::CuPtr{Cvoid},
+                                                          lwork_bytes::Ptr{Csize_t})::cusolverStatus_t
 end
 
 @checked function cusolverDnZKgesv_bufferSize(handle, n, nrhs, dA, ldda, dipiv, dB, lddb,
                                               dX, lddx, dWorkspace, lwork_bytes)
     initialize_context()
-    @ccall libcusolver.cusolverDnZKgesv_bufferSize(handle::cusolverDnHandle_t,
-                                                   n::cusolver_int_t, nrhs::cusolver_int_t,
-                                                   dA::CuPtr{cuDoubleComplex},
-                                                   ldda::cusolver_int_t,
-                                                   dipiv::CuPtr{cusolver_int_t},
-                                                   dB::CuPtr{cuDoubleComplex},
-                                                   lddb::cusolver_int_t,
-                                                   dX::CuPtr{cuDoubleComplex},
-                                                   lddx::cusolver_int_t,
-                                                   dWorkspace::CuPtr{Cvoid},
-                                                   lwork_bytes::Ptr{Csize_t})::cusolverStatus_t
+    @gcsafe_ccall libcusolver.cusolverDnZKgesv_bufferSize(handle::cusolverDnHandle_t,
+                                                          n::cusolver_int_t,
+                                                          nrhs::cusolver_int_t,
+                                                          dA::CuPtr{cuDoubleComplex},
+                                                          ldda::cusolver_int_t,
+                                                          dipiv::CuPtr{cusolver_int_t},
+                                                          dB::CuPtr{cuDoubleComplex},
+                                                          lddb::cusolver_int_t,
+                                                          dX::CuPtr{cuDoubleComplex},
+                                                          lddx::cusolver_int_t,
+                                                          dWorkspace::CuPtr{Cvoid},
+                                                          lwork_bytes::Ptr{Csize_t})::cusolverStatus_t
 end
 
 @checked function cusolverDnZEgesv_bufferSize(handle, n, nrhs, dA, ldda, dipiv, dB, lddb,
                                               dX, lddx, dWorkspace, lwork_bytes)
     initialize_context()
-    @ccall libcusolver.cusolverDnZEgesv_bufferSize(handle::cusolverDnHandle_t,
-                                                   n::cusolver_int_t, nrhs::cusolver_int_t,
-                                                   dA::CuPtr{cuDoubleComplex},
-                                                   ldda::cusolver_int_t,
-                                                   dipiv::CuPtr{cusolver_int_t},
-                                                   dB::CuPtr{cuDoubleComplex},
-                                                   lddb::cusolver_int_t,
-                                                   dX::CuPtr{cuDoubleComplex},
-                                                   lddx::cusolver_int_t,
-                                                   dWorkspace::CuPtr{Cvoid},
-                                                   lwork_bytes::Ptr{Csize_t})::cusolverStatus_t
+    @gcsafe_ccall libcusolver.cusolverDnZEgesv_bufferSize(handle::cusolverDnHandle_t,
+                                                          n::cusolver_int_t,
+                                                          nrhs::cusolver_int_t,
+                                                          dA::CuPtr{cuDoubleComplex},
+                                                          ldda::cusolver_int_t,
+                                                          dipiv::CuPtr{cusolver_int_t},
+                                                          dB::CuPtr{cuDoubleComplex},
+                                                          lddb::cusolver_int_t,
+                                                          dX::CuPtr{cuDoubleComplex},
+                                                          lddx::cusolver_int_t,
+                                                          dWorkspace::CuPtr{Cvoid},
+                                                          lwork_bytes::Ptr{Csize_t})::cusolverStatus_t
 end
 
 @checked function cusolverDnZYgesv_bufferSize(handle, n, nrhs, dA, ldda, dipiv, dB, lddb,
                                               dX, lddx, dWorkspace, lwork_bytes)
     initialize_context()
-    @ccall libcusolver.cusolverDnZYgesv_bufferSize(handle::cusolverDnHandle_t,
-                                                   n::cusolver_int_t, nrhs::cusolver_int_t,
-                                                   dA::CuPtr{cuDoubleComplex},
-                                                   ldda::cusolver_int_t,
-                                                   dipiv::CuPtr{cusolver_int_t},
-                                                   dB::CuPtr{cuDoubleComplex},
-                                                   lddb::cusolver_int_t,
-                                                   dX::CuPtr{cuDoubleComplex},
-                                                   lddx::cusolver_int_t,
-                                                   dWorkspace::CuPtr{Cvoid},
-                                                   lwork_bytes::Ptr{Csize_t})::cusolverStatus_t
+    @gcsafe_ccall libcusolver.cusolverDnZYgesv_bufferSize(handle::cusolverDnHandle_t,
+                                                          n::cusolver_int_t,
+                                                          nrhs::cusolver_int_t,
+                                                          dA::CuPtr{cuDoubleComplex},
+                                                          ldda::cusolver_int_t,
+                                                          dipiv::CuPtr{cusolver_int_t},
+                                                          dB::CuPtr{cuDoubleComplex},
+                                                          lddb::cusolver_int_t,
+                                                          dX::CuPtr{cuDoubleComplex},
+                                                          lddx::cusolver_int_t,
+                                                          dWorkspace::CuPtr{Cvoid},
+                                                          lwork_bytes::Ptr{Csize_t})::cusolverStatus_t
 end
 
 @checked function cusolverDnCCgesv_bufferSize(handle, n, nrhs, dA, ldda, dipiv, dB, lddb,
                                               dX, lddx, dWorkspace, lwork_bytes)
     initialize_context()
-    @ccall libcusolver.cusolverDnCCgesv_bufferSize(handle::cusolverDnHandle_t,
-                                                   n::cusolver_int_t, nrhs::cusolver_int_t,
-                                                   dA::CuPtr{cuComplex},
-                                                   ldda::cusolver_int_t,
-                                                   dipiv::CuPtr{cusolver_int_t},
-                                                   dB::CuPtr{cuComplex},
-                                                   lddb::cusolver_int_t,
-                                                   dX::CuPtr{cuComplex},
-                                                   lddx::cusolver_int_t,
-                                                   dWorkspace::CuPtr{Cvoid},
-                                                   lwork_bytes::Ptr{Csize_t})::cusolverStatus_t
+    @gcsafe_ccall libcusolver.cusolverDnCCgesv_bufferSize(handle::cusolverDnHandle_t,
+                                                          n::cusolver_int_t,
+                                                          nrhs::cusolver_int_t,
+                                                          dA::CuPtr{cuComplex},
+                                                          ldda::cusolver_int_t,
+                                                          dipiv::CuPtr{cusolver_int_t},
+                                                          dB::CuPtr{cuComplex},
+                                                          lddb::cusolver_int_t,
+                                                          dX::CuPtr{cuComplex},
+                                                          lddx::cusolver_int_t,
+                                                          dWorkspace::CuPtr{Cvoid},
+                                                          lwork_bytes::Ptr{Csize_t})::cusolverStatus_t
 end
 
 @checked function cusolverDnCKgesv_bufferSize(handle, n, nrhs, dA, ldda, dipiv, dB, lddb,
                                               dX, lddx, dWorkspace, lwork_bytes)
     initialize_context()
-    @ccall libcusolver.cusolverDnCKgesv_bufferSize(handle::cusolverDnHandle_t,
-                                                   n::cusolver_int_t, nrhs::cusolver_int_t,
-                                                   dA::CuPtr{cuComplex},
-                                                   ldda::cusolver_int_t,
-                                                   dipiv::CuPtr{cusolver_int_t},
-                                                   dB::CuPtr{cuComplex},
-                                                   lddb::cusolver_int_t,
-                                                   dX::CuPtr{cuComplex},
-                                                   lddx::cusolver_int_t,
-                                                   dWorkspace::CuPtr{Cvoid},
-                                                   lwork_bytes::Ptr{Csize_t})::cusolverStatus_t
+    @gcsafe_ccall libcusolver.cusolverDnCKgesv_bufferSize(handle::cusolverDnHandle_t,
+                                                          n::cusolver_int_t,
+                                                          nrhs::cusolver_int_t,
+                                                          dA::CuPtr{cuComplex},
+                                                          ldda::cusolver_int_t,
+                                                          dipiv::CuPtr{cusolver_int_t},
+                                                          dB::CuPtr{cuComplex},
+                                                          lddb::cusolver_int_t,
+                                                          dX::CuPtr{cuComplex},
+                                                          lddx::cusolver_int_t,
+                                                          dWorkspace::CuPtr{Cvoid},
+                                                          lwork_bytes::Ptr{Csize_t})::cusolverStatus_t
 end
 
 @checked function cusolverDnCEgesv_bufferSize(handle, n, nrhs, dA, ldda, dipiv, dB, lddb,
                                               dX, lddx, dWorkspace, lwork_bytes)
     initialize_context()
-    @ccall libcusolver.cusolverDnCEgesv_bufferSize(handle::cusolverDnHandle_t,
-                                                   n::cusolver_int_t, nrhs::cusolver_int_t,
-                                                   dA::CuPtr{cuComplex},
-                                                   ldda::cusolver_int_t,
-                                                   dipiv::CuPtr{cusolver_int_t},
-                                                   dB::CuPtr{cuComplex},
-                                                   lddb::cusolver_int_t,
-                                                   dX::CuPtr{cuComplex},
-                                                   lddx::cusolver_int_t,
-                                                   dWorkspace::CuPtr{Cvoid},
-                                                   lwork_bytes::Ptr{Csize_t})::cusolverStatus_t
+    @gcsafe_ccall libcusolver.cusolverDnCEgesv_bufferSize(handle::cusolverDnHandle_t,
+                                                          n::cusolver_int_t,
+                                                          nrhs::cusolver_int_t,
+                                                          dA::CuPtr{cuComplex},
+                                                          ldda::cusolver_int_t,
+                                                          dipiv::CuPtr{cusolver_int_t},
+                                                          dB::CuPtr{cuComplex},
+                                                          lddb::cusolver_int_t,
+                                                          dX::CuPtr{cuComplex},
+                                                          lddx::cusolver_int_t,
+                                                          dWorkspace::CuPtr{Cvoid},
+                                                          lwork_bytes::Ptr{Csize_t})::cusolverStatus_t
 end
 
 @checked function cusolverDnCYgesv_bufferSize(handle, n, nrhs, dA, ldda, dipiv, dB, lddb,
                                               dX, lddx, dWorkspace, lwork_bytes)
     initialize_context()
-    @ccall libcusolver.cusolverDnCYgesv_bufferSize(handle::cusolverDnHandle_t,
-                                                   n::cusolver_int_t, nrhs::cusolver_int_t,
-                                                   dA::CuPtr{cuComplex},
-                                                   ldda::cusolver_int_t,
-                                                   dipiv::CuPtr{cusolver_int_t},
-                                                   dB::CuPtr{cuComplex},
-                                                   lddb::cusolver_int_t,
-                                                   dX::CuPtr{cuComplex},
-                                                   lddx::cusolver_int_t,
-                                                   dWorkspace::CuPtr{Cvoid},
-                                                   lwork_bytes::Ptr{Csize_t})::cusolverStatus_t
+    @gcsafe_ccall libcusolver.cusolverDnCYgesv_bufferSize(handle::cusolverDnHandle_t,
+                                                          n::cusolver_int_t,
+                                                          nrhs::cusolver_int_t,
+                                                          dA::CuPtr{cuComplex},
+                                                          ldda::cusolver_int_t,
+                                                          dipiv::CuPtr{cusolver_int_t},
+                                                          dB::CuPtr{cuComplex},
+                                                          lddb::cusolver_int_t,
+                                                          dX::CuPtr{cuComplex},
+                                                          lddx::cusolver_int_t,
+                                                          dWorkspace::CuPtr{Cvoid},
+                                                          lwork_bytes::Ptr{Csize_t})::cusolverStatus_t
 end
 
 @checked function cusolverDnDDgesv_bufferSize(handle, n, nrhs, dA, ldda, dipiv, dB, lddb,
                                               dX, lddx, dWorkspace, lwork_bytes)
     initialize_context()
-    @ccall libcusolver.cusolverDnDDgesv_bufferSize(handle::cusolverDnHandle_t,
-                                                   n::cusolver_int_t, nrhs::cusolver_int_t,
-                                                   dA::CuPtr{Cdouble}, ldda::cusolver_int_t,
-                                                   dipiv::CuPtr{cusolver_int_t},
-                                                   dB::CuPtr{Cdouble}, lddb::cusolver_int_t,
-                                                   dX::CuPtr{Cdouble}, lddx::cusolver_int_t,
-                                                   dWorkspace::CuPtr{Cvoid},
-                                                   lwork_bytes::Ptr{Csize_t})::cusolverStatus_t
+    @gcsafe_ccall libcusolver.cusolverDnDDgesv_bufferSize(handle::cusolverDnHandle_t,
+                                                          n::cusolver_int_t,
+                                                          nrhs::cusolver_int_t,
+                                                          dA::CuPtr{Cdouble},
+                                                          ldda::cusolver_int_t,
+                                                          dipiv::CuPtr{cusolver_int_t},
+                                                          dB::CuPtr{Cdouble},
+                                                          lddb::cusolver_int_t,
+                                                          dX::CuPtr{Cdouble},
+                                                          lddx::cusolver_int_t,
+                                                          dWorkspace::CuPtr{Cvoid},
+                                                          lwork_bytes::Ptr{Csize_t})::cusolverStatus_t
 end
 
 @checked function cusolverDnDSgesv_bufferSize(handle, n, nrhs, dA, ldda, dipiv, dB, lddb,
                                               dX, lddx, dWorkspace, lwork_bytes)
     initialize_context()
-    @ccall libcusolver.cusolverDnDSgesv_bufferSize(handle::cusolverDnHandle_t,
-                                                   n::cusolver_int_t, nrhs::cusolver_int_t,
-                                                   dA::CuPtr{Cdouble}, ldda::cusolver_int_t,
-                                                   dipiv::CuPtr{cusolver_int_t},
-                                                   dB::CuPtr{Cdouble}, lddb::cusolver_int_t,
-                                                   dX::CuPtr{Cdouble}, lddx::cusolver_int_t,
-                                                   dWorkspace::CuPtr{Cvoid},
-                                                   lwork_bytes::Ptr{Csize_t})::cusolverStatus_t
+    @gcsafe_ccall libcusolver.cusolverDnDSgesv_bufferSize(handle::cusolverDnHandle_t,
+                                                          n::cusolver_int_t,
+                                                          nrhs::cusolver_int_t,
+                                                          dA::CuPtr{Cdouble},
+                                                          ldda::cusolver_int_t,
+                                                          dipiv::CuPtr{cusolver_int_t},
+                                                          dB::CuPtr{Cdouble},
+                                                          lddb::cusolver_int_t,
+                                                          dX::CuPtr{Cdouble},
+                                                          lddx::cusolver_int_t,
+                                                          dWorkspace::CuPtr{Cvoid},
+                                                          lwork_bytes::Ptr{Csize_t})::cusolverStatus_t
 end
 
 @checked function cusolverDnDHgesv_bufferSize(handle, n, nrhs, dA, ldda, dipiv, dB, lddb,
                                               dX, lddx, dWorkspace, lwork_bytes)
     initialize_context()
-    @ccall libcusolver.cusolverDnDHgesv_bufferSize(handle::cusolverDnHandle_t,
-                                                   n::cusolver_int_t, nrhs::cusolver_int_t,
-                                                   dA::CuPtr{Cdouble}, ldda::cusolver_int_t,
-                                                   dipiv::CuPtr{cusolver_int_t},
-                                                   dB::CuPtr{Cdouble}, lddb::cusolver_int_t,
-                                                   dX::CuPtr{Cdouble}, lddx::cusolver_int_t,
-                                                   dWorkspace::CuPtr{Cvoid},
-                                                   lwork_bytes::Ptr{Csize_t})::cusolverStatus_t
+    @gcsafe_ccall libcusolver.cusolverDnDHgesv_bufferSize(handle::cusolverDnHandle_t,
+                                                          n::cusolver_int_t,
+                                                          nrhs::cusolver_int_t,
+                                                          dA::CuPtr{Cdouble},
+                                                          ldda::cusolver_int_t,
+                                                          dipiv::CuPtr{cusolver_int_t},
+                                                          dB::CuPtr{Cdouble},
+                                                          lddb::cusolver_int_t,
+                                                          dX::CuPtr{Cdouble},
+                                                          lddx::cusolver_int_t,
+                                                          dWorkspace::CuPtr{Cvoid},
+                                                          lwork_bytes::Ptr{Csize_t})::cusolverStatus_t
 end
 
 @checked function cusolverDnDBgesv_bufferSize(handle, n, nrhs, dA, ldda, dipiv, dB, lddb,
                                               dX, lddx, dWorkspace, lwork_bytes)
     initialize_context()
-    @ccall libcusolver.cusolverDnDBgesv_bufferSize(handle::cusolverDnHandle_t,
-                                                   n::cusolver_int_t, nrhs::cusolver_int_t,
-                                                   dA::CuPtr{Cdouble}, ldda::cusolver_int_t,
-                                                   dipiv::CuPtr{cusolver_int_t},
-                                                   dB::CuPtr{Cdouble}, lddb::cusolver_int_t,
-                                                   dX::CuPtr{Cdouble}, lddx::cusolver_int_t,
-                                                   dWorkspace::CuPtr{Cvoid},
-                                                   lwork_bytes::Ptr{Csize_t})::cusolverStatus_t
+    @gcsafe_ccall libcusolver.cusolverDnDBgesv_bufferSize(handle::cusolverDnHandle_t,
+                                                          n::cusolver_int_t,
+                                                          nrhs::cusolver_int_t,
+                                                          dA::CuPtr{Cdouble},
+                                                          ldda::cusolver_int_t,
+                                                          dipiv::CuPtr{cusolver_int_t},
+                                                          dB::CuPtr{Cdouble},
+                                                          lddb::cusolver_int_t,
+                                                          dX::CuPtr{Cdouble},
+                                                          lddx::cusolver_int_t,
+                                                          dWorkspace::CuPtr{Cvoid},
+                                                          lwork_bytes::Ptr{Csize_t})::cusolverStatus_t
 end
 
 @checked function cusolverDnDXgesv_bufferSize(handle, n, nrhs, dA, ldda, dipiv, dB, lddb,
                                               dX, lddx, dWorkspace, lwork_bytes)
     initialize_context()
-    @ccall libcusolver.cusolverDnDXgesv_bufferSize(handle::cusolverDnHandle_t,
-                                                   n::cusolver_int_t, nrhs::cusolver_int_t,
-                                                   dA::CuPtr{Cdouble}, ldda::cusolver_int_t,
-                                                   dipiv::CuPtr{cusolver_int_t},
-                                                   dB::CuPtr{Cdouble}, lddb::cusolver_int_t,
-                                                   dX::CuPtr{Cdouble}, lddx::cusolver_int_t,
-                                                   dWorkspace::CuPtr{Cvoid},
-                                                   lwork_bytes::Ptr{Csize_t})::cusolverStatus_t
+    @gcsafe_ccall libcusolver.cusolverDnDXgesv_bufferSize(handle::cusolverDnHandle_t,
+                                                          n::cusolver_int_t,
+                                                          nrhs::cusolver_int_t,
+                                                          dA::CuPtr{Cdouble},
+                                                          ldda::cusolver_int_t,
+                                                          dipiv::CuPtr{cusolver_int_t},
+                                                          dB::CuPtr{Cdouble},
+                                                          lddb::cusolver_int_t,
+                                                          dX::CuPtr{Cdouble},
+                                                          lddx::cusolver_int_t,
+                                                          dWorkspace::CuPtr{Cvoid},
+                                                          lwork_bytes::Ptr{Csize_t})::cusolverStatus_t
 end
 
 @checked function cusolverDnSSgesv_bufferSize(handle, n, nrhs, dA, ldda, dipiv, dB, lddb,
                                               dX, lddx, dWorkspace, lwork_bytes)
     initialize_context()
-    @ccall libcusolver.cusolverDnSSgesv_bufferSize(handle::cusolverDnHandle_t,
-                                                   n::cusolver_int_t, nrhs::cusolver_int_t,
-                                                   dA::CuPtr{Cfloat}, ldda::cusolver_int_t,
-                                                   dipiv::CuPtr{cusolver_int_t},
-                                                   dB::CuPtr{Cfloat}, lddb::cusolver_int_t,
-                                                   dX::CuPtr{Cfloat}, lddx::cusolver_int_t,
-                                                   dWorkspace::CuPtr{Cvoid},
-                                                   lwork_bytes::Ptr{Csize_t})::cusolverStatus_t
+    @gcsafe_ccall libcusolver.cusolverDnSSgesv_bufferSize(handle::cusolverDnHandle_t,
+                                                          n::cusolver_int_t,
+                                                          nrhs::cusolver_int_t,
+                                                          dA::CuPtr{Cfloat},
+                                                          ldda::cusolver_int_t,
+                                                          dipiv::CuPtr{cusolver_int_t},
+                                                          dB::CuPtr{Cfloat},
+                                                          lddb::cusolver_int_t,
+                                                          dX::CuPtr{Cfloat},
+                                                          lddx::cusolver_int_t,
+                                                          dWorkspace::CuPtr{Cvoid},
+                                                          lwork_bytes::Ptr{Csize_t})::cusolverStatus_t
 end
 
 @checked function cusolverDnSHgesv_bufferSize(handle, n, nrhs, dA, ldda, dipiv, dB, lddb,
                                               dX, lddx, dWorkspace, lwork_bytes)
     initialize_context()
-    @ccall libcusolver.cusolverDnSHgesv_bufferSize(handle::cusolverDnHandle_t,
-                                                   n::cusolver_int_t, nrhs::cusolver_int_t,
-                                                   dA::CuPtr{Cfloat}, ldda::cusolver_int_t,
-                                                   dipiv::CuPtr{cusolver_int_t},
-                                                   dB::CuPtr{Cfloat}, lddb::cusolver_int_t,
-                                                   dX::CuPtr{Cfloat}, lddx::cusolver_int_t,
-                                                   dWorkspace::CuPtr{Cvoid},
-                                                   lwork_bytes::Ptr{Csize_t})::cusolverStatus_t
+    @gcsafe_ccall libcusolver.cusolverDnSHgesv_bufferSize(handle::cusolverDnHandle_t,
+                                                          n::cusolver_int_t,
+                                                          nrhs::cusolver_int_t,
+                                                          dA::CuPtr{Cfloat},
+                                                          ldda::cusolver_int_t,
+                                                          dipiv::CuPtr{cusolver_int_t},
+                                                          dB::CuPtr{Cfloat},
+                                                          lddb::cusolver_int_t,
+                                                          dX::CuPtr{Cfloat},
+                                                          lddx::cusolver_int_t,
+                                                          dWorkspace::CuPtr{Cvoid},
+                                                          lwork_bytes::Ptr{Csize_t})::cusolverStatus_t
 end
 
 @checked function cusolverDnSBgesv_bufferSize(handle, n, nrhs, dA, ldda, dipiv, dB, lddb,
                                               dX, lddx, dWorkspace, lwork_bytes)
     initialize_context()
-    @ccall libcusolver.cusolverDnSBgesv_bufferSize(handle::cusolverDnHandle_t,
-                                                   n::cusolver_int_t, nrhs::cusolver_int_t,
-                                                   dA::CuPtr{Cfloat}, ldda::cusolver_int_t,
-                                                   dipiv::CuPtr{cusolver_int_t},
-                                                   dB::CuPtr{Cfloat}, lddb::cusolver_int_t,
-                                                   dX::CuPtr{Cfloat}, lddx::cusolver_int_t,
-                                                   dWorkspace::CuPtr{Cvoid},
-                                                   lwork_bytes::Ptr{Csize_t})::cusolverStatus_t
+    @gcsafe_ccall libcusolver.cusolverDnSBgesv_bufferSize(handle::cusolverDnHandle_t,
+                                                          n::cusolver_int_t,
+                                                          nrhs::cusolver_int_t,
+                                                          dA::CuPtr{Cfloat},
+                                                          ldda::cusolver_int_t,
+                                                          dipiv::CuPtr{cusolver_int_t},
+                                                          dB::CuPtr{Cfloat},
+                                                          lddb::cusolver_int_t,
+                                                          dX::CuPtr{Cfloat},
+                                                          lddx::cusolver_int_t,
+                                                          dWorkspace::CuPtr{Cvoid},
+                                                          lwork_bytes::Ptr{Csize_t})::cusolverStatus_t
 end
 
 @checked function cusolverDnSXgesv_bufferSize(handle, n, nrhs, dA, ldda, dipiv, dB, lddb,
                                               dX, lddx, dWorkspace, lwork_bytes)
     initialize_context()
-    @ccall libcusolver.cusolverDnSXgesv_bufferSize(handle::cusolverDnHandle_t,
-                                                   n::cusolver_int_t, nrhs::cusolver_int_t,
-                                                   dA::CuPtr{Cfloat}, ldda::cusolver_int_t,
-                                                   dipiv::CuPtr{cusolver_int_t},
-                                                   dB::CuPtr{Cfloat}, lddb::cusolver_int_t,
-                                                   dX::CuPtr{Cfloat}, lddx::cusolver_int_t,
-                                                   dWorkspace::CuPtr{Cvoid},
-                                                   lwork_bytes::Ptr{Csize_t})::cusolverStatus_t
+    @gcsafe_ccall libcusolver.cusolverDnSXgesv_bufferSize(handle::cusolverDnHandle_t,
+                                                          n::cusolver_int_t,
+                                                          nrhs::cusolver_int_t,
+                                                          dA::CuPtr{Cfloat},
+                                                          ldda::cusolver_int_t,
+                                                          dipiv::CuPtr{cusolver_int_t},
+                                                          dB::CuPtr{Cfloat},
+                                                          lddb::cusolver_int_t,
+                                                          dX::CuPtr{Cfloat},
+                                                          lddx::cusolver_int_t,
+                                                          dWorkspace::CuPtr{Cvoid},
+                                                          lwork_bytes::Ptr{Csize_t})::cusolverStatus_t
 end
 
 @checked function cusolverDnZZgels(handle, m, n, nrhs, dA, ldda, dB, lddb, dX, lddx,
                                    dWorkspace, lwork_bytes, iter, d_info)
     initialize_context()
-    @ccall libcusolver.cusolverDnZZgels(handle::cusolverDnHandle_t, m::cusolver_int_t,
-                                        n::cusolver_int_t, nrhs::cusolver_int_t,
-                                        dA::CuPtr{cuDoubleComplex}, ldda::cusolver_int_t,
-                                        dB::CuPtr{cuDoubleComplex}, lddb::cusolver_int_t,
-                                        dX::CuPtr{cuDoubleComplex}, lddx::cusolver_int_t,
-                                        dWorkspace::CuPtr{Cvoid}, lwork_bytes::Csize_t,
-                                        iter::Ptr{cusolver_int_t},
-                                        d_info::CuPtr{cusolver_int_t})::cusolverStatus_t
+    @gcsafe_ccall libcusolver.cusolverDnZZgels(handle::cusolverDnHandle_t,
+                                               m::cusolver_int_t, n::cusolver_int_t,
+                                               nrhs::cusolver_int_t,
+                                               dA::CuPtr{cuDoubleComplex},
+                                               ldda::cusolver_int_t,
+                                               dB::CuPtr{cuDoubleComplex},
+                                               lddb::cusolver_int_t,
+                                               dX::CuPtr{cuDoubleComplex},
+                                               lddx::cusolver_int_t,
+                                               dWorkspace::CuPtr{Cvoid},
+                                               lwork_bytes::Csize_t,
+                                               iter::Ptr{cusolver_int_t},
+                                               d_info::CuPtr{cusolver_int_t})::cusolverStatus_t
 end
 
 @checked function cusolverDnZCgels(handle, m, n, nrhs, dA, ldda, dB, lddb, dX, lddx,
                                    dWorkspace, lwork_bytes, iter, d_info)
     initialize_context()
-    @ccall libcusolver.cusolverDnZCgels(handle::cusolverDnHandle_t, m::cusolver_int_t,
-                                        n::cusolver_int_t, nrhs::cusolver_int_t,
-                                        dA::CuPtr{cuDoubleComplex}, ldda::cusolver_int_t,
-                                        dB::CuPtr{cuDoubleComplex}, lddb::cusolver_int_t,
-                                        dX::CuPtr{cuDoubleComplex}, lddx::cusolver_int_t,
-                                        dWorkspace::CuPtr{Cvoid}, lwork_bytes::Csize_t,
-                                        iter::Ptr{cusolver_int_t},
-                                        d_info::CuPtr{cusolver_int_t})::cusolverStatus_t
+    @gcsafe_ccall libcusolver.cusolverDnZCgels(handle::cusolverDnHandle_t,
+                                               m::cusolver_int_t, n::cusolver_int_t,
+                                               nrhs::cusolver_int_t,
+                                               dA::CuPtr{cuDoubleComplex},
+                                               ldda::cusolver_int_t,
+                                               dB::CuPtr{cuDoubleComplex},
+                                               lddb::cusolver_int_t,
+                                               dX::CuPtr{cuDoubleComplex},
+                                               lddx::cusolver_int_t,
+                                               dWorkspace::CuPtr{Cvoid},
+                                               lwork_bytes::Csize_t,
+                                               iter::Ptr{cusolver_int_t},
+                                               d_info::CuPtr{cusolver_int_t})::cusolverStatus_t
 end
 
 @checked function cusolverDnZKgels(handle, m, n, nrhs, dA, ldda, dB, lddb, dX, lddx,
                                    dWorkspace, lwork_bytes, iter, d_info)
     initialize_context()
-    @ccall libcusolver.cusolverDnZKgels(handle::cusolverDnHandle_t, m::cusolver_int_t,
-                                        n::cusolver_int_t, nrhs::cusolver_int_t,
-                                        dA::CuPtr{cuDoubleComplex}, ldda::cusolver_int_t,
-                                        dB::CuPtr{cuDoubleComplex}, lddb::cusolver_int_t,
-                                        dX::CuPtr{cuDoubleComplex}, lddx::cusolver_int_t,
-                                        dWorkspace::CuPtr{Cvoid}, lwork_bytes::Csize_t,
-                                        iter::Ptr{cusolver_int_t},
-                                        d_info::CuPtr{cusolver_int_t})::cusolverStatus_t
+    @gcsafe_ccall libcusolver.cusolverDnZKgels(handle::cusolverDnHandle_t,
+                                               m::cusolver_int_t, n::cusolver_int_t,
+                                               nrhs::cusolver_int_t,
+                                               dA::CuPtr{cuDoubleComplex},
+                                               ldda::cusolver_int_t,
+                                               dB::CuPtr{cuDoubleComplex},
+                                               lddb::cusolver_int_t,
+                                               dX::CuPtr{cuDoubleComplex},
+                                               lddx::cusolver_int_t,
+                                               dWorkspace::CuPtr{Cvoid},
+                                               lwork_bytes::Csize_t,
+                                               iter::Ptr{cusolver_int_t},
+                                               d_info::CuPtr{cusolver_int_t})::cusolverStatus_t
 end
 
 @checked function cusolverDnZEgels(handle, m, n, nrhs, dA, ldda, dB, lddb, dX, lddx,
                                    dWorkspace, lwork_bytes, iter, d_info)
     initialize_context()
-    @ccall libcusolver.cusolverDnZEgels(handle::cusolverDnHandle_t, m::cusolver_int_t,
-                                        n::cusolver_int_t, nrhs::cusolver_int_t,
-                                        dA::CuPtr{cuDoubleComplex}, ldda::cusolver_int_t,
-                                        dB::CuPtr{cuDoubleComplex}, lddb::cusolver_int_t,
-                                        dX::CuPtr{cuDoubleComplex}, lddx::cusolver_int_t,
-                                        dWorkspace::CuPtr{Cvoid}, lwork_bytes::Csize_t,
-                                        iter::Ptr{cusolver_int_t},
-                                        d_info::CuPtr{cusolver_int_t})::cusolverStatus_t
+    @gcsafe_ccall libcusolver.cusolverDnZEgels(handle::cusolverDnHandle_t,
+                                               m::cusolver_int_t, n::cusolver_int_t,
+                                               nrhs::cusolver_int_t,
+                                               dA::CuPtr{cuDoubleComplex},
+                                               ldda::cusolver_int_t,
+                                               dB::CuPtr{cuDoubleComplex},
+                                               lddb::cusolver_int_t,
+                                               dX::CuPtr{cuDoubleComplex},
+                                               lddx::cusolver_int_t,
+                                               dWorkspace::CuPtr{Cvoid},
+                                               lwork_bytes::Csize_t,
+                                               iter::Ptr{cusolver_int_t},
+                                               d_info::CuPtr{cusolver_int_t})::cusolverStatus_t
 end
 
 @checked function cusolverDnZYgels(handle, m, n, nrhs, dA, ldda, dB, lddb, dX, lddx,
                                    dWorkspace, lwork_bytes, iter, d_info)
     initialize_context()
-    @ccall libcusolver.cusolverDnZYgels(handle::cusolverDnHandle_t, m::cusolver_int_t,
-                                        n::cusolver_int_t, nrhs::cusolver_int_t,
-                                        dA::CuPtr{cuDoubleComplex}, ldda::cusolver_int_t,
-                                        dB::CuPtr{cuDoubleComplex}, lddb::cusolver_int_t,
-                                        dX::CuPtr{cuDoubleComplex}, lddx::cusolver_int_t,
-                                        dWorkspace::CuPtr{Cvoid}, lwork_bytes::Csize_t,
-                                        iter::Ptr{cusolver_int_t},
-                                        d_info::CuPtr{cusolver_int_t})::cusolverStatus_t
+    @gcsafe_ccall libcusolver.cusolverDnZYgels(handle::cusolverDnHandle_t,
+                                               m::cusolver_int_t, n::cusolver_int_t,
+                                               nrhs::cusolver_int_t,
+                                               dA::CuPtr{cuDoubleComplex},
+                                               ldda::cusolver_int_t,
+                                               dB::CuPtr{cuDoubleComplex},
+                                               lddb::cusolver_int_t,
+                                               dX::CuPtr{cuDoubleComplex},
+                                               lddx::cusolver_int_t,
+                                               dWorkspace::CuPtr{Cvoid},
+                                               lwork_bytes::Csize_t,
+                                               iter::Ptr{cusolver_int_t},
+                                               d_info::CuPtr{cusolver_int_t})::cusolverStatus_t
 end
 
 @checked function cusolverDnCCgels(handle, m, n, nrhs, dA, ldda, dB, lddb, dX, lddx,
                                    dWorkspace, lwork_bytes, iter, d_info)
     initialize_context()
-    @ccall libcusolver.cusolverDnCCgels(handle::cusolverDnHandle_t, m::cusolver_int_t,
-                                        n::cusolver_int_t, nrhs::cusolver_int_t,
-                                        dA::CuPtr{cuComplex}, ldda::cusolver_int_t,
-                                        dB::CuPtr{cuComplex}, lddb::cusolver_int_t,
-                                        dX::CuPtr{cuComplex}, lddx::cusolver_int_t,
-                                        dWorkspace::CuPtr{Cvoid}, lwork_bytes::Csize_t,
-                                        iter::Ptr{cusolver_int_t},
-                                        d_info::CuPtr{cusolver_int_t})::cusolverStatus_t
+    @gcsafe_ccall libcusolver.cusolverDnCCgels(handle::cusolverDnHandle_t,
+                                               m::cusolver_int_t, n::cusolver_int_t,
+                                               nrhs::cusolver_int_t, dA::CuPtr{cuComplex},
+                                               ldda::cusolver_int_t, dB::CuPtr{cuComplex},
+                                               lddb::cusolver_int_t, dX::CuPtr{cuComplex},
+                                               lddx::cusolver_int_t,
+                                               dWorkspace::CuPtr{Cvoid},
+                                               lwork_bytes::Csize_t,
+                                               iter::Ptr{cusolver_int_t},
+                                               d_info::CuPtr{cusolver_int_t})::cusolverStatus_t
 end
 
 @checked function cusolverDnCKgels(handle, m, n, nrhs, dA, ldda, dB, lddb, dX, lddx,
                                    dWorkspace, lwork_bytes, iter, d_info)
     initialize_context()
-    @ccall libcusolver.cusolverDnCKgels(handle::cusolverDnHandle_t, m::cusolver_int_t,
-                                        n::cusolver_int_t, nrhs::cusolver_int_t,
-                                        dA::CuPtr{cuComplex}, ldda::cusolver_int_t,
-                                        dB::CuPtr{cuComplex}, lddb::cusolver_int_t,
-                                        dX::CuPtr{cuComplex}, lddx::cusolver_int_t,
-                                        dWorkspace::CuPtr{Cvoid}, lwork_bytes::Csize_t,
-                                        iter::Ptr{cusolver_int_t},
-                                        d_info::CuPtr{cusolver_int_t})::cusolverStatus_t
+    @gcsafe_ccall libcusolver.cusolverDnCKgels(handle::cusolverDnHandle_t,
+                                               m::cusolver_int_t, n::cusolver_int_t,
+                                               nrhs::cusolver_int_t, dA::CuPtr{cuComplex},
+                                               ldda::cusolver_int_t, dB::CuPtr{cuComplex},
+                                               lddb::cusolver_int_t, dX::CuPtr{cuComplex},
+                                               lddx::cusolver_int_t,
+                                               dWorkspace::CuPtr{Cvoid},
+                                               lwork_bytes::Csize_t,
+                                               iter::Ptr{cusolver_int_t},
+                                               d_info::CuPtr{cusolver_int_t})::cusolverStatus_t
 end
 
 @checked function cusolverDnCEgels(handle, m, n, nrhs, dA, ldda, dB, lddb, dX, lddx,
                                    dWorkspace, lwork_bytes, iter, d_info)
     initialize_context()
-    @ccall libcusolver.cusolverDnCEgels(handle::cusolverDnHandle_t, m::cusolver_int_t,
-                                        n::cusolver_int_t, nrhs::cusolver_int_t,
-                                        dA::CuPtr{cuComplex}, ldda::cusolver_int_t,
-                                        dB::CuPtr{cuComplex}, lddb::cusolver_int_t,
-                                        dX::CuPtr{cuComplex}, lddx::cusolver_int_t,
-                                        dWorkspace::CuPtr{Cvoid}, lwork_bytes::Csize_t,
-                                        iter::Ptr{cusolver_int_t},
-                                        d_info::CuPtr{cusolver_int_t})::cusolverStatus_t
+    @gcsafe_ccall libcusolver.cusolverDnCEgels(handle::cusolverDnHandle_t,
+                                               m::cusolver_int_t, n::cusolver_int_t,
+                                               nrhs::cusolver_int_t, dA::CuPtr{cuComplex},
+                                               ldda::cusolver_int_t, dB::CuPtr{cuComplex},
+                                               lddb::cusolver_int_t, dX::CuPtr{cuComplex},
+                                               lddx::cusolver_int_t,
+                                               dWorkspace::CuPtr{Cvoid},
+                                               lwork_bytes::Csize_t,
+                                               iter::Ptr{cusolver_int_t},
+                                               d_info::CuPtr{cusolver_int_t})::cusolverStatus_t
 end
 
 @checked function cusolverDnCYgels(handle, m, n, nrhs, dA, ldda, dB, lddb, dX, lddx,
                                    dWorkspace, lwork_bytes, iter, d_info)
     initialize_context()
-    @ccall libcusolver.cusolverDnCYgels(handle::cusolverDnHandle_t, m::cusolver_int_t,
-                                        n::cusolver_int_t, nrhs::cusolver_int_t,
-                                        dA::CuPtr{cuComplex}, ldda::cusolver_int_t,
-                                        dB::CuPtr{cuComplex}, lddb::cusolver_int_t,
-                                        dX::CuPtr{cuComplex}, lddx::cusolver_int_t,
-                                        dWorkspace::CuPtr{Cvoid}, lwork_bytes::Csize_t,
-                                        iter::Ptr{cusolver_int_t},
-                                        d_info::CuPtr{cusolver_int_t})::cusolverStatus_t
+    @gcsafe_ccall libcusolver.cusolverDnCYgels(handle::cusolverDnHandle_t,
+                                               m::cusolver_int_t, n::cusolver_int_t,
+                                               nrhs::cusolver_int_t, dA::CuPtr{cuComplex},
+                                               ldda::cusolver_int_t, dB::CuPtr{cuComplex},
+                                               lddb::cusolver_int_t, dX::CuPtr{cuComplex},
+                                               lddx::cusolver_int_t,
+                                               dWorkspace::CuPtr{Cvoid},
+                                               lwork_bytes::Csize_t,
+                                               iter::Ptr{cusolver_int_t},
+                                               d_info::CuPtr{cusolver_int_t})::cusolverStatus_t
 end
 
 @checked function cusolverDnDDgels(handle, m, n, nrhs, dA, ldda, dB, lddb, dX, lddx,
                                    dWorkspace, lwork_bytes, iter, d_info)
     initialize_context()
-    @ccall libcusolver.cusolverDnDDgels(handle::cusolverDnHandle_t, m::cusolver_int_t,
-                                        n::cusolver_int_t, nrhs::cusolver_int_t,
-                                        dA::CuPtr{Cdouble}, ldda::cusolver_int_t,
-                                        dB::CuPtr{Cdouble}, lddb::cusolver_int_t,
-                                        dX::CuPtr{Cdouble}, lddx::cusolver_int_t,
-                                        dWorkspace::CuPtr{Cvoid}, lwork_bytes::Csize_t,
-                                        iter::Ptr{cusolver_int_t},
-                                        d_info::CuPtr{cusolver_int_t})::cusolverStatus_t
+    @gcsafe_ccall libcusolver.cusolverDnDDgels(handle::cusolverDnHandle_t,
+                                               m::cusolver_int_t, n::cusolver_int_t,
+                                               nrhs::cusolver_int_t, dA::CuPtr{Cdouble},
+                                               ldda::cusolver_int_t, dB::CuPtr{Cdouble},
+                                               lddb::cusolver_int_t, dX::CuPtr{Cdouble},
+                                               lddx::cusolver_int_t,
+                                               dWorkspace::CuPtr{Cvoid},
+                                               lwork_bytes::Csize_t,
+                                               iter::Ptr{cusolver_int_t},
+                                               d_info::CuPtr{cusolver_int_t})::cusolverStatus_t
 end
 
 @checked function cusolverDnDSgels(handle, m, n, nrhs, dA, ldda, dB, lddb, dX, lddx,
                                    dWorkspace, lwork_bytes, iter, d_info)
     initialize_context()
-    @ccall libcusolver.cusolverDnDSgels(handle::cusolverDnHandle_t, m::cusolver_int_t,
-                                        n::cusolver_int_t, nrhs::cusolver_int_t,
-                                        dA::CuPtr{Cdouble}, ldda::cusolver_int_t,
-                                        dB::CuPtr{Cdouble}, lddb::cusolver_int_t,
-                                        dX::CuPtr{Cdouble}, lddx::cusolver_int_t,
-                                        dWorkspace::CuPtr{Cvoid}, lwork_bytes::Csize_t,
-                                        iter::Ptr{cusolver_int_t},
-                                        d_info::CuPtr{cusolver_int_t})::cusolverStatus_t
+    @gcsafe_ccall libcusolver.cusolverDnDSgels(handle::cusolverDnHandle_t,
+                                               m::cusolver_int_t, n::cusolver_int_t,
+                                               nrhs::cusolver_int_t, dA::CuPtr{Cdouble},
+                                               ldda::cusolver_int_t, dB::CuPtr{Cdouble},
+                                               lddb::cusolver_int_t, dX::CuPtr{Cdouble},
+                                               lddx::cusolver_int_t,
+                                               dWorkspace::CuPtr{Cvoid},
+                                               lwork_bytes::Csize_t,
+                                               iter::Ptr{cusolver_int_t},
+                                               d_info::CuPtr{cusolver_int_t})::cusolverStatus_t
 end
 
 @checked function cusolverDnDHgels(handle, m, n, nrhs, dA, ldda, dB, lddb, dX, lddx,
                                    dWorkspace, lwork_bytes, iter, d_info)
     initialize_context()
-    @ccall libcusolver.cusolverDnDHgels(handle::cusolverDnHandle_t, m::cusolver_int_t,
-                                        n::cusolver_int_t, nrhs::cusolver_int_t,
-                                        dA::CuPtr{Cdouble}, ldda::cusolver_int_t,
-                                        dB::CuPtr{Cdouble}, lddb::cusolver_int_t,
-                                        dX::CuPtr{Cdouble}, lddx::cusolver_int_t,
-                                        dWorkspace::CuPtr{Cvoid}, lwork_bytes::Csize_t,
-                                        iter::Ptr{cusolver_int_t},
-                                        d_info::CuPtr{cusolver_int_t})::cusolverStatus_t
+    @gcsafe_ccall libcusolver.cusolverDnDHgels(handle::cusolverDnHandle_t,
+                                               m::cusolver_int_t, n::cusolver_int_t,
+                                               nrhs::cusolver_int_t, dA::CuPtr{Cdouble},
+                                               ldda::cusolver_int_t, dB::CuPtr{Cdouble},
+                                               lddb::cusolver_int_t, dX::CuPtr{Cdouble},
+                                               lddx::cusolver_int_t,
+                                               dWorkspace::CuPtr{Cvoid},
+                                               lwork_bytes::Csize_t,
+                                               iter::Ptr{cusolver_int_t},
+                                               d_info::CuPtr{cusolver_int_t})::cusolverStatus_t
 end
 
 @checked function cusolverDnDBgels(handle, m, n, nrhs, dA, ldda, dB, lddb, dX, lddx,
                                    dWorkspace, lwork_bytes, iter, d_info)
     initialize_context()
-    @ccall libcusolver.cusolverDnDBgels(handle::cusolverDnHandle_t, m::cusolver_int_t,
-                                        n::cusolver_int_t, nrhs::cusolver_int_t,
-                                        dA::CuPtr{Cdouble}, ldda::cusolver_int_t,
-                                        dB::CuPtr{Cdouble}, lddb::cusolver_int_t,
-                                        dX::CuPtr{Cdouble}, lddx::cusolver_int_t,
-                                        dWorkspace::CuPtr{Cvoid}, lwork_bytes::Csize_t,
-                                        iter::Ptr{cusolver_int_t},
-                                        d_info::CuPtr{cusolver_int_t})::cusolverStatus_t
+    @gcsafe_ccall libcusolver.cusolverDnDBgels(handle::cusolverDnHandle_t,
+                                               m::cusolver_int_t, n::cusolver_int_t,
+                                               nrhs::cusolver_int_t, dA::CuPtr{Cdouble},
+                                               ldda::cusolver_int_t, dB::CuPtr{Cdouble},
+                                               lddb::cusolver_int_t, dX::CuPtr{Cdouble},
+                                               lddx::cusolver_int_t,
+                                               dWorkspace::CuPtr{Cvoid},
+                                               lwork_bytes::Csize_t,
+                                               iter::Ptr{cusolver_int_t},
+                                               d_info::CuPtr{cusolver_int_t})::cusolverStatus_t
 end
 
 @checked function cusolverDnDXgels(handle, m, n, nrhs, dA, ldda, dB, lddb, dX, lddx,
                                    dWorkspace, lwork_bytes, iter, d_info)
     initialize_context()
-    @ccall libcusolver.cusolverDnDXgels(handle::cusolverDnHandle_t, m::cusolver_int_t,
-                                        n::cusolver_int_t, nrhs::cusolver_int_t,
-                                        dA::CuPtr{Cdouble}, ldda::cusolver_int_t,
-                                        dB::CuPtr{Cdouble}, lddb::cusolver_int_t,
-                                        dX::CuPtr{Cdouble}, lddx::cusolver_int_t,
-                                        dWorkspace::CuPtr{Cvoid}, lwork_bytes::Csize_t,
-                                        iter::Ptr{cusolver_int_t},
-                                        d_info::CuPtr{cusolver_int_t})::cusolverStatus_t
+    @gcsafe_ccall libcusolver.cusolverDnDXgels(handle::cusolverDnHandle_t,
+                                               m::cusolver_int_t, n::cusolver_int_t,
+                                               nrhs::cusolver_int_t, dA::CuPtr{Cdouble},
+                                               ldda::cusolver_int_t, dB::CuPtr{Cdouble},
+                                               lddb::cusolver_int_t, dX::CuPtr{Cdouble},
+                                               lddx::cusolver_int_t,
+                                               dWorkspace::CuPtr{Cvoid},
+                                               lwork_bytes::Csize_t,
+                                               iter::Ptr{cusolver_int_t},
+                                               d_info::CuPtr{cusolver_int_t})::cusolverStatus_t
 end
 
 @checked function cusolverDnSSgels(handle, m, n, nrhs, dA, ldda, dB, lddb, dX, lddx,
                                    dWorkspace, lwork_bytes, iter, d_info)
     initialize_context()
-    @ccall libcusolver.cusolverDnSSgels(handle::cusolverDnHandle_t, m::cusolver_int_t,
-                                        n::cusolver_int_t, nrhs::cusolver_int_t,
-                                        dA::CuPtr{Cfloat}, ldda::cusolver_int_t,
-                                        dB::CuPtr{Cfloat}, lddb::cusolver_int_t,
-                                        dX::CuPtr{Cfloat}, lddx::cusolver_int_t,
-                                        dWorkspace::CuPtr{Cvoid}, lwork_bytes::Csize_t,
-                                        iter::Ptr{cusolver_int_t},
-                                        d_info::CuPtr{cusolver_int_t})::cusolverStatus_t
+    @gcsafe_ccall libcusolver.cusolverDnSSgels(handle::cusolverDnHandle_t,
+                                               m::cusolver_int_t, n::cusolver_int_t,
+                                               nrhs::cusolver_int_t, dA::CuPtr{Cfloat},
+                                               ldda::cusolver_int_t, dB::CuPtr{Cfloat},
+                                               lddb::cusolver_int_t, dX::CuPtr{Cfloat},
+                                               lddx::cusolver_int_t,
+                                               dWorkspace::CuPtr{Cvoid},
+                                               lwork_bytes::Csize_t,
+                                               iter::Ptr{cusolver_int_t},
+                                               d_info::CuPtr{cusolver_int_t})::cusolverStatus_t
 end
 
 @checked function cusolverDnSHgels(handle, m, n, nrhs, dA, ldda, dB, lddb, dX, lddx,
                                    dWorkspace, lwork_bytes, iter, d_info)
     initialize_context()
-    @ccall libcusolver.cusolverDnSHgels(handle::cusolverDnHandle_t, m::cusolver_int_t,
-                                        n::cusolver_int_t, nrhs::cusolver_int_t,
-                                        dA::CuPtr{Cfloat}, ldda::cusolver_int_t,
-                                        dB::CuPtr{Cfloat}, lddb::cusolver_int_t,
-                                        dX::CuPtr{Cfloat}, lddx::cusolver_int_t,
-                                        dWorkspace::CuPtr{Cvoid}, lwork_bytes::Csize_t,
-                                        iter::Ptr{cusolver_int_t},
-                                        d_info::CuPtr{cusolver_int_t})::cusolverStatus_t
+    @gcsafe_ccall libcusolver.cusolverDnSHgels(handle::cusolverDnHandle_t,
+                                               m::cusolver_int_t, n::cusolver_int_t,
+                                               nrhs::cusolver_int_t, dA::CuPtr{Cfloat},
+                                               ldda::cusolver_int_t, dB::CuPtr{Cfloat},
+                                               lddb::cusolver_int_t, dX::CuPtr{Cfloat},
+                                               lddx::cusolver_int_t,
+                                               dWorkspace::CuPtr{Cvoid},
+                                               lwork_bytes::Csize_t,
+                                               iter::Ptr{cusolver_int_t},
+                                               d_info::CuPtr{cusolver_int_t})::cusolverStatus_t
 end
 
 @checked function cusolverDnSBgels(handle, m, n, nrhs, dA, ldda, dB, lddb, dX, lddx,
                                    dWorkspace, lwork_bytes, iter, d_info)
     initialize_context()
-    @ccall libcusolver.cusolverDnSBgels(handle::cusolverDnHandle_t, m::cusolver_int_t,
-                                        n::cusolver_int_t, nrhs::cusolver_int_t,
-                                        dA::CuPtr{Cfloat}, ldda::cusolver_int_t,
-                                        dB::CuPtr{Cfloat}, lddb::cusolver_int_t,
-                                        dX::CuPtr{Cfloat}, lddx::cusolver_int_t,
-                                        dWorkspace::CuPtr{Cvoid}, lwork_bytes::Csize_t,
-                                        iter::Ptr{cusolver_int_t},
-                                        d_info::CuPtr{cusolver_int_t})::cusolverStatus_t
+    @gcsafe_ccall libcusolver.cusolverDnSBgels(handle::cusolverDnHandle_t,
+                                               m::cusolver_int_t, n::cusolver_int_t,
+                                               nrhs::cusolver_int_t, dA::CuPtr{Cfloat},
+                                               ldda::cusolver_int_t, dB::CuPtr{Cfloat},
+                                               lddb::cusolver_int_t, dX::CuPtr{Cfloat},
+                                               lddx::cusolver_int_t,
+                                               dWorkspace::CuPtr{Cvoid},
+                                               lwork_bytes::Csize_t,
+                                               iter::Ptr{cusolver_int_t},
+                                               d_info::CuPtr{cusolver_int_t})::cusolverStatus_t
 end
 
 @checked function cusolverDnSXgels(handle, m, n, nrhs, dA, ldda, dB, lddb, dX, lddx,
                                    dWorkspace, lwork_bytes, iter, d_info)
     initialize_context()
-    @ccall libcusolver.cusolverDnSXgels(handle::cusolverDnHandle_t, m::cusolver_int_t,
-                                        n::cusolver_int_t, nrhs::cusolver_int_t,
-                                        dA::CuPtr{Cfloat}, ldda::cusolver_int_t,
-                                        dB::CuPtr{Cfloat}, lddb::cusolver_int_t,
-                                        dX::CuPtr{Cfloat}, lddx::cusolver_int_t,
-                                        dWorkspace::CuPtr{Cvoid}, lwork_bytes::Csize_t,
-                                        iter::Ptr{cusolver_int_t},
-                                        d_info::CuPtr{cusolver_int_t})::cusolverStatus_t
+    @gcsafe_ccall libcusolver.cusolverDnSXgels(handle::cusolverDnHandle_t,
+                                               m::cusolver_int_t, n::cusolver_int_t,
+                                               nrhs::cusolver_int_t, dA::CuPtr{Cfloat},
+                                               ldda::cusolver_int_t, dB::CuPtr{Cfloat},
+                                               lddb::cusolver_int_t, dX::CuPtr{Cfloat},
+                                               lddx::cusolver_int_t,
+                                               dWorkspace::CuPtr{Cvoid},
+                                               lwork_bytes::Csize_t,
+                                               iter::Ptr{cusolver_int_t},
+                                               d_info::CuPtr{cusolver_int_t})::cusolverStatus_t
 end
 
 @checked function cusolverDnZZgels_bufferSize(handle, m, n, nrhs, dA, ldda, dB, lddb, dX,
                                               lddx, dWorkspace, lwork_bytes)
     initialize_context()
-    @ccall libcusolver.cusolverDnZZgels_bufferSize(handle::cusolverDnHandle_t,
-                                                   m::cusolver_int_t, n::cusolver_int_t,
-                                                   nrhs::cusolver_int_t,
-                                                   dA::CuPtr{cuDoubleComplex},
-                                                   ldda::cusolver_int_t,
-                                                   dB::CuPtr{cuDoubleComplex},
-                                                   lddb::cusolver_int_t,
-                                                   dX::CuPtr{cuDoubleComplex},
-                                                   lddx::cusolver_int_t,
-                                                   dWorkspace::CuPtr{Cvoid},
-                                                   lwork_bytes::Ptr{Csize_t})::cusolverStatus_t
+    @gcsafe_ccall libcusolver.cusolverDnZZgels_bufferSize(handle::cusolverDnHandle_t,
+                                                          m::cusolver_int_t,
+                                                          n::cusolver_int_t,
+                                                          nrhs::cusolver_int_t,
+                                                          dA::CuPtr{cuDoubleComplex},
+                                                          ldda::cusolver_int_t,
+                                                          dB::CuPtr{cuDoubleComplex},
+                                                          lddb::cusolver_int_t,
+                                                          dX::CuPtr{cuDoubleComplex},
+                                                          lddx::cusolver_int_t,
+                                                          dWorkspace::CuPtr{Cvoid},
+                                                          lwork_bytes::Ptr{Csize_t})::cusolverStatus_t
 end
 
 @checked function cusolverDnZCgels_bufferSize(handle, m, n, nrhs, dA, ldda, dB, lddb, dX,
                                               lddx, dWorkspace, lwork_bytes)
     initialize_context()
-    @ccall libcusolver.cusolverDnZCgels_bufferSize(handle::cusolverDnHandle_t,
-                                                   m::cusolver_int_t, n::cusolver_int_t,
-                                                   nrhs::cusolver_int_t,
-                                                   dA::CuPtr{cuDoubleComplex},
-                                                   ldda::cusolver_int_t,
-                                                   dB::CuPtr{cuDoubleComplex},
-                                                   lddb::cusolver_int_t,
-                                                   dX::CuPtr{cuDoubleComplex},
-                                                   lddx::cusolver_int_t,
-                                                   dWorkspace::CuPtr{Cvoid},
-                                                   lwork_bytes::Ptr{Csize_t})::cusolverStatus_t
+    @gcsafe_ccall libcusolver.cusolverDnZCgels_bufferSize(handle::cusolverDnHandle_t,
+                                                          m::cusolver_int_t,
+                                                          n::cusolver_int_t,
+                                                          nrhs::cusolver_int_t,
+                                                          dA::CuPtr{cuDoubleComplex},
+                                                          ldda::cusolver_int_t,
+                                                          dB::CuPtr{cuDoubleComplex},
+                                                          lddb::cusolver_int_t,
+                                                          dX::CuPtr{cuDoubleComplex},
+                                                          lddx::cusolver_int_t,
+                                                          dWorkspace::CuPtr{Cvoid},
+                                                          lwork_bytes::Ptr{Csize_t})::cusolverStatus_t
 end
 
 @checked function cusolverDnZKgels_bufferSize(handle, m, n, nrhs, dA, ldda, dB, lddb, dX,
                                               lddx, dWorkspace, lwork_bytes)
     initialize_context()
-    @ccall libcusolver.cusolverDnZKgels_bufferSize(handle::cusolverDnHandle_t,
-                                                   m::cusolver_int_t, n::cusolver_int_t,
-                                                   nrhs::cusolver_int_t,
-                                                   dA::CuPtr{cuDoubleComplex},
-                                                   ldda::cusolver_int_t,
-                                                   dB::CuPtr{cuDoubleComplex},
-                                                   lddb::cusolver_int_t,
-                                                   dX::CuPtr{cuDoubleComplex},
-                                                   lddx::cusolver_int_t,
-                                                   dWorkspace::CuPtr{Cvoid},
-                                                   lwork_bytes::Ptr{Csize_t})::cusolverStatus_t
+    @gcsafe_ccall libcusolver.cusolverDnZKgels_bufferSize(handle::cusolverDnHandle_t,
+                                                          m::cusolver_int_t,
+                                                          n::cusolver_int_t,
+                                                          nrhs::cusolver_int_t,
+                                                          dA::CuPtr{cuDoubleComplex},
+                                                          ldda::cusolver_int_t,
+                                                          dB::CuPtr{cuDoubleComplex},
+                                                          lddb::cusolver_int_t,
+                                                          dX::CuPtr{cuDoubleComplex},
+                                                          lddx::cusolver_int_t,
+                                                          dWorkspace::CuPtr{Cvoid},
+                                                          lwork_bytes::Ptr{Csize_t})::cusolverStatus_t
 end
 
 @checked function cusolverDnZEgels_bufferSize(handle, m, n, nrhs, dA, ldda, dB, lddb, dX,
                                               lddx, dWorkspace, lwork_bytes)
     initialize_context()
-    @ccall libcusolver.cusolverDnZEgels_bufferSize(handle::cusolverDnHandle_t,
-                                                   m::cusolver_int_t, n::cusolver_int_t,
-                                                   nrhs::cusolver_int_t,
-                                                   dA::CuPtr{cuDoubleComplex},
-                                                   ldda::cusolver_int_t,
-                                                   dB::CuPtr{cuDoubleComplex},
-                                                   lddb::cusolver_int_t,
-                                                   dX::CuPtr{cuDoubleComplex},
-                                                   lddx::cusolver_int_t,
-                                                   dWorkspace::CuPtr{Cvoid},
-                                                   lwork_bytes::Ptr{Csize_t})::cusolverStatus_t
+    @gcsafe_ccall libcusolver.cusolverDnZEgels_bufferSize(handle::cusolverDnHandle_t,
+                                                          m::cusolver_int_t,
+                                                          n::cusolver_int_t,
+                                                          nrhs::cusolver_int_t,
+                                                          dA::CuPtr{cuDoubleComplex},
+                                                          ldda::cusolver_int_t,
+                                                          dB::CuPtr{cuDoubleComplex},
+                                                          lddb::cusolver_int_t,
+                                                          dX::CuPtr{cuDoubleComplex},
+                                                          lddx::cusolver_int_t,
+                                                          dWorkspace::CuPtr{Cvoid},
+                                                          lwork_bytes::Ptr{Csize_t})::cusolverStatus_t
 end
 
 @checked function cusolverDnZYgels_bufferSize(handle, m, n, nrhs, dA, ldda, dB, lddb, dX,
                                               lddx, dWorkspace, lwork_bytes)
     initialize_context()
-    @ccall libcusolver.cusolverDnZYgels_bufferSize(handle::cusolverDnHandle_t,
-                                                   m::cusolver_int_t, n::cusolver_int_t,
-                                                   nrhs::cusolver_int_t,
-                                                   dA::CuPtr{cuDoubleComplex},
-                                                   ldda::cusolver_int_t,
-                                                   dB::CuPtr{cuDoubleComplex},
-                                                   lddb::cusolver_int_t,
-                                                   dX::CuPtr{cuDoubleComplex},
-                                                   lddx::cusolver_int_t,
-                                                   dWorkspace::CuPtr{Cvoid},
-                                                   lwork_bytes::Ptr{Csize_t})::cusolverStatus_t
+    @gcsafe_ccall libcusolver.cusolverDnZYgels_bufferSize(handle::cusolverDnHandle_t,
+                                                          m::cusolver_int_t,
+                                                          n::cusolver_int_t,
+                                                          nrhs::cusolver_int_t,
+                                                          dA::CuPtr{cuDoubleComplex},
+                                                          ldda::cusolver_int_t,
+                                                          dB::CuPtr{cuDoubleComplex},
+                                                          lddb::cusolver_int_t,
+                                                          dX::CuPtr{cuDoubleComplex},
+                                                          lddx::cusolver_int_t,
+                                                          dWorkspace::CuPtr{Cvoid},
+                                                          lwork_bytes::Ptr{Csize_t})::cusolverStatus_t
 end
 
 @checked function cusolverDnCCgels_bufferSize(handle, m, n, nrhs, dA, ldda, dB, lddb, dX,
                                               lddx, dWorkspace, lwork_bytes)
     initialize_context()
-    @ccall libcusolver.cusolverDnCCgels_bufferSize(handle::cusolverDnHandle_t,
-                                                   m::cusolver_int_t, n::cusolver_int_t,
-                                                   nrhs::cusolver_int_t,
-                                                   dA::CuPtr{cuComplex},
-                                                   ldda::cusolver_int_t,
-                                                   dB::CuPtr{cuComplex},
-                                                   lddb::cusolver_int_t,
-                                                   dX::CuPtr{cuComplex},
-                                                   lddx::cusolver_int_t,
-                                                   dWorkspace::CuPtr{Cvoid},
-                                                   lwork_bytes::Ptr{Csize_t})::cusolverStatus_t
+    @gcsafe_ccall libcusolver.cusolverDnCCgels_bufferSize(handle::cusolverDnHandle_t,
+                                                          m::cusolver_int_t,
+                                                          n::cusolver_int_t,
+                                                          nrhs::cusolver_int_t,
+                                                          dA::CuPtr{cuComplex},
+                                                          ldda::cusolver_int_t,
+                                                          dB::CuPtr{cuComplex},
+                                                          lddb::cusolver_int_t,
+                                                          dX::CuPtr{cuComplex},
+                                                          lddx::cusolver_int_t,
+                                                          dWorkspace::CuPtr{Cvoid},
+                                                          lwork_bytes::Ptr{Csize_t})::cusolverStatus_t
 end
 
 @checked function cusolverDnCKgels_bufferSize(handle, m, n, nrhs, dA, ldda, dB, lddb, dX,
                                               lddx, dWorkspace, lwork_bytes)
     initialize_context()
-    @ccall libcusolver.cusolverDnCKgels_bufferSize(handle::cusolverDnHandle_t,
-                                                   m::cusolver_int_t, n::cusolver_int_t,
-                                                   nrhs::cusolver_int_t,
-                                                   dA::CuPtr{cuComplex},
-                                                   ldda::cusolver_int_t,
-                                                   dB::CuPtr{cuComplex},
-                                                   lddb::cusolver_int_t,
-                                                   dX::CuPtr{cuComplex},
-                                                   lddx::cusolver_int_t,
-                                                   dWorkspace::CuPtr{Cvoid},
-                                                   lwork_bytes::Ptr{Csize_t})::cusolverStatus_t
+    @gcsafe_ccall libcusolver.cusolverDnCKgels_bufferSize(handle::cusolverDnHandle_t,
+                                                          m::cusolver_int_t,
+                                                          n::cusolver_int_t,
+                                                          nrhs::cusolver_int_t,
+                                                          dA::CuPtr{cuComplex},
+                                                          ldda::cusolver_int_t,
+                                                          dB::CuPtr{cuComplex},
+                                                          lddb::cusolver_int_t,
+                                                          dX::CuPtr{cuComplex},
+                                                          lddx::cusolver_int_t,
+                                                          dWorkspace::CuPtr{Cvoid},
+                                                          lwork_bytes::Ptr{Csize_t})::cusolverStatus_t
 end
 
 @checked function cusolverDnCEgels_bufferSize(handle, m, n, nrhs, dA, ldda, dB, lddb, dX,
                                               lddx, dWorkspace, lwork_bytes)
     initialize_context()
-    @ccall libcusolver.cusolverDnCEgels_bufferSize(handle::cusolverDnHandle_t,
-                                                   m::cusolver_int_t, n::cusolver_int_t,
-                                                   nrhs::cusolver_int_t,
-                                                   dA::CuPtr{cuComplex},
-                                                   ldda::cusolver_int_t,
-                                                   dB::CuPtr{cuComplex},
-                                                   lddb::cusolver_int_t,
-                                                   dX::CuPtr{cuComplex},
-                                                   lddx::cusolver_int_t,
-                                                   dWorkspace::CuPtr{Cvoid},
-                                                   lwork_bytes::Ptr{Csize_t})::cusolverStatus_t
+    @gcsafe_ccall libcusolver.cusolverDnCEgels_bufferSize(handle::cusolverDnHandle_t,
+                                                          m::cusolver_int_t,
+                                                          n::cusolver_int_t,
+                                                          nrhs::cusolver_int_t,
+                                                          dA::CuPtr{cuComplex},
+                                                          ldda::cusolver_int_t,
+                                                          dB::CuPtr{cuComplex},
+                                                          lddb::cusolver_int_t,
+                                                          dX::CuPtr{cuComplex},
+                                                          lddx::cusolver_int_t,
+                                                          dWorkspace::CuPtr{Cvoid},
+                                                          lwork_bytes::Ptr{Csize_t})::cusolverStatus_t
 end
 
 @checked function cusolverDnCYgels_bufferSize(handle, m, n, nrhs, dA, ldda, dB, lddb, dX,
                                               lddx, dWorkspace, lwork_bytes)
     initialize_context()
-    @ccall libcusolver.cusolverDnCYgels_bufferSize(handle::cusolverDnHandle_t,
-                                                   m::cusolver_int_t, n::cusolver_int_t,
-                                                   nrhs::cusolver_int_t,
-                                                   dA::CuPtr{cuComplex},
-                                                   ldda::cusolver_int_t,
-                                                   dB::CuPtr{cuComplex},
-                                                   lddb::cusolver_int_t,
-                                                   dX::CuPtr{cuComplex},
-                                                   lddx::cusolver_int_t,
-                                                   dWorkspace::CuPtr{Cvoid},
-                                                   lwork_bytes::Ptr{Csize_t})::cusolverStatus_t
+    @gcsafe_ccall libcusolver.cusolverDnCYgels_bufferSize(handle::cusolverDnHandle_t,
+                                                          m::cusolver_int_t,
+                                                          n::cusolver_int_t,
+                                                          nrhs::cusolver_int_t,
+                                                          dA::CuPtr{cuComplex},
+                                                          ldda::cusolver_int_t,
+                                                          dB::CuPtr{cuComplex},
+                                                          lddb::cusolver_int_t,
+                                                          dX::CuPtr{cuComplex},
+                                                          lddx::cusolver_int_t,
+                                                          dWorkspace::CuPtr{Cvoid},
+                                                          lwork_bytes::Ptr{Csize_t})::cusolverStatus_t
 end
 
 @checked function cusolverDnDDgels_bufferSize(handle, m, n, nrhs, dA, ldda, dB, lddb, dX,
                                               lddx, dWorkspace, lwork_bytes)
     initialize_context()
-    @ccall libcusolver.cusolverDnDDgels_bufferSize(handle::cusolverDnHandle_t,
-                                                   m::cusolver_int_t, n::cusolver_int_t,
-                                                   nrhs::cusolver_int_t, dA::CuPtr{Cdouble},
-                                                   ldda::cusolver_int_t, dB::CuPtr{Cdouble},
-                                                   lddb::cusolver_int_t, dX::CuPtr{Cdouble},
-                                                   lddx::cusolver_int_t,
-                                                   dWorkspace::CuPtr{Cvoid},
-                                                   lwork_bytes::Ptr{Csize_t})::cusolverStatus_t
+    @gcsafe_ccall libcusolver.cusolverDnDDgels_bufferSize(handle::cusolverDnHandle_t,
+                                                          m::cusolver_int_t,
+                                                          n::cusolver_int_t,
+                                                          nrhs::cusolver_int_t,
+                                                          dA::CuPtr{Cdouble},
+                                                          ldda::cusolver_int_t,
+                                                          dB::CuPtr{Cdouble},
+                                                          lddb::cusolver_int_t,
+                                                          dX::CuPtr{Cdouble},
+                                                          lddx::cusolver_int_t,
+                                                          dWorkspace::CuPtr{Cvoid},
+                                                          lwork_bytes::Ptr{Csize_t})::cusolverStatus_t
 end
 
 @checked function cusolverDnDSgels_bufferSize(handle, m, n, nrhs, dA, ldda, dB, lddb, dX,
                                               lddx, dWorkspace, lwork_bytes)
     initialize_context()
-    @ccall libcusolver.cusolverDnDSgels_bufferSize(handle::cusolverDnHandle_t,
-                                                   m::cusolver_int_t, n::cusolver_int_t,
-                                                   nrhs::cusolver_int_t, dA::CuPtr{Cdouble},
-                                                   ldda::cusolver_int_t, dB::CuPtr{Cdouble},
-                                                   lddb::cusolver_int_t, dX::CuPtr{Cdouble},
-                                                   lddx::cusolver_int_t,
-                                                   dWorkspace::CuPtr{Cvoid},
-                                                   lwork_bytes::Ptr{Csize_t})::cusolverStatus_t
+    @gcsafe_ccall libcusolver.cusolverDnDSgels_bufferSize(handle::cusolverDnHandle_t,
+                                                          m::cusolver_int_t,
+                                                          n::cusolver_int_t,
+                                                          nrhs::cusolver_int_t,
+                                                          dA::CuPtr{Cdouble},
+                                                          ldda::cusolver_int_t,
+                                                          dB::CuPtr{Cdouble},
+                                                          lddb::cusolver_int_t,
+                                                          dX::CuPtr{Cdouble},
+                                                          lddx::cusolver_int_t,
+                                                          dWorkspace::CuPtr{Cvoid},
+                                                          lwork_bytes::Ptr{Csize_t})::cusolverStatus_t
 end
 
 @checked function cusolverDnDHgels_bufferSize(handle, m, n, nrhs, dA, ldda, dB, lddb, dX,
                                               lddx, dWorkspace, lwork_bytes)
     initialize_context()
-    @ccall libcusolver.cusolverDnDHgels_bufferSize(handle::cusolverDnHandle_t,
-                                                   m::cusolver_int_t, n::cusolver_int_t,
-                                                   nrhs::cusolver_int_t, dA::CuPtr{Cdouble},
-                                                   ldda::cusolver_int_t, dB::CuPtr{Cdouble},
-                                                   lddb::cusolver_int_t, dX::CuPtr{Cdouble},
-                                                   lddx::cusolver_int_t,
-                                                   dWorkspace::CuPtr{Cvoid},
-                                                   lwork_bytes::Ptr{Csize_t})::cusolverStatus_t
+    @gcsafe_ccall libcusolver.cusolverDnDHgels_bufferSize(handle::cusolverDnHandle_t,
+                                                          m::cusolver_int_t,
+                                                          n::cusolver_int_t,
+                                                          nrhs::cusolver_int_t,
+                                                          dA::CuPtr{Cdouble},
+                                                          ldda::cusolver_int_t,
+                                                          dB::CuPtr{Cdouble},
+                                                          lddb::cusolver_int_t,
+                                                          dX::CuPtr{Cdouble},
+                                                          lddx::cusolver_int_t,
+                                                          dWorkspace::CuPtr{Cvoid},
+                                                          lwork_bytes::Ptr{Csize_t})::cusolverStatus_t
 end
 
 @checked function cusolverDnDBgels_bufferSize(handle, m, n, nrhs, dA, ldda, dB, lddb, dX,
                                               lddx, dWorkspace, lwork_bytes)
     initialize_context()
-    @ccall libcusolver.cusolverDnDBgels_bufferSize(handle::cusolverDnHandle_t,
-                                                   m::cusolver_int_t, n::cusolver_int_t,
-                                                   nrhs::cusolver_int_t, dA::CuPtr{Cdouble},
-                                                   ldda::cusolver_int_t, dB::CuPtr{Cdouble},
-                                                   lddb::cusolver_int_t, dX::CuPtr{Cdouble},
-                                                   lddx::cusolver_int_t,
-                                                   dWorkspace::CuPtr{Cvoid},
-                                                   lwork_bytes::Ptr{Csize_t})::cusolverStatus_t
+    @gcsafe_ccall libcusolver.cusolverDnDBgels_bufferSize(handle::cusolverDnHandle_t,
+                                                          m::cusolver_int_t,
+                                                          n::cusolver_int_t,
+                                                          nrhs::cusolver_int_t,
+                                                          dA::CuPtr{Cdouble},
+                                                          ldda::cusolver_int_t,
+                                                          dB::CuPtr{Cdouble},
+                                                          lddb::cusolver_int_t,
+                                                          dX::CuPtr{Cdouble},
+                                                          lddx::cusolver_int_t,
+                                                          dWorkspace::CuPtr{Cvoid},
+                                                          lwork_bytes::Ptr{Csize_t})::cusolverStatus_t
 end
 
 @checked function cusolverDnDXgels_bufferSize(handle, m, n, nrhs, dA, ldda, dB, lddb, dX,
                                               lddx, dWorkspace, lwork_bytes)
     initialize_context()
-    @ccall libcusolver.cusolverDnDXgels_bufferSize(handle::cusolverDnHandle_t,
-                                                   m::cusolver_int_t, n::cusolver_int_t,
-                                                   nrhs::cusolver_int_t, dA::CuPtr{Cdouble},
-                                                   ldda::cusolver_int_t, dB::CuPtr{Cdouble},
-                                                   lddb::cusolver_int_t, dX::CuPtr{Cdouble},
-                                                   lddx::cusolver_int_t,
-                                                   dWorkspace::CuPtr{Cvoid},
-                                                   lwork_bytes::Ptr{Csize_t})::cusolverStatus_t
+    @gcsafe_ccall libcusolver.cusolverDnDXgels_bufferSize(handle::cusolverDnHandle_t,
+                                                          m::cusolver_int_t,
+                                                          n::cusolver_int_t,
+                                                          nrhs::cusolver_int_t,
+                                                          dA::CuPtr{Cdouble},
+                                                          ldda::cusolver_int_t,
+                                                          dB::CuPtr{Cdouble},
+                                                          lddb::cusolver_int_t,
+                                                          dX::CuPtr{Cdouble},
+                                                          lddx::cusolver_int_t,
+                                                          dWorkspace::CuPtr{Cvoid},
+                                                          lwork_bytes::Ptr{Csize_t})::cusolverStatus_t
 end
 
 @checked function cusolverDnSSgels_bufferSize(handle, m, n, nrhs, dA, ldda, dB, lddb, dX,
                                               lddx, dWorkspace, lwork_bytes)
     initialize_context()
-    @ccall libcusolver.cusolverDnSSgels_bufferSize(handle::cusolverDnHandle_t,
-                                                   m::cusolver_int_t, n::cusolver_int_t,
-                                                   nrhs::cusolver_int_t, dA::CuPtr{Cfloat},
-                                                   ldda::cusolver_int_t, dB::CuPtr{Cfloat},
-                                                   lddb::cusolver_int_t, dX::CuPtr{Cfloat},
-                                                   lddx::cusolver_int_t,
-                                                   dWorkspace::CuPtr{Cvoid},
-                                                   lwork_bytes::Ptr{Csize_t})::cusolverStatus_t
+    @gcsafe_ccall libcusolver.cusolverDnSSgels_bufferSize(handle::cusolverDnHandle_t,
+                                                          m::cusolver_int_t,
+                                                          n::cusolver_int_t,
+                                                          nrhs::cusolver_int_t,
+                                                          dA::CuPtr{Cfloat},
+                                                          ldda::cusolver_int_t,
+                                                          dB::CuPtr{Cfloat},
+                                                          lddb::cusolver_int_t,
+                                                          dX::CuPtr{Cfloat},
+                                                          lddx::cusolver_int_t,
+                                                          dWorkspace::CuPtr{Cvoid},
+                                                          lwork_bytes::Ptr{Csize_t})::cusolverStatus_t
 end
 
 @checked function cusolverDnSHgels_bufferSize(handle, m, n, nrhs, dA, ldda, dB, lddb, dX,
                                               lddx, dWorkspace, lwork_bytes)
     initialize_context()
-    @ccall libcusolver.cusolverDnSHgels_bufferSize(handle::cusolverDnHandle_t,
-                                                   m::cusolver_int_t, n::cusolver_int_t,
-                                                   nrhs::cusolver_int_t, dA::CuPtr{Cfloat},
-                                                   ldda::cusolver_int_t, dB::CuPtr{Cfloat},
-                                                   lddb::cusolver_int_t, dX::CuPtr{Cfloat},
-                                                   lddx::cusolver_int_t,
-                                                   dWorkspace::CuPtr{Cvoid},
-                                                   lwork_bytes::Ptr{Csize_t})::cusolverStatus_t
+    @gcsafe_ccall libcusolver.cusolverDnSHgels_bufferSize(handle::cusolverDnHandle_t,
+                                                          m::cusolver_int_t,
+                                                          n::cusolver_int_t,
+                                                          nrhs::cusolver_int_t,
+                                                          dA::CuPtr{Cfloat},
+                                                          ldda::cusolver_int_t,
+                                                          dB::CuPtr{Cfloat},
+                                                          lddb::cusolver_int_t,
+                                                          dX::CuPtr{Cfloat},
+                                                          lddx::cusolver_int_t,
+                                                          dWorkspace::CuPtr{Cvoid},
+                                                          lwork_bytes::Ptr{Csize_t})::cusolverStatus_t
 end
 
 @checked function cusolverDnSBgels_bufferSize(handle, m, n, nrhs, dA, ldda, dB, lddb, dX,
                                               lddx, dWorkspace, lwork_bytes)
     initialize_context()
-    @ccall libcusolver.cusolverDnSBgels_bufferSize(handle::cusolverDnHandle_t,
-                                                   m::cusolver_int_t, n::cusolver_int_t,
-                                                   nrhs::cusolver_int_t, dA::CuPtr{Cfloat},
-                                                   ldda::cusolver_int_t, dB::CuPtr{Cfloat},
-                                                   lddb::cusolver_int_t, dX::CuPtr{Cfloat},
-                                                   lddx::cusolver_int_t,
-                                                   dWorkspace::CuPtr{Cvoid},
-                                                   lwork_bytes::Ptr{Csize_t})::cusolverStatus_t
+    @gcsafe_ccall libcusolver.cusolverDnSBgels_bufferSize(handle::cusolverDnHandle_t,
+                                                          m::cusolver_int_t,
+                                                          n::cusolver_int_t,
+                                                          nrhs::cusolver_int_t,
+                                                          dA::CuPtr{Cfloat},
+                                                          ldda::cusolver_int_t,
+                                                          dB::CuPtr{Cfloat},
+                                                          lddb::cusolver_int_t,
+                                                          dX::CuPtr{Cfloat},
+                                                          lddx::cusolver_int_t,
+                                                          dWorkspace::CuPtr{Cvoid},
+                                                          lwork_bytes::Ptr{Csize_t})::cusolverStatus_t
 end
 
 @checked function cusolverDnSXgels_bufferSize(handle, m, n, nrhs, dA, ldda, dB, lddb, dX,
                                               lddx, dWorkspace, lwork_bytes)
     initialize_context()
-    @ccall libcusolver.cusolverDnSXgels_bufferSize(handle::cusolverDnHandle_t,
-                                                   m::cusolver_int_t, n::cusolver_int_t,
-                                                   nrhs::cusolver_int_t, dA::CuPtr{Cfloat},
-                                                   ldda::cusolver_int_t, dB::CuPtr{Cfloat},
-                                                   lddb::cusolver_int_t, dX::CuPtr{Cfloat},
-                                                   lddx::cusolver_int_t,
-                                                   dWorkspace::CuPtr{Cvoid},
-                                                   lwork_bytes::Ptr{Csize_t})::cusolverStatus_t
+    @gcsafe_ccall libcusolver.cusolverDnSXgels_bufferSize(handle::cusolverDnHandle_t,
+                                                          m::cusolver_int_t,
+                                                          n::cusolver_int_t,
+                                                          nrhs::cusolver_int_t,
+                                                          dA::CuPtr{Cfloat},
+                                                          ldda::cusolver_int_t,
+                                                          dB::CuPtr{Cfloat},
+                                                          lddb::cusolver_int_t,
+                                                          dX::CuPtr{Cfloat},
+                                                          lddx::cusolver_int_t,
+                                                          dWorkspace::CuPtr{Cvoid},
+                                                          lwork_bytes::Ptr{Csize_t})::cusolverStatus_t
 end
 
 @checked function cusolverDnIRSXgesv(handle, gesv_irs_params, gesv_irs_infos, n, nrhs, dA,
                                      ldda, dB, lddb, dX, lddx, dWorkspace, lwork_bytes,
                                      niters, d_info)
     initialize_context()
-    @ccall libcusolver.cusolverDnIRSXgesv(handle::cusolverDnHandle_t,
-                                          gesv_irs_params::cusolverDnIRSParams_t,
-                                          gesv_irs_infos::cusolverDnIRSInfos_t,
-                                          n::cusolver_int_t, nrhs::cusolver_int_t,
-                                          dA::CuPtr{Cvoid}, ldda::cusolver_int_t,
-                                          dB::CuPtr{Cvoid}, lddb::cusolver_int_t,
-                                          dX::CuPtr{Cvoid}, lddx::cusolver_int_t,
-                                          dWorkspace::CuPtr{Cvoid}, lwork_bytes::Csize_t,
-                                          niters::Ptr{cusolver_int_t},
-                                          d_info::CuPtr{cusolver_int_t})::cusolverStatus_t
+    @gcsafe_ccall libcusolver.cusolverDnIRSXgesv(handle::cusolverDnHandle_t,
+                                                 gesv_irs_params::cusolverDnIRSParams_t,
+                                                 gesv_irs_infos::cusolverDnIRSInfos_t,
+                                                 n::cusolver_int_t, nrhs::cusolver_int_t,
+                                                 dA::CuPtr{Cvoid}, ldda::cusolver_int_t,
+                                                 dB::CuPtr{Cvoid}, lddb::cusolver_int_t,
+                                                 dX::CuPtr{Cvoid}, lddx::cusolver_int_t,
+                                                 dWorkspace::CuPtr{Cvoid},
+                                                 lwork_bytes::Csize_t,
+                                                 niters::Ptr{cusolver_int_t},
+                                                 d_info::CuPtr{cusolver_int_t})::cusolverStatus_t
 end
 
 @checked function cusolverDnIRSXgesv_bufferSize(handle, params, n, nrhs, lwork_bytes)
     initialize_context()
-    @ccall libcusolver.cusolverDnIRSXgesv_bufferSize(handle::cusolverDnHandle_t,
-                                                     params::cusolverDnIRSParams_t,
-                                                     n::cusolver_int_t,
-                                                     nrhs::cusolver_int_t,
-                                                     lwork_bytes::Ptr{Csize_t})::cusolverStatus_t
+    @gcsafe_ccall libcusolver.cusolverDnIRSXgesv_bufferSize(handle::cusolverDnHandle_t,
+                                                            params::cusolverDnIRSParams_t,
+                                                            n::cusolver_int_t,
+                                                            nrhs::cusolver_int_t,
+                                                            lwork_bytes::Ptr{Csize_t})::cusolverStatus_t
 end
 
 @checked function cusolverDnIRSXgels(handle, gels_irs_params, gels_irs_infos, m, n, nrhs,
                                      dA, ldda, dB, lddb, dX, lddx, dWorkspace, lwork_bytes,
                                      niters, d_info)
     initialize_context()
-    @ccall libcusolver.cusolverDnIRSXgels(handle::cusolverDnHandle_t,
-                                          gels_irs_params::cusolverDnIRSParams_t,
-                                          gels_irs_infos::cusolverDnIRSInfos_t,
-                                          m::cusolver_int_t, n::cusolver_int_t,
-                                          nrhs::cusolver_int_t, dA::CuPtr{Cvoid},
-                                          ldda::cusolver_int_t, dB::CuPtr{Cvoid},
-                                          lddb::cusolver_int_t, dX::CuPtr{Cvoid},
-                                          lddx::cusolver_int_t, dWorkspace::CuPtr{Cvoid},
-                                          lwork_bytes::Csize_t, niters::Ptr{cusolver_int_t},
-                                          d_info::CuPtr{cusolver_int_t})::cusolverStatus_t
+    @gcsafe_ccall libcusolver.cusolverDnIRSXgels(handle::cusolverDnHandle_t,
+                                                 gels_irs_params::cusolverDnIRSParams_t,
+                                                 gels_irs_infos::cusolverDnIRSInfos_t,
+                                                 m::cusolver_int_t, n::cusolver_int_t,
+                                                 nrhs::cusolver_int_t, dA::CuPtr{Cvoid},
+                                                 ldda::cusolver_int_t, dB::CuPtr{Cvoid},
+                                                 lddb::cusolver_int_t, dX::CuPtr{Cvoid},
+                                                 lddx::cusolver_int_t,
+                                                 dWorkspace::CuPtr{Cvoid},
+                                                 lwork_bytes::Csize_t,
+                                                 niters::Ptr{cusolver_int_t},
+                                                 d_info::CuPtr{cusolver_int_t})::cusolverStatus_t
 end
 
 @checked function cusolverDnIRSXgels_bufferSize(handle, params, m, n, nrhs, lwork_bytes)
     initialize_context()
-    @ccall libcusolver.cusolverDnIRSXgels_bufferSize(handle::cusolverDnHandle_t,
-                                                     params::cusolverDnIRSParams_t,
-                                                     m::cusolver_int_t, n::cusolver_int_t,
-                                                     nrhs::cusolver_int_t,
-                                                     lwork_bytes::Ptr{Csize_t})::cusolverStatus_t
+    @gcsafe_ccall libcusolver.cusolverDnIRSXgels_bufferSize(handle::cusolverDnHandle_t,
+                                                            params::cusolverDnIRSParams_t,
+                                                            m::cusolver_int_t,
+                                                            n::cusolver_int_t,
+                                                            nrhs::cusolver_int_t,
+                                                            lwork_bytes::Ptr{Csize_t})::cusolverStatus_t
 end
 
 @checked function cusolverDnSpotrf_bufferSize(handle, uplo, n, A, lda, Lwork)
     initialize_context()
-    @ccall libcusolver.cusolverDnSpotrf_bufferSize(handle::cusolverDnHandle_t,
-                                                   uplo::cublasFillMode_t, n::Cint,
-                                                   A::CuPtr{Cfloat}, lda::Cint,
-                                                   Lwork::Ptr{Cint})::cusolverStatus_t
+    @gcsafe_ccall libcusolver.cusolverDnSpotrf_bufferSize(handle::cusolverDnHandle_t,
+                                                          uplo::cublasFillMode_t, n::Cint,
+                                                          A::CuPtr{Cfloat}, lda::Cint,
+                                                          Lwork::Ptr{Cint})::cusolverStatus_t
 end
 
 @checked function cusolverDnDpotrf_bufferSize(handle, uplo, n, A, lda, Lwork)
     initialize_context()
-    @ccall libcusolver.cusolverDnDpotrf_bufferSize(handle::cusolverDnHandle_t,
-                                                   uplo::cublasFillMode_t, n::Cint,
-                                                   A::CuPtr{Cdouble}, lda::Cint,
-                                                   Lwork::Ptr{Cint})::cusolverStatus_t
+    @gcsafe_ccall libcusolver.cusolverDnDpotrf_bufferSize(handle::cusolverDnHandle_t,
+                                                          uplo::cublasFillMode_t, n::Cint,
+                                                          A::CuPtr{Cdouble}, lda::Cint,
+                                                          Lwork::Ptr{Cint})::cusolverStatus_t
 end
 
 @checked function cusolverDnCpotrf_bufferSize(handle, uplo, n, A, lda, Lwork)
     initialize_context()
-    @ccall libcusolver.cusolverDnCpotrf_bufferSize(handle::cusolverDnHandle_t,
-                                                   uplo::cublasFillMode_t, n::Cint,
-                                                   A::CuPtr{cuComplex}, lda::Cint,
-                                                   Lwork::Ptr{Cint})::cusolverStatus_t
+    @gcsafe_ccall libcusolver.cusolverDnCpotrf_bufferSize(handle::cusolverDnHandle_t,
+                                                          uplo::cublasFillMode_t, n::Cint,
+                                                          A::CuPtr{cuComplex}, lda::Cint,
+                                                          Lwork::Ptr{Cint})::cusolverStatus_t
 end
 
 @checked function cusolverDnZpotrf_bufferSize(handle, uplo, n, A, lda, Lwork)
     initialize_context()
-    @ccall libcusolver.cusolverDnZpotrf_bufferSize(handle::cusolverDnHandle_t,
-                                                   uplo::cublasFillMode_t, n::Cint,
-                                                   A::CuPtr{cuDoubleComplex}, lda::Cint,
-                                                   Lwork::Ptr{Cint})::cusolverStatus_t
+    @gcsafe_ccall libcusolver.cusolverDnZpotrf_bufferSize(handle::cusolverDnHandle_t,
+                                                          uplo::cublasFillMode_t, n::Cint,
+                                                          A::CuPtr{cuDoubleComplex},
+                                                          lda::Cint,
+                                                          Lwork::Ptr{Cint})::cusolverStatus_t
 end
 
 @checked function cusolverDnSpotrf(handle, uplo, n, A, lda, Workspace, Lwork, devInfo)
     initialize_context()
-    @ccall libcusolver.cusolverDnSpotrf(handle::cusolverDnHandle_t, uplo::cublasFillMode_t,
-                                        n::Cint, A::CuPtr{Cfloat}, lda::Cint,
-                                        Workspace::CuPtr{Cfloat}, Lwork::Cint,
-                                        devInfo::CuPtr{Cint})::cusolverStatus_t
+    @gcsafe_ccall libcusolver.cusolverDnSpotrf(handle::cusolverDnHandle_t,
+                                               uplo::cublasFillMode_t, n::Cint,
+                                               A::CuPtr{Cfloat}, lda::Cint,
+                                               Workspace::CuPtr{Cfloat}, Lwork::Cint,
+                                               devInfo::CuPtr{Cint})::cusolverStatus_t
 end
 
 @checked function cusolverDnDpotrf(handle, uplo, n, A, lda, Workspace, Lwork, devInfo)
     initialize_context()
-    @ccall libcusolver.cusolverDnDpotrf(handle::cusolverDnHandle_t, uplo::cublasFillMode_t,
-                                        n::Cint, A::CuPtr{Cdouble}, lda::Cint,
-                                        Workspace::CuPtr{Cdouble}, Lwork::Cint,
-                                        devInfo::CuPtr{Cint})::cusolverStatus_t
+    @gcsafe_ccall libcusolver.cusolverDnDpotrf(handle::cusolverDnHandle_t,
+                                               uplo::cublasFillMode_t, n::Cint,
+                                               A::CuPtr{Cdouble}, lda::Cint,
+                                               Workspace::CuPtr{Cdouble}, Lwork::Cint,
+                                               devInfo::CuPtr{Cint})::cusolverStatus_t
 end
 
 @checked function cusolverDnCpotrf(handle, uplo, n, A, lda, Workspace, Lwork, devInfo)
     initialize_context()
-    @ccall libcusolver.cusolverDnCpotrf(handle::cusolverDnHandle_t, uplo::cublasFillMode_t,
-                                        n::Cint, A::CuPtr{cuComplex}, lda::Cint,
-                                        Workspace::CuPtr{cuComplex}, Lwork::Cint,
-                                        devInfo::CuPtr{Cint})::cusolverStatus_t
+    @gcsafe_ccall libcusolver.cusolverDnCpotrf(handle::cusolverDnHandle_t,
+                                               uplo::cublasFillMode_t, n::Cint,
+                                               A::CuPtr{cuComplex}, lda::Cint,
+                                               Workspace::CuPtr{cuComplex}, Lwork::Cint,
+                                               devInfo::CuPtr{Cint})::cusolverStatus_t
 end
 
 @checked function cusolverDnZpotrf(handle, uplo, n, A, lda, Workspace, Lwork, devInfo)
     initialize_context()
-    @ccall libcusolver.cusolverDnZpotrf(handle::cusolverDnHandle_t, uplo::cublasFillMode_t,
-                                        n::Cint, A::CuPtr{cuDoubleComplex}, lda::Cint,
-                                        Workspace::CuPtr{cuDoubleComplex}, Lwork::Cint,
-                                        devInfo::CuPtr{Cint})::cusolverStatus_t
+    @gcsafe_ccall libcusolver.cusolverDnZpotrf(handle::cusolverDnHandle_t,
+                                               uplo::cublasFillMode_t, n::Cint,
+                                               A::CuPtr{cuDoubleComplex}, lda::Cint,
+                                               Workspace::CuPtr{cuDoubleComplex},
+                                               Lwork::Cint,
+                                               devInfo::CuPtr{Cint})::cusolverStatus_t
 end
 
 @checked function cusolverDnSpotrs(handle, uplo, n, nrhs, A, lda, B, ldb, devInfo)
     initialize_context()
-    @ccall libcusolver.cusolverDnSpotrs(handle::cusolverDnHandle_t, uplo::cublasFillMode_t,
-                                        n::Cint, nrhs::Cint, A::CuPtr{Cfloat}, lda::Cint,
-                                        B::CuPtr{Cfloat}, ldb::Cint,
-                                        devInfo::CuPtr{Cint})::cusolverStatus_t
+    @gcsafe_ccall libcusolver.cusolverDnSpotrs(handle::cusolverDnHandle_t,
+                                               uplo::cublasFillMode_t, n::Cint, nrhs::Cint,
+                                               A::CuPtr{Cfloat}, lda::Cint,
+                                               B::CuPtr{Cfloat}, ldb::Cint,
+                                               devInfo::CuPtr{Cint})::cusolverStatus_t
 end
 
 @checked function cusolverDnDpotrs(handle, uplo, n, nrhs, A, lda, B, ldb, devInfo)
     initialize_context()
-    @ccall libcusolver.cusolverDnDpotrs(handle::cusolverDnHandle_t, uplo::cublasFillMode_t,
-                                        n::Cint, nrhs::Cint, A::CuPtr{Cdouble}, lda::Cint,
-                                        B::CuPtr{Cdouble}, ldb::Cint,
-                                        devInfo::CuPtr{Cint})::cusolverStatus_t
+    @gcsafe_ccall libcusolver.cusolverDnDpotrs(handle::cusolverDnHandle_t,
+                                               uplo::cublasFillMode_t, n::Cint, nrhs::Cint,
+                                               A::CuPtr{Cdouble}, lda::Cint,
+                                               B::CuPtr{Cdouble}, ldb::Cint,
+                                               devInfo::CuPtr{Cint})::cusolverStatus_t
 end
 
 @checked function cusolverDnCpotrs(handle, uplo, n, nrhs, A, lda, B, ldb, devInfo)
     initialize_context()
-    @ccall libcusolver.cusolverDnCpotrs(handle::cusolverDnHandle_t, uplo::cublasFillMode_t,
-                                        n::Cint, nrhs::Cint, A::CuPtr{cuComplex}, lda::Cint,
-                                        B::CuPtr{cuComplex}, ldb::Cint,
-                                        devInfo::CuPtr{Cint})::cusolverStatus_t
+    @gcsafe_ccall libcusolver.cusolverDnCpotrs(handle::cusolverDnHandle_t,
+                                               uplo::cublasFillMode_t, n::Cint, nrhs::Cint,
+                                               A::CuPtr{cuComplex}, lda::Cint,
+                                               B::CuPtr{cuComplex}, ldb::Cint,
+                                               devInfo::CuPtr{Cint})::cusolverStatus_t
 end
 
 @checked function cusolverDnZpotrs(handle, uplo, n, nrhs, A, lda, B, ldb, devInfo)
     initialize_context()
-    @ccall libcusolver.cusolverDnZpotrs(handle::cusolverDnHandle_t, uplo::cublasFillMode_t,
-                                        n::Cint, nrhs::Cint, A::CuPtr{cuDoubleComplex},
-                                        lda::Cint, B::CuPtr{cuDoubleComplex}, ldb::Cint,
-                                        devInfo::CuPtr{Cint})::cusolverStatus_t
+    @gcsafe_ccall libcusolver.cusolverDnZpotrs(handle::cusolverDnHandle_t,
+                                               uplo::cublasFillMode_t, n::Cint, nrhs::Cint,
+                                               A::CuPtr{cuDoubleComplex}, lda::Cint,
+                                               B::CuPtr{cuDoubleComplex}, ldb::Cint,
+                                               devInfo::CuPtr{Cint})::cusolverStatus_t
 end
 
 @checked function cusolverDnSpotrfBatched(handle, uplo, n, Aarray, lda, infoArray,
                                           batchSize)
     initialize_context()
-    @ccall libcusolver.cusolverDnSpotrfBatched(handle::cusolverDnHandle_t,
-                                               uplo::cublasFillMode_t, n::Cint,
-                                               Aarray::CuPtr{Ptr{Cfloat}}, lda::Cint,
-                                               infoArray::CuPtr{Cint},
-                                               batchSize::Cint)::cusolverStatus_t
+    @gcsafe_ccall libcusolver.cusolverDnSpotrfBatched(handle::cusolverDnHandle_t,
+                                                      uplo::cublasFillMode_t, n::Cint,
+                                                      Aarray::CuPtr{Ptr{Cfloat}}, lda::Cint,
+                                                      infoArray::CuPtr{Cint},
+                                                      batchSize::Cint)::cusolverStatus_t
 end
 
 @checked function cusolverDnDpotrfBatched(handle, uplo, n, Aarray, lda, infoArray,
                                           batchSize)
     initialize_context()
-    @ccall libcusolver.cusolverDnDpotrfBatched(handle::cusolverDnHandle_t,
-                                               uplo::cublasFillMode_t, n::Cint,
-                                               Aarray::CuPtr{Ptr{Cdouble}}, lda::Cint,
-                                               infoArray::CuPtr{Cint},
-                                               batchSize::Cint)::cusolverStatus_t
+    @gcsafe_ccall libcusolver.cusolverDnDpotrfBatched(handle::cusolverDnHandle_t,
+                                                      uplo::cublasFillMode_t, n::Cint,
+                                                      Aarray::CuPtr{Ptr{Cdouble}},
+                                                      lda::Cint, infoArray::CuPtr{Cint},
+                                                      batchSize::Cint)::cusolverStatus_t
 end
 
 @checked function cusolverDnCpotrfBatched(handle, uplo, n, Aarray, lda, infoArray,
                                           batchSize)
     initialize_context()
-    @ccall libcusolver.cusolverDnCpotrfBatched(handle::cusolverDnHandle_t,
-                                               uplo::cublasFillMode_t, n::Cint,
-                                               Aarray::CuPtr{Ptr{cuComplex}}, lda::Cint,
-                                               infoArray::CuPtr{Cint},
-                                               batchSize::Cint)::cusolverStatus_t
+    @gcsafe_ccall libcusolver.cusolverDnCpotrfBatched(handle::cusolverDnHandle_t,
+                                                      uplo::cublasFillMode_t, n::Cint,
+                                                      Aarray::CuPtr{Ptr{cuComplex}},
+                                                      lda::Cint, infoArray::CuPtr{Cint},
+                                                      batchSize::Cint)::cusolverStatus_t
 end
 
 @checked function cusolverDnZpotrfBatched(handle, uplo, n, Aarray, lda, infoArray,
                                           batchSize)
     initialize_context()
-    @ccall libcusolver.cusolverDnZpotrfBatched(handle::cusolverDnHandle_t,
-                                               uplo::cublasFillMode_t, n::Cint,
-                                               Aarray::CuPtr{Ptr{cuDoubleComplex}},
-                                               lda::Cint, infoArray::CuPtr{Cint},
-                                               batchSize::Cint)::cusolverStatus_t
+    @gcsafe_ccall libcusolver.cusolverDnZpotrfBatched(handle::cusolverDnHandle_t,
+                                                      uplo::cublasFillMode_t, n::Cint,
+                                                      Aarray::CuPtr{Ptr{cuDoubleComplex}},
+                                                      lda::Cint, infoArray::CuPtr{Cint},
+                                                      batchSize::Cint)::cusolverStatus_t
 end
 
 @checked function cusolverDnSpotrsBatched(handle, uplo, n, nrhs, A, lda, B, ldb, d_info,
                                           batchSize)
     initialize_context()
-    @ccall libcusolver.cusolverDnSpotrsBatched(handle::cusolverDnHandle_t,
-                                               uplo::cublasFillMode_t, n::Cint, nrhs::Cint,
-                                               A::CuPtr{Ptr{Cfloat}}, lda::Cint,
-                                               B::CuPtr{Ptr{Cfloat}}, ldb::Cint,
-                                               d_info::CuPtr{Cint},
-                                               batchSize::Cint)::cusolverStatus_t
+    @gcsafe_ccall libcusolver.cusolverDnSpotrsBatched(handle::cusolverDnHandle_t,
+                                                      uplo::cublasFillMode_t, n::Cint,
+                                                      nrhs::Cint, A::CuPtr{Ptr{Cfloat}},
+                                                      lda::Cint, B::CuPtr{Ptr{Cfloat}},
+                                                      ldb::Cint, d_info::CuPtr{Cint},
+                                                      batchSize::Cint)::cusolverStatus_t
 end
 
 @checked function cusolverDnDpotrsBatched(handle, uplo, n, nrhs, A, lda, B, ldb, d_info,
                                           batchSize)
     initialize_context()
-    @ccall libcusolver.cusolverDnDpotrsBatched(handle::cusolverDnHandle_t,
-                                               uplo::cublasFillMode_t, n::Cint, nrhs::Cint,
-                                               A::CuPtr{Ptr{Cdouble}}, lda::Cint,
-                                               B::CuPtr{Ptr{Cdouble}}, ldb::Cint,
-                                               d_info::CuPtr{Cint},
-                                               batchSize::Cint)::cusolverStatus_t
+    @gcsafe_ccall libcusolver.cusolverDnDpotrsBatched(handle::cusolverDnHandle_t,
+                                                      uplo::cublasFillMode_t, n::Cint,
+                                                      nrhs::Cint, A::CuPtr{Ptr{Cdouble}},
+                                                      lda::Cint, B::CuPtr{Ptr{Cdouble}},
+                                                      ldb::Cint, d_info::CuPtr{Cint},
+                                                      batchSize::Cint)::cusolverStatus_t
 end
 
 @checked function cusolverDnCpotrsBatched(handle, uplo, n, nrhs, A, lda, B, ldb, d_info,
                                           batchSize)
     initialize_context()
-    @ccall libcusolver.cusolverDnCpotrsBatched(handle::cusolverDnHandle_t,
-                                               uplo::cublasFillMode_t, n::Cint, nrhs::Cint,
-                                               A::CuPtr{Ptr{cuComplex}}, lda::Cint,
-                                               B::CuPtr{Ptr{cuComplex}}, ldb::Cint,
-                                               d_info::CuPtr{Cint},
-                                               batchSize::Cint)::cusolverStatus_t
+    @gcsafe_ccall libcusolver.cusolverDnCpotrsBatched(handle::cusolverDnHandle_t,
+                                                      uplo::cublasFillMode_t, n::Cint,
+                                                      nrhs::Cint, A::CuPtr{Ptr{cuComplex}},
+                                                      lda::Cint, B::CuPtr{Ptr{cuComplex}},
+                                                      ldb::Cint, d_info::CuPtr{Cint},
+                                                      batchSize::Cint)::cusolverStatus_t
 end
 
 @checked function cusolverDnZpotrsBatched(handle, uplo, n, nrhs, A, lda, B, ldb, d_info,
                                           batchSize)
     initialize_context()
-    @ccall libcusolver.cusolverDnZpotrsBatched(handle::cusolverDnHandle_t,
-                                               uplo::cublasFillMode_t, n::Cint, nrhs::Cint,
-                                               A::CuPtr{Ptr{cuDoubleComplex}}, lda::Cint,
-                                               B::CuPtr{Ptr{cuDoubleComplex}}, ldb::Cint,
-                                               d_info::CuPtr{Cint},
-                                               batchSize::Cint)::cusolverStatus_t
+    @gcsafe_ccall libcusolver.cusolverDnZpotrsBatched(handle::cusolverDnHandle_t,
+                                                      uplo::cublasFillMode_t, n::Cint,
+                                                      nrhs::Cint,
+                                                      A::CuPtr{Ptr{cuDoubleComplex}},
+                                                      lda::Cint,
+                                                      B::CuPtr{Ptr{cuDoubleComplex}},
+                                                      ldb::Cint, d_info::CuPtr{Cint},
+                                                      batchSize::Cint)::cusolverStatus_t
 end
 
 @checked function cusolverDnSpotri_bufferSize(handle, uplo, n, A, lda, lwork)
     initialize_context()
-    @ccall libcusolver.cusolverDnSpotri_bufferSize(handle::cusolverDnHandle_t,
-                                                   uplo::cublasFillMode_t, n::Cint,
-                                                   A::CuPtr{Cfloat}, lda::Cint,
-                                                   lwork::Ptr{Cint})::cusolverStatus_t
+    @gcsafe_ccall libcusolver.cusolverDnSpotri_bufferSize(handle::cusolverDnHandle_t,
+                                                          uplo::cublasFillMode_t, n::Cint,
+                                                          A::CuPtr{Cfloat}, lda::Cint,
+                                                          lwork::Ptr{Cint})::cusolverStatus_t
 end
 
 @checked function cusolverDnDpotri_bufferSize(handle, uplo, n, A, lda, lwork)
     initialize_context()
-    @ccall libcusolver.cusolverDnDpotri_bufferSize(handle::cusolverDnHandle_t,
-                                                   uplo::cublasFillMode_t, n::Cint,
-                                                   A::CuPtr{Cdouble}, lda::Cint,
-                                                   lwork::Ptr{Cint})::cusolverStatus_t
+    @gcsafe_ccall libcusolver.cusolverDnDpotri_bufferSize(handle::cusolverDnHandle_t,
+                                                          uplo::cublasFillMode_t, n::Cint,
+                                                          A::CuPtr{Cdouble}, lda::Cint,
+                                                          lwork::Ptr{Cint})::cusolverStatus_t
 end
 
 @checked function cusolverDnCpotri_bufferSize(handle, uplo, n, A, lda, lwork)
     initialize_context()
-    @ccall libcusolver.cusolverDnCpotri_bufferSize(handle::cusolverDnHandle_t,
-                                                   uplo::cublasFillMode_t, n::Cint,
-                                                   A::CuPtr{cuComplex}, lda::Cint,
-                                                   lwork::Ptr{Cint})::cusolverStatus_t
+    @gcsafe_ccall libcusolver.cusolverDnCpotri_bufferSize(handle::cusolverDnHandle_t,
+                                                          uplo::cublasFillMode_t, n::Cint,
+                                                          A::CuPtr{cuComplex}, lda::Cint,
+                                                          lwork::Ptr{Cint})::cusolverStatus_t
 end
 
 @checked function cusolverDnZpotri_bufferSize(handle, uplo, n, A, lda, lwork)
     initialize_context()
-    @ccall libcusolver.cusolverDnZpotri_bufferSize(handle::cusolverDnHandle_t,
-                                                   uplo::cublasFillMode_t, n::Cint,
-                                                   A::CuPtr{cuDoubleComplex}, lda::Cint,
-                                                   lwork::Ptr{Cint})::cusolverStatus_t
+    @gcsafe_ccall libcusolver.cusolverDnZpotri_bufferSize(handle::cusolverDnHandle_t,
+                                                          uplo::cublasFillMode_t, n::Cint,
+                                                          A::CuPtr{cuDoubleComplex},
+                                                          lda::Cint,
+                                                          lwork::Ptr{Cint})::cusolverStatus_t
 end
 
 @checked function cusolverDnSpotri(handle, uplo, n, A, lda, work, lwork, devInfo)
     initialize_context()
-    @ccall libcusolver.cusolverDnSpotri(handle::cusolverDnHandle_t, uplo::cublasFillMode_t,
-                                        n::Cint, A::CuPtr{Cfloat}, lda::Cint,
-                                        work::CuPtr{Cfloat}, lwork::Cint,
-                                        devInfo::CuPtr{Cint})::cusolverStatus_t
+    @gcsafe_ccall libcusolver.cusolverDnSpotri(handle::cusolverDnHandle_t,
+                                               uplo::cublasFillMode_t, n::Cint,
+                                               A::CuPtr{Cfloat}, lda::Cint,
+                                               work::CuPtr{Cfloat}, lwork::Cint,
+                                               devInfo::CuPtr{Cint})::cusolverStatus_t
 end
 
 @checked function cusolverDnDpotri(handle, uplo, n, A, lda, work, lwork, devInfo)
     initialize_context()
-    @ccall libcusolver.cusolverDnDpotri(handle::cusolverDnHandle_t, uplo::cublasFillMode_t,
-                                        n::Cint, A::CuPtr{Cdouble}, lda::Cint,
-                                        work::CuPtr{Cdouble}, lwork::Cint,
-                                        devInfo::CuPtr{Cint})::cusolverStatus_t
+    @gcsafe_ccall libcusolver.cusolverDnDpotri(handle::cusolverDnHandle_t,
+                                               uplo::cublasFillMode_t, n::Cint,
+                                               A::CuPtr{Cdouble}, lda::Cint,
+                                               work::CuPtr{Cdouble}, lwork::Cint,
+                                               devInfo::CuPtr{Cint})::cusolverStatus_t
 end
 
 @checked function cusolverDnCpotri(handle, uplo, n, A, lda, work, lwork, devInfo)
     initialize_context()
-    @ccall libcusolver.cusolverDnCpotri(handle::cusolverDnHandle_t, uplo::cublasFillMode_t,
-                                        n::Cint, A::CuPtr{cuComplex}, lda::Cint,
-                                        work::CuPtr{cuComplex}, lwork::Cint,
-                                        devInfo::CuPtr{Cint})::cusolverStatus_t
+    @gcsafe_ccall libcusolver.cusolverDnCpotri(handle::cusolverDnHandle_t,
+                                               uplo::cublasFillMode_t, n::Cint,
+                                               A::CuPtr{cuComplex}, lda::Cint,
+                                               work::CuPtr{cuComplex}, lwork::Cint,
+                                               devInfo::CuPtr{Cint})::cusolverStatus_t
 end
 
 @checked function cusolverDnZpotri(handle, uplo, n, A, lda, work, lwork, devInfo)
     initialize_context()
-    @ccall libcusolver.cusolverDnZpotri(handle::cusolverDnHandle_t, uplo::cublasFillMode_t,
-                                        n::Cint, A::CuPtr{cuDoubleComplex}, lda::Cint,
-                                        work::CuPtr{cuDoubleComplex}, lwork::Cint,
-                                        devInfo::CuPtr{Cint})::cusolverStatus_t
+    @gcsafe_ccall libcusolver.cusolverDnZpotri(handle::cusolverDnHandle_t,
+                                               uplo::cublasFillMode_t, n::Cint,
+                                               A::CuPtr{cuDoubleComplex}, lda::Cint,
+                                               work::CuPtr{cuDoubleComplex}, lwork::Cint,
+                                               devInfo::CuPtr{Cint})::cusolverStatus_t
 end
 
 @checked function cusolverDnXtrtri_bufferSize(handle, uplo, diag, n, dataTypeA, A, lda,
                                               workspaceInBytesOnDevice,
                                               workspaceInBytesOnHost)
     initialize_context()
-    @ccall libcusolver.cusolverDnXtrtri_bufferSize(handle::cusolverDnHandle_t,
-                                                   uplo::cublasFillMode_t,
-                                                   diag::cublasDiagType_t, n::Int64,
-                                                   dataTypeA::cudaDataType, A::CuPtr{Cvoid},
-                                                   lda::Int64,
-                                                   workspaceInBytesOnDevice::Ptr{Csize_t},
-                                                   workspaceInBytesOnHost::Ptr{Csize_t})::cusolverStatus_t
+    @gcsafe_ccall libcusolver.cusolverDnXtrtri_bufferSize(handle::cusolverDnHandle_t,
+                                                          uplo::cublasFillMode_t,
+                                                          diag::cublasDiagType_t, n::Int64,
+                                                          dataTypeA::cudaDataType,
+                                                          A::CuPtr{Cvoid}, lda::Int64,
+                                                          workspaceInBytesOnDevice::Ptr{Csize_t},
+                                                          workspaceInBytesOnHost::Ptr{Csize_t})::cusolverStatus_t
 end
 
 @checked function cusolverDnXtrtri(handle, uplo, diag, n, dataTypeA, A, lda, bufferOnDevice,
                                    workspaceInBytesOnDevice, bufferOnHost,
                                    workspaceInBytesOnHost, devInfo)
     initialize_context()
-    @ccall libcusolver.cusolverDnXtrtri(handle::cusolverDnHandle_t, uplo::cublasFillMode_t,
-                                        diag::cublasDiagType_t, n::Int64,
-                                        dataTypeA::cudaDataType, A::CuPtr{Cvoid},
-                                        lda::Int64, bufferOnDevice::CuPtr{Cvoid},
-                                        workspaceInBytesOnDevice::Csize_t,
-                                        bufferOnHost::Ptr{Cvoid},
-                                        workspaceInBytesOnHost::Csize_t,
-                                        devInfo::CuPtr{Cint})::cusolverStatus_t
+    @gcsafe_ccall libcusolver.cusolverDnXtrtri(handle::cusolverDnHandle_t,
+                                               uplo::cublasFillMode_t,
+                                               diag::cublasDiagType_t, n::Int64,
+                                               dataTypeA::cudaDataType, A::CuPtr{Cvoid},
+                                               lda::Int64, bufferOnDevice::CuPtr{Cvoid},
+                                               workspaceInBytesOnDevice::Csize_t,
+                                               bufferOnHost::Ptr{Cvoid},
+                                               workspaceInBytesOnHost::Csize_t,
+                                               devInfo::CuPtr{Cint})::cusolverStatus_t
 end
 
 @checked function cusolverDnSlauum_bufferSize(handle, uplo, n, A, lda, lwork)
     initialize_context()
-    @ccall libcusolver.cusolverDnSlauum_bufferSize(handle::cusolverDnHandle_t,
-                                                   uplo::cublasFillMode_t, n::Cint,
-                                                   A::CuPtr{Cfloat}, lda::Cint,
-                                                   lwork::Ptr{Cint})::cusolverStatus_t
+    @gcsafe_ccall libcusolver.cusolverDnSlauum_bufferSize(handle::cusolverDnHandle_t,
+                                                          uplo::cublasFillMode_t, n::Cint,
+                                                          A::CuPtr{Cfloat}, lda::Cint,
+                                                          lwork::Ptr{Cint})::cusolverStatus_t
 end
 
 @checked function cusolverDnDlauum_bufferSize(handle, uplo, n, A, lda, lwork)
     initialize_context()
-    @ccall libcusolver.cusolverDnDlauum_bufferSize(handle::cusolverDnHandle_t,
-                                                   uplo::cublasFillMode_t, n::Cint,
-                                                   A::CuPtr{Cdouble}, lda::Cint,
-                                                   lwork::Ptr{Cint})::cusolverStatus_t
+    @gcsafe_ccall libcusolver.cusolverDnDlauum_bufferSize(handle::cusolverDnHandle_t,
+                                                          uplo::cublasFillMode_t, n::Cint,
+                                                          A::CuPtr{Cdouble}, lda::Cint,
+                                                          lwork::Ptr{Cint})::cusolverStatus_t
 end
 
 @checked function cusolverDnClauum_bufferSize(handle, uplo, n, A, lda, lwork)
     initialize_context()
-    @ccall libcusolver.cusolverDnClauum_bufferSize(handle::cusolverDnHandle_t,
-                                                   uplo::cublasFillMode_t, n::Cint,
-                                                   A::CuPtr{cuComplex}, lda::Cint,
-                                                   lwork::Ptr{Cint})::cusolverStatus_t
+    @gcsafe_ccall libcusolver.cusolverDnClauum_bufferSize(handle::cusolverDnHandle_t,
+                                                          uplo::cublasFillMode_t, n::Cint,
+                                                          A::CuPtr{cuComplex}, lda::Cint,
+                                                          lwork::Ptr{Cint})::cusolverStatus_t
 end
 
 @checked function cusolverDnZlauum_bufferSize(handle, uplo, n, A, lda, lwork)
     initialize_context()
-    @ccall libcusolver.cusolverDnZlauum_bufferSize(handle::cusolverDnHandle_t,
-                                                   uplo::cublasFillMode_t, n::Cint,
-                                                   A::CuPtr{cuDoubleComplex}, lda::Cint,
-                                                   lwork::Ptr{Cint})::cusolverStatus_t
+    @gcsafe_ccall libcusolver.cusolverDnZlauum_bufferSize(handle::cusolverDnHandle_t,
+                                                          uplo::cublasFillMode_t, n::Cint,
+                                                          A::CuPtr{cuDoubleComplex},
+                                                          lda::Cint,
+                                                          lwork::Ptr{Cint})::cusolverStatus_t
 end
 
 @checked function cusolverDnSlauum(handle, uplo, n, A, lda, work, lwork, devInfo)
     initialize_context()
-    @ccall libcusolver.cusolverDnSlauum(handle::cusolverDnHandle_t, uplo::cublasFillMode_t,
-                                        n::Cint, A::CuPtr{Cfloat}, lda::Cint,
-                                        work::CuPtr{Cfloat}, lwork::Cint,
-                                        devInfo::CuPtr{Cint})::cusolverStatus_t
+    @gcsafe_ccall libcusolver.cusolverDnSlauum(handle::cusolverDnHandle_t,
+                                               uplo::cublasFillMode_t, n::Cint,
+                                               A::CuPtr{Cfloat}, lda::Cint,
+                                               work::CuPtr{Cfloat}, lwork::Cint,
+                                               devInfo::CuPtr{Cint})::cusolverStatus_t
 end
 
 @checked function cusolverDnDlauum(handle, uplo, n, A, lda, work, lwork, devInfo)
     initialize_context()
-    @ccall libcusolver.cusolverDnDlauum(handle::cusolverDnHandle_t, uplo::cublasFillMode_t,
-                                        n::Cint, A::CuPtr{Cdouble}, lda::Cint,
-                                        work::CuPtr{Cdouble}, lwork::Cint,
-                                        devInfo::CuPtr{Cint})::cusolverStatus_t
+    @gcsafe_ccall libcusolver.cusolverDnDlauum(handle::cusolverDnHandle_t,
+                                               uplo::cublasFillMode_t, n::Cint,
+                                               A::CuPtr{Cdouble}, lda::Cint,
+                                               work::CuPtr{Cdouble}, lwork::Cint,
+                                               devInfo::CuPtr{Cint})::cusolverStatus_t
 end
 
 @checked function cusolverDnClauum(handle, uplo, n, A, lda, work, lwork, devInfo)
     initialize_context()
-    @ccall libcusolver.cusolverDnClauum(handle::cusolverDnHandle_t, uplo::cublasFillMode_t,
-                                        n::Cint, A::CuPtr{cuComplex}, lda::Cint,
-                                        work::CuPtr{cuComplex}, lwork::Cint,
-                                        devInfo::CuPtr{Cint})::cusolverStatus_t
+    @gcsafe_ccall libcusolver.cusolverDnClauum(handle::cusolverDnHandle_t,
+                                               uplo::cublasFillMode_t, n::Cint,
+                                               A::CuPtr{cuComplex}, lda::Cint,
+                                               work::CuPtr{cuComplex}, lwork::Cint,
+                                               devInfo::CuPtr{Cint})::cusolverStatus_t
 end
 
 @checked function cusolverDnZlauum(handle, uplo, n, A, lda, work, lwork, devInfo)
     initialize_context()
-    @ccall libcusolver.cusolverDnZlauum(handle::cusolverDnHandle_t, uplo::cublasFillMode_t,
-                                        n::Cint, A::CuPtr{cuDoubleComplex}, lda::Cint,
-                                        work::CuPtr{cuDoubleComplex}, lwork::Cint,
-                                        devInfo::CuPtr{Cint})::cusolverStatus_t
+    @gcsafe_ccall libcusolver.cusolverDnZlauum(handle::cusolverDnHandle_t,
+                                               uplo::cublasFillMode_t, n::Cint,
+                                               A::CuPtr{cuDoubleComplex}, lda::Cint,
+                                               work::CuPtr{cuDoubleComplex}, lwork::Cint,
+                                               devInfo::CuPtr{Cint})::cusolverStatus_t
 end
 
 @checked function cusolverDnSgetrf_bufferSize(handle, m, n, A, lda, Lwork)
     initialize_context()
-    @ccall libcusolver.cusolverDnSgetrf_bufferSize(handle::cusolverDnHandle_t, m::Cint,
-                                                   n::Cint, A::CuPtr{Cfloat}, lda::Cint,
-                                                   Lwork::Ptr{Cint})::cusolverStatus_t
+    @gcsafe_ccall libcusolver.cusolverDnSgetrf_bufferSize(handle::cusolverDnHandle_t,
+                                                          m::Cint, n::Cint,
+                                                          A::CuPtr{Cfloat}, lda::Cint,
+                                                          Lwork::Ptr{Cint})::cusolverStatus_t
 end
 
 @checked function cusolverDnDgetrf_bufferSize(handle, m, n, A, lda, Lwork)
     initialize_context()
-    @ccall libcusolver.cusolverDnDgetrf_bufferSize(handle::cusolverDnHandle_t, m::Cint,
-                                                   n::Cint, A::CuPtr{Cdouble}, lda::Cint,
-                                                   Lwork::Ptr{Cint})::cusolverStatus_t
+    @gcsafe_ccall libcusolver.cusolverDnDgetrf_bufferSize(handle::cusolverDnHandle_t,
+                                                          m::Cint, n::Cint,
+                                                          A::CuPtr{Cdouble}, lda::Cint,
+                                                          Lwork::Ptr{Cint})::cusolverStatus_t
 end
 
 @checked function cusolverDnCgetrf_bufferSize(handle, m, n, A, lda, Lwork)
     initialize_context()
-    @ccall libcusolver.cusolverDnCgetrf_bufferSize(handle::cusolverDnHandle_t, m::Cint,
-                                                   n::Cint, A::CuPtr{cuComplex}, lda::Cint,
-                                                   Lwork::Ptr{Cint})::cusolverStatus_t
+    @gcsafe_ccall libcusolver.cusolverDnCgetrf_bufferSize(handle::cusolverDnHandle_t,
+                                                          m::Cint, n::Cint,
+                                                          A::CuPtr{cuComplex}, lda::Cint,
+                                                          Lwork::Ptr{Cint})::cusolverStatus_t
 end
 
 @checked function cusolverDnZgetrf_bufferSize(handle, m, n, A, lda, Lwork)
     initialize_context()
-    @ccall libcusolver.cusolverDnZgetrf_bufferSize(handle::cusolverDnHandle_t, m::Cint,
-                                                   n::Cint, A::CuPtr{cuDoubleComplex},
-                                                   lda::Cint,
-                                                   Lwork::Ptr{Cint})::cusolverStatus_t
+    @gcsafe_ccall libcusolver.cusolverDnZgetrf_bufferSize(handle::cusolverDnHandle_t,
+                                                          m::Cint, n::Cint,
+                                                          A::CuPtr{cuDoubleComplex},
+                                                          lda::Cint,
+                                                          Lwork::Ptr{Cint})::cusolverStatus_t
 end
 
 @checked function cusolverDnSgetrf(handle, m, n, A, lda, Workspace, devIpiv, devInfo)
     initialize_context()
-    @ccall libcusolver.cusolverDnSgetrf(handle::cusolverDnHandle_t, m::Cint, n::Cint,
-                                        A::CuPtr{Cfloat}, lda::Cint,
-                                        Workspace::CuPtr{Cfloat}, devIpiv::CuPtr{Cint},
-                                        devInfo::CuPtr{Cint})::cusolverStatus_t
+    @gcsafe_ccall libcusolver.cusolverDnSgetrf(handle::cusolverDnHandle_t, m::Cint, n::Cint,
+                                               A::CuPtr{Cfloat}, lda::Cint,
+                                               Workspace::CuPtr{Cfloat},
+                                               devIpiv::CuPtr{Cint},
+                                               devInfo::CuPtr{Cint})::cusolverStatus_t
 end
 
 @checked function cusolverDnDgetrf(handle, m, n, A, lda, Workspace, devIpiv, devInfo)
     initialize_context()
-    @ccall libcusolver.cusolverDnDgetrf(handle::cusolverDnHandle_t, m::Cint, n::Cint,
-                                        A::CuPtr{Cdouble}, lda::Cint,
-                                        Workspace::CuPtr{Cdouble}, devIpiv::CuPtr{Cint},
-                                        devInfo::CuPtr{Cint})::cusolverStatus_t
+    @gcsafe_ccall libcusolver.cusolverDnDgetrf(handle::cusolverDnHandle_t, m::Cint, n::Cint,
+                                               A::CuPtr{Cdouble}, lda::Cint,
+                                               Workspace::CuPtr{Cdouble},
+                                               devIpiv::CuPtr{Cint},
+                                               devInfo::CuPtr{Cint})::cusolverStatus_t
 end
 
 @checked function cusolverDnCgetrf(handle, m, n, A, lda, Workspace, devIpiv, devInfo)
     initialize_context()
-    @ccall libcusolver.cusolverDnCgetrf(handle::cusolverDnHandle_t, m::Cint, n::Cint,
-                                        A::CuPtr{cuComplex}, lda::Cint,
-                                        Workspace::CuPtr{cuComplex}, devIpiv::CuPtr{Cint},
-                                        devInfo::CuPtr{Cint})::cusolverStatus_t
+    @gcsafe_ccall libcusolver.cusolverDnCgetrf(handle::cusolverDnHandle_t, m::Cint, n::Cint,
+                                               A::CuPtr{cuComplex}, lda::Cint,
+                                               Workspace::CuPtr{cuComplex},
+                                               devIpiv::CuPtr{Cint},
+                                               devInfo::CuPtr{Cint})::cusolverStatus_t
 end
 
 @checked function cusolverDnZgetrf(handle, m, n, A, lda, Workspace, devIpiv, devInfo)
     initialize_context()
-    @ccall libcusolver.cusolverDnZgetrf(handle::cusolverDnHandle_t, m::Cint, n::Cint,
-                                        A::CuPtr{cuDoubleComplex}, lda::Cint,
-                                        Workspace::CuPtr{cuDoubleComplex},
-                                        devIpiv::CuPtr{Cint},
-                                        devInfo::CuPtr{Cint})::cusolverStatus_t
+    @gcsafe_ccall libcusolver.cusolverDnZgetrf(handle::cusolverDnHandle_t, m::Cint, n::Cint,
+                                               A::CuPtr{cuDoubleComplex}, lda::Cint,
+                                               Workspace::CuPtr{cuDoubleComplex},
+                                               devIpiv::CuPtr{Cint},
+                                               devInfo::CuPtr{Cint})::cusolverStatus_t
 end
 
 @checked function cusolverDnSlaswp(handle, n, A, lda, k1, k2, devIpiv, incx)
     initialize_context()
-    @ccall libcusolver.cusolverDnSlaswp(handle::cusolverDnHandle_t, n::Cint,
-                                        A::CuPtr{Cfloat}, lda::Cint, k1::Cint, k2::Cint,
-                                        devIpiv::CuPtr{Cint}, incx::Cint)::cusolverStatus_t
+    @gcsafe_ccall libcusolver.cusolverDnSlaswp(handle::cusolverDnHandle_t, n::Cint,
+                                               A::CuPtr{Cfloat}, lda::Cint, k1::Cint,
+                                               k2::Cint, devIpiv::CuPtr{Cint},
+                                               incx::Cint)::cusolverStatus_t
 end
 
 @checked function cusolverDnDlaswp(handle, n, A, lda, k1, k2, devIpiv, incx)
     initialize_context()
-    @ccall libcusolver.cusolverDnDlaswp(handle::cusolverDnHandle_t, n::Cint,
-                                        A::CuPtr{Cdouble}, lda::Cint, k1::Cint, k2::Cint,
-                                        devIpiv::CuPtr{Cint}, incx::Cint)::cusolverStatus_t
+    @gcsafe_ccall libcusolver.cusolverDnDlaswp(handle::cusolverDnHandle_t, n::Cint,
+                                               A::CuPtr{Cdouble}, lda::Cint, k1::Cint,
+                                               k2::Cint, devIpiv::CuPtr{Cint},
+                                               incx::Cint)::cusolverStatus_t
 end
 
 @checked function cusolverDnClaswp(handle, n, A, lda, k1, k2, devIpiv, incx)
     initialize_context()
-    @ccall libcusolver.cusolverDnClaswp(handle::cusolverDnHandle_t, n::Cint,
-                                        A::CuPtr{cuComplex}, lda::Cint, k1::Cint, k2::Cint,
-                                        devIpiv::CuPtr{Cint}, incx::Cint)::cusolverStatus_t
+    @gcsafe_ccall libcusolver.cusolverDnClaswp(handle::cusolverDnHandle_t, n::Cint,
+                                               A::CuPtr{cuComplex}, lda::Cint, k1::Cint,
+                                               k2::Cint, devIpiv::CuPtr{Cint},
+                                               incx::Cint)::cusolverStatus_t
 end
 
 @checked function cusolverDnZlaswp(handle, n, A, lda, k1, k2, devIpiv, incx)
     initialize_context()
-    @ccall libcusolver.cusolverDnZlaswp(handle::cusolverDnHandle_t, n::Cint,
-                                        A::CuPtr{cuDoubleComplex}, lda::Cint, k1::Cint,
-                                        k2::Cint, devIpiv::CuPtr{Cint},
-                                        incx::Cint)::cusolverStatus_t
+    @gcsafe_ccall libcusolver.cusolverDnZlaswp(handle::cusolverDnHandle_t, n::Cint,
+                                               A::CuPtr{cuDoubleComplex}, lda::Cint,
+                                               k1::Cint, k2::Cint, devIpiv::CuPtr{Cint},
+                                               incx::Cint)::cusolverStatus_t
 end
 
 @checked function cusolverDnSgetrs(handle, trans, n, nrhs, A, lda, devIpiv, B, ldb, devInfo)
     initialize_context()
-    @ccall libcusolver.cusolverDnSgetrs(handle::cusolverDnHandle_t,
-                                        trans::cublasOperation_t, n::Cint, nrhs::Cint,
-                                        A::CuPtr{Cfloat}, lda::Cint, devIpiv::CuPtr{Cint},
-                                        B::CuPtr{Cfloat}, ldb::Cint,
-                                        devInfo::CuPtr{Cint})::cusolverStatus_t
+    @gcsafe_ccall libcusolver.cusolverDnSgetrs(handle::cusolverDnHandle_t,
+                                               trans::cublasOperation_t, n::Cint,
+                                               nrhs::Cint, A::CuPtr{Cfloat}, lda::Cint,
+                                               devIpiv::CuPtr{Cint}, B::CuPtr{Cfloat},
+                                               ldb::Cint,
+                                               devInfo::CuPtr{Cint})::cusolverStatus_t
 end
 
 @checked function cusolverDnDgetrs(handle, trans, n, nrhs, A, lda, devIpiv, B, ldb, devInfo)
     initialize_context()
-    @ccall libcusolver.cusolverDnDgetrs(handle::cusolverDnHandle_t,
-                                        trans::cublasOperation_t, n::Cint, nrhs::Cint,
-                                        A::CuPtr{Cdouble}, lda::Cint, devIpiv::CuPtr{Cint},
-                                        B::CuPtr{Cdouble}, ldb::Cint,
-                                        devInfo::CuPtr{Cint})::cusolverStatus_t
+    @gcsafe_ccall libcusolver.cusolverDnDgetrs(handle::cusolverDnHandle_t,
+                                               trans::cublasOperation_t, n::Cint,
+                                               nrhs::Cint, A::CuPtr{Cdouble}, lda::Cint,
+                                               devIpiv::CuPtr{Cint}, B::CuPtr{Cdouble},
+                                               ldb::Cint,
+                                               devInfo::CuPtr{Cint})::cusolverStatus_t
 end
 
 @checked function cusolverDnCgetrs(handle, trans, n, nrhs, A, lda, devIpiv, B, ldb, devInfo)
     initialize_context()
-    @ccall libcusolver.cusolverDnCgetrs(handle::cusolverDnHandle_t,
-                                        trans::cublasOperation_t, n::Cint, nrhs::Cint,
-                                        A::CuPtr{cuComplex}, lda::Cint,
-                                        devIpiv::CuPtr{Cint}, B::CuPtr{cuComplex},
-                                        ldb::Cint, devInfo::CuPtr{Cint})::cusolverStatus_t
+    @gcsafe_ccall libcusolver.cusolverDnCgetrs(handle::cusolverDnHandle_t,
+                                               trans::cublasOperation_t, n::Cint,
+                                               nrhs::Cint, A::CuPtr{cuComplex}, lda::Cint,
+                                               devIpiv::CuPtr{Cint}, B::CuPtr{cuComplex},
+                                               ldb::Cint,
+                                               devInfo::CuPtr{Cint})::cusolverStatus_t
 end
 
 @checked function cusolverDnZgetrs(handle, trans, n, nrhs, A, lda, devIpiv, B, ldb, devInfo)
     initialize_context()
-    @ccall libcusolver.cusolverDnZgetrs(handle::cusolverDnHandle_t,
-                                        trans::cublasOperation_t, n::Cint, nrhs::Cint,
-                                        A::CuPtr{cuDoubleComplex}, lda::Cint,
-                                        devIpiv::CuPtr{Cint}, B::CuPtr{cuDoubleComplex},
-                                        ldb::Cint, devInfo::CuPtr{Cint})::cusolverStatus_t
+    @gcsafe_ccall libcusolver.cusolverDnZgetrs(handle::cusolverDnHandle_t,
+                                               trans::cublasOperation_t, n::Cint,
+                                               nrhs::Cint, A::CuPtr{cuDoubleComplex},
+                                               lda::Cint, devIpiv::CuPtr{Cint},
+                                               B::CuPtr{cuDoubleComplex}, ldb::Cint,
+                                               devInfo::CuPtr{Cint})::cusolverStatus_t
 end
 
 @checked function cusolverDnSgeqrf_bufferSize(handle, m, n, A, lda, lwork)
     initialize_context()
-    @ccall libcusolver.cusolverDnSgeqrf_bufferSize(handle::cusolverDnHandle_t, m::Cint,
-                                                   n::Cint, A::CuPtr{Cfloat}, lda::Cint,
-                                                   lwork::Ptr{Cint})::cusolverStatus_t
+    @gcsafe_ccall libcusolver.cusolverDnSgeqrf_bufferSize(handle::cusolverDnHandle_t,
+                                                          m::Cint, n::Cint,
+                                                          A::CuPtr{Cfloat}, lda::Cint,
+                                                          lwork::Ptr{Cint})::cusolverStatus_t
 end
 
 @checked function cusolverDnDgeqrf_bufferSize(handle, m, n, A, lda, lwork)
     initialize_context()
-    @ccall libcusolver.cusolverDnDgeqrf_bufferSize(handle::cusolverDnHandle_t, m::Cint,
-                                                   n::Cint, A::CuPtr{Cdouble}, lda::Cint,
-                                                   lwork::Ptr{Cint})::cusolverStatus_t
+    @gcsafe_ccall libcusolver.cusolverDnDgeqrf_bufferSize(handle::cusolverDnHandle_t,
+                                                          m::Cint, n::Cint,
+                                                          A::CuPtr{Cdouble}, lda::Cint,
+                                                          lwork::Ptr{Cint})::cusolverStatus_t
 end
 
 @checked function cusolverDnCgeqrf_bufferSize(handle, m, n, A, lda, lwork)
     initialize_context()
-    @ccall libcusolver.cusolverDnCgeqrf_bufferSize(handle::cusolverDnHandle_t, m::Cint,
-                                                   n::Cint, A::CuPtr{cuComplex}, lda::Cint,
-                                                   lwork::Ptr{Cint})::cusolverStatus_t
+    @gcsafe_ccall libcusolver.cusolverDnCgeqrf_bufferSize(handle::cusolverDnHandle_t,
+                                                          m::Cint, n::Cint,
+                                                          A::CuPtr{cuComplex}, lda::Cint,
+                                                          lwork::Ptr{Cint})::cusolverStatus_t
 end
 
 @checked function cusolverDnZgeqrf_bufferSize(handle, m, n, A, lda, lwork)
     initialize_context()
-    @ccall libcusolver.cusolverDnZgeqrf_bufferSize(handle::cusolverDnHandle_t, m::Cint,
-                                                   n::Cint, A::CuPtr{cuDoubleComplex},
-                                                   lda::Cint,
-                                                   lwork::Ptr{Cint})::cusolverStatus_t
+    @gcsafe_ccall libcusolver.cusolverDnZgeqrf_bufferSize(handle::cusolverDnHandle_t,
+                                                          m::Cint, n::Cint,
+                                                          A::CuPtr{cuDoubleComplex},
+                                                          lda::Cint,
+                                                          lwork::Ptr{Cint})::cusolverStatus_t
 end
 
 @checked function cusolverDnSgeqrf(handle, m, n, A, lda, TAU, Workspace, Lwork, devInfo)
     initialize_context()
-    @ccall libcusolver.cusolverDnSgeqrf(handle::cusolverDnHandle_t, m::Cint, n::Cint,
-                                        A::CuPtr{Cfloat}, lda::Cint, TAU::CuPtr{Cfloat},
-                                        Workspace::CuPtr{Cfloat}, Lwork::Cint,
-                                        devInfo::CuPtr{Cint})::cusolverStatus_t
+    @gcsafe_ccall libcusolver.cusolverDnSgeqrf(handle::cusolverDnHandle_t, m::Cint, n::Cint,
+                                               A::CuPtr{Cfloat}, lda::Cint,
+                                               TAU::CuPtr{Cfloat}, Workspace::CuPtr{Cfloat},
+                                               Lwork::Cint,
+                                               devInfo::CuPtr{Cint})::cusolverStatus_t
 end
 
 @checked function cusolverDnDgeqrf(handle, m, n, A, lda, TAU, Workspace, Lwork, devInfo)
     initialize_context()
-    @ccall libcusolver.cusolverDnDgeqrf(handle::cusolverDnHandle_t, m::Cint, n::Cint,
-                                        A::CuPtr{Cdouble}, lda::Cint, TAU::CuPtr{Cdouble},
-                                        Workspace::CuPtr{Cdouble}, Lwork::Cint,
-                                        devInfo::CuPtr{Cint})::cusolverStatus_t
+    @gcsafe_ccall libcusolver.cusolverDnDgeqrf(handle::cusolverDnHandle_t, m::Cint, n::Cint,
+                                               A::CuPtr{Cdouble}, lda::Cint,
+                                               TAU::CuPtr{Cdouble},
+                                               Workspace::CuPtr{Cdouble}, Lwork::Cint,
+                                               devInfo::CuPtr{Cint})::cusolverStatus_t
 end
 
 @checked function cusolverDnCgeqrf(handle, m, n, A, lda, TAU, Workspace, Lwork, devInfo)
     initialize_context()
-    @ccall libcusolver.cusolverDnCgeqrf(handle::cusolverDnHandle_t, m::Cint, n::Cint,
-                                        A::CuPtr{cuComplex}, lda::Cint,
-                                        TAU::CuPtr{cuComplex}, Workspace::CuPtr{cuComplex},
-                                        Lwork::Cint, devInfo::CuPtr{Cint})::cusolverStatus_t
+    @gcsafe_ccall libcusolver.cusolverDnCgeqrf(handle::cusolverDnHandle_t, m::Cint, n::Cint,
+                                               A::CuPtr{cuComplex}, lda::Cint,
+                                               TAU::CuPtr{cuComplex},
+                                               Workspace::CuPtr{cuComplex}, Lwork::Cint,
+                                               devInfo::CuPtr{Cint})::cusolverStatus_t
 end
 
 @checked function cusolverDnZgeqrf(handle, m, n, A, lda, TAU, Workspace, Lwork, devInfo)
     initialize_context()
-    @ccall libcusolver.cusolverDnZgeqrf(handle::cusolverDnHandle_t, m::Cint, n::Cint,
-                                        A::CuPtr{cuDoubleComplex}, lda::Cint,
-                                        TAU::CuPtr{cuDoubleComplex},
-                                        Workspace::CuPtr{cuDoubleComplex}, Lwork::Cint,
-                                        devInfo::CuPtr{Cint})::cusolverStatus_t
+    @gcsafe_ccall libcusolver.cusolverDnZgeqrf(handle::cusolverDnHandle_t, m::Cint, n::Cint,
+                                               A::CuPtr{cuDoubleComplex}, lda::Cint,
+                                               TAU::CuPtr{cuDoubleComplex},
+                                               Workspace::CuPtr{cuDoubleComplex},
+                                               Lwork::Cint,
+                                               devInfo::CuPtr{Cint})::cusolverStatus_t
 end
 
 @checked function cusolverDnSorgqr_bufferSize(handle, m, n, k, A, lda, tau, lwork)
     initialize_context()
-    @ccall libcusolver.cusolverDnSorgqr_bufferSize(handle::cusolverDnHandle_t, m::Cint,
-                                                   n::Cint, k::Cint, A::CuPtr{Cfloat},
-                                                   lda::Cint, tau::CuPtr{Cfloat},
-                                                   lwork::Ptr{Cint})::cusolverStatus_t
+    @gcsafe_ccall libcusolver.cusolverDnSorgqr_bufferSize(handle::cusolverDnHandle_t,
+                                                          m::Cint, n::Cint, k::Cint,
+                                                          A::CuPtr{Cfloat}, lda::Cint,
+                                                          tau::CuPtr{Cfloat},
+                                                          lwork::Ptr{Cint})::cusolverStatus_t
 end
 
 @checked function cusolverDnDorgqr_bufferSize(handle, m, n, k, A, lda, tau, lwork)
     initialize_context()
-    @ccall libcusolver.cusolverDnDorgqr_bufferSize(handle::cusolverDnHandle_t, m::Cint,
-                                                   n::Cint, k::Cint, A::CuPtr{Cdouble},
-                                                   lda::Cint, tau::CuPtr{Cdouble},
-                                                   lwork::Ptr{Cint})::cusolverStatus_t
+    @gcsafe_ccall libcusolver.cusolverDnDorgqr_bufferSize(handle::cusolverDnHandle_t,
+                                                          m::Cint, n::Cint, k::Cint,
+                                                          A::CuPtr{Cdouble}, lda::Cint,
+                                                          tau::CuPtr{Cdouble},
+                                                          lwork::Ptr{Cint})::cusolverStatus_t
 end
 
 @checked function cusolverDnCungqr_bufferSize(handle, m, n, k, A, lda, tau, lwork)
     initialize_context()
-    @ccall libcusolver.cusolverDnCungqr_bufferSize(handle::cusolverDnHandle_t, m::Cint,
-                                                   n::Cint, k::Cint, A::CuPtr{cuComplex},
-                                                   lda::Cint, tau::CuPtr{cuComplex},
-                                                   lwork::Ptr{Cint})::cusolverStatus_t
+    @gcsafe_ccall libcusolver.cusolverDnCungqr_bufferSize(handle::cusolverDnHandle_t,
+                                                          m::Cint, n::Cint, k::Cint,
+                                                          A::CuPtr{cuComplex}, lda::Cint,
+                                                          tau::CuPtr{cuComplex},
+                                                          lwork::Ptr{Cint})::cusolverStatus_t
 end
 
 @checked function cusolverDnZungqr_bufferSize(handle, m, n, k, A, lda, tau, lwork)
     initialize_context()
-    @ccall libcusolver.cusolverDnZungqr_bufferSize(handle::cusolverDnHandle_t, m::Cint,
-                                                   n::Cint, k::Cint,
-                                                   A::CuPtr{cuDoubleComplex}, lda::Cint,
-                                                   tau::CuPtr{cuDoubleComplex},
-                                                   lwork::Ptr{Cint})::cusolverStatus_t
+    @gcsafe_ccall libcusolver.cusolverDnZungqr_bufferSize(handle::cusolverDnHandle_t,
+                                                          m::Cint, n::Cint, k::Cint,
+                                                          A::CuPtr{cuDoubleComplex},
+                                                          lda::Cint,
+                                                          tau::CuPtr{cuDoubleComplex},
+                                                          lwork::Ptr{Cint})::cusolverStatus_t
 end
 
 @checked function cusolverDnSorgqr(handle, m, n, k, A, lda, tau, work, lwork, info)
     initialize_context()
-    @ccall libcusolver.cusolverDnSorgqr(handle::cusolverDnHandle_t, m::Cint, n::Cint,
-                                        k::Cint, A::CuPtr{Cfloat}, lda::Cint,
-                                        tau::CuPtr{Cfloat}, work::CuPtr{Cfloat},
-                                        lwork::Cint, info::CuPtr{Cint})::cusolverStatus_t
+    @gcsafe_ccall libcusolver.cusolverDnSorgqr(handle::cusolverDnHandle_t, m::Cint, n::Cint,
+                                               k::Cint, A::CuPtr{Cfloat}, lda::Cint,
+                                               tau::CuPtr{Cfloat}, work::CuPtr{Cfloat},
+                                               lwork::Cint,
+                                               info::CuPtr{Cint})::cusolverStatus_t
 end
 
 @checked function cusolverDnDorgqr(handle, m, n, k, A, lda, tau, work, lwork, info)
     initialize_context()
-    @ccall libcusolver.cusolverDnDorgqr(handle::cusolverDnHandle_t, m::Cint, n::Cint,
-                                        k::Cint, A::CuPtr{Cdouble}, lda::Cint,
-                                        tau::CuPtr{Cdouble}, work::CuPtr{Cdouble},
-                                        lwork::Cint, info::CuPtr{Cint})::cusolverStatus_t
+    @gcsafe_ccall libcusolver.cusolverDnDorgqr(handle::cusolverDnHandle_t, m::Cint, n::Cint,
+                                               k::Cint, A::CuPtr{Cdouble}, lda::Cint,
+                                               tau::CuPtr{Cdouble}, work::CuPtr{Cdouble},
+                                               lwork::Cint,
+                                               info::CuPtr{Cint})::cusolverStatus_t
 end
 
 @checked function cusolverDnCungqr(handle, m, n, k, A, lda, tau, work, lwork, info)
     initialize_context()
-    @ccall libcusolver.cusolverDnCungqr(handle::cusolverDnHandle_t, m::Cint, n::Cint,
-                                        k::Cint, A::CuPtr{cuComplex}, lda::Cint,
-                                        tau::CuPtr{cuComplex}, work::CuPtr{cuComplex},
-                                        lwork::Cint, info::CuPtr{Cint})::cusolverStatus_t
+    @gcsafe_ccall libcusolver.cusolverDnCungqr(handle::cusolverDnHandle_t, m::Cint, n::Cint,
+                                               k::Cint, A::CuPtr{cuComplex}, lda::Cint,
+                                               tau::CuPtr{cuComplex},
+                                               work::CuPtr{cuComplex}, lwork::Cint,
+                                               info::CuPtr{Cint})::cusolverStatus_t
 end
 
 @checked function cusolverDnZungqr(handle, m, n, k, A, lda, tau, work, lwork, info)
     initialize_context()
-    @ccall libcusolver.cusolverDnZungqr(handle::cusolverDnHandle_t, m::Cint, n::Cint,
-                                        k::Cint, A::CuPtr{cuDoubleComplex}, lda::Cint,
-                                        tau::CuPtr{cuDoubleComplex},
-                                        work::CuPtr{cuDoubleComplex}, lwork::Cint,
-                                        info::CuPtr{Cint})::cusolverStatus_t
+    @gcsafe_ccall libcusolver.cusolverDnZungqr(handle::cusolverDnHandle_t, m::Cint, n::Cint,
+                                               k::Cint, A::CuPtr{cuDoubleComplex},
+                                               lda::Cint, tau::CuPtr{cuDoubleComplex},
+                                               work::CuPtr{cuDoubleComplex}, lwork::Cint,
+                                               info::CuPtr{Cint})::cusolverStatus_t
 end
 
 @checked function cusolverDnSormqr_bufferSize(handle, side, trans, m, n, k, A, lda, tau, C,
                                               ldc, lwork)
     initialize_context()
-    @ccall libcusolver.cusolverDnSormqr_bufferSize(handle::cusolverDnHandle_t,
-                                                   side::cublasSideMode_t,
-                                                   trans::cublasOperation_t, m::Cint,
-                                                   n::Cint, k::Cint, A::CuPtr{Cfloat},
-                                                   lda::Cint, tau::CuPtr{Cfloat},
-                                                   C::CuPtr{Cfloat}, ldc::Cint,
-                                                   lwork::Ptr{Cint})::cusolverStatus_t
+    @gcsafe_ccall libcusolver.cusolverDnSormqr_bufferSize(handle::cusolverDnHandle_t,
+                                                          side::cublasSideMode_t,
+                                                          trans::cublasOperation_t, m::Cint,
+                                                          n::Cint, k::Cint,
+                                                          A::CuPtr{Cfloat}, lda::Cint,
+                                                          tau::CuPtr{Cfloat},
+                                                          C::CuPtr{Cfloat}, ldc::Cint,
+                                                          lwork::Ptr{Cint})::cusolverStatus_t
 end
 
 @checked function cusolverDnDormqr_bufferSize(handle, side, trans, m, n, k, A, lda, tau, C,
                                               ldc, lwork)
     initialize_context()
-    @ccall libcusolver.cusolverDnDormqr_bufferSize(handle::cusolverDnHandle_t,
-                                                   side::cublasSideMode_t,
-                                                   trans::cublasOperation_t, m::Cint,
-                                                   n::Cint, k::Cint, A::CuPtr{Cdouble},
-                                                   lda::Cint, tau::CuPtr{Cdouble},
-                                                   C::CuPtr{Cdouble}, ldc::Cint,
-                                                   lwork::Ptr{Cint})::cusolverStatus_t
+    @gcsafe_ccall libcusolver.cusolverDnDormqr_bufferSize(handle::cusolverDnHandle_t,
+                                                          side::cublasSideMode_t,
+                                                          trans::cublasOperation_t, m::Cint,
+                                                          n::Cint, k::Cint,
+                                                          A::CuPtr{Cdouble}, lda::Cint,
+                                                          tau::CuPtr{Cdouble},
+                                                          C::CuPtr{Cdouble}, ldc::Cint,
+                                                          lwork::Ptr{Cint})::cusolverStatus_t
 end
 
 @checked function cusolverDnCunmqr_bufferSize(handle, side, trans, m, n, k, A, lda, tau, C,
                                               ldc, lwork)
     initialize_context()
-    @ccall libcusolver.cusolverDnCunmqr_bufferSize(handle::cusolverDnHandle_t,
-                                                   side::cublasSideMode_t,
-                                                   trans::cublasOperation_t, m::Cint,
-                                                   n::Cint, k::Cint, A::CuPtr{cuComplex},
-                                                   lda::Cint, tau::CuPtr{cuComplex},
-                                                   C::CuPtr{cuComplex}, ldc::Cint,
-                                                   lwork::Ptr{Cint})::cusolverStatus_t
+    @gcsafe_ccall libcusolver.cusolverDnCunmqr_bufferSize(handle::cusolverDnHandle_t,
+                                                          side::cublasSideMode_t,
+                                                          trans::cublasOperation_t, m::Cint,
+                                                          n::Cint, k::Cint,
+                                                          A::CuPtr{cuComplex}, lda::Cint,
+                                                          tau::CuPtr{cuComplex},
+                                                          C::CuPtr{cuComplex}, ldc::Cint,
+                                                          lwork::Ptr{Cint})::cusolverStatus_t
 end
 
 @checked function cusolverDnZunmqr_bufferSize(handle, side, trans, m, n, k, A, lda, tau, C,
                                               ldc, lwork)
     initialize_context()
-    @ccall libcusolver.cusolverDnZunmqr_bufferSize(handle::cusolverDnHandle_t,
-                                                   side::cublasSideMode_t,
-                                                   trans::cublasOperation_t, m::Cint,
-                                                   n::Cint, k::Cint,
-                                                   A::CuPtr{cuDoubleComplex}, lda::Cint,
-                                                   tau::CuPtr{cuDoubleComplex},
-                                                   C::CuPtr{cuDoubleComplex}, ldc::Cint,
-                                                   lwork::Ptr{Cint})::cusolverStatus_t
+    @gcsafe_ccall libcusolver.cusolverDnZunmqr_bufferSize(handle::cusolverDnHandle_t,
+                                                          side::cublasSideMode_t,
+                                                          trans::cublasOperation_t, m::Cint,
+                                                          n::Cint, k::Cint,
+                                                          A::CuPtr{cuDoubleComplex},
+                                                          lda::Cint,
+                                                          tau::CuPtr{cuDoubleComplex},
+                                                          C::CuPtr{cuDoubleComplex},
+                                                          ldc::Cint,
+                                                          lwork::Ptr{Cint})::cusolverStatus_t
 end
 
 @checked function cusolverDnSormqr(handle, side, trans, m, n, k, A, lda, tau, C, ldc, work,
                                    lwork, devInfo)
     initialize_context()
-    @ccall libcusolver.cusolverDnSormqr(handle::cusolverDnHandle_t, side::cublasSideMode_t,
-                                        trans::cublasOperation_t, m::Cint, n::Cint, k::Cint,
-                                        A::CuPtr{Cfloat}, lda::Cint, tau::CuPtr{Cfloat},
-                                        C::CuPtr{Cfloat}, ldc::Cint, work::CuPtr{Cfloat},
-                                        lwork::Cint, devInfo::CuPtr{Cint})::cusolverStatus_t
+    @gcsafe_ccall libcusolver.cusolverDnSormqr(handle::cusolverDnHandle_t,
+                                               side::cublasSideMode_t,
+                                               trans::cublasOperation_t, m::Cint, n::Cint,
+                                               k::Cint, A::CuPtr{Cfloat}, lda::Cint,
+                                               tau::CuPtr{Cfloat}, C::CuPtr{Cfloat},
+                                               ldc::Cint, work::CuPtr{Cfloat}, lwork::Cint,
+                                               devInfo::CuPtr{Cint})::cusolverStatus_t
 end
 
 @checked function cusolverDnDormqr(handle, side, trans, m, n, k, A, lda, tau, C, ldc, work,
                                    lwork, devInfo)
     initialize_context()
-    @ccall libcusolver.cusolverDnDormqr(handle::cusolverDnHandle_t, side::cublasSideMode_t,
-                                        trans::cublasOperation_t, m::Cint, n::Cint, k::Cint,
-                                        A::CuPtr{Cdouble}, lda::Cint, tau::CuPtr{Cdouble},
-                                        C::CuPtr{Cdouble}, ldc::Cint, work::CuPtr{Cdouble},
-                                        lwork::Cint, devInfo::CuPtr{Cint})::cusolverStatus_t
+    @gcsafe_ccall libcusolver.cusolverDnDormqr(handle::cusolverDnHandle_t,
+                                               side::cublasSideMode_t,
+                                               trans::cublasOperation_t, m::Cint, n::Cint,
+                                               k::Cint, A::CuPtr{Cdouble}, lda::Cint,
+                                               tau::CuPtr{Cdouble}, C::CuPtr{Cdouble},
+                                               ldc::Cint, work::CuPtr{Cdouble}, lwork::Cint,
+                                               devInfo::CuPtr{Cint})::cusolverStatus_t
 end
 
 @checked function cusolverDnCunmqr(handle, side, trans, m, n, k, A, lda, tau, C, ldc, work,
                                    lwork, devInfo)
     initialize_context()
-    @ccall libcusolver.cusolverDnCunmqr(handle::cusolverDnHandle_t, side::cublasSideMode_t,
-                                        trans::cublasOperation_t, m::Cint, n::Cint, k::Cint,
-                                        A::CuPtr{cuComplex}, lda::Cint,
-                                        tau::CuPtr{cuComplex}, C::CuPtr{cuComplex},
-                                        ldc::Cint, work::CuPtr{cuComplex}, lwork::Cint,
-                                        devInfo::CuPtr{Cint})::cusolverStatus_t
+    @gcsafe_ccall libcusolver.cusolverDnCunmqr(handle::cusolverDnHandle_t,
+                                               side::cublasSideMode_t,
+                                               trans::cublasOperation_t, m::Cint, n::Cint,
+                                               k::Cint, A::CuPtr{cuComplex}, lda::Cint,
+                                               tau::CuPtr{cuComplex}, C::CuPtr{cuComplex},
+                                               ldc::Cint, work::CuPtr{cuComplex},
+                                               lwork::Cint,
+                                               devInfo::CuPtr{Cint})::cusolverStatus_t
 end
 
 @checked function cusolverDnZunmqr(handle, side, trans, m, n, k, A, lda, tau, C, ldc, work,
                                    lwork, devInfo)
     initialize_context()
-    @ccall libcusolver.cusolverDnZunmqr(handle::cusolverDnHandle_t, side::cublasSideMode_t,
-                                        trans::cublasOperation_t, m::Cint, n::Cint, k::Cint,
-                                        A::CuPtr{cuDoubleComplex}, lda::Cint,
-                                        tau::CuPtr{cuDoubleComplex},
-                                        C::CuPtr{cuDoubleComplex}, ldc::Cint,
-                                        work::CuPtr{cuDoubleComplex}, lwork::Cint,
-                                        devInfo::CuPtr{Cint})::cusolverStatus_t
+    @gcsafe_ccall libcusolver.cusolverDnZunmqr(handle::cusolverDnHandle_t,
+                                               side::cublasSideMode_t,
+                                               trans::cublasOperation_t, m::Cint, n::Cint,
+                                               k::Cint, A::CuPtr{cuDoubleComplex},
+                                               lda::Cint, tau::CuPtr{cuDoubleComplex},
+                                               C::CuPtr{cuDoubleComplex}, ldc::Cint,
+                                               work::CuPtr{cuDoubleComplex}, lwork::Cint,
+                                               devInfo::CuPtr{Cint})::cusolverStatus_t
 end
 
 @checked function cusolverDnSsytrf_bufferSize(handle, n, A, lda, lwork)
     initialize_context()
-    @ccall libcusolver.cusolverDnSsytrf_bufferSize(handle::cusolverDnHandle_t, n::Cint,
-                                                   A::CuPtr{Cfloat}, lda::Cint,
-                                                   lwork::Ptr{Cint})::cusolverStatus_t
+    @gcsafe_ccall libcusolver.cusolverDnSsytrf_bufferSize(handle::cusolverDnHandle_t,
+                                                          n::Cint, A::CuPtr{Cfloat},
+                                                          lda::Cint,
+                                                          lwork::Ptr{Cint})::cusolverStatus_t
 end
 
 @checked function cusolverDnDsytrf_bufferSize(handle, n, A, lda, lwork)
     initialize_context()
-    @ccall libcusolver.cusolverDnDsytrf_bufferSize(handle::cusolverDnHandle_t, n::Cint,
-                                                   A::CuPtr{Cdouble}, lda::Cint,
-                                                   lwork::Ptr{Cint})::cusolverStatus_t
+    @gcsafe_ccall libcusolver.cusolverDnDsytrf_bufferSize(handle::cusolverDnHandle_t,
+                                                          n::Cint, A::CuPtr{Cdouble},
+                                                          lda::Cint,
+                                                          lwork::Ptr{Cint})::cusolverStatus_t
 end
 
 @checked function cusolverDnCsytrf_bufferSize(handle, n, A, lda, lwork)
     initialize_context()
-    @ccall libcusolver.cusolverDnCsytrf_bufferSize(handle::cusolverDnHandle_t, n::Cint,
-                                                   A::CuPtr{cuComplex}, lda::Cint,
-                                                   lwork::Ptr{Cint})::cusolverStatus_t
+    @gcsafe_ccall libcusolver.cusolverDnCsytrf_bufferSize(handle::cusolverDnHandle_t,
+                                                          n::Cint, A::CuPtr{cuComplex},
+                                                          lda::Cint,
+                                                          lwork::Ptr{Cint})::cusolverStatus_t
 end
 
 @checked function cusolverDnZsytrf_bufferSize(handle, n, A, lda, lwork)
     initialize_context()
-    @ccall libcusolver.cusolverDnZsytrf_bufferSize(handle::cusolverDnHandle_t, n::Cint,
-                                                   A::CuPtr{cuDoubleComplex}, lda::Cint,
-                                                   lwork::Ptr{Cint})::cusolverStatus_t
+    @gcsafe_ccall libcusolver.cusolverDnZsytrf_bufferSize(handle::cusolverDnHandle_t,
+                                                          n::Cint,
+                                                          A::CuPtr{cuDoubleComplex},
+                                                          lda::Cint,
+                                                          lwork::Ptr{Cint})::cusolverStatus_t
 end
 
 @checked function cusolverDnSsytrf(handle, uplo, n, A, lda, ipiv, work, lwork, info)
     initialize_context()
-    @ccall libcusolver.cusolverDnSsytrf(handle::cusolverDnHandle_t, uplo::cublasFillMode_t,
-                                        n::Cint, A::CuPtr{Cfloat}, lda::Cint,
-                                        ipiv::CuPtr{Cint}, work::CuPtr{Cfloat}, lwork::Cint,
-                                        info::CuPtr{Cint})::cusolverStatus_t
+    @gcsafe_ccall libcusolver.cusolverDnSsytrf(handle::cusolverDnHandle_t,
+                                               uplo::cublasFillMode_t, n::Cint,
+                                               A::CuPtr{Cfloat}, lda::Cint,
+                                               ipiv::CuPtr{Cint}, work::CuPtr{Cfloat},
+                                               lwork::Cint,
+                                               info::CuPtr{Cint})::cusolverStatus_t
 end
 
 @checked function cusolverDnDsytrf(handle, uplo, n, A, lda, ipiv, work, lwork, info)
     initialize_context()
-    @ccall libcusolver.cusolverDnDsytrf(handle::cusolverDnHandle_t, uplo::cublasFillMode_t,
-                                        n::Cint, A::CuPtr{Cdouble}, lda::Cint,
-                                        ipiv::CuPtr{Cint}, work::CuPtr{Cdouble},
-                                        lwork::Cint, info::CuPtr{Cint})::cusolverStatus_t
+    @gcsafe_ccall libcusolver.cusolverDnDsytrf(handle::cusolverDnHandle_t,
+                                               uplo::cublasFillMode_t, n::Cint,
+                                               A::CuPtr{Cdouble}, lda::Cint,
+                                               ipiv::CuPtr{Cint}, work::CuPtr{Cdouble},
+                                               lwork::Cint,
+                                               info::CuPtr{Cint})::cusolverStatus_t
 end
 
 @checked function cusolverDnCsytrf(handle, uplo, n, A, lda, ipiv, work, lwork, info)
     initialize_context()
-    @ccall libcusolver.cusolverDnCsytrf(handle::cusolverDnHandle_t, uplo::cublasFillMode_t,
-                                        n::Cint, A::CuPtr{cuComplex}, lda::Cint,
-                                        ipiv::CuPtr{Cint}, work::CuPtr{cuComplex},
-                                        lwork::Cint, info::CuPtr{Cint})::cusolverStatus_t
+    @gcsafe_ccall libcusolver.cusolverDnCsytrf(handle::cusolverDnHandle_t,
+                                               uplo::cublasFillMode_t, n::Cint,
+                                               A::CuPtr{cuComplex}, lda::Cint,
+                                               ipiv::CuPtr{Cint}, work::CuPtr{cuComplex},
+                                               lwork::Cint,
+                                               info::CuPtr{Cint})::cusolverStatus_t
 end
 
 @checked function cusolverDnZsytrf(handle, uplo, n, A, lda, ipiv, work, lwork, info)
     initialize_context()
-    @ccall libcusolver.cusolverDnZsytrf(handle::cusolverDnHandle_t, uplo::cublasFillMode_t,
-                                        n::Cint, A::CuPtr{cuDoubleComplex}, lda::Cint,
-                                        ipiv::CuPtr{Cint}, work::CuPtr{cuDoubleComplex},
-                                        lwork::Cint, info::CuPtr{Cint})::cusolverStatus_t
+    @gcsafe_ccall libcusolver.cusolverDnZsytrf(handle::cusolverDnHandle_t,
+                                               uplo::cublasFillMode_t, n::Cint,
+                                               A::CuPtr{cuDoubleComplex}, lda::Cint,
+                                               ipiv::CuPtr{Cint},
+                                               work::CuPtr{cuDoubleComplex}, lwork::Cint,
+                                               info::CuPtr{Cint})::cusolverStatus_t
 end
 
 @checked function cusolverDnXsytrs_bufferSize(handle, uplo, n, nrhs, dataTypeA, A, lda,
@@ -2110,15 +2383,16 @@ end
                                               workspaceInBytesOnDevice,
                                               workspaceInBytesOnHost)
     initialize_context()
-    @ccall libcusolver.cusolverDnXsytrs_bufferSize(handle::cusolverDnHandle_t,
-                                                   uplo::cublasFillMode_t, n::Int64,
-                                                   nrhs::Int64, dataTypeA::cudaDataType,
-                                                   A::CuPtr{Cvoid}, lda::Int64,
-                                                   ipiv::CuPtr{Int64},
-                                                   dataTypeB::cudaDataType, B::CuPtr{Cvoid},
-                                                   ldb::Int64,
-                                                   workspaceInBytesOnDevice::Ptr{Csize_t},
-                                                   workspaceInBytesOnHost::Ptr{Csize_t})::cusolverStatus_t
+    @gcsafe_ccall libcusolver.cusolverDnXsytrs_bufferSize(handle::cusolverDnHandle_t,
+                                                          uplo::cublasFillMode_t, n::Int64,
+                                                          nrhs::Int64,
+                                                          dataTypeA::cudaDataType,
+                                                          A::CuPtr{Cvoid}, lda::Int64,
+                                                          ipiv::CuPtr{Int64},
+                                                          dataTypeB::cudaDataType,
+                                                          B::CuPtr{Cvoid}, ldb::Int64,
+                                                          workspaceInBytesOnDevice::Ptr{Csize_t},
+                                                          workspaceInBytesOnHost::Ptr{Csize_t})::cusolverStatus_t
 end
 
 @checked function cusolverDnXsytrs(handle, uplo, n, nrhs, dataTypeA, A, lda, ipiv,
@@ -2126,1522 +2400,1694 @@ end
                                    workspaceInBytesOnDevice, bufferOnHost,
                                    workspaceInBytesOnHost, info)
     initialize_context()
-    @ccall libcusolver.cusolverDnXsytrs(handle::cusolverDnHandle_t, uplo::cublasFillMode_t,
-                                        n::Int64, nrhs::Int64, dataTypeA::cudaDataType,
-                                        A::CuPtr{Cvoid}, lda::Int64, ipiv::CuPtr{Int64},
-                                        dataTypeB::cudaDataType, B::CuPtr{Cvoid},
-                                        ldb::Int64, bufferOnDevice::CuPtr{Cvoid},
-                                        workspaceInBytesOnDevice::Csize_t,
-                                        bufferOnHost::Ptr{Cvoid},
-                                        workspaceInBytesOnHost::Csize_t,
-                                        info::CuPtr{Cint})::cusolverStatus_t
+    @gcsafe_ccall libcusolver.cusolverDnXsytrs(handle::cusolverDnHandle_t,
+                                               uplo::cublasFillMode_t, n::Int64,
+                                               nrhs::Int64, dataTypeA::cudaDataType,
+                                               A::CuPtr{Cvoid}, lda::Int64,
+                                               ipiv::CuPtr{Int64}, dataTypeB::cudaDataType,
+                                               B::CuPtr{Cvoid}, ldb::Int64,
+                                               bufferOnDevice::CuPtr{Cvoid},
+                                               workspaceInBytesOnDevice::Csize_t,
+                                               bufferOnHost::Ptr{Cvoid},
+                                               workspaceInBytesOnHost::Csize_t,
+                                               info::CuPtr{Cint})::cusolverStatus_t
 end
 
 @checked function cusolverDnSsytri_bufferSize(handle, uplo, n, A, lda, ipiv, lwork)
     initialize_context()
-    @ccall libcusolver.cusolverDnSsytri_bufferSize(handle::cusolverDnHandle_t,
-                                                   uplo::cublasFillMode_t, n::Cint,
-                                                   A::CuPtr{Cfloat}, lda::Cint,
-                                                   ipiv::CuPtr{Cint},
-                                                   lwork::Ptr{Cint})::cusolverStatus_t
+    @gcsafe_ccall libcusolver.cusolverDnSsytri_bufferSize(handle::cusolverDnHandle_t,
+                                                          uplo::cublasFillMode_t, n::Cint,
+                                                          A::CuPtr{Cfloat}, lda::Cint,
+                                                          ipiv::CuPtr{Cint},
+                                                          lwork::Ptr{Cint})::cusolverStatus_t
 end
 
 @checked function cusolverDnDsytri_bufferSize(handle, uplo, n, A, lda, ipiv, lwork)
     initialize_context()
-    @ccall libcusolver.cusolverDnDsytri_bufferSize(handle::cusolverDnHandle_t,
-                                                   uplo::cublasFillMode_t, n::Cint,
-                                                   A::CuPtr{Cdouble}, lda::Cint,
-                                                   ipiv::CuPtr{Cint},
-                                                   lwork::Ptr{Cint})::cusolverStatus_t
+    @gcsafe_ccall libcusolver.cusolverDnDsytri_bufferSize(handle::cusolverDnHandle_t,
+                                                          uplo::cublasFillMode_t, n::Cint,
+                                                          A::CuPtr{Cdouble}, lda::Cint,
+                                                          ipiv::CuPtr{Cint},
+                                                          lwork::Ptr{Cint})::cusolverStatus_t
 end
 
 @checked function cusolverDnCsytri_bufferSize(handle, uplo, n, A, lda, ipiv, lwork)
     initialize_context()
-    @ccall libcusolver.cusolverDnCsytri_bufferSize(handle::cusolverDnHandle_t,
-                                                   uplo::cublasFillMode_t, n::Cint,
-                                                   A::CuPtr{cuComplex}, lda::Cint,
-                                                   ipiv::CuPtr{Cint},
-                                                   lwork::Ptr{Cint})::cusolverStatus_t
+    @gcsafe_ccall libcusolver.cusolverDnCsytri_bufferSize(handle::cusolverDnHandle_t,
+                                                          uplo::cublasFillMode_t, n::Cint,
+                                                          A::CuPtr{cuComplex}, lda::Cint,
+                                                          ipiv::CuPtr{Cint},
+                                                          lwork::Ptr{Cint})::cusolverStatus_t
 end
 
 @checked function cusolverDnZsytri_bufferSize(handle, uplo, n, A, lda, ipiv, lwork)
     initialize_context()
-    @ccall libcusolver.cusolverDnZsytri_bufferSize(handle::cusolverDnHandle_t,
-                                                   uplo::cublasFillMode_t, n::Cint,
-                                                   A::CuPtr{cuDoubleComplex}, lda::Cint,
-                                                   ipiv::CuPtr{Cint},
-                                                   lwork::Ptr{Cint})::cusolverStatus_t
+    @gcsafe_ccall libcusolver.cusolverDnZsytri_bufferSize(handle::cusolverDnHandle_t,
+                                                          uplo::cublasFillMode_t, n::Cint,
+                                                          A::CuPtr{cuDoubleComplex},
+                                                          lda::Cint, ipiv::CuPtr{Cint},
+                                                          lwork::Ptr{Cint})::cusolverStatus_t
 end
 
 @checked function cusolverDnSsytri(handle, uplo, n, A, lda, ipiv, work, lwork, info)
     initialize_context()
-    @ccall libcusolver.cusolverDnSsytri(handle::cusolverDnHandle_t, uplo::cublasFillMode_t,
-                                        n::Cint, A::CuPtr{Cfloat}, lda::Cint,
-                                        ipiv::CuPtr{Cint}, work::CuPtr{Cfloat}, lwork::Cint,
-                                        info::CuPtr{Cint})::cusolverStatus_t
+    @gcsafe_ccall libcusolver.cusolverDnSsytri(handle::cusolverDnHandle_t,
+                                               uplo::cublasFillMode_t, n::Cint,
+                                               A::CuPtr{Cfloat}, lda::Cint,
+                                               ipiv::CuPtr{Cint}, work::CuPtr{Cfloat},
+                                               lwork::Cint,
+                                               info::CuPtr{Cint})::cusolverStatus_t
 end
 
 @checked function cusolverDnDsytri(handle, uplo, n, A, lda, ipiv, work, lwork, info)
     initialize_context()
-    @ccall libcusolver.cusolverDnDsytri(handle::cusolverDnHandle_t, uplo::cublasFillMode_t,
-                                        n::Cint, A::CuPtr{Cdouble}, lda::Cint,
-                                        ipiv::CuPtr{Cint}, work::CuPtr{Cdouble},
-                                        lwork::Cint, info::CuPtr{Cint})::cusolverStatus_t
+    @gcsafe_ccall libcusolver.cusolverDnDsytri(handle::cusolverDnHandle_t,
+                                               uplo::cublasFillMode_t, n::Cint,
+                                               A::CuPtr{Cdouble}, lda::Cint,
+                                               ipiv::CuPtr{Cint}, work::CuPtr{Cdouble},
+                                               lwork::Cint,
+                                               info::CuPtr{Cint})::cusolverStatus_t
 end
 
 @checked function cusolverDnCsytri(handle, uplo, n, A, lda, ipiv, work, lwork, info)
     initialize_context()
-    @ccall libcusolver.cusolverDnCsytri(handle::cusolverDnHandle_t, uplo::cublasFillMode_t,
-                                        n::Cint, A::CuPtr{cuComplex}, lda::Cint,
-                                        ipiv::CuPtr{Cint}, work::CuPtr{cuComplex},
-                                        lwork::Cint, info::CuPtr{Cint})::cusolverStatus_t
+    @gcsafe_ccall libcusolver.cusolverDnCsytri(handle::cusolverDnHandle_t,
+                                               uplo::cublasFillMode_t, n::Cint,
+                                               A::CuPtr{cuComplex}, lda::Cint,
+                                               ipiv::CuPtr{Cint}, work::CuPtr{cuComplex},
+                                               lwork::Cint,
+                                               info::CuPtr{Cint})::cusolverStatus_t
 end
 
 @checked function cusolverDnZsytri(handle, uplo, n, A, lda, ipiv, work, lwork, info)
     initialize_context()
-    @ccall libcusolver.cusolverDnZsytri(handle::cusolverDnHandle_t, uplo::cublasFillMode_t,
-                                        n::Cint, A::CuPtr{cuDoubleComplex}, lda::Cint,
-                                        ipiv::CuPtr{Cint}, work::CuPtr{cuDoubleComplex},
-                                        lwork::Cint, info::CuPtr{Cint})::cusolverStatus_t
+    @gcsafe_ccall libcusolver.cusolverDnZsytri(handle::cusolverDnHandle_t,
+                                               uplo::cublasFillMode_t, n::Cint,
+                                               A::CuPtr{cuDoubleComplex}, lda::Cint,
+                                               ipiv::CuPtr{Cint},
+                                               work::CuPtr{cuDoubleComplex}, lwork::Cint,
+                                               info::CuPtr{Cint})::cusolverStatus_t
 end
 
 @checked function cusolverDnSgebrd_bufferSize(handle, m, n, Lwork)
     initialize_context()
-    @ccall libcusolver.cusolverDnSgebrd_bufferSize(handle::cusolverDnHandle_t, m::Cint,
-                                                   n::Cint,
-                                                   Lwork::Ptr{Cint})::cusolverStatus_t
+    @gcsafe_ccall libcusolver.cusolverDnSgebrd_bufferSize(handle::cusolverDnHandle_t,
+                                                          m::Cint, n::Cint,
+                                                          Lwork::Ptr{Cint})::cusolverStatus_t
 end
 
 @checked function cusolverDnDgebrd_bufferSize(handle, m, n, Lwork)
     initialize_context()
-    @ccall libcusolver.cusolverDnDgebrd_bufferSize(handle::cusolverDnHandle_t, m::Cint,
-                                                   n::Cint,
-                                                   Lwork::Ptr{Cint})::cusolverStatus_t
+    @gcsafe_ccall libcusolver.cusolverDnDgebrd_bufferSize(handle::cusolverDnHandle_t,
+                                                          m::Cint, n::Cint,
+                                                          Lwork::Ptr{Cint})::cusolverStatus_t
 end
 
 @checked function cusolverDnCgebrd_bufferSize(handle, m, n, Lwork)
     initialize_context()
-    @ccall libcusolver.cusolverDnCgebrd_bufferSize(handle::cusolverDnHandle_t, m::Cint,
-                                                   n::Cint,
-                                                   Lwork::Ptr{Cint})::cusolverStatus_t
+    @gcsafe_ccall libcusolver.cusolverDnCgebrd_bufferSize(handle::cusolverDnHandle_t,
+                                                          m::Cint, n::Cint,
+                                                          Lwork::Ptr{Cint})::cusolverStatus_t
 end
 
 @checked function cusolverDnZgebrd_bufferSize(handle, m, n, Lwork)
     initialize_context()
-    @ccall libcusolver.cusolverDnZgebrd_bufferSize(handle::cusolverDnHandle_t, m::Cint,
-                                                   n::Cint,
-                                                   Lwork::Ptr{Cint})::cusolverStatus_t
+    @gcsafe_ccall libcusolver.cusolverDnZgebrd_bufferSize(handle::cusolverDnHandle_t,
+                                                          m::Cint, n::Cint,
+                                                          Lwork::Ptr{Cint})::cusolverStatus_t
 end
 
 @checked function cusolverDnSgebrd(handle, m, n, A, lda, D, E, TAUQ, TAUP, Work, Lwork,
                                    devInfo)
     initialize_context()
-    @ccall libcusolver.cusolverDnSgebrd(handle::cusolverDnHandle_t, m::Cint, n::Cint,
-                                        A::CuPtr{Cfloat}, lda::Cint, D::CuPtr{Cfloat},
-                                        E::CuPtr{Cfloat}, TAUQ::CuPtr{Cfloat},
-                                        TAUP::CuPtr{Cfloat}, Work::CuPtr{Cfloat},
-                                        Lwork::Cint, devInfo::CuPtr{Cint})::cusolverStatus_t
+    @gcsafe_ccall libcusolver.cusolverDnSgebrd(handle::cusolverDnHandle_t, m::Cint, n::Cint,
+                                               A::CuPtr{Cfloat}, lda::Cint,
+                                               D::CuPtr{Cfloat}, E::CuPtr{Cfloat},
+                                               TAUQ::CuPtr{Cfloat}, TAUP::CuPtr{Cfloat},
+                                               Work::CuPtr{Cfloat}, Lwork::Cint,
+                                               devInfo::CuPtr{Cint})::cusolverStatus_t
 end
 
 @checked function cusolverDnDgebrd(handle, m, n, A, lda, D, E, TAUQ, TAUP, Work, Lwork,
                                    devInfo)
     initialize_context()
-    @ccall libcusolver.cusolverDnDgebrd(handle::cusolverDnHandle_t, m::Cint, n::Cint,
-                                        A::CuPtr{Cdouble}, lda::Cint, D::CuPtr{Cdouble},
-                                        E::CuPtr{Cdouble}, TAUQ::CuPtr{Cdouble},
-                                        TAUP::CuPtr{Cdouble}, Work::CuPtr{Cdouble},
-                                        Lwork::Cint, devInfo::CuPtr{Cint})::cusolverStatus_t
+    @gcsafe_ccall libcusolver.cusolverDnDgebrd(handle::cusolverDnHandle_t, m::Cint, n::Cint,
+                                               A::CuPtr{Cdouble}, lda::Cint,
+                                               D::CuPtr{Cdouble}, E::CuPtr{Cdouble},
+                                               TAUQ::CuPtr{Cdouble}, TAUP::CuPtr{Cdouble},
+                                               Work::CuPtr{Cdouble}, Lwork::Cint,
+                                               devInfo::CuPtr{Cint})::cusolverStatus_t
 end
 
 @checked function cusolverDnCgebrd(handle, m, n, A, lda, D, E, TAUQ, TAUP, Work, Lwork,
                                    devInfo)
     initialize_context()
-    @ccall libcusolver.cusolverDnCgebrd(handle::cusolverDnHandle_t, m::Cint, n::Cint,
-                                        A::CuPtr{cuComplex}, lda::Cint, D::CuPtr{Cfloat},
-                                        E::CuPtr{Cfloat}, TAUQ::CuPtr{cuComplex},
-                                        TAUP::CuPtr{cuComplex}, Work::CuPtr{cuComplex},
-                                        Lwork::Cint, devInfo::CuPtr{Cint})::cusolverStatus_t
+    @gcsafe_ccall libcusolver.cusolverDnCgebrd(handle::cusolverDnHandle_t, m::Cint, n::Cint,
+                                               A::CuPtr{cuComplex}, lda::Cint,
+                                               D::CuPtr{Cfloat}, E::CuPtr{Cfloat},
+                                               TAUQ::CuPtr{cuComplex},
+                                               TAUP::CuPtr{cuComplex},
+                                               Work::CuPtr{cuComplex}, Lwork::Cint,
+                                               devInfo::CuPtr{Cint})::cusolverStatus_t
 end
 
 @checked function cusolverDnZgebrd(handle, m, n, A, lda, D, E, TAUQ, TAUP, Work, Lwork,
                                    devInfo)
     initialize_context()
-    @ccall libcusolver.cusolverDnZgebrd(handle::cusolverDnHandle_t, m::Cint, n::Cint,
-                                        A::CuPtr{cuDoubleComplex}, lda::Cint,
-                                        D::CuPtr{Cdouble}, E::CuPtr{Cdouble},
-                                        TAUQ::CuPtr{cuDoubleComplex},
-                                        TAUP::CuPtr{cuDoubleComplex},
-                                        Work::CuPtr{cuDoubleComplex}, Lwork::Cint,
-                                        devInfo::CuPtr{Cint})::cusolverStatus_t
+    @gcsafe_ccall libcusolver.cusolverDnZgebrd(handle::cusolverDnHandle_t, m::Cint, n::Cint,
+                                               A::CuPtr{cuDoubleComplex}, lda::Cint,
+                                               D::CuPtr{Cdouble}, E::CuPtr{Cdouble},
+                                               TAUQ::CuPtr{cuDoubleComplex},
+                                               TAUP::CuPtr{cuDoubleComplex},
+                                               Work::CuPtr{cuDoubleComplex}, Lwork::Cint,
+                                               devInfo::CuPtr{Cint})::cusolverStatus_t
 end
 
 @checked function cusolverDnSorgbr_bufferSize(handle, side, m, n, k, A, lda, tau, lwork)
     initialize_context()
-    @ccall libcusolver.cusolverDnSorgbr_bufferSize(handle::cusolverDnHandle_t,
-                                                   side::cublasSideMode_t, m::Cint, n::Cint,
-                                                   k::Cint, A::CuPtr{Cfloat}, lda::Cint,
-                                                   tau::CuPtr{Cfloat},
-                                                   lwork::Ptr{Cint})::cusolverStatus_t
+    @gcsafe_ccall libcusolver.cusolverDnSorgbr_bufferSize(handle::cusolverDnHandle_t,
+                                                          side::cublasSideMode_t, m::Cint,
+                                                          n::Cint, k::Cint,
+                                                          A::CuPtr{Cfloat}, lda::Cint,
+                                                          tau::CuPtr{Cfloat},
+                                                          lwork::Ptr{Cint})::cusolverStatus_t
 end
 
 @checked function cusolverDnDorgbr_bufferSize(handle, side, m, n, k, A, lda, tau, lwork)
     initialize_context()
-    @ccall libcusolver.cusolverDnDorgbr_bufferSize(handle::cusolverDnHandle_t,
-                                                   side::cublasSideMode_t, m::Cint, n::Cint,
-                                                   k::Cint, A::CuPtr{Cdouble}, lda::Cint,
-                                                   tau::CuPtr{Cdouble},
-                                                   lwork::Ptr{Cint})::cusolverStatus_t
+    @gcsafe_ccall libcusolver.cusolverDnDorgbr_bufferSize(handle::cusolverDnHandle_t,
+                                                          side::cublasSideMode_t, m::Cint,
+                                                          n::Cint, k::Cint,
+                                                          A::CuPtr{Cdouble}, lda::Cint,
+                                                          tau::CuPtr{Cdouble},
+                                                          lwork::Ptr{Cint})::cusolverStatus_t
 end
 
 @checked function cusolverDnCungbr_bufferSize(handle, side, m, n, k, A, lda, tau, lwork)
     initialize_context()
-    @ccall libcusolver.cusolverDnCungbr_bufferSize(handle::cusolverDnHandle_t,
-                                                   side::cublasSideMode_t, m::Cint, n::Cint,
-                                                   k::Cint, A::CuPtr{cuComplex}, lda::Cint,
-                                                   tau::CuPtr{cuComplex},
-                                                   lwork::Ptr{Cint})::cusolverStatus_t
+    @gcsafe_ccall libcusolver.cusolverDnCungbr_bufferSize(handle::cusolverDnHandle_t,
+                                                          side::cublasSideMode_t, m::Cint,
+                                                          n::Cint, k::Cint,
+                                                          A::CuPtr{cuComplex}, lda::Cint,
+                                                          tau::CuPtr{cuComplex},
+                                                          lwork::Ptr{Cint})::cusolverStatus_t
 end
 
 @checked function cusolverDnZungbr_bufferSize(handle, side, m, n, k, A, lda, tau, lwork)
     initialize_context()
-    @ccall libcusolver.cusolverDnZungbr_bufferSize(handle::cusolverDnHandle_t,
-                                                   side::cublasSideMode_t, m::Cint, n::Cint,
-                                                   k::Cint, A::CuPtr{cuDoubleComplex},
-                                                   lda::Cint, tau::CuPtr{cuDoubleComplex},
-                                                   lwork::Ptr{Cint})::cusolverStatus_t
+    @gcsafe_ccall libcusolver.cusolverDnZungbr_bufferSize(handle::cusolverDnHandle_t,
+                                                          side::cublasSideMode_t, m::Cint,
+                                                          n::Cint, k::Cint,
+                                                          A::CuPtr{cuDoubleComplex},
+                                                          lda::Cint,
+                                                          tau::CuPtr{cuDoubleComplex},
+                                                          lwork::Ptr{Cint})::cusolverStatus_t
 end
 
 @checked function cusolverDnSorgbr(handle, side, m, n, k, A, lda, tau, work, lwork, info)
     initialize_context()
-    @ccall libcusolver.cusolverDnSorgbr(handle::cusolverDnHandle_t, side::cublasSideMode_t,
-                                        m::Cint, n::Cint, k::Cint, A::CuPtr{Cfloat},
-                                        lda::Cint, tau::CuPtr{Cfloat}, work::CuPtr{Cfloat},
-                                        lwork::Cint, info::CuPtr{Cint})::cusolverStatus_t
+    @gcsafe_ccall libcusolver.cusolverDnSorgbr(handle::cusolverDnHandle_t,
+                                               side::cublasSideMode_t, m::Cint, n::Cint,
+                                               k::Cint, A::CuPtr{Cfloat}, lda::Cint,
+                                               tau::CuPtr{Cfloat}, work::CuPtr{Cfloat},
+                                               lwork::Cint,
+                                               info::CuPtr{Cint})::cusolverStatus_t
 end
 
 @checked function cusolverDnDorgbr(handle, side, m, n, k, A, lda, tau, work, lwork, info)
     initialize_context()
-    @ccall libcusolver.cusolverDnDorgbr(handle::cusolverDnHandle_t, side::cublasSideMode_t,
-                                        m::Cint, n::Cint, k::Cint, A::CuPtr{Cdouble},
-                                        lda::Cint, tau::CuPtr{Cdouble},
-                                        work::CuPtr{Cdouble}, lwork::Cint,
-                                        info::CuPtr{Cint})::cusolverStatus_t
+    @gcsafe_ccall libcusolver.cusolverDnDorgbr(handle::cusolverDnHandle_t,
+                                               side::cublasSideMode_t, m::Cint, n::Cint,
+                                               k::Cint, A::CuPtr{Cdouble}, lda::Cint,
+                                               tau::CuPtr{Cdouble}, work::CuPtr{Cdouble},
+                                               lwork::Cint,
+                                               info::CuPtr{Cint})::cusolverStatus_t
 end
 
 @checked function cusolverDnCungbr(handle, side, m, n, k, A, lda, tau, work, lwork, info)
     initialize_context()
-    @ccall libcusolver.cusolverDnCungbr(handle::cusolverDnHandle_t, side::cublasSideMode_t,
-                                        m::Cint, n::Cint, k::Cint, A::CuPtr{cuComplex},
-                                        lda::Cint, tau::CuPtr{cuComplex},
-                                        work::CuPtr{cuComplex}, lwork::Cint,
-                                        info::CuPtr{Cint})::cusolverStatus_t
+    @gcsafe_ccall libcusolver.cusolverDnCungbr(handle::cusolverDnHandle_t,
+                                               side::cublasSideMode_t, m::Cint, n::Cint,
+                                               k::Cint, A::CuPtr{cuComplex}, lda::Cint,
+                                               tau::CuPtr{cuComplex},
+                                               work::CuPtr{cuComplex}, lwork::Cint,
+                                               info::CuPtr{Cint})::cusolverStatus_t
 end
 
 @checked function cusolverDnZungbr(handle, side, m, n, k, A, lda, tau, work, lwork, info)
     initialize_context()
-    @ccall libcusolver.cusolverDnZungbr(handle::cusolverDnHandle_t, side::cublasSideMode_t,
-                                        m::Cint, n::Cint, k::Cint,
-                                        A::CuPtr{cuDoubleComplex}, lda::Cint,
-                                        tau::CuPtr{cuDoubleComplex},
-                                        work::CuPtr{cuDoubleComplex}, lwork::Cint,
-                                        info::CuPtr{Cint})::cusolverStatus_t
+    @gcsafe_ccall libcusolver.cusolverDnZungbr(handle::cusolverDnHandle_t,
+                                               side::cublasSideMode_t, m::Cint, n::Cint,
+                                               k::Cint, A::CuPtr{cuDoubleComplex},
+                                               lda::Cint, tau::CuPtr{cuDoubleComplex},
+                                               work::CuPtr{cuDoubleComplex}, lwork::Cint,
+                                               info::CuPtr{Cint})::cusolverStatus_t
 end
 
 @checked function cusolverDnSsytrd_bufferSize(handle, uplo, n, A, lda, d, e, tau, lwork)
     initialize_context()
-    @ccall libcusolver.cusolverDnSsytrd_bufferSize(handle::cusolverDnHandle_t,
-                                                   uplo::cublasFillMode_t, n::Cint,
-                                                   A::CuPtr{Cfloat}, lda::Cint,
-                                                   d::CuPtr{Cfloat}, e::CuPtr{Cfloat},
-                                                   tau::CuPtr{Cfloat},
-                                                   lwork::Ptr{Cint})::cusolverStatus_t
+    @gcsafe_ccall libcusolver.cusolverDnSsytrd_bufferSize(handle::cusolverDnHandle_t,
+                                                          uplo::cublasFillMode_t, n::Cint,
+                                                          A::CuPtr{Cfloat}, lda::Cint,
+                                                          d::CuPtr{Cfloat},
+                                                          e::CuPtr{Cfloat},
+                                                          tau::CuPtr{Cfloat},
+                                                          lwork::Ptr{Cint})::cusolverStatus_t
 end
 
 @checked function cusolverDnDsytrd_bufferSize(handle, uplo, n, A, lda, d, e, tau, lwork)
     initialize_context()
-    @ccall libcusolver.cusolverDnDsytrd_bufferSize(handle::cusolverDnHandle_t,
-                                                   uplo::cublasFillMode_t, n::Cint,
-                                                   A::CuPtr{Cdouble}, lda::Cint,
-                                                   d::CuPtr{Cdouble}, e::CuPtr{Cdouble},
-                                                   tau::CuPtr{Cdouble},
-                                                   lwork::Ptr{Cint})::cusolverStatus_t
+    @gcsafe_ccall libcusolver.cusolverDnDsytrd_bufferSize(handle::cusolverDnHandle_t,
+                                                          uplo::cublasFillMode_t, n::Cint,
+                                                          A::CuPtr{Cdouble}, lda::Cint,
+                                                          d::CuPtr{Cdouble},
+                                                          e::CuPtr{Cdouble},
+                                                          tau::CuPtr{Cdouble},
+                                                          lwork::Ptr{Cint})::cusolverStatus_t
 end
 
 @checked function cusolverDnChetrd_bufferSize(handle, uplo, n, A, lda, d, e, tau, lwork)
     initialize_context()
-    @ccall libcusolver.cusolverDnChetrd_bufferSize(handle::cusolverDnHandle_t,
-                                                   uplo::cublasFillMode_t, n::Cint,
-                                                   A::CuPtr{cuComplex}, lda::Cint,
-                                                   d::CuPtr{Cfloat}, e::CuPtr{Cfloat},
-                                                   tau::CuPtr{cuComplex},
-                                                   lwork::Ptr{Cint})::cusolverStatus_t
+    @gcsafe_ccall libcusolver.cusolverDnChetrd_bufferSize(handle::cusolverDnHandle_t,
+                                                          uplo::cublasFillMode_t, n::Cint,
+                                                          A::CuPtr{cuComplex}, lda::Cint,
+                                                          d::CuPtr{Cfloat},
+                                                          e::CuPtr{Cfloat},
+                                                          tau::CuPtr{cuComplex},
+                                                          lwork::Ptr{Cint})::cusolverStatus_t
 end
 
 @checked function cusolverDnZhetrd_bufferSize(handle, uplo, n, A, lda, d, e, tau, lwork)
     initialize_context()
-    @ccall libcusolver.cusolverDnZhetrd_bufferSize(handle::cusolverDnHandle_t,
-                                                   uplo::cublasFillMode_t, n::Cint,
-                                                   A::CuPtr{cuDoubleComplex}, lda::Cint,
-                                                   d::CuPtr{Cdouble}, e::CuPtr{Cdouble},
-                                                   tau::CuPtr{cuDoubleComplex},
-                                                   lwork::Ptr{Cint})::cusolverStatus_t
+    @gcsafe_ccall libcusolver.cusolverDnZhetrd_bufferSize(handle::cusolverDnHandle_t,
+                                                          uplo::cublasFillMode_t, n::Cint,
+                                                          A::CuPtr{cuDoubleComplex},
+                                                          lda::Cint, d::CuPtr{Cdouble},
+                                                          e::CuPtr{Cdouble},
+                                                          tau::CuPtr{cuDoubleComplex},
+                                                          lwork::Ptr{Cint})::cusolverStatus_t
 end
 
 @checked function cusolverDnSsytrd(handle, uplo, n, A, lda, d, e, tau, work, lwork, info)
     initialize_context()
-    @ccall libcusolver.cusolverDnSsytrd(handle::cusolverDnHandle_t, uplo::cublasFillMode_t,
-                                        n::Cint, A::CuPtr{Cfloat}, lda::Cint,
-                                        d::CuPtr{Cfloat}, e::CuPtr{Cfloat},
-                                        tau::CuPtr{Cfloat}, work::CuPtr{Cfloat},
-                                        lwork::Cint, info::CuPtr{Cint})::cusolverStatus_t
+    @gcsafe_ccall libcusolver.cusolverDnSsytrd(handle::cusolverDnHandle_t,
+                                               uplo::cublasFillMode_t, n::Cint,
+                                               A::CuPtr{Cfloat}, lda::Cint,
+                                               d::CuPtr{Cfloat}, e::CuPtr{Cfloat},
+                                               tau::CuPtr{Cfloat}, work::CuPtr{Cfloat},
+                                               lwork::Cint,
+                                               info::CuPtr{Cint})::cusolverStatus_t
 end
 
 @checked function cusolverDnDsytrd(handle, uplo, n, A, lda, d, e, tau, work, lwork, info)
     initialize_context()
-    @ccall libcusolver.cusolverDnDsytrd(handle::cusolverDnHandle_t, uplo::cublasFillMode_t,
-                                        n::Cint, A::CuPtr{Cdouble}, lda::Cint,
-                                        d::CuPtr{Cdouble}, e::CuPtr{Cdouble},
-                                        tau::CuPtr{Cdouble}, work::CuPtr{Cdouble},
-                                        lwork::Cint, info::CuPtr{Cint})::cusolverStatus_t
+    @gcsafe_ccall libcusolver.cusolverDnDsytrd(handle::cusolverDnHandle_t,
+                                               uplo::cublasFillMode_t, n::Cint,
+                                               A::CuPtr{Cdouble}, lda::Cint,
+                                               d::CuPtr{Cdouble}, e::CuPtr{Cdouble},
+                                               tau::CuPtr{Cdouble}, work::CuPtr{Cdouble},
+                                               lwork::Cint,
+                                               info::CuPtr{Cint})::cusolverStatus_t
 end
 
 @checked function cusolverDnChetrd(handle, uplo, n, A, lda, d, e, tau, work, lwork, info)
     initialize_context()
-    @ccall libcusolver.cusolverDnChetrd(handle::cusolverDnHandle_t, uplo::cublasFillMode_t,
-                                        n::Cint, A::CuPtr{cuComplex}, lda::Cint,
-                                        d::CuPtr{Cfloat}, e::CuPtr{Cfloat},
-                                        tau::CuPtr{cuComplex}, work::CuPtr{cuComplex},
-                                        lwork::Cint, info::CuPtr{Cint})::cusolverStatus_t
+    @gcsafe_ccall libcusolver.cusolverDnChetrd(handle::cusolverDnHandle_t,
+                                               uplo::cublasFillMode_t, n::Cint,
+                                               A::CuPtr{cuComplex}, lda::Cint,
+                                               d::CuPtr{Cfloat}, e::CuPtr{Cfloat},
+                                               tau::CuPtr{cuComplex},
+                                               work::CuPtr{cuComplex}, lwork::Cint,
+                                               info::CuPtr{Cint})::cusolverStatus_t
 end
 
 @checked function cusolverDnZhetrd(handle, uplo, n, A, lda, d, e, tau, work, lwork, info)
     initialize_context()
-    @ccall libcusolver.cusolverDnZhetrd(handle::cusolverDnHandle_t, uplo::cublasFillMode_t,
-                                        n::Cint, A::CuPtr{cuDoubleComplex}, lda::Cint,
-                                        d::CuPtr{Cdouble}, e::CuPtr{Cdouble},
-                                        tau::CuPtr{cuDoubleComplex},
-                                        work::CuPtr{cuDoubleComplex}, lwork::Cint,
-                                        info::CuPtr{Cint})::cusolverStatus_t
+    @gcsafe_ccall libcusolver.cusolverDnZhetrd(handle::cusolverDnHandle_t,
+                                               uplo::cublasFillMode_t, n::Cint,
+                                               A::CuPtr{cuDoubleComplex}, lda::Cint,
+                                               d::CuPtr{Cdouble}, e::CuPtr{Cdouble},
+                                               tau::CuPtr{cuDoubleComplex},
+                                               work::CuPtr{cuDoubleComplex}, lwork::Cint,
+                                               info::CuPtr{Cint})::cusolverStatus_t
 end
 
 @checked function cusolverDnSorgtr_bufferSize(handle, uplo, n, A, lda, tau, lwork)
     initialize_context()
-    @ccall libcusolver.cusolverDnSorgtr_bufferSize(handle::cusolverDnHandle_t,
-                                                   uplo::cublasFillMode_t, n::Cint,
-                                                   A::CuPtr{Cfloat}, lda::Cint,
-                                                   tau::CuPtr{Cfloat},
-                                                   lwork::Ptr{Cint})::cusolverStatus_t
+    @gcsafe_ccall libcusolver.cusolverDnSorgtr_bufferSize(handle::cusolverDnHandle_t,
+                                                          uplo::cublasFillMode_t, n::Cint,
+                                                          A::CuPtr{Cfloat}, lda::Cint,
+                                                          tau::CuPtr{Cfloat},
+                                                          lwork::Ptr{Cint})::cusolverStatus_t
 end
 
 @checked function cusolverDnDorgtr_bufferSize(handle, uplo, n, A, lda, tau, lwork)
     initialize_context()
-    @ccall libcusolver.cusolverDnDorgtr_bufferSize(handle::cusolverDnHandle_t,
-                                                   uplo::cublasFillMode_t, n::Cint,
-                                                   A::CuPtr{Cdouble}, lda::Cint,
-                                                   tau::CuPtr{Cdouble},
-                                                   lwork::Ptr{Cint})::cusolverStatus_t
+    @gcsafe_ccall libcusolver.cusolverDnDorgtr_bufferSize(handle::cusolverDnHandle_t,
+                                                          uplo::cublasFillMode_t, n::Cint,
+                                                          A::CuPtr{Cdouble}, lda::Cint,
+                                                          tau::CuPtr{Cdouble},
+                                                          lwork::Ptr{Cint})::cusolverStatus_t
 end
 
 @checked function cusolverDnCungtr_bufferSize(handle, uplo, n, A, lda, tau, lwork)
     initialize_context()
-    @ccall libcusolver.cusolverDnCungtr_bufferSize(handle::cusolverDnHandle_t,
-                                                   uplo::cublasFillMode_t, n::Cint,
-                                                   A::CuPtr{cuComplex}, lda::Cint,
-                                                   tau::CuPtr{cuComplex},
-                                                   lwork::Ptr{Cint})::cusolverStatus_t
+    @gcsafe_ccall libcusolver.cusolverDnCungtr_bufferSize(handle::cusolverDnHandle_t,
+                                                          uplo::cublasFillMode_t, n::Cint,
+                                                          A::CuPtr{cuComplex}, lda::Cint,
+                                                          tau::CuPtr{cuComplex},
+                                                          lwork::Ptr{Cint})::cusolverStatus_t
 end
 
 @checked function cusolverDnZungtr_bufferSize(handle, uplo, n, A, lda, tau, lwork)
     initialize_context()
-    @ccall libcusolver.cusolverDnZungtr_bufferSize(handle::cusolverDnHandle_t,
-                                                   uplo::cublasFillMode_t, n::Cint,
-                                                   A::CuPtr{cuDoubleComplex}, lda::Cint,
-                                                   tau::CuPtr{cuDoubleComplex},
-                                                   lwork::Ptr{Cint})::cusolverStatus_t
+    @gcsafe_ccall libcusolver.cusolverDnZungtr_bufferSize(handle::cusolverDnHandle_t,
+                                                          uplo::cublasFillMode_t, n::Cint,
+                                                          A::CuPtr{cuDoubleComplex},
+                                                          lda::Cint,
+                                                          tau::CuPtr{cuDoubleComplex},
+                                                          lwork::Ptr{Cint})::cusolverStatus_t
 end
 
 @checked function cusolverDnSorgtr(handle, uplo, n, A, lda, tau, work, lwork, info)
     initialize_context()
-    @ccall libcusolver.cusolverDnSorgtr(handle::cusolverDnHandle_t, uplo::cublasFillMode_t,
-                                        n::Cint, A::CuPtr{Cfloat}, lda::Cint,
-                                        tau::CuPtr{Cfloat}, work::CuPtr{Cfloat},
-                                        lwork::Cint, info::CuPtr{Cint})::cusolverStatus_t
+    @gcsafe_ccall libcusolver.cusolverDnSorgtr(handle::cusolverDnHandle_t,
+                                               uplo::cublasFillMode_t, n::Cint,
+                                               A::CuPtr{Cfloat}, lda::Cint,
+                                               tau::CuPtr{Cfloat}, work::CuPtr{Cfloat},
+                                               lwork::Cint,
+                                               info::CuPtr{Cint})::cusolverStatus_t
 end
 
 @checked function cusolverDnDorgtr(handle, uplo, n, A, lda, tau, work, lwork, info)
     initialize_context()
-    @ccall libcusolver.cusolverDnDorgtr(handle::cusolverDnHandle_t, uplo::cublasFillMode_t,
-                                        n::Cint, A::CuPtr{Cdouble}, lda::Cint,
-                                        tau::CuPtr{Cdouble}, work::CuPtr{Cdouble},
-                                        lwork::Cint, info::CuPtr{Cint})::cusolverStatus_t
+    @gcsafe_ccall libcusolver.cusolverDnDorgtr(handle::cusolverDnHandle_t,
+                                               uplo::cublasFillMode_t, n::Cint,
+                                               A::CuPtr{Cdouble}, lda::Cint,
+                                               tau::CuPtr{Cdouble}, work::CuPtr{Cdouble},
+                                               lwork::Cint,
+                                               info::CuPtr{Cint})::cusolverStatus_t
 end
 
 @checked function cusolverDnCungtr(handle, uplo, n, A, lda, tau, work, lwork, info)
     initialize_context()
-    @ccall libcusolver.cusolverDnCungtr(handle::cusolverDnHandle_t, uplo::cublasFillMode_t,
-                                        n::Cint, A::CuPtr{cuComplex}, lda::Cint,
-                                        tau::CuPtr{cuComplex}, work::CuPtr{cuComplex},
-                                        lwork::Cint, info::CuPtr{Cint})::cusolverStatus_t
+    @gcsafe_ccall libcusolver.cusolverDnCungtr(handle::cusolverDnHandle_t,
+                                               uplo::cublasFillMode_t, n::Cint,
+                                               A::CuPtr{cuComplex}, lda::Cint,
+                                               tau::CuPtr{cuComplex},
+                                               work::CuPtr{cuComplex}, lwork::Cint,
+                                               info::CuPtr{Cint})::cusolverStatus_t
 end
 
 @checked function cusolverDnZungtr(handle, uplo, n, A, lda, tau, work, lwork, info)
     initialize_context()
-    @ccall libcusolver.cusolverDnZungtr(handle::cusolverDnHandle_t, uplo::cublasFillMode_t,
-                                        n::Cint, A::CuPtr{cuDoubleComplex}, lda::Cint,
-                                        tau::CuPtr{cuDoubleComplex},
-                                        work::CuPtr{cuDoubleComplex}, lwork::Cint,
-                                        info::CuPtr{Cint})::cusolverStatus_t
+    @gcsafe_ccall libcusolver.cusolverDnZungtr(handle::cusolverDnHandle_t,
+                                               uplo::cublasFillMode_t, n::Cint,
+                                               A::CuPtr{cuDoubleComplex}, lda::Cint,
+                                               tau::CuPtr{cuDoubleComplex},
+                                               work::CuPtr{cuDoubleComplex}, lwork::Cint,
+                                               info::CuPtr{Cint})::cusolverStatus_t
 end
 
 @checked function cusolverDnSormtr_bufferSize(handle, side, uplo, trans, m, n, A, lda, tau,
                                               C, ldc, lwork)
     initialize_context()
-    @ccall libcusolver.cusolverDnSormtr_bufferSize(handle::cusolverDnHandle_t,
-                                                   side::cublasSideMode_t,
-                                                   uplo::cublasFillMode_t,
-                                                   trans::cublasOperation_t, m::Cint,
-                                                   n::Cint, A::CuPtr{Cfloat}, lda::Cint,
-                                                   tau::CuPtr{Cfloat}, C::CuPtr{Cfloat},
-                                                   ldc::Cint,
-                                                   lwork::Ptr{Cint})::cusolverStatus_t
+    @gcsafe_ccall libcusolver.cusolverDnSormtr_bufferSize(handle::cusolverDnHandle_t,
+                                                          side::cublasSideMode_t,
+                                                          uplo::cublasFillMode_t,
+                                                          trans::cublasOperation_t, m::Cint,
+                                                          n::Cint, A::CuPtr{Cfloat},
+                                                          lda::Cint, tau::CuPtr{Cfloat},
+                                                          C::CuPtr{Cfloat}, ldc::Cint,
+                                                          lwork::Ptr{Cint})::cusolverStatus_t
 end
 
 @checked function cusolverDnDormtr_bufferSize(handle, side, uplo, trans, m, n, A, lda, tau,
                                               C, ldc, lwork)
     initialize_context()
-    @ccall libcusolver.cusolverDnDormtr_bufferSize(handle::cusolverDnHandle_t,
-                                                   side::cublasSideMode_t,
-                                                   uplo::cublasFillMode_t,
-                                                   trans::cublasOperation_t, m::Cint,
-                                                   n::Cint, A::CuPtr{Cdouble}, lda::Cint,
-                                                   tau::CuPtr{Cdouble}, C::CuPtr{Cdouble},
-                                                   ldc::Cint,
-                                                   lwork::Ptr{Cint})::cusolverStatus_t
+    @gcsafe_ccall libcusolver.cusolverDnDormtr_bufferSize(handle::cusolverDnHandle_t,
+                                                          side::cublasSideMode_t,
+                                                          uplo::cublasFillMode_t,
+                                                          trans::cublasOperation_t, m::Cint,
+                                                          n::Cint, A::CuPtr{Cdouble},
+                                                          lda::Cint, tau::CuPtr{Cdouble},
+                                                          C::CuPtr{Cdouble}, ldc::Cint,
+                                                          lwork::Ptr{Cint})::cusolverStatus_t
 end
 
 @checked function cusolverDnCunmtr_bufferSize(handle, side, uplo, trans, m, n, A, lda, tau,
                                               C, ldc, lwork)
     initialize_context()
-    @ccall libcusolver.cusolverDnCunmtr_bufferSize(handle::cusolverDnHandle_t,
-                                                   side::cublasSideMode_t,
-                                                   uplo::cublasFillMode_t,
-                                                   trans::cublasOperation_t, m::Cint,
-                                                   n::Cint, A::CuPtr{cuComplex}, lda::Cint,
-                                                   tau::CuPtr{cuComplex},
-                                                   C::CuPtr{cuComplex}, ldc::Cint,
-                                                   lwork::Ptr{Cint})::cusolverStatus_t
+    @gcsafe_ccall libcusolver.cusolverDnCunmtr_bufferSize(handle::cusolverDnHandle_t,
+                                                          side::cublasSideMode_t,
+                                                          uplo::cublasFillMode_t,
+                                                          trans::cublasOperation_t, m::Cint,
+                                                          n::Cint, A::CuPtr{cuComplex},
+                                                          lda::Cint, tau::CuPtr{cuComplex},
+                                                          C::CuPtr{cuComplex}, ldc::Cint,
+                                                          lwork::Ptr{Cint})::cusolverStatus_t
 end
 
 @checked function cusolverDnZunmtr_bufferSize(handle, side, uplo, trans, m, n, A, lda, tau,
                                               C, ldc, lwork)
     initialize_context()
-    @ccall libcusolver.cusolverDnZunmtr_bufferSize(handle::cusolverDnHandle_t,
-                                                   side::cublasSideMode_t,
-                                                   uplo::cublasFillMode_t,
-                                                   trans::cublasOperation_t, m::Cint,
-                                                   n::Cint, A::CuPtr{cuDoubleComplex},
-                                                   lda::Cint, tau::CuPtr{cuDoubleComplex},
-                                                   C::CuPtr{cuDoubleComplex}, ldc::Cint,
-                                                   lwork::Ptr{Cint})::cusolverStatus_t
+    @gcsafe_ccall libcusolver.cusolverDnZunmtr_bufferSize(handle::cusolverDnHandle_t,
+                                                          side::cublasSideMode_t,
+                                                          uplo::cublasFillMode_t,
+                                                          trans::cublasOperation_t, m::Cint,
+                                                          n::Cint,
+                                                          A::CuPtr{cuDoubleComplex},
+                                                          lda::Cint,
+                                                          tau::CuPtr{cuDoubleComplex},
+                                                          C::CuPtr{cuDoubleComplex},
+                                                          ldc::Cint,
+                                                          lwork::Ptr{Cint})::cusolverStatus_t
 end
 
 @checked function cusolverDnSormtr(handle, side, uplo, trans, m, n, A, lda, tau, C, ldc,
                                    work, lwork, info)
     initialize_context()
-    @ccall libcusolver.cusolverDnSormtr(handle::cusolverDnHandle_t, side::cublasSideMode_t,
-                                        uplo::cublasFillMode_t, trans::cublasOperation_t,
-                                        m::Cint, n::Cint, A::CuPtr{Cfloat}, lda::Cint,
-                                        tau::CuPtr{Cfloat}, C::CuPtr{Cfloat}, ldc::Cint,
-                                        work::CuPtr{Cfloat}, lwork::Cint,
-                                        info::CuPtr{Cint})::cusolverStatus_t
+    @gcsafe_ccall libcusolver.cusolverDnSormtr(handle::cusolverDnHandle_t,
+                                               side::cublasSideMode_t,
+                                               uplo::cublasFillMode_t,
+                                               trans::cublasOperation_t, m::Cint, n::Cint,
+                                               A::CuPtr{Cfloat}, lda::Cint,
+                                               tau::CuPtr{Cfloat}, C::CuPtr{Cfloat},
+                                               ldc::Cint, work::CuPtr{Cfloat}, lwork::Cint,
+                                               info::CuPtr{Cint})::cusolverStatus_t
 end
 
 @checked function cusolverDnDormtr(handle, side, uplo, trans, m, n, A, lda, tau, C, ldc,
                                    work, lwork, info)
     initialize_context()
-    @ccall libcusolver.cusolverDnDormtr(handle::cusolverDnHandle_t, side::cublasSideMode_t,
-                                        uplo::cublasFillMode_t, trans::cublasOperation_t,
-                                        m::Cint, n::Cint, A::CuPtr{Cdouble}, lda::Cint,
-                                        tau::CuPtr{Cdouble}, C::CuPtr{Cdouble}, ldc::Cint,
-                                        work::CuPtr{Cdouble}, lwork::Cint,
-                                        info::CuPtr{Cint})::cusolverStatus_t
+    @gcsafe_ccall libcusolver.cusolverDnDormtr(handle::cusolverDnHandle_t,
+                                               side::cublasSideMode_t,
+                                               uplo::cublasFillMode_t,
+                                               trans::cublasOperation_t, m::Cint, n::Cint,
+                                               A::CuPtr{Cdouble}, lda::Cint,
+                                               tau::CuPtr{Cdouble}, C::CuPtr{Cdouble},
+                                               ldc::Cint, work::CuPtr{Cdouble}, lwork::Cint,
+                                               info::CuPtr{Cint})::cusolverStatus_t
 end
 
 @checked function cusolverDnCunmtr(handle, side, uplo, trans, m, n, A, lda, tau, C, ldc,
                                    work, lwork, info)
     initialize_context()
-    @ccall libcusolver.cusolverDnCunmtr(handle::cusolverDnHandle_t, side::cublasSideMode_t,
-                                        uplo::cublasFillMode_t, trans::cublasOperation_t,
-                                        m::Cint, n::Cint, A::CuPtr{cuComplex}, lda::Cint,
-                                        tau::CuPtr{cuComplex}, C::CuPtr{cuComplex},
-                                        ldc::Cint, work::CuPtr{cuComplex}, lwork::Cint,
-                                        info::CuPtr{Cint})::cusolverStatus_t
+    @gcsafe_ccall libcusolver.cusolverDnCunmtr(handle::cusolverDnHandle_t,
+                                               side::cublasSideMode_t,
+                                               uplo::cublasFillMode_t,
+                                               trans::cublasOperation_t, m::Cint, n::Cint,
+                                               A::CuPtr{cuComplex}, lda::Cint,
+                                               tau::CuPtr{cuComplex}, C::CuPtr{cuComplex},
+                                               ldc::Cint, work::CuPtr{cuComplex},
+                                               lwork::Cint,
+                                               info::CuPtr{Cint})::cusolverStatus_t
 end
 
 @checked function cusolverDnZunmtr(handle, side, uplo, trans, m, n, A, lda, tau, C, ldc,
                                    work, lwork, info)
     initialize_context()
-    @ccall libcusolver.cusolverDnZunmtr(handle::cusolverDnHandle_t, side::cublasSideMode_t,
-                                        uplo::cublasFillMode_t, trans::cublasOperation_t,
-                                        m::Cint, n::Cint, A::CuPtr{cuDoubleComplex},
-                                        lda::Cint, tau::CuPtr{cuDoubleComplex},
-                                        C::CuPtr{cuDoubleComplex}, ldc::Cint,
-                                        work::CuPtr{cuDoubleComplex}, lwork::Cint,
-                                        info::CuPtr{Cint})::cusolverStatus_t
+    @gcsafe_ccall libcusolver.cusolverDnZunmtr(handle::cusolverDnHandle_t,
+                                               side::cublasSideMode_t,
+                                               uplo::cublasFillMode_t,
+                                               trans::cublasOperation_t, m::Cint, n::Cint,
+                                               A::CuPtr{cuDoubleComplex}, lda::Cint,
+                                               tau::CuPtr{cuDoubleComplex},
+                                               C::CuPtr{cuDoubleComplex}, ldc::Cint,
+                                               work::CuPtr{cuDoubleComplex}, lwork::Cint,
+                                               info::CuPtr{Cint})::cusolverStatus_t
 end
 
 @checked function cusolverDnSgesvd_bufferSize(handle, m, n, lwork)
     initialize_context()
-    @ccall libcusolver.cusolverDnSgesvd_bufferSize(handle::cusolverDnHandle_t, m::Cint,
-                                                   n::Cint,
-                                                   lwork::Ptr{Cint})::cusolverStatus_t
+    @gcsafe_ccall libcusolver.cusolverDnSgesvd_bufferSize(handle::cusolverDnHandle_t,
+                                                          m::Cint, n::Cint,
+                                                          lwork::Ptr{Cint})::cusolverStatus_t
 end
 
 @checked function cusolverDnDgesvd_bufferSize(handle, m, n, lwork)
     initialize_context()
-    @ccall libcusolver.cusolverDnDgesvd_bufferSize(handle::cusolverDnHandle_t, m::Cint,
-                                                   n::Cint,
-                                                   lwork::Ptr{Cint})::cusolverStatus_t
+    @gcsafe_ccall libcusolver.cusolverDnDgesvd_bufferSize(handle::cusolverDnHandle_t,
+                                                          m::Cint, n::Cint,
+                                                          lwork::Ptr{Cint})::cusolverStatus_t
 end
 
 @checked function cusolverDnCgesvd_bufferSize(handle, m, n, lwork)
     initialize_context()
-    @ccall libcusolver.cusolverDnCgesvd_bufferSize(handle::cusolverDnHandle_t, m::Cint,
-                                                   n::Cint,
-                                                   lwork::Ptr{Cint})::cusolverStatus_t
+    @gcsafe_ccall libcusolver.cusolverDnCgesvd_bufferSize(handle::cusolverDnHandle_t,
+                                                          m::Cint, n::Cint,
+                                                          lwork::Ptr{Cint})::cusolverStatus_t
 end
 
 @checked function cusolverDnZgesvd_bufferSize(handle, m, n, lwork)
     initialize_context()
-    @ccall libcusolver.cusolverDnZgesvd_bufferSize(handle::cusolverDnHandle_t, m::Cint,
-                                                   n::Cint,
-                                                   lwork::Ptr{Cint})::cusolverStatus_t
+    @gcsafe_ccall libcusolver.cusolverDnZgesvd_bufferSize(handle::cusolverDnHandle_t,
+                                                          m::Cint, n::Cint,
+                                                          lwork::Ptr{Cint})::cusolverStatus_t
 end
 
 @checked function cusolverDnSgesvd(handle, jobu, jobvt, m, n, A, lda, S, U, ldu, VT, ldvt,
                                    work, lwork, rwork, info)
     initialize_context()
-    @ccall libcusolver.cusolverDnSgesvd(handle::cusolverDnHandle_t, jobu::Int8, jobvt::Int8,
-                                        m::Cint, n::Cint, A::CuPtr{Cfloat}, lda::Cint,
-                                        S::CuPtr{Cfloat}, U::CuPtr{Cfloat}, ldu::Cint,
-                                        VT::CuPtr{Cfloat}, ldvt::Cint, work::CuPtr{Cfloat},
-                                        lwork::Cint, rwork::CuPtr{Cfloat},
-                                        info::CuPtr{Cint})::cusolverStatus_t
+    @gcsafe_ccall libcusolver.cusolverDnSgesvd(handle::cusolverDnHandle_t, jobu::Int8,
+                                               jobvt::Int8, m::Cint, n::Cint,
+                                               A::CuPtr{Cfloat}, lda::Cint,
+                                               S::CuPtr{Cfloat}, U::CuPtr{Cfloat},
+                                               ldu::Cint, VT::CuPtr{Cfloat}, ldvt::Cint,
+                                               work::CuPtr{Cfloat}, lwork::Cint,
+                                               rwork::CuPtr{Cfloat},
+                                               info::CuPtr{Cint})::cusolverStatus_t
 end
 
 @checked function cusolverDnDgesvd(handle, jobu, jobvt, m, n, A, lda, S, U, ldu, VT, ldvt,
                                    work, lwork, rwork, info)
     initialize_context()
-    @ccall libcusolver.cusolverDnDgesvd(handle::cusolverDnHandle_t, jobu::Int8, jobvt::Int8,
-                                        m::Cint, n::Cint, A::CuPtr{Cdouble}, lda::Cint,
-                                        S::CuPtr{Cdouble}, U::CuPtr{Cdouble}, ldu::Cint,
-                                        VT::CuPtr{Cdouble}, ldvt::Cint,
-                                        work::CuPtr{Cdouble}, lwork::Cint,
-                                        rwork::CuPtr{Cdouble},
-                                        info::CuPtr{Cint})::cusolverStatus_t
+    @gcsafe_ccall libcusolver.cusolverDnDgesvd(handle::cusolverDnHandle_t, jobu::Int8,
+                                               jobvt::Int8, m::Cint, n::Cint,
+                                               A::CuPtr{Cdouble}, lda::Cint,
+                                               S::CuPtr{Cdouble}, U::CuPtr{Cdouble},
+                                               ldu::Cint, VT::CuPtr{Cdouble}, ldvt::Cint,
+                                               work::CuPtr{Cdouble}, lwork::Cint,
+                                               rwork::CuPtr{Cdouble},
+                                               info::CuPtr{Cint})::cusolverStatus_t
 end
 
 @checked function cusolverDnCgesvd(handle, jobu, jobvt, m, n, A, lda, S, U, ldu, VT, ldvt,
                                    work, lwork, rwork, info)
     initialize_context()
-    @ccall libcusolver.cusolverDnCgesvd(handle::cusolverDnHandle_t, jobu::Int8, jobvt::Int8,
-                                        m::Cint, n::Cint, A::CuPtr{cuComplex}, lda::Cint,
-                                        S::CuPtr{Cfloat}, U::CuPtr{cuComplex}, ldu::Cint,
-                                        VT::CuPtr{cuComplex}, ldvt::Cint,
-                                        work::CuPtr{cuComplex}, lwork::Cint,
-                                        rwork::CuPtr{Cfloat},
-                                        info::CuPtr{Cint})::cusolverStatus_t
+    @gcsafe_ccall libcusolver.cusolverDnCgesvd(handle::cusolverDnHandle_t, jobu::Int8,
+                                               jobvt::Int8, m::Cint, n::Cint,
+                                               A::CuPtr{cuComplex}, lda::Cint,
+                                               S::CuPtr{Cfloat}, U::CuPtr{cuComplex},
+                                               ldu::Cint, VT::CuPtr{cuComplex}, ldvt::Cint,
+                                               work::CuPtr{cuComplex}, lwork::Cint,
+                                               rwork::CuPtr{Cfloat},
+                                               info::CuPtr{Cint})::cusolverStatus_t
 end
 
 @checked function cusolverDnZgesvd(handle, jobu, jobvt, m, n, A, lda, S, U, ldu, VT, ldvt,
                                    work, lwork, rwork, info)
     initialize_context()
-    @ccall libcusolver.cusolverDnZgesvd(handle::cusolverDnHandle_t, jobu::Int8, jobvt::Int8,
-                                        m::Cint, n::Cint, A::CuPtr{cuDoubleComplex},
-                                        lda::Cint, S::CuPtr{Cdouble},
-                                        U::CuPtr{cuDoubleComplex}, ldu::Cint,
-                                        VT::CuPtr{cuDoubleComplex}, ldvt::Cint,
-                                        work::CuPtr{cuDoubleComplex}, lwork::Cint,
-                                        rwork::CuPtr{Cdouble},
-                                        info::CuPtr{Cint})::cusolverStatus_t
+    @gcsafe_ccall libcusolver.cusolverDnZgesvd(handle::cusolverDnHandle_t, jobu::Int8,
+                                               jobvt::Int8, m::Cint, n::Cint,
+                                               A::CuPtr{cuDoubleComplex}, lda::Cint,
+                                               S::CuPtr{Cdouble}, U::CuPtr{cuDoubleComplex},
+                                               ldu::Cint, VT::CuPtr{cuDoubleComplex},
+                                               ldvt::Cint, work::CuPtr{cuDoubleComplex},
+                                               lwork::Cint, rwork::CuPtr{Cdouble},
+                                               info::CuPtr{Cint})::cusolverStatus_t
 end
 
 @checked function cusolverDnSsyevd_bufferSize(handle, jobz, uplo, n, A, lda, W, lwork)
     initialize_context()
-    @ccall libcusolver.cusolverDnSsyevd_bufferSize(handle::cusolverDnHandle_t,
-                                                   jobz::cusolverEigMode_t,
-                                                   uplo::cublasFillMode_t, n::Cint,
-                                                   A::CuPtr{Cfloat}, lda::Cint,
-                                                   W::CuPtr{Cfloat},
-                                                   lwork::Ptr{Cint})::cusolverStatus_t
-end
-
-@checked function cusolverDnDsyevd_bufferSize(handle, jobz, uplo, n, A, lda, W, lwork)
-    initialize_context()
-    @ccall libcusolver.cusolverDnDsyevd_bufferSize(handle::cusolverDnHandle_t,
-                                                   jobz::cusolverEigMode_t,
-                                                   uplo::cublasFillMode_t, n::Cint,
-                                                   A::CuPtr{Cdouble}, lda::Cint,
-                                                   W::CuPtr{Cdouble},
-                                                   lwork::Ptr{Cint})::cusolverStatus_t
-end
-
-@checked function cusolverDnCheevd_bufferSize(handle, jobz, uplo, n, A, lda, W, lwork)
-    initialize_context()
-    @ccall libcusolver.cusolverDnCheevd_bufferSize(handle::cusolverDnHandle_t,
-                                                   jobz::cusolverEigMode_t,
-                                                   uplo::cublasFillMode_t, n::Cint,
-                                                   A::CuPtr{cuComplex}, lda::Cint,
-                                                   W::CuPtr{Cfloat},
-                                                   lwork::Ptr{Cint})::cusolverStatus_t
-end
-
-@checked function cusolverDnZheevd_bufferSize(handle, jobz, uplo, n, A, lda, W, lwork)
-    initialize_context()
-    @ccall libcusolver.cusolverDnZheevd_bufferSize(handle::cusolverDnHandle_t,
-                                                   jobz::cusolverEigMode_t,
-                                                   uplo::cublasFillMode_t, n::Cint,
-                                                   A::CuPtr{cuDoubleComplex}, lda::Cint,
-                                                   W::CuPtr{Cdouble},
-                                                   lwork::Ptr{Cint})::cusolverStatus_t
-end
-
-@checked function cusolverDnSsyevd(handle, jobz, uplo, n, A, lda, W, work, lwork, info)
-    initialize_context()
-    @ccall libcusolver.cusolverDnSsyevd(handle::cusolverDnHandle_t, jobz::cusolverEigMode_t,
-                                        uplo::cublasFillMode_t, n::Cint, A::CuPtr{Cfloat},
-                                        lda::Cint, W::CuPtr{Cfloat}, work::CuPtr{Cfloat},
-                                        lwork::Cint, info::CuPtr{Cint})::cusolverStatus_t
-end
-
-@checked function cusolverDnDsyevd(handle, jobz, uplo, n, A, lda, W, work, lwork, info)
-    initialize_context()
-    @ccall libcusolver.cusolverDnDsyevd(handle::cusolverDnHandle_t, jobz::cusolverEigMode_t,
-                                        uplo::cublasFillMode_t, n::Cint, A::CuPtr{Cdouble},
-                                        lda::Cint, W::CuPtr{Cdouble}, work::CuPtr{Cdouble},
-                                        lwork::Cint, info::CuPtr{Cint})::cusolverStatus_t
-end
-
-@checked function cusolverDnCheevd(handle, jobz, uplo, n, A, lda, W, work, lwork, info)
-    initialize_context()
-    @ccall libcusolver.cusolverDnCheevd(handle::cusolverDnHandle_t, jobz::cusolverEigMode_t,
-                                        uplo::cublasFillMode_t, n::Cint,
-                                        A::CuPtr{cuComplex}, lda::Cint, W::CuPtr{Cfloat},
-                                        work::CuPtr{cuComplex}, lwork::Cint,
-                                        info::CuPtr{Cint})::cusolverStatus_t
-end
-
-@checked function cusolverDnZheevd(handle, jobz, uplo, n, A, lda, W, work, lwork, info)
-    initialize_context()
-    @ccall libcusolver.cusolverDnZheevd(handle::cusolverDnHandle_t, jobz::cusolverEigMode_t,
-                                        uplo::cublasFillMode_t, n::Cint,
-                                        A::CuPtr{cuDoubleComplex}, lda::Cint,
-                                        W::CuPtr{Cdouble}, work::CuPtr{cuDoubleComplex},
-                                        lwork::Cint, info::CuPtr{Cint})::cusolverStatus_t
-end
-
-@checked function cusolverDnSsyevdx_bufferSize(handle, jobz, range, uplo, n, A, lda, vl, vu,
-                                               il, iu, meig, W, lwork)
-    initialize_context()
-    @ccall libcusolver.cusolverDnSsyevdx_bufferSize(handle::cusolverDnHandle_t,
-                                                    jobz::cusolverEigMode_t,
-                                                    range::cusolverEigRange_t,
-                                                    uplo::cublasFillMode_t, n::Cint,
-                                                    A::CuPtr{Cfloat}, lda::Cint, vl::Cfloat,
-                                                    vu::Cfloat, il::Cint, iu::Cint,
-                                                    meig::Ptr{Cint}, W::CuPtr{Cfloat},
-                                                    lwork::Ptr{Cint})::cusolverStatus_t
-end
-
-@checked function cusolverDnDsyevdx_bufferSize(handle, jobz, range, uplo, n, A, lda, vl, vu,
-                                               il, iu, meig, W, lwork)
-    initialize_context()
-    @ccall libcusolver.cusolverDnDsyevdx_bufferSize(handle::cusolverDnHandle_t,
-                                                    jobz::cusolverEigMode_t,
-                                                    range::cusolverEigRange_t,
-                                                    uplo::cublasFillMode_t, n::Cint,
-                                                    A::CuPtr{Cdouble}, lda::Cint,
-                                                    vl::Cdouble, vu::Cdouble, il::Cint,
-                                                    iu::Cint, meig::Ptr{Cint},
-                                                    W::CuPtr{Cdouble},
-                                                    lwork::Ptr{Cint})::cusolverStatus_t
-end
-
-@checked function cusolverDnCheevdx_bufferSize(handle, jobz, range, uplo, n, A, lda, vl, vu,
-                                               il, iu, meig, W, lwork)
-    initialize_context()
-    @ccall libcusolver.cusolverDnCheevdx_bufferSize(handle::cusolverDnHandle_t,
-                                                    jobz::cusolverEigMode_t,
-                                                    range::cusolverEigRange_t,
-                                                    uplo::cublasFillMode_t, n::Cint,
-                                                    A::CuPtr{cuComplex}, lda::Cint,
-                                                    vl::Cfloat, vu::Cfloat, il::Cint,
-                                                    iu::Cint, meig::Ptr{Cint},
-                                                    W::CuPtr{Cfloat},
-                                                    lwork::Ptr{Cint})::cusolverStatus_t
-end
-
-@checked function cusolverDnZheevdx_bufferSize(handle, jobz, range, uplo, n, A, lda, vl, vu,
-                                               il, iu, meig, W, lwork)
-    initialize_context()
-    @ccall libcusolver.cusolverDnZheevdx_bufferSize(handle::cusolverDnHandle_t,
-                                                    jobz::cusolverEigMode_t,
-                                                    range::cusolverEigRange_t,
-                                                    uplo::cublasFillMode_t, n::Cint,
-                                                    A::CuPtr{cuDoubleComplex}, lda::Cint,
-                                                    vl::Cdouble, vu::Cdouble, il::Cint,
-                                                    iu::Cint, meig::Ptr{Cint},
-                                                    W::CuPtr{Cdouble},
-                                                    lwork::Ptr{Cint})::cusolverStatus_t
-end
-
-@checked function cusolverDnSsyevdx(handle, jobz, range, uplo, n, A, lda, vl, vu, il, iu,
-                                    meig, W, work, lwork, info)
-    initialize_context()
-    @ccall libcusolver.cusolverDnSsyevdx(handle::cusolverDnHandle_t,
-                                         jobz::cusolverEigMode_t, range::cusolverEigRange_t,
-                                         uplo::cublasFillMode_t, n::Cint, A::CuPtr{Cfloat},
-                                         lda::Cint, vl::Cfloat, vu::Cfloat, il::Cint,
-                                         iu::Cint, meig::Ptr{Cint}, W::CuPtr{Cfloat},
-                                         work::CuPtr{Cfloat}, lwork::Cint,
-                                         info::CuPtr{Cint})::cusolverStatus_t
-end
-
-@checked function cusolverDnDsyevdx(handle, jobz, range, uplo, n, A, lda, vl, vu, il, iu,
-                                    meig, W, work, lwork, info)
-    initialize_context()
-    @ccall libcusolver.cusolverDnDsyevdx(handle::cusolverDnHandle_t,
-                                         jobz::cusolverEigMode_t, range::cusolverEigRange_t,
-                                         uplo::cublasFillMode_t, n::Cint, A::CuPtr{Cdouble},
-                                         lda::Cint, vl::Cdouble, vu::Cdouble, il::Cint,
-                                         iu::Cint, meig::Ptr{Cint}, W::CuPtr{Cdouble},
-                                         work::CuPtr{Cdouble}, lwork::Cint,
-                                         info::CuPtr{Cint})::cusolverStatus_t
-end
-
-@checked function cusolverDnCheevdx(handle, jobz, range, uplo, n, A, lda, vl, vu, il, iu,
-                                    meig, W, work, lwork, info)
-    initialize_context()
-    @ccall libcusolver.cusolverDnCheevdx(handle::cusolverDnHandle_t,
-                                         jobz::cusolverEigMode_t, range::cusolverEigRange_t,
-                                         uplo::cublasFillMode_t, n::Cint,
-                                         A::CuPtr{cuComplex}, lda::Cint, vl::Cfloat,
-                                         vu::Cfloat, il::Cint, iu::Cint, meig::Ptr{Cint},
-                                         W::CuPtr{Cfloat}, work::CuPtr{cuComplex},
-                                         lwork::Cint, info::CuPtr{Cint})::cusolverStatus_t
-end
-
-@checked function cusolverDnZheevdx(handle, jobz, range, uplo, n, A, lda, vl, vu, il, iu,
-                                    meig, W, work, lwork, info)
-    initialize_context()
-    @ccall libcusolver.cusolverDnZheevdx(handle::cusolverDnHandle_t,
-                                         jobz::cusolverEigMode_t, range::cusolverEigRange_t,
-                                         uplo::cublasFillMode_t, n::Cint,
-                                         A::CuPtr{cuDoubleComplex}, lda::Cint, vl::Cdouble,
-                                         vu::Cdouble, il::Cint, iu::Cint, meig::Ptr{Cint},
-                                         W::CuPtr{Cdouble}, work::CuPtr{cuDoubleComplex},
-                                         lwork::Cint, info::CuPtr{Cint})::cusolverStatus_t
-end
-
-@checked function cusolverDnSsygvdx_bufferSize(handle, itype, jobz, range, uplo, n, A, lda,
-                                               B, ldb, vl, vu, il, iu, meig, W, lwork)
-    initialize_context()
-    @ccall libcusolver.cusolverDnSsygvdx_bufferSize(handle::cusolverDnHandle_t,
-                                                    itype::cusolverEigType_t,
-                                                    jobz::cusolverEigMode_t,
-                                                    range::cusolverEigRange_t,
-                                                    uplo::cublasFillMode_t, n::Cint,
-                                                    A::CuPtr{Cfloat}, lda::Cint,
-                                                    B::CuPtr{Cfloat}, ldb::Cint, vl::Cfloat,
-                                                    vu::Cfloat, il::Cint, iu::Cint,
-                                                    meig::Ptr{Cint}, W::CuPtr{Cfloat},
-                                                    lwork::Ptr{Cint})::cusolverStatus_t
-end
-
-@checked function cusolverDnDsygvdx_bufferSize(handle, itype, jobz, range, uplo, n, A, lda,
-                                               B, ldb, vl, vu, il, iu, meig, W, lwork)
-    initialize_context()
-    @ccall libcusolver.cusolverDnDsygvdx_bufferSize(handle::cusolverDnHandle_t,
-                                                    itype::cusolverEigType_t,
-                                                    jobz::cusolverEigMode_t,
-                                                    range::cusolverEigRange_t,
-                                                    uplo::cublasFillMode_t, n::Cint,
-                                                    A::CuPtr{Cdouble}, lda::Cint,
-                                                    B::CuPtr{Cdouble}, ldb::Cint,
-                                                    vl::Cdouble, vu::Cdouble, il::Cint,
-                                                    iu::Cint, meig::Ptr{Cint},
-                                                    W::CuPtr{Cdouble},
-                                                    lwork::Ptr{Cint})::cusolverStatus_t
-end
-
-@checked function cusolverDnChegvdx_bufferSize(handle, itype, jobz, range, uplo, n, A, lda,
-                                               B, ldb, vl, vu, il, iu, meig, W, lwork)
-    initialize_context()
-    @ccall libcusolver.cusolverDnChegvdx_bufferSize(handle::cusolverDnHandle_t,
-                                                    itype::cusolverEigType_t,
-                                                    jobz::cusolverEigMode_t,
-                                                    range::cusolverEigRange_t,
-                                                    uplo::cublasFillMode_t, n::Cint,
-                                                    A::CuPtr{cuComplex}, lda::Cint,
-                                                    B::CuPtr{cuComplex}, ldb::Cint,
-                                                    vl::Cfloat, vu::Cfloat, il::Cint,
-                                                    iu::Cint, meig::Ptr{Cint},
-                                                    W::CuPtr{Cfloat},
-                                                    lwork::Ptr{Cint})::cusolverStatus_t
-end
-
-@checked function cusolverDnZhegvdx_bufferSize(handle, itype, jobz, range, uplo, n, A, lda,
-                                               B, ldb, vl, vu, il, iu, meig, W, lwork)
-    initialize_context()
-    @ccall libcusolver.cusolverDnZhegvdx_bufferSize(handle::cusolverDnHandle_t,
-                                                    itype::cusolverEigType_t,
-                                                    jobz::cusolverEigMode_t,
-                                                    range::cusolverEigRange_t,
-                                                    uplo::cublasFillMode_t, n::Cint,
-                                                    A::CuPtr{cuDoubleComplex}, lda::Cint,
-                                                    B::CuPtr{cuDoubleComplex}, ldb::Cint,
-                                                    vl::Cdouble, vu::Cdouble, il::Cint,
-                                                    iu::Cint, meig::Ptr{Cint},
-                                                    W::CuPtr{Cdouble},
-                                                    lwork::Ptr{Cint})::cusolverStatus_t
-end
-
-@checked function cusolverDnSsygvdx(handle, itype, jobz, range, uplo, n, A, lda, B, ldb, vl,
-                                    vu, il, iu, meig, W, work, lwork, info)
-    initialize_context()
-    @ccall libcusolver.cusolverDnSsygvdx(handle::cusolverDnHandle_t,
-                                         itype::cusolverEigType_t, jobz::cusolverEigMode_t,
-                                         range::cusolverEigRange_t, uplo::cublasFillMode_t,
-                                         n::Cint, A::CuPtr{Cfloat}, lda::Cint,
-                                         B::CuPtr{Cfloat}, ldb::Cint, vl::Cfloat,
-                                         vu::Cfloat, il::Cint, iu::Cint, meig::Ptr{Cint},
-                                         W::CuPtr{Cfloat}, work::CuPtr{Cfloat}, lwork::Cint,
-                                         info::CuPtr{Cint})::cusolverStatus_t
-end
-
-@checked function cusolverDnDsygvdx(handle, itype, jobz, range, uplo, n, A, lda, B, ldb, vl,
-                                    vu, il, iu, meig, W, work, lwork, info)
-    initialize_context()
-    @ccall libcusolver.cusolverDnDsygvdx(handle::cusolverDnHandle_t,
-                                         itype::cusolverEigType_t, jobz::cusolverEigMode_t,
-                                         range::cusolverEigRange_t, uplo::cublasFillMode_t,
-                                         n::Cint, A::CuPtr{Cdouble}, lda::Cint,
-                                         B::CuPtr{Cdouble}, ldb::Cint, vl::Cdouble,
-                                         vu::Cdouble, il::Cint, iu::Cint, meig::Ptr{Cint},
-                                         W::CuPtr{Cdouble}, work::CuPtr{Cdouble},
-                                         lwork::Cint, info::CuPtr{Cint})::cusolverStatus_t
-end
-
-@checked function cusolverDnChegvdx(handle, itype, jobz, range, uplo, n, A, lda, B, ldb, vl,
-                                    vu, il, iu, meig, W, work, lwork, info)
-    initialize_context()
-    @ccall libcusolver.cusolverDnChegvdx(handle::cusolverDnHandle_t,
-                                         itype::cusolverEigType_t, jobz::cusolverEigMode_t,
-                                         range::cusolverEigRange_t, uplo::cublasFillMode_t,
-                                         n::Cint, A::CuPtr{cuComplex}, lda::Cint,
-                                         B::CuPtr{cuComplex}, ldb::Cint, vl::Cfloat,
-                                         vu::Cfloat, il::Cint, iu::Cint, meig::Ptr{Cint},
-                                         W::CuPtr{Cfloat}, work::CuPtr{cuComplex},
-                                         lwork::Cint, info::CuPtr{Cint})::cusolverStatus_t
-end
-
-@checked function cusolverDnZhegvdx(handle, itype, jobz, range, uplo, n, A, lda, B, ldb, vl,
-                                    vu, il, iu, meig, W, work, lwork, info)
-    initialize_context()
-    @ccall libcusolver.cusolverDnZhegvdx(handle::cusolverDnHandle_t,
-                                         itype::cusolverEigType_t, jobz::cusolverEigMode_t,
-                                         range::cusolverEigRange_t, uplo::cublasFillMode_t,
-                                         n::Cint, A::CuPtr{cuDoubleComplex}, lda::Cint,
-                                         B::CuPtr{cuDoubleComplex}, ldb::Cint, vl::Cdouble,
-                                         vu::Cdouble, il::Cint, iu::Cint, meig::Ptr{Cint},
-                                         W::CuPtr{Cdouble}, work::CuPtr{cuDoubleComplex},
-                                         lwork::Cint, info::CuPtr{Cint})::cusolverStatus_t
-end
-
-@checked function cusolverDnSsygvd_bufferSize(handle, itype, jobz, uplo, n, A, lda, B, ldb,
-                                              W, lwork)
-    initialize_context()
-    @ccall libcusolver.cusolverDnSsygvd_bufferSize(handle::cusolverDnHandle_t,
-                                                   itype::cusolverEigType_t,
-                                                   jobz::cusolverEigMode_t,
-                                                   uplo::cublasFillMode_t, n::Cint,
-                                                   A::CuPtr{Cfloat}, lda::Cint,
-                                                   B::CuPtr{Cfloat}, ldb::Cint,
-                                                   W::CuPtr{Cfloat},
-                                                   lwork::Ptr{Cint})::cusolverStatus_t
-end
-
-@checked function cusolverDnDsygvd_bufferSize(handle, itype, jobz, uplo, n, A, lda, B, ldb,
-                                              W, lwork)
-    initialize_context()
-    @ccall libcusolver.cusolverDnDsygvd_bufferSize(handle::cusolverDnHandle_t,
-                                                   itype::cusolverEigType_t,
-                                                   jobz::cusolverEigMode_t,
-                                                   uplo::cublasFillMode_t, n::Cint,
-                                                   A::CuPtr{Cdouble}, lda::Cint,
-                                                   B::CuPtr{Cdouble}, ldb::Cint,
-                                                   W::CuPtr{Cdouble},
-                                                   lwork::Ptr{Cint})::cusolverStatus_t
-end
-
-@checked function cusolverDnChegvd_bufferSize(handle, itype, jobz, uplo, n, A, lda, B, ldb,
-                                              W, lwork)
-    initialize_context()
-    @ccall libcusolver.cusolverDnChegvd_bufferSize(handle::cusolverDnHandle_t,
-                                                   itype::cusolverEigType_t,
-                                                   jobz::cusolverEigMode_t,
-                                                   uplo::cublasFillMode_t, n::Cint,
-                                                   A::CuPtr{cuComplex}, lda::Cint,
-                                                   B::CuPtr{cuComplex}, ldb::Cint,
-                                                   W::CuPtr{Cfloat},
-                                                   lwork::Ptr{Cint})::cusolverStatus_t
-end
-
-@checked function cusolverDnZhegvd_bufferSize(handle, itype, jobz, uplo, n, A, lda, B, ldb,
-                                              W, lwork)
-    initialize_context()
-    @ccall libcusolver.cusolverDnZhegvd_bufferSize(handle::cusolverDnHandle_t,
-                                                   itype::cusolverEigType_t,
-                                                   jobz::cusolverEigMode_t,
-                                                   uplo::cublasFillMode_t, n::Cint,
-                                                   A::CuPtr{cuDoubleComplex}, lda::Cint,
-                                                   B::CuPtr{cuDoubleComplex}, ldb::Cint,
-                                                   W::CuPtr{Cdouble},
-                                                   lwork::Ptr{Cint})::cusolverStatus_t
-end
-
-@checked function cusolverDnSsygvd(handle, itype, jobz, uplo, n, A, lda, B, ldb, W, work,
-                                   lwork, info)
-    initialize_context()
-    @ccall libcusolver.cusolverDnSsygvd(handle::cusolverDnHandle_t,
-                                        itype::cusolverEigType_t, jobz::cusolverEigMode_t,
-                                        uplo::cublasFillMode_t, n::Cint, A::CuPtr{Cfloat},
-                                        lda::Cint, B::CuPtr{Cfloat}, ldb::Cint,
-                                        W::CuPtr{Cfloat}, work::CuPtr{Cfloat}, lwork::Cint,
-                                        info::CuPtr{Cint})::cusolverStatus_t
-end
-
-@checked function cusolverDnDsygvd(handle, itype, jobz, uplo, n, A, lda, B, ldb, W, work,
-                                   lwork, info)
-    initialize_context()
-    @ccall libcusolver.cusolverDnDsygvd(handle::cusolverDnHandle_t,
-                                        itype::cusolverEigType_t, jobz::cusolverEigMode_t,
-                                        uplo::cublasFillMode_t, n::Cint, A::CuPtr{Cdouble},
-                                        lda::Cint, B::CuPtr{Cdouble}, ldb::Cint,
-                                        W::CuPtr{Cdouble}, work::CuPtr{Cdouble},
-                                        lwork::Cint, info::CuPtr{Cint})::cusolverStatus_t
-end
-
-@checked function cusolverDnChegvd(handle, itype, jobz, uplo, n, A, lda, B, ldb, W, work,
-                                   lwork, info)
-    initialize_context()
-    @ccall libcusolver.cusolverDnChegvd(handle::cusolverDnHandle_t,
-                                        itype::cusolverEigType_t, jobz::cusolverEigMode_t,
-                                        uplo::cublasFillMode_t, n::Cint,
-                                        A::CuPtr{cuComplex}, lda::Cint, B::CuPtr{cuComplex},
-                                        ldb::Cint, W::CuPtr{Cfloat}, work::CuPtr{cuComplex},
-                                        lwork::Cint, info::CuPtr{Cint})::cusolverStatus_t
-end
-
-@checked function cusolverDnZhegvd(handle, itype, jobz, uplo, n, A, lda, B, ldb, W, work,
-                                   lwork, info)
-    initialize_context()
-    @ccall libcusolver.cusolverDnZhegvd(handle::cusolverDnHandle_t,
-                                        itype::cusolverEigType_t, jobz::cusolverEigMode_t,
-                                        uplo::cublasFillMode_t, n::Cint,
-                                        A::CuPtr{cuDoubleComplex}, lda::Cint,
-                                        B::CuPtr{cuDoubleComplex}, ldb::Cint,
-                                        W::CuPtr{Cdouble}, work::CuPtr{cuDoubleComplex},
-                                        lwork::Cint, info::CuPtr{Cint})::cusolverStatus_t
-end
-
-@checked function cusolverDnCreateSyevjInfo(info)
-    initialize_context()
-    @ccall libcusolver.cusolverDnCreateSyevjInfo(info::Ptr{syevjInfo_t})::cusolverStatus_t
-end
-
-@checked function cusolverDnDestroySyevjInfo(info)
-    initialize_context()
-    @ccall libcusolver.cusolverDnDestroySyevjInfo(info::syevjInfo_t)::cusolverStatus_t
-end
-
-@checked function cusolverDnXsyevjSetTolerance(info, tolerance)
-    initialize_context()
-    @ccall libcusolver.cusolverDnXsyevjSetTolerance(info::syevjInfo_t,
-                                                    tolerance::Cdouble)::cusolverStatus_t
-end
-
-@checked function cusolverDnXsyevjSetMaxSweeps(info, max_sweeps)
-    initialize_context()
-    @ccall libcusolver.cusolverDnXsyevjSetMaxSweeps(info::syevjInfo_t,
-                                                    max_sweeps::Cint)::cusolverStatus_t
-end
-
-@checked function cusolverDnXsyevjSetSortEig(info, sort_eig)
-    initialize_context()
-    @ccall libcusolver.cusolverDnXsyevjSetSortEig(info::syevjInfo_t,
-                                                  sort_eig::Cint)::cusolverStatus_t
-end
-
-@checked function cusolverDnXsyevjGetResidual(handle, info, residual)
-    initialize_context()
-    @ccall libcusolver.cusolverDnXsyevjGetResidual(handle::cusolverDnHandle_t,
-                                                   info::syevjInfo_t,
-                                                   residual::Ptr{Cdouble})::cusolverStatus_t
-end
-
-@checked function cusolverDnXsyevjGetSweeps(handle, info, executed_sweeps)
-    initialize_context()
-    @ccall libcusolver.cusolverDnXsyevjGetSweeps(handle::cusolverDnHandle_t,
-                                                 info::syevjInfo_t,
-                                                 executed_sweeps::Ptr{Cint})::cusolverStatus_t
-end
-
-@checked function cusolverDnSsyevjBatched_bufferSize(handle, jobz, uplo, n, A, lda, W,
-                                                     lwork, params, batchSize)
-    initialize_context()
-    @ccall libcusolver.cusolverDnSsyevjBatched_bufferSize(handle::cusolverDnHandle_t,
+    @gcsafe_ccall libcusolver.cusolverDnSsyevd_bufferSize(handle::cusolverDnHandle_t,
                                                           jobz::cusolverEigMode_t,
                                                           uplo::cublasFillMode_t, n::Cint,
                                                           A::CuPtr{Cfloat}, lda::Cint,
                                                           W::CuPtr{Cfloat},
-                                                          lwork::Ptr{Cint},
-                                                          params::syevjInfo_t,
-                                                          batchSize::Cint)::cusolverStatus_t
+                                                          lwork::Ptr{Cint})::cusolverStatus_t
 end
 
-@checked function cusolverDnDsyevjBatched_bufferSize(handle, jobz, uplo, n, A, lda, W,
-                                                     lwork, params, batchSize)
+@checked function cusolverDnDsyevd_bufferSize(handle, jobz, uplo, n, A, lda, W, lwork)
     initialize_context()
-    @ccall libcusolver.cusolverDnDsyevjBatched_bufferSize(handle::cusolverDnHandle_t,
+    @gcsafe_ccall libcusolver.cusolverDnDsyevd_bufferSize(handle::cusolverDnHandle_t,
                                                           jobz::cusolverEigMode_t,
                                                           uplo::cublasFillMode_t, n::Cint,
                                                           A::CuPtr{Cdouble}, lda::Cint,
                                                           W::CuPtr{Cdouble},
-                                                          lwork::Ptr{Cint},
-                                                          params::syevjInfo_t,
-                                                          batchSize::Cint)::cusolverStatus_t
+                                                          lwork::Ptr{Cint})::cusolverStatus_t
 end
 
-@checked function cusolverDnCheevjBatched_bufferSize(handle, jobz, uplo, n, A, lda, W,
-                                                     lwork, params, batchSize)
+@checked function cusolverDnCheevd_bufferSize(handle, jobz, uplo, n, A, lda, W, lwork)
     initialize_context()
-    @ccall libcusolver.cusolverDnCheevjBatched_bufferSize(handle::cusolverDnHandle_t,
+    @gcsafe_ccall libcusolver.cusolverDnCheevd_bufferSize(handle::cusolverDnHandle_t,
                                                           jobz::cusolverEigMode_t,
                                                           uplo::cublasFillMode_t, n::Cint,
                                                           A::CuPtr{cuComplex}, lda::Cint,
                                                           W::CuPtr{Cfloat},
-                                                          lwork::Ptr{Cint},
-                                                          params::syevjInfo_t,
-                                                          batchSize::Cint)::cusolverStatus_t
+                                                          lwork::Ptr{Cint})::cusolverStatus_t
 end
 
-@checked function cusolverDnZheevjBatched_bufferSize(handle, jobz, uplo, n, A, lda, W,
-                                                     lwork, params, batchSize)
+@checked function cusolverDnZheevd_bufferSize(handle, jobz, uplo, n, A, lda, W, lwork)
     initialize_context()
-    @ccall libcusolver.cusolverDnZheevjBatched_bufferSize(handle::cusolverDnHandle_t,
+    @gcsafe_ccall libcusolver.cusolverDnZheevd_bufferSize(handle::cusolverDnHandle_t,
                                                           jobz::cusolverEigMode_t,
                                                           uplo::cublasFillMode_t, n::Cint,
                                                           A::CuPtr{cuDoubleComplex},
                                                           lda::Cint, W::CuPtr{Cdouble},
-                                                          lwork::Ptr{Cint},
-                                                          params::syevjInfo_t,
-                                                          batchSize::Cint)::cusolverStatus_t
+                                                          lwork::Ptr{Cint})::cusolverStatus_t
 end
 
-@checked function cusolverDnSsyevjBatched(handle, jobz, uplo, n, A, lda, W, work, lwork,
-                                          info, params, batchSize)
+@checked function cusolverDnSsyevd(handle, jobz, uplo, n, A, lda, W, work, lwork, info)
     initialize_context()
-    @ccall libcusolver.cusolverDnSsyevjBatched(handle::cusolverDnHandle_t,
+    @gcsafe_ccall libcusolver.cusolverDnSsyevd(handle::cusolverDnHandle_t,
                                                jobz::cusolverEigMode_t,
                                                uplo::cublasFillMode_t, n::Cint,
                                                A::CuPtr{Cfloat}, lda::Cint,
                                                W::CuPtr{Cfloat}, work::CuPtr{Cfloat},
-                                               lwork::Cint, info::CuPtr{Cint},
-                                               params::syevjInfo_t,
-                                               batchSize::Cint)::cusolverStatus_t
+                                               lwork::Cint,
+                                               info::CuPtr{Cint})::cusolverStatus_t
 end
 
-@checked function cusolverDnDsyevjBatched(handle, jobz, uplo, n, A, lda, W, work, lwork,
-                                          info, params, batchSize)
+@checked function cusolverDnDsyevd(handle, jobz, uplo, n, A, lda, W, work, lwork, info)
     initialize_context()
-    @ccall libcusolver.cusolverDnDsyevjBatched(handle::cusolverDnHandle_t,
+    @gcsafe_ccall libcusolver.cusolverDnDsyevd(handle::cusolverDnHandle_t,
                                                jobz::cusolverEigMode_t,
                                                uplo::cublasFillMode_t, n::Cint,
                                                A::CuPtr{Cdouble}, lda::Cint,
                                                W::CuPtr{Cdouble}, work::CuPtr{Cdouble},
-                                               lwork::Cint, info::CuPtr{Cint},
-                                               params::syevjInfo_t,
-                                               batchSize::Cint)::cusolverStatus_t
+                                               lwork::Cint,
+                                               info::CuPtr{Cint})::cusolverStatus_t
 end
 
-@checked function cusolverDnCheevjBatched(handle, jobz, uplo, n, A, lda, W, work, lwork,
-                                          info, params, batchSize)
+@checked function cusolverDnCheevd(handle, jobz, uplo, n, A, lda, W, work, lwork, info)
     initialize_context()
-    @ccall libcusolver.cusolverDnCheevjBatched(handle::cusolverDnHandle_t,
+    @gcsafe_ccall libcusolver.cusolverDnCheevd(handle::cusolverDnHandle_t,
                                                jobz::cusolverEigMode_t,
                                                uplo::cublasFillMode_t, n::Cint,
                                                A::CuPtr{cuComplex}, lda::Cint,
                                                W::CuPtr{Cfloat}, work::CuPtr{cuComplex},
-                                               lwork::Cint, info::CuPtr{Cint},
-                                               params::syevjInfo_t,
-                                               batchSize::Cint)::cusolverStatus_t
+                                               lwork::Cint,
+                                               info::CuPtr{Cint})::cusolverStatus_t
 end
 
-@checked function cusolverDnZheevjBatched(handle, jobz, uplo, n, A, lda, W, work, lwork,
-                                          info, params, batchSize)
+@checked function cusolverDnZheevd(handle, jobz, uplo, n, A, lda, W, work, lwork, info)
     initialize_context()
-    @ccall libcusolver.cusolverDnZheevjBatched(handle::cusolverDnHandle_t,
+    @gcsafe_ccall libcusolver.cusolverDnZheevd(handle::cusolverDnHandle_t,
                                                jobz::cusolverEigMode_t,
                                                uplo::cublasFillMode_t, n::Cint,
                                                A::CuPtr{cuDoubleComplex}, lda::Cint,
                                                W::CuPtr{Cdouble},
                                                work::CuPtr{cuDoubleComplex}, lwork::Cint,
-                                               info::CuPtr{Cint}, params::syevjInfo_t,
-                                               batchSize::Cint)::cusolverStatus_t
+                                               info::CuPtr{Cint})::cusolverStatus_t
+end
+
+@checked function cusolverDnSsyevdx_bufferSize(handle, jobz, range, uplo, n, A, lda, vl, vu,
+                                               il, iu, meig, W, lwork)
+    initialize_context()
+    @gcsafe_ccall libcusolver.cusolverDnSsyevdx_bufferSize(handle::cusolverDnHandle_t,
+                                                           jobz::cusolverEigMode_t,
+                                                           range::cusolverEigRange_t,
+                                                           uplo::cublasFillMode_t, n::Cint,
+                                                           A::CuPtr{Cfloat}, lda::Cint,
+                                                           vl::Cfloat, vu::Cfloat, il::Cint,
+                                                           iu::Cint, meig::Ptr{Cint},
+                                                           W::CuPtr{Cfloat},
+                                                           lwork::Ptr{Cint})::cusolverStatus_t
+end
+
+@checked function cusolverDnDsyevdx_bufferSize(handle, jobz, range, uplo, n, A, lda, vl, vu,
+                                               il, iu, meig, W, lwork)
+    initialize_context()
+    @gcsafe_ccall libcusolver.cusolverDnDsyevdx_bufferSize(handle::cusolverDnHandle_t,
+                                                           jobz::cusolverEigMode_t,
+                                                           range::cusolverEigRange_t,
+                                                           uplo::cublasFillMode_t, n::Cint,
+                                                           A::CuPtr{Cdouble}, lda::Cint,
+                                                           vl::Cdouble, vu::Cdouble,
+                                                           il::Cint, iu::Cint,
+                                                           meig::Ptr{Cint},
+                                                           W::CuPtr{Cdouble},
+                                                           lwork::Ptr{Cint})::cusolverStatus_t
+end
+
+@checked function cusolverDnCheevdx_bufferSize(handle, jobz, range, uplo, n, A, lda, vl, vu,
+                                               il, iu, meig, W, lwork)
+    initialize_context()
+    @gcsafe_ccall libcusolver.cusolverDnCheevdx_bufferSize(handle::cusolverDnHandle_t,
+                                                           jobz::cusolverEigMode_t,
+                                                           range::cusolverEigRange_t,
+                                                           uplo::cublasFillMode_t, n::Cint,
+                                                           A::CuPtr{cuComplex}, lda::Cint,
+                                                           vl::Cfloat, vu::Cfloat, il::Cint,
+                                                           iu::Cint, meig::Ptr{Cint},
+                                                           W::CuPtr{Cfloat},
+                                                           lwork::Ptr{Cint})::cusolverStatus_t
+end
+
+@checked function cusolverDnZheevdx_bufferSize(handle, jobz, range, uplo, n, A, lda, vl, vu,
+                                               il, iu, meig, W, lwork)
+    initialize_context()
+    @gcsafe_ccall libcusolver.cusolverDnZheevdx_bufferSize(handle::cusolverDnHandle_t,
+                                                           jobz::cusolverEigMode_t,
+                                                           range::cusolverEigRange_t,
+                                                           uplo::cublasFillMode_t, n::Cint,
+                                                           A::CuPtr{cuDoubleComplex},
+                                                           lda::Cint, vl::Cdouble,
+                                                           vu::Cdouble, il::Cint, iu::Cint,
+                                                           meig::Ptr{Cint},
+                                                           W::CuPtr{Cdouble},
+                                                           lwork::Ptr{Cint})::cusolverStatus_t
+end
+
+@checked function cusolverDnSsyevdx(handle, jobz, range, uplo, n, A, lda, vl, vu, il, iu,
+                                    meig, W, work, lwork, info)
+    initialize_context()
+    @gcsafe_ccall libcusolver.cusolverDnSsyevdx(handle::cusolverDnHandle_t,
+                                                jobz::cusolverEigMode_t,
+                                                range::cusolverEigRange_t,
+                                                uplo::cublasFillMode_t, n::Cint,
+                                                A::CuPtr{Cfloat}, lda::Cint, vl::Cfloat,
+                                                vu::Cfloat, il::Cint, iu::Cint,
+                                                meig::Ptr{Cint}, W::CuPtr{Cfloat},
+                                                work::CuPtr{Cfloat}, lwork::Cint,
+                                                info::CuPtr{Cint})::cusolverStatus_t
+end
+
+@checked function cusolverDnDsyevdx(handle, jobz, range, uplo, n, A, lda, vl, vu, il, iu,
+                                    meig, W, work, lwork, info)
+    initialize_context()
+    @gcsafe_ccall libcusolver.cusolverDnDsyevdx(handle::cusolverDnHandle_t,
+                                                jobz::cusolverEigMode_t,
+                                                range::cusolverEigRange_t,
+                                                uplo::cublasFillMode_t, n::Cint,
+                                                A::CuPtr{Cdouble}, lda::Cint, vl::Cdouble,
+                                                vu::Cdouble, il::Cint, iu::Cint,
+                                                meig::Ptr{Cint}, W::CuPtr{Cdouble},
+                                                work::CuPtr{Cdouble}, lwork::Cint,
+                                                info::CuPtr{Cint})::cusolverStatus_t
+end
+
+@checked function cusolverDnCheevdx(handle, jobz, range, uplo, n, A, lda, vl, vu, il, iu,
+                                    meig, W, work, lwork, info)
+    initialize_context()
+    @gcsafe_ccall libcusolver.cusolverDnCheevdx(handle::cusolverDnHandle_t,
+                                                jobz::cusolverEigMode_t,
+                                                range::cusolverEigRange_t,
+                                                uplo::cublasFillMode_t, n::Cint,
+                                                A::CuPtr{cuComplex}, lda::Cint, vl::Cfloat,
+                                                vu::Cfloat, il::Cint, iu::Cint,
+                                                meig::Ptr{Cint}, W::CuPtr{Cfloat},
+                                                work::CuPtr{cuComplex}, lwork::Cint,
+                                                info::CuPtr{Cint})::cusolverStatus_t
+end
+
+@checked function cusolverDnZheevdx(handle, jobz, range, uplo, n, A, lda, vl, vu, il, iu,
+                                    meig, W, work, lwork, info)
+    initialize_context()
+    @gcsafe_ccall libcusolver.cusolverDnZheevdx(handle::cusolverDnHandle_t,
+                                                jobz::cusolverEigMode_t,
+                                                range::cusolverEigRange_t,
+                                                uplo::cublasFillMode_t, n::Cint,
+                                                A::CuPtr{cuDoubleComplex}, lda::Cint,
+                                                vl::Cdouble, vu::Cdouble, il::Cint,
+                                                iu::Cint, meig::Ptr{Cint},
+                                                W::CuPtr{Cdouble},
+                                                work::CuPtr{cuDoubleComplex}, lwork::Cint,
+                                                info::CuPtr{Cint})::cusolverStatus_t
+end
+
+@checked function cusolverDnSsygvdx_bufferSize(handle, itype, jobz, range, uplo, n, A, lda,
+                                               B, ldb, vl, vu, il, iu, meig, W, lwork)
+    initialize_context()
+    @gcsafe_ccall libcusolver.cusolverDnSsygvdx_bufferSize(handle::cusolverDnHandle_t,
+                                                           itype::cusolverEigType_t,
+                                                           jobz::cusolverEigMode_t,
+                                                           range::cusolverEigRange_t,
+                                                           uplo::cublasFillMode_t, n::Cint,
+                                                           A::CuPtr{Cfloat}, lda::Cint,
+                                                           B::CuPtr{Cfloat}, ldb::Cint,
+                                                           vl::Cfloat, vu::Cfloat, il::Cint,
+                                                           iu::Cint, meig::Ptr{Cint},
+                                                           W::CuPtr{Cfloat},
+                                                           lwork::Ptr{Cint})::cusolverStatus_t
+end
+
+@checked function cusolverDnDsygvdx_bufferSize(handle, itype, jobz, range, uplo, n, A, lda,
+                                               B, ldb, vl, vu, il, iu, meig, W, lwork)
+    initialize_context()
+    @gcsafe_ccall libcusolver.cusolverDnDsygvdx_bufferSize(handle::cusolverDnHandle_t,
+                                                           itype::cusolverEigType_t,
+                                                           jobz::cusolverEigMode_t,
+                                                           range::cusolverEigRange_t,
+                                                           uplo::cublasFillMode_t, n::Cint,
+                                                           A::CuPtr{Cdouble}, lda::Cint,
+                                                           B::CuPtr{Cdouble}, ldb::Cint,
+                                                           vl::Cdouble, vu::Cdouble,
+                                                           il::Cint, iu::Cint,
+                                                           meig::Ptr{Cint},
+                                                           W::CuPtr{Cdouble},
+                                                           lwork::Ptr{Cint})::cusolverStatus_t
+end
+
+@checked function cusolverDnChegvdx_bufferSize(handle, itype, jobz, range, uplo, n, A, lda,
+                                               B, ldb, vl, vu, il, iu, meig, W, lwork)
+    initialize_context()
+    @gcsafe_ccall libcusolver.cusolverDnChegvdx_bufferSize(handle::cusolverDnHandle_t,
+                                                           itype::cusolverEigType_t,
+                                                           jobz::cusolverEigMode_t,
+                                                           range::cusolverEigRange_t,
+                                                           uplo::cublasFillMode_t, n::Cint,
+                                                           A::CuPtr{cuComplex}, lda::Cint,
+                                                           B::CuPtr{cuComplex}, ldb::Cint,
+                                                           vl::Cfloat, vu::Cfloat, il::Cint,
+                                                           iu::Cint, meig::Ptr{Cint},
+                                                           W::CuPtr{Cfloat},
+                                                           lwork::Ptr{Cint})::cusolverStatus_t
+end
+
+@checked function cusolverDnZhegvdx_bufferSize(handle, itype, jobz, range, uplo, n, A, lda,
+                                               B, ldb, vl, vu, il, iu, meig, W, lwork)
+    initialize_context()
+    @gcsafe_ccall libcusolver.cusolverDnZhegvdx_bufferSize(handle::cusolverDnHandle_t,
+                                                           itype::cusolverEigType_t,
+                                                           jobz::cusolverEigMode_t,
+                                                           range::cusolverEigRange_t,
+                                                           uplo::cublasFillMode_t, n::Cint,
+                                                           A::CuPtr{cuDoubleComplex},
+                                                           lda::Cint,
+                                                           B::CuPtr{cuDoubleComplex},
+                                                           ldb::Cint, vl::Cdouble,
+                                                           vu::Cdouble, il::Cint, iu::Cint,
+                                                           meig::Ptr{Cint},
+                                                           W::CuPtr{Cdouble},
+                                                           lwork::Ptr{Cint})::cusolverStatus_t
+end
+
+@checked function cusolverDnSsygvdx(handle, itype, jobz, range, uplo, n, A, lda, B, ldb, vl,
+                                    vu, il, iu, meig, W, work, lwork, info)
+    initialize_context()
+    @gcsafe_ccall libcusolver.cusolverDnSsygvdx(handle::cusolverDnHandle_t,
+                                                itype::cusolverEigType_t,
+                                                jobz::cusolverEigMode_t,
+                                                range::cusolverEigRange_t,
+                                                uplo::cublasFillMode_t, n::Cint,
+                                                A::CuPtr{Cfloat}, lda::Cint,
+                                                B::CuPtr{Cfloat}, ldb::Cint, vl::Cfloat,
+                                                vu::Cfloat, il::Cint, iu::Cint,
+                                                meig::Ptr{Cint}, W::CuPtr{Cfloat},
+                                                work::CuPtr{Cfloat}, lwork::Cint,
+                                                info::CuPtr{Cint})::cusolverStatus_t
+end
+
+@checked function cusolverDnDsygvdx(handle, itype, jobz, range, uplo, n, A, lda, B, ldb, vl,
+                                    vu, il, iu, meig, W, work, lwork, info)
+    initialize_context()
+    @gcsafe_ccall libcusolver.cusolverDnDsygvdx(handle::cusolverDnHandle_t,
+                                                itype::cusolverEigType_t,
+                                                jobz::cusolverEigMode_t,
+                                                range::cusolverEigRange_t,
+                                                uplo::cublasFillMode_t, n::Cint,
+                                                A::CuPtr{Cdouble}, lda::Cint,
+                                                B::CuPtr{Cdouble}, ldb::Cint, vl::Cdouble,
+                                                vu::Cdouble, il::Cint, iu::Cint,
+                                                meig::Ptr{Cint}, W::CuPtr{Cdouble},
+                                                work::CuPtr{Cdouble}, lwork::Cint,
+                                                info::CuPtr{Cint})::cusolverStatus_t
+end
+
+@checked function cusolverDnChegvdx(handle, itype, jobz, range, uplo, n, A, lda, B, ldb, vl,
+                                    vu, il, iu, meig, W, work, lwork, info)
+    initialize_context()
+    @gcsafe_ccall libcusolver.cusolverDnChegvdx(handle::cusolverDnHandle_t,
+                                                itype::cusolverEigType_t,
+                                                jobz::cusolverEigMode_t,
+                                                range::cusolverEigRange_t,
+                                                uplo::cublasFillMode_t, n::Cint,
+                                                A::CuPtr{cuComplex}, lda::Cint,
+                                                B::CuPtr{cuComplex}, ldb::Cint, vl::Cfloat,
+                                                vu::Cfloat, il::Cint, iu::Cint,
+                                                meig::Ptr{Cint}, W::CuPtr{Cfloat},
+                                                work::CuPtr{cuComplex}, lwork::Cint,
+                                                info::CuPtr{Cint})::cusolverStatus_t
+end
+
+@checked function cusolverDnZhegvdx(handle, itype, jobz, range, uplo, n, A, lda, B, ldb, vl,
+                                    vu, il, iu, meig, W, work, lwork, info)
+    initialize_context()
+    @gcsafe_ccall libcusolver.cusolverDnZhegvdx(handle::cusolverDnHandle_t,
+                                                itype::cusolverEigType_t,
+                                                jobz::cusolverEigMode_t,
+                                                range::cusolverEigRange_t,
+                                                uplo::cublasFillMode_t, n::Cint,
+                                                A::CuPtr{cuDoubleComplex}, lda::Cint,
+                                                B::CuPtr{cuDoubleComplex}, ldb::Cint,
+                                                vl::Cdouble, vu::Cdouble, il::Cint,
+                                                iu::Cint, meig::Ptr{Cint},
+                                                W::CuPtr{Cdouble},
+                                                work::CuPtr{cuDoubleComplex}, lwork::Cint,
+                                                info::CuPtr{Cint})::cusolverStatus_t
+end
+
+@checked function cusolverDnSsygvd_bufferSize(handle, itype, jobz, uplo, n, A, lda, B, ldb,
+                                              W, lwork)
+    initialize_context()
+    @gcsafe_ccall libcusolver.cusolverDnSsygvd_bufferSize(handle::cusolverDnHandle_t,
+                                                          itype::cusolverEigType_t,
+                                                          jobz::cusolverEigMode_t,
+                                                          uplo::cublasFillMode_t, n::Cint,
+                                                          A::CuPtr{Cfloat}, lda::Cint,
+                                                          B::CuPtr{Cfloat}, ldb::Cint,
+                                                          W::CuPtr{Cfloat},
+                                                          lwork::Ptr{Cint})::cusolverStatus_t
+end
+
+@checked function cusolverDnDsygvd_bufferSize(handle, itype, jobz, uplo, n, A, lda, B, ldb,
+                                              W, lwork)
+    initialize_context()
+    @gcsafe_ccall libcusolver.cusolverDnDsygvd_bufferSize(handle::cusolverDnHandle_t,
+                                                          itype::cusolverEigType_t,
+                                                          jobz::cusolverEigMode_t,
+                                                          uplo::cublasFillMode_t, n::Cint,
+                                                          A::CuPtr{Cdouble}, lda::Cint,
+                                                          B::CuPtr{Cdouble}, ldb::Cint,
+                                                          W::CuPtr{Cdouble},
+                                                          lwork::Ptr{Cint})::cusolverStatus_t
+end
+
+@checked function cusolverDnChegvd_bufferSize(handle, itype, jobz, uplo, n, A, lda, B, ldb,
+                                              W, lwork)
+    initialize_context()
+    @gcsafe_ccall libcusolver.cusolverDnChegvd_bufferSize(handle::cusolverDnHandle_t,
+                                                          itype::cusolverEigType_t,
+                                                          jobz::cusolverEigMode_t,
+                                                          uplo::cublasFillMode_t, n::Cint,
+                                                          A::CuPtr{cuComplex}, lda::Cint,
+                                                          B::CuPtr{cuComplex}, ldb::Cint,
+                                                          W::CuPtr{Cfloat},
+                                                          lwork::Ptr{Cint})::cusolverStatus_t
+end
+
+@checked function cusolverDnZhegvd_bufferSize(handle, itype, jobz, uplo, n, A, lda, B, ldb,
+                                              W, lwork)
+    initialize_context()
+    @gcsafe_ccall libcusolver.cusolverDnZhegvd_bufferSize(handle::cusolverDnHandle_t,
+                                                          itype::cusolverEigType_t,
+                                                          jobz::cusolverEigMode_t,
+                                                          uplo::cublasFillMode_t, n::Cint,
+                                                          A::CuPtr{cuDoubleComplex},
+                                                          lda::Cint,
+                                                          B::CuPtr{cuDoubleComplex},
+                                                          ldb::Cint, W::CuPtr{Cdouble},
+                                                          lwork::Ptr{Cint})::cusolverStatus_t
+end
+
+@checked function cusolverDnSsygvd(handle, itype, jobz, uplo, n, A, lda, B, ldb, W, work,
+                                   lwork, info)
+    initialize_context()
+    @gcsafe_ccall libcusolver.cusolverDnSsygvd(handle::cusolverDnHandle_t,
+                                               itype::cusolverEigType_t,
+                                               jobz::cusolverEigMode_t,
+                                               uplo::cublasFillMode_t, n::Cint,
+                                               A::CuPtr{Cfloat}, lda::Cint,
+                                               B::CuPtr{Cfloat}, ldb::Cint,
+                                               W::CuPtr{Cfloat}, work::CuPtr{Cfloat},
+                                               lwork::Cint,
+                                               info::CuPtr{Cint})::cusolverStatus_t
+end
+
+@checked function cusolverDnDsygvd(handle, itype, jobz, uplo, n, A, lda, B, ldb, W, work,
+                                   lwork, info)
+    initialize_context()
+    @gcsafe_ccall libcusolver.cusolverDnDsygvd(handle::cusolverDnHandle_t,
+                                               itype::cusolverEigType_t,
+                                               jobz::cusolverEigMode_t,
+                                               uplo::cublasFillMode_t, n::Cint,
+                                               A::CuPtr{Cdouble}, lda::Cint,
+                                               B::CuPtr{Cdouble}, ldb::Cint,
+                                               W::CuPtr{Cdouble}, work::CuPtr{Cdouble},
+                                               lwork::Cint,
+                                               info::CuPtr{Cint})::cusolverStatus_t
+end
+
+@checked function cusolverDnChegvd(handle, itype, jobz, uplo, n, A, lda, B, ldb, W, work,
+                                   lwork, info)
+    initialize_context()
+    @gcsafe_ccall libcusolver.cusolverDnChegvd(handle::cusolverDnHandle_t,
+                                               itype::cusolverEigType_t,
+                                               jobz::cusolverEigMode_t,
+                                               uplo::cublasFillMode_t, n::Cint,
+                                               A::CuPtr{cuComplex}, lda::Cint,
+                                               B::CuPtr{cuComplex}, ldb::Cint,
+                                               W::CuPtr{Cfloat}, work::CuPtr{cuComplex},
+                                               lwork::Cint,
+                                               info::CuPtr{Cint})::cusolverStatus_t
+end
+
+@checked function cusolverDnZhegvd(handle, itype, jobz, uplo, n, A, lda, B, ldb, W, work,
+                                   lwork, info)
+    initialize_context()
+    @gcsafe_ccall libcusolver.cusolverDnZhegvd(handle::cusolverDnHandle_t,
+                                               itype::cusolverEigType_t,
+                                               jobz::cusolverEigMode_t,
+                                               uplo::cublasFillMode_t, n::Cint,
+                                               A::CuPtr{cuDoubleComplex}, lda::Cint,
+                                               B::CuPtr{cuDoubleComplex}, ldb::Cint,
+                                               W::CuPtr{Cdouble},
+                                               work::CuPtr{cuDoubleComplex}, lwork::Cint,
+                                               info::CuPtr{Cint})::cusolverStatus_t
+end
+
+@checked function cusolverDnCreateSyevjInfo(info)
+    initialize_context()
+    @gcsafe_ccall libcusolver.cusolverDnCreateSyevjInfo(info::Ptr{syevjInfo_t})::cusolverStatus_t
+end
+
+@checked function cusolverDnDestroySyevjInfo(info)
+    initialize_context()
+    @gcsafe_ccall libcusolver.cusolverDnDestroySyevjInfo(info::syevjInfo_t)::cusolverStatus_t
+end
+
+@checked function cusolverDnXsyevjSetTolerance(info, tolerance)
+    initialize_context()
+    @gcsafe_ccall libcusolver.cusolverDnXsyevjSetTolerance(info::syevjInfo_t,
+                                                           tolerance::Cdouble)::cusolverStatus_t
+end
+
+@checked function cusolverDnXsyevjSetMaxSweeps(info, max_sweeps)
+    initialize_context()
+    @gcsafe_ccall libcusolver.cusolverDnXsyevjSetMaxSweeps(info::syevjInfo_t,
+                                                           max_sweeps::Cint)::cusolverStatus_t
+end
+
+@checked function cusolverDnXsyevjSetSortEig(info, sort_eig)
+    initialize_context()
+    @gcsafe_ccall libcusolver.cusolverDnXsyevjSetSortEig(info::syevjInfo_t,
+                                                         sort_eig::Cint)::cusolverStatus_t
+end
+
+@checked function cusolverDnXsyevjGetResidual(handle, info, residual)
+    initialize_context()
+    @gcsafe_ccall libcusolver.cusolverDnXsyevjGetResidual(handle::cusolverDnHandle_t,
+                                                          info::syevjInfo_t,
+                                                          residual::Ptr{Cdouble})::cusolverStatus_t
+end
+
+@checked function cusolverDnXsyevjGetSweeps(handle, info, executed_sweeps)
+    initialize_context()
+    @gcsafe_ccall libcusolver.cusolverDnXsyevjGetSweeps(handle::cusolverDnHandle_t,
+                                                        info::syevjInfo_t,
+                                                        executed_sweeps::Ptr{Cint})::cusolverStatus_t
+end
+
+@checked function cusolverDnSsyevjBatched_bufferSize(handle, jobz, uplo, n, A, lda, W,
+                                                     lwork, params, batchSize)
+    initialize_context()
+    @gcsafe_ccall libcusolver.cusolverDnSsyevjBatched_bufferSize(handle::cusolverDnHandle_t,
+                                                                 jobz::cusolverEigMode_t,
+                                                                 uplo::cublasFillMode_t,
+                                                                 n::Cint, A::CuPtr{Cfloat},
+                                                                 lda::Cint,
+                                                                 W::CuPtr{Cfloat},
+                                                                 lwork::Ptr{Cint},
+                                                                 params::syevjInfo_t,
+                                                                 batchSize::Cint)::cusolverStatus_t
+end
+
+@checked function cusolverDnDsyevjBatched_bufferSize(handle, jobz, uplo, n, A, lda, W,
+                                                     lwork, params, batchSize)
+    initialize_context()
+    @gcsafe_ccall libcusolver.cusolverDnDsyevjBatched_bufferSize(handle::cusolverDnHandle_t,
+                                                                 jobz::cusolverEigMode_t,
+                                                                 uplo::cublasFillMode_t,
+                                                                 n::Cint, A::CuPtr{Cdouble},
+                                                                 lda::Cint,
+                                                                 W::CuPtr{Cdouble},
+                                                                 lwork::Ptr{Cint},
+                                                                 params::syevjInfo_t,
+                                                                 batchSize::Cint)::cusolverStatus_t
+end
+
+@checked function cusolverDnCheevjBatched_bufferSize(handle, jobz, uplo, n, A, lda, W,
+                                                     lwork, params, batchSize)
+    initialize_context()
+    @gcsafe_ccall libcusolver.cusolverDnCheevjBatched_bufferSize(handle::cusolverDnHandle_t,
+                                                                 jobz::cusolverEigMode_t,
+                                                                 uplo::cublasFillMode_t,
+                                                                 n::Cint,
+                                                                 A::CuPtr{cuComplex},
+                                                                 lda::Cint,
+                                                                 W::CuPtr{Cfloat},
+                                                                 lwork::Ptr{Cint},
+                                                                 params::syevjInfo_t,
+                                                                 batchSize::Cint)::cusolverStatus_t
+end
+
+@checked function cusolverDnZheevjBatched_bufferSize(handle, jobz, uplo, n, A, lda, W,
+                                                     lwork, params, batchSize)
+    initialize_context()
+    @gcsafe_ccall libcusolver.cusolverDnZheevjBatched_bufferSize(handle::cusolverDnHandle_t,
+                                                                 jobz::cusolverEigMode_t,
+                                                                 uplo::cublasFillMode_t,
+                                                                 n::Cint,
+                                                                 A::CuPtr{cuDoubleComplex},
+                                                                 lda::Cint,
+                                                                 W::CuPtr{Cdouble},
+                                                                 lwork::Ptr{Cint},
+                                                                 params::syevjInfo_t,
+                                                                 batchSize::Cint)::cusolverStatus_t
+end
+
+@checked function cusolverDnSsyevjBatched(handle, jobz, uplo, n, A, lda, W, work, lwork,
+                                          info, params, batchSize)
+    initialize_context()
+    @gcsafe_ccall libcusolver.cusolverDnSsyevjBatched(handle::cusolverDnHandle_t,
+                                                      jobz::cusolverEigMode_t,
+                                                      uplo::cublasFillMode_t, n::Cint,
+                                                      A::CuPtr{Cfloat}, lda::Cint,
+                                                      W::CuPtr{Cfloat}, work::CuPtr{Cfloat},
+                                                      lwork::Cint, info::CuPtr{Cint},
+                                                      params::syevjInfo_t,
+                                                      batchSize::Cint)::cusolverStatus_t
+end
+
+@checked function cusolverDnDsyevjBatched(handle, jobz, uplo, n, A, lda, W, work, lwork,
+                                          info, params, batchSize)
+    initialize_context()
+    @gcsafe_ccall libcusolver.cusolverDnDsyevjBatched(handle::cusolverDnHandle_t,
+                                                      jobz::cusolverEigMode_t,
+                                                      uplo::cublasFillMode_t, n::Cint,
+                                                      A::CuPtr{Cdouble}, lda::Cint,
+                                                      W::CuPtr{Cdouble},
+                                                      work::CuPtr{Cdouble}, lwork::Cint,
+                                                      info::CuPtr{Cint},
+                                                      params::syevjInfo_t,
+                                                      batchSize::Cint)::cusolverStatus_t
+end
+
+@checked function cusolverDnCheevjBatched(handle, jobz, uplo, n, A, lda, W, work, lwork,
+                                          info, params, batchSize)
+    initialize_context()
+    @gcsafe_ccall libcusolver.cusolverDnCheevjBatched(handle::cusolverDnHandle_t,
+                                                      jobz::cusolverEigMode_t,
+                                                      uplo::cublasFillMode_t, n::Cint,
+                                                      A::CuPtr{cuComplex}, lda::Cint,
+                                                      W::CuPtr{Cfloat},
+                                                      work::CuPtr{cuComplex}, lwork::Cint,
+                                                      info::CuPtr{Cint},
+                                                      params::syevjInfo_t,
+                                                      batchSize::Cint)::cusolverStatus_t
+end
+
+@checked function cusolverDnZheevjBatched(handle, jobz, uplo, n, A, lda, W, work, lwork,
+                                          info, params, batchSize)
+    initialize_context()
+    @gcsafe_ccall libcusolver.cusolverDnZheevjBatched(handle::cusolverDnHandle_t,
+                                                      jobz::cusolverEigMode_t,
+                                                      uplo::cublasFillMode_t, n::Cint,
+                                                      A::CuPtr{cuDoubleComplex}, lda::Cint,
+                                                      W::CuPtr{Cdouble},
+                                                      work::CuPtr{cuDoubleComplex},
+                                                      lwork::Cint, info::CuPtr{Cint},
+                                                      params::syevjInfo_t,
+                                                      batchSize::Cint)::cusolverStatus_t
 end
 
 @checked function cusolverDnSsyevj_bufferSize(handle, jobz, uplo, n, A, lda, W, lwork,
                                               params)
     initialize_context()
-    @ccall libcusolver.cusolverDnSsyevj_bufferSize(handle::cusolverDnHandle_t,
-                                                   jobz::cusolverEigMode_t,
-                                                   uplo::cublasFillMode_t, n::Cint,
-                                                   A::CuPtr{Cfloat}, lda::Cint,
-                                                   W::CuPtr{Cfloat}, lwork::Ptr{Cint},
-                                                   params::syevjInfo_t)::cusolverStatus_t
+    @gcsafe_ccall libcusolver.cusolverDnSsyevj_bufferSize(handle::cusolverDnHandle_t,
+                                                          jobz::cusolverEigMode_t,
+                                                          uplo::cublasFillMode_t, n::Cint,
+                                                          A::CuPtr{Cfloat}, lda::Cint,
+                                                          W::CuPtr{Cfloat},
+                                                          lwork::Ptr{Cint},
+                                                          params::syevjInfo_t)::cusolverStatus_t
 end
 
 @checked function cusolverDnDsyevj_bufferSize(handle, jobz, uplo, n, A, lda, W, lwork,
                                               params)
     initialize_context()
-    @ccall libcusolver.cusolverDnDsyevj_bufferSize(handle::cusolverDnHandle_t,
-                                                   jobz::cusolverEigMode_t,
-                                                   uplo::cublasFillMode_t, n::Cint,
-                                                   A::CuPtr{Cdouble}, lda::Cint,
-                                                   W::CuPtr{Cdouble}, lwork::Ptr{Cint},
-                                                   params::syevjInfo_t)::cusolverStatus_t
+    @gcsafe_ccall libcusolver.cusolverDnDsyevj_bufferSize(handle::cusolverDnHandle_t,
+                                                          jobz::cusolverEigMode_t,
+                                                          uplo::cublasFillMode_t, n::Cint,
+                                                          A::CuPtr{Cdouble}, lda::Cint,
+                                                          W::CuPtr{Cdouble},
+                                                          lwork::Ptr{Cint},
+                                                          params::syevjInfo_t)::cusolverStatus_t
 end
 
 @checked function cusolverDnCheevj_bufferSize(handle, jobz, uplo, n, A, lda, W, lwork,
                                               params)
     initialize_context()
-    @ccall libcusolver.cusolverDnCheevj_bufferSize(handle::cusolverDnHandle_t,
-                                                   jobz::cusolverEigMode_t,
-                                                   uplo::cublasFillMode_t, n::Cint,
-                                                   A::CuPtr{cuComplex}, lda::Cint,
-                                                   W::CuPtr{Cfloat}, lwork::Ptr{Cint},
-                                                   params::syevjInfo_t)::cusolverStatus_t
+    @gcsafe_ccall libcusolver.cusolverDnCheevj_bufferSize(handle::cusolverDnHandle_t,
+                                                          jobz::cusolverEigMode_t,
+                                                          uplo::cublasFillMode_t, n::Cint,
+                                                          A::CuPtr{cuComplex}, lda::Cint,
+                                                          W::CuPtr{Cfloat},
+                                                          lwork::Ptr{Cint},
+                                                          params::syevjInfo_t)::cusolverStatus_t
 end
 
 @checked function cusolverDnZheevj_bufferSize(handle, jobz, uplo, n, A, lda, W, lwork,
                                               params)
     initialize_context()
-    @ccall libcusolver.cusolverDnZheevj_bufferSize(handle::cusolverDnHandle_t,
-                                                   jobz::cusolverEigMode_t,
-                                                   uplo::cublasFillMode_t, n::Cint,
-                                                   A::CuPtr{cuDoubleComplex}, lda::Cint,
-                                                   W::CuPtr{Cdouble}, lwork::Ptr{Cint},
-                                                   params::syevjInfo_t)::cusolverStatus_t
+    @gcsafe_ccall libcusolver.cusolverDnZheevj_bufferSize(handle::cusolverDnHandle_t,
+                                                          jobz::cusolverEigMode_t,
+                                                          uplo::cublasFillMode_t, n::Cint,
+                                                          A::CuPtr{cuDoubleComplex},
+                                                          lda::Cint, W::CuPtr{Cdouble},
+                                                          lwork::Ptr{Cint},
+                                                          params::syevjInfo_t)::cusolverStatus_t
 end
 
 @checked function cusolverDnSsyevj(handle, jobz, uplo, n, A, lda, W, work, lwork, info,
                                    params)
     initialize_context()
-    @ccall libcusolver.cusolverDnSsyevj(handle::cusolverDnHandle_t, jobz::cusolverEigMode_t,
-                                        uplo::cublasFillMode_t, n::Cint, A::CuPtr{Cfloat},
-                                        lda::Cint, W::CuPtr{Cfloat}, work::CuPtr{Cfloat},
-                                        lwork::Cint, info::CuPtr{Cint},
-                                        params::syevjInfo_t)::cusolverStatus_t
+    @gcsafe_ccall libcusolver.cusolverDnSsyevj(handle::cusolverDnHandle_t,
+                                               jobz::cusolverEigMode_t,
+                                               uplo::cublasFillMode_t, n::Cint,
+                                               A::CuPtr{Cfloat}, lda::Cint,
+                                               W::CuPtr{Cfloat}, work::CuPtr{Cfloat},
+                                               lwork::Cint, info::CuPtr{Cint},
+                                               params::syevjInfo_t)::cusolverStatus_t
 end
 
 @checked function cusolverDnDsyevj(handle, jobz, uplo, n, A, lda, W, work, lwork, info,
                                    params)
     initialize_context()
-    @ccall libcusolver.cusolverDnDsyevj(handle::cusolverDnHandle_t, jobz::cusolverEigMode_t,
-                                        uplo::cublasFillMode_t, n::Cint, A::CuPtr{Cdouble},
-                                        lda::Cint, W::CuPtr{Cdouble}, work::CuPtr{Cdouble},
-                                        lwork::Cint, info::CuPtr{Cint},
-                                        params::syevjInfo_t)::cusolverStatus_t
+    @gcsafe_ccall libcusolver.cusolverDnDsyevj(handle::cusolverDnHandle_t,
+                                               jobz::cusolverEigMode_t,
+                                               uplo::cublasFillMode_t, n::Cint,
+                                               A::CuPtr{Cdouble}, lda::Cint,
+                                               W::CuPtr{Cdouble}, work::CuPtr{Cdouble},
+                                               lwork::Cint, info::CuPtr{Cint},
+                                               params::syevjInfo_t)::cusolverStatus_t
 end
 
 @checked function cusolverDnCheevj(handle, jobz, uplo, n, A, lda, W, work, lwork, info,
                                    params)
     initialize_context()
-    @ccall libcusolver.cusolverDnCheevj(handle::cusolverDnHandle_t, jobz::cusolverEigMode_t,
-                                        uplo::cublasFillMode_t, n::Cint,
-                                        A::CuPtr{cuComplex}, lda::Cint, W::CuPtr{Cfloat},
-                                        work::CuPtr{cuComplex}, lwork::Cint,
-                                        info::CuPtr{Cint},
-                                        params::syevjInfo_t)::cusolverStatus_t
+    @gcsafe_ccall libcusolver.cusolverDnCheevj(handle::cusolverDnHandle_t,
+                                               jobz::cusolverEigMode_t,
+                                               uplo::cublasFillMode_t, n::Cint,
+                                               A::CuPtr{cuComplex}, lda::Cint,
+                                               W::CuPtr{Cfloat}, work::CuPtr{cuComplex},
+                                               lwork::Cint, info::CuPtr{Cint},
+                                               params::syevjInfo_t)::cusolverStatus_t
 end
 
 @checked function cusolverDnZheevj(handle, jobz, uplo, n, A, lda, W, work, lwork, info,
                                    params)
     initialize_context()
-    @ccall libcusolver.cusolverDnZheevj(handle::cusolverDnHandle_t, jobz::cusolverEigMode_t,
-                                        uplo::cublasFillMode_t, n::Cint,
-                                        A::CuPtr{cuDoubleComplex}, lda::Cint,
-                                        W::CuPtr{Cdouble}, work::CuPtr{cuDoubleComplex},
-                                        lwork::Cint, info::CuPtr{Cint},
-                                        params::syevjInfo_t)::cusolverStatus_t
+    @gcsafe_ccall libcusolver.cusolverDnZheevj(handle::cusolverDnHandle_t,
+                                               jobz::cusolverEigMode_t,
+                                               uplo::cublasFillMode_t, n::Cint,
+                                               A::CuPtr{cuDoubleComplex}, lda::Cint,
+                                               W::CuPtr{Cdouble},
+                                               work::CuPtr{cuDoubleComplex}, lwork::Cint,
+                                               info::CuPtr{Cint},
+                                               params::syevjInfo_t)::cusolverStatus_t
 end
 
 @checked function cusolverDnSsygvj_bufferSize(handle, itype, jobz, uplo, n, A, lda, B, ldb,
                                               W, lwork, params)
     initialize_context()
-    @ccall libcusolver.cusolverDnSsygvj_bufferSize(handle::cusolverDnHandle_t,
-                                                   itype::cusolverEigType_t,
-                                                   jobz::cusolverEigMode_t,
-                                                   uplo::cublasFillMode_t, n::Cint,
-                                                   A::CuPtr{Cfloat}, lda::Cint,
-                                                   B::CuPtr{Cfloat}, ldb::Cint,
-                                                   W::CuPtr{Cfloat}, lwork::Ptr{Cint},
-                                                   params::syevjInfo_t)::cusolverStatus_t
+    @gcsafe_ccall libcusolver.cusolverDnSsygvj_bufferSize(handle::cusolverDnHandle_t,
+                                                          itype::cusolverEigType_t,
+                                                          jobz::cusolverEigMode_t,
+                                                          uplo::cublasFillMode_t, n::Cint,
+                                                          A::CuPtr{Cfloat}, lda::Cint,
+                                                          B::CuPtr{Cfloat}, ldb::Cint,
+                                                          W::CuPtr{Cfloat},
+                                                          lwork::Ptr{Cint},
+                                                          params::syevjInfo_t)::cusolverStatus_t
 end
 
 @checked function cusolverDnDsygvj_bufferSize(handle, itype, jobz, uplo, n, A, lda, B, ldb,
                                               W, lwork, params)
     initialize_context()
-    @ccall libcusolver.cusolverDnDsygvj_bufferSize(handle::cusolverDnHandle_t,
-                                                   itype::cusolverEigType_t,
-                                                   jobz::cusolverEigMode_t,
-                                                   uplo::cublasFillMode_t, n::Cint,
-                                                   A::CuPtr{Cdouble}, lda::Cint,
-                                                   B::CuPtr{Cdouble}, ldb::Cint,
-                                                   W::CuPtr{Cdouble}, lwork::Ptr{Cint},
-                                                   params::syevjInfo_t)::cusolverStatus_t
+    @gcsafe_ccall libcusolver.cusolverDnDsygvj_bufferSize(handle::cusolverDnHandle_t,
+                                                          itype::cusolverEigType_t,
+                                                          jobz::cusolverEigMode_t,
+                                                          uplo::cublasFillMode_t, n::Cint,
+                                                          A::CuPtr{Cdouble}, lda::Cint,
+                                                          B::CuPtr{Cdouble}, ldb::Cint,
+                                                          W::CuPtr{Cdouble},
+                                                          lwork::Ptr{Cint},
+                                                          params::syevjInfo_t)::cusolverStatus_t
 end
 
 @checked function cusolverDnChegvj_bufferSize(handle, itype, jobz, uplo, n, A, lda, B, ldb,
                                               W, lwork, params)
     initialize_context()
-    @ccall libcusolver.cusolverDnChegvj_bufferSize(handle::cusolverDnHandle_t,
-                                                   itype::cusolverEigType_t,
-                                                   jobz::cusolverEigMode_t,
-                                                   uplo::cublasFillMode_t, n::Cint,
-                                                   A::CuPtr{cuComplex}, lda::Cint,
-                                                   B::CuPtr{cuComplex}, ldb::Cint,
-                                                   W::CuPtr{Cfloat}, lwork::Ptr{Cint},
-                                                   params::syevjInfo_t)::cusolverStatus_t
+    @gcsafe_ccall libcusolver.cusolverDnChegvj_bufferSize(handle::cusolverDnHandle_t,
+                                                          itype::cusolverEigType_t,
+                                                          jobz::cusolverEigMode_t,
+                                                          uplo::cublasFillMode_t, n::Cint,
+                                                          A::CuPtr{cuComplex}, lda::Cint,
+                                                          B::CuPtr{cuComplex}, ldb::Cint,
+                                                          W::CuPtr{Cfloat},
+                                                          lwork::Ptr{Cint},
+                                                          params::syevjInfo_t)::cusolverStatus_t
 end
 
 @checked function cusolverDnZhegvj_bufferSize(handle, itype, jobz, uplo, n, A, lda, B, ldb,
                                               W, lwork, params)
     initialize_context()
-    @ccall libcusolver.cusolverDnZhegvj_bufferSize(handle::cusolverDnHandle_t,
-                                                   itype::cusolverEigType_t,
-                                                   jobz::cusolverEigMode_t,
-                                                   uplo::cublasFillMode_t, n::Cint,
-                                                   A::CuPtr{cuDoubleComplex}, lda::Cint,
-                                                   B::CuPtr{cuDoubleComplex}, ldb::Cint,
-                                                   W::CuPtr{Cdouble}, lwork::Ptr{Cint},
-                                                   params::syevjInfo_t)::cusolverStatus_t
+    @gcsafe_ccall libcusolver.cusolverDnZhegvj_bufferSize(handle::cusolverDnHandle_t,
+                                                          itype::cusolverEigType_t,
+                                                          jobz::cusolverEigMode_t,
+                                                          uplo::cublasFillMode_t, n::Cint,
+                                                          A::CuPtr{cuDoubleComplex},
+                                                          lda::Cint,
+                                                          B::CuPtr{cuDoubleComplex},
+                                                          ldb::Cint, W::CuPtr{Cdouble},
+                                                          lwork::Ptr{Cint},
+                                                          params::syevjInfo_t)::cusolverStatus_t
 end
 
 @checked function cusolverDnSsygvj(handle, itype, jobz, uplo, n, A, lda, B, ldb, W, work,
                                    lwork, info, params)
     initialize_context()
-    @ccall libcusolver.cusolverDnSsygvj(handle::cusolverDnHandle_t,
-                                        itype::cusolverEigType_t, jobz::cusolverEigMode_t,
-                                        uplo::cublasFillMode_t, n::Cint, A::CuPtr{Cfloat},
-                                        lda::Cint, B::CuPtr{Cfloat}, ldb::Cint,
-                                        W::CuPtr{Cfloat}, work::CuPtr{Cfloat}, lwork::Cint,
-                                        info::CuPtr{Cint},
-                                        params::syevjInfo_t)::cusolverStatus_t
+    @gcsafe_ccall libcusolver.cusolverDnSsygvj(handle::cusolverDnHandle_t,
+                                               itype::cusolverEigType_t,
+                                               jobz::cusolverEigMode_t,
+                                               uplo::cublasFillMode_t, n::Cint,
+                                               A::CuPtr{Cfloat}, lda::Cint,
+                                               B::CuPtr{Cfloat}, ldb::Cint,
+                                               W::CuPtr{Cfloat}, work::CuPtr{Cfloat},
+                                               lwork::Cint, info::CuPtr{Cint},
+                                               params::syevjInfo_t)::cusolverStatus_t
 end
 
 @checked function cusolverDnDsygvj(handle, itype, jobz, uplo, n, A, lda, B, ldb, W, work,
                                    lwork, info, params)
     initialize_context()
-    @ccall libcusolver.cusolverDnDsygvj(handle::cusolverDnHandle_t,
-                                        itype::cusolverEigType_t, jobz::cusolverEigMode_t,
-                                        uplo::cublasFillMode_t, n::Cint, A::CuPtr{Cdouble},
-                                        lda::Cint, B::CuPtr{Cdouble}, ldb::Cint,
-                                        W::CuPtr{Cdouble}, work::CuPtr{Cdouble},
-                                        lwork::Cint, info::CuPtr{Cint},
-                                        params::syevjInfo_t)::cusolverStatus_t
+    @gcsafe_ccall libcusolver.cusolverDnDsygvj(handle::cusolverDnHandle_t,
+                                               itype::cusolverEigType_t,
+                                               jobz::cusolverEigMode_t,
+                                               uplo::cublasFillMode_t, n::Cint,
+                                               A::CuPtr{Cdouble}, lda::Cint,
+                                               B::CuPtr{Cdouble}, ldb::Cint,
+                                               W::CuPtr{Cdouble}, work::CuPtr{Cdouble},
+                                               lwork::Cint, info::CuPtr{Cint},
+                                               params::syevjInfo_t)::cusolverStatus_t
 end
 
 @checked function cusolverDnChegvj(handle, itype, jobz, uplo, n, A, lda, B, ldb, W, work,
                                    lwork, info, params)
     initialize_context()
-    @ccall libcusolver.cusolverDnChegvj(handle::cusolverDnHandle_t,
-                                        itype::cusolverEigType_t, jobz::cusolverEigMode_t,
-                                        uplo::cublasFillMode_t, n::Cint,
-                                        A::CuPtr{cuComplex}, lda::Cint, B::CuPtr{cuComplex},
-                                        ldb::Cint, W::CuPtr{Cfloat}, work::CuPtr{cuComplex},
-                                        lwork::Cint, info::CuPtr{Cint},
-                                        params::syevjInfo_t)::cusolverStatus_t
+    @gcsafe_ccall libcusolver.cusolverDnChegvj(handle::cusolverDnHandle_t,
+                                               itype::cusolverEigType_t,
+                                               jobz::cusolverEigMode_t,
+                                               uplo::cublasFillMode_t, n::Cint,
+                                               A::CuPtr{cuComplex}, lda::Cint,
+                                               B::CuPtr{cuComplex}, ldb::Cint,
+                                               W::CuPtr{Cfloat}, work::CuPtr{cuComplex},
+                                               lwork::Cint, info::CuPtr{Cint},
+                                               params::syevjInfo_t)::cusolverStatus_t
 end
 
 @checked function cusolverDnZhegvj(handle, itype, jobz, uplo, n, A, lda, B, ldb, W, work,
                                    lwork, info, params)
     initialize_context()
-    @ccall libcusolver.cusolverDnZhegvj(handle::cusolverDnHandle_t,
-                                        itype::cusolverEigType_t, jobz::cusolverEigMode_t,
-                                        uplo::cublasFillMode_t, n::Cint,
-                                        A::CuPtr{cuDoubleComplex}, lda::Cint,
-                                        B::CuPtr{cuDoubleComplex}, ldb::Cint,
-                                        W::CuPtr{Cdouble}, work::CuPtr{cuDoubleComplex},
-                                        lwork::Cint, info::CuPtr{Cint},
-                                        params::syevjInfo_t)::cusolverStatus_t
+    @gcsafe_ccall libcusolver.cusolverDnZhegvj(handle::cusolverDnHandle_t,
+                                               itype::cusolverEigType_t,
+                                               jobz::cusolverEigMode_t,
+                                               uplo::cublasFillMode_t, n::Cint,
+                                               A::CuPtr{cuDoubleComplex}, lda::Cint,
+                                               B::CuPtr{cuDoubleComplex}, ldb::Cint,
+                                               W::CuPtr{Cdouble},
+                                               work::CuPtr{cuDoubleComplex}, lwork::Cint,
+                                               info::CuPtr{Cint},
+                                               params::syevjInfo_t)::cusolverStatus_t
 end
 
 @checked function cusolverDnCreateGesvdjInfo(info)
     initialize_context()
-    @ccall libcusolver.cusolverDnCreateGesvdjInfo(info::Ptr{gesvdjInfo_t})::cusolverStatus_t
+    @gcsafe_ccall libcusolver.cusolverDnCreateGesvdjInfo(info::Ptr{gesvdjInfo_t})::cusolverStatus_t
 end
 
 @checked function cusolverDnDestroyGesvdjInfo(info)
     initialize_context()
-    @ccall libcusolver.cusolverDnDestroyGesvdjInfo(info::gesvdjInfo_t)::cusolverStatus_t
+    @gcsafe_ccall libcusolver.cusolverDnDestroyGesvdjInfo(info::gesvdjInfo_t)::cusolverStatus_t
 end
 
 @checked function cusolverDnXgesvdjSetTolerance(info, tolerance)
     initialize_context()
-    @ccall libcusolver.cusolverDnXgesvdjSetTolerance(info::gesvdjInfo_t,
-                                                     tolerance::Cdouble)::cusolverStatus_t
+    @gcsafe_ccall libcusolver.cusolverDnXgesvdjSetTolerance(info::gesvdjInfo_t,
+                                                            tolerance::Cdouble)::cusolverStatus_t
 end
 
 @checked function cusolverDnXgesvdjSetMaxSweeps(info, max_sweeps)
     initialize_context()
-    @ccall libcusolver.cusolverDnXgesvdjSetMaxSweeps(info::gesvdjInfo_t,
-                                                     max_sweeps::Cint)::cusolverStatus_t
+    @gcsafe_ccall libcusolver.cusolverDnXgesvdjSetMaxSweeps(info::gesvdjInfo_t,
+                                                            max_sweeps::Cint)::cusolverStatus_t
 end
 
 @checked function cusolverDnXgesvdjSetSortEig(info, sort_svd)
     initialize_context()
-    @ccall libcusolver.cusolverDnXgesvdjSetSortEig(info::gesvdjInfo_t,
-                                                   sort_svd::Cint)::cusolverStatus_t
+    @gcsafe_ccall libcusolver.cusolverDnXgesvdjSetSortEig(info::gesvdjInfo_t,
+                                                          sort_svd::Cint)::cusolverStatus_t
 end
 
 @checked function cusolverDnXgesvdjGetResidual(handle, info, residual)
     initialize_context()
-    @ccall libcusolver.cusolverDnXgesvdjGetResidual(handle::cusolverDnHandle_t,
-                                                    info::gesvdjInfo_t,
-                                                    residual::Ptr{Cdouble})::cusolverStatus_t
+    @gcsafe_ccall libcusolver.cusolverDnXgesvdjGetResidual(handle::cusolverDnHandle_t,
+                                                           info::gesvdjInfo_t,
+                                                           residual::Ptr{Cdouble})::cusolverStatus_t
 end
 
 @checked function cusolverDnXgesvdjGetSweeps(handle, info, executed_sweeps)
     initialize_context()
-    @ccall libcusolver.cusolverDnXgesvdjGetSweeps(handle::cusolverDnHandle_t,
-                                                  info::gesvdjInfo_t,
-                                                  executed_sweeps::Ptr{Cint})::cusolverStatus_t
+    @gcsafe_ccall libcusolver.cusolverDnXgesvdjGetSweeps(handle::cusolverDnHandle_t,
+                                                         info::gesvdjInfo_t,
+                                                         executed_sweeps::Ptr{Cint})::cusolverStatus_t
 end
 
 @checked function cusolverDnSgesvdjBatched_bufferSize(handle, jobz, m, n, A, lda, S, U, ldu,
                                                       V, ldv, lwork, params, batchSize)
     initialize_context()
-    @ccall libcusolver.cusolverDnSgesvdjBatched_bufferSize(handle::cusolverDnHandle_t,
-                                                           jobz::cusolverEigMode_t, m::Cint,
-                                                           n::Cint, A::CuPtr{Cfloat},
-                                                           lda::Cint, S::CuPtr{Cfloat},
-                                                           U::CuPtr{Cfloat}, ldu::Cint,
-                                                           V::CuPtr{Cfloat}, ldv::Cint,
-                                                           lwork::Ptr{Cint},
-                                                           params::gesvdjInfo_t,
-                                                           batchSize::Cint)::cusolverStatus_t
+    @gcsafe_ccall libcusolver.cusolverDnSgesvdjBatched_bufferSize(handle::cusolverDnHandle_t,
+                                                                  jobz::cusolverEigMode_t,
+                                                                  m::Cint, n::Cint,
+                                                                  A::CuPtr{Cfloat},
+                                                                  lda::Cint,
+                                                                  S::CuPtr{Cfloat},
+                                                                  U::CuPtr{Cfloat},
+                                                                  ldu::Cint,
+                                                                  V::CuPtr{Cfloat},
+                                                                  ldv::Cint,
+                                                                  lwork::Ptr{Cint},
+                                                                  params::gesvdjInfo_t,
+                                                                  batchSize::Cint)::cusolverStatus_t
 end
 
 @checked function cusolverDnDgesvdjBatched_bufferSize(handle, jobz, m, n, A, lda, S, U, ldu,
                                                       V, ldv, lwork, params, batchSize)
     initialize_context()
-    @ccall libcusolver.cusolverDnDgesvdjBatched_bufferSize(handle::cusolverDnHandle_t,
-                                                           jobz::cusolverEigMode_t, m::Cint,
-                                                           n::Cint, A::CuPtr{Cdouble},
-                                                           lda::Cint, S::CuPtr{Cdouble},
-                                                           U::CuPtr{Cdouble}, ldu::Cint,
-                                                           V::CuPtr{Cdouble}, ldv::Cint,
-                                                           lwork::Ptr{Cint},
-                                                           params::gesvdjInfo_t,
-                                                           batchSize::Cint)::cusolverStatus_t
+    @gcsafe_ccall libcusolver.cusolverDnDgesvdjBatched_bufferSize(handle::cusolverDnHandle_t,
+                                                                  jobz::cusolverEigMode_t,
+                                                                  m::Cint, n::Cint,
+                                                                  A::CuPtr{Cdouble},
+                                                                  lda::Cint,
+                                                                  S::CuPtr{Cdouble},
+                                                                  U::CuPtr{Cdouble},
+                                                                  ldu::Cint,
+                                                                  V::CuPtr{Cdouble},
+                                                                  ldv::Cint,
+                                                                  lwork::Ptr{Cint},
+                                                                  params::gesvdjInfo_t,
+                                                                  batchSize::Cint)::cusolverStatus_t
 end
 
 @checked function cusolverDnCgesvdjBatched_bufferSize(handle, jobz, m, n, A, lda, S, U, ldu,
                                                       V, ldv, lwork, params, batchSize)
     initialize_context()
-    @ccall libcusolver.cusolverDnCgesvdjBatched_bufferSize(handle::cusolverDnHandle_t,
-                                                           jobz::cusolverEigMode_t, m::Cint,
-                                                           n::Cint, A::CuPtr{cuComplex},
-                                                           lda::Cint, S::CuPtr{Cfloat},
-                                                           U::CuPtr{cuComplex}, ldu::Cint,
-                                                           V::CuPtr{cuComplex}, ldv::Cint,
-                                                           lwork::Ptr{Cint},
-                                                           params::gesvdjInfo_t,
-                                                           batchSize::Cint)::cusolverStatus_t
+    @gcsafe_ccall libcusolver.cusolverDnCgesvdjBatched_bufferSize(handle::cusolverDnHandle_t,
+                                                                  jobz::cusolverEigMode_t,
+                                                                  m::Cint, n::Cint,
+                                                                  A::CuPtr{cuComplex},
+                                                                  lda::Cint,
+                                                                  S::CuPtr{Cfloat},
+                                                                  U::CuPtr{cuComplex},
+                                                                  ldu::Cint,
+                                                                  V::CuPtr{cuComplex},
+                                                                  ldv::Cint,
+                                                                  lwork::Ptr{Cint},
+                                                                  params::gesvdjInfo_t,
+                                                                  batchSize::Cint)::cusolverStatus_t
 end
 
 @checked function cusolverDnZgesvdjBatched_bufferSize(handle, jobz, m, n, A, lda, S, U, ldu,
                                                       V, ldv, lwork, params, batchSize)
     initialize_context()
-    @ccall libcusolver.cusolverDnZgesvdjBatched_bufferSize(handle::cusolverDnHandle_t,
-                                                           jobz::cusolverEigMode_t, m::Cint,
-                                                           n::Cint,
+    @gcsafe_ccall libcusolver.cusolverDnZgesvdjBatched_bufferSize(handle::cusolverDnHandle_t,
+                                                                  jobz::cusolverEigMode_t,
+                                                                  m::Cint, n::Cint,
+                                                                  A::CuPtr{cuDoubleComplex},
+                                                                  lda::Cint,
+                                                                  S::CuPtr{Cdouble},
+                                                                  U::CuPtr{cuDoubleComplex},
+                                                                  ldu::Cint,
+                                                                  V::CuPtr{cuDoubleComplex},
+                                                                  ldv::Cint,
+                                                                  lwork::Ptr{Cint},
+                                                                  params::gesvdjInfo_t,
+                                                                  batchSize::Cint)::cusolverStatus_t
+end
+
+@checked function cusolverDnSgesvdjBatched(handle, jobz, m, n, A, lda, S, U, ldu, V, ldv,
+                                           work, lwork, info, params, batchSize)
+    initialize_context()
+    @gcsafe_ccall libcusolver.cusolverDnSgesvdjBatched(handle::cusolverDnHandle_t,
+                                                       jobz::cusolverEigMode_t, m::Cint,
+                                                       n::Cint, A::CuPtr{Cfloat}, lda::Cint,
+                                                       S::CuPtr{Cfloat}, U::CuPtr{Cfloat},
+                                                       ldu::Cint, V::CuPtr{Cfloat},
+                                                       ldv::Cint, work::CuPtr{Cfloat},
+                                                       lwork::Cint, info::CuPtr{Cint},
+                                                       params::gesvdjInfo_t,
+                                                       batchSize::Cint)::cusolverStatus_t
+end
+
+@checked function cusolverDnDgesvdjBatched(handle, jobz, m, n, A, lda, S, U, ldu, V, ldv,
+                                           work, lwork, info, params, batchSize)
+    initialize_context()
+    @gcsafe_ccall libcusolver.cusolverDnDgesvdjBatched(handle::cusolverDnHandle_t,
+                                                       jobz::cusolverEigMode_t, m::Cint,
+                                                       n::Cint, A::CuPtr{Cdouble},
+                                                       lda::Cint, S::CuPtr{Cdouble},
+                                                       U::CuPtr{Cdouble}, ldu::Cint,
+                                                       V::CuPtr{Cdouble}, ldv::Cint,
+                                                       work::CuPtr{Cdouble}, lwork::Cint,
+                                                       info::CuPtr{Cint},
+                                                       params::gesvdjInfo_t,
+                                                       batchSize::Cint)::cusolverStatus_t
+end
+
+@checked function cusolverDnCgesvdjBatched(handle, jobz, m, n, A, lda, S, U, ldu, V, ldv,
+                                           work, lwork, info, params, batchSize)
+    initialize_context()
+    @gcsafe_ccall libcusolver.cusolverDnCgesvdjBatched(handle::cusolverDnHandle_t,
+                                                       jobz::cusolverEigMode_t, m::Cint,
+                                                       n::Cint, A::CuPtr{cuComplex},
+                                                       lda::Cint, S::CuPtr{Cfloat},
+                                                       U::CuPtr{cuComplex}, ldu::Cint,
+                                                       V::CuPtr{cuComplex}, ldv::Cint,
+                                                       work::CuPtr{cuComplex}, lwork::Cint,
+                                                       info::CuPtr{Cint},
+                                                       params::gesvdjInfo_t,
+                                                       batchSize::Cint)::cusolverStatus_t
+end
+
+@checked function cusolverDnZgesvdjBatched(handle, jobz, m, n, A, lda, S, U, ldu, V, ldv,
+                                           work, lwork, info, params, batchSize)
+    initialize_context()
+    @gcsafe_ccall libcusolver.cusolverDnZgesvdjBatched(handle::cusolverDnHandle_t,
+                                                       jobz::cusolverEigMode_t, m::Cint,
+                                                       n::Cint, A::CuPtr{cuDoubleComplex},
+                                                       lda::Cint, S::CuPtr{Cdouble},
+                                                       U::CuPtr{cuDoubleComplex}, ldu::Cint,
+                                                       V::CuPtr{cuDoubleComplex}, ldv::Cint,
+                                                       work::CuPtr{cuDoubleComplex},
+                                                       lwork::Cint, info::CuPtr{Cint},
+                                                       params::gesvdjInfo_t,
+                                                       batchSize::Cint)::cusolverStatus_t
+end
+
+@checked function cusolverDnSgesvdj_bufferSize(handle, jobz, econ, m, n, A, lda, S, U, ldu,
+                                               V, ldv, lwork, params)
+    initialize_context()
+    @gcsafe_ccall libcusolver.cusolverDnSgesvdj_bufferSize(handle::cusolverDnHandle_t,
+                                                           jobz::cusolverEigMode_t,
+                                                           econ::Cint, m::Cint, n::Cint,
+                                                           A::CuPtr{Cfloat}, lda::Cint,
+                                                           S::CuPtr{Cfloat},
+                                                           U::CuPtr{Cfloat}, ldu::Cint,
+                                                           V::CuPtr{Cfloat}, ldv::Cint,
+                                                           lwork::Ptr{Cint},
+                                                           params::gesvdjInfo_t)::cusolverStatus_t
+end
+
+@checked function cusolverDnDgesvdj_bufferSize(handle, jobz, econ, m, n, A, lda, S, U, ldu,
+                                               V, ldv, lwork, params)
+    initialize_context()
+    @gcsafe_ccall libcusolver.cusolverDnDgesvdj_bufferSize(handle::cusolverDnHandle_t,
+                                                           jobz::cusolverEigMode_t,
+                                                           econ::Cint, m::Cint, n::Cint,
+                                                           A::CuPtr{Cdouble}, lda::Cint,
+                                                           S::CuPtr{Cdouble},
+                                                           U::CuPtr{Cdouble}, ldu::Cint,
+                                                           V::CuPtr{Cdouble}, ldv::Cint,
+                                                           lwork::Ptr{Cint},
+                                                           params::gesvdjInfo_t)::cusolverStatus_t
+end
+
+@checked function cusolverDnCgesvdj_bufferSize(handle, jobz, econ, m, n, A, lda, S, U, ldu,
+                                               V, ldv, lwork, params)
+    initialize_context()
+    @gcsafe_ccall libcusolver.cusolverDnCgesvdj_bufferSize(handle::cusolverDnHandle_t,
+                                                           jobz::cusolverEigMode_t,
+                                                           econ::Cint, m::Cint, n::Cint,
+                                                           A::CuPtr{cuComplex}, lda::Cint,
+                                                           S::CuPtr{Cfloat},
+                                                           U::CuPtr{cuComplex}, ldu::Cint,
+                                                           V::CuPtr{cuComplex}, ldv::Cint,
+                                                           lwork::Ptr{Cint},
+                                                           params::gesvdjInfo_t)::cusolverStatus_t
+end
+
+@checked function cusolverDnZgesvdj_bufferSize(handle, jobz, econ, m, n, A, lda, S, U, ldu,
+                                               V, ldv, lwork, params)
+    initialize_context()
+    @gcsafe_ccall libcusolver.cusolverDnZgesvdj_bufferSize(handle::cusolverDnHandle_t,
+                                                           jobz::cusolverEigMode_t,
+                                                           econ::Cint, m::Cint, n::Cint,
                                                            A::CuPtr{cuDoubleComplex},
                                                            lda::Cint, S::CuPtr{Cdouble},
                                                            U::CuPtr{cuDoubleComplex},
                                                            ldu::Cint,
                                                            V::CuPtr{cuDoubleComplex},
                                                            ldv::Cint, lwork::Ptr{Cint},
-                                                           params::gesvdjInfo_t,
-                                                           batchSize::Cint)::cusolverStatus_t
-end
-
-@checked function cusolverDnSgesvdjBatched(handle, jobz, m, n, A, lda, S, U, ldu, V, ldv,
-                                           work, lwork, info, params, batchSize)
-    initialize_context()
-    @ccall libcusolver.cusolverDnSgesvdjBatched(handle::cusolverDnHandle_t,
-                                                jobz::cusolverEigMode_t, m::Cint, n::Cint,
-                                                A::CuPtr{Cfloat}, lda::Cint,
-                                                S::CuPtr{Cfloat}, U::CuPtr{Cfloat},
-                                                ldu::Cint, V::CuPtr{Cfloat}, ldv::Cint,
-                                                work::CuPtr{Cfloat}, lwork::Cint,
-                                                info::CuPtr{Cint}, params::gesvdjInfo_t,
-                                                batchSize::Cint)::cusolverStatus_t
-end
-
-@checked function cusolverDnDgesvdjBatched(handle, jobz, m, n, A, lda, S, U, ldu, V, ldv,
-                                           work, lwork, info, params, batchSize)
-    initialize_context()
-    @ccall libcusolver.cusolverDnDgesvdjBatched(handle::cusolverDnHandle_t,
-                                                jobz::cusolverEigMode_t, m::Cint, n::Cint,
-                                                A::CuPtr{Cdouble}, lda::Cint,
-                                                S::CuPtr{Cdouble}, U::CuPtr{Cdouble},
-                                                ldu::Cint, V::CuPtr{Cdouble}, ldv::Cint,
-                                                work::CuPtr{Cdouble}, lwork::Cint,
-                                                info::CuPtr{Cint}, params::gesvdjInfo_t,
-                                                batchSize::Cint)::cusolverStatus_t
-end
-
-@checked function cusolverDnCgesvdjBatched(handle, jobz, m, n, A, lda, S, U, ldu, V, ldv,
-                                           work, lwork, info, params, batchSize)
-    initialize_context()
-    @ccall libcusolver.cusolverDnCgesvdjBatched(handle::cusolverDnHandle_t,
-                                                jobz::cusolverEigMode_t, m::Cint, n::Cint,
-                                                A::CuPtr{cuComplex}, lda::Cint,
-                                                S::CuPtr{Cfloat}, U::CuPtr{cuComplex},
-                                                ldu::Cint, V::CuPtr{cuComplex}, ldv::Cint,
-                                                work::CuPtr{cuComplex}, lwork::Cint,
-                                                info::CuPtr{Cint}, params::gesvdjInfo_t,
-                                                batchSize::Cint)::cusolverStatus_t
-end
-
-@checked function cusolverDnZgesvdjBatched(handle, jobz, m, n, A, lda, S, U, ldu, V, ldv,
-                                           work, lwork, info, params, batchSize)
-    initialize_context()
-    @ccall libcusolver.cusolverDnZgesvdjBatched(handle::cusolverDnHandle_t,
-                                                jobz::cusolverEigMode_t, m::Cint, n::Cint,
-                                                A::CuPtr{cuDoubleComplex}, lda::Cint,
-                                                S::CuPtr{Cdouble},
-                                                U::CuPtr{cuDoubleComplex}, ldu::Cint,
-                                                V::CuPtr{cuDoubleComplex}, ldv::Cint,
-                                                work::CuPtr{cuDoubleComplex}, lwork::Cint,
-                                                info::CuPtr{Cint}, params::gesvdjInfo_t,
-                                                batchSize::Cint)::cusolverStatus_t
-end
-
-@checked function cusolverDnSgesvdj_bufferSize(handle, jobz, econ, m, n, A, lda, S, U, ldu,
-                                               V, ldv, lwork, params)
-    initialize_context()
-    @ccall libcusolver.cusolverDnSgesvdj_bufferSize(handle::cusolverDnHandle_t,
-                                                    jobz::cusolverEigMode_t, econ::Cint,
-                                                    m::Cint, n::Cint, A::CuPtr{Cfloat},
-                                                    lda::Cint, S::CuPtr{Cfloat},
-                                                    U::CuPtr{Cfloat}, ldu::Cint,
-                                                    V::CuPtr{Cfloat}, ldv::Cint,
-                                                    lwork::Ptr{Cint},
-                                                    params::gesvdjInfo_t)::cusolverStatus_t
-end
-
-@checked function cusolverDnDgesvdj_bufferSize(handle, jobz, econ, m, n, A, lda, S, U, ldu,
-                                               V, ldv, lwork, params)
-    initialize_context()
-    @ccall libcusolver.cusolverDnDgesvdj_bufferSize(handle::cusolverDnHandle_t,
-                                                    jobz::cusolverEigMode_t, econ::Cint,
-                                                    m::Cint, n::Cint, A::CuPtr{Cdouble},
-                                                    lda::Cint, S::CuPtr{Cdouble},
-                                                    U::CuPtr{Cdouble}, ldu::Cint,
-                                                    V::CuPtr{Cdouble}, ldv::Cint,
-                                                    lwork::Ptr{Cint},
-                                                    params::gesvdjInfo_t)::cusolverStatus_t
-end
-
-@checked function cusolverDnCgesvdj_bufferSize(handle, jobz, econ, m, n, A, lda, S, U, ldu,
-                                               V, ldv, lwork, params)
-    initialize_context()
-    @ccall libcusolver.cusolverDnCgesvdj_bufferSize(handle::cusolverDnHandle_t,
-                                                    jobz::cusolverEigMode_t, econ::Cint,
-                                                    m::Cint, n::Cint, A::CuPtr{cuComplex},
-                                                    lda::Cint, S::CuPtr{Cfloat},
-                                                    U::CuPtr{cuComplex}, ldu::Cint,
-                                                    V::CuPtr{cuComplex}, ldv::Cint,
-                                                    lwork::Ptr{Cint},
-                                                    params::gesvdjInfo_t)::cusolverStatus_t
-end
-
-@checked function cusolverDnZgesvdj_bufferSize(handle, jobz, econ, m, n, A, lda, S, U, ldu,
-                                               V, ldv, lwork, params)
-    initialize_context()
-    @ccall libcusolver.cusolverDnZgesvdj_bufferSize(handle::cusolverDnHandle_t,
-                                                    jobz::cusolverEigMode_t, econ::Cint,
-                                                    m::Cint, n::Cint,
-                                                    A::CuPtr{cuDoubleComplex}, lda::Cint,
-                                                    S::CuPtr{Cdouble},
-                                                    U::CuPtr{cuDoubleComplex}, ldu::Cint,
-                                                    V::CuPtr{cuDoubleComplex}, ldv::Cint,
-                                                    lwork::Ptr{Cint},
-                                                    params::gesvdjInfo_t)::cusolverStatus_t
+                                                           params::gesvdjInfo_t)::cusolverStatus_t
 end
 
 @checked function cusolverDnSgesvdj(handle, jobz, econ, m, n, A, lda, S, U, ldu, V, ldv,
                                     work, lwork, info, params)
     initialize_context()
-    @ccall libcusolver.cusolverDnSgesvdj(handle::cusolverDnHandle_t,
-                                         jobz::cusolverEigMode_t, econ::Cint, m::Cint,
-                                         n::Cint, A::CuPtr{Cfloat}, lda::Cint,
-                                         S::CuPtr{Cfloat}, U::CuPtr{Cfloat}, ldu::Cint,
-                                         V::CuPtr{Cfloat}, ldv::Cint, work::CuPtr{Cfloat},
-                                         lwork::Cint, info::CuPtr{Cint},
-                                         params::gesvdjInfo_t)::cusolverStatus_t
+    @gcsafe_ccall libcusolver.cusolverDnSgesvdj(handle::cusolverDnHandle_t,
+                                                jobz::cusolverEigMode_t, econ::Cint,
+                                                m::Cint, n::Cint, A::CuPtr{Cfloat},
+                                                lda::Cint, S::CuPtr{Cfloat},
+                                                U::CuPtr{Cfloat}, ldu::Cint,
+                                                V::CuPtr{Cfloat}, ldv::Cint,
+                                                work::CuPtr{Cfloat}, lwork::Cint,
+                                                info::CuPtr{Cint},
+                                                params::gesvdjInfo_t)::cusolverStatus_t
 end
 
 @checked function cusolverDnDgesvdj(handle, jobz, econ, m, n, A, lda, S, U, ldu, V, ldv,
                                     work, lwork, info, params)
     initialize_context()
-    @ccall libcusolver.cusolverDnDgesvdj(handle::cusolverDnHandle_t,
-                                         jobz::cusolverEigMode_t, econ::Cint, m::Cint,
-                                         n::Cint, A::CuPtr{Cdouble}, lda::Cint,
-                                         S::CuPtr{Cdouble}, U::CuPtr{Cdouble}, ldu::Cint,
-                                         V::CuPtr{Cdouble}, ldv::Cint, work::CuPtr{Cdouble},
-                                         lwork::Cint, info::CuPtr{Cint},
-                                         params::gesvdjInfo_t)::cusolverStatus_t
+    @gcsafe_ccall libcusolver.cusolverDnDgesvdj(handle::cusolverDnHandle_t,
+                                                jobz::cusolverEigMode_t, econ::Cint,
+                                                m::Cint, n::Cint, A::CuPtr{Cdouble},
+                                                lda::Cint, S::CuPtr{Cdouble},
+                                                U::CuPtr{Cdouble}, ldu::Cint,
+                                                V::CuPtr{Cdouble}, ldv::Cint,
+                                                work::CuPtr{Cdouble}, lwork::Cint,
+                                                info::CuPtr{Cint},
+                                                params::gesvdjInfo_t)::cusolverStatus_t
 end
 
 @checked function cusolverDnCgesvdj(handle, jobz, econ, m, n, A, lda, S, U, ldu, V, ldv,
                                     work, lwork, info, params)
     initialize_context()
-    @ccall libcusolver.cusolverDnCgesvdj(handle::cusolverDnHandle_t,
-                                         jobz::cusolverEigMode_t, econ::Cint, m::Cint,
-                                         n::Cint, A::CuPtr{cuComplex}, lda::Cint,
-                                         S::CuPtr{Cfloat}, U::CuPtr{cuComplex}, ldu::Cint,
-                                         V::CuPtr{cuComplex}, ldv::Cint,
-                                         work::CuPtr{cuComplex}, lwork::Cint,
-                                         info::CuPtr{Cint},
-                                         params::gesvdjInfo_t)::cusolverStatus_t
+    @gcsafe_ccall libcusolver.cusolverDnCgesvdj(handle::cusolverDnHandle_t,
+                                                jobz::cusolverEigMode_t, econ::Cint,
+                                                m::Cint, n::Cint, A::CuPtr{cuComplex},
+                                                lda::Cint, S::CuPtr{Cfloat},
+                                                U::CuPtr{cuComplex}, ldu::Cint,
+                                                V::CuPtr{cuComplex}, ldv::Cint,
+                                                work::CuPtr{cuComplex}, lwork::Cint,
+                                                info::CuPtr{Cint},
+                                                params::gesvdjInfo_t)::cusolverStatus_t
 end
 
 @checked function cusolverDnZgesvdj(handle, jobz, econ, m, n, A, lda, S, U, ldu, V, ldv,
                                     work, lwork, info, params)
     initialize_context()
-    @ccall libcusolver.cusolverDnZgesvdj(handle::cusolverDnHandle_t,
-                                         jobz::cusolverEigMode_t, econ::Cint, m::Cint,
-                                         n::Cint, A::CuPtr{cuDoubleComplex}, lda::Cint,
-                                         S::CuPtr{Cdouble}, U::CuPtr{cuDoubleComplex},
-                                         ldu::Cint, V::CuPtr{cuDoubleComplex}, ldv::Cint,
-                                         work::CuPtr{cuDoubleComplex}, lwork::Cint,
-                                         info::CuPtr{Cint},
-                                         params::gesvdjInfo_t)::cusolverStatus_t
+    @gcsafe_ccall libcusolver.cusolverDnZgesvdj(handle::cusolverDnHandle_t,
+                                                jobz::cusolverEigMode_t, econ::Cint,
+                                                m::Cint, n::Cint, A::CuPtr{cuDoubleComplex},
+                                                lda::Cint, S::CuPtr{Cdouble},
+                                                U::CuPtr{cuDoubleComplex}, ldu::Cint,
+                                                V::CuPtr{cuDoubleComplex}, ldv::Cint,
+                                                work::CuPtr{cuDoubleComplex}, lwork::Cint,
+                                                info::CuPtr{Cint},
+                                                params::gesvdjInfo_t)::cusolverStatus_t
 end
 
 @checked function cusolverDnSgesvdaStridedBatched_bufferSize(handle, jobz, rank, m, n, d_A,
@@ -3649,23 +4095,23 @@ end
                                                              d_U, ldu, strideU, d_V, ldv,
                                                              strideV, lwork, batchSize)
     initialize_context()
-    @ccall libcusolver.cusolverDnSgesvdaStridedBatched_bufferSize(handle::cusolverDnHandle_t,
-                                                                  jobz::cusolverEigMode_t,
-                                                                  rank::Cint, m::Cint,
-                                                                  n::Cint,
-                                                                  d_A::CuPtr{Cfloat},
-                                                                  lda::Cint,
-                                                                  strideA::Clonglong,
-                                                                  d_S::CuPtr{Cfloat},
-                                                                  strideS::Clonglong,
-                                                                  d_U::CuPtr{Cfloat},
-                                                                  ldu::Cint,
-                                                                  strideU::Clonglong,
-                                                                  d_V::CuPtr{Cfloat},
-                                                                  ldv::Cint,
-                                                                  strideV::Clonglong,
-                                                                  lwork::Ptr{Cint},
-                                                                  batchSize::Cint)::cusolverStatus_t
+    @gcsafe_ccall libcusolver.cusolverDnSgesvdaStridedBatched_bufferSize(handle::cusolverDnHandle_t,
+                                                                         jobz::cusolverEigMode_t,
+                                                                         rank::Cint,
+                                                                         m::Cint, n::Cint,
+                                                                         d_A::CuPtr{Cfloat},
+                                                                         lda::Cint,
+                                                                         strideA::Clonglong,
+                                                                         d_S::CuPtr{Cfloat},
+                                                                         strideS::Clonglong,
+                                                                         d_U::CuPtr{Cfloat},
+                                                                         ldu::Cint,
+                                                                         strideU::Clonglong,
+                                                                         d_V::CuPtr{Cfloat},
+                                                                         ldv::Cint,
+                                                                         strideV::Clonglong,
+                                                                         lwork::Ptr{Cint},
+                                                                         batchSize::Cint)::cusolverStatus_t
 end
 
 @checked function cusolverDnDgesvdaStridedBatched_bufferSize(handle, jobz, rank, m, n, d_A,
@@ -3673,23 +4119,23 @@ end
                                                              d_U, ldu, strideU, d_V, ldv,
                                                              strideV, lwork, batchSize)
     initialize_context()
-    @ccall libcusolver.cusolverDnDgesvdaStridedBatched_bufferSize(handle::cusolverDnHandle_t,
-                                                                  jobz::cusolverEigMode_t,
-                                                                  rank::Cint, m::Cint,
-                                                                  n::Cint,
-                                                                  d_A::CuPtr{Cdouble},
-                                                                  lda::Cint,
-                                                                  strideA::Clonglong,
-                                                                  d_S::CuPtr{Cdouble},
-                                                                  strideS::Clonglong,
-                                                                  d_U::CuPtr{Cdouble},
-                                                                  ldu::Cint,
-                                                                  strideU::Clonglong,
-                                                                  d_V::CuPtr{Cdouble},
-                                                                  ldv::Cint,
-                                                                  strideV::Clonglong,
-                                                                  lwork::Ptr{Cint},
-                                                                  batchSize::Cint)::cusolverStatus_t
+    @gcsafe_ccall libcusolver.cusolverDnDgesvdaStridedBatched_bufferSize(handle::cusolverDnHandle_t,
+                                                                         jobz::cusolverEigMode_t,
+                                                                         rank::Cint,
+                                                                         m::Cint, n::Cint,
+                                                                         d_A::CuPtr{Cdouble},
+                                                                         lda::Cint,
+                                                                         strideA::Clonglong,
+                                                                         d_S::CuPtr{Cdouble},
+                                                                         strideS::Clonglong,
+                                                                         d_U::CuPtr{Cdouble},
+                                                                         ldu::Cint,
+                                                                         strideU::Clonglong,
+                                                                         d_V::CuPtr{Cdouble},
+                                                                         ldv::Cint,
+                                                                         strideV::Clonglong,
+                                                                         lwork::Ptr{Cint},
+                                                                         batchSize::Cint)::cusolverStatus_t
 end
 
 @checked function cusolverDnCgesvdaStridedBatched_bufferSize(handle, jobz, rank, m, n, d_A,
@@ -3697,23 +4143,23 @@ end
                                                              d_U, ldu, strideU, d_V, ldv,
                                                              strideV, lwork, batchSize)
     initialize_context()
-    @ccall libcusolver.cusolverDnCgesvdaStridedBatched_bufferSize(handle::cusolverDnHandle_t,
-                                                                  jobz::cusolverEigMode_t,
-                                                                  rank::Cint, m::Cint,
-                                                                  n::Cint,
-                                                                  d_A::CuPtr{cuComplex},
-                                                                  lda::Cint,
-                                                                  strideA::Clonglong,
-                                                                  d_S::CuPtr{Cfloat},
-                                                                  strideS::Clonglong,
-                                                                  d_U::CuPtr{cuComplex},
-                                                                  ldu::Cint,
-                                                                  strideU::Clonglong,
-                                                                  d_V::CuPtr{cuComplex},
-                                                                  ldv::Cint,
-                                                                  strideV::Clonglong,
-                                                                  lwork::Ptr{Cint},
-                                                                  batchSize::Cint)::cusolverStatus_t
+    @gcsafe_ccall libcusolver.cusolverDnCgesvdaStridedBatched_bufferSize(handle::cusolverDnHandle_t,
+                                                                         jobz::cusolverEigMode_t,
+                                                                         rank::Cint,
+                                                                         m::Cint, n::Cint,
+                                                                         d_A::CuPtr{cuComplex},
+                                                                         lda::Cint,
+                                                                         strideA::Clonglong,
+                                                                         d_S::CuPtr{Cfloat},
+                                                                         strideS::Clonglong,
+                                                                         d_U::CuPtr{cuComplex},
+                                                                         ldu::Cint,
+                                                                         strideU::Clonglong,
+                                                                         d_V::CuPtr{cuComplex},
+                                                                         ldv::Cint,
+                                                                         strideV::Clonglong,
+                                                                         lwork::Ptr{Cint},
+                                                                         batchSize::Cint)::cusolverStatus_t
 end
 
 @checked function cusolverDnZgesvdaStridedBatched_bufferSize(handle, jobz, rank, m, n, d_A,
@@ -3721,23 +4167,23 @@ end
                                                              d_U, ldu, strideU, d_V, ldv,
                                                              strideV, lwork, batchSize)
     initialize_context()
-    @ccall libcusolver.cusolverDnZgesvdaStridedBatched_bufferSize(handle::cusolverDnHandle_t,
-                                                                  jobz::cusolverEigMode_t,
-                                                                  rank::Cint, m::Cint,
-                                                                  n::Cint,
-                                                                  d_A::CuPtr{cuDoubleComplex},
-                                                                  lda::Cint,
-                                                                  strideA::Clonglong,
-                                                                  d_S::CuPtr{Cdouble},
-                                                                  strideS::Clonglong,
-                                                                  d_U::CuPtr{cuDoubleComplex},
-                                                                  ldu::Cint,
-                                                                  strideU::Clonglong,
-                                                                  d_V::CuPtr{cuDoubleComplex},
-                                                                  ldv::Cint,
-                                                                  strideV::Clonglong,
-                                                                  lwork::Ptr{Cint},
-                                                                  batchSize::Cint)::cusolverStatus_t
+    @gcsafe_ccall libcusolver.cusolverDnZgesvdaStridedBatched_bufferSize(handle::cusolverDnHandle_t,
+                                                                         jobz::cusolverEigMode_t,
+                                                                         rank::Cint,
+                                                                         m::Cint, n::Cint,
+                                                                         d_A::CuPtr{cuDoubleComplex},
+                                                                         lda::Cint,
+                                                                         strideA::Clonglong,
+                                                                         d_S::CuPtr{Cdouble},
+                                                                         strideS::Clonglong,
+                                                                         d_U::CuPtr{cuDoubleComplex},
+                                                                         ldu::Cint,
+                                                                         strideU::Clonglong,
+                                                                         d_V::CuPtr{cuDoubleComplex},
+                                                                         ldv::Cint,
+                                                                         strideV::Clonglong,
+                                                                         lwork::Ptr{Cint},
+                                                                         batchSize::Cint)::cusolverStatus_t
 end
 
 @checked function cusolverDnSgesvdaStridedBatched(handle, jobz, rank, m, n, d_A, lda,
@@ -3745,20 +4191,22 @@ end
                                                   d_V, ldv, strideV, d_work, lwork, d_info,
                                                   h_R_nrmF, batchSize)
     initialize_context()
-    @ccall libcusolver.cusolverDnSgesvdaStridedBatched(handle::cusolverDnHandle_t,
-                                                       jobz::cusolverEigMode_t, rank::Cint,
-                                                       m::Cint, n::Cint, d_A::CuPtr{Cfloat},
-                                                       lda::Cint, strideA::Clonglong,
-                                                       d_S::CuPtr{Cfloat},
-                                                       strideS::Clonglong,
-                                                       d_U::CuPtr{Cfloat}, ldu::Cint,
-                                                       strideU::Clonglong,
-                                                       d_V::CuPtr{Cfloat}, ldv::Cint,
-                                                       strideV::Clonglong,
-                                                       d_work::CuPtr{Cfloat}, lwork::Cint,
-                                                       d_info::CuPtr{Cint},
-                                                       h_R_nrmF::Ptr{Cdouble},
-                                                       batchSize::Cint)::cusolverStatus_t
+    @gcsafe_ccall libcusolver.cusolverDnSgesvdaStridedBatched(handle::cusolverDnHandle_t,
+                                                              jobz::cusolverEigMode_t,
+                                                              rank::Cint, m::Cint, n::Cint,
+                                                              d_A::CuPtr{Cfloat}, lda::Cint,
+                                                              strideA::Clonglong,
+                                                              d_S::CuPtr{Cfloat},
+                                                              strideS::Clonglong,
+                                                              d_U::CuPtr{Cfloat}, ldu::Cint,
+                                                              strideU::Clonglong,
+                                                              d_V::CuPtr{Cfloat}, ldv::Cint,
+                                                              strideV::Clonglong,
+                                                              d_work::CuPtr{Cfloat},
+                                                              lwork::Cint,
+                                                              d_info::CuPtr{Cint},
+                                                              h_R_nrmF::Ptr{Cdouble},
+                                                              batchSize::Cint)::cusolverStatus_t
 end
 
 @checked function cusolverDnDgesvdaStridedBatched(handle, jobz, rank, m, n, d_A, lda,
@@ -3766,21 +4214,22 @@ end
                                                   d_V, ldv, strideV, d_work, lwork, d_info,
                                                   h_R_nrmF, batchSize)
     initialize_context()
-    @ccall libcusolver.cusolverDnDgesvdaStridedBatched(handle::cusolverDnHandle_t,
-                                                       jobz::cusolverEigMode_t, rank::Cint,
-                                                       m::Cint, n::Cint,
-                                                       d_A::CuPtr{Cdouble}, lda::Cint,
-                                                       strideA::Clonglong,
-                                                       d_S::CuPtr{Cdouble},
-                                                       strideS::Clonglong,
-                                                       d_U::CuPtr{Cdouble}, ldu::Cint,
-                                                       strideU::Clonglong,
-                                                       d_V::CuPtr{Cdouble}, ldv::Cint,
-                                                       strideV::Clonglong,
-                                                       d_work::CuPtr{Cdouble}, lwork::Cint,
-                                                       d_info::CuPtr{Cint},
-                                                       h_R_nrmF::Ptr{Cdouble},
-                                                       batchSize::Cint)::cusolverStatus_t
+    @gcsafe_ccall libcusolver.cusolverDnDgesvdaStridedBatched(handle::cusolverDnHandle_t,
+                                                              jobz::cusolverEigMode_t,
+                                                              rank::Cint, m::Cint, n::Cint,
+                                                              d_A::CuPtr{Cdouble},
+                                                              lda::Cint, strideA::Clonglong,
+                                                              d_S::CuPtr{Cdouble},
+                                                              strideS::Clonglong,
+                                                              d_U::CuPtr{Cdouble},
+                                                              ldu::Cint, strideU::Clonglong,
+                                                              d_V::CuPtr{Cdouble},
+                                                              ldv::Cint, strideV::Clonglong,
+                                                              d_work::CuPtr{Cdouble},
+                                                              lwork::Cint,
+                                                              d_info::CuPtr{Cint},
+                                                              h_R_nrmF::Ptr{Cdouble},
+                                                              batchSize::Cint)::cusolverStatus_t
 end
 
 @checked function cusolverDnCgesvdaStridedBatched(handle, jobz, rank, m, n, d_A, lda,
@@ -3788,21 +4237,22 @@ end
                                                   d_V, ldv, strideV, d_work, lwork, d_info,
                                                   h_R_nrmF, batchSize)
     initialize_context()
-    @ccall libcusolver.cusolverDnCgesvdaStridedBatched(handle::cusolverDnHandle_t,
-                                                       jobz::cusolverEigMode_t, rank::Cint,
-                                                       m::Cint, n::Cint,
-                                                       d_A::CuPtr{cuComplex}, lda::Cint,
-                                                       strideA::Clonglong,
-                                                       d_S::CuPtr{Cfloat},
-                                                       strideS::Clonglong,
-                                                       d_U::CuPtr{cuComplex}, ldu::Cint,
-                                                       strideU::Clonglong,
-                                                       d_V::CuPtr{cuComplex}, ldv::Cint,
-                                                       strideV::Clonglong,
-                                                       d_work::CuPtr{cuComplex},
-                                                       lwork::Cint, d_info::CuPtr{Cint},
-                                                       h_R_nrmF::Ptr{Cdouble},
-                                                       batchSize::Cint)::cusolverStatus_t
+    @gcsafe_ccall libcusolver.cusolverDnCgesvdaStridedBatched(handle::cusolverDnHandle_t,
+                                                              jobz::cusolverEigMode_t,
+                                                              rank::Cint, m::Cint, n::Cint,
+                                                              d_A::CuPtr{cuComplex},
+                                                              lda::Cint, strideA::Clonglong,
+                                                              d_S::CuPtr{Cfloat},
+                                                              strideS::Clonglong,
+                                                              d_U::CuPtr{cuComplex},
+                                                              ldu::Cint, strideU::Clonglong,
+                                                              d_V::CuPtr{cuComplex},
+                                                              ldv::Cint, strideV::Clonglong,
+                                                              d_work::CuPtr{cuComplex},
+                                                              lwork::Cint,
+                                                              d_info::CuPtr{Cint},
+                                                              h_R_nrmF::Ptr{Cdouble},
+                                                              batchSize::Cint)::cusolverStatus_t
 end
 
 @checked function cusolverDnZgesvdaStridedBatched(handle, jobz, rank, m, n, d_A, lda,
@@ -3810,193 +4260,214 @@ end
                                                   d_V, ldv, strideV, d_work, lwork, d_info,
                                                   h_R_nrmF, batchSize)
     initialize_context()
-    @ccall libcusolver.cusolverDnZgesvdaStridedBatched(handle::cusolverDnHandle_t,
-                                                       jobz::cusolverEigMode_t, rank::Cint,
-                                                       m::Cint, n::Cint,
-                                                       d_A::CuPtr{cuDoubleComplex},
-                                                       lda::Cint, strideA::Clonglong,
-                                                       d_S::CuPtr{Cdouble},
-                                                       strideS::Clonglong,
-                                                       d_U::CuPtr{cuDoubleComplex},
-                                                       ldu::Cint, strideU::Clonglong,
-                                                       d_V::CuPtr{cuDoubleComplex},
-                                                       ldv::Cint, strideV::Clonglong,
-                                                       d_work::CuPtr{cuDoubleComplex},
-                                                       lwork::Cint, d_info::CuPtr{Cint},
-                                                       h_R_nrmF::Ptr{Cdouble},
-                                                       batchSize::Cint)::cusolverStatus_t
+    @gcsafe_ccall libcusolver.cusolverDnZgesvdaStridedBatched(handle::cusolverDnHandle_t,
+                                                              jobz::cusolverEigMode_t,
+                                                              rank::Cint, m::Cint, n::Cint,
+                                                              d_A::CuPtr{cuDoubleComplex},
+                                                              lda::Cint, strideA::Clonglong,
+                                                              d_S::CuPtr{Cdouble},
+                                                              strideS::Clonglong,
+                                                              d_U::CuPtr{cuDoubleComplex},
+                                                              ldu::Cint, strideU::Clonglong,
+                                                              d_V::CuPtr{cuDoubleComplex},
+                                                              ldv::Cint, strideV::Clonglong,
+                                                              d_work::CuPtr{cuDoubleComplex},
+                                                              lwork::Cint,
+                                                              d_info::CuPtr{Cint},
+                                                              h_R_nrmF::Ptr{Cdouble},
+                                                              batchSize::Cint)::cusolverStatus_t
 end
 
 @checked function cusolverDnCreateParams(params)
     initialize_context()
-    @ccall libcusolver.cusolverDnCreateParams(params::Ptr{cusolverDnParams_t})::cusolverStatus_t
+    @gcsafe_ccall libcusolver.cusolverDnCreateParams(params::Ptr{cusolverDnParams_t})::cusolverStatus_t
 end
 
 @checked function cusolverDnDestroyParams(params)
     initialize_context()
-    @ccall libcusolver.cusolverDnDestroyParams(params::cusolverDnParams_t)::cusolverStatus_t
+    @gcsafe_ccall libcusolver.cusolverDnDestroyParams(params::cusolverDnParams_t)::cusolverStatus_t
 end
 
 @checked function cusolverDnSetAdvOptions(params, _function, algo)
     initialize_context()
-    @ccall libcusolver.cusolverDnSetAdvOptions(params::cusolverDnParams_t,
-                                               _function::cusolverDnFunction_t,
-                                               algo::cusolverAlgMode_t)::cusolverStatus_t
+    @gcsafe_ccall libcusolver.cusolverDnSetAdvOptions(params::cusolverDnParams_t,
+                                                      _function::cusolverDnFunction_t,
+                                                      algo::cusolverAlgMode_t)::cusolverStatus_t
 end
 
 @checked function cusolverDnPotrf_bufferSize(handle, params, uplo, n, dataTypeA, A, lda,
                                              computeType, workspaceInBytes)
     initialize_context()
-    @ccall libcusolver.cusolverDnPotrf_bufferSize(handle::cusolverDnHandle_t,
-                                                  params::cusolverDnParams_t,
-                                                  uplo::cublasFillMode_t, n::Int64,
-                                                  dataTypeA::cudaDataType, A::CuPtr{Cvoid},
-                                                  lda::Int64, computeType::cudaDataType,
-                                                  workspaceInBytes::Ptr{Csize_t})::cusolverStatus_t
+    @gcsafe_ccall libcusolver.cusolverDnPotrf_bufferSize(handle::cusolverDnHandle_t,
+                                                         params::cusolverDnParams_t,
+                                                         uplo::cublasFillMode_t, n::Int64,
+                                                         dataTypeA::cudaDataType,
+                                                         A::CuPtr{Cvoid}, lda::Int64,
+                                                         computeType::cudaDataType,
+                                                         workspaceInBytes::Ptr{Csize_t})::cusolverStatus_t
 end
 
 @checked function cusolverDnPotrf(handle, params, uplo, n, dataTypeA, A, lda, computeType,
                                   pBuffer, workspaceInBytes, info)
     initialize_context()
-    @ccall libcusolver.cusolverDnPotrf(handle::cusolverDnHandle_t,
-                                       params::cusolverDnParams_t, uplo::cublasFillMode_t,
-                                       n::Int64, dataTypeA::cudaDataType, A::CuPtr{Cvoid},
-                                       lda::Int64, computeType::cudaDataType,
-                                       pBuffer::CuPtr{Cvoid}, workspaceInBytes::Csize_t,
-                                       info::CuPtr{Cint})::cusolverStatus_t
+    @gcsafe_ccall libcusolver.cusolverDnPotrf(handle::cusolverDnHandle_t,
+                                              params::cusolverDnParams_t,
+                                              uplo::cublasFillMode_t, n::Int64,
+                                              dataTypeA::cudaDataType, A::CuPtr{Cvoid},
+                                              lda::Int64, computeType::cudaDataType,
+                                              pBuffer::CuPtr{Cvoid},
+                                              workspaceInBytes::Csize_t,
+                                              info::CuPtr{Cint})::cusolverStatus_t
 end
 
 @checked function cusolverDnPotrs(handle, params, uplo, n, nrhs, dataTypeA, A, lda,
                                   dataTypeB, B, ldb, info)
     initialize_context()
-    @ccall libcusolver.cusolverDnPotrs(handle::cusolverDnHandle_t,
-                                       params::cusolverDnParams_t, uplo::cublasFillMode_t,
-                                       n::Int64, nrhs::Int64, dataTypeA::cudaDataType,
-                                       A::CuPtr{Cvoid}, lda::Int64, dataTypeB::cudaDataType,
-                                       B::CuPtr{Cvoid}, ldb::Int64,
-                                       info::CuPtr{Cint})::cusolverStatus_t
+    @gcsafe_ccall libcusolver.cusolverDnPotrs(handle::cusolverDnHandle_t,
+                                              params::cusolverDnParams_t,
+                                              uplo::cublasFillMode_t, n::Int64, nrhs::Int64,
+                                              dataTypeA::cudaDataType, A::CuPtr{Cvoid},
+                                              lda::Int64, dataTypeB::cudaDataType,
+                                              B::CuPtr{Cvoid}, ldb::Int64,
+                                              info::CuPtr{Cint})::cusolverStatus_t
 end
 
 @checked function cusolverDnGeqrf_bufferSize(handle, params, m, n, dataTypeA, A, lda,
                                              dataTypeTau, tau, computeType,
                                              workspaceInBytes)
     initialize_context()
-    @ccall libcusolver.cusolverDnGeqrf_bufferSize(handle::cusolverDnHandle_t,
-                                                  params::cusolverDnParams_t, m::Int64,
-                                                  n::Int64, dataTypeA::cudaDataType,
-                                                  A::CuPtr{Cvoid}, lda::Int64,
-                                                  dataTypeTau::cudaDataType,
-                                                  tau::CuPtr{Cvoid},
-                                                  computeType::cudaDataType,
-                                                  workspaceInBytes::Ptr{Csize_t})::cusolverStatus_t
+    @gcsafe_ccall libcusolver.cusolverDnGeqrf_bufferSize(handle::cusolverDnHandle_t,
+                                                         params::cusolverDnParams_t,
+                                                         m::Int64, n::Int64,
+                                                         dataTypeA::cudaDataType,
+                                                         A::CuPtr{Cvoid}, lda::Int64,
+                                                         dataTypeTau::cudaDataType,
+                                                         tau::CuPtr{Cvoid},
+                                                         computeType::cudaDataType,
+                                                         workspaceInBytes::Ptr{Csize_t})::cusolverStatus_t
 end
 
 @checked function cusolverDnGeqrf(handle, params, m, n, dataTypeA, A, lda, dataTypeTau, tau,
                                   computeType, pBuffer, workspaceInBytes, info)
     initialize_context()
-    @ccall libcusolver.cusolverDnGeqrf(handle::cusolverDnHandle_t,
-                                       params::cusolverDnParams_t, m::Int64, n::Int64,
-                                       dataTypeA::cudaDataType, A::CuPtr{Cvoid}, lda::Int64,
-                                       dataTypeTau::cudaDataType, tau::CuPtr{Cvoid},
-                                       computeType::cudaDataType, pBuffer::CuPtr{Cvoid},
-                                       workspaceInBytes::Csize_t,
-                                       info::CuPtr{Cint})::cusolverStatus_t
+    @gcsafe_ccall libcusolver.cusolverDnGeqrf(handle::cusolverDnHandle_t,
+                                              params::cusolverDnParams_t, m::Int64,
+                                              n::Int64, dataTypeA::cudaDataType,
+                                              A::CuPtr{Cvoid}, lda::Int64,
+                                              dataTypeTau::cudaDataType, tau::CuPtr{Cvoid},
+                                              computeType::cudaDataType,
+                                              pBuffer::CuPtr{Cvoid},
+                                              workspaceInBytes::Csize_t,
+                                              info::CuPtr{Cint})::cusolverStatus_t
 end
 
 @checked function cusolverDnGetrf_bufferSize(handle, params, m, n, dataTypeA, A, lda,
                                              computeType, workspaceInBytes)
     initialize_context()
-    @ccall libcusolver.cusolverDnGetrf_bufferSize(handle::cusolverDnHandle_t,
-                                                  params::cusolverDnParams_t, m::Int64,
-                                                  n::Int64, dataTypeA::cudaDataType,
-                                                  A::CuPtr{Cvoid}, lda::Int64,
-                                                  computeType::cudaDataType,
-                                                  workspaceInBytes::Ptr{Csize_t})::cusolverStatus_t
+    @gcsafe_ccall libcusolver.cusolverDnGetrf_bufferSize(handle::cusolverDnHandle_t,
+                                                         params::cusolverDnParams_t,
+                                                         m::Int64, n::Int64,
+                                                         dataTypeA::cudaDataType,
+                                                         A::CuPtr{Cvoid}, lda::Int64,
+                                                         computeType::cudaDataType,
+                                                         workspaceInBytes::Ptr{Csize_t})::cusolverStatus_t
 end
 
 @checked function cusolverDnGetrf(handle, params, m, n, dataTypeA, A, lda, ipiv,
                                   computeType, pBuffer, workspaceInBytes, info)
     initialize_context()
-    @ccall libcusolver.cusolverDnGetrf(handle::cusolverDnHandle_t,
-                                       params::cusolverDnParams_t, m::Int64, n::Int64,
-                                       dataTypeA::cudaDataType, A::CuPtr{Cvoid}, lda::Int64,
-                                       ipiv::CuPtr{Int64}, computeType::cudaDataType,
-                                       pBuffer::CuPtr{Cvoid}, workspaceInBytes::Csize_t,
-                                       info::CuPtr{Cint})::cusolverStatus_t
+    @gcsafe_ccall libcusolver.cusolverDnGetrf(handle::cusolverDnHandle_t,
+                                              params::cusolverDnParams_t, m::Int64,
+                                              n::Int64, dataTypeA::cudaDataType,
+                                              A::CuPtr{Cvoid}, lda::Int64,
+                                              ipiv::CuPtr{Int64}, computeType::cudaDataType,
+                                              pBuffer::CuPtr{Cvoid},
+                                              workspaceInBytes::Csize_t,
+                                              info::CuPtr{Cint})::cusolverStatus_t
 end
 
 @checked function cusolverDnGetrs(handle, params, trans, n, nrhs, dataTypeA, A, lda, ipiv,
                                   dataTypeB, B, ldb, info)
     initialize_context()
-    @ccall libcusolver.cusolverDnGetrs(handle::cusolverDnHandle_t,
-                                       params::cusolverDnParams_t, trans::cublasOperation_t,
-                                       n::Int64, nrhs::Int64, dataTypeA::cudaDataType,
-                                       A::CuPtr{Cvoid}, lda::Int64, ipiv::CuPtr{Int64},
-                                       dataTypeB::cudaDataType, B::CuPtr{Cvoid}, ldb::Int64,
-                                       info::CuPtr{Cint})::cusolverStatus_t
+    @gcsafe_ccall libcusolver.cusolverDnGetrs(handle::cusolverDnHandle_t,
+                                              params::cusolverDnParams_t,
+                                              trans::cublasOperation_t, n::Int64,
+                                              nrhs::Int64, dataTypeA::cudaDataType,
+                                              A::CuPtr{Cvoid}, lda::Int64,
+                                              ipiv::CuPtr{Int64}, dataTypeB::cudaDataType,
+                                              B::CuPtr{Cvoid}, ldb::Int64,
+                                              info::CuPtr{Cint})::cusolverStatus_t
 end
 
 @checked function cusolverDnSyevd_bufferSize(handle, params, jobz, uplo, n, dataTypeA, A,
                                              lda, dataTypeW, W, computeType,
                                              workspaceInBytes)
     initialize_context()
-    @ccall libcusolver.cusolverDnSyevd_bufferSize(handle::cusolverDnHandle_t,
-                                                  params::cusolverDnParams_t,
-                                                  jobz::cusolverEigMode_t,
-                                                  uplo::cublasFillMode_t, n::Int64,
-                                                  dataTypeA::cudaDataType, A::CuPtr{Cvoid},
-                                                  lda::Int64, dataTypeW::cudaDataType,
-                                                  W::CuPtr{Cvoid},
-                                                  computeType::cudaDataType,
-                                                  workspaceInBytes::Ptr{Csize_t})::cusolverStatus_t
+    @gcsafe_ccall libcusolver.cusolverDnSyevd_bufferSize(handle::cusolverDnHandle_t,
+                                                         params::cusolverDnParams_t,
+                                                         jobz::cusolverEigMode_t,
+                                                         uplo::cublasFillMode_t, n::Int64,
+                                                         dataTypeA::cudaDataType,
+                                                         A::CuPtr{Cvoid}, lda::Int64,
+                                                         dataTypeW::cudaDataType,
+                                                         W::CuPtr{Cvoid},
+                                                         computeType::cudaDataType,
+                                                         workspaceInBytes::Ptr{Csize_t})::cusolverStatus_t
 end
 
 @checked function cusolverDnSyevd(handle, params, jobz, uplo, n, dataTypeA, A, lda,
                                   dataTypeW, W, computeType, pBuffer, workspaceInBytes,
                                   info)
     initialize_context()
-    @ccall libcusolver.cusolverDnSyevd(handle::cusolverDnHandle_t,
-                                       params::cusolverDnParams_t, jobz::cusolverEigMode_t,
-                                       uplo::cublasFillMode_t, n::Int64,
-                                       dataTypeA::cudaDataType, A::CuPtr{Cvoid}, lda::Int64,
-                                       dataTypeW::cudaDataType, W::CuPtr{Cvoid},
-                                       computeType::cudaDataType, pBuffer::CuPtr{Cvoid},
-                                       workspaceInBytes::Csize_t,
-                                       info::CuPtr{Cint})::cusolverStatus_t
+    @gcsafe_ccall libcusolver.cusolverDnSyevd(handle::cusolverDnHandle_t,
+                                              params::cusolverDnParams_t,
+                                              jobz::cusolverEigMode_t,
+                                              uplo::cublasFillMode_t, n::Int64,
+                                              dataTypeA::cudaDataType, A::CuPtr{Cvoid},
+                                              lda::Int64, dataTypeW::cudaDataType,
+                                              W::CuPtr{Cvoid}, computeType::cudaDataType,
+                                              pBuffer::CuPtr{Cvoid},
+                                              workspaceInBytes::Csize_t,
+                                              info::CuPtr{Cint})::cusolverStatus_t
 end
 
 @checked function cusolverDnSyevdx_bufferSize(handle, params, jobz, range, uplo, n,
                                               dataTypeA, A, lda, vl, vu, il, iu, h_meig,
                                               dataTypeW, W, computeType, workspaceInBytes)
     initialize_context()
-    @ccall libcusolver.cusolverDnSyevdx_bufferSize(handle::cusolverDnHandle_t,
-                                                   params::cusolverDnParams_t,
-                                                   jobz::cusolverEigMode_t,
-                                                   range::cusolverEigRange_t,
-                                                   uplo::cublasFillMode_t, n::Int64,
-                                                   dataTypeA::cudaDataType, A::CuPtr{Cvoid},
-                                                   lda::Int64, vl::Ptr{Cvoid},
-                                                   vu::Ptr{Cvoid}, il::Int64, iu::Int64,
-                                                   h_meig::Ptr{Int64},
-                                                   dataTypeW::cudaDataType, W::CuPtr{Cvoid},
-                                                   computeType::cudaDataType,
-                                                   workspaceInBytes::Ptr{Csize_t})::cusolverStatus_t
+    @gcsafe_ccall libcusolver.cusolverDnSyevdx_bufferSize(handle::cusolverDnHandle_t,
+                                                          params::cusolverDnParams_t,
+                                                          jobz::cusolverEigMode_t,
+                                                          range::cusolverEigRange_t,
+                                                          uplo::cublasFillMode_t, n::Int64,
+                                                          dataTypeA::cudaDataType,
+                                                          A::CuPtr{Cvoid}, lda::Int64,
+                                                          vl::Ptr{Cvoid}, vu::Ptr{Cvoid},
+                                                          il::Int64, iu::Int64,
+                                                          h_meig::Ptr{Int64},
+                                                          dataTypeW::cudaDataType,
+                                                          W::CuPtr{Cvoid},
+                                                          computeType::cudaDataType,
+                                                          workspaceInBytes::Ptr{Csize_t})::cusolverStatus_t
 end
 
 @checked function cusolverDnSyevdx(handle, params, jobz, range, uplo, n, dataTypeA, A, lda,
                                    vl, vu, il, iu, meig64, dataTypeW, W, computeType,
                                    pBuffer, workspaceInBytes, info)
     initialize_context()
-    @ccall libcusolver.cusolverDnSyevdx(handle::cusolverDnHandle_t,
-                                        params::cusolverDnParams_t, jobz::cusolverEigMode_t,
-                                        range::cusolverEigRange_t, uplo::cublasFillMode_t,
-                                        n::Int64, dataTypeA::cudaDataType, A::CuPtr{Cvoid},
-                                        lda::Int64, vl::Ptr{Cvoid}, vu::Ptr{Cvoid},
-                                        il::Int64, iu::Int64, meig64::Ptr{Int64},
-                                        dataTypeW::cudaDataType, W::CuPtr{Cvoid},
-                                        computeType::cudaDataType, pBuffer::CuPtr{Cvoid},
-                                        workspaceInBytes::Csize_t,
-                                        info::CuPtr{Cint})::cusolverStatus_t
+    @gcsafe_ccall libcusolver.cusolverDnSyevdx(handle::cusolverDnHandle_t,
+                                               params::cusolverDnParams_t,
+                                               jobz::cusolverEigMode_t,
+                                               range::cusolverEigRange_t,
+                                               uplo::cublasFillMode_t, n::Int64,
+                                               dataTypeA::cudaDataType, A::CuPtr{Cvoid},
+                                               lda::Int64, vl::Ptr{Cvoid}, vu::Ptr{Cvoid},
+                                               il::Int64, iu::Int64, meig64::Ptr{Int64},
+                                               dataTypeW::cudaDataType, W::CuPtr{Cvoid},
+                                               computeType::cudaDataType,
+                                               pBuffer::CuPtr{Cvoid},
+                                               workspaceInBytes::Csize_t,
+                                               info::CuPtr{Cint})::cusolverStatus_t
 end
 
 @checked function cusolverDnGesvd_bufferSize(handle, params, jobu, jobvt, m, n, dataTypeA,
@@ -4004,72 +4475,80 @@ end
                                              dataTypeVT, VT, ldvt, computeType,
                                              workspaceInBytes)
     initialize_context()
-    @ccall libcusolver.cusolverDnGesvd_bufferSize(handle::cusolverDnHandle_t,
-                                                  params::cusolverDnParams_t, jobu::Int8,
-                                                  jobvt::Int8, m::Int64, n::Int64,
-                                                  dataTypeA::cudaDataType, A::CuPtr{Cvoid},
-                                                  lda::Int64, dataTypeS::cudaDataType,
-                                                  S::CuPtr{Cvoid}, dataTypeU::cudaDataType,
-                                                  U::CuPtr{Cvoid}, ldu::Int64,
-                                                  dataTypeVT::cudaDataType,
-                                                  VT::CuPtr{Cvoid}, ldvt::Int64,
-                                                  computeType::cudaDataType,
-                                                  workspaceInBytes::Ptr{Csize_t})::cusolverStatus_t
+    @gcsafe_ccall libcusolver.cusolverDnGesvd_bufferSize(handle::cusolverDnHandle_t,
+                                                         params::cusolverDnParams_t,
+                                                         jobu::Int8, jobvt::Int8, m::Int64,
+                                                         n::Int64, dataTypeA::cudaDataType,
+                                                         A::CuPtr{Cvoid}, lda::Int64,
+                                                         dataTypeS::cudaDataType,
+                                                         S::CuPtr{Cvoid},
+                                                         dataTypeU::cudaDataType,
+                                                         U::CuPtr{Cvoid}, ldu::Int64,
+                                                         dataTypeVT::cudaDataType,
+                                                         VT::CuPtr{Cvoid}, ldvt::Int64,
+                                                         computeType::cudaDataType,
+                                                         workspaceInBytes::Ptr{Csize_t})::cusolverStatus_t
 end
 
 @checked function cusolverDnGesvd(handle, params, jobu, jobvt, m, n, dataTypeA, A, lda,
                                   dataTypeS, S, dataTypeU, U, ldu, dataTypeVT, VT, ldvt,
                                   computeType, pBuffer, workspaceInBytes, info)
     initialize_context()
-    @ccall libcusolver.cusolverDnGesvd(handle::cusolverDnHandle_t,
-                                       params::cusolverDnParams_t, jobu::Int8, jobvt::Int8,
-                                       m::Int64, n::Int64, dataTypeA::cudaDataType,
-                                       A::CuPtr{Cvoid}, lda::Int64, dataTypeS::cudaDataType,
-                                       S::CuPtr{Cvoid}, dataTypeU::cudaDataType,
-                                       U::CuPtr{Cvoid}, ldu::Int64,
-                                       dataTypeVT::cudaDataType, VT::CuPtr{Cvoid},
-                                       ldvt::Int64, computeType::cudaDataType,
-                                       pBuffer::CuPtr{Cvoid}, workspaceInBytes::Csize_t,
-                                       info::CuPtr{Cint})::cusolverStatus_t
+    @gcsafe_ccall libcusolver.cusolverDnGesvd(handle::cusolverDnHandle_t,
+                                              params::cusolverDnParams_t, jobu::Int8,
+                                              jobvt::Int8, m::Int64, n::Int64,
+                                              dataTypeA::cudaDataType, A::CuPtr{Cvoid},
+                                              lda::Int64, dataTypeS::cudaDataType,
+                                              S::CuPtr{Cvoid}, dataTypeU::cudaDataType,
+                                              U::CuPtr{Cvoid}, ldu::Int64,
+                                              dataTypeVT::cudaDataType, VT::CuPtr{Cvoid},
+                                              ldvt::Int64, computeType::cudaDataType,
+                                              pBuffer::CuPtr{Cvoid},
+                                              workspaceInBytes::Csize_t,
+                                              info::CuPtr{Cint})::cusolverStatus_t
 end
 
 @checked function cusolverDnXpotrf_bufferSize(handle, params, uplo, n, dataTypeA, A, lda,
                                               computeType, workspaceInBytesOnDevice,
                                               workspaceInBytesOnHost)
     initialize_context()
-    @ccall libcusolver.cusolverDnXpotrf_bufferSize(handle::cusolverDnHandle_t,
-                                                   params::cusolverDnParams_t,
-                                                   uplo::cublasFillMode_t, n::Int64,
-                                                   dataTypeA::cudaDataType, A::CuPtr{Cvoid},
-                                                   lda::Int64, computeType::cudaDataType,
-                                                   workspaceInBytesOnDevice::Ptr{Csize_t},
-                                                   workspaceInBytesOnHost::Ptr{Csize_t})::cusolverStatus_t
+    @gcsafe_ccall libcusolver.cusolverDnXpotrf_bufferSize(handle::cusolverDnHandle_t,
+                                                          params::cusolverDnParams_t,
+                                                          uplo::cublasFillMode_t, n::Int64,
+                                                          dataTypeA::cudaDataType,
+                                                          A::CuPtr{Cvoid}, lda::Int64,
+                                                          computeType::cudaDataType,
+                                                          workspaceInBytesOnDevice::Ptr{Csize_t},
+                                                          workspaceInBytesOnHost::Ptr{Csize_t})::cusolverStatus_t
 end
 
 @checked function cusolverDnXpotrf(handle, params, uplo, n, dataTypeA, A, lda, computeType,
                                    bufferOnDevice, workspaceInBytesOnDevice, bufferOnHost,
                                    workspaceInBytesOnHost, info)
     initialize_context()
-    @ccall libcusolver.cusolverDnXpotrf(handle::cusolverDnHandle_t,
-                                        params::cusolverDnParams_t, uplo::cublasFillMode_t,
-                                        n::Int64, dataTypeA::cudaDataType, A::CuPtr{Cvoid},
-                                        lda::Int64, computeType::cudaDataType,
-                                        bufferOnDevice::CuPtr{Cvoid},
-                                        workspaceInBytesOnDevice::Csize_t,
-                                        bufferOnHost::Ptr{Cvoid},
-                                        workspaceInBytesOnHost::Csize_t,
-                                        info::CuPtr{Cint})::cusolverStatus_t
+    @gcsafe_ccall libcusolver.cusolverDnXpotrf(handle::cusolverDnHandle_t,
+                                               params::cusolverDnParams_t,
+                                               uplo::cublasFillMode_t, n::Int64,
+                                               dataTypeA::cudaDataType, A::CuPtr{Cvoid},
+                                               lda::Int64, computeType::cudaDataType,
+                                               bufferOnDevice::CuPtr{Cvoid},
+                                               workspaceInBytesOnDevice::Csize_t,
+                                               bufferOnHost::Ptr{Cvoid},
+                                               workspaceInBytesOnHost::Csize_t,
+                                               info::CuPtr{Cint})::cusolverStatus_t
 end
 
 @checked function cusolverDnXpotrs(handle, params, uplo, n, nrhs, dataTypeA, A, lda,
                                    dataTypeB, B, ldb, info)
     initialize_context()
-    @ccall libcusolver.cusolverDnXpotrs(handle::cusolverDnHandle_t,
-                                        params::cusolverDnParams_t, uplo::cublasFillMode_t,
-                                        n::Int64, nrhs::Int64, dataTypeA::cudaDataType,
-                                        A::CuPtr{Cvoid}, lda::Int64,
-                                        dataTypeB::cudaDataType, B::CuPtr{Cvoid},
-                                        ldb::Int64, info::CuPtr{Cint})::cusolverStatus_t
+    @gcsafe_ccall libcusolver.cusolverDnXpotrs(handle::cusolverDnHandle_t,
+                                               params::cusolverDnParams_t,
+                                               uplo::cublasFillMode_t, n::Int64,
+                                               nrhs::Int64, dataTypeA::cudaDataType,
+                                               A::CuPtr{Cvoid}, lda::Int64,
+                                               dataTypeB::cudaDataType, B::CuPtr{Cvoid},
+                                               ldb::Int64,
+                                               info::CuPtr{Cint})::cusolverStatus_t
 end
 
 @checked function cusolverDnXgeqrf_bufferSize(handle, params, m, n, dataTypeA, A, lda,
@@ -4077,15 +4556,16 @@ end
                                               workspaceInBytesOnDevice,
                                               workspaceInBytesOnHost)
     initialize_context()
-    @ccall libcusolver.cusolverDnXgeqrf_bufferSize(handle::cusolverDnHandle_t,
-                                                   params::cusolverDnParams_t, m::Int64,
-                                                   n::Int64, dataTypeA::cudaDataType,
-                                                   A::CuPtr{Cvoid}, lda::Int64,
-                                                   dataTypeTau::cudaDataType,
-                                                   tau::CuPtr{Cvoid},
-                                                   computeType::cudaDataType,
-                                                   workspaceInBytesOnDevice::Ptr{Csize_t},
-                                                   workspaceInBytesOnHost::Ptr{Csize_t})::cusolverStatus_t
+    @gcsafe_ccall libcusolver.cusolverDnXgeqrf_bufferSize(handle::cusolverDnHandle_t,
+                                                          params::cusolverDnParams_t,
+                                                          m::Int64, n::Int64,
+                                                          dataTypeA::cudaDataType,
+                                                          A::CuPtr{Cvoid}, lda::Int64,
+                                                          dataTypeTau::cudaDataType,
+                                                          tau::CuPtr{Cvoid},
+                                                          computeType::cudaDataType,
+                                                          workspaceInBytesOnDevice::Ptr{Csize_t},
+                                                          workspaceInBytesOnHost::Ptr{Csize_t})::cusolverStatus_t
 end
 
 @checked function cusolverDnXgeqrf(handle, params, m, n, dataTypeA, A, lda, dataTypeTau,
@@ -4093,57 +4573,61 @@ end
                                    workspaceInBytesOnDevice, bufferOnHost,
                                    workspaceInBytesOnHost, info)
     initialize_context()
-    @ccall libcusolver.cusolverDnXgeqrf(handle::cusolverDnHandle_t,
-                                        params::cusolverDnParams_t, m::Int64, n::Int64,
-                                        dataTypeA::cudaDataType, A::CuPtr{Cvoid},
-                                        lda::Int64, dataTypeTau::cudaDataType,
-                                        tau::CuPtr{Cvoid}, computeType::cudaDataType,
-                                        bufferOnDevice::CuPtr{Cvoid},
-                                        workspaceInBytesOnDevice::Csize_t,
-                                        bufferOnHost::Ptr{Cvoid},
-                                        workspaceInBytesOnHost::Csize_t,
-                                        info::CuPtr{Cint})::cusolverStatus_t
+    @gcsafe_ccall libcusolver.cusolverDnXgeqrf(handle::cusolverDnHandle_t,
+                                               params::cusolverDnParams_t, m::Int64,
+                                               n::Int64, dataTypeA::cudaDataType,
+                                               A::CuPtr{Cvoid}, lda::Int64,
+                                               dataTypeTau::cudaDataType, tau::CuPtr{Cvoid},
+                                               computeType::cudaDataType,
+                                               bufferOnDevice::CuPtr{Cvoid},
+                                               workspaceInBytesOnDevice::Csize_t,
+                                               bufferOnHost::Ptr{Cvoid},
+                                               workspaceInBytesOnHost::Csize_t,
+                                               info::CuPtr{Cint})::cusolverStatus_t
 end
 
 @checked function cusolverDnXgetrf_bufferSize(handle, params, m, n, dataTypeA, A, lda,
                                               computeType, workspaceInBytesOnDevice,
                                               workspaceInBytesOnHost)
     initialize_context()
-    @ccall libcusolver.cusolverDnXgetrf_bufferSize(handle::cusolverDnHandle_t,
-                                                   params::cusolverDnParams_t, m::Int64,
-                                                   n::Int64, dataTypeA::cudaDataType,
-                                                   A::CuPtr{Cvoid}, lda::Int64,
-                                                   computeType::cudaDataType,
-                                                   workspaceInBytesOnDevice::Ptr{Csize_t},
-                                                   workspaceInBytesOnHost::Ptr{Csize_t})::cusolverStatus_t
+    @gcsafe_ccall libcusolver.cusolverDnXgetrf_bufferSize(handle::cusolverDnHandle_t,
+                                                          params::cusolverDnParams_t,
+                                                          m::Int64, n::Int64,
+                                                          dataTypeA::cudaDataType,
+                                                          A::CuPtr{Cvoid}, lda::Int64,
+                                                          computeType::cudaDataType,
+                                                          workspaceInBytesOnDevice::Ptr{Csize_t},
+                                                          workspaceInBytesOnHost::Ptr{Csize_t})::cusolverStatus_t
 end
 
 @checked function cusolverDnXgetrf(handle, params, m, n, dataTypeA, A, lda, ipiv,
                                    computeType, bufferOnDevice, workspaceInBytesOnDevice,
                                    bufferOnHost, workspaceInBytesOnHost, info)
     initialize_context()
-    @ccall libcusolver.cusolverDnXgetrf(handle::cusolverDnHandle_t,
-                                        params::cusolverDnParams_t, m::Int64, n::Int64,
-                                        dataTypeA::cudaDataType, A::CuPtr{Cvoid},
-                                        lda::Int64, ipiv::CuPtr{Int64},
-                                        computeType::cudaDataType,
-                                        bufferOnDevice::CuPtr{Cvoid},
-                                        workspaceInBytesOnDevice::Csize_t,
-                                        bufferOnHost::Ptr{Cvoid},
-                                        workspaceInBytesOnHost::Csize_t,
-                                        info::CuPtr{Cint})::cusolverStatus_t
+    @gcsafe_ccall libcusolver.cusolverDnXgetrf(handle::cusolverDnHandle_t,
+                                               params::cusolverDnParams_t, m::Int64,
+                                               n::Int64, dataTypeA::cudaDataType,
+                                               A::CuPtr{Cvoid}, lda::Int64,
+                                               ipiv::CuPtr{Int64},
+                                               computeType::cudaDataType,
+                                               bufferOnDevice::CuPtr{Cvoid},
+                                               workspaceInBytesOnDevice::Csize_t,
+                                               bufferOnHost::Ptr{Cvoid},
+                                               workspaceInBytesOnHost::Csize_t,
+                                               info::CuPtr{Cint})::cusolverStatus_t
 end
 
 @checked function cusolverDnXgetrs(handle, params, trans, n, nrhs, dataTypeA, A, lda, ipiv,
                                    dataTypeB, B, ldb, info)
     initialize_context()
-    @ccall libcusolver.cusolverDnXgetrs(handle::cusolverDnHandle_t,
-                                        params::cusolverDnParams_t,
-                                        trans::cublasOperation_t, n::Int64, nrhs::Int64,
-                                        dataTypeA::cudaDataType, A::CuPtr{Cvoid},
-                                        lda::Int64, ipiv::CuPtr{Int64},
-                                        dataTypeB::cudaDataType, B::CuPtr{Cvoid},
-                                        ldb::Int64, info::CuPtr{Cint})::cusolverStatus_t
+    @gcsafe_ccall libcusolver.cusolverDnXgetrs(handle::cusolverDnHandle_t,
+                                               params::cusolverDnParams_t,
+                                               trans::cublasOperation_t, n::Int64,
+                                               nrhs::Int64, dataTypeA::cudaDataType,
+                                               A::CuPtr{Cvoid}, lda::Int64,
+                                               ipiv::CuPtr{Int64}, dataTypeB::cudaDataType,
+                                               B::CuPtr{Cvoid}, ldb::Int64,
+                                               info::CuPtr{Cint})::cusolverStatus_t
 end
 
 @checked function cusolverDnXsyevd_bufferSize(handle, params, jobz, uplo, n, dataTypeA, A,
@@ -4151,16 +4635,17 @@ end
                                               workspaceInBytesOnDevice,
                                               workspaceInBytesOnHost)
     initialize_context()
-    @ccall libcusolver.cusolverDnXsyevd_bufferSize(handle::cusolverDnHandle_t,
-                                                   params::cusolverDnParams_t,
-                                                   jobz::cusolverEigMode_t,
-                                                   uplo::cublasFillMode_t, n::Int64,
-                                                   dataTypeA::cudaDataType, A::CuPtr{Cvoid},
-                                                   lda::Int64, dataTypeW::cudaDataType,
-                                                   W::CuPtr{Cvoid},
-                                                   computeType::cudaDataType,
-                                                   workspaceInBytesOnDevice::Ptr{Csize_t},
-                                                   workspaceInBytesOnHost::Ptr{Csize_t})::cusolverStatus_t
+    @gcsafe_ccall libcusolver.cusolverDnXsyevd_bufferSize(handle::cusolverDnHandle_t,
+                                                          params::cusolverDnParams_t,
+                                                          jobz::cusolverEigMode_t,
+                                                          uplo::cublasFillMode_t, n::Int64,
+                                                          dataTypeA::cudaDataType,
+                                                          A::CuPtr{Cvoid}, lda::Int64,
+                                                          dataTypeW::cudaDataType,
+                                                          W::CuPtr{Cvoid},
+                                                          computeType::cudaDataType,
+                                                          workspaceInBytesOnDevice::Ptr{Csize_t},
+                                                          workspaceInBytesOnHost::Ptr{Csize_t})::cusolverStatus_t
 end
 
 @checked function cusolverDnXsyevd(handle, params, jobz, uplo, n, dataTypeA, A, lda,
@@ -4168,17 +4653,18 @@ end
                                    workspaceInBytesOnDevice, bufferOnHost,
                                    workspaceInBytesOnHost, info)
     initialize_context()
-    @ccall libcusolver.cusolverDnXsyevd(handle::cusolverDnHandle_t,
-                                        params::cusolverDnParams_t, jobz::cusolverEigMode_t,
-                                        uplo::cublasFillMode_t, n::Int64,
-                                        dataTypeA::cudaDataType, A::CuPtr{Cvoid},
-                                        lda::Int64, dataTypeW::cudaDataType,
-                                        W::CuPtr{Cvoid}, computeType::cudaDataType,
-                                        bufferOnDevice::CuPtr{Cvoid},
-                                        workspaceInBytesOnDevice::Csize_t,
-                                        bufferOnHost::Ptr{Cvoid},
-                                        workspaceInBytesOnHost::Csize_t,
-                                        info::CuPtr{Cint})::cusolverStatus_t
+    @gcsafe_ccall libcusolver.cusolverDnXsyevd(handle::cusolverDnHandle_t,
+                                               params::cusolverDnParams_t,
+                                               jobz::cusolverEigMode_t,
+                                               uplo::cublasFillMode_t, n::Int64,
+                                               dataTypeA::cudaDataType, A::CuPtr{Cvoid},
+                                               lda::Int64, dataTypeW::cudaDataType,
+                                               W::CuPtr{Cvoid}, computeType::cudaDataType,
+                                               bufferOnDevice::CuPtr{Cvoid},
+                                               workspaceInBytesOnDevice::Csize_t,
+                                               bufferOnHost::Ptr{Cvoid},
+                                               workspaceInBytesOnHost::Csize_t,
+                                               info::CuPtr{Cint})::cusolverStatus_t
 end
 
 @checked function cusolverDnXsyevdx_bufferSize(handle, params, jobz, range, uplo, n,
@@ -4187,21 +4673,21 @@ end
                                                workspaceInBytesOnDevice,
                                                workspaceInBytesOnHost)
     initialize_context()
-    @ccall libcusolver.cusolverDnXsyevdx_bufferSize(handle::cusolverDnHandle_t,
-                                                    params::cusolverDnParams_t,
-                                                    jobz::cusolverEigMode_t,
-                                                    range::cusolverEigRange_t,
-                                                    uplo::cublasFillMode_t, n::Int64,
-                                                    dataTypeA::cudaDataType,
-                                                    A::CuPtr{Cvoid}, lda::Int64,
-                                                    vl::Ptr{Cvoid}, vu::Ptr{Cvoid},
-                                                    il::Int64, iu::Int64,
-                                                    h_meig::Ptr{Int64},
-                                                    dataTypeW::cudaDataType,
-                                                    W::CuPtr{Cvoid},
-                                                    computeType::cudaDataType,
-                                                    workspaceInBytesOnDevice::Ptr{Csize_t},
-                                                    workspaceInBytesOnHost::Ptr{Csize_t})::cusolverStatus_t
+    @gcsafe_ccall libcusolver.cusolverDnXsyevdx_bufferSize(handle::cusolverDnHandle_t,
+                                                           params::cusolverDnParams_t,
+                                                           jobz::cusolverEigMode_t,
+                                                           range::cusolverEigRange_t,
+                                                           uplo::cublasFillMode_t, n::Int64,
+                                                           dataTypeA::cudaDataType,
+                                                           A::CuPtr{Cvoid}, lda::Int64,
+                                                           vl::Ptr{Cvoid}, vu::Ptr{Cvoid},
+                                                           il::Int64, iu::Int64,
+                                                           h_meig::Ptr{Int64},
+                                                           dataTypeW::cudaDataType,
+                                                           W::CuPtr{Cvoid},
+                                                           computeType::cudaDataType,
+                                                           workspaceInBytesOnDevice::Ptr{Csize_t},
+                                                           workspaceInBytesOnHost::Ptr{Csize_t})::cusolverStatus_t
 end
 
 @checked function cusolverDnXsyevdx(handle, params, jobz, range, uplo, n, dataTypeA, A, lda,
@@ -4209,20 +4695,21 @@ end
                                     bufferOnDevice, workspaceInBytesOnDevice, bufferOnHost,
                                     workspaceInBytesOnHost, info)
     initialize_context()
-    @ccall libcusolver.cusolverDnXsyevdx(handle::cusolverDnHandle_t,
-                                         params::cusolverDnParams_t,
-                                         jobz::cusolverEigMode_t, range::cusolverEigRange_t,
-                                         uplo::cublasFillMode_t, n::Int64,
-                                         dataTypeA::cudaDataType, A::CuPtr{Cvoid},
-                                         lda::Int64, vl::Ptr{Cvoid}, vu::Ptr{Cvoid},
-                                         il::Int64, iu::Int64, meig64::Ptr{Int64},
-                                         dataTypeW::cudaDataType, W::CuPtr{Cvoid},
-                                         computeType::cudaDataType,
-                                         bufferOnDevice::CuPtr{Cvoid},
-                                         workspaceInBytesOnDevice::Csize_t,
-                                         bufferOnHost::Ptr{Cvoid},
-                                         workspaceInBytesOnHost::Csize_t,
-                                         info::CuPtr{Cint})::cusolverStatus_t
+    @gcsafe_ccall libcusolver.cusolverDnXsyevdx(handle::cusolverDnHandle_t,
+                                                params::cusolverDnParams_t,
+                                                jobz::cusolverEigMode_t,
+                                                range::cusolverEigRange_t,
+                                                uplo::cublasFillMode_t, n::Int64,
+                                                dataTypeA::cudaDataType, A::CuPtr{Cvoid},
+                                                lda::Int64, vl::Ptr{Cvoid}, vu::Ptr{Cvoid},
+                                                il::Int64, iu::Int64, meig64::Ptr{Int64},
+                                                dataTypeW::cudaDataType, W::CuPtr{Cvoid},
+                                                computeType::cudaDataType,
+                                                bufferOnDevice::CuPtr{Cvoid},
+                                                workspaceInBytesOnDevice::Csize_t,
+                                                bufferOnHost::Ptr{Cvoid},
+                                                workspaceInBytesOnHost::Csize_t,
+                                                info::CuPtr{Cint})::cusolverStatus_t
 end
 
 @checked function cusolverDnXgesvd_bufferSize(handle, params, jobu, jobvt, m, n, dataTypeA,
@@ -4231,18 +4718,20 @@ end
                                               workspaceInBytesOnDevice,
                                               workspaceInBytesOnHost)
     initialize_context()
-    @ccall libcusolver.cusolverDnXgesvd_bufferSize(handle::cusolverDnHandle_t,
-                                                   params::cusolverDnParams_t, jobu::Int8,
-                                                   jobvt::Int8, m::Int64, n::Int64,
-                                                   dataTypeA::cudaDataType, A::CuPtr{Cvoid},
-                                                   lda::Int64, dataTypeS::cudaDataType,
-                                                   S::CuPtr{Cvoid}, dataTypeU::cudaDataType,
-                                                   U::CuPtr{Cvoid}, ldu::Int64,
-                                                   dataTypeVT::cudaDataType,
-                                                   VT::CuPtr{Cvoid}, ldvt::Int64,
-                                                   computeType::cudaDataType,
-                                                   workspaceInBytesOnDevice::Ptr{Csize_t},
-                                                   workspaceInBytesOnHost::Ptr{Csize_t})::cusolverStatus_t
+    @gcsafe_ccall libcusolver.cusolverDnXgesvd_bufferSize(handle::cusolverDnHandle_t,
+                                                          params::cusolverDnParams_t,
+                                                          jobu::Int8, jobvt::Int8, m::Int64,
+                                                          n::Int64, dataTypeA::cudaDataType,
+                                                          A::CuPtr{Cvoid}, lda::Int64,
+                                                          dataTypeS::cudaDataType,
+                                                          S::CuPtr{Cvoid},
+                                                          dataTypeU::cudaDataType,
+                                                          U::CuPtr{Cvoid}, ldu::Int64,
+                                                          dataTypeVT::cudaDataType,
+                                                          VT::CuPtr{Cvoid}, ldvt::Int64,
+                                                          computeType::cudaDataType,
+                                                          workspaceInBytesOnDevice::Ptr{Csize_t},
+                                                          workspaceInBytesOnHost::Ptr{Csize_t})::cusolverStatus_t
 end
 
 @checked function cusolverDnXgesvd(handle, params, jobu, jobvt, m, n, dataTypeA, A, lda,
@@ -4250,20 +4739,20 @@ end
                                    computeType, bufferOnDevice, workspaceInBytesOnDevice,
                                    bufferOnHost, workspaceInBytesOnHost, info)
     initialize_context()
-    @ccall libcusolver.cusolverDnXgesvd(handle::cusolverDnHandle_t,
-                                        params::cusolverDnParams_t, jobu::Int8, jobvt::Int8,
-                                        m::Int64, n::Int64, dataTypeA::cudaDataType,
-                                        A::CuPtr{Cvoid}, lda::Int64,
-                                        dataTypeS::cudaDataType, S::CuPtr{Cvoid},
-                                        dataTypeU::cudaDataType, U::CuPtr{Cvoid},
-                                        ldu::Int64, dataTypeVT::cudaDataType,
-                                        VT::CuPtr{Cvoid}, ldvt::Int64,
-                                        computeType::cudaDataType,
-                                        bufferOnDevice::CuPtr{Cvoid},
-                                        workspaceInBytesOnDevice::Csize_t,
-                                        bufferOnHost::Ptr{Cvoid},
-                                        workspaceInBytesOnHost::Csize_t,
-                                        info::CuPtr{Cint})::cusolverStatus_t
+    @gcsafe_ccall libcusolver.cusolverDnXgesvd(handle::cusolverDnHandle_t,
+                                               params::cusolverDnParams_t, jobu::Int8,
+                                               jobvt::Int8, m::Int64, n::Int64,
+                                               dataTypeA::cudaDataType, A::CuPtr{Cvoid},
+                                               lda::Int64, dataTypeS::cudaDataType,
+                                               S::CuPtr{Cvoid}, dataTypeU::cudaDataType,
+                                               U::CuPtr{Cvoid}, ldu::Int64,
+                                               dataTypeVT::cudaDataType, VT::CuPtr{Cvoid},
+                                               ldvt::Int64, computeType::cudaDataType,
+                                               bufferOnDevice::CuPtr{Cvoid},
+                                               workspaceInBytesOnDevice::Csize_t,
+                                               bufferOnHost::Ptr{Cvoid},
+                                               workspaceInBytesOnHost::Csize_t,
+                                               info::CuPtr{Cint})::cusolverStatus_t
 end
 
 @checked function cusolverDnXgesvdp_bufferSize(handle, params, jobz, econ, m, n, dataTypeA,
@@ -4272,21 +4761,21 @@ end
                                                workspaceInBytesOnDevice,
                                                workspaceInBytesOnHost)
     initialize_context()
-    @ccall libcusolver.cusolverDnXgesvdp_bufferSize(handle::cusolverDnHandle_t,
-                                                    params::cusolverDnParams_t,
-                                                    jobz::cusolverEigMode_t, econ::Cint,
-                                                    m::Int64, n::Int64,
-                                                    dataTypeA::cudaDataType,
-                                                    A::CuPtr{Cvoid}, lda::Int64,
-                                                    dataTypeS::cudaDataType,
-                                                    S::CuPtr{Cvoid},
-                                                    dataTypeU::cudaDataType,
-                                                    U::CuPtr{Cvoid}, ldu::Int64,
-                                                    dataTypeV::cudaDataType,
-                                                    V::CuPtr{Cvoid}, ldv::Int64,
-                                                    computeType::cudaDataType,
-                                                    workspaceInBytesOnDevice::Ptr{Csize_t},
-                                                    workspaceInBytesOnHost::Ptr{Csize_t})::cusolverStatus_t
+    @gcsafe_ccall libcusolver.cusolverDnXgesvdp_bufferSize(handle::cusolverDnHandle_t,
+                                                           params::cusolverDnParams_t,
+                                                           jobz::cusolverEigMode_t,
+                                                           econ::Cint, m::Int64, n::Int64,
+                                                           dataTypeA::cudaDataType,
+                                                           A::CuPtr{Cvoid}, lda::Int64,
+                                                           dataTypeS::cudaDataType,
+                                                           S::CuPtr{Cvoid},
+                                                           dataTypeU::cudaDataType,
+                                                           U::CuPtr{Cvoid}, ldu::Int64,
+                                                           dataTypeV::cudaDataType,
+                                                           V::CuPtr{Cvoid}, ldv::Int64,
+                                                           computeType::cudaDataType,
+                                                           workspaceInBytesOnDevice::Ptr{Csize_t},
+                                                           workspaceInBytesOnHost::Ptr{Csize_t})::cusolverStatus_t
 end
 
 @checked function cusolverDnXgesvdp(handle, params, jobz, econ, m, n, dataTypeA, A, lda,
@@ -4295,21 +4784,22 @@ end
                                     bufferOnHost, workspaceInBytesOnHost, d_info,
                                     h_err_sigma)
     initialize_context()
-    @ccall libcusolver.cusolverDnXgesvdp(handle::cusolverDnHandle_t,
-                                         params::cusolverDnParams_t,
-                                         jobz::cusolverEigMode_t, econ::Cint, m::Int64,
-                                         n::Int64, dataTypeA::cudaDataType, A::CuPtr{Cvoid},
-                                         lda::Int64, dataTypeS::cudaDataType,
-                                         S::CuPtr{Cvoid}, dataTypeU::cudaDataType,
-                                         U::CuPtr{Cvoid}, ldu::Int64,
-                                         dataTypeV::cudaDataType, V::CuPtr{Cvoid},
-                                         ldv::Int64, computeType::cudaDataType,
-                                         bufferOnDevice::CuPtr{Cvoid},
-                                         workspaceInBytesOnDevice::Csize_t,
-                                         bufferOnHost::Ptr{Cvoid},
-                                         workspaceInBytesOnHost::Csize_t,
-                                         d_info::CuPtr{Cint},
-                                         h_err_sigma::Ptr{Cdouble})::cusolverStatus_t
+    @gcsafe_ccall libcusolver.cusolverDnXgesvdp(handle::cusolverDnHandle_t,
+                                                params::cusolverDnParams_t,
+                                                jobz::cusolverEigMode_t, econ::Cint,
+                                                m::Int64, n::Int64, dataTypeA::cudaDataType,
+                                                A::CuPtr{Cvoid}, lda::Int64,
+                                                dataTypeS::cudaDataType, S::CuPtr{Cvoid},
+                                                dataTypeU::cudaDataType, U::CuPtr{Cvoid},
+                                                ldu::Int64, dataTypeV::cudaDataType,
+                                                V::CuPtr{Cvoid}, ldv::Int64,
+                                                computeType::cudaDataType,
+                                                bufferOnDevice::CuPtr{Cvoid},
+                                                workspaceInBytesOnDevice::Csize_t,
+                                                bufferOnHost::Ptr{Cvoid},
+                                                workspaceInBytesOnHost::Csize_t,
+                                                d_info::CuPtr{Cint},
+                                                h_err_sigma::Ptr{Cdouble})::cusolverStatus_t
 end
 
 @checked function cusolverDnXgesvdr_bufferSize(handle, params, jobu, jobv, m, n, k, p,
@@ -4319,21 +4809,24 @@ end
                                                workspaceInBytesOnDevice,
                                                workspaceInBytesOnHost)
     initialize_context()
-    @ccall libcusolver.cusolverDnXgesvdr_bufferSize(handle::cusolverDnHandle_t,
-                                                    params::cusolverDnParams_t, jobu::Int8,
-                                                    jobv::Int8, m::Int64, n::Int64,
-                                                    k::Int64, p::Int64, niters::Int64,
-                                                    dataTypeA::cudaDataType,
-                                                    A::CuPtr{Cvoid}, lda::Int64,
-                                                    dataTypeSrand::cudaDataType,
-                                                    Srand::CuPtr{Cvoid},
-                                                    dataTypeUrand::cudaDataType,
-                                                    Urand::CuPtr{Cvoid}, ldUrand::Int64,
-                                                    dataTypeVrand::cudaDataType,
-                                                    Vrand::CuPtr{Cvoid}, ldVrand::Int64,
-                                                    computeType::cudaDataType,
-                                                    workspaceInBytesOnDevice::Ptr{Csize_t},
-                                                    workspaceInBytesOnHost::Ptr{Csize_t})::cusolverStatus_t
+    @gcsafe_ccall libcusolver.cusolverDnXgesvdr_bufferSize(handle::cusolverDnHandle_t,
+                                                           params::cusolverDnParams_t,
+                                                           jobu::Int8, jobv::Int8, m::Int64,
+                                                           n::Int64, k::Int64, p::Int64,
+                                                           niters::Int64,
+                                                           dataTypeA::cudaDataType,
+                                                           A::CuPtr{Cvoid}, lda::Int64,
+                                                           dataTypeSrand::cudaDataType,
+                                                           Srand::CuPtr{Cvoid},
+                                                           dataTypeUrand::cudaDataType,
+                                                           Urand::CuPtr{Cvoid},
+                                                           ldUrand::Int64,
+                                                           dataTypeVrand::cudaDataType,
+                                                           Vrand::CuPtr{Cvoid},
+                                                           ldVrand::Int64,
+                                                           computeType::cudaDataType,
+                                                           workspaceInBytesOnDevice::Ptr{Csize_t},
+                                                           workspaceInBytesOnHost::Ptr{Csize_t})::cusolverStatus_t
 end
 
 @checked function cusolverDnXgesvdr(handle, params, jobu, jobv, m, n, k, p, niters,
@@ -4342,21 +4835,23 @@ end
                                     computeType, bufferOnDevice, workspaceInBytesOnDevice,
                                     bufferOnHost, workspaceInBytesOnHost, d_info)
     initialize_context()
-    @ccall libcusolver.cusolverDnXgesvdr(handle::cusolverDnHandle_t,
-                                         params::cusolverDnParams_t, jobu::Int8, jobv::Int8,
-                                         m::Int64, n::Int64, k::Int64, p::Int64,
-                                         niters::Int64, dataTypeA::cudaDataType,
-                                         A::CuPtr{Cvoid}, lda::Int64,
-                                         dataTypeSrand::cudaDataType, Srand::CuPtr{Cvoid},
-                                         dataTypeUrand::cudaDataType, Urand::CuPtr{Cvoid},
-                                         ldUrand::Int64, dataTypeVrand::cudaDataType,
-                                         Vrand::CuPtr{Cvoid}, ldVrand::Int64,
-                                         computeType::cudaDataType,
-                                         bufferOnDevice::CuPtr{Cvoid},
-                                         workspaceInBytesOnDevice::Csize_t,
-                                         bufferOnHost::Ptr{Cvoid},
-                                         workspaceInBytesOnHost::Csize_t,
-                                         d_info::CuPtr{Cint})::cusolverStatus_t
+    @gcsafe_ccall libcusolver.cusolverDnXgesvdr(handle::cusolverDnHandle_t,
+                                                params::cusolverDnParams_t, jobu::Int8,
+                                                jobv::Int8, m::Int64, n::Int64, k::Int64,
+                                                p::Int64, niters::Int64,
+                                                dataTypeA::cudaDataType, A::CuPtr{Cvoid},
+                                                lda::Int64, dataTypeSrand::cudaDataType,
+                                                Srand::CuPtr{Cvoid},
+                                                dataTypeUrand::cudaDataType,
+                                                Urand::CuPtr{Cvoid}, ldUrand::Int64,
+                                                dataTypeVrand::cudaDataType,
+                                                Vrand::CuPtr{Cvoid}, ldVrand::Int64,
+                                                computeType::cudaDataType,
+                                                bufferOnDevice::CuPtr{Cvoid},
+                                                workspaceInBytesOnDevice::Csize_t,
+                                                bufferOnHost::Ptr{Cvoid},
+                                                workspaceInBytesOnHost::Csize_t,
+                                                d_info::CuPtr{Cint})::cusolverStatus_t
 end
 
 # typedef void ( * cusolverDnLoggerCallback_t ) ( int logLevel , const char * functionName , const char * message )
@@ -4364,33 +4859,33 @@ const cusolverDnLoggerCallback_t = Ptr{Cvoid}
 
 @checked function cusolverDnLoggerSetCallback(callback)
     initialize_context()
-    @ccall libcusolver.cusolverDnLoggerSetCallback(callback::cusolverDnLoggerCallback_t)::cusolverStatus_t
+    @gcsafe_ccall libcusolver.cusolverDnLoggerSetCallback(callback::cusolverDnLoggerCallback_t)::cusolverStatus_t
 end
 
 @checked function cusolverDnLoggerSetFile(file)
     initialize_context()
-    @ccall libcusolver.cusolverDnLoggerSetFile(file::Ptr{Libc.FILE})::cusolverStatus_t
+    @gcsafe_ccall libcusolver.cusolverDnLoggerSetFile(file::Ptr{Libc.FILE})::cusolverStatus_t
 end
 
 @checked function cusolverDnLoggerOpenFile(logFile)
     initialize_context()
-    @ccall libcusolver.cusolverDnLoggerOpenFile(logFile::Cstring)::cusolverStatus_t
+    @gcsafe_ccall libcusolver.cusolverDnLoggerOpenFile(logFile::Cstring)::cusolverStatus_t
 end
 
 @checked function cusolverDnLoggerSetLevel(level)
     initialize_context()
-    @ccall libcusolver.cusolverDnLoggerSetLevel(level::Cint)::cusolverStatus_t
+    @gcsafe_ccall libcusolver.cusolverDnLoggerSetLevel(level::Cint)::cusolverStatus_t
 end
 
 @checked function cusolverDnLoggerSetMask(mask)
     initialize_context()
-    @ccall libcusolver.cusolverDnLoggerSetMask(mask::Cint)::cusolverStatus_t
+    @gcsafe_ccall libcusolver.cusolverDnLoggerSetMask(mask::Cint)::cusolverStatus_t
 end
 
 # no prototype is found for this function at cusolverDn.h:4881:32, please use with caution
 @checked function cusolverDnLoggerForceDisable()
     initialize_context()
-    @ccall libcusolver.cusolverDnLoggerForceDisable()::cusolverStatus_t
+    @gcsafe_ccall libcusolver.cusolverDnLoggerForceDisable()::cusolverStatus_t
 end
 
 mutable struct cusolverSpContext end
@@ -4403,715 +4898,795 @@ const csrqrInfo_t = Ptr{csrqrInfo}
 
 @checked function cusolverSpCreate(handle)
     initialize_context()
-    @ccall libcusolver.cusolverSpCreate(handle::Ptr{cusolverSpHandle_t})::cusolverStatus_t
+    @gcsafe_ccall libcusolver.cusolverSpCreate(handle::Ptr{cusolverSpHandle_t})::cusolverStatus_t
 end
 
 @checked function cusolverSpDestroy(handle)
     initialize_context()
-    @ccall libcusolver.cusolverSpDestroy(handle::cusolverSpHandle_t)::cusolverStatus_t
+    @gcsafe_ccall libcusolver.cusolverSpDestroy(handle::cusolverSpHandle_t)::cusolverStatus_t
 end
 
 @checked function cusolverSpSetStream(handle, streamId)
     initialize_context()
-    @ccall libcusolver.cusolverSpSetStream(handle::cusolverSpHandle_t,
-                                           streamId::cudaStream_t)::cusolverStatus_t
+    @gcsafe_ccall libcusolver.cusolverSpSetStream(handle::cusolverSpHandle_t,
+                                                  streamId::cudaStream_t)::cusolverStatus_t
 end
 
 @checked function cusolverSpGetStream(handle, streamId)
     initialize_context()
-    @ccall libcusolver.cusolverSpGetStream(handle::cusolverSpHandle_t,
-                                           streamId::Ptr{cudaStream_t})::cusolverStatus_t
+    @gcsafe_ccall libcusolver.cusolverSpGetStream(handle::cusolverSpHandle_t,
+                                                  streamId::Ptr{cudaStream_t})::cusolverStatus_t
 end
 
 @checked function cusolverSpXcsrissymHost(handle, m, nnzA, descrA, csrRowPtrA, csrEndPtrA,
                                           csrColIndA, issym)
     initialize_context()
-    @ccall libcusolver.cusolverSpXcsrissymHost(handle::cusolverSpHandle_t, m::Cint,
-                                               nnzA::Cint, descrA::cusparseMatDescr_t,
-                                               csrRowPtrA::Ptr{Cint}, csrEndPtrA::Ptr{Cint},
-                                               csrColIndA::Ptr{Cint},
-                                               issym::Ptr{Cint})::cusolverStatus_t
+    @gcsafe_ccall libcusolver.cusolverSpXcsrissymHost(handle::cusolverSpHandle_t, m::Cint,
+                                                      nnzA::Cint,
+                                                      descrA::cusparseMatDescr_t,
+                                                      csrRowPtrA::Ptr{Cint},
+                                                      csrEndPtrA::Ptr{Cint},
+                                                      csrColIndA::Ptr{Cint},
+                                                      issym::Ptr{Cint})::cusolverStatus_t
 end
 
 @checked function cusolverSpScsrlsvluHost(handle, n, nnzA, descrA, csrValA, csrRowPtrA,
                                           csrColIndA, b, tol, reorder, x, singularity)
     initialize_context()
-    @ccall libcusolver.cusolverSpScsrlsvluHost(handle::cusolverSpHandle_t, n::Cint,
-                                               nnzA::Cint, descrA::cusparseMatDescr_t,
-                                               csrValA::Ptr{Cfloat}, csrRowPtrA::Ptr{Cint},
-                                               csrColIndA::Ptr{Cint}, b::Ptr{Cfloat},
-                                               tol::Cfloat, reorder::Cint, x::Ptr{Cfloat},
-                                               singularity::Ptr{Cint})::cusolverStatus_t
+    @gcsafe_ccall libcusolver.cusolverSpScsrlsvluHost(handle::cusolverSpHandle_t, n::Cint,
+                                                      nnzA::Cint,
+                                                      descrA::cusparseMatDescr_t,
+                                                      csrValA::Ptr{Cfloat},
+                                                      csrRowPtrA::Ptr{Cint},
+                                                      csrColIndA::Ptr{Cint}, b::Ptr{Cfloat},
+                                                      tol::Cfloat, reorder::Cint,
+                                                      x::Ptr{Cfloat},
+                                                      singularity::Ptr{Cint})::cusolverStatus_t
 end
 
 @checked function cusolverSpDcsrlsvluHost(handle, n, nnzA, descrA, csrValA, csrRowPtrA,
                                           csrColIndA, b, tol, reorder, x, singularity)
     initialize_context()
-    @ccall libcusolver.cusolverSpDcsrlsvluHost(handle::cusolverSpHandle_t, n::Cint,
-                                               nnzA::Cint, descrA::cusparseMatDescr_t,
-                                               csrValA::Ptr{Cdouble}, csrRowPtrA::Ptr{Cint},
-                                               csrColIndA::Ptr{Cint}, b::Ptr{Cdouble},
-                                               tol::Cdouble, reorder::Cint, x::Ptr{Cdouble},
-                                               singularity::Ptr{Cint})::cusolverStatus_t
+    @gcsafe_ccall libcusolver.cusolverSpDcsrlsvluHost(handle::cusolverSpHandle_t, n::Cint,
+                                                      nnzA::Cint,
+                                                      descrA::cusparseMatDescr_t,
+                                                      csrValA::Ptr{Cdouble},
+                                                      csrRowPtrA::Ptr{Cint},
+                                                      csrColIndA::Ptr{Cint},
+                                                      b::Ptr{Cdouble}, tol::Cdouble,
+                                                      reorder::Cint, x::Ptr{Cdouble},
+                                                      singularity::Ptr{Cint})::cusolverStatus_t
 end
 
 @checked function cusolverSpCcsrlsvluHost(handle, n, nnzA, descrA, csrValA, csrRowPtrA,
                                           csrColIndA, b, tol, reorder, x, singularity)
     initialize_context()
-    @ccall libcusolver.cusolverSpCcsrlsvluHost(handle::cusolverSpHandle_t, n::Cint,
-                                               nnzA::Cint, descrA::cusparseMatDescr_t,
-                                               csrValA::Ptr{cuComplex},
-                                               csrRowPtrA::Ptr{Cint}, csrColIndA::Ptr{Cint},
-                                               b::Ptr{cuComplex}, tol::Cfloat,
-                                               reorder::Cint, x::Ptr{cuComplex},
-                                               singularity::Ptr{Cint})::cusolverStatus_t
+    @gcsafe_ccall libcusolver.cusolverSpCcsrlsvluHost(handle::cusolverSpHandle_t, n::Cint,
+                                                      nnzA::Cint,
+                                                      descrA::cusparseMatDescr_t,
+                                                      csrValA::Ptr{cuComplex},
+                                                      csrRowPtrA::Ptr{Cint},
+                                                      csrColIndA::Ptr{Cint},
+                                                      b::Ptr{cuComplex}, tol::Cfloat,
+                                                      reorder::Cint, x::Ptr{cuComplex},
+                                                      singularity::Ptr{Cint})::cusolverStatus_t
 end
 
 @checked function cusolverSpZcsrlsvluHost(handle, n, nnzA, descrA, csrValA, csrRowPtrA,
                                           csrColIndA, b, tol, reorder, x, singularity)
     initialize_context()
-    @ccall libcusolver.cusolverSpZcsrlsvluHost(handle::cusolverSpHandle_t, n::Cint,
-                                               nnzA::Cint, descrA::cusparseMatDescr_t,
-                                               csrValA::Ptr{cuDoubleComplex},
-                                               csrRowPtrA::Ptr{Cint}, csrColIndA::Ptr{Cint},
-                                               b::Ptr{cuDoubleComplex}, tol::Cdouble,
-                                               reorder::Cint, x::Ptr{cuDoubleComplex},
-                                               singularity::Ptr{Cint})::cusolverStatus_t
+    @gcsafe_ccall libcusolver.cusolverSpZcsrlsvluHost(handle::cusolverSpHandle_t, n::Cint,
+                                                      nnzA::Cint,
+                                                      descrA::cusparseMatDescr_t,
+                                                      csrValA::Ptr{cuDoubleComplex},
+                                                      csrRowPtrA::Ptr{Cint},
+                                                      csrColIndA::Ptr{Cint},
+                                                      b::Ptr{cuDoubleComplex}, tol::Cdouble,
+                                                      reorder::Cint,
+                                                      x::Ptr{cuDoubleComplex},
+                                                      singularity::Ptr{Cint})::cusolverStatus_t
 end
 
 @checked function cusolverSpScsrlsvqr(handle, m, nnz, descrA, csrVal, csrRowPtr, csrColInd,
                                       b, tol, reorder, x, singularity)
     initialize_context()
-    @ccall libcusolver.cusolverSpScsrlsvqr(handle::cusolverSpHandle_t, m::Cint, nnz::Cint,
-                                           descrA::cusparseMatDescr_t,
-                                           csrVal::CuPtr{Cfloat}, csrRowPtr::CuPtr{Cint},
-                                           csrColInd::CuPtr{Cint}, b::CuPtr{Cfloat},
-                                           tol::Cfloat, reorder::Cint, x::CuPtr{Cfloat},
-                                           singularity::Ptr{Cint})::cusolverStatus_t
+    @gcsafe_ccall libcusolver.cusolverSpScsrlsvqr(handle::cusolverSpHandle_t, m::Cint,
+                                                  nnz::Cint, descrA::cusparseMatDescr_t,
+                                                  csrVal::CuPtr{Cfloat},
+                                                  csrRowPtr::CuPtr{Cint},
+                                                  csrColInd::CuPtr{Cint}, b::CuPtr{Cfloat},
+                                                  tol::Cfloat, reorder::Cint,
+                                                  x::CuPtr{Cfloat},
+                                                  singularity::Ptr{Cint})::cusolverStatus_t
 end
 
 @checked function cusolverSpDcsrlsvqr(handle, m, nnz, descrA, csrVal, csrRowPtr, csrColInd,
                                       b, tol, reorder, x, singularity)
     initialize_context()
-    @ccall libcusolver.cusolverSpDcsrlsvqr(handle::cusolverSpHandle_t, m::Cint, nnz::Cint,
-                                           descrA::cusparseMatDescr_t,
-                                           csrVal::CuPtr{Cdouble}, csrRowPtr::CuPtr{Cint},
-                                           csrColInd::CuPtr{Cint}, b::CuPtr{Cdouble},
-                                           tol::Cdouble, reorder::Cint, x::CuPtr{Cdouble},
-                                           singularity::Ptr{Cint})::cusolverStatus_t
+    @gcsafe_ccall libcusolver.cusolverSpDcsrlsvqr(handle::cusolverSpHandle_t, m::Cint,
+                                                  nnz::Cint, descrA::cusparseMatDescr_t,
+                                                  csrVal::CuPtr{Cdouble},
+                                                  csrRowPtr::CuPtr{Cint},
+                                                  csrColInd::CuPtr{Cint}, b::CuPtr{Cdouble},
+                                                  tol::Cdouble, reorder::Cint,
+                                                  x::CuPtr{Cdouble},
+                                                  singularity::Ptr{Cint})::cusolverStatus_t
 end
 
 @checked function cusolverSpCcsrlsvqr(handle, m, nnz, descrA, csrVal, csrRowPtr, csrColInd,
                                       b, tol, reorder, x, singularity)
     initialize_context()
-    @ccall libcusolver.cusolverSpCcsrlsvqr(handle::cusolverSpHandle_t, m::Cint, nnz::Cint,
-                                           descrA::cusparseMatDescr_t,
-                                           csrVal::CuPtr{cuComplex}, csrRowPtr::CuPtr{Cint},
-                                           csrColInd::CuPtr{Cint}, b::CuPtr{cuComplex},
-                                           tol::Cfloat, reorder::Cint, x::CuPtr{cuComplex},
-                                           singularity::Ptr{Cint})::cusolverStatus_t
+    @gcsafe_ccall libcusolver.cusolverSpCcsrlsvqr(handle::cusolverSpHandle_t, m::Cint,
+                                                  nnz::Cint, descrA::cusparseMatDescr_t,
+                                                  csrVal::CuPtr{cuComplex},
+                                                  csrRowPtr::CuPtr{Cint},
+                                                  csrColInd::CuPtr{Cint},
+                                                  b::CuPtr{cuComplex}, tol::Cfloat,
+                                                  reorder::Cint, x::CuPtr{cuComplex},
+                                                  singularity::Ptr{Cint})::cusolverStatus_t
 end
 
 @checked function cusolverSpZcsrlsvqr(handle, m, nnz, descrA, csrVal, csrRowPtr, csrColInd,
                                       b, tol, reorder, x, singularity)
     initialize_context()
-    @ccall libcusolver.cusolverSpZcsrlsvqr(handle::cusolverSpHandle_t, m::Cint, nnz::Cint,
-                                           descrA::cusparseMatDescr_t,
-                                           csrVal::CuPtr{cuDoubleComplex},
-                                           csrRowPtr::CuPtr{Cint}, csrColInd::CuPtr{Cint},
-                                           b::CuPtr{cuDoubleComplex}, tol::Cdouble,
-                                           reorder::Cint, x::CuPtr{cuDoubleComplex},
-                                           singularity::Ptr{Cint})::cusolverStatus_t
+    @gcsafe_ccall libcusolver.cusolverSpZcsrlsvqr(handle::cusolverSpHandle_t, m::Cint,
+                                                  nnz::Cint, descrA::cusparseMatDescr_t,
+                                                  csrVal::CuPtr{cuDoubleComplex},
+                                                  csrRowPtr::CuPtr{Cint},
+                                                  csrColInd::CuPtr{Cint},
+                                                  b::CuPtr{cuDoubleComplex}, tol::Cdouble,
+                                                  reorder::Cint, x::CuPtr{cuDoubleComplex},
+                                                  singularity::Ptr{Cint})::cusolverStatus_t
 end
 
 @checked function cusolverSpScsrlsvqrHost(handle, m, nnz, descrA, csrValA, csrRowPtrA,
                                           csrColIndA, b, tol, reorder, x, singularity)
     initialize_context()
-    @ccall libcusolver.cusolverSpScsrlsvqrHost(handle::cusolverSpHandle_t, m::Cint,
-                                               nnz::Cint, descrA::cusparseMatDescr_t,
-                                               csrValA::Ptr{Cfloat}, csrRowPtrA::Ptr{Cint},
-                                               csrColIndA::Ptr{Cint}, b::Ptr{Cfloat},
-                                               tol::Cfloat, reorder::Cint, x::Ptr{Cfloat},
-                                               singularity::Ptr{Cint})::cusolverStatus_t
+    @gcsafe_ccall libcusolver.cusolverSpScsrlsvqrHost(handle::cusolverSpHandle_t, m::Cint,
+                                                      nnz::Cint, descrA::cusparseMatDescr_t,
+                                                      csrValA::Ptr{Cfloat},
+                                                      csrRowPtrA::Ptr{Cint},
+                                                      csrColIndA::Ptr{Cint}, b::Ptr{Cfloat},
+                                                      tol::Cfloat, reorder::Cint,
+                                                      x::Ptr{Cfloat},
+                                                      singularity::Ptr{Cint})::cusolverStatus_t
 end
 
 @checked function cusolverSpDcsrlsvqrHost(handle, m, nnz, descrA, csrValA, csrRowPtrA,
                                           csrColIndA, b, tol, reorder, x, singularity)
     initialize_context()
-    @ccall libcusolver.cusolverSpDcsrlsvqrHost(handle::cusolverSpHandle_t, m::Cint,
-                                               nnz::Cint, descrA::cusparseMatDescr_t,
-                                               csrValA::Ptr{Cdouble}, csrRowPtrA::Ptr{Cint},
-                                               csrColIndA::Ptr{Cint}, b::Ptr{Cdouble},
-                                               tol::Cdouble, reorder::Cint, x::Ptr{Cdouble},
-                                               singularity::Ptr{Cint})::cusolverStatus_t
+    @gcsafe_ccall libcusolver.cusolverSpDcsrlsvqrHost(handle::cusolverSpHandle_t, m::Cint,
+                                                      nnz::Cint, descrA::cusparseMatDescr_t,
+                                                      csrValA::Ptr{Cdouble},
+                                                      csrRowPtrA::Ptr{Cint},
+                                                      csrColIndA::Ptr{Cint},
+                                                      b::Ptr{Cdouble}, tol::Cdouble,
+                                                      reorder::Cint, x::Ptr{Cdouble},
+                                                      singularity::Ptr{Cint})::cusolverStatus_t
 end
 
 @checked function cusolverSpCcsrlsvqrHost(handle, m, nnz, descrA, csrValA, csrRowPtrA,
                                           csrColIndA, b, tol, reorder, x, singularity)
     initialize_context()
-    @ccall libcusolver.cusolverSpCcsrlsvqrHost(handle::cusolverSpHandle_t, m::Cint,
-                                               nnz::Cint, descrA::cusparseMatDescr_t,
-                                               csrValA::Ptr{cuComplex},
-                                               csrRowPtrA::Ptr{Cint}, csrColIndA::Ptr{Cint},
-                                               b::Ptr{cuComplex}, tol::Cfloat,
-                                               reorder::Cint, x::Ptr{cuComplex},
-                                               singularity::Ptr{Cint})::cusolverStatus_t
+    @gcsafe_ccall libcusolver.cusolverSpCcsrlsvqrHost(handle::cusolverSpHandle_t, m::Cint,
+                                                      nnz::Cint, descrA::cusparseMatDescr_t,
+                                                      csrValA::Ptr{cuComplex},
+                                                      csrRowPtrA::Ptr{Cint},
+                                                      csrColIndA::Ptr{Cint},
+                                                      b::Ptr{cuComplex}, tol::Cfloat,
+                                                      reorder::Cint, x::Ptr{cuComplex},
+                                                      singularity::Ptr{Cint})::cusolverStatus_t
 end
 
 @checked function cusolverSpZcsrlsvqrHost(handle, m, nnz, descrA, csrValA, csrRowPtrA,
                                           csrColIndA, b, tol, reorder, x, singularity)
     initialize_context()
-    @ccall libcusolver.cusolverSpZcsrlsvqrHost(handle::cusolverSpHandle_t, m::Cint,
-                                               nnz::Cint, descrA::cusparseMatDescr_t,
-                                               csrValA::Ptr{cuDoubleComplex},
-                                               csrRowPtrA::Ptr{Cint}, csrColIndA::Ptr{Cint},
-                                               b::Ptr{cuDoubleComplex}, tol::Cdouble,
-                                               reorder::Cint, x::Ptr{cuDoubleComplex},
-                                               singularity::Ptr{Cint})::cusolverStatus_t
+    @gcsafe_ccall libcusolver.cusolverSpZcsrlsvqrHost(handle::cusolverSpHandle_t, m::Cint,
+                                                      nnz::Cint, descrA::cusparseMatDescr_t,
+                                                      csrValA::Ptr{cuDoubleComplex},
+                                                      csrRowPtrA::Ptr{Cint},
+                                                      csrColIndA::Ptr{Cint},
+                                                      b::Ptr{cuDoubleComplex}, tol::Cdouble,
+                                                      reorder::Cint,
+                                                      x::Ptr{cuDoubleComplex},
+                                                      singularity::Ptr{Cint})::cusolverStatus_t
 end
 
 @checked function cusolverSpScsrlsvcholHost(handle, m, nnz, descrA, csrVal, csrRowPtr,
                                             csrColInd, b, tol, reorder, x, singularity)
     initialize_context()
-    @ccall libcusolver.cusolverSpScsrlsvcholHost(handle::cusolverSpHandle_t, m::Cint,
-                                                 nnz::Cint, descrA::cusparseMatDescr_t,
-                                                 csrVal::Ptr{Cfloat}, csrRowPtr::Ptr{Cint},
-                                                 csrColInd::Ptr{Cint}, b::Ptr{Cfloat},
-                                                 tol::Cfloat, reorder::Cint, x::Ptr{Cfloat},
-                                                 singularity::Ptr{Cint})::cusolverStatus_t
+    @gcsafe_ccall libcusolver.cusolverSpScsrlsvcholHost(handle::cusolverSpHandle_t, m::Cint,
+                                                        nnz::Cint,
+                                                        descrA::cusparseMatDescr_t,
+                                                        csrVal::Ptr{Cfloat},
+                                                        csrRowPtr::Ptr{Cint},
+                                                        csrColInd::Ptr{Cint},
+                                                        b::Ptr{Cfloat}, tol::Cfloat,
+                                                        reorder::Cint, x::Ptr{Cfloat},
+                                                        singularity::Ptr{Cint})::cusolverStatus_t
 end
 
 @checked function cusolverSpDcsrlsvcholHost(handle, m, nnz, descrA, csrVal, csrRowPtr,
                                             csrColInd, b, tol, reorder, x, singularity)
     initialize_context()
-    @ccall libcusolver.cusolverSpDcsrlsvcholHost(handle::cusolverSpHandle_t, m::Cint,
-                                                 nnz::Cint, descrA::cusparseMatDescr_t,
-                                                 csrVal::Ptr{Cdouble}, csrRowPtr::Ptr{Cint},
-                                                 csrColInd::Ptr{Cint}, b::Ptr{Cdouble},
-                                                 tol::Cdouble, reorder::Cint,
-                                                 x::Ptr{Cdouble},
-                                                 singularity::Ptr{Cint})::cusolverStatus_t
+    @gcsafe_ccall libcusolver.cusolverSpDcsrlsvcholHost(handle::cusolverSpHandle_t, m::Cint,
+                                                        nnz::Cint,
+                                                        descrA::cusparseMatDescr_t,
+                                                        csrVal::Ptr{Cdouble},
+                                                        csrRowPtr::Ptr{Cint},
+                                                        csrColInd::Ptr{Cint},
+                                                        b::Ptr{Cdouble}, tol::Cdouble,
+                                                        reorder::Cint, x::Ptr{Cdouble},
+                                                        singularity::Ptr{Cint})::cusolverStatus_t
 end
 
 @checked function cusolverSpCcsrlsvcholHost(handle, m, nnz, descrA, csrVal, csrRowPtr,
                                             csrColInd, b, tol, reorder, x, singularity)
     initialize_context()
-    @ccall libcusolver.cusolverSpCcsrlsvcholHost(handle::cusolverSpHandle_t, m::Cint,
-                                                 nnz::Cint, descrA::cusparseMatDescr_t,
-                                                 csrVal::Ptr{cuComplex},
-                                                 csrRowPtr::Ptr{Cint}, csrColInd::Ptr{Cint},
-                                                 b::Ptr{cuComplex}, tol::Cfloat,
-                                                 reorder::Cint, x::Ptr{cuComplex},
-                                                 singularity::Ptr{Cint})::cusolverStatus_t
+    @gcsafe_ccall libcusolver.cusolverSpCcsrlsvcholHost(handle::cusolverSpHandle_t, m::Cint,
+                                                        nnz::Cint,
+                                                        descrA::cusparseMatDescr_t,
+                                                        csrVal::Ptr{cuComplex},
+                                                        csrRowPtr::Ptr{Cint},
+                                                        csrColInd::Ptr{Cint},
+                                                        b::Ptr{cuComplex}, tol::Cfloat,
+                                                        reorder::Cint, x::Ptr{cuComplex},
+                                                        singularity::Ptr{Cint})::cusolverStatus_t
 end
 
 @checked function cusolverSpZcsrlsvcholHost(handle, m, nnz, descrA, csrVal, csrRowPtr,
                                             csrColInd, b, tol, reorder, x, singularity)
     initialize_context()
-    @ccall libcusolver.cusolverSpZcsrlsvcholHost(handle::cusolverSpHandle_t, m::Cint,
-                                                 nnz::Cint, descrA::cusparseMatDescr_t,
-                                                 csrVal::Ptr{cuDoubleComplex},
-                                                 csrRowPtr::Ptr{Cint}, csrColInd::Ptr{Cint},
-                                                 b::Ptr{cuDoubleComplex}, tol::Cdouble,
-                                                 reorder::Cint, x::Ptr{cuDoubleComplex},
-                                                 singularity::Ptr{Cint})::cusolverStatus_t
+    @gcsafe_ccall libcusolver.cusolverSpZcsrlsvcholHost(handle::cusolverSpHandle_t, m::Cint,
+                                                        nnz::Cint,
+                                                        descrA::cusparseMatDescr_t,
+                                                        csrVal::Ptr{cuDoubleComplex},
+                                                        csrRowPtr::Ptr{Cint},
+                                                        csrColInd::Ptr{Cint},
+                                                        b::Ptr{cuDoubleComplex},
+                                                        tol::Cdouble, reorder::Cint,
+                                                        x::Ptr{cuDoubleComplex},
+                                                        singularity::Ptr{Cint})::cusolverStatus_t
 end
 
 @checked function cusolverSpScsrlsvchol(handle, m, nnz, descrA, csrVal, csrRowPtr,
                                         csrColInd, b, tol, reorder, x, singularity)
     initialize_context()
-    @ccall libcusolver.cusolverSpScsrlsvchol(handle::cusolverSpHandle_t, m::Cint, nnz::Cint,
-                                             descrA::cusparseMatDescr_t,
-                                             csrVal::CuPtr{Cfloat}, csrRowPtr::CuPtr{Cint},
-                                             csrColInd::CuPtr{Cint}, b::CuPtr{Cfloat},
-                                             tol::Cfloat, reorder::Cint, x::CuPtr{Cfloat},
-                                             singularity::Ptr{Cint})::cusolverStatus_t
+    @gcsafe_ccall libcusolver.cusolverSpScsrlsvchol(handle::cusolverSpHandle_t, m::Cint,
+                                                    nnz::Cint, descrA::cusparseMatDescr_t,
+                                                    csrVal::CuPtr{Cfloat},
+                                                    csrRowPtr::CuPtr{Cint},
+                                                    csrColInd::CuPtr{Cint},
+                                                    b::CuPtr{Cfloat}, tol::Cfloat,
+                                                    reorder::Cint, x::CuPtr{Cfloat},
+                                                    singularity::Ptr{Cint})::cusolverStatus_t
 end
 
 @checked function cusolverSpDcsrlsvchol(handle, m, nnz, descrA, csrVal, csrRowPtr,
                                         csrColInd, b, tol, reorder, x, singularity)
     initialize_context()
-    @ccall libcusolver.cusolverSpDcsrlsvchol(handle::cusolverSpHandle_t, m::Cint, nnz::Cint,
-                                             descrA::cusparseMatDescr_t,
-                                             csrVal::CuPtr{Cdouble}, csrRowPtr::CuPtr{Cint},
-                                             csrColInd::CuPtr{Cint}, b::CuPtr{Cdouble},
-                                             tol::Cdouble, reorder::Cint, x::CuPtr{Cdouble},
-                                             singularity::Ptr{Cint})::cusolverStatus_t
+    @gcsafe_ccall libcusolver.cusolverSpDcsrlsvchol(handle::cusolverSpHandle_t, m::Cint,
+                                                    nnz::Cint, descrA::cusparseMatDescr_t,
+                                                    csrVal::CuPtr{Cdouble},
+                                                    csrRowPtr::CuPtr{Cint},
+                                                    csrColInd::CuPtr{Cint},
+                                                    b::CuPtr{Cdouble}, tol::Cdouble,
+                                                    reorder::Cint, x::CuPtr{Cdouble},
+                                                    singularity::Ptr{Cint})::cusolverStatus_t
 end
 
 @checked function cusolverSpCcsrlsvchol(handle, m, nnz, descrA, csrVal, csrRowPtr,
                                         csrColInd, b, tol, reorder, x, singularity)
     initialize_context()
-    @ccall libcusolver.cusolverSpCcsrlsvchol(handle::cusolverSpHandle_t, m::Cint, nnz::Cint,
-                                             descrA::cusparseMatDescr_t,
-                                             csrVal::CuPtr{cuComplex},
-                                             csrRowPtr::CuPtr{Cint}, csrColInd::CuPtr{Cint},
-                                             b::CuPtr{cuComplex}, tol::Cfloat,
-                                             reorder::Cint, x::CuPtr{cuComplex},
-                                             singularity::Ptr{Cint})::cusolverStatus_t
+    @gcsafe_ccall libcusolver.cusolverSpCcsrlsvchol(handle::cusolverSpHandle_t, m::Cint,
+                                                    nnz::Cint, descrA::cusparseMatDescr_t,
+                                                    csrVal::CuPtr{cuComplex},
+                                                    csrRowPtr::CuPtr{Cint},
+                                                    csrColInd::CuPtr{Cint},
+                                                    b::CuPtr{cuComplex}, tol::Cfloat,
+                                                    reorder::Cint, x::CuPtr{cuComplex},
+                                                    singularity::Ptr{Cint})::cusolverStatus_t
 end
 
 @checked function cusolverSpZcsrlsvchol(handle, m, nnz, descrA, csrVal, csrRowPtr,
                                         csrColInd, b, tol, reorder, x, singularity)
     initialize_context()
-    @ccall libcusolver.cusolverSpZcsrlsvchol(handle::cusolverSpHandle_t, m::Cint, nnz::Cint,
-                                             descrA::cusparseMatDescr_t,
-                                             csrVal::CuPtr{cuDoubleComplex},
-                                             csrRowPtr::CuPtr{Cint}, csrColInd::CuPtr{Cint},
-                                             b::CuPtr{cuDoubleComplex}, tol::Cdouble,
-                                             reorder::Cint, x::CuPtr{cuDoubleComplex},
-                                             singularity::Ptr{Cint})::cusolverStatus_t
+    @gcsafe_ccall libcusolver.cusolverSpZcsrlsvchol(handle::cusolverSpHandle_t, m::Cint,
+                                                    nnz::Cint, descrA::cusparseMatDescr_t,
+                                                    csrVal::CuPtr{cuDoubleComplex},
+                                                    csrRowPtr::CuPtr{Cint},
+                                                    csrColInd::CuPtr{Cint},
+                                                    b::CuPtr{cuDoubleComplex}, tol::Cdouble,
+                                                    reorder::Cint,
+                                                    x::CuPtr{cuDoubleComplex},
+                                                    singularity::Ptr{Cint})::cusolverStatus_t
 end
 
 @checked function cusolverSpScsrlsqvqrHost(handle, m, n, nnz, descrA, csrValA, csrRowPtrA,
                                            csrColIndA, b, tol, rankA, x, p, min_norm)
     initialize_context()
-    @ccall libcusolver.cusolverSpScsrlsqvqrHost(handle::cusolverSpHandle_t, m::Cint,
-                                                n::Cint, nnz::Cint,
-                                                descrA::cusparseMatDescr_t,
-                                                csrValA::Ptr{Cfloat}, csrRowPtrA::Ptr{Cint},
-                                                csrColIndA::Ptr{Cint}, b::Ptr{Cfloat},
-                                                tol::Cfloat, rankA::Ptr{Cint},
-                                                x::Ptr{Cfloat}, p::Ptr{Cint},
-                                                min_norm::Ptr{Cfloat})::cusolverStatus_t
+    @gcsafe_ccall libcusolver.cusolverSpScsrlsqvqrHost(handle::cusolverSpHandle_t, m::Cint,
+                                                       n::Cint, nnz::Cint,
+                                                       descrA::cusparseMatDescr_t,
+                                                       csrValA::Ptr{Cfloat},
+                                                       csrRowPtrA::Ptr{Cint},
+                                                       csrColIndA::Ptr{Cint},
+                                                       b::Ptr{Cfloat}, tol::Cfloat,
+                                                       rankA::Ptr{Cint}, x::Ptr{Cfloat},
+                                                       p::Ptr{Cint},
+                                                       min_norm::Ptr{Cfloat})::cusolverStatus_t
 end
 
 @checked function cusolverSpDcsrlsqvqrHost(handle, m, n, nnz, descrA, csrValA, csrRowPtrA,
                                            csrColIndA, b, tol, rankA, x, p, min_norm)
     initialize_context()
-    @ccall libcusolver.cusolverSpDcsrlsqvqrHost(handle::cusolverSpHandle_t, m::Cint,
-                                                n::Cint, nnz::Cint,
-                                                descrA::cusparseMatDescr_t,
-                                                csrValA::Ptr{Cdouble},
-                                                csrRowPtrA::Ptr{Cint},
-                                                csrColIndA::Ptr{Cint}, b::Ptr{Cdouble},
-                                                tol::Cdouble, rankA::Ptr{Cint},
-                                                x::Ptr{Cdouble}, p::Ptr{Cint},
-                                                min_norm::Ptr{Cdouble})::cusolverStatus_t
+    @gcsafe_ccall libcusolver.cusolverSpDcsrlsqvqrHost(handle::cusolverSpHandle_t, m::Cint,
+                                                       n::Cint, nnz::Cint,
+                                                       descrA::cusparseMatDescr_t,
+                                                       csrValA::Ptr{Cdouble},
+                                                       csrRowPtrA::Ptr{Cint},
+                                                       csrColIndA::Ptr{Cint},
+                                                       b::Ptr{Cdouble}, tol::Cdouble,
+                                                       rankA::Ptr{Cint}, x::Ptr{Cdouble},
+                                                       p::Ptr{Cint},
+                                                       min_norm::Ptr{Cdouble})::cusolverStatus_t
 end
 
 @checked function cusolverSpCcsrlsqvqrHost(handle, m, n, nnz, descrA, csrValA, csrRowPtrA,
                                            csrColIndA, b, tol, rankA, x, p, min_norm)
     initialize_context()
-    @ccall libcusolver.cusolverSpCcsrlsqvqrHost(handle::cusolverSpHandle_t, m::Cint,
-                                                n::Cint, nnz::Cint,
-                                                descrA::cusparseMatDescr_t,
-                                                csrValA::Ptr{cuComplex},
-                                                csrRowPtrA::Ptr{Cint},
-                                                csrColIndA::Ptr{Cint}, b::Ptr{cuComplex},
-                                                tol::Cfloat, rankA::Ptr{Cint},
-                                                x::Ptr{cuComplex}, p::Ptr{Cint},
-                                                min_norm::Ptr{Cfloat})::cusolverStatus_t
+    @gcsafe_ccall libcusolver.cusolverSpCcsrlsqvqrHost(handle::cusolverSpHandle_t, m::Cint,
+                                                       n::Cint, nnz::Cint,
+                                                       descrA::cusparseMatDescr_t,
+                                                       csrValA::Ptr{cuComplex},
+                                                       csrRowPtrA::Ptr{Cint},
+                                                       csrColIndA::Ptr{Cint},
+                                                       b::Ptr{cuComplex}, tol::Cfloat,
+                                                       rankA::Ptr{Cint}, x::Ptr{cuComplex},
+                                                       p::Ptr{Cint},
+                                                       min_norm::Ptr{Cfloat})::cusolverStatus_t
 end
 
 @checked function cusolverSpZcsrlsqvqrHost(handle, m, n, nnz, descrA, csrValA, csrRowPtrA,
                                            csrColIndA, b, tol, rankA, x, p, min_norm)
     initialize_context()
-    @ccall libcusolver.cusolverSpZcsrlsqvqrHost(handle::cusolverSpHandle_t, m::Cint,
-                                                n::Cint, nnz::Cint,
-                                                descrA::cusparseMatDescr_t,
-                                                csrValA::Ptr{cuDoubleComplex},
-                                                csrRowPtrA::Ptr{Cint},
-                                                csrColIndA::Ptr{Cint},
-                                                b::Ptr{cuDoubleComplex}, tol::Cdouble,
-                                                rankA::Ptr{Cint}, x::Ptr{cuDoubleComplex},
-                                                p::Ptr{Cint},
-                                                min_norm::Ptr{Cdouble})::cusolverStatus_t
+    @gcsafe_ccall libcusolver.cusolverSpZcsrlsqvqrHost(handle::cusolverSpHandle_t, m::Cint,
+                                                       n::Cint, nnz::Cint,
+                                                       descrA::cusparseMatDescr_t,
+                                                       csrValA::Ptr{cuDoubleComplex},
+                                                       csrRowPtrA::Ptr{Cint},
+                                                       csrColIndA::Ptr{Cint},
+                                                       b::Ptr{cuDoubleComplex},
+                                                       tol::Cdouble, rankA::Ptr{Cint},
+                                                       x::Ptr{cuDoubleComplex},
+                                                       p::Ptr{Cint},
+                                                       min_norm::Ptr{Cdouble})::cusolverStatus_t
 end
 
 @checked function cusolverSpScsreigvsiHost(handle, m, nnz, descrA, csrValA, csrRowPtrA,
                                            csrColIndA, mu0, x0, maxite, tol, mu, x)
     initialize_context()
-    @ccall libcusolver.cusolverSpScsreigvsiHost(handle::cusolverSpHandle_t, m::Cint,
-                                                nnz::Cint, descrA::cusparseMatDescr_t,
-                                                csrValA::Ptr{Cfloat}, csrRowPtrA::Ptr{Cint},
-                                                csrColIndA::Ptr{Cint}, mu0::Cfloat,
-                                                x0::Ptr{Cfloat}, maxite::Cint, tol::Cfloat,
-                                                mu::Ptr{Cfloat},
-                                                x::Ptr{Cfloat})::cusolverStatus_t
+    @gcsafe_ccall libcusolver.cusolverSpScsreigvsiHost(handle::cusolverSpHandle_t, m::Cint,
+                                                       nnz::Cint,
+                                                       descrA::cusparseMatDescr_t,
+                                                       csrValA::Ptr{Cfloat},
+                                                       csrRowPtrA::Ptr{Cint},
+                                                       csrColIndA::Ptr{Cint}, mu0::Cfloat,
+                                                       x0::Ptr{Cfloat}, maxite::Cint,
+                                                       tol::Cfloat, mu::Ptr{Cfloat},
+                                                       x::Ptr{Cfloat})::cusolverStatus_t
 end
 
 @checked function cusolverSpDcsreigvsiHost(handle, m, nnz, descrA, csrValA, csrRowPtrA,
                                            csrColIndA, mu0, x0, maxite, tol, mu, x)
     initialize_context()
-    @ccall libcusolver.cusolverSpDcsreigvsiHost(handle::cusolverSpHandle_t, m::Cint,
-                                                nnz::Cint, descrA::cusparseMatDescr_t,
-                                                csrValA::Ptr{Cdouble},
-                                                csrRowPtrA::Ptr{Cint},
-                                                csrColIndA::Ptr{Cint}, mu0::Cdouble,
-                                                x0::Ptr{Cdouble}, maxite::Cint,
-                                                tol::Cdouble, mu::Ptr{Cdouble},
-                                                x::Ptr{Cdouble})::cusolverStatus_t
+    @gcsafe_ccall libcusolver.cusolverSpDcsreigvsiHost(handle::cusolverSpHandle_t, m::Cint,
+                                                       nnz::Cint,
+                                                       descrA::cusparseMatDescr_t,
+                                                       csrValA::Ptr{Cdouble},
+                                                       csrRowPtrA::Ptr{Cint},
+                                                       csrColIndA::Ptr{Cint}, mu0::Cdouble,
+                                                       x0::Ptr{Cdouble}, maxite::Cint,
+                                                       tol::Cdouble, mu::Ptr{Cdouble},
+                                                       x::Ptr{Cdouble})::cusolverStatus_t
 end
 
 @checked function cusolverSpCcsreigvsiHost(handle, m, nnz, descrA, csrValA, csrRowPtrA,
                                            csrColIndA, mu0, x0, maxite, tol, mu, x)
     initialize_context()
-    @ccall libcusolver.cusolverSpCcsreigvsiHost(handle::cusolverSpHandle_t, m::Cint,
-                                                nnz::Cint, descrA::cusparseMatDescr_t,
-                                                csrValA::Ptr{cuComplex},
-                                                csrRowPtrA::Ptr{Cint},
-                                                csrColIndA::Ptr{Cint}, mu0::cuComplex,
-                                                x0::Ptr{cuComplex}, maxite::Cint,
-                                                tol::Cfloat, mu::Ptr{cuComplex},
-                                                x::Ptr{cuComplex})::cusolverStatus_t
+    @gcsafe_ccall libcusolver.cusolverSpCcsreigvsiHost(handle::cusolverSpHandle_t, m::Cint,
+                                                       nnz::Cint,
+                                                       descrA::cusparseMatDescr_t,
+                                                       csrValA::Ptr{cuComplex},
+                                                       csrRowPtrA::Ptr{Cint},
+                                                       csrColIndA::Ptr{Cint},
+                                                       mu0::cuComplex, x0::Ptr{cuComplex},
+                                                       maxite::Cint, tol::Cfloat,
+                                                       mu::Ptr{cuComplex},
+                                                       x::Ptr{cuComplex})::cusolverStatus_t
 end
 
 @checked function cusolverSpZcsreigvsiHost(handle, m, nnz, descrA, csrValA, csrRowPtrA,
                                            csrColIndA, mu0, x0, maxite, tol, mu, x)
     initialize_context()
-    @ccall libcusolver.cusolverSpZcsreigvsiHost(handle::cusolverSpHandle_t, m::Cint,
-                                                nnz::Cint, descrA::cusparseMatDescr_t,
-                                                csrValA::Ptr{cuDoubleComplex},
-                                                csrRowPtrA::Ptr{Cint},
-                                                csrColIndA::Ptr{Cint}, mu0::cuDoubleComplex,
-                                                x0::Ptr{cuDoubleComplex}, maxite::Cint,
-                                                tol::Cdouble, mu::Ptr{cuDoubleComplex},
-                                                x::Ptr{cuDoubleComplex})::cusolverStatus_t
+    @gcsafe_ccall libcusolver.cusolverSpZcsreigvsiHost(handle::cusolverSpHandle_t, m::Cint,
+                                                       nnz::Cint,
+                                                       descrA::cusparseMatDescr_t,
+                                                       csrValA::Ptr{cuDoubleComplex},
+                                                       csrRowPtrA::Ptr{Cint},
+                                                       csrColIndA::Ptr{Cint},
+                                                       mu0::cuDoubleComplex,
+                                                       x0::Ptr{cuDoubleComplex},
+                                                       maxite::Cint, tol::Cdouble,
+                                                       mu::Ptr{cuDoubleComplex},
+                                                       x::Ptr{cuDoubleComplex})::cusolverStatus_t
 end
 
 @checked function cusolverSpScsreigvsi(handle, m, nnz, descrA, csrValA, csrRowPtrA,
                                        csrColIndA, mu0, x0, maxite, eps, mu, x)
     initialize_context()
-    @ccall libcusolver.cusolverSpScsreigvsi(handle::cusolverSpHandle_t, m::Cint, nnz::Cint,
-                                            descrA::cusparseMatDescr_t,
-                                            csrValA::CuPtr{Cfloat}, csrRowPtrA::CuPtr{Cint},
-                                            csrColIndA::CuPtr{Cint}, mu0::Cfloat,
-                                            x0::CuPtr{Cfloat}, maxite::Cint, eps::Cfloat,
-                                            mu::CuPtr{Cfloat},
-                                            x::CuPtr{Cfloat})::cusolverStatus_t
+    @gcsafe_ccall libcusolver.cusolverSpScsreigvsi(handle::cusolverSpHandle_t, m::Cint,
+                                                   nnz::Cint, descrA::cusparseMatDescr_t,
+                                                   csrValA::CuPtr{Cfloat},
+                                                   csrRowPtrA::CuPtr{Cint},
+                                                   csrColIndA::CuPtr{Cint}, mu0::Cfloat,
+                                                   x0::CuPtr{Cfloat}, maxite::Cint,
+                                                   eps::Cfloat, mu::CuPtr{Cfloat},
+                                                   x::CuPtr{Cfloat})::cusolverStatus_t
 end
 
 @checked function cusolverSpDcsreigvsi(handle, m, nnz, descrA, csrValA, csrRowPtrA,
                                        csrColIndA, mu0, x0, maxite, eps, mu, x)
     initialize_context()
-    @ccall libcusolver.cusolverSpDcsreigvsi(handle::cusolverSpHandle_t, m::Cint, nnz::Cint,
-                                            descrA::cusparseMatDescr_t,
-                                            csrValA::CuPtr{Cdouble},
-                                            csrRowPtrA::CuPtr{Cint},
-                                            csrColIndA::CuPtr{Cint}, mu0::Cdouble,
-                                            x0::CuPtr{Cdouble}, maxite::Cint, eps::Cdouble,
-                                            mu::CuPtr{Cdouble},
-                                            x::CuPtr{Cdouble})::cusolverStatus_t
+    @gcsafe_ccall libcusolver.cusolverSpDcsreigvsi(handle::cusolverSpHandle_t, m::Cint,
+                                                   nnz::Cint, descrA::cusparseMatDescr_t,
+                                                   csrValA::CuPtr{Cdouble},
+                                                   csrRowPtrA::CuPtr{Cint},
+                                                   csrColIndA::CuPtr{Cint}, mu0::Cdouble,
+                                                   x0::CuPtr{Cdouble}, maxite::Cint,
+                                                   eps::Cdouble, mu::CuPtr{Cdouble},
+                                                   x::CuPtr{Cdouble})::cusolverStatus_t
 end
 
 @checked function cusolverSpCcsreigvsi(handle, m, nnz, descrA, csrValA, csrRowPtrA,
                                        csrColIndA, mu0, x0, maxite, eps, mu, x)
     initialize_context()
-    @ccall libcusolver.cusolverSpCcsreigvsi(handle::cusolverSpHandle_t, m::Cint, nnz::Cint,
-                                            descrA::cusparseMatDescr_t,
-                                            csrValA::CuPtr{cuComplex},
-                                            csrRowPtrA::CuPtr{Cint},
-                                            csrColIndA::CuPtr{Cint}, mu0::cuComplex,
-                                            x0::CuPtr{cuComplex}, maxite::Cint, eps::Cfloat,
-                                            mu::CuPtr{cuComplex},
-                                            x::CuPtr{cuComplex})::cusolverStatus_t
+    @gcsafe_ccall libcusolver.cusolverSpCcsreigvsi(handle::cusolverSpHandle_t, m::Cint,
+                                                   nnz::Cint, descrA::cusparseMatDescr_t,
+                                                   csrValA::CuPtr{cuComplex},
+                                                   csrRowPtrA::CuPtr{Cint},
+                                                   csrColIndA::CuPtr{Cint}, mu0::cuComplex,
+                                                   x0::CuPtr{cuComplex}, maxite::Cint,
+                                                   eps::Cfloat, mu::CuPtr{cuComplex},
+                                                   x::CuPtr{cuComplex})::cusolverStatus_t
 end
 
 @checked function cusolverSpZcsreigvsi(handle, m, nnz, descrA, csrValA, csrRowPtrA,
                                        csrColIndA, mu0, x0, maxite, eps, mu, x)
     initialize_context()
-    @ccall libcusolver.cusolverSpZcsreigvsi(handle::cusolverSpHandle_t, m::Cint, nnz::Cint,
-                                            descrA::cusparseMatDescr_t,
-                                            csrValA::CuPtr{cuDoubleComplex},
-                                            csrRowPtrA::CuPtr{Cint},
-                                            csrColIndA::CuPtr{Cint}, mu0::cuDoubleComplex,
-                                            x0::CuPtr{cuDoubleComplex}, maxite::Cint,
-                                            eps::Cdouble, mu::CuPtr{cuDoubleComplex},
-                                            x::CuPtr{cuDoubleComplex})::cusolverStatus_t
+    @gcsafe_ccall libcusolver.cusolverSpZcsreigvsi(handle::cusolverSpHandle_t, m::Cint,
+                                                   nnz::Cint, descrA::cusparseMatDescr_t,
+                                                   csrValA::CuPtr{cuDoubleComplex},
+                                                   csrRowPtrA::CuPtr{Cint},
+                                                   csrColIndA::CuPtr{Cint},
+                                                   mu0::cuDoubleComplex,
+                                                   x0::CuPtr{cuDoubleComplex}, maxite::Cint,
+                                                   eps::Cdouble, mu::CuPtr{cuDoubleComplex},
+                                                   x::CuPtr{cuDoubleComplex})::cusolverStatus_t
 end
 
 @checked function cusolverSpScsreigsHost(handle, m, nnz, descrA, csrValA, csrRowPtrA,
                                          csrColIndA, left_bottom_corner, right_upper_corner,
                                          num_eigs)
     initialize_context()
-    @ccall libcusolver.cusolverSpScsreigsHost(handle::cusolverSpHandle_t, m::Cint,
-                                              nnz::Cint, descrA::cusparseMatDescr_t,
-                                              csrValA::Ptr{Cfloat}, csrRowPtrA::Ptr{Cint},
-                                              csrColIndA::Ptr{Cint},
-                                              left_bottom_corner::cuComplex,
-                                              right_upper_corner::cuComplex,
-                                              num_eigs::Ptr{Cint})::cusolverStatus_t
+    @gcsafe_ccall libcusolver.cusolverSpScsreigsHost(handle::cusolverSpHandle_t, m::Cint,
+                                                     nnz::Cint, descrA::cusparseMatDescr_t,
+                                                     csrValA::Ptr{Cfloat},
+                                                     csrRowPtrA::Ptr{Cint},
+                                                     csrColIndA::Ptr{Cint},
+                                                     left_bottom_corner::cuComplex,
+                                                     right_upper_corner::cuComplex,
+                                                     num_eigs::Ptr{Cint})::cusolverStatus_t
 end
 
 @checked function cusolverSpDcsreigsHost(handle, m, nnz, descrA, csrValA, csrRowPtrA,
                                          csrColIndA, left_bottom_corner, right_upper_corner,
                                          num_eigs)
     initialize_context()
-    @ccall libcusolver.cusolverSpDcsreigsHost(handle::cusolverSpHandle_t, m::Cint,
-                                              nnz::Cint, descrA::cusparseMatDescr_t,
-                                              csrValA::Ptr{Cdouble}, csrRowPtrA::Ptr{Cint},
-                                              csrColIndA::Ptr{Cint},
-                                              left_bottom_corner::cuDoubleComplex,
-                                              right_upper_corner::cuDoubleComplex,
-                                              num_eigs::Ptr{Cint})::cusolverStatus_t
+    @gcsafe_ccall libcusolver.cusolverSpDcsreigsHost(handle::cusolverSpHandle_t, m::Cint,
+                                                     nnz::Cint, descrA::cusparseMatDescr_t,
+                                                     csrValA::Ptr{Cdouble},
+                                                     csrRowPtrA::Ptr{Cint},
+                                                     csrColIndA::Ptr{Cint},
+                                                     left_bottom_corner::cuDoubleComplex,
+                                                     right_upper_corner::cuDoubleComplex,
+                                                     num_eigs::Ptr{Cint})::cusolverStatus_t
 end
 
 @checked function cusolverSpCcsreigsHost(handle, m, nnz, descrA, csrValA, csrRowPtrA,
                                          csrColIndA, left_bottom_corner, right_upper_corner,
                                          num_eigs)
     initialize_context()
-    @ccall libcusolver.cusolverSpCcsreigsHost(handle::cusolverSpHandle_t, m::Cint,
-                                              nnz::Cint, descrA::cusparseMatDescr_t,
-                                              csrValA::Ptr{cuComplex},
-                                              csrRowPtrA::Ptr{Cint}, csrColIndA::Ptr{Cint},
-                                              left_bottom_corner::cuComplex,
-                                              right_upper_corner::cuComplex,
-                                              num_eigs::Ptr{Cint})::cusolverStatus_t
+    @gcsafe_ccall libcusolver.cusolverSpCcsreigsHost(handle::cusolverSpHandle_t, m::Cint,
+                                                     nnz::Cint, descrA::cusparseMatDescr_t,
+                                                     csrValA::Ptr{cuComplex},
+                                                     csrRowPtrA::Ptr{Cint},
+                                                     csrColIndA::Ptr{Cint},
+                                                     left_bottom_corner::cuComplex,
+                                                     right_upper_corner::cuComplex,
+                                                     num_eigs::Ptr{Cint})::cusolverStatus_t
 end
 
 @checked function cusolverSpZcsreigsHost(handle, m, nnz, descrA, csrValA, csrRowPtrA,
                                          csrColIndA, left_bottom_corner, right_upper_corner,
                                          num_eigs)
     initialize_context()
-    @ccall libcusolver.cusolverSpZcsreigsHost(handle::cusolverSpHandle_t, m::Cint,
-                                              nnz::Cint, descrA::cusparseMatDescr_t,
-                                              csrValA::Ptr{cuDoubleComplex},
-                                              csrRowPtrA::Ptr{Cint}, csrColIndA::Ptr{Cint},
-                                              left_bottom_corner::cuDoubleComplex,
-                                              right_upper_corner::cuDoubleComplex,
-                                              num_eigs::Ptr{Cint})::cusolverStatus_t
+    @gcsafe_ccall libcusolver.cusolverSpZcsreigsHost(handle::cusolverSpHandle_t, m::Cint,
+                                                     nnz::Cint, descrA::cusparseMatDescr_t,
+                                                     csrValA::Ptr{cuDoubleComplex},
+                                                     csrRowPtrA::Ptr{Cint},
+                                                     csrColIndA::Ptr{Cint},
+                                                     left_bottom_corner::cuDoubleComplex,
+                                                     right_upper_corner::cuDoubleComplex,
+                                                     num_eigs::Ptr{Cint})::cusolverStatus_t
 end
 
 @checked function cusolverSpXcsrsymrcmHost(handle, n, nnzA, descrA, csrRowPtrA, csrColIndA,
                                            p)
     initialize_context()
-    @ccall libcusolver.cusolverSpXcsrsymrcmHost(handle::cusolverSpHandle_t, n::Cint,
-                                                nnzA::Cint, descrA::cusparseMatDescr_t,
-                                                csrRowPtrA::Ptr{Cint},
-                                                csrColIndA::Ptr{Cint},
-                                                p::Ptr{Cint})::cusolverStatus_t
+    @gcsafe_ccall libcusolver.cusolverSpXcsrsymrcmHost(handle::cusolverSpHandle_t, n::Cint,
+                                                       nnzA::Cint,
+                                                       descrA::cusparseMatDescr_t,
+                                                       csrRowPtrA::Ptr{Cint},
+                                                       csrColIndA::Ptr{Cint},
+                                                       p::Ptr{Cint})::cusolverStatus_t
 end
 
 @checked function cusolverSpXcsrsymmdqHost(handle, n, nnzA, descrA, csrRowPtrA, csrColIndA,
                                            p)
     initialize_context()
-    @ccall libcusolver.cusolverSpXcsrsymmdqHost(handle::cusolverSpHandle_t, n::Cint,
-                                                nnzA::Cint, descrA::cusparseMatDescr_t,
-                                                csrRowPtrA::Ptr{Cint},
-                                                csrColIndA::Ptr{Cint},
-                                                p::Ptr{Cint})::cusolverStatus_t
+    @gcsafe_ccall libcusolver.cusolverSpXcsrsymmdqHost(handle::cusolverSpHandle_t, n::Cint,
+                                                       nnzA::Cint,
+                                                       descrA::cusparseMatDescr_t,
+                                                       csrRowPtrA::Ptr{Cint},
+                                                       csrColIndA::Ptr{Cint},
+                                                       p::Ptr{Cint})::cusolverStatus_t
 end
 
 @checked function cusolverSpXcsrsymamdHost(handle, n, nnzA, descrA, csrRowPtrA, csrColIndA,
                                            p)
     initialize_context()
-    @ccall libcusolver.cusolverSpXcsrsymamdHost(handle::cusolverSpHandle_t, n::Cint,
-                                                nnzA::Cint, descrA::cusparseMatDescr_t,
-                                                csrRowPtrA::Ptr{Cint},
-                                                csrColIndA::Ptr{Cint},
-                                                p::Ptr{Cint})::cusolverStatus_t
+    @gcsafe_ccall libcusolver.cusolverSpXcsrsymamdHost(handle::cusolverSpHandle_t, n::Cint,
+                                                       nnzA::Cint,
+                                                       descrA::cusparseMatDescr_t,
+                                                       csrRowPtrA::Ptr{Cint},
+                                                       csrColIndA::Ptr{Cint},
+                                                       p::Ptr{Cint})::cusolverStatus_t
 end
 
 @checked function cusolverSpXcsrmetisndHost(handle, n, nnzA, descrA, csrRowPtrA, csrColIndA,
                                             options, p)
     initialize_context()
-    @ccall libcusolver.cusolverSpXcsrmetisndHost(handle::cusolverSpHandle_t, n::Cint,
-                                                 nnzA::Cint, descrA::cusparseMatDescr_t,
-                                                 csrRowPtrA::Ptr{Cint},
-                                                 csrColIndA::Ptr{Cint}, options::Ptr{Int64},
-                                                 p::Ptr{Cint})::cusolverStatus_t
+    @gcsafe_ccall libcusolver.cusolverSpXcsrmetisndHost(handle::cusolverSpHandle_t, n::Cint,
+                                                        nnzA::Cint,
+                                                        descrA::cusparseMatDescr_t,
+                                                        csrRowPtrA::Ptr{Cint},
+                                                        csrColIndA::Ptr{Cint},
+                                                        options::Ptr{Int64},
+                                                        p::Ptr{Cint})::cusolverStatus_t
 end
 
 @checked function cusolverSpScsrzfdHost(handle, n, nnz, descrA, csrValA, csrRowPtrA,
                                         csrColIndA, P, numnz)
     initialize_context()
-    @ccall libcusolver.cusolverSpScsrzfdHost(handle::cusolverSpHandle_t, n::Cint, nnz::Cint,
-                                             descrA::cusparseMatDescr_t,
-                                             csrValA::Ptr{Cfloat}, csrRowPtrA::Ptr{Cint},
-                                             csrColIndA::Ptr{Cint}, P::Ptr{Cint},
-                                             numnz::Ptr{Cint})::cusolverStatus_t
+    @gcsafe_ccall libcusolver.cusolverSpScsrzfdHost(handle::cusolverSpHandle_t, n::Cint,
+                                                    nnz::Cint, descrA::cusparseMatDescr_t,
+                                                    csrValA::Ptr{Cfloat},
+                                                    csrRowPtrA::Ptr{Cint},
+                                                    csrColIndA::Ptr{Cint}, P::Ptr{Cint},
+                                                    numnz::Ptr{Cint})::cusolverStatus_t
 end
 
 @checked function cusolverSpDcsrzfdHost(handle, n, nnz, descrA, csrValA, csrRowPtrA,
                                         csrColIndA, P, numnz)
     initialize_context()
-    @ccall libcusolver.cusolverSpDcsrzfdHost(handle::cusolverSpHandle_t, n::Cint, nnz::Cint,
-                                             descrA::cusparseMatDescr_t,
-                                             csrValA::Ptr{Cdouble}, csrRowPtrA::Ptr{Cint},
-                                             csrColIndA::Ptr{Cint}, P::Ptr{Cint},
-                                             numnz::Ptr{Cint})::cusolverStatus_t
+    @gcsafe_ccall libcusolver.cusolverSpDcsrzfdHost(handle::cusolverSpHandle_t, n::Cint,
+                                                    nnz::Cint, descrA::cusparseMatDescr_t,
+                                                    csrValA::Ptr{Cdouble},
+                                                    csrRowPtrA::Ptr{Cint},
+                                                    csrColIndA::Ptr{Cint}, P::Ptr{Cint},
+                                                    numnz::Ptr{Cint})::cusolverStatus_t
 end
 
 @checked function cusolverSpCcsrzfdHost(handle, n, nnz, descrA, csrValA, csrRowPtrA,
                                         csrColIndA, P, numnz)
     initialize_context()
-    @ccall libcusolver.cusolverSpCcsrzfdHost(handle::cusolverSpHandle_t, n::Cint, nnz::Cint,
-                                             descrA::cusparseMatDescr_t,
-                                             csrValA::Ptr{cuComplex}, csrRowPtrA::Ptr{Cint},
-                                             csrColIndA::Ptr{Cint}, P::Ptr{Cint},
-                                             numnz::Ptr{Cint})::cusolverStatus_t
+    @gcsafe_ccall libcusolver.cusolverSpCcsrzfdHost(handle::cusolverSpHandle_t, n::Cint,
+                                                    nnz::Cint, descrA::cusparseMatDescr_t,
+                                                    csrValA::Ptr{cuComplex},
+                                                    csrRowPtrA::Ptr{Cint},
+                                                    csrColIndA::Ptr{Cint}, P::Ptr{Cint},
+                                                    numnz::Ptr{Cint})::cusolverStatus_t
 end
 
 @checked function cusolverSpZcsrzfdHost(handle, n, nnz, descrA, csrValA, csrRowPtrA,
                                         csrColIndA, P, numnz)
     initialize_context()
-    @ccall libcusolver.cusolverSpZcsrzfdHost(handle::cusolverSpHandle_t, n::Cint, nnz::Cint,
-                                             descrA::cusparseMatDescr_t,
-                                             csrValA::Ptr{cuDoubleComplex},
-                                             csrRowPtrA::Ptr{Cint}, csrColIndA::Ptr{Cint},
-                                             P::Ptr{Cint},
-                                             numnz::Ptr{Cint})::cusolverStatus_t
+    @gcsafe_ccall libcusolver.cusolverSpZcsrzfdHost(handle::cusolverSpHandle_t, n::Cint,
+                                                    nnz::Cint, descrA::cusparseMatDescr_t,
+                                                    csrValA::Ptr{cuDoubleComplex},
+                                                    csrRowPtrA::Ptr{Cint},
+                                                    csrColIndA::Ptr{Cint}, P::Ptr{Cint},
+                                                    numnz::Ptr{Cint})::cusolverStatus_t
 end
 
 @checked function cusolverSpXcsrperm_bufferSizeHost(handle, m, n, nnzA, descrA, csrRowPtrA,
                                                     csrColIndA, p, q, bufferSizeInBytes)
     initialize_context()
-    @ccall libcusolver.cusolverSpXcsrperm_bufferSizeHost(handle::cusolverSpHandle_t,
-                                                         m::Cint, n::Cint, nnzA::Cint,
-                                                         descrA::cusparseMatDescr_t,
-                                                         csrRowPtrA::Ptr{Cint},
-                                                         csrColIndA::Ptr{Cint},
-                                                         p::Ptr{Cint}, q::Ptr{Cint},
-                                                         bufferSizeInBytes::Ptr{Csize_t})::cusolverStatus_t
+    @gcsafe_ccall libcusolver.cusolverSpXcsrperm_bufferSizeHost(handle::cusolverSpHandle_t,
+                                                                m::Cint, n::Cint,
+                                                                nnzA::Cint,
+                                                                descrA::cusparseMatDescr_t,
+                                                                csrRowPtrA::Ptr{Cint},
+                                                                csrColIndA::Ptr{Cint},
+                                                                p::Ptr{Cint}, q::Ptr{Cint},
+                                                                bufferSizeInBytes::Ptr{Csize_t})::cusolverStatus_t
 end
 
 @checked function cusolverSpXcsrpermHost(handle, m, n, nnzA, descrA, csrRowPtrA, csrColIndA,
                                          p, q, map, pBuffer)
     initialize_context()
-    @ccall libcusolver.cusolverSpXcsrpermHost(handle::cusolverSpHandle_t, m::Cint, n::Cint,
-                                              nnzA::Cint, descrA::cusparseMatDescr_t,
-                                              csrRowPtrA::Ptr{Cint}, csrColIndA::Ptr{Cint},
-                                              p::Ptr{Cint}, q::Ptr{Cint}, map::Ptr{Cint},
-                                              pBuffer::Ptr{Cvoid})::cusolverStatus_t
+    @gcsafe_ccall libcusolver.cusolverSpXcsrpermHost(handle::cusolverSpHandle_t, m::Cint,
+                                                     n::Cint, nnzA::Cint,
+                                                     descrA::cusparseMatDescr_t,
+                                                     csrRowPtrA::Ptr{Cint},
+                                                     csrColIndA::Ptr{Cint}, p::Ptr{Cint},
+                                                     q::Ptr{Cint}, map::Ptr{Cint},
+                                                     pBuffer::Ptr{Cvoid})::cusolverStatus_t
 end
 
 @checked function cusolverSpCreateCsrqrInfo(info)
     initialize_context()
-    @ccall libcusolver.cusolverSpCreateCsrqrInfo(info::Ptr{csrqrInfo_t})::cusolverStatus_t
+    @gcsafe_ccall libcusolver.cusolverSpCreateCsrqrInfo(info::Ptr{csrqrInfo_t})::cusolverStatus_t
 end
 
 @checked function cusolverSpDestroyCsrqrInfo(info)
     initialize_context()
-    @ccall libcusolver.cusolverSpDestroyCsrqrInfo(info::csrqrInfo_t)::cusolverStatus_t
+    @gcsafe_ccall libcusolver.cusolverSpDestroyCsrqrInfo(info::csrqrInfo_t)::cusolverStatus_t
 end
 
 @checked function cusolverSpXcsrqrAnalysisBatched(handle, m, n, nnzA, descrA, csrRowPtrA,
                                                   csrColIndA, info)
     initialize_context()
-    @ccall libcusolver.cusolverSpXcsrqrAnalysisBatched(handle::cusolverSpHandle_t, m::Cint,
-                                                       n::Cint, nnzA::Cint,
-                                                       descrA::cusparseMatDescr_t,
-                                                       csrRowPtrA::CuPtr{Cint},
-                                                       csrColIndA::CuPtr{Cint},
-                                                       info::csrqrInfo_t)::cusolverStatus_t
+    @gcsafe_ccall libcusolver.cusolverSpXcsrqrAnalysisBatched(handle::cusolverSpHandle_t,
+                                                              m::Cint, n::Cint, nnzA::Cint,
+                                                              descrA::cusparseMatDescr_t,
+                                                              csrRowPtrA::CuPtr{Cint},
+                                                              csrColIndA::CuPtr{Cint},
+                                                              info::csrqrInfo_t)::cusolverStatus_t
 end
 
 @checked function cusolverSpScsrqrBufferInfoBatched(handle, m, n, nnz, descrA, csrVal,
                                                     csrRowPtr, csrColInd, batchSize, info,
                                                     internalDataInBytes, workspaceInBytes)
     initialize_context()
-    @ccall libcusolver.cusolverSpScsrqrBufferInfoBatched(handle::cusolverSpHandle_t,
-                                                         m::Cint, n::Cint, nnz::Cint,
-                                                         descrA::cusparseMatDescr_t,
-                                                         csrVal::CuPtr{Cfloat},
-                                                         csrRowPtr::CuPtr{Cint},
-                                                         csrColInd::CuPtr{Cint},
-                                                         batchSize::Cint, info::csrqrInfo_t,
-                                                         internalDataInBytes::Ptr{Csize_t},
-                                                         workspaceInBytes::Ptr{Csize_t})::cusolverStatus_t
+    @gcsafe_ccall libcusolver.cusolverSpScsrqrBufferInfoBatched(handle::cusolverSpHandle_t,
+                                                                m::Cint, n::Cint, nnz::Cint,
+                                                                descrA::cusparseMatDescr_t,
+                                                                csrVal::CuPtr{Cfloat},
+                                                                csrRowPtr::CuPtr{Cint},
+                                                                csrColInd::CuPtr{Cint},
+                                                                batchSize::Cint,
+                                                                info::csrqrInfo_t,
+                                                                internalDataInBytes::Ptr{Csize_t},
+                                                                workspaceInBytes::Ptr{Csize_t})::cusolverStatus_t
 end
 
 @checked function cusolverSpDcsrqrBufferInfoBatched(handle, m, n, nnz, descrA, csrVal,
                                                     csrRowPtr, csrColInd, batchSize, info,
                                                     internalDataInBytes, workspaceInBytes)
     initialize_context()
-    @ccall libcusolver.cusolverSpDcsrqrBufferInfoBatched(handle::cusolverSpHandle_t,
-                                                         m::Cint, n::Cint, nnz::Cint,
-                                                         descrA::cusparseMatDescr_t,
-                                                         csrVal::CuPtr{Cdouble},
-                                                         csrRowPtr::CuPtr{Cint},
-                                                         csrColInd::CuPtr{Cint},
-                                                         batchSize::Cint, info::csrqrInfo_t,
-                                                         internalDataInBytes::Ptr{Csize_t},
-                                                         workspaceInBytes::Ptr{Csize_t})::cusolverStatus_t
+    @gcsafe_ccall libcusolver.cusolverSpDcsrqrBufferInfoBatched(handle::cusolverSpHandle_t,
+                                                                m::Cint, n::Cint, nnz::Cint,
+                                                                descrA::cusparseMatDescr_t,
+                                                                csrVal::CuPtr{Cdouble},
+                                                                csrRowPtr::CuPtr{Cint},
+                                                                csrColInd::CuPtr{Cint},
+                                                                batchSize::Cint,
+                                                                info::csrqrInfo_t,
+                                                                internalDataInBytes::Ptr{Csize_t},
+                                                                workspaceInBytes::Ptr{Csize_t})::cusolverStatus_t
 end
 
 @checked function cusolverSpCcsrqrBufferInfoBatched(handle, m, n, nnz, descrA, csrVal,
                                                     csrRowPtr, csrColInd, batchSize, info,
                                                     internalDataInBytes, workspaceInBytes)
     initialize_context()
-    @ccall libcusolver.cusolverSpCcsrqrBufferInfoBatched(handle::cusolverSpHandle_t,
-                                                         m::Cint, n::Cint, nnz::Cint,
-                                                         descrA::cusparseMatDescr_t,
-                                                         csrVal::CuPtr{cuComplex},
-                                                         csrRowPtr::CuPtr{Cint},
-                                                         csrColInd::CuPtr{Cint},
-                                                         batchSize::Cint, info::csrqrInfo_t,
-                                                         internalDataInBytes::Ptr{Csize_t},
-                                                         workspaceInBytes::Ptr{Csize_t})::cusolverStatus_t
+    @gcsafe_ccall libcusolver.cusolverSpCcsrqrBufferInfoBatched(handle::cusolverSpHandle_t,
+                                                                m::Cint, n::Cint, nnz::Cint,
+                                                                descrA::cusparseMatDescr_t,
+                                                                csrVal::CuPtr{cuComplex},
+                                                                csrRowPtr::CuPtr{Cint},
+                                                                csrColInd::CuPtr{Cint},
+                                                                batchSize::Cint,
+                                                                info::csrqrInfo_t,
+                                                                internalDataInBytes::Ptr{Csize_t},
+                                                                workspaceInBytes::Ptr{Csize_t})::cusolverStatus_t
 end
 
 @checked function cusolverSpZcsrqrBufferInfoBatched(handle, m, n, nnz, descrA, csrVal,
                                                     csrRowPtr, csrColInd, batchSize, info,
                                                     internalDataInBytes, workspaceInBytes)
     initialize_context()
-    @ccall libcusolver.cusolverSpZcsrqrBufferInfoBatched(handle::cusolverSpHandle_t,
-                                                         m::Cint, n::Cint, nnz::Cint,
-                                                         descrA::cusparseMatDescr_t,
-                                                         csrVal::CuPtr{cuDoubleComplex},
-                                                         csrRowPtr::CuPtr{Cint},
-                                                         csrColInd::CuPtr{Cint},
-                                                         batchSize::Cint, info::csrqrInfo_t,
-                                                         internalDataInBytes::Ptr{Csize_t},
-                                                         workspaceInBytes::Ptr{Csize_t})::cusolverStatus_t
+    @gcsafe_ccall libcusolver.cusolverSpZcsrqrBufferInfoBatched(handle::cusolverSpHandle_t,
+                                                                m::Cint, n::Cint, nnz::Cint,
+                                                                descrA::cusparseMatDescr_t,
+                                                                csrVal::CuPtr{cuDoubleComplex},
+                                                                csrRowPtr::CuPtr{Cint},
+                                                                csrColInd::CuPtr{Cint},
+                                                                batchSize::Cint,
+                                                                info::csrqrInfo_t,
+                                                                internalDataInBytes::Ptr{Csize_t},
+                                                                workspaceInBytes::Ptr{Csize_t})::cusolverStatus_t
 end
 
 @checked function cusolverSpScsrqrsvBatched(handle, m, n, nnz, descrA, csrValA, csrRowPtrA,
                                             csrColIndA, b, x, batchSize, info, pBuffer)
     initialize_context()
-    @ccall libcusolver.cusolverSpScsrqrsvBatched(handle::cusolverSpHandle_t, m::Cint,
-                                                 n::Cint, nnz::Cint,
-                                                 descrA::cusparseMatDescr_t,
-                                                 csrValA::CuPtr{Cfloat},
-                                                 csrRowPtrA::CuPtr{Cint},
-                                                 csrColIndA::CuPtr{Cint}, b::CuPtr{Cfloat},
-                                                 x::CuPtr{Cfloat}, batchSize::Cint,
-                                                 info::csrqrInfo_t,
-                                                 pBuffer::CuPtr{Cvoid})::cusolverStatus_t
+    @gcsafe_ccall libcusolver.cusolverSpScsrqrsvBatched(handle::cusolverSpHandle_t, m::Cint,
+                                                        n::Cint, nnz::Cint,
+                                                        descrA::cusparseMatDescr_t,
+                                                        csrValA::CuPtr{Cfloat},
+                                                        csrRowPtrA::CuPtr{Cint},
+                                                        csrColIndA::CuPtr{Cint},
+                                                        b::CuPtr{Cfloat}, x::CuPtr{Cfloat},
+                                                        batchSize::Cint, info::csrqrInfo_t,
+                                                        pBuffer::CuPtr{Cvoid})::cusolverStatus_t
 end
 
 @checked function cusolverSpDcsrqrsvBatched(handle, m, n, nnz, descrA, csrValA, csrRowPtrA,
                                             csrColIndA, b, x, batchSize, info, pBuffer)
     initialize_context()
-    @ccall libcusolver.cusolverSpDcsrqrsvBatched(handle::cusolverSpHandle_t, m::Cint,
-                                                 n::Cint, nnz::Cint,
-                                                 descrA::cusparseMatDescr_t,
-                                                 csrValA::CuPtr{Cdouble},
-                                                 csrRowPtrA::CuPtr{Cint},
-                                                 csrColIndA::CuPtr{Cint}, b::CuPtr{Cdouble},
-                                                 x::CuPtr{Cdouble}, batchSize::Cint,
-                                                 info::csrqrInfo_t,
-                                                 pBuffer::CuPtr{Cvoid})::cusolverStatus_t
+    @gcsafe_ccall libcusolver.cusolverSpDcsrqrsvBatched(handle::cusolverSpHandle_t, m::Cint,
+                                                        n::Cint, nnz::Cint,
+                                                        descrA::cusparseMatDescr_t,
+                                                        csrValA::CuPtr{Cdouble},
+                                                        csrRowPtrA::CuPtr{Cint},
+                                                        csrColIndA::CuPtr{Cint},
+                                                        b::CuPtr{Cdouble},
+                                                        x::CuPtr{Cdouble}, batchSize::Cint,
+                                                        info::csrqrInfo_t,
+                                                        pBuffer::CuPtr{Cvoid})::cusolverStatus_t
 end
 
 @checked function cusolverSpCcsrqrsvBatched(handle, m, n, nnz, descrA, csrValA, csrRowPtrA,
                                             csrColIndA, b, x, batchSize, info, pBuffer)
     initialize_context()
-    @ccall libcusolver.cusolverSpCcsrqrsvBatched(handle::cusolverSpHandle_t, m::Cint,
-                                                 n::Cint, nnz::Cint,
-                                                 descrA::cusparseMatDescr_t,
-                                                 csrValA::CuPtr{cuComplex},
-                                                 csrRowPtrA::CuPtr{Cint},
-                                                 csrColIndA::CuPtr{Cint},
-                                                 b::CuPtr{cuComplex}, x::CuPtr{cuComplex},
-                                                 batchSize::Cint, info::csrqrInfo_t,
-                                                 pBuffer::CuPtr{Cvoid})::cusolverStatus_t
+    @gcsafe_ccall libcusolver.cusolverSpCcsrqrsvBatched(handle::cusolverSpHandle_t, m::Cint,
+                                                        n::Cint, nnz::Cint,
+                                                        descrA::cusparseMatDescr_t,
+                                                        csrValA::CuPtr{cuComplex},
+                                                        csrRowPtrA::CuPtr{Cint},
+                                                        csrColIndA::CuPtr{Cint},
+                                                        b::CuPtr{cuComplex},
+                                                        x::CuPtr{cuComplex},
+                                                        batchSize::Cint, info::csrqrInfo_t,
+                                                        pBuffer::CuPtr{Cvoid})::cusolverStatus_t
 end
 
 @checked function cusolverSpZcsrqrsvBatched(handle, m, n, nnz, descrA, csrValA, csrRowPtrA,
                                             csrColIndA, b, x, batchSize, info, pBuffer)
     initialize_context()
-    @ccall libcusolver.cusolverSpZcsrqrsvBatched(handle::cusolverSpHandle_t, m::Cint,
-                                                 n::Cint, nnz::Cint,
-                                                 descrA::cusparseMatDescr_t,
-                                                 csrValA::CuPtr{cuDoubleComplex},
-                                                 csrRowPtrA::CuPtr{Cint},
-                                                 csrColIndA::CuPtr{Cint},
-                                                 b::CuPtr{cuDoubleComplex},
-                                                 x::CuPtr{cuDoubleComplex}, batchSize::Cint,
-                                                 info::csrqrInfo_t,
-                                                 pBuffer::CuPtr{Cvoid})::cusolverStatus_t
+    @gcsafe_ccall libcusolver.cusolverSpZcsrqrsvBatched(handle::cusolverSpHandle_t, m::Cint,
+                                                        n::Cint, nnz::Cint,
+                                                        descrA::cusparseMatDescr_t,
+                                                        csrValA::CuPtr{cuDoubleComplex},
+                                                        csrRowPtrA::CuPtr{Cint},
+                                                        csrColIndA::CuPtr{Cint},
+                                                        b::CuPtr{cuDoubleComplex},
+                                                        x::CuPtr{cuDoubleComplex},
+                                                        batchSize::Cint, info::csrqrInfo_t,
+                                                        pBuffer::CuPtr{Cvoid})::cusolverStatus_t
 end
 
 mutable struct csrluInfoHost end
@@ -5132,1104 +5707,1160 @@ const csrcholInfo_t = Ptr{csrcholInfo}
 
 @checked function cusolverSpCreateCsrluInfoHost(info)
     initialize_context()
-    @ccall libcusolver.cusolverSpCreateCsrluInfoHost(info::Ptr{csrluInfoHost_t})::cusolverStatus_t
+    @gcsafe_ccall libcusolver.cusolverSpCreateCsrluInfoHost(info::Ptr{csrluInfoHost_t})::cusolverStatus_t
 end
 
 @checked function cusolverSpDestroyCsrluInfoHost(info)
     initialize_context()
-    @ccall libcusolver.cusolverSpDestroyCsrluInfoHost(info::csrluInfoHost_t)::cusolverStatus_t
+    @gcsafe_ccall libcusolver.cusolverSpDestroyCsrluInfoHost(info::csrluInfoHost_t)::cusolverStatus_t
 end
 
 @checked function cusolverSpXcsrluAnalysisHost(handle, n, nnzA, descrA, csrRowPtrA,
                                                csrColIndA, info)
     initialize_context()
-    @ccall libcusolver.cusolverSpXcsrluAnalysisHost(handle::cusolverSpHandle_t, n::Cint,
-                                                    nnzA::Cint, descrA::cusparseMatDescr_t,
-                                                    csrRowPtrA::Ptr{Cint},
-                                                    csrColIndA::Ptr{Cint},
-                                                    info::csrluInfoHost_t)::cusolverStatus_t
+    @gcsafe_ccall libcusolver.cusolverSpXcsrluAnalysisHost(handle::cusolverSpHandle_t,
+                                                           n::Cint, nnzA::Cint,
+                                                           descrA::cusparseMatDescr_t,
+                                                           csrRowPtrA::Ptr{Cint},
+                                                           csrColIndA::Ptr{Cint},
+                                                           info::csrluInfoHost_t)::cusolverStatus_t
 end
 
 @checked function cusolverSpScsrluBufferInfoHost(handle, n, nnzA, descrA, csrValA,
                                                  csrRowPtrA, csrColIndA, info,
                                                  internalDataInBytes, workspaceInBytes)
     initialize_context()
-    @ccall libcusolver.cusolverSpScsrluBufferInfoHost(handle::cusolverSpHandle_t, n::Cint,
-                                                      nnzA::Cint,
-                                                      descrA::cusparseMatDescr_t,
-                                                      csrValA::Ptr{Cfloat},
-                                                      csrRowPtrA::Ptr{Cint},
-                                                      csrColIndA::Ptr{Cint},
-                                                      info::csrluInfoHost_t,
-                                                      internalDataInBytes::Ptr{Csize_t},
-                                                      workspaceInBytes::Ptr{Csize_t})::cusolverStatus_t
+    @gcsafe_ccall libcusolver.cusolverSpScsrluBufferInfoHost(handle::cusolverSpHandle_t,
+                                                             n::Cint, nnzA::Cint,
+                                                             descrA::cusparseMatDescr_t,
+                                                             csrValA::Ptr{Cfloat},
+                                                             csrRowPtrA::Ptr{Cint},
+                                                             csrColIndA::Ptr{Cint},
+                                                             info::csrluInfoHost_t,
+                                                             internalDataInBytes::Ptr{Csize_t},
+                                                             workspaceInBytes::Ptr{Csize_t})::cusolverStatus_t
 end
 
 @checked function cusolverSpDcsrluBufferInfoHost(handle, n, nnzA, descrA, csrValA,
                                                  csrRowPtrA, csrColIndA, info,
                                                  internalDataInBytes, workspaceInBytes)
     initialize_context()
-    @ccall libcusolver.cusolverSpDcsrluBufferInfoHost(handle::cusolverSpHandle_t, n::Cint,
-                                                      nnzA::Cint,
-                                                      descrA::cusparseMatDescr_t,
-                                                      csrValA::Ptr{Cdouble},
-                                                      csrRowPtrA::Ptr{Cint},
-                                                      csrColIndA::Ptr{Cint},
-                                                      info::csrluInfoHost_t,
-                                                      internalDataInBytes::Ptr{Csize_t},
-                                                      workspaceInBytes::Ptr{Csize_t})::cusolverStatus_t
+    @gcsafe_ccall libcusolver.cusolverSpDcsrluBufferInfoHost(handle::cusolverSpHandle_t,
+                                                             n::Cint, nnzA::Cint,
+                                                             descrA::cusparseMatDescr_t,
+                                                             csrValA::Ptr{Cdouble},
+                                                             csrRowPtrA::Ptr{Cint},
+                                                             csrColIndA::Ptr{Cint},
+                                                             info::csrluInfoHost_t,
+                                                             internalDataInBytes::Ptr{Csize_t},
+                                                             workspaceInBytes::Ptr{Csize_t})::cusolverStatus_t
 end
 
 @checked function cusolverSpCcsrluBufferInfoHost(handle, n, nnzA, descrA, csrValA,
                                                  csrRowPtrA, csrColIndA, info,
                                                  internalDataInBytes, workspaceInBytes)
     initialize_context()
-    @ccall libcusolver.cusolverSpCcsrluBufferInfoHost(handle::cusolverSpHandle_t, n::Cint,
-                                                      nnzA::Cint,
-                                                      descrA::cusparseMatDescr_t,
-                                                      csrValA::Ptr{cuComplex},
-                                                      csrRowPtrA::Ptr{Cint},
-                                                      csrColIndA::Ptr{Cint},
-                                                      info::csrluInfoHost_t,
-                                                      internalDataInBytes::Ptr{Csize_t},
-                                                      workspaceInBytes::Ptr{Csize_t})::cusolverStatus_t
+    @gcsafe_ccall libcusolver.cusolverSpCcsrluBufferInfoHost(handle::cusolverSpHandle_t,
+                                                             n::Cint, nnzA::Cint,
+                                                             descrA::cusparseMatDescr_t,
+                                                             csrValA::Ptr{cuComplex},
+                                                             csrRowPtrA::Ptr{Cint},
+                                                             csrColIndA::Ptr{Cint},
+                                                             info::csrluInfoHost_t,
+                                                             internalDataInBytes::Ptr{Csize_t},
+                                                             workspaceInBytes::Ptr{Csize_t})::cusolverStatus_t
 end
 
 @checked function cusolverSpZcsrluBufferInfoHost(handle, n, nnzA, descrA, csrValA,
                                                  csrRowPtrA, csrColIndA, info,
                                                  internalDataInBytes, workspaceInBytes)
     initialize_context()
-    @ccall libcusolver.cusolverSpZcsrluBufferInfoHost(handle::cusolverSpHandle_t, n::Cint,
-                                                      nnzA::Cint,
-                                                      descrA::cusparseMatDescr_t,
-                                                      csrValA::Ptr{cuDoubleComplex},
-                                                      csrRowPtrA::Ptr{Cint},
-                                                      csrColIndA::Ptr{Cint},
-                                                      info::csrluInfoHost_t,
-                                                      internalDataInBytes::Ptr{Csize_t},
-                                                      workspaceInBytes::Ptr{Csize_t})::cusolverStatus_t
+    @gcsafe_ccall libcusolver.cusolverSpZcsrluBufferInfoHost(handle::cusolverSpHandle_t,
+                                                             n::Cint, nnzA::Cint,
+                                                             descrA::cusparseMatDescr_t,
+                                                             csrValA::Ptr{cuDoubleComplex},
+                                                             csrRowPtrA::Ptr{Cint},
+                                                             csrColIndA::Ptr{Cint},
+                                                             info::csrluInfoHost_t,
+                                                             internalDataInBytes::Ptr{Csize_t},
+                                                             workspaceInBytes::Ptr{Csize_t})::cusolverStatus_t
 end
 
 @checked function cusolverSpScsrluFactorHost(handle, n, nnzA, descrA, csrValA, csrRowPtrA,
                                              csrColIndA, info, pivot_threshold, pBuffer)
     initialize_context()
-    @ccall libcusolver.cusolverSpScsrluFactorHost(handle::cusolverSpHandle_t, n::Cint,
-                                                  nnzA::Cint, descrA::cusparseMatDescr_t,
-                                                  csrValA::Ptr{Cfloat},
-                                                  csrRowPtrA::Ptr{Cint},
-                                                  csrColIndA::Ptr{Cint},
-                                                  info::csrluInfoHost_t,
-                                                  pivot_threshold::Cfloat,
-                                                  pBuffer::Ptr{Cvoid})::cusolverStatus_t
+    @gcsafe_ccall libcusolver.cusolverSpScsrluFactorHost(handle::cusolverSpHandle_t,
+                                                         n::Cint, nnzA::Cint,
+                                                         descrA::cusparseMatDescr_t,
+                                                         csrValA::Ptr{Cfloat},
+                                                         csrRowPtrA::Ptr{Cint},
+                                                         csrColIndA::Ptr{Cint},
+                                                         info::csrluInfoHost_t,
+                                                         pivot_threshold::Cfloat,
+                                                         pBuffer::Ptr{Cvoid})::cusolverStatus_t
 end
 
 @checked function cusolverSpDcsrluFactorHost(handle, n, nnzA, descrA, csrValA, csrRowPtrA,
                                              csrColIndA, info, pivot_threshold, pBuffer)
     initialize_context()
-    @ccall libcusolver.cusolverSpDcsrluFactorHost(handle::cusolverSpHandle_t, n::Cint,
-                                                  nnzA::Cint, descrA::cusparseMatDescr_t,
-                                                  csrValA::Ptr{Cdouble},
-                                                  csrRowPtrA::Ptr{Cint},
-                                                  csrColIndA::Ptr{Cint},
-                                                  info::csrluInfoHost_t,
-                                                  pivot_threshold::Cdouble,
-                                                  pBuffer::Ptr{Cvoid})::cusolverStatus_t
+    @gcsafe_ccall libcusolver.cusolverSpDcsrluFactorHost(handle::cusolverSpHandle_t,
+                                                         n::Cint, nnzA::Cint,
+                                                         descrA::cusparseMatDescr_t,
+                                                         csrValA::Ptr{Cdouble},
+                                                         csrRowPtrA::Ptr{Cint},
+                                                         csrColIndA::Ptr{Cint},
+                                                         info::csrluInfoHost_t,
+                                                         pivot_threshold::Cdouble,
+                                                         pBuffer::Ptr{Cvoid})::cusolverStatus_t
 end
 
 @checked function cusolverSpCcsrluFactorHost(handle, n, nnzA, descrA, csrValA, csrRowPtrA,
                                              csrColIndA, info, pivot_threshold, pBuffer)
     initialize_context()
-    @ccall libcusolver.cusolverSpCcsrluFactorHost(handle::cusolverSpHandle_t, n::Cint,
-                                                  nnzA::Cint, descrA::cusparseMatDescr_t,
-                                                  csrValA::Ptr{cuComplex},
-                                                  csrRowPtrA::Ptr{Cint},
-                                                  csrColIndA::Ptr{Cint},
-                                                  info::csrluInfoHost_t,
-                                                  pivot_threshold::Cfloat,
-                                                  pBuffer::Ptr{Cvoid})::cusolverStatus_t
+    @gcsafe_ccall libcusolver.cusolverSpCcsrluFactorHost(handle::cusolverSpHandle_t,
+                                                         n::Cint, nnzA::Cint,
+                                                         descrA::cusparseMatDescr_t,
+                                                         csrValA::Ptr{cuComplex},
+                                                         csrRowPtrA::Ptr{Cint},
+                                                         csrColIndA::Ptr{Cint},
+                                                         info::csrluInfoHost_t,
+                                                         pivot_threshold::Cfloat,
+                                                         pBuffer::Ptr{Cvoid})::cusolverStatus_t
 end
 
 @checked function cusolverSpZcsrluFactorHost(handle, n, nnzA, descrA, csrValA, csrRowPtrA,
                                              csrColIndA, info, pivot_threshold, pBuffer)
     initialize_context()
-    @ccall libcusolver.cusolverSpZcsrluFactorHost(handle::cusolverSpHandle_t, n::Cint,
-                                                  nnzA::Cint, descrA::cusparseMatDescr_t,
-                                                  csrValA::Ptr{cuDoubleComplex},
-                                                  csrRowPtrA::Ptr{Cint},
-                                                  csrColIndA::Ptr{Cint},
-                                                  info::csrluInfoHost_t,
-                                                  pivot_threshold::Cdouble,
-                                                  pBuffer::Ptr{Cvoid})::cusolverStatus_t
+    @gcsafe_ccall libcusolver.cusolverSpZcsrluFactorHost(handle::cusolverSpHandle_t,
+                                                         n::Cint, nnzA::Cint,
+                                                         descrA::cusparseMatDescr_t,
+                                                         csrValA::Ptr{cuDoubleComplex},
+                                                         csrRowPtrA::Ptr{Cint},
+                                                         csrColIndA::Ptr{Cint},
+                                                         info::csrluInfoHost_t,
+                                                         pivot_threshold::Cdouble,
+                                                         pBuffer::Ptr{Cvoid})::cusolverStatus_t
 end
 
 @checked function cusolverSpScsrluZeroPivotHost(handle, info, tol, position)
     initialize_context()
-    @ccall libcusolver.cusolverSpScsrluZeroPivotHost(handle::cusolverSpHandle_t,
-                                                     info::csrluInfoHost_t, tol::Cfloat,
-                                                     position::Ptr{Cint})::cusolverStatus_t
+    @gcsafe_ccall libcusolver.cusolverSpScsrluZeroPivotHost(handle::cusolverSpHandle_t,
+                                                            info::csrluInfoHost_t,
+                                                            tol::Cfloat,
+                                                            position::Ptr{Cint})::cusolverStatus_t
 end
 
 @checked function cusolverSpDcsrluZeroPivotHost(handle, info, tol, position)
     initialize_context()
-    @ccall libcusolver.cusolverSpDcsrluZeroPivotHost(handle::cusolverSpHandle_t,
-                                                     info::csrluInfoHost_t, tol::Cdouble,
-                                                     position::Ptr{Cint})::cusolverStatus_t
+    @gcsafe_ccall libcusolver.cusolverSpDcsrluZeroPivotHost(handle::cusolverSpHandle_t,
+                                                            info::csrluInfoHost_t,
+                                                            tol::Cdouble,
+                                                            position::Ptr{Cint})::cusolverStatus_t
 end
 
 @checked function cusolverSpCcsrluZeroPivotHost(handle, info, tol, position)
     initialize_context()
-    @ccall libcusolver.cusolverSpCcsrluZeroPivotHost(handle::cusolverSpHandle_t,
-                                                     info::csrluInfoHost_t, tol::Cfloat,
-                                                     position::Ptr{Cint})::cusolverStatus_t
+    @gcsafe_ccall libcusolver.cusolverSpCcsrluZeroPivotHost(handle::cusolverSpHandle_t,
+                                                            info::csrluInfoHost_t,
+                                                            tol::Cfloat,
+                                                            position::Ptr{Cint})::cusolverStatus_t
 end
 
 @checked function cusolverSpZcsrluZeroPivotHost(handle, info, tol, position)
     initialize_context()
-    @ccall libcusolver.cusolverSpZcsrluZeroPivotHost(handle::cusolverSpHandle_t,
-                                                     info::csrluInfoHost_t, tol::Cdouble,
-                                                     position::Ptr{Cint})::cusolverStatus_t
+    @gcsafe_ccall libcusolver.cusolverSpZcsrluZeroPivotHost(handle::cusolverSpHandle_t,
+                                                            info::csrluInfoHost_t,
+                                                            tol::Cdouble,
+                                                            position::Ptr{Cint})::cusolverStatus_t
 end
 
 @checked function cusolverSpScsrluSolveHost(handle, n, b, x, info, pBuffer)
     initialize_context()
-    @ccall libcusolver.cusolverSpScsrluSolveHost(handle::cusolverSpHandle_t, n::Cint,
-                                                 b::Ptr{Cfloat}, x::Ptr{Cfloat},
-                                                 info::csrluInfoHost_t,
-                                                 pBuffer::Ptr{Cvoid})::cusolverStatus_t
+    @gcsafe_ccall libcusolver.cusolverSpScsrluSolveHost(handle::cusolverSpHandle_t, n::Cint,
+                                                        b::Ptr{Cfloat}, x::Ptr{Cfloat},
+                                                        info::csrluInfoHost_t,
+                                                        pBuffer::Ptr{Cvoid})::cusolverStatus_t
 end
 
 @checked function cusolverSpDcsrluSolveHost(handle, n, b, x, info, pBuffer)
     initialize_context()
-    @ccall libcusolver.cusolverSpDcsrluSolveHost(handle::cusolverSpHandle_t, n::Cint,
-                                                 b::Ptr{Cdouble}, x::Ptr{Cdouble},
-                                                 info::csrluInfoHost_t,
-                                                 pBuffer::Ptr{Cvoid})::cusolverStatus_t
+    @gcsafe_ccall libcusolver.cusolverSpDcsrluSolveHost(handle::cusolverSpHandle_t, n::Cint,
+                                                        b::Ptr{Cdouble}, x::Ptr{Cdouble},
+                                                        info::csrluInfoHost_t,
+                                                        pBuffer::Ptr{Cvoid})::cusolverStatus_t
 end
 
 @checked function cusolverSpCcsrluSolveHost(handle, n, b, x, info, pBuffer)
     initialize_context()
-    @ccall libcusolver.cusolverSpCcsrluSolveHost(handle::cusolverSpHandle_t, n::Cint,
-                                                 b::Ptr{cuComplex}, x::Ptr{cuComplex},
-                                                 info::csrluInfoHost_t,
-                                                 pBuffer::Ptr{Cvoid})::cusolverStatus_t
+    @gcsafe_ccall libcusolver.cusolverSpCcsrluSolveHost(handle::cusolverSpHandle_t, n::Cint,
+                                                        b::Ptr{cuComplex},
+                                                        x::Ptr{cuComplex},
+                                                        info::csrluInfoHost_t,
+                                                        pBuffer::Ptr{Cvoid})::cusolverStatus_t
 end
 
 @checked function cusolverSpZcsrluSolveHost(handle, n, b, x, info, pBuffer)
     initialize_context()
-    @ccall libcusolver.cusolverSpZcsrluSolveHost(handle::cusolverSpHandle_t, n::Cint,
-                                                 b::Ptr{cuDoubleComplex},
-                                                 x::Ptr{cuDoubleComplex},
-                                                 info::csrluInfoHost_t,
-                                                 pBuffer::Ptr{Cvoid})::cusolverStatus_t
+    @gcsafe_ccall libcusolver.cusolverSpZcsrluSolveHost(handle::cusolverSpHandle_t, n::Cint,
+                                                        b::Ptr{cuDoubleComplex},
+                                                        x::Ptr{cuDoubleComplex},
+                                                        info::csrluInfoHost_t,
+                                                        pBuffer::Ptr{Cvoid})::cusolverStatus_t
 end
 
 @checked function cusolverSpXcsrluNnzHost(handle, nnzLRef, nnzURef, info)
     initialize_context()
-    @ccall libcusolver.cusolverSpXcsrluNnzHost(handle::cusolverSpHandle_t,
-                                               nnzLRef::Ptr{Cint}, nnzURef::Ptr{Cint},
-                                               info::csrluInfoHost_t)::cusolverStatus_t
+    @gcsafe_ccall libcusolver.cusolverSpXcsrluNnzHost(handle::cusolverSpHandle_t,
+                                                      nnzLRef::Ptr{Cint},
+                                                      nnzURef::Ptr{Cint},
+                                                      info::csrluInfoHost_t)::cusolverStatus_t
 end
 
 @checked function cusolverSpScsrluExtractHost(handle, P, Q, descrL, csrValL, csrRowPtrL,
                                               csrColIndL, descrU, csrValU, csrRowPtrU,
                                               csrColIndU, info, pBuffer)
     initialize_context()
-    @ccall libcusolver.cusolverSpScsrluExtractHost(handle::cusolverSpHandle_t, P::Ptr{Cint},
-                                                   Q::Ptr{Cint}, descrL::cusparseMatDescr_t,
-                                                   csrValL::Ptr{Cfloat},
-                                                   csrRowPtrL::Ptr{Cint},
-                                                   csrColIndL::Ptr{Cint},
-                                                   descrU::cusparseMatDescr_t,
-                                                   csrValU::Ptr{Cfloat},
-                                                   csrRowPtrU::Ptr{Cint},
-                                                   csrColIndU::Ptr{Cint},
-                                                   info::csrluInfoHost_t,
-                                                   pBuffer::Ptr{Cvoid})::cusolverStatus_t
+    @gcsafe_ccall libcusolver.cusolverSpScsrluExtractHost(handle::cusolverSpHandle_t,
+                                                          P::Ptr{Cint}, Q::Ptr{Cint},
+                                                          descrL::cusparseMatDescr_t,
+                                                          csrValL::Ptr{Cfloat},
+                                                          csrRowPtrL::Ptr{Cint},
+                                                          csrColIndL::Ptr{Cint},
+                                                          descrU::cusparseMatDescr_t,
+                                                          csrValU::Ptr{Cfloat},
+                                                          csrRowPtrU::Ptr{Cint},
+                                                          csrColIndU::Ptr{Cint},
+                                                          info::csrluInfoHost_t,
+                                                          pBuffer::Ptr{Cvoid})::cusolverStatus_t
 end
 
 @checked function cusolverSpDcsrluExtractHost(handle, P, Q, descrL, csrValL, csrRowPtrL,
                                               csrColIndL, descrU, csrValU, csrRowPtrU,
                                               csrColIndU, info, pBuffer)
     initialize_context()
-    @ccall libcusolver.cusolverSpDcsrluExtractHost(handle::cusolverSpHandle_t, P::Ptr{Cint},
-                                                   Q::Ptr{Cint}, descrL::cusparseMatDescr_t,
-                                                   csrValL::Ptr{Cdouble},
-                                                   csrRowPtrL::Ptr{Cint},
-                                                   csrColIndL::Ptr{Cint},
-                                                   descrU::cusparseMatDescr_t,
-                                                   csrValU::Ptr{Cdouble},
-                                                   csrRowPtrU::Ptr{Cint},
-                                                   csrColIndU::Ptr{Cint},
-                                                   info::csrluInfoHost_t,
-                                                   pBuffer::Ptr{Cvoid})::cusolverStatus_t
+    @gcsafe_ccall libcusolver.cusolverSpDcsrluExtractHost(handle::cusolverSpHandle_t,
+                                                          P::Ptr{Cint}, Q::Ptr{Cint},
+                                                          descrL::cusparseMatDescr_t,
+                                                          csrValL::Ptr{Cdouble},
+                                                          csrRowPtrL::Ptr{Cint},
+                                                          csrColIndL::Ptr{Cint},
+                                                          descrU::cusparseMatDescr_t,
+                                                          csrValU::Ptr{Cdouble},
+                                                          csrRowPtrU::Ptr{Cint},
+                                                          csrColIndU::Ptr{Cint},
+                                                          info::csrluInfoHost_t,
+                                                          pBuffer::Ptr{Cvoid})::cusolverStatus_t
 end
 
 @checked function cusolverSpCcsrluExtractHost(handle, P, Q, descrL, csrValL, csrRowPtrL,
                                               csrColIndL, descrU, csrValU, csrRowPtrU,
                                               csrColIndU, info, pBuffer)
     initialize_context()
-    @ccall libcusolver.cusolverSpCcsrluExtractHost(handle::cusolverSpHandle_t, P::Ptr{Cint},
-                                                   Q::Ptr{Cint}, descrL::cusparseMatDescr_t,
-                                                   csrValL::Ptr{cuComplex},
-                                                   csrRowPtrL::Ptr{Cint},
-                                                   csrColIndL::Ptr{Cint},
-                                                   descrU::cusparseMatDescr_t,
-                                                   csrValU::Ptr{cuComplex},
-                                                   csrRowPtrU::Ptr{Cint},
-                                                   csrColIndU::Ptr{Cint},
-                                                   info::csrluInfoHost_t,
-                                                   pBuffer::Ptr{Cvoid})::cusolverStatus_t
+    @gcsafe_ccall libcusolver.cusolverSpCcsrluExtractHost(handle::cusolverSpHandle_t,
+                                                          P::Ptr{Cint}, Q::Ptr{Cint},
+                                                          descrL::cusparseMatDescr_t,
+                                                          csrValL::Ptr{cuComplex},
+                                                          csrRowPtrL::Ptr{Cint},
+                                                          csrColIndL::Ptr{Cint},
+                                                          descrU::cusparseMatDescr_t,
+                                                          csrValU::Ptr{cuComplex},
+                                                          csrRowPtrU::Ptr{Cint},
+                                                          csrColIndU::Ptr{Cint},
+                                                          info::csrluInfoHost_t,
+                                                          pBuffer::Ptr{Cvoid})::cusolverStatus_t
 end
 
 @checked function cusolverSpZcsrluExtractHost(handle, P, Q, descrL, csrValL, csrRowPtrL,
                                               csrColIndL, descrU, csrValU, csrRowPtrU,
                                               csrColIndU, info, pBuffer)
     initialize_context()
-    @ccall libcusolver.cusolverSpZcsrluExtractHost(handle::cusolverSpHandle_t, P::Ptr{Cint},
-                                                   Q::Ptr{Cint}, descrL::cusparseMatDescr_t,
-                                                   csrValL::Ptr{cuDoubleComplex},
-                                                   csrRowPtrL::Ptr{Cint},
-                                                   csrColIndL::Ptr{Cint},
-                                                   descrU::cusparseMatDescr_t,
-                                                   csrValU::Ptr{cuDoubleComplex},
-                                                   csrRowPtrU::Ptr{Cint},
-                                                   csrColIndU::Ptr{Cint},
-                                                   info::csrluInfoHost_t,
-                                                   pBuffer::Ptr{Cvoid})::cusolverStatus_t
+    @gcsafe_ccall libcusolver.cusolverSpZcsrluExtractHost(handle::cusolverSpHandle_t,
+                                                          P::Ptr{Cint}, Q::Ptr{Cint},
+                                                          descrL::cusparseMatDescr_t,
+                                                          csrValL::Ptr{cuDoubleComplex},
+                                                          csrRowPtrL::Ptr{Cint},
+                                                          csrColIndL::Ptr{Cint},
+                                                          descrU::cusparseMatDescr_t,
+                                                          csrValU::Ptr{cuDoubleComplex},
+                                                          csrRowPtrU::Ptr{Cint},
+                                                          csrColIndU::Ptr{Cint},
+                                                          info::csrluInfoHost_t,
+                                                          pBuffer::Ptr{Cvoid})::cusolverStatus_t
 end
 
 @checked function cusolverSpCreateCsrqrInfoHost(info)
     initialize_context()
-    @ccall libcusolver.cusolverSpCreateCsrqrInfoHost(info::Ptr{csrqrInfoHost_t})::cusolverStatus_t
+    @gcsafe_ccall libcusolver.cusolverSpCreateCsrqrInfoHost(info::Ptr{csrqrInfoHost_t})::cusolverStatus_t
 end
 
 @checked function cusolverSpDestroyCsrqrInfoHost(info)
     initialize_context()
-    @ccall libcusolver.cusolverSpDestroyCsrqrInfoHost(info::csrqrInfoHost_t)::cusolverStatus_t
+    @gcsafe_ccall libcusolver.cusolverSpDestroyCsrqrInfoHost(info::csrqrInfoHost_t)::cusolverStatus_t
 end
 
 @checked function cusolverSpXcsrqrAnalysisHost(handle, m, n, nnzA, descrA, csrRowPtrA,
                                                csrColIndA, info)
     initialize_context()
-    @ccall libcusolver.cusolverSpXcsrqrAnalysisHost(handle::cusolverSpHandle_t, m::Cint,
-                                                    n::Cint, nnzA::Cint,
-                                                    descrA::cusparseMatDescr_t,
-                                                    csrRowPtrA::Ptr{Cint},
-                                                    csrColIndA::Ptr{Cint},
-                                                    info::csrqrInfoHost_t)::cusolverStatus_t
+    @gcsafe_ccall libcusolver.cusolverSpXcsrqrAnalysisHost(handle::cusolverSpHandle_t,
+                                                           m::Cint, n::Cint, nnzA::Cint,
+                                                           descrA::cusparseMatDescr_t,
+                                                           csrRowPtrA::Ptr{Cint},
+                                                           csrColIndA::Ptr{Cint},
+                                                           info::csrqrInfoHost_t)::cusolverStatus_t
 end
 
 @checked function cusolverSpScsrqrBufferInfoHost(handle, m, n, nnzA, descrA, csrValA,
                                                  csrRowPtrA, csrColIndA, info,
                                                  internalDataInBytes, workspaceInBytes)
     initialize_context()
-    @ccall libcusolver.cusolverSpScsrqrBufferInfoHost(handle::cusolverSpHandle_t, m::Cint,
-                                                      n::Cint, nnzA::Cint,
-                                                      descrA::cusparseMatDescr_t,
-                                                      csrValA::Ptr{Cfloat},
-                                                      csrRowPtrA::Ptr{Cint},
-                                                      csrColIndA::Ptr{Cint},
-                                                      info::csrqrInfoHost_t,
-                                                      internalDataInBytes::Ptr{Csize_t},
-                                                      workspaceInBytes::Ptr{Csize_t})::cusolverStatus_t
+    @gcsafe_ccall libcusolver.cusolverSpScsrqrBufferInfoHost(handle::cusolverSpHandle_t,
+                                                             m::Cint, n::Cint, nnzA::Cint,
+                                                             descrA::cusparseMatDescr_t,
+                                                             csrValA::Ptr{Cfloat},
+                                                             csrRowPtrA::Ptr{Cint},
+                                                             csrColIndA::Ptr{Cint},
+                                                             info::csrqrInfoHost_t,
+                                                             internalDataInBytes::Ptr{Csize_t},
+                                                             workspaceInBytes::Ptr{Csize_t})::cusolverStatus_t
 end
 
 @checked function cusolverSpDcsrqrBufferInfoHost(handle, m, n, nnzA, descrA, csrValA,
                                                  csrRowPtrA, csrColIndA, info,
                                                  internalDataInBytes, workspaceInBytes)
     initialize_context()
-    @ccall libcusolver.cusolverSpDcsrqrBufferInfoHost(handle::cusolverSpHandle_t, m::Cint,
-                                                      n::Cint, nnzA::Cint,
-                                                      descrA::cusparseMatDescr_t,
-                                                      csrValA::Ptr{Cdouble},
-                                                      csrRowPtrA::Ptr{Cint},
-                                                      csrColIndA::Ptr{Cint},
-                                                      info::csrqrInfoHost_t,
-                                                      internalDataInBytes::Ptr{Csize_t},
-                                                      workspaceInBytes::Ptr{Csize_t})::cusolverStatus_t
+    @gcsafe_ccall libcusolver.cusolverSpDcsrqrBufferInfoHost(handle::cusolverSpHandle_t,
+                                                             m::Cint, n::Cint, nnzA::Cint,
+                                                             descrA::cusparseMatDescr_t,
+                                                             csrValA::Ptr{Cdouble},
+                                                             csrRowPtrA::Ptr{Cint},
+                                                             csrColIndA::Ptr{Cint},
+                                                             info::csrqrInfoHost_t,
+                                                             internalDataInBytes::Ptr{Csize_t},
+                                                             workspaceInBytes::Ptr{Csize_t})::cusolverStatus_t
 end
 
 @checked function cusolverSpCcsrqrBufferInfoHost(handle, m, n, nnzA, descrA, csrValA,
                                                  csrRowPtrA, csrColIndA, info,
                                                  internalDataInBytes, workspaceInBytes)
     initialize_context()
-    @ccall libcusolver.cusolverSpCcsrqrBufferInfoHost(handle::cusolverSpHandle_t, m::Cint,
-                                                      n::Cint, nnzA::Cint,
-                                                      descrA::cusparseMatDescr_t,
-                                                      csrValA::Ptr{cuComplex},
-                                                      csrRowPtrA::Ptr{Cint},
-                                                      csrColIndA::Ptr{Cint},
-                                                      info::csrqrInfoHost_t,
-                                                      internalDataInBytes::Ptr{Csize_t},
-                                                      workspaceInBytes::Ptr{Csize_t})::cusolverStatus_t
+    @gcsafe_ccall libcusolver.cusolverSpCcsrqrBufferInfoHost(handle::cusolverSpHandle_t,
+                                                             m::Cint, n::Cint, nnzA::Cint,
+                                                             descrA::cusparseMatDescr_t,
+                                                             csrValA::Ptr{cuComplex},
+                                                             csrRowPtrA::Ptr{Cint},
+                                                             csrColIndA::Ptr{Cint},
+                                                             info::csrqrInfoHost_t,
+                                                             internalDataInBytes::Ptr{Csize_t},
+                                                             workspaceInBytes::Ptr{Csize_t})::cusolverStatus_t
 end
 
 @checked function cusolverSpZcsrqrBufferInfoHost(handle, m, n, nnzA, descrA, csrValA,
                                                  csrRowPtrA, csrColIndA, info,
                                                  internalDataInBytes, workspaceInBytes)
     initialize_context()
-    @ccall libcusolver.cusolverSpZcsrqrBufferInfoHost(handle::cusolverSpHandle_t, m::Cint,
-                                                      n::Cint, nnzA::Cint,
-                                                      descrA::cusparseMatDescr_t,
-                                                      csrValA::Ptr{cuDoubleComplex},
-                                                      csrRowPtrA::Ptr{Cint},
-                                                      csrColIndA::Ptr{Cint},
-                                                      info::csrqrInfoHost_t,
-                                                      internalDataInBytes::Ptr{Csize_t},
-                                                      workspaceInBytes::Ptr{Csize_t})::cusolverStatus_t
+    @gcsafe_ccall libcusolver.cusolverSpZcsrqrBufferInfoHost(handle::cusolverSpHandle_t,
+                                                             m::Cint, n::Cint, nnzA::Cint,
+                                                             descrA::cusparseMatDescr_t,
+                                                             csrValA::Ptr{cuDoubleComplex},
+                                                             csrRowPtrA::Ptr{Cint},
+                                                             csrColIndA::Ptr{Cint},
+                                                             info::csrqrInfoHost_t,
+                                                             internalDataInBytes::Ptr{Csize_t},
+                                                             workspaceInBytes::Ptr{Csize_t})::cusolverStatus_t
 end
 
 @checked function cusolverSpScsrqrSetupHost(handle, m, n, nnzA, descrA, csrValA, csrRowPtrA,
                                             csrColIndA, mu, info)
     initialize_context()
-    @ccall libcusolver.cusolverSpScsrqrSetupHost(handle::cusolverSpHandle_t, m::Cint,
-                                                 n::Cint, nnzA::Cint,
-                                                 descrA::cusparseMatDescr_t,
-                                                 csrValA::Ptr{Cfloat},
-                                                 csrRowPtrA::Ptr{Cint},
-                                                 csrColIndA::Ptr{Cint}, mu::Cfloat,
-                                                 info::csrqrInfoHost_t)::cusolverStatus_t
+    @gcsafe_ccall libcusolver.cusolverSpScsrqrSetupHost(handle::cusolverSpHandle_t, m::Cint,
+                                                        n::Cint, nnzA::Cint,
+                                                        descrA::cusparseMatDescr_t,
+                                                        csrValA::Ptr{Cfloat},
+                                                        csrRowPtrA::Ptr{Cint},
+                                                        csrColIndA::Ptr{Cint}, mu::Cfloat,
+                                                        info::csrqrInfoHost_t)::cusolverStatus_t
 end
 
 @checked function cusolverSpDcsrqrSetupHost(handle, m, n, nnzA, descrA, csrValA, csrRowPtrA,
                                             csrColIndA, mu, info)
     initialize_context()
-    @ccall libcusolver.cusolverSpDcsrqrSetupHost(handle::cusolverSpHandle_t, m::Cint,
-                                                 n::Cint, nnzA::Cint,
-                                                 descrA::cusparseMatDescr_t,
-                                                 csrValA::Ptr{Cdouble},
-                                                 csrRowPtrA::Ptr{Cint},
-                                                 csrColIndA::Ptr{Cint}, mu::Cdouble,
-                                                 info::csrqrInfoHost_t)::cusolverStatus_t
+    @gcsafe_ccall libcusolver.cusolverSpDcsrqrSetupHost(handle::cusolverSpHandle_t, m::Cint,
+                                                        n::Cint, nnzA::Cint,
+                                                        descrA::cusparseMatDescr_t,
+                                                        csrValA::Ptr{Cdouble},
+                                                        csrRowPtrA::Ptr{Cint},
+                                                        csrColIndA::Ptr{Cint}, mu::Cdouble,
+                                                        info::csrqrInfoHost_t)::cusolverStatus_t
 end
 
 @checked function cusolverSpCcsrqrSetupHost(handle, m, n, nnzA, descrA, csrValA, csrRowPtrA,
                                             csrColIndA, mu, info)
     initialize_context()
-    @ccall libcusolver.cusolverSpCcsrqrSetupHost(handle::cusolverSpHandle_t, m::Cint,
-                                                 n::Cint, nnzA::Cint,
-                                                 descrA::cusparseMatDescr_t,
-                                                 csrValA::Ptr{cuComplex},
-                                                 csrRowPtrA::Ptr{Cint},
-                                                 csrColIndA::Ptr{Cint}, mu::cuComplex,
-                                                 info::csrqrInfoHost_t)::cusolverStatus_t
+    @gcsafe_ccall libcusolver.cusolverSpCcsrqrSetupHost(handle::cusolverSpHandle_t, m::Cint,
+                                                        n::Cint, nnzA::Cint,
+                                                        descrA::cusparseMatDescr_t,
+                                                        csrValA::Ptr{cuComplex},
+                                                        csrRowPtrA::Ptr{Cint},
+                                                        csrColIndA::Ptr{Cint},
+                                                        mu::cuComplex,
+                                                        info::csrqrInfoHost_t)::cusolverStatus_t
 end
 
 @checked function cusolverSpZcsrqrSetupHost(handle, m, n, nnzA, descrA, csrValA, csrRowPtrA,
                                             csrColIndA, mu, info)
     initialize_context()
-    @ccall libcusolver.cusolverSpZcsrqrSetupHost(handle::cusolverSpHandle_t, m::Cint,
-                                                 n::Cint, nnzA::Cint,
-                                                 descrA::cusparseMatDescr_t,
-                                                 csrValA::Ptr{cuDoubleComplex},
-                                                 csrRowPtrA::Ptr{Cint},
-                                                 csrColIndA::Ptr{Cint}, mu::cuDoubleComplex,
-                                                 info::csrqrInfoHost_t)::cusolverStatus_t
+    @gcsafe_ccall libcusolver.cusolverSpZcsrqrSetupHost(handle::cusolverSpHandle_t, m::Cint,
+                                                        n::Cint, nnzA::Cint,
+                                                        descrA::cusparseMatDescr_t,
+                                                        csrValA::Ptr{cuDoubleComplex},
+                                                        csrRowPtrA::Ptr{Cint},
+                                                        csrColIndA::Ptr{Cint},
+                                                        mu::cuDoubleComplex,
+                                                        info::csrqrInfoHost_t)::cusolverStatus_t
 end
 
 @checked function cusolverSpScsrqrFactorHost(handle, m, n, nnzA, b, x, info, pBuffer)
     initialize_context()
-    @ccall libcusolver.cusolverSpScsrqrFactorHost(handle::cusolverSpHandle_t, m::Cint,
-                                                  n::Cint, nnzA::Cint, b::Ptr{Cfloat},
-                                                  x::Ptr{Cfloat}, info::csrqrInfoHost_t,
-                                                  pBuffer::Ptr{Cvoid})::cusolverStatus_t
+    @gcsafe_ccall libcusolver.cusolverSpScsrqrFactorHost(handle::cusolverSpHandle_t,
+                                                         m::Cint, n::Cint, nnzA::Cint,
+                                                         b::Ptr{Cfloat}, x::Ptr{Cfloat},
+                                                         info::csrqrInfoHost_t,
+                                                         pBuffer::Ptr{Cvoid})::cusolverStatus_t
 end
 
 @checked function cusolverSpDcsrqrFactorHost(handle, m, n, nnzA, b, x, info, pBuffer)
     initialize_context()
-    @ccall libcusolver.cusolverSpDcsrqrFactorHost(handle::cusolverSpHandle_t, m::Cint,
-                                                  n::Cint, nnzA::Cint, b::Ptr{Cdouble},
-                                                  x::Ptr{Cdouble}, info::csrqrInfoHost_t,
-                                                  pBuffer::Ptr{Cvoid})::cusolverStatus_t
+    @gcsafe_ccall libcusolver.cusolverSpDcsrqrFactorHost(handle::cusolverSpHandle_t,
+                                                         m::Cint, n::Cint, nnzA::Cint,
+                                                         b::Ptr{Cdouble}, x::Ptr{Cdouble},
+                                                         info::csrqrInfoHost_t,
+                                                         pBuffer::Ptr{Cvoid})::cusolverStatus_t
 end
 
 @checked function cusolverSpCcsrqrFactorHost(handle, m, n, nnzA, b, x, info, pBuffer)
     initialize_context()
-    @ccall libcusolver.cusolverSpCcsrqrFactorHost(handle::cusolverSpHandle_t, m::Cint,
-                                                  n::Cint, nnzA::Cint, b::Ptr{cuComplex},
-                                                  x::Ptr{cuComplex}, info::csrqrInfoHost_t,
-                                                  pBuffer::Ptr{Cvoid})::cusolverStatus_t
+    @gcsafe_ccall libcusolver.cusolverSpCcsrqrFactorHost(handle::cusolverSpHandle_t,
+                                                         m::Cint, n::Cint, nnzA::Cint,
+                                                         b::Ptr{cuComplex},
+                                                         x::Ptr{cuComplex},
+                                                         info::csrqrInfoHost_t,
+                                                         pBuffer::Ptr{Cvoid})::cusolverStatus_t
 end
 
 @checked function cusolverSpZcsrqrFactorHost(handle, m, n, nnzA, b, x, info, pBuffer)
     initialize_context()
-    @ccall libcusolver.cusolverSpZcsrqrFactorHost(handle::cusolverSpHandle_t, m::Cint,
-                                                  n::Cint, nnzA::Cint,
-                                                  b::Ptr{cuDoubleComplex},
-                                                  x::Ptr{cuDoubleComplex},
-                                                  info::csrqrInfoHost_t,
-                                                  pBuffer::Ptr{Cvoid})::cusolverStatus_t
+    @gcsafe_ccall libcusolver.cusolverSpZcsrqrFactorHost(handle::cusolverSpHandle_t,
+                                                         m::Cint, n::Cint, nnzA::Cint,
+                                                         b::Ptr{cuDoubleComplex},
+                                                         x::Ptr{cuDoubleComplex},
+                                                         info::csrqrInfoHost_t,
+                                                         pBuffer::Ptr{Cvoid})::cusolverStatus_t
 end
 
 @checked function cusolverSpScsrqrZeroPivotHost(handle, info, tol, position)
     initialize_context()
-    @ccall libcusolver.cusolverSpScsrqrZeroPivotHost(handle::cusolverSpHandle_t,
-                                                     info::csrqrInfoHost_t, tol::Cfloat,
-                                                     position::Ptr{Cint})::cusolverStatus_t
+    @gcsafe_ccall libcusolver.cusolverSpScsrqrZeroPivotHost(handle::cusolverSpHandle_t,
+                                                            info::csrqrInfoHost_t,
+                                                            tol::Cfloat,
+                                                            position::Ptr{Cint})::cusolverStatus_t
 end
 
 @checked function cusolverSpDcsrqrZeroPivotHost(handle, info, tol, position)
     initialize_context()
-    @ccall libcusolver.cusolverSpDcsrqrZeroPivotHost(handle::cusolverSpHandle_t,
-                                                     info::csrqrInfoHost_t, tol::Cdouble,
-                                                     position::Ptr{Cint})::cusolverStatus_t
+    @gcsafe_ccall libcusolver.cusolverSpDcsrqrZeroPivotHost(handle::cusolverSpHandle_t,
+                                                            info::csrqrInfoHost_t,
+                                                            tol::Cdouble,
+                                                            position::Ptr{Cint})::cusolverStatus_t
 end
 
 @checked function cusolverSpCcsrqrZeroPivotHost(handle, info, tol, position)
     initialize_context()
-    @ccall libcusolver.cusolverSpCcsrqrZeroPivotHost(handle::cusolverSpHandle_t,
-                                                     info::csrqrInfoHost_t, tol::Cfloat,
-                                                     position::Ptr{Cint})::cusolverStatus_t
+    @gcsafe_ccall libcusolver.cusolverSpCcsrqrZeroPivotHost(handle::cusolverSpHandle_t,
+                                                            info::csrqrInfoHost_t,
+                                                            tol::Cfloat,
+                                                            position::Ptr{Cint})::cusolverStatus_t
 end
 
 @checked function cusolverSpZcsrqrZeroPivotHost(handle, info, tol, position)
     initialize_context()
-    @ccall libcusolver.cusolverSpZcsrqrZeroPivotHost(handle::cusolverSpHandle_t,
-                                                     info::csrqrInfoHost_t, tol::Cdouble,
-                                                     position::Ptr{Cint})::cusolverStatus_t
+    @gcsafe_ccall libcusolver.cusolverSpZcsrqrZeroPivotHost(handle::cusolverSpHandle_t,
+                                                            info::csrqrInfoHost_t,
+                                                            tol::Cdouble,
+                                                            position::Ptr{Cint})::cusolverStatus_t
 end
 
 @checked function cusolverSpScsrqrSolveHost(handle, m, n, b, x, info, pBuffer)
     initialize_context()
-    @ccall libcusolver.cusolverSpScsrqrSolveHost(handle::cusolverSpHandle_t, m::Cint,
-                                                 n::Cint, b::Ptr{Cfloat}, x::Ptr{Cfloat},
-                                                 info::csrqrInfoHost_t,
-                                                 pBuffer::Ptr{Cvoid})::cusolverStatus_t
+    @gcsafe_ccall libcusolver.cusolverSpScsrqrSolveHost(handle::cusolverSpHandle_t, m::Cint,
+                                                        n::Cint, b::Ptr{Cfloat},
+                                                        x::Ptr{Cfloat},
+                                                        info::csrqrInfoHost_t,
+                                                        pBuffer::Ptr{Cvoid})::cusolverStatus_t
 end
 
 @checked function cusolverSpDcsrqrSolveHost(handle, m, n, b, x, info, pBuffer)
     initialize_context()
-    @ccall libcusolver.cusolverSpDcsrqrSolveHost(handle::cusolverSpHandle_t, m::Cint,
-                                                 n::Cint, b::Ptr{Cdouble}, x::Ptr{Cdouble},
-                                                 info::csrqrInfoHost_t,
-                                                 pBuffer::Ptr{Cvoid})::cusolverStatus_t
+    @gcsafe_ccall libcusolver.cusolverSpDcsrqrSolveHost(handle::cusolverSpHandle_t, m::Cint,
+                                                        n::Cint, b::Ptr{Cdouble},
+                                                        x::Ptr{Cdouble},
+                                                        info::csrqrInfoHost_t,
+                                                        pBuffer::Ptr{Cvoid})::cusolverStatus_t
 end
 
 @checked function cusolverSpCcsrqrSolveHost(handle, m, n, b, x, info, pBuffer)
     initialize_context()
-    @ccall libcusolver.cusolverSpCcsrqrSolveHost(handle::cusolverSpHandle_t, m::Cint,
-                                                 n::Cint, b::Ptr{cuComplex},
-                                                 x::Ptr{cuComplex}, info::csrqrInfoHost_t,
-                                                 pBuffer::Ptr{Cvoid})::cusolverStatus_t
+    @gcsafe_ccall libcusolver.cusolverSpCcsrqrSolveHost(handle::cusolverSpHandle_t, m::Cint,
+                                                        n::Cint, b::Ptr{cuComplex},
+                                                        x::Ptr{cuComplex},
+                                                        info::csrqrInfoHost_t,
+                                                        pBuffer::Ptr{Cvoid})::cusolverStatus_t
 end
 
 @checked function cusolverSpZcsrqrSolveHost(handle, m, n, b, x, info, pBuffer)
     initialize_context()
-    @ccall libcusolver.cusolverSpZcsrqrSolveHost(handle::cusolverSpHandle_t, m::Cint,
-                                                 n::Cint, b::Ptr{cuDoubleComplex},
-                                                 x::Ptr{cuDoubleComplex},
-                                                 info::csrqrInfoHost_t,
-                                                 pBuffer::Ptr{Cvoid})::cusolverStatus_t
+    @gcsafe_ccall libcusolver.cusolverSpZcsrqrSolveHost(handle::cusolverSpHandle_t, m::Cint,
+                                                        n::Cint, b::Ptr{cuDoubleComplex},
+                                                        x::Ptr{cuDoubleComplex},
+                                                        info::csrqrInfoHost_t,
+                                                        pBuffer::Ptr{Cvoid})::cusolverStatus_t
 end
 
 @checked function cusolverSpXcsrqrAnalysis(handle, m, n, nnzA, descrA, csrRowPtrA,
                                            csrColIndA, info)
     initialize_context()
-    @ccall libcusolver.cusolverSpXcsrqrAnalysis(handle::cusolverSpHandle_t, m::Cint,
-                                                n::Cint, nnzA::Cint,
-                                                descrA::cusparseMatDescr_t,
-                                                csrRowPtrA::CuPtr{Cint},
-                                                csrColIndA::CuPtr{Cint},
-                                                info::csrqrInfo_t)::cusolverStatus_t
+    @gcsafe_ccall libcusolver.cusolverSpXcsrqrAnalysis(handle::cusolverSpHandle_t, m::Cint,
+                                                       n::Cint, nnzA::Cint,
+                                                       descrA::cusparseMatDescr_t,
+                                                       csrRowPtrA::CuPtr{Cint},
+                                                       csrColIndA::CuPtr{Cint},
+                                                       info::csrqrInfo_t)::cusolverStatus_t
 end
 
 @checked function cusolverSpScsrqrBufferInfo(handle, m, n, nnzA, descrA, csrValA,
                                              csrRowPtrA, csrColIndA, info,
                                              internalDataInBytes, workspaceInBytes)
     initialize_context()
-    @ccall libcusolver.cusolverSpScsrqrBufferInfo(handle::cusolverSpHandle_t, m::Cint,
-                                                  n::Cint, nnzA::Cint,
-                                                  descrA::cusparseMatDescr_t,
-                                                  csrValA::CuPtr{Cfloat},
-                                                  csrRowPtrA::CuPtr{Cint},
-                                                  csrColIndA::CuPtr{Cint},
-                                                  info::csrqrInfo_t,
-                                                  internalDataInBytes::Ptr{Csize_t},
-                                                  workspaceInBytes::Ptr{Csize_t})::cusolverStatus_t
+    @gcsafe_ccall libcusolver.cusolverSpScsrqrBufferInfo(handle::cusolverSpHandle_t,
+                                                         m::Cint, n::Cint, nnzA::Cint,
+                                                         descrA::cusparseMatDescr_t,
+                                                         csrValA::CuPtr{Cfloat},
+                                                         csrRowPtrA::CuPtr{Cint},
+                                                         csrColIndA::CuPtr{Cint},
+                                                         info::csrqrInfo_t,
+                                                         internalDataInBytes::Ptr{Csize_t},
+                                                         workspaceInBytes::Ptr{Csize_t})::cusolverStatus_t
 end
 
 @checked function cusolverSpDcsrqrBufferInfo(handle, m, n, nnzA, descrA, csrValA,
                                              csrRowPtrA, csrColIndA, info,
                                              internalDataInBytes, workspaceInBytes)
     initialize_context()
-    @ccall libcusolver.cusolverSpDcsrqrBufferInfo(handle::cusolverSpHandle_t, m::Cint,
-                                                  n::Cint, nnzA::Cint,
-                                                  descrA::cusparseMatDescr_t,
-                                                  csrValA::CuPtr{Cdouble},
-                                                  csrRowPtrA::CuPtr{Cint},
-                                                  csrColIndA::CuPtr{Cint},
-                                                  info::csrqrInfo_t,
-                                                  internalDataInBytes::Ptr{Csize_t},
-                                                  workspaceInBytes::Ptr{Csize_t})::cusolverStatus_t
+    @gcsafe_ccall libcusolver.cusolverSpDcsrqrBufferInfo(handle::cusolverSpHandle_t,
+                                                         m::Cint, n::Cint, nnzA::Cint,
+                                                         descrA::cusparseMatDescr_t,
+                                                         csrValA::CuPtr{Cdouble},
+                                                         csrRowPtrA::CuPtr{Cint},
+                                                         csrColIndA::CuPtr{Cint},
+                                                         info::csrqrInfo_t,
+                                                         internalDataInBytes::Ptr{Csize_t},
+                                                         workspaceInBytes::Ptr{Csize_t})::cusolverStatus_t
 end
 
 @checked function cusolverSpCcsrqrBufferInfo(handle, m, n, nnzA, descrA, csrValA,
                                              csrRowPtrA, csrColIndA, info,
                                              internalDataInBytes, workspaceInBytes)
     initialize_context()
-    @ccall libcusolver.cusolverSpCcsrqrBufferInfo(handle::cusolverSpHandle_t, m::Cint,
-                                                  n::Cint, nnzA::Cint,
-                                                  descrA::cusparseMatDescr_t,
-                                                  csrValA::CuPtr{cuComplex},
-                                                  csrRowPtrA::CuPtr{Cint},
-                                                  csrColIndA::CuPtr{Cint},
-                                                  info::csrqrInfo_t,
-                                                  internalDataInBytes::Ptr{Csize_t},
-                                                  workspaceInBytes::Ptr{Csize_t})::cusolverStatus_t
+    @gcsafe_ccall libcusolver.cusolverSpCcsrqrBufferInfo(handle::cusolverSpHandle_t,
+                                                         m::Cint, n::Cint, nnzA::Cint,
+                                                         descrA::cusparseMatDescr_t,
+                                                         csrValA::CuPtr{cuComplex},
+                                                         csrRowPtrA::CuPtr{Cint},
+                                                         csrColIndA::CuPtr{Cint},
+                                                         info::csrqrInfo_t,
+                                                         internalDataInBytes::Ptr{Csize_t},
+                                                         workspaceInBytes::Ptr{Csize_t})::cusolverStatus_t
 end
 
 @checked function cusolverSpZcsrqrBufferInfo(handle, m, n, nnzA, descrA, csrValA,
                                              csrRowPtrA, csrColIndA, info,
                                              internalDataInBytes, workspaceInBytes)
     initialize_context()
-    @ccall libcusolver.cusolverSpZcsrqrBufferInfo(handle::cusolverSpHandle_t, m::Cint,
-                                                  n::Cint, nnzA::Cint,
-                                                  descrA::cusparseMatDescr_t,
-                                                  csrValA::CuPtr{cuDoubleComplex},
-                                                  csrRowPtrA::CuPtr{Cint},
-                                                  csrColIndA::CuPtr{Cint},
-                                                  info::csrqrInfo_t,
-                                                  internalDataInBytes::Ptr{Csize_t},
-                                                  workspaceInBytes::Ptr{Csize_t})::cusolverStatus_t
+    @gcsafe_ccall libcusolver.cusolverSpZcsrqrBufferInfo(handle::cusolverSpHandle_t,
+                                                         m::Cint, n::Cint, nnzA::Cint,
+                                                         descrA::cusparseMatDescr_t,
+                                                         csrValA::CuPtr{cuDoubleComplex},
+                                                         csrRowPtrA::CuPtr{Cint},
+                                                         csrColIndA::CuPtr{Cint},
+                                                         info::csrqrInfo_t,
+                                                         internalDataInBytes::Ptr{Csize_t},
+                                                         workspaceInBytes::Ptr{Csize_t})::cusolverStatus_t
 end
 
 @checked function cusolverSpScsrqrSetup(handle, m, n, nnzA, descrA, csrValA, csrRowPtrA,
                                         csrColIndA, mu, info)
     initialize_context()
-    @ccall libcusolver.cusolverSpScsrqrSetup(handle::cusolverSpHandle_t, m::Cint, n::Cint,
-                                             nnzA::Cint, descrA::cusparseMatDescr_t,
-                                             csrValA::CuPtr{Cfloat},
-                                             csrRowPtrA::CuPtr{Cint},
-                                             csrColIndA::CuPtr{Cint}, mu::Cfloat,
-                                             info::csrqrInfo_t)::cusolverStatus_t
+    @gcsafe_ccall libcusolver.cusolverSpScsrqrSetup(handle::cusolverSpHandle_t, m::Cint,
+                                                    n::Cint, nnzA::Cint,
+                                                    descrA::cusparseMatDescr_t,
+                                                    csrValA::CuPtr{Cfloat},
+                                                    csrRowPtrA::CuPtr{Cint},
+                                                    csrColIndA::CuPtr{Cint}, mu::Cfloat,
+                                                    info::csrqrInfo_t)::cusolverStatus_t
 end
 
 @checked function cusolverSpDcsrqrSetup(handle, m, n, nnzA, descrA, csrValA, csrRowPtrA,
                                         csrColIndA, mu, info)
     initialize_context()
-    @ccall libcusolver.cusolverSpDcsrqrSetup(handle::cusolverSpHandle_t, m::Cint, n::Cint,
-                                             nnzA::Cint, descrA::cusparseMatDescr_t,
-                                             csrValA::CuPtr{Cdouble},
-                                             csrRowPtrA::CuPtr{Cint},
-                                             csrColIndA::CuPtr{Cint}, mu::Cdouble,
-                                             info::csrqrInfo_t)::cusolverStatus_t
+    @gcsafe_ccall libcusolver.cusolverSpDcsrqrSetup(handle::cusolverSpHandle_t, m::Cint,
+                                                    n::Cint, nnzA::Cint,
+                                                    descrA::cusparseMatDescr_t,
+                                                    csrValA::CuPtr{Cdouble},
+                                                    csrRowPtrA::CuPtr{Cint},
+                                                    csrColIndA::CuPtr{Cint}, mu::Cdouble,
+                                                    info::csrqrInfo_t)::cusolverStatus_t
 end
 
 @checked function cusolverSpCcsrqrSetup(handle, m, n, nnzA, descrA, csrValA, csrRowPtrA,
                                         csrColIndA, mu, info)
     initialize_context()
-    @ccall libcusolver.cusolverSpCcsrqrSetup(handle::cusolverSpHandle_t, m::Cint, n::Cint,
-                                             nnzA::Cint, descrA::cusparseMatDescr_t,
-                                             csrValA::CuPtr{cuComplex},
-                                             csrRowPtrA::CuPtr{Cint},
-                                             csrColIndA::CuPtr{Cint}, mu::cuComplex,
-                                             info::csrqrInfo_t)::cusolverStatus_t
+    @gcsafe_ccall libcusolver.cusolverSpCcsrqrSetup(handle::cusolverSpHandle_t, m::Cint,
+                                                    n::Cint, nnzA::Cint,
+                                                    descrA::cusparseMatDescr_t,
+                                                    csrValA::CuPtr{cuComplex},
+                                                    csrRowPtrA::CuPtr{Cint},
+                                                    csrColIndA::CuPtr{Cint}, mu::cuComplex,
+                                                    info::csrqrInfo_t)::cusolverStatus_t
 end
 
 @checked function cusolverSpZcsrqrSetup(handle, m, n, nnzA, descrA, csrValA, csrRowPtrA,
                                         csrColIndA, mu, info)
     initialize_context()
-    @ccall libcusolver.cusolverSpZcsrqrSetup(handle::cusolverSpHandle_t, m::Cint, n::Cint,
-                                             nnzA::Cint, descrA::cusparseMatDescr_t,
-                                             csrValA::CuPtr{cuDoubleComplex},
-                                             csrRowPtrA::CuPtr{Cint},
-                                             csrColIndA::CuPtr{Cint}, mu::cuDoubleComplex,
-                                             info::csrqrInfo_t)::cusolverStatus_t
+    @gcsafe_ccall libcusolver.cusolverSpZcsrqrSetup(handle::cusolverSpHandle_t, m::Cint,
+                                                    n::Cint, nnzA::Cint,
+                                                    descrA::cusparseMatDescr_t,
+                                                    csrValA::CuPtr{cuDoubleComplex},
+                                                    csrRowPtrA::CuPtr{Cint},
+                                                    csrColIndA::CuPtr{Cint},
+                                                    mu::cuDoubleComplex,
+                                                    info::csrqrInfo_t)::cusolverStatus_t
 end
 
 @checked function cusolverSpScsrqrFactor(handle, m, n, nnzA, b, x, info, pBuffer)
     initialize_context()
-    @ccall libcusolver.cusolverSpScsrqrFactor(handle::cusolverSpHandle_t, m::Cint, n::Cint,
-                                              nnzA::Cint, b::CuPtr{Cfloat},
-                                              x::CuPtr{Cfloat}, info::csrqrInfo_t,
-                                              pBuffer::CuPtr{Cvoid})::cusolverStatus_t
+    @gcsafe_ccall libcusolver.cusolverSpScsrqrFactor(handle::cusolverSpHandle_t, m::Cint,
+                                                     n::Cint, nnzA::Cint, b::CuPtr{Cfloat},
+                                                     x::CuPtr{Cfloat}, info::csrqrInfo_t,
+                                                     pBuffer::CuPtr{Cvoid})::cusolverStatus_t
 end
 
 @checked function cusolverSpDcsrqrFactor(handle, m, n, nnzA, b, x, info, pBuffer)
     initialize_context()
-    @ccall libcusolver.cusolverSpDcsrqrFactor(handle::cusolverSpHandle_t, m::Cint, n::Cint,
-                                              nnzA::Cint, b::CuPtr{Cdouble},
-                                              x::CuPtr{Cdouble}, info::csrqrInfo_t,
-                                              pBuffer::CuPtr{Cvoid})::cusolverStatus_t
+    @gcsafe_ccall libcusolver.cusolverSpDcsrqrFactor(handle::cusolverSpHandle_t, m::Cint,
+                                                     n::Cint, nnzA::Cint, b::CuPtr{Cdouble},
+                                                     x::CuPtr{Cdouble}, info::csrqrInfo_t,
+                                                     pBuffer::CuPtr{Cvoid})::cusolverStatus_t
 end
 
 @checked function cusolverSpCcsrqrFactor(handle, m, n, nnzA, b, x, info, pBuffer)
     initialize_context()
-    @ccall libcusolver.cusolverSpCcsrqrFactor(handle::cusolverSpHandle_t, m::Cint, n::Cint,
-                                              nnzA::Cint, b::CuPtr{cuComplex},
-                                              x::CuPtr{cuComplex}, info::csrqrInfo_t,
-                                              pBuffer::CuPtr{Cvoid})::cusolverStatus_t
+    @gcsafe_ccall libcusolver.cusolverSpCcsrqrFactor(handle::cusolverSpHandle_t, m::Cint,
+                                                     n::Cint, nnzA::Cint,
+                                                     b::CuPtr{cuComplex},
+                                                     x::CuPtr{cuComplex}, info::csrqrInfo_t,
+                                                     pBuffer::CuPtr{Cvoid})::cusolverStatus_t
 end
 
 @checked function cusolverSpZcsrqrFactor(handle, m, n, nnzA, b, x, info, pBuffer)
     initialize_context()
-    @ccall libcusolver.cusolverSpZcsrqrFactor(handle::cusolverSpHandle_t, m::Cint, n::Cint,
-                                              nnzA::Cint, b::CuPtr{cuDoubleComplex},
-                                              x::CuPtr{cuDoubleComplex}, info::csrqrInfo_t,
-                                              pBuffer::CuPtr{Cvoid})::cusolverStatus_t
+    @gcsafe_ccall libcusolver.cusolverSpZcsrqrFactor(handle::cusolverSpHandle_t, m::Cint,
+                                                     n::Cint, nnzA::Cint,
+                                                     b::CuPtr{cuDoubleComplex},
+                                                     x::CuPtr{cuDoubleComplex},
+                                                     info::csrqrInfo_t,
+                                                     pBuffer::CuPtr{Cvoid})::cusolverStatus_t
 end
 
 @checked function cusolverSpScsrqrZeroPivot(handle, info, tol, position)
     initialize_context()
-    @ccall libcusolver.cusolverSpScsrqrZeroPivot(handle::cusolverSpHandle_t,
-                                                 info::csrqrInfo_t, tol::Cfloat,
-                                                 position::Ptr{Cint})::cusolverStatus_t
+    @gcsafe_ccall libcusolver.cusolverSpScsrqrZeroPivot(handle::cusolverSpHandle_t,
+                                                        info::csrqrInfo_t, tol::Cfloat,
+                                                        position::Ptr{Cint})::cusolverStatus_t
 end
 
 @checked function cusolverSpDcsrqrZeroPivot(handle, info, tol, position)
     initialize_context()
-    @ccall libcusolver.cusolverSpDcsrqrZeroPivot(handle::cusolverSpHandle_t,
-                                                 info::csrqrInfo_t, tol::Cdouble,
-                                                 position::Ptr{Cint})::cusolverStatus_t
+    @gcsafe_ccall libcusolver.cusolverSpDcsrqrZeroPivot(handle::cusolverSpHandle_t,
+                                                        info::csrqrInfo_t, tol::Cdouble,
+                                                        position::Ptr{Cint})::cusolverStatus_t
 end
 
 @checked function cusolverSpCcsrqrZeroPivot(handle, info, tol, position)
     initialize_context()
-    @ccall libcusolver.cusolverSpCcsrqrZeroPivot(handle::cusolverSpHandle_t,
-                                                 info::csrqrInfo_t, tol::Cfloat,
-                                                 position::Ptr{Cint})::cusolverStatus_t
+    @gcsafe_ccall libcusolver.cusolverSpCcsrqrZeroPivot(handle::cusolverSpHandle_t,
+                                                        info::csrqrInfo_t, tol::Cfloat,
+                                                        position::Ptr{Cint})::cusolverStatus_t
 end
 
 @checked function cusolverSpZcsrqrZeroPivot(handle, info, tol, position)
     initialize_context()
-    @ccall libcusolver.cusolverSpZcsrqrZeroPivot(handle::cusolverSpHandle_t,
-                                                 info::csrqrInfo_t, tol::Cdouble,
-                                                 position::Ptr{Cint})::cusolverStatus_t
+    @gcsafe_ccall libcusolver.cusolverSpZcsrqrZeroPivot(handle::cusolverSpHandle_t,
+                                                        info::csrqrInfo_t, tol::Cdouble,
+                                                        position::Ptr{Cint})::cusolverStatus_t
 end
 
 @checked function cusolverSpScsrqrSolve(handle, m, n, b, x, info, pBuffer)
     initialize_context()
-    @ccall libcusolver.cusolverSpScsrqrSolve(handle::cusolverSpHandle_t, m::Cint, n::Cint,
-                                             b::CuPtr{Cfloat}, x::CuPtr{Cfloat},
-                                             info::csrqrInfo_t,
-                                             pBuffer::CuPtr{Cvoid})::cusolverStatus_t
+    @gcsafe_ccall libcusolver.cusolverSpScsrqrSolve(handle::cusolverSpHandle_t, m::Cint,
+                                                    n::Cint, b::CuPtr{Cfloat},
+                                                    x::CuPtr{Cfloat}, info::csrqrInfo_t,
+                                                    pBuffer::CuPtr{Cvoid})::cusolverStatus_t
 end
 
 @checked function cusolverSpDcsrqrSolve(handle, m, n, b, x, info, pBuffer)
     initialize_context()
-    @ccall libcusolver.cusolverSpDcsrqrSolve(handle::cusolverSpHandle_t, m::Cint, n::Cint,
-                                             b::CuPtr{Cdouble}, x::CuPtr{Cdouble},
-                                             info::csrqrInfo_t,
-                                             pBuffer::CuPtr{Cvoid})::cusolverStatus_t
+    @gcsafe_ccall libcusolver.cusolverSpDcsrqrSolve(handle::cusolverSpHandle_t, m::Cint,
+                                                    n::Cint, b::CuPtr{Cdouble},
+                                                    x::CuPtr{Cdouble}, info::csrqrInfo_t,
+                                                    pBuffer::CuPtr{Cvoid})::cusolverStatus_t
 end
 
 @checked function cusolverSpCcsrqrSolve(handle, m, n, b, x, info, pBuffer)
     initialize_context()
-    @ccall libcusolver.cusolverSpCcsrqrSolve(handle::cusolverSpHandle_t, m::Cint, n::Cint,
-                                             b::CuPtr{cuComplex}, x::CuPtr{cuComplex},
-                                             info::csrqrInfo_t,
-                                             pBuffer::CuPtr{Cvoid})::cusolverStatus_t
+    @gcsafe_ccall libcusolver.cusolverSpCcsrqrSolve(handle::cusolverSpHandle_t, m::Cint,
+                                                    n::Cint, b::CuPtr{cuComplex},
+                                                    x::CuPtr{cuComplex}, info::csrqrInfo_t,
+                                                    pBuffer::CuPtr{Cvoid})::cusolverStatus_t
 end
 
 @checked function cusolverSpZcsrqrSolve(handle, m, n, b, x, info, pBuffer)
     initialize_context()
-    @ccall libcusolver.cusolverSpZcsrqrSolve(handle::cusolverSpHandle_t, m::Cint, n::Cint,
-                                             b::CuPtr{cuDoubleComplex},
-                                             x::CuPtr{cuDoubleComplex}, info::csrqrInfo_t,
-                                             pBuffer::CuPtr{Cvoid})::cusolverStatus_t
+    @gcsafe_ccall libcusolver.cusolverSpZcsrqrSolve(handle::cusolverSpHandle_t, m::Cint,
+                                                    n::Cint, b::CuPtr{cuDoubleComplex},
+                                                    x::CuPtr{cuDoubleComplex},
+                                                    info::csrqrInfo_t,
+                                                    pBuffer::CuPtr{Cvoid})::cusolverStatus_t
 end
 
 @checked function cusolverSpCreateCsrcholInfoHost(info)
     initialize_context()
-    @ccall libcusolver.cusolverSpCreateCsrcholInfoHost(info::Ptr{csrcholInfoHost_t})::cusolverStatus_t
+    @gcsafe_ccall libcusolver.cusolverSpCreateCsrcholInfoHost(info::Ptr{csrcholInfoHost_t})::cusolverStatus_t
 end
 
 @checked function cusolverSpDestroyCsrcholInfoHost(info)
     initialize_context()
-    @ccall libcusolver.cusolverSpDestroyCsrcholInfoHost(info::csrcholInfoHost_t)::cusolverStatus_t
+    @gcsafe_ccall libcusolver.cusolverSpDestroyCsrcholInfoHost(info::csrcholInfoHost_t)::cusolverStatus_t
 end
 
 @checked function cusolverSpXcsrcholAnalysisHost(handle, n, nnzA, descrA, csrRowPtrA,
                                                  csrColIndA, info)
     initialize_context()
-    @ccall libcusolver.cusolverSpXcsrcholAnalysisHost(handle::cusolverSpHandle_t, n::Cint,
-                                                      nnzA::Cint,
-                                                      descrA::cusparseMatDescr_t,
-                                                      csrRowPtrA::Ptr{Cint},
-                                                      csrColIndA::Ptr{Cint},
-                                                      info::csrcholInfoHost_t)::cusolverStatus_t
+    @gcsafe_ccall libcusolver.cusolverSpXcsrcholAnalysisHost(handle::cusolverSpHandle_t,
+                                                             n::Cint, nnzA::Cint,
+                                                             descrA::cusparseMatDescr_t,
+                                                             csrRowPtrA::Ptr{Cint},
+                                                             csrColIndA::Ptr{Cint},
+                                                             info::csrcholInfoHost_t)::cusolverStatus_t
 end
 
 @checked function cusolverSpScsrcholBufferInfoHost(handle, n, nnzA, descrA, csrValA,
                                                    csrRowPtrA, csrColIndA, info,
                                                    internalDataInBytes, workspaceInBytes)
     initialize_context()
-    @ccall libcusolver.cusolverSpScsrcholBufferInfoHost(handle::cusolverSpHandle_t, n::Cint,
-                                                        nnzA::Cint,
-                                                        descrA::cusparseMatDescr_t,
-                                                        csrValA::Ptr{Cfloat},
-                                                        csrRowPtrA::Ptr{Cint},
-                                                        csrColIndA::Ptr{Cint},
-                                                        info::csrcholInfoHost_t,
-                                                        internalDataInBytes::Ptr{Csize_t},
-                                                        workspaceInBytes::Ptr{Csize_t})::cusolverStatus_t
+    @gcsafe_ccall libcusolver.cusolverSpScsrcholBufferInfoHost(handle::cusolverSpHandle_t,
+                                                               n::Cint, nnzA::Cint,
+                                                               descrA::cusparseMatDescr_t,
+                                                               csrValA::Ptr{Cfloat},
+                                                               csrRowPtrA::Ptr{Cint},
+                                                               csrColIndA::Ptr{Cint},
+                                                               info::csrcholInfoHost_t,
+                                                               internalDataInBytes::Ptr{Csize_t},
+                                                               workspaceInBytes::Ptr{Csize_t})::cusolverStatus_t
 end
 
 @checked function cusolverSpDcsrcholBufferInfoHost(handle, n, nnzA, descrA, csrValA,
                                                    csrRowPtrA, csrColIndA, info,
                                                    internalDataInBytes, workspaceInBytes)
     initialize_context()
-    @ccall libcusolver.cusolverSpDcsrcholBufferInfoHost(handle::cusolverSpHandle_t, n::Cint,
-                                                        nnzA::Cint,
-                                                        descrA::cusparseMatDescr_t,
-                                                        csrValA::Ptr{Cdouble},
-                                                        csrRowPtrA::Ptr{Cint},
-                                                        csrColIndA::Ptr{Cint},
-                                                        info::csrcholInfoHost_t,
-                                                        internalDataInBytes::Ptr{Csize_t},
-                                                        workspaceInBytes::Ptr{Csize_t})::cusolverStatus_t
+    @gcsafe_ccall libcusolver.cusolverSpDcsrcholBufferInfoHost(handle::cusolverSpHandle_t,
+                                                               n::Cint, nnzA::Cint,
+                                                               descrA::cusparseMatDescr_t,
+                                                               csrValA::Ptr{Cdouble},
+                                                               csrRowPtrA::Ptr{Cint},
+                                                               csrColIndA::Ptr{Cint},
+                                                               info::csrcholInfoHost_t,
+                                                               internalDataInBytes::Ptr{Csize_t},
+                                                               workspaceInBytes::Ptr{Csize_t})::cusolverStatus_t
 end
 
 @checked function cusolverSpCcsrcholBufferInfoHost(handle, n, nnzA, descrA, csrValA,
                                                    csrRowPtrA, csrColIndA, info,
                                                    internalDataInBytes, workspaceInBytes)
     initialize_context()
-    @ccall libcusolver.cusolverSpCcsrcholBufferInfoHost(handle::cusolverSpHandle_t, n::Cint,
-                                                        nnzA::Cint,
-                                                        descrA::cusparseMatDescr_t,
-                                                        csrValA::Ptr{cuComplex},
-                                                        csrRowPtrA::Ptr{Cint},
-                                                        csrColIndA::Ptr{Cint},
-                                                        info::csrcholInfoHost_t,
-                                                        internalDataInBytes::Ptr{Csize_t},
-                                                        workspaceInBytes::Ptr{Csize_t})::cusolverStatus_t
+    @gcsafe_ccall libcusolver.cusolverSpCcsrcholBufferInfoHost(handle::cusolverSpHandle_t,
+                                                               n::Cint, nnzA::Cint,
+                                                               descrA::cusparseMatDescr_t,
+                                                               csrValA::Ptr{cuComplex},
+                                                               csrRowPtrA::Ptr{Cint},
+                                                               csrColIndA::Ptr{Cint},
+                                                               info::csrcholInfoHost_t,
+                                                               internalDataInBytes::Ptr{Csize_t},
+                                                               workspaceInBytes::Ptr{Csize_t})::cusolverStatus_t
 end
 
 @checked function cusolverSpZcsrcholBufferInfoHost(handle, n, nnzA, descrA, csrValA,
                                                    csrRowPtrA, csrColIndA, info,
                                                    internalDataInBytes, workspaceInBytes)
     initialize_context()
-    @ccall libcusolver.cusolverSpZcsrcholBufferInfoHost(handle::cusolverSpHandle_t, n::Cint,
-                                                        nnzA::Cint,
-                                                        descrA::cusparseMatDescr_t,
-                                                        csrValA::Ptr{cuDoubleComplex},
-                                                        csrRowPtrA::Ptr{Cint},
-                                                        csrColIndA::Ptr{Cint},
-                                                        info::csrcholInfoHost_t,
-                                                        internalDataInBytes::Ptr{Csize_t},
-                                                        workspaceInBytes::Ptr{Csize_t})::cusolverStatus_t
+    @gcsafe_ccall libcusolver.cusolverSpZcsrcholBufferInfoHost(handle::cusolverSpHandle_t,
+                                                               n::Cint, nnzA::Cint,
+                                                               descrA::cusparseMatDescr_t,
+                                                               csrValA::Ptr{cuDoubleComplex},
+                                                               csrRowPtrA::Ptr{Cint},
+                                                               csrColIndA::Ptr{Cint},
+                                                               info::csrcholInfoHost_t,
+                                                               internalDataInBytes::Ptr{Csize_t},
+                                                               workspaceInBytes::Ptr{Csize_t})::cusolverStatus_t
 end
 
 @checked function cusolverSpScsrcholFactorHost(handle, n, nnzA, descrA, csrValA, csrRowPtrA,
                                                csrColIndA, info, pBuffer)
     initialize_context()
-    @ccall libcusolver.cusolverSpScsrcholFactorHost(handle::cusolverSpHandle_t, n::Cint,
-                                                    nnzA::Cint, descrA::cusparseMatDescr_t,
-                                                    csrValA::Ptr{Cfloat},
-                                                    csrRowPtrA::Ptr{Cint},
-                                                    csrColIndA::Ptr{Cint},
-                                                    info::csrcholInfoHost_t,
-                                                    pBuffer::Ptr{Cvoid})::cusolverStatus_t
+    @gcsafe_ccall libcusolver.cusolverSpScsrcholFactorHost(handle::cusolverSpHandle_t,
+                                                           n::Cint, nnzA::Cint,
+                                                           descrA::cusparseMatDescr_t,
+                                                           csrValA::Ptr{Cfloat},
+                                                           csrRowPtrA::Ptr{Cint},
+                                                           csrColIndA::Ptr{Cint},
+                                                           info::csrcholInfoHost_t,
+                                                           pBuffer::Ptr{Cvoid})::cusolverStatus_t
 end
 
 @checked function cusolverSpDcsrcholFactorHost(handle, n, nnzA, descrA, csrValA, csrRowPtrA,
                                                csrColIndA, info, pBuffer)
     initialize_context()
-    @ccall libcusolver.cusolverSpDcsrcholFactorHost(handle::cusolverSpHandle_t, n::Cint,
-                                                    nnzA::Cint, descrA::cusparseMatDescr_t,
-                                                    csrValA::Ptr{Cdouble},
-                                                    csrRowPtrA::Ptr{Cint},
-                                                    csrColIndA::Ptr{Cint},
-                                                    info::csrcholInfoHost_t,
-                                                    pBuffer::Ptr{Cvoid})::cusolverStatus_t
+    @gcsafe_ccall libcusolver.cusolverSpDcsrcholFactorHost(handle::cusolverSpHandle_t,
+                                                           n::Cint, nnzA::Cint,
+                                                           descrA::cusparseMatDescr_t,
+                                                           csrValA::Ptr{Cdouble},
+                                                           csrRowPtrA::Ptr{Cint},
+                                                           csrColIndA::Ptr{Cint},
+                                                           info::csrcholInfoHost_t,
+                                                           pBuffer::Ptr{Cvoid})::cusolverStatus_t
 end
 
 @checked function cusolverSpCcsrcholFactorHost(handle, n, nnzA, descrA, csrValA, csrRowPtrA,
                                                csrColIndA, info, pBuffer)
     initialize_context()
-    @ccall libcusolver.cusolverSpCcsrcholFactorHost(handle::cusolverSpHandle_t, n::Cint,
-                                                    nnzA::Cint, descrA::cusparseMatDescr_t,
-                                                    csrValA::Ptr{cuComplex},
-                                                    csrRowPtrA::Ptr{Cint},
-                                                    csrColIndA::Ptr{Cint},
-                                                    info::csrcholInfoHost_t,
-                                                    pBuffer::Ptr{Cvoid})::cusolverStatus_t
+    @gcsafe_ccall libcusolver.cusolverSpCcsrcholFactorHost(handle::cusolverSpHandle_t,
+                                                           n::Cint, nnzA::Cint,
+                                                           descrA::cusparseMatDescr_t,
+                                                           csrValA::Ptr{cuComplex},
+                                                           csrRowPtrA::Ptr{Cint},
+                                                           csrColIndA::Ptr{Cint},
+                                                           info::csrcholInfoHost_t,
+                                                           pBuffer::Ptr{Cvoid})::cusolverStatus_t
 end
 
 @checked function cusolverSpZcsrcholFactorHost(handle, n, nnzA, descrA, csrValA, csrRowPtrA,
                                                csrColIndA, info, pBuffer)
     initialize_context()
-    @ccall libcusolver.cusolverSpZcsrcholFactorHost(handle::cusolverSpHandle_t, n::Cint,
-                                                    nnzA::Cint, descrA::cusparseMatDescr_t,
-                                                    csrValA::Ptr{cuDoubleComplex},
-                                                    csrRowPtrA::Ptr{Cint},
-                                                    csrColIndA::Ptr{Cint},
-                                                    info::csrcholInfoHost_t,
-                                                    pBuffer::Ptr{Cvoid})::cusolverStatus_t
+    @gcsafe_ccall libcusolver.cusolverSpZcsrcholFactorHost(handle::cusolverSpHandle_t,
+                                                           n::Cint, nnzA::Cint,
+                                                           descrA::cusparseMatDescr_t,
+                                                           csrValA::Ptr{cuDoubleComplex},
+                                                           csrRowPtrA::Ptr{Cint},
+                                                           csrColIndA::Ptr{Cint},
+                                                           info::csrcholInfoHost_t,
+                                                           pBuffer::Ptr{Cvoid})::cusolverStatus_t
 end
 
 @checked function cusolverSpScsrcholZeroPivotHost(handle, info, tol, position)
     initialize_context()
-    @ccall libcusolver.cusolverSpScsrcholZeroPivotHost(handle::cusolverSpHandle_t,
-                                                       info::csrcholInfoHost_t, tol::Cfloat,
-                                                       position::Ptr{Cint})::cusolverStatus_t
+    @gcsafe_ccall libcusolver.cusolverSpScsrcholZeroPivotHost(handle::cusolverSpHandle_t,
+                                                              info::csrcholInfoHost_t,
+                                                              tol::Cfloat,
+                                                              position::Ptr{Cint})::cusolverStatus_t
 end
 
 @checked function cusolverSpDcsrcholZeroPivotHost(handle, info, tol, position)
     initialize_context()
-    @ccall libcusolver.cusolverSpDcsrcholZeroPivotHost(handle::cusolverSpHandle_t,
-                                                       info::csrcholInfoHost_t,
-                                                       tol::Cdouble,
-                                                       position::Ptr{Cint})::cusolverStatus_t
+    @gcsafe_ccall libcusolver.cusolverSpDcsrcholZeroPivotHost(handle::cusolverSpHandle_t,
+                                                              info::csrcholInfoHost_t,
+                                                              tol::Cdouble,
+                                                              position::Ptr{Cint})::cusolverStatus_t
 end
 
 @checked function cusolverSpCcsrcholZeroPivotHost(handle, info, tol, position)
     initialize_context()
-    @ccall libcusolver.cusolverSpCcsrcholZeroPivotHost(handle::cusolverSpHandle_t,
-                                                       info::csrcholInfoHost_t, tol::Cfloat,
-                                                       position::Ptr{Cint})::cusolverStatus_t
+    @gcsafe_ccall libcusolver.cusolverSpCcsrcholZeroPivotHost(handle::cusolverSpHandle_t,
+                                                              info::csrcholInfoHost_t,
+                                                              tol::Cfloat,
+                                                              position::Ptr{Cint})::cusolverStatus_t
 end
 
 @checked function cusolverSpZcsrcholZeroPivotHost(handle, info, tol, position)
     initialize_context()
-    @ccall libcusolver.cusolverSpZcsrcholZeroPivotHost(handle::cusolverSpHandle_t,
-                                                       info::csrcholInfoHost_t,
-                                                       tol::Cdouble,
-                                                       position::Ptr{Cint})::cusolverStatus_t
+    @gcsafe_ccall libcusolver.cusolverSpZcsrcholZeroPivotHost(handle::cusolverSpHandle_t,
+                                                              info::csrcholInfoHost_t,
+                                                              tol::Cdouble,
+                                                              position::Ptr{Cint})::cusolverStatus_t
 end
 
 @checked function cusolverSpScsrcholSolveHost(handle, n, b, x, info, pBuffer)
     initialize_context()
-    @ccall libcusolver.cusolverSpScsrcholSolveHost(handle::cusolverSpHandle_t, n::Cint,
-                                                   b::Ptr{Cfloat}, x::Ptr{Cfloat},
-                                                   info::csrcholInfoHost_t,
-                                                   pBuffer::Ptr{Cvoid})::cusolverStatus_t
+    @gcsafe_ccall libcusolver.cusolverSpScsrcholSolveHost(handle::cusolverSpHandle_t,
+                                                          n::Cint, b::Ptr{Cfloat},
+                                                          x::Ptr{Cfloat},
+                                                          info::csrcholInfoHost_t,
+                                                          pBuffer::Ptr{Cvoid})::cusolverStatus_t
 end
 
 @checked function cusolverSpDcsrcholSolveHost(handle, n, b, x, info, pBuffer)
     initialize_context()
-    @ccall libcusolver.cusolverSpDcsrcholSolveHost(handle::cusolverSpHandle_t, n::Cint,
-                                                   b::Ptr{Cdouble}, x::Ptr{Cdouble},
-                                                   info::csrcholInfoHost_t,
-                                                   pBuffer::Ptr{Cvoid})::cusolverStatus_t
+    @gcsafe_ccall libcusolver.cusolverSpDcsrcholSolveHost(handle::cusolverSpHandle_t,
+                                                          n::Cint, b::Ptr{Cdouble},
+                                                          x::Ptr{Cdouble},
+                                                          info::csrcholInfoHost_t,
+                                                          pBuffer::Ptr{Cvoid})::cusolverStatus_t
 end
 
 @checked function cusolverSpCcsrcholSolveHost(handle, n, b, x, info, pBuffer)
     initialize_context()
-    @ccall libcusolver.cusolverSpCcsrcholSolveHost(handle::cusolverSpHandle_t, n::Cint,
-                                                   b::Ptr{cuComplex}, x::Ptr{cuComplex},
-                                                   info::csrcholInfoHost_t,
-                                                   pBuffer::Ptr{Cvoid})::cusolverStatus_t
+    @gcsafe_ccall libcusolver.cusolverSpCcsrcholSolveHost(handle::cusolverSpHandle_t,
+                                                          n::Cint, b::Ptr{cuComplex},
+                                                          x::Ptr{cuComplex},
+                                                          info::csrcholInfoHost_t,
+                                                          pBuffer::Ptr{Cvoid})::cusolverStatus_t
 end
 
 @checked function cusolverSpZcsrcholSolveHost(handle, n, b, x, info, pBuffer)
     initialize_context()
-    @ccall libcusolver.cusolverSpZcsrcholSolveHost(handle::cusolverSpHandle_t, n::Cint,
-                                                   b::Ptr{cuDoubleComplex},
-                                                   x::Ptr{cuDoubleComplex},
-                                                   info::csrcholInfoHost_t,
-                                                   pBuffer::Ptr{Cvoid})::cusolverStatus_t
+    @gcsafe_ccall libcusolver.cusolverSpZcsrcholSolveHost(handle::cusolverSpHandle_t,
+                                                          n::Cint, b::Ptr{cuDoubleComplex},
+                                                          x::Ptr{cuDoubleComplex},
+                                                          info::csrcholInfoHost_t,
+                                                          pBuffer::Ptr{Cvoid})::cusolverStatus_t
 end
 
 @checked function cusolverSpCreateCsrcholInfo(info)
     initialize_context()
-    @ccall libcusolver.cusolverSpCreateCsrcholInfo(info::Ptr{csrcholInfo_t})::cusolverStatus_t
+    @gcsafe_ccall libcusolver.cusolverSpCreateCsrcholInfo(info::Ptr{csrcholInfo_t})::cusolverStatus_t
 end
 
 @checked function cusolverSpDestroyCsrcholInfo(info)
     initialize_context()
-    @ccall libcusolver.cusolverSpDestroyCsrcholInfo(info::csrcholInfo_t)::cusolverStatus_t
+    @gcsafe_ccall libcusolver.cusolverSpDestroyCsrcholInfo(info::csrcholInfo_t)::cusolverStatus_t
 end
 
 @checked function cusolverSpXcsrcholAnalysis(handle, n, nnzA, descrA, csrRowPtrA,
                                              csrColIndA, info)
     initialize_context()
-    @ccall libcusolver.cusolverSpXcsrcholAnalysis(handle::cusolverSpHandle_t, n::Cint,
-                                                  nnzA::Cint, descrA::cusparseMatDescr_t,
-                                                  csrRowPtrA::CuPtr{Cint},
-                                                  csrColIndA::CuPtr{Cint},
-                                                  info::csrcholInfo_t)::cusolverStatus_t
+    @gcsafe_ccall libcusolver.cusolverSpXcsrcholAnalysis(handle::cusolverSpHandle_t,
+                                                         n::Cint, nnzA::Cint,
+                                                         descrA::cusparseMatDescr_t,
+                                                         csrRowPtrA::CuPtr{Cint},
+                                                         csrColIndA::CuPtr{Cint},
+                                                         info::csrcholInfo_t)::cusolverStatus_t
 end
 
 @checked function cusolverSpScsrcholBufferInfo(handle, n, nnzA, descrA, csrValA, csrRowPtrA,
                                                csrColIndA, info, internalDataInBytes,
                                                workspaceInBytes)
     initialize_context()
-    @ccall libcusolver.cusolverSpScsrcholBufferInfo(handle::cusolverSpHandle_t, n::Cint,
-                                                    nnzA::Cint, descrA::cusparseMatDescr_t,
-                                                    csrValA::CuPtr{Cfloat},
-                                                    csrRowPtrA::CuPtr{Cint},
-                                                    csrColIndA::CuPtr{Cint},
-                                                    info::csrcholInfo_t,
-                                                    internalDataInBytes::Ptr{Csize_t},
-                                                    workspaceInBytes::Ptr{Csize_t})::cusolverStatus_t
+    @gcsafe_ccall libcusolver.cusolverSpScsrcholBufferInfo(handle::cusolverSpHandle_t,
+                                                           n::Cint, nnzA::Cint,
+                                                           descrA::cusparseMatDescr_t,
+                                                           csrValA::CuPtr{Cfloat},
+                                                           csrRowPtrA::CuPtr{Cint},
+                                                           csrColIndA::CuPtr{Cint},
+                                                           info::csrcholInfo_t,
+                                                           internalDataInBytes::Ptr{Csize_t},
+                                                           workspaceInBytes::Ptr{Csize_t})::cusolverStatus_t
 end
 
 @checked function cusolverSpDcsrcholBufferInfo(handle, n, nnzA, descrA, csrValA, csrRowPtrA,
                                                csrColIndA, info, internalDataInBytes,
                                                workspaceInBytes)
     initialize_context()
-    @ccall libcusolver.cusolverSpDcsrcholBufferInfo(handle::cusolverSpHandle_t, n::Cint,
-                                                    nnzA::Cint, descrA::cusparseMatDescr_t,
-                                                    csrValA::CuPtr{Cdouble},
-                                                    csrRowPtrA::CuPtr{Cint},
-                                                    csrColIndA::CuPtr{Cint},
-                                                    info::csrcholInfo_t,
-                                                    internalDataInBytes::Ptr{Csize_t},
-                                                    workspaceInBytes::Ptr{Csize_t})::cusolverStatus_t
+    @gcsafe_ccall libcusolver.cusolverSpDcsrcholBufferInfo(handle::cusolverSpHandle_t,
+                                                           n::Cint, nnzA::Cint,
+                                                           descrA::cusparseMatDescr_t,
+                                                           csrValA::CuPtr{Cdouble},
+                                                           csrRowPtrA::CuPtr{Cint},
+                                                           csrColIndA::CuPtr{Cint},
+                                                           info::csrcholInfo_t,
+                                                           internalDataInBytes::Ptr{Csize_t},
+                                                           workspaceInBytes::Ptr{Csize_t})::cusolverStatus_t
 end
 
 @checked function cusolverSpCcsrcholBufferInfo(handle, n, nnzA, descrA, csrValA, csrRowPtrA,
                                                csrColIndA, info, internalDataInBytes,
                                                workspaceInBytes)
     initialize_context()
-    @ccall libcusolver.cusolverSpCcsrcholBufferInfo(handle::cusolverSpHandle_t, n::Cint,
-                                                    nnzA::Cint, descrA::cusparseMatDescr_t,
-                                                    csrValA::CuPtr{cuComplex},
-                                                    csrRowPtrA::CuPtr{Cint},
-                                                    csrColIndA::CuPtr{Cint},
-                                                    info::csrcholInfo_t,
-                                                    internalDataInBytes::Ptr{Csize_t},
-                                                    workspaceInBytes::Ptr{Csize_t})::cusolverStatus_t
+    @gcsafe_ccall libcusolver.cusolverSpCcsrcholBufferInfo(handle::cusolverSpHandle_t,
+                                                           n::Cint, nnzA::Cint,
+                                                           descrA::cusparseMatDescr_t,
+                                                           csrValA::CuPtr{cuComplex},
+                                                           csrRowPtrA::CuPtr{Cint},
+                                                           csrColIndA::CuPtr{Cint},
+                                                           info::csrcholInfo_t,
+                                                           internalDataInBytes::Ptr{Csize_t},
+                                                           workspaceInBytes::Ptr{Csize_t})::cusolverStatus_t
 end
 
 @checked function cusolverSpZcsrcholBufferInfo(handle, n, nnzA, descrA, csrValA, csrRowPtrA,
                                                csrColIndA, info, internalDataInBytes,
                                                workspaceInBytes)
     initialize_context()
-    @ccall libcusolver.cusolverSpZcsrcholBufferInfo(handle::cusolverSpHandle_t, n::Cint,
-                                                    nnzA::Cint, descrA::cusparseMatDescr_t,
-                                                    csrValA::CuPtr{cuDoubleComplex},
-                                                    csrRowPtrA::CuPtr{Cint},
-                                                    csrColIndA::CuPtr{Cint},
-                                                    info::csrcholInfo_t,
-                                                    internalDataInBytes::Ptr{Csize_t},
-                                                    workspaceInBytes::Ptr{Csize_t})::cusolverStatus_t
+    @gcsafe_ccall libcusolver.cusolverSpZcsrcholBufferInfo(handle::cusolverSpHandle_t,
+                                                           n::Cint, nnzA::Cint,
+                                                           descrA::cusparseMatDescr_t,
+                                                           csrValA::CuPtr{cuDoubleComplex},
+                                                           csrRowPtrA::CuPtr{Cint},
+                                                           csrColIndA::CuPtr{Cint},
+                                                           info::csrcholInfo_t,
+                                                           internalDataInBytes::Ptr{Csize_t},
+                                                           workspaceInBytes::Ptr{Csize_t})::cusolverStatus_t
 end
 
 @checked function cusolverSpScsrcholFactor(handle, n, nnzA, descrA, csrValA, csrRowPtrA,
                                            csrColIndA, info, pBuffer)
     initialize_context()
-    @ccall libcusolver.cusolverSpScsrcholFactor(handle::cusolverSpHandle_t, n::Cint,
-                                                nnzA::Cint, descrA::cusparseMatDescr_t,
-                                                csrValA::CuPtr{Cfloat},
-                                                csrRowPtrA::CuPtr{Cint},
-                                                csrColIndA::CuPtr{Cint},
-                                                info::csrcholInfo_t,
-                                                pBuffer::CuPtr{Cvoid})::cusolverStatus_t
+    @gcsafe_ccall libcusolver.cusolverSpScsrcholFactor(handle::cusolverSpHandle_t, n::Cint,
+                                                       nnzA::Cint,
+                                                       descrA::cusparseMatDescr_t,
+                                                       csrValA::CuPtr{Cfloat},
+                                                       csrRowPtrA::CuPtr{Cint},
+                                                       csrColIndA::CuPtr{Cint},
+                                                       info::csrcholInfo_t,
+                                                       pBuffer::CuPtr{Cvoid})::cusolverStatus_t
 end
 
 @checked function cusolverSpDcsrcholFactor(handle, n, nnzA, descrA, csrValA, csrRowPtrA,
                                            csrColIndA, info, pBuffer)
     initialize_context()
-    @ccall libcusolver.cusolverSpDcsrcholFactor(handle::cusolverSpHandle_t, n::Cint,
-                                                nnzA::Cint, descrA::cusparseMatDescr_t,
-                                                csrValA::CuPtr{Cdouble},
-                                                csrRowPtrA::CuPtr{Cint},
-                                                csrColIndA::CuPtr{Cint},
-                                                info::csrcholInfo_t,
-                                                pBuffer::CuPtr{Cvoid})::cusolverStatus_t
+    @gcsafe_ccall libcusolver.cusolverSpDcsrcholFactor(handle::cusolverSpHandle_t, n::Cint,
+                                                       nnzA::Cint,
+                                                       descrA::cusparseMatDescr_t,
+                                                       csrValA::CuPtr{Cdouble},
+                                                       csrRowPtrA::CuPtr{Cint},
+                                                       csrColIndA::CuPtr{Cint},
+                                                       info::csrcholInfo_t,
+                                                       pBuffer::CuPtr{Cvoid})::cusolverStatus_t
 end
 
 @checked function cusolverSpCcsrcholFactor(handle, n, nnzA, descrA, csrValA, csrRowPtrA,
                                            csrColIndA, info, pBuffer)
     initialize_context()
-    @ccall libcusolver.cusolverSpCcsrcholFactor(handle::cusolverSpHandle_t, n::Cint,
-                                                nnzA::Cint, descrA::cusparseMatDescr_t,
-                                                csrValA::CuPtr{cuComplex},
-                                                csrRowPtrA::CuPtr{Cint},
-                                                csrColIndA::CuPtr{Cint},
-                                                info::csrcholInfo_t,
-                                                pBuffer::CuPtr{Cvoid})::cusolverStatus_t
+    @gcsafe_ccall libcusolver.cusolverSpCcsrcholFactor(handle::cusolverSpHandle_t, n::Cint,
+                                                       nnzA::Cint,
+                                                       descrA::cusparseMatDescr_t,
+                                                       csrValA::CuPtr{cuComplex},
+                                                       csrRowPtrA::CuPtr{Cint},
+                                                       csrColIndA::CuPtr{Cint},
+                                                       info::csrcholInfo_t,
+                                                       pBuffer::CuPtr{Cvoid})::cusolverStatus_t
 end
 
 @checked function cusolverSpZcsrcholFactor(handle, n, nnzA, descrA, csrValA, csrRowPtrA,
                                            csrColIndA, info, pBuffer)
     initialize_context()
-    @ccall libcusolver.cusolverSpZcsrcholFactor(handle::cusolverSpHandle_t, n::Cint,
-                                                nnzA::Cint, descrA::cusparseMatDescr_t,
-                                                csrValA::CuPtr{cuDoubleComplex},
-                                                csrRowPtrA::CuPtr{Cint},
-                                                csrColIndA::CuPtr{Cint},
-                                                info::csrcholInfo_t,
-                                                pBuffer::CuPtr{Cvoid})::cusolverStatus_t
+    @gcsafe_ccall libcusolver.cusolverSpZcsrcholFactor(handle::cusolverSpHandle_t, n::Cint,
+                                                       nnzA::Cint,
+                                                       descrA::cusparseMatDescr_t,
+                                                       csrValA::CuPtr{cuDoubleComplex},
+                                                       csrRowPtrA::CuPtr{Cint},
+                                                       csrColIndA::CuPtr{Cint},
+                                                       info::csrcholInfo_t,
+                                                       pBuffer::CuPtr{Cvoid})::cusolverStatus_t
 end
 
 @checked function cusolverSpScsrcholZeroPivot(handle, info, tol, position)
     initialize_context()
-    @ccall libcusolver.cusolverSpScsrcholZeroPivot(handle::cusolverSpHandle_t,
-                                                   info::csrcholInfo_t, tol::Cfloat,
-                                                   position::Ptr{Cint})::cusolverStatus_t
+    @gcsafe_ccall libcusolver.cusolverSpScsrcholZeroPivot(handle::cusolverSpHandle_t,
+                                                          info::csrcholInfo_t, tol::Cfloat,
+                                                          position::Ptr{Cint})::cusolverStatus_t
 end
 
 @checked function cusolverSpDcsrcholZeroPivot(handle, info, tol, position)
     initialize_context()
-    @ccall libcusolver.cusolverSpDcsrcholZeroPivot(handle::cusolverSpHandle_t,
-                                                   info::csrcholInfo_t, tol::Cdouble,
-                                                   position::Ptr{Cint})::cusolverStatus_t
+    @gcsafe_ccall libcusolver.cusolverSpDcsrcholZeroPivot(handle::cusolverSpHandle_t,
+                                                          info::csrcholInfo_t, tol::Cdouble,
+                                                          position::Ptr{Cint})::cusolverStatus_t
 end
 
 @checked function cusolverSpCcsrcholZeroPivot(handle, info, tol, position)
     initialize_context()
-    @ccall libcusolver.cusolverSpCcsrcholZeroPivot(handle::cusolverSpHandle_t,
-                                                   info::csrcholInfo_t, tol::Cfloat,
-                                                   position::Ptr{Cint})::cusolverStatus_t
+    @gcsafe_ccall libcusolver.cusolverSpCcsrcholZeroPivot(handle::cusolverSpHandle_t,
+                                                          info::csrcholInfo_t, tol::Cfloat,
+                                                          position::Ptr{Cint})::cusolverStatus_t
 end
 
 @checked function cusolverSpZcsrcholZeroPivot(handle, info, tol, position)
     initialize_context()
-    @ccall libcusolver.cusolverSpZcsrcholZeroPivot(handle::cusolverSpHandle_t,
-                                                   info::csrcholInfo_t, tol::Cdouble,
-                                                   position::Ptr{Cint})::cusolverStatus_t
+    @gcsafe_ccall libcusolver.cusolverSpZcsrcholZeroPivot(handle::cusolverSpHandle_t,
+                                                          info::csrcholInfo_t, tol::Cdouble,
+                                                          position::Ptr{Cint})::cusolverStatus_t
 end
 
 @checked function cusolverSpScsrcholSolve(handle, n, b, x, info, pBuffer)
     initialize_context()
-    @ccall libcusolver.cusolverSpScsrcholSolve(handle::cusolverSpHandle_t, n::Cint,
-                                               b::CuPtr{Cfloat}, x::CuPtr{Cfloat},
-                                               info::csrcholInfo_t,
-                                               pBuffer::CuPtr{Cvoid})::cusolverStatus_t
+    @gcsafe_ccall libcusolver.cusolverSpScsrcholSolve(handle::cusolverSpHandle_t, n::Cint,
+                                                      b::CuPtr{Cfloat}, x::CuPtr{Cfloat},
+                                                      info::csrcholInfo_t,
+                                                      pBuffer::CuPtr{Cvoid})::cusolverStatus_t
 end
 
 @checked function cusolverSpDcsrcholSolve(handle, n, b, x, info, pBuffer)
     initialize_context()
-    @ccall libcusolver.cusolverSpDcsrcholSolve(handle::cusolverSpHandle_t, n::Cint,
-                                               b::CuPtr{Cdouble}, x::CuPtr{Cdouble},
-                                               info::csrcholInfo_t,
-                                               pBuffer::CuPtr{Cvoid})::cusolverStatus_t
+    @gcsafe_ccall libcusolver.cusolverSpDcsrcholSolve(handle::cusolverSpHandle_t, n::Cint,
+                                                      b::CuPtr{Cdouble}, x::CuPtr{Cdouble},
+                                                      info::csrcholInfo_t,
+                                                      pBuffer::CuPtr{Cvoid})::cusolverStatus_t
 end
 
 @checked function cusolverSpCcsrcholSolve(handle, n, b, x, info, pBuffer)
     initialize_context()
-    @ccall libcusolver.cusolverSpCcsrcholSolve(handle::cusolverSpHandle_t, n::Cint,
-                                               b::CuPtr{cuComplex}, x::CuPtr{cuComplex},
-                                               info::csrcholInfo_t,
-                                               pBuffer::CuPtr{Cvoid})::cusolverStatus_t
+    @gcsafe_ccall libcusolver.cusolverSpCcsrcholSolve(handle::cusolverSpHandle_t, n::Cint,
+                                                      b::CuPtr{cuComplex},
+                                                      x::CuPtr{cuComplex},
+                                                      info::csrcholInfo_t,
+                                                      pBuffer::CuPtr{Cvoid})::cusolverStatus_t
 end
 
 @checked function cusolverSpZcsrcholSolve(handle, n, b, x, info, pBuffer)
     initialize_context()
-    @ccall libcusolver.cusolverSpZcsrcholSolve(handle::cusolverSpHandle_t, n::Cint,
-                                               b::CuPtr{cuDoubleComplex},
-                                               x::CuPtr{cuDoubleComplex},
-                                               info::csrcholInfo_t,
-                                               pBuffer::CuPtr{Cvoid})::cusolverStatus_t
+    @gcsafe_ccall libcusolver.cusolverSpZcsrcholSolve(handle::cusolverSpHandle_t, n::Cint,
+                                                      b::CuPtr{cuDoubleComplex},
+                                                      x::CuPtr{cuDoubleComplex},
+                                                      info::csrcholInfo_t,
+                                                      pBuffer::CuPtr{Cvoid})::cusolverStatus_t
 end
 
 @checked function cusolverSpScsrcholDiag(handle, info, diag)
     initialize_context()
-    @ccall libcusolver.cusolverSpScsrcholDiag(handle::cusolverSpHandle_t,
-                                              info::csrcholInfo_t,
-                                              diag::CuPtr{Cfloat})::cusolverStatus_t
+    @gcsafe_ccall libcusolver.cusolverSpScsrcholDiag(handle::cusolverSpHandle_t,
+                                                     info::csrcholInfo_t,
+                                                     diag::CuPtr{Cfloat})::cusolverStatus_t
 end
 
 @checked function cusolverSpDcsrcholDiag(handle, info, diag)
     initialize_context()
-    @ccall libcusolver.cusolverSpDcsrcholDiag(handle::cusolverSpHandle_t,
-                                              info::csrcholInfo_t,
-                                              diag::CuPtr{Cdouble})::cusolverStatus_t
+    @gcsafe_ccall libcusolver.cusolverSpDcsrcholDiag(handle::cusolverSpHandle_t,
+                                                     info::csrcholInfo_t,
+                                                     diag::CuPtr{Cdouble})::cusolverStatus_t
 end
 
 @checked function cusolverSpCcsrcholDiag(handle, info, diag)
     initialize_context()
-    @ccall libcusolver.cusolverSpCcsrcholDiag(handle::cusolverSpHandle_t,
-                                              info::csrcholInfo_t,
-                                              diag::CuPtr{Cfloat})::cusolverStatus_t
+    @gcsafe_ccall libcusolver.cusolverSpCcsrcholDiag(handle::cusolverSpHandle_t,
+                                                     info::csrcholInfo_t,
+                                                     diag::CuPtr{Cfloat})::cusolverStatus_t
 end
 
 @checked function cusolverSpZcsrcholDiag(handle, info, diag)
     initialize_context()
-    @ccall libcusolver.cusolverSpZcsrcholDiag(handle::cusolverSpHandle_t,
-                                              info::csrcholInfo_t,
-                                              diag::CuPtr{Cdouble})::cusolverStatus_t
+    @gcsafe_ccall libcusolver.cusolverSpZcsrcholDiag(handle::cusolverSpHandle_t,
+                                                     info::csrcholInfo_t,
+                                                     diag::CuPtr{Cdouble})::cusolverStatus_t
 end

--- a/lib/cusolver/libcusolverMg.jl
+++ b/lib/cusolver/libcusolverMg.jl
@@ -18,202 +18,224 @@ const cudaLibMgMatrixDesc_t = Ptr{Cvoid}
 
 @checked function cusolverMgCreate(handle)
     initialize_context()
-    @ccall libcusolverMg.cusolverMgCreate(handle::Ptr{cusolverMgHandle_t})::cusolverStatus_t
+    @gcsafe_ccall libcusolverMg.cusolverMgCreate(handle::Ptr{cusolverMgHandle_t})::cusolverStatus_t
 end
 
 @checked function cusolverMgDestroy(handle)
     initialize_context()
-    @ccall libcusolverMg.cusolverMgDestroy(handle::cusolverMgHandle_t)::cusolverStatus_t
+    @gcsafe_ccall libcusolverMg.cusolverMgDestroy(handle::cusolverMgHandle_t)::cusolverStatus_t
 end
 
 @checked function cusolverMgDeviceSelect(handle, nbDevices, deviceId)
     initialize_context()
-    @ccall libcusolverMg.cusolverMgDeviceSelect(handle::cusolverMgHandle_t, nbDevices::Cint,
-                                                deviceId::Ptr{Cint})::cusolverStatus_t
+    @gcsafe_ccall libcusolverMg.cusolverMgDeviceSelect(handle::cusolverMgHandle_t,
+                                                       nbDevices::Cint,
+                                                       deviceId::Ptr{Cint})::cusolverStatus_t
 end
 
 @checked function cusolverMgCreateDeviceGrid(grid, numRowDevices, numColDevices, deviceId,
                                              mapping)
     initialize_context()
-    @ccall libcusolverMg.cusolverMgCreateDeviceGrid(grid::Ptr{cudaLibMgGrid_t},
-                                                    numRowDevices::Int32,
-                                                    numColDevices::Int32,
-                                                    deviceId::Ptr{Int32},
-                                                    mapping::cusolverMgGridMapping_t)::cusolverStatus_t
+    @gcsafe_ccall libcusolverMg.cusolverMgCreateDeviceGrid(grid::Ptr{cudaLibMgGrid_t},
+                                                           numRowDevices::Int32,
+                                                           numColDevices::Int32,
+                                                           deviceId::Ptr{Int32},
+                                                           mapping::cusolverMgGridMapping_t)::cusolverStatus_t
 end
 
 @checked function cusolverMgDestroyGrid(grid)
     initialize_context()
-    @ccall libcusolverMg.cusolverMgDestroyGrid(grid::cudaLibMgGrid_t)::cusolverStatus_t
+    @gcsafe_ccall libcusolverMg.cusolverMgDestroyGrid(grid::cudaLibMgGrid_t)::cusolverStatus_t
 end
 
 @checked function cusolverMgCreateMatrixDesc(desc, numRows, numCols, rowBlockSize,
                                              colBlockSize, dataType, grid)
     initialize_context()
-    @ccall libcusolverMg.cusolverMgCreateMatrixDesc(desc::Ptr{cudaLibMgMatrixDesc_t},
-                                                    numRows::Int64, numCols::Int64,
-                                                    rowBlockSize::Int64,
-                                                    colBlockSize::Int64,
-                                                    dataType::cudaDataType,
-                                                    grid::cudaLibMgGrid_t)::cusolverStatus_t
+    @gcsafe_ccall libcusolverMg.cusolverMgCreateMatrixDesc(desc::Ptr{cudaLibMgMatrixDesc_t},
+                                                           numRows::Int64, numCols::Int64,
+                                                           rowBlockSize::Int64,
+                                                           colBlockSize::Int64,
+                                                           dataType::cudaDataType,
+                                                           grid::cudaLibMgGrid_t)::cusolverStatus_t
 end
 
 @checked function cusolverMgDestroyMatrixDesc(desc)
     initialize_context()
-    @ccall libcusolverMg.cusolverMgDestroyMatrixDesc(desc::cudaLibMgMatrixDesc_t)::cusolverStatus_t
+    @gcsafe_ccall libcusolverMg.cusolverMgDestroyMatrixDesc(desc::cudaLibMgMatrixDesc_t)::cusolverStatus_t
 end
 
 @checked function cusolverMgSyevd_bufferSize(handle, jobz, uplo, N, array_d_A, IA, JA,
                                              descrA, W, dataTypeW, computeType, lwork)
     initialize_context()
-    @ccall libcusolverMg.cusolverMgSyevd_bufferSize(handle::cusolverMgHandle_t,
-                                                    jobz::cusolverEigMode_t,
-                                                    uplo::cublasFillMode_t, N::Cint,
-                                                    array_d_A::Ptr{CuPtr{Cvoid}}, IA::Cint,
-                                                    JA::Cint, descrA::cudaLibMgMatrixDesc_t,
-                                                    W::Ptr{Cvoid}, dataTypeW::cudaDataType,
-                                                    computeType::cudaDataType,
-                                                    lwork::Ptr{Int64})::cusolverStatus_t
+    @gcsafe_ccall libcusolverMg.cusolverMgSyevd_bufferSize(handle::cusolverMgHandle_t,
+                                                           jobz::cusolverEigMode_t,
+                                                           uplo::cublasFillMode_t, N::Cint,
+                                                           array_d_A::Ptr{CuPtr{Cvoid}},
+                                                           IA::Cint, JA::Cint,
+                                                           descrA::cudaLibMgMatrixDesc_t,
+                                                           W::Ptr{Cvoid},
+                                                           dataTypeW::cudaDataType,
+                                                           computeType::cudaDataType,
+                                                           lwork::Ptr{Int64})::cusolverStatus_t
 end
 
 @checked function cusolverMgSyevd(handle, jobz, uplo, N, array_d_A, IA, JA, descrA, W,
                                   dataTypeW, computeType, array_d_work, lwork, info)
     initialize_context()
-    @ccall libcusolverMg.cusolverMgSyevd(handle::cusolverMgHandle_t,
-                                         jobz::cusolverEigMode_t, uplo::cublasFillMode_t,
-                                         N::Cint, array_d_A::Ptr{CuPtr{Cvoid}}, IA::Cint,
-                                         JA::Cint, descrA::cudaLibMgMatrixDesc_t,
-                                         W::Ptr{Cvoid}, dataTypeW::cudaDataType,
-                                         computeType::cudaDataType,
-                                         array_d_work::Ptr{CuPtr{Cvoid}}, lwork::Int64,
-                                         info::Ptr{Cint})::cusolverStatus_t
+    @gcsafe_ccall libcusolverMg.cusolverMgSyevd(handle::cusolverMgHandle_t,
+                                                jobz::cusolverEigMode_t,
+                                                uplo::cublasFillMode_t, N::Cint,
+                                                array_d_A::Ptr{CuPtr{Cvoid}}, IA::Cint,
+                                                JA::Cint, descrA::cudaLibMgMatrixDesc_t,
+                                                W::Ptr{Cvoid}, dataTypeW::cudaDataType,
+                                                computeType::cudaDataType,
+                                                array_d_work::Ptr{CuPtr{Cvoid}},
+                                                lwork::Int64,
+                                                info::Ptr{Cint})::cusolverStatus_t
 end
 
 @checked function cusolverMgGetrf_bufferSize(handle, M, N, array_d_A, IA, JA, descrA,
                                              array_d_IPIV, computeType, lwork)
     initialize_context()
-    @ccall libcusolverMg.cusolverMgGetrf_bufferSize(handle::cusolverMgHandle_t, M::Cint,
-                                                    N::Cint, array_d_A::Ptr{CuPtr{Cvoid}},
-                                                    IA::Cint, JA::Cint,
-                                                    descrA::cudaLibMgMatrixDesc_t,
-                                                    array_d_IPIV::Ptr{CuPtr{Cint}},
-                                                    computeType::cudaDataType,
-                                                    lwork::Ptr{Int64})::cusolverStatus_t
+    @gcsafe_ccall libcusolverMg.cusolverMgGetrf_bufferSize(handle::cusolverMgHandle_t,
+                                                           M::Cint, N::Cint,
+                                                           array_d_A::Ptr{CuPtr{Cvoid}},
+                                                           IA::Cint, JA::Cint,
+                                                           descrA::cudaLibMgMatrixDesc_t,
+                                                           array_d_IPIV::Ptr{CuPtr{Cint}},
+                                                           computeType::cudaDataType,
+                                                           lwork::Ptr{Int64})::cusolverStatus_t
 end
 
 @checked function cusolverMgGetrf(handle, M, N, array_d_A, IA, JA, descrA, array_d_IPIV,
                                   computeType, array_d_work, lwork, info)
     initialize_context()
-    @ccall libcusolverMg.cusolverMgGetrf(handle::cusolverMgHandle_t, M::Cint, N::Cint,
-                                         array_d_A::Ptr{CuPtr{Cvoid}}, IA::Cint, JA::Cint,
-                                         descrA::cudaLibMgMatrixDesc_t,
-                                         array_d_IPIV::Ptr{CuPtr{Cint}},
-                                         computeType::cudaDataType,
-                                         array_d_work::Ptr{CuPtr{Cvoid}}, lwork::Int64,
-                                         info::Ptr{Cint})::cusolverStatus_t
+    @gcsafe_ccall libcusolverMg.cusolverMgGetrf(handle::cusolverMgHandle_t, M::Cint,
+                                                N::Cint, array_d_A::Ptr{CuPtr{Cvoid}},
+                                                IA::Cint, JA::Cint,
+                                                descrA::cudaLibMgMatrixDesc_t,
+                                                array_d_IPIV::Ptr{CuPtr{Cint}},
+                                                computeType::cudaDataType,
+                                                array_d_work::Ptr{CuPtr{Cvoid}},
+                                                lwork::Int64,
+                                                info::Ptr{Cint})::cusolverStatus_t
 end
 
 @checked function cusolverMgGetrs_bufferSize(handle, TRANS, N, NRHS, array_d_A, IA, JA,
                                              descrA, array_d_IPIV, array_d_B, IB, JB,
                                              descrB, computeType, lwork)
     initialize_context()
-    @ccall libcusolverMg.cusolverMgGetrs_bufferSize(handle::cusolverMgHandle_t,
-                                                    TRANS::cublasOperation_t, N::Cint,
-                                                    NRHS::Cint,
-                                                    array_d_A::Ptr{CuPtr{Cvoid}}, IA::Cint,
-                                                    JA::Cint, descrA::cudaLibMgMatrixDesc_t,
-                                                    array_d_IPIV::Ptr{CuPtr{Cint}},
-                                                    array_d_B::Ptr{CuPtr{Cvoid}}, IB::Cint,
-                                                    JB::Cint, descrB::cudaLibMgMatrixDesc_t,
-                                                    computeType::cudaDataType,
-                                                    lwork::Ptr{Int64})::cusolverStatus_t
+    @gcsafe_ccall libcusolverMg.cusolverMgGetrs_bufferSize(handle::cusolverMgHandle_t,
+                                                           TRANS::cublasOperation_t,
+                                                           N::Cint, NRHS::Cint,
+                                                           array_d_A::Ptr{CuPtr{Cvoid}},
+                                                           IA::Cint, JA::Cint,
+                                                           descrA::cudaLibMgMatrixDesc_t,
+                                                           array_d_IPIV::Ptr{CuPtr{Cint}},
+                                                           array_d_B::Ptr{CuPtr{Cvoid}},
+                                                           IB::Cint, JB::Cint,
+                                                           descrB::cudaLibMgMatrixDesc_t,
+                                                           computeType::cudaDataType,
+                                                           lwork::Ptr{Int64})::cusolverStatus_t
 end
 
 @checked function cusolverMgGetrs(handle, TRANS, N, NRHS, array_d_A, IA, JA, descrA,
                                   array_d_IPIV, array_d_B, IB, JB, descrB, computeType,
                                   array_d_work, lwork, info)
     initialize_context()
-    @ccall libcusolverMg.cusolverMgGetrs(handle::cusolverMgHandle_t,
-                                         TRANS::cublasOperation_t, N::Cint, NRHS::Cint,
-                                         array_d_A::Ptr{CuPtr{Cvoid}}, IA::Cint, JA::Cint,
-                                         descrA::cudaLibMgMatrixDesc_t,
-                                         array_d_IPIV::Ptr{CuPtr{Cint}},
-                                         array_d_B::Ptr{CuPtr{Cvoid}}, IB::Cint, JB::Cint,
-                                         descrB::cudaLibMgMatrixDesc_t,
-                                         computeType::cudaDataType,
-                                         array_d_work::Ptr{CuPtr{Cvoid}}, lwork::Int64,
-                                         info::Ptr{Cint})::cusolverStatus_t
+    @gcsafe_ccall libcusolverMg.cusolverMgGetrs(handle::cusolverMgHandle_t,
+                                                TRANS::cublasOperation_t, N::Cint,
+                                                NRHS::Cint, array_d_A::Ptr{CuPtr{Cvoid}},
+                                                IA::Cint, JA::Cint,
+                                                descrA::cudaLibMgMatrixDesc_t,
+                                                array_d_IPIV::Ptr{CuPtr{Cint}},
+                                                array_d_B::Ptr{CuPtr{Cvoid}}, IB::Cint,
+                                                JB::Cint, descrB::cudaLibMgMatrixDesc_t,
+                                                computeType::cudaDataType,
+                                                array_d_work::Ptr{CuPtr{Cvoid}},
+                                                lwork::Int64,
+                                                info::Ptr{Cint})::cusolverStatus_t
 end
 
 @checked function cusolverMgPotrf_bufferSize(handle, uplo, N, array_d_A, IA, JA, descrA,
                                              computeType, lwork)
     initialize_context()
-    @ccall libcusolverMg.cusolverMgPotrf_bufferSize(handle::cusolverMgHandle_t,
-                                                    uplo::cublasFillMode_t, N::Cint,
-                                                    array_d_A::Ptr{CuPtr{Cvoid}}, IA::Cint,
-                                                    JA::Cint, descrA::cudaLibMgMatrixDesc_t,
-                                                    computeType::cudaDataType,
-                                                    lwork::Ptr{Int64})::cusolverStatus_t
+    @gcsafe_ccall libcusolverMg.cusolverMgPotrf_bufferSize(handle::cusolverMgHandle_t,
+                                                           uplo::cublasFillMode_t, N::Cint,
+                                                           array_d_A::Ptr{CuPtr{Cvoid}},
+                                                           IA::Cint, JA::Cint,
+                                                           descrA::cudaLibMgMatrixDesc_t,
+                                                           computeType::cudaDataType,
+                                                           lwork::Ptr{Int64})::cusolverStatus_t
 end
 
 @checked function cusolverMgPotrf(handle, uplo, N, array_d_A, IA, JA, descrA, computeType,
                                   array_d_work, lwork, h_info)
     initialize_context()
-    @ccall libcusolverMg.cusolverMgPotrf(handle::cusolverMgHandle_t, uplo::cublasFillMode_t,
-                                         N::Cint, array_d_A::Ptr{CuPtr{Cvoid}}, IA::Cint,
-                                         JA::Cint, descrA::cudaLibMgMatrixDesc_t,
-                                         computeType::cudaDataType,
-                                         array_d_work::Ptr{CuPtr{Cvoid}}, lwork::Int64,
-                                         h_info::Ptr{Cint})::cusolverStatus_t
+    @gcsafe_ccall libcusolverMg.cusolverMgPotrf(handle::cusolverMgHandle_t,
+                                                uplo::cublasFillMode_t, N::Cint,
+                                                array_d_A::Ptr{CuPtr{Cvoid}}, IA::Cint,
+                                                JA::Cint, descrA::cudaLibMgMatrixDesc_t,
+                                                computeType::cudaDataType,
+                                                array_d_work::Ptr{CuPtr{Cvoid}},
+                                                lwork::Int64,
+                                                h_info::Ptr{Cint})::cusolverStatus_t
 end
 
 @checked function cusolverMgPotrs_bufferSize(handle, uplo, n, nrhs, array_d_A, IA, JA,
                                              descrA, array_d_B, IB, JB, descrB, computeType,
                                              lwork)
     initialize_context()
-    @ccall libcusolverMg.cusolverMgPotrs_bufferSize(handle::cusolverMgHandle_t,
-                                                    uplo::cublasFillMode_t, n::Cint,
-                                                    nrhs::Cint,
-                                                    array_d_A::Ptr{CuPtr{Cvoid}}, IA::Cint,
-                                                    JA::Cint, descrA::cudaLibMgMatrixDesc_t,
-                                                    array_d_B::Ptr{CuPtr{Cvoid}}, IB::Cint,
-                                                    JB::Cint, descrB::cudaLibMgMatrixDesc_t,
-                                                    computeType::cudaDataType,
-                                                    lwork::Ptr{Int64})::cusolverStatus_t
+    @gcsafe_ccall libcusolverMg.cusolverMgPotrs_bufferSize(handle::cusolverMgHandle_t,
+                                                           uplo::cublasFillMode_t, n::Cint,
+                                                           nrhs::Cint,
+                                                           array_d_A::Ptr{CuPtr{Cvoid}},
+                                                           IA::Cint, JA::Cint,
+                                                           descrA::cudaLibMgMatrixDesc_t,
+                                                           array_d_B::Ptr{CuPtr{Cvoid}},
+                                                           IB::Cint, JB::Cint,
+                                                           descrB::cudaLibMgMatrixDesc_t,
+                                                           computeType::cudaDataType,
+                                                           lwork::Ptr{Int64})::cusolverStatus_t
 end
 
 @checked function cusolverMgPotrs(handle, uplo, n, nrhs, array_d_A, IA, JA, descrA,
                                   array_d_B, IB, JB, descrB, computeType, array_d_work,
                                   lwork, h_info)
     initialize_context()
-    @ccall libcusolverMg.cusolverMgPotrs(handle::cusolverMgHandle_t, uplo::cublasFillMode_t,
-                                         n::Cint, nrhs::Cint, array_d_A::Ptr{CuPtr{Cvoid}},
-                                         IA::Cint, JA::Cint, descrA::cudaLibMgMatrixDesc_t,
-                                         array_d_B::Ptr{CuPtr{Cvoid}}, IB::Cint, JB::Cint,
-                                         descrB::cudaLibMgMatrixDesc_t,
-                                         computeType::cudaDataType,
-                                         array_d_work::Ptr{CuPtr{Cvoid}}, lwork::Int64,
-                                         h_info::Ptr{Cint})::cusolverStatus_t
+    @gcsafe_ccall libcusolverMg.cusolverMgPotrs(handle::cusolverMgHandle_t,
+                                                uplo::cublasFillMode_t, n::Cint, nrhs::Cint,
+                                                array_d_A::Ptr{CuPtr{Cvoid}}, IA::Cint,
+                                                JA::Cint, descrA::cudaLibMgMatrixDesc_t,
+                                                array_d_B::Ptr{CuPtr{Cvoid}}, IB::Cint,
+                                                JB::Cint, descrB::cudaLibMgMatrixDesc_t,
+                                                computeType::cudaDataType,
+                                                array_d_work::Ptr{CuPtr{Cvoid}},
+                                                lwork::Int64,
+                                                h_info::Ptr{Cint})::cusolverStatus_t
 end
 
 @checked function cusolverMgPotri_bufferSize(handle, uplo, N, array_d_A, IA, JA, descrA,
                                              computeType, lwork)
     initialize_context()
-    @ccall libcusolverMg.cusolverMgPotri_bufferSize(handle::cusolverMgHandle_t,
-                                                    uplo::cublasFillMode_t, N::Cint,
-                                                    array_d_A::Ptr{CuPtr{Cvoid}}, IA::Cint,
-                                                    JA::Cint, descrA::cudaLibMgMatrixDesc_t,
-                                                    computeType::cudaDataType,
-                                                    lwork::Ptr{Int64})::cusolverStatus_t
+    @gcsafe_ccall libcusolverMg.cusolverMgPotri_bufferSize(handle::cusolverMgHandle_t,
+                                                           uplo::cublasFillMode_t, N::Cint,
+                                                           array_d_A::Ptr{CuPtr{Cvoid}},
+                                                           IA::Cint, JA::Cint,
+                                                           descrA::cudaLibMgMatrixDesc_t,
+                                                           computeType::cudaDataType,
+                                                           lwork::Ptr{Int64})::cusolverStatus_t
 end
 
 @checked function cusolverMgPotri(handle, uplo, N, array_d_A, IA, JA, descrA, computeType,
                                   array_d_work, lwork, h_info)
     initialize_context()
-    @ccall libcusolverMg.cusolverMgPotri(handle::cusolverMgHandle_t, uplo::cublasFillMode_t,
-                                         N::Cint, array_d_A::Ptr{CuPtr{Cvoid}}, IA::Cint,
-                                         JA::Cint, descrA::cudaLibMgMatrixDesc_t,
-                                         computeType::cudaDataType,
-                                         array_d_work::Ptr{CuPtr{Cvoid}}, lwork::Int64,
-                                         h_info::Ptr{Cint})::cusolverStatus_t
+    @gcsafe_ccall libcusolverMg.cusolverMgPotri(handle::cusolverMgHandle_t,
+                                                uplo::cublasFillMode_t, N::Cint,
+                                                array_d_A::Ptr{CuPtr{Cvoid}}, IA::Cint,
+                                                JA::Cint, descrA::cudaLibMgMatrixDesc_t,
+                                                computeType::cudaDataType,
+                                                array_d_work::Ptr{CuPtr{Cvoid}},
+                                                lwork::Int64,
+                                                h_info::Ptr{Cint})::cusolverStatus_t
 end

--- a/lib/cusolver/libcusolverRF.jl
+++ b/lib/cusolver/libcusolverRF.jl
@@ -43,72 +43,72 @@ const cusolverRfHandle_t = Ptr{cusolverRfCommon}
 
 @checked function cusolverRfCreate(handle)
     initialize_context()
-    @ccall libcusolver.cusolverRfCreate(handle::Ptr{cusolverRfHandle_t})::cusolverStatus_t
+    @gcsafe_ccall libcusolver.cusolverRfCreate(handle::Ptr{cusolverRfHandle_t})::cusolverStatus_t
 end
 
 @checked function cusolverRfDestroy(handle)
     initialize_context()
-    @ccall libcusolver.cusolverRfDestroy(handle::cusolverRfHandle_t)::cusolverStatus_t
+    @gcsafe_ccall libcusolver.cusolverRfDestroy(handle::cusolverRfHandle_t)::cusolverStatus_t
 end
 
 @checked function cusolverRfGetMatrixFormat(handle, format, diag)
     initialize_context()
-    @ccall libcusolver.cusolverRfGetMatrixFormat(handle::cusolverRfHandle_t,
-                                                 format::Ptr{cusolverRfMatrixFormat_t},
-                                                 diag::Ptr{cusolverRfUnitDiagonal_t})::cusolverStatus_t
+    @gcsafe_ccall libcusolver.cusolverRfGetMatrixFormat(handle::cusolverRfHandle_t,
+                                                        format::Ptr{cusolverRfMatrixFormat_t},
+                                                        diag::Ptr{cusolverRfUnitDiagonal_t})::cusolverStatus_t
 end
 
 @checked function cusolverRfSetMatrixFormat(handle, format, diag)
     initialize_context()
-    @ccall libcusolver.cusolverRfSetMatrixFormat(handle::cusolverRfHandle_t,
-                                                 format::cusolverRfMatrixFormat_t,
-                                                 diag::cusolverRfUnitDiagonal_t)::cusolverStatus_t
+    @gcsafe_ccall libcusolver.cusolverRfSetMatrixFormat(handle::cusolverRfHandle_t,
+                                                        format::cusolverRfMatrixFormat_t,
+                                                        diag::cusolverRfUnitDiagonal_t)::cusolverStatus_t
 end
 
 @checked function cusolverRfSetNumericProperties(handle, zero, boost)
     initialize_context()
-    @ccall libcusolver.cusolverRfSetNumericProperties(handle::cusolverRfHandle_t,
-                                                      zero::Cdouble,
-                                                      boost::Cdouble)::cusolverStatus_t
+    @gcsafe_ccall libcusolver.cusolverRfSetNumericProperties(handle::cusolverRfHandle_t,
+                                                             zero::Cdouble,
+                                                             boost::Cdouble)::cusolverStatus_t
 end
 
 @checked function cusolverRfGetNumericProperties(handle, zero, boost)
     initialize_context()
-    @ccall libcusolver.cusolverRfGetNumericProperties(handle::cusolverRfHandle_t,
-                                                      zero::Ptr{Cdouble},
-                                                      boost::Ptr{Cdouble})::cusolverStatus_t
+    @gcsafe_ccall libcusolver.cusolverRfGetNumericProperties(handle::cusolverRfHandle_t,
+                                                             zero::Ptr{Cdouble},
+                                                             boost::Ptr{Cdouble})::cusolverStatus_t
 end
 
 @checked function cusolverRfGetNumericBoostReport(handle, report)
     initialize_context()
-    @ccall libcusolver.cusolverRfGetNumericBoostReport(handle::cusolverRfHandle_t,
-                                                       report::Ptr{cusolverRfNumericBoostReport_t})::cusolverStatus_t
+    @gcsafe_ccall libcusolver.cusolverRfGetNumericBoostReport(handle::cusolverRfHandle_t,
+                                                              report::Ptr{cusolverRfNumericBoostReport_t})::cusolverStatus_t
 end
 
 @checked function cusolverRfSetAlgs(handle, factAlg, solveAlg)
     initialize_context()
-    @ccall libcusolver.cusolverRfSetAlgs(handle::cusolverRfHandle_t,
-                                         factAlg::cusolverRfFactorization_t,
-                                         solveAlg::cusolverRfTriangularSolve_t)::cusolverStatus_t
+    @gcsafe_ccall libcusolver.cusolverRfSetAlgs(handle::cusolverRfHandle_t,
+                                                factAlg::cusolverRfFactorization_t,
+                                                solveAlg::cusolverRfTriangularSolve_t)::cusolverStatus_t
 end
 
 @checked function cusolverRfGetAlgs(handle, factAlg, solveAlg)
     initialize_context()
-    @ccall libcusolver.cusolverRfGetAlgs(handle::cusolverRfHandle_t,
-                                         factAlg::Ptr{cusolverRfFactorization_t},
-                                         solveAlg::Ptr{cusolverRfTriangularSolve_t})::cusolverStatus_t
+    @gcsafe_ccall libcusolver.cusolverRfGetAlgs(handle::cusolverRfHandle_t,
+                                                factAlg::Ptr{cusolverRfFactorization_t},
+                                                solveAlg::Ptr{cusolverRfTriangularSolve_t})::cusolverStatus_t
 end
 
 @checked function cusolverRfGetResetValuesFastMode(handle, fastMode)
     initialize_context()
-    @ccall libcusolver.cusolverRfGetResetValuesFastMode(handle::cusolverRfHandle_t,
-                                                        fastMode::Ptr{cusolverRfResetValuesFastMode_t})::cusolverStatus_t
+    @gcsafe_ccall libcusolver.cusolverRfGetResetValuesFastMode(handle::cusolverRfHandle_t,
+                                                               fastMode::Ptr{cusolverRfResetValuesFastMode_t})::cusolverStatus_t
 end
 
 @checked function cusolverRfSetResetValuesFastMode(handle, fastMode)
     initialize_context()
-    @ccall libcusolver.cusolverRfSetResetValuesFastMode(handle::cusolverRfHandle_t,
-                                                        fastMode::cusolverRfResetValuesFastMode_t)::cusolverStatus_t
+    @gcsafe_ccall libcusolver.cusolverRfSetResetValuesFastMode(handle::cusolverRfHandle_t,
+                                                               fastMode::cusolverRfResetValuesFastMode_t)::cusolverStatus_t
 end
 
 @checked function cusolverRfSetupHost(n, nnzA, h_csrRowPtrA, h_csrColIndA, h_csrValA, nnzL,
@@ -116,92 +116,99 @@ end
                                       h_csrRowPtrU, h_csrColIndU, h_csrValU, h_P, h_Q,
                                       handle)
     initialize_context()
-    @ccall libcusolver.cusolverRfSetupHost(n::Cint, nnzA::Cint, h_csrRowPtrA::Ptr{Cint},
-                                           h_csrColIndA::Ptr{Cint}, h_csrValA::Ptr{Cdouble},
-                                           nnzL::Cint, h_csrRowPtrL::Ptr{Cint},
-                                           h_csrColIndL::Ptr{Cint}, h_csrValL::Ptr{Cdouble},
-                                           nnzU::Cint, h_csrRowPtrU::Ptr{Cint},
-                                           h_csrColIndU::Ptr{Cint}, h_csrValU::Ptr{Cdouble},
-                                           h_P::Ptr{Cint}, h_Q::Ptr{Cint},
-                                           handle::cusolverRfHandle_t)::cusolverStatus_t
+    @gcsafe_ccall libcusolver.cusolverRfSetupHost(n::Cint, nnzA::Cint,
+                                                  h_csrRowPtrA::Ptr{Cint},
+                                                  h_csrColIndA::Ptr{Cint},
+                                                  h_csrValA::Ptr{Cdouble}, nnzL::Cint,
+                                                  h_csrRowPtrL::Ptr{Cint},
+                                                  h_csrColIndL::Ptr{Cint},
+                                                  h_csrValL::Ptr{Cdouble}, nnzU::Cint,
+                                                  h_csrRowPtrU::Ptr{Cint},
+                                                  h_csrColIndU::Ptr{Cint},
+                                                  h_csrValU::Ptr{Cdouble}, h_P::Ptr{Cint},
+                                                  h_Q::Ptr{Cint},
+                                                  handle::cusolverRfHandle_t)::cusolverStatus_t
 end
 
 @checked function cusolverRfSetupDevice(n, nnzA, csrRowPtrA, csrColIndA, csrValA, nnzL,
                                         csrRowPtrL, csrColIndL, csrValL, nnzU, csrRowPtrU,
                                         csrColIndU, csrValU, P, Q, handle)
     initialize_context()
-    @ccall libcusolver.cusolverRfSetupDevice(n::Cint, nnzA::Cint, csrRowPtrA::CuPtr{Cint},
-                                             csrColIndA::CuPtr{Cint},
-                                             csrValA::CuPtr{Cdouble}, nnzL::Cint,
-                                             csrRowPtrL::CuPtr{Cint},
-                                             csrColIndL::CuPtr{Cint},
-                                             csrValL::CuPtr{Cdouble}, nnzU::Cint,
-                                             csrRowPtrU::CuPtr{Cint},
-                                             csrColIndU::CuPtr{Cint},
-                                             csrValU::CuPtr{Cdouble}, P::CuPtr{Cint},
-                                             Q::CuPtr{Cint},
-                                             handle::cusolverRfHandle_t)::cusolverStatus_t
+    @gcsafe_ccall libcusolver.cusolverRfSetupDevice(n::Cint, nnzA::Cint,
+                                                    csrRowPtrA::CuPtr{Cint},
+                                                    csrColIndA::CuPtr{Cint},
+                                                    csrValA::CuPtr{Cdouble}, nnzL::Cint,
+                                                    csrRowPtrL::CuPtr{Cint},
+                                                    csrColIndL::CuPtr{Cint},
+                                                    csrValL::CuPtr{Cdouble}, nnzU::Cint,
+                                                    csrRowPtrU::CuPtr{Cint},
+                                                    csrColIndU::CuPtr{Cint},
+                                                    csrValU::CuPtr{Cdouble}, P::CuPtr{Cint},
+                                                    Q::CuPtr{Cint},
+                                                    handle::cusolverRfHandle_t)::cusolverStatus_t
 end
 
 @checked function cusolverRfResetValues(n, nnzA, csrRowPtrA, csrColIndA, csrValA, P, Q,
                                         handle)
     initialize_context()
-    @ccall libcusolver.cusolverRfResetValues(n::Cint, nnzA::Cint, csrRowPtrA::CuPtr{Cint},
-                                             csrColIndA::CuPtr{Cint},
-                                             csrValA::CuPtr{Cdouble}, P::CuPtr{Cint},
-                                             Q::CuPtr{Cint},
-                                             handle::cusolverRfHandle_t)::cusolverStatus_t
+    @gcsafe_ccall libcusolver.cusolverRfResetValues(n::Cint, nnzA::Cint,
+                                                    csrRowPtrA::CuPtr{Cint},
+                                                    csrColIndA::CuPtr{Cint},
+                                                    csrValA::CuPtr{Cdouble}, P::CuPtr{Cint},
+                                                    Q::CuPtr{Cint},
+                                                    handle::cusolverRfHandle_t)::cusolverStatus_t
 end
 
 @checked function cusolverRfAnalyze(handle)
     initialize_context()
-    @ccall libcusolver.cusolverRfAnalyze(handle::cusolverRfHandle_t)::cusolverStatus_t
+    @gcsafe_ccall libcusolver.cusolverRfAnalyze(handle::cusolverRfHandle_t)::cusolverStatus_t
 end
 
 @checked function cusolverRfRefactor(handle)
     initialize_context()
-    @ccall libcusolver.cusolverRfRefactor(handle::cusolverRfHandle_t)::cusolverStatus_t
+    @gcsafe_ccall libcusolver.cusolverRfRefactor(handle::cusolverRfHandle_t)::cusolverStatus_t
 end
 
 @checked function cusolverRfAccessBundledFactorsDevice(handle, nnzM, Mp, Mi, Mx)
     initialize_context()
-    @ccall libcusolver.cusolverRfAccessBundledFactorsDevice(handle::cusolverRfHandle_t,
-                                                            nnzM::Ptr{Cint},
-                                                            Mp::CuPtr{Ptr{Cint}},
-                                                            Mi::CuPtr{Ptr{Cint}},
-                                                            Mx::CuPtr{Ptr{Cdouble}})::cusolverStatus_t
+    @gcsafe_ccall libcusolver.cusolverRfAccessBundledFactorsDevice(handle::cusolverRfHandle_t,
+                                                                   nnzM::Ptr{Cint},
+                                                                   Mp::CuPtr{Ptr{Cint}},
+                                                                   Mi::CuPtr{Ptr{Cint}},
+                                                                   Mx::CuPtr{Ptr{Cdouble}})::cusolverStatus_t
 end
 
 @checked function cusolverRfExtractBundledFactorsHost(handle, h_nnzM, h_Mp, h_Mi, h_Mx)
     initialize_context()
-    @ccall libcusolver.cusolverRfExtractBundledFactorsHost(handle::cusolverRfHandle_t,
-                                                           h_nnzM::Ptr{Cint},
-                                                           h_Mp::Ptr{Ptr{Cint}},
-                                                           h_Mi::Ptr{Ptr{Cint}},
-                                                           h_Mx::Ptr{Ptr{Cdouble}})::cusolverStatus_t
+    @gcsafe_ccall libcusolver.cusolverRfExtractBundledFactorsHost(handle::cusolverRfHandle_t,
+                                                                  h_nnzM::Ptr{Cint},
+                                                                  h_Mp::Ptr{Ptr{Cint}},
+                                                                  h_Mi::Ptr{Ptr{Cint}},
+                                                                  h_Mx::Ptr{Ptr{Cdouble}})::cusolverStatus_t
 end
 
 @checked function cusolverRfExtractSplitFactorsHost(handle, h_nnzL, h_csrRowPtrL,
                                                     h_csrColIndL, h_csrValL, h_nnzU,
                                                     h_csrRowPtrU, h_csrColIndU, h_csrValU)
     initialize_context()
-    @ccall libcusolver.cusolverRfExtractSplitFactorsHost(handle::cusolverRfHandle_t,
-                                                         h_nnzL::Ptr{Cint},
-                                                         h_csrRowPtrL::Ptr{Ptr{Cint}},
-                                                         h_csrColIndL::Ptr{Ptr{Cint}},
-                                                         h_csrValL::Ptr{Ptr{Cdouble}},
-                                                         h_nnzU::Ptr{Cint},
-                                                         h_csrRowPtrU::Ptr{Ptr{Cint}},
-                                                         h_csrColIndU::Ptr{Ptr{Cint}},
-                                                         h_csrValU::Ptr{Ptr{Cdouble}})::cusolverStatus_t
+    @gcsafe_ccall libcusolver.cusolverRfExtractSplitFactorsHost(handle::cusolverRfHandle_t,
+                                                                h_nnzL::Ptr{Cint},
+                                                                h_csrRowPtrL::Ptr{Ptr{Cint}},
+                                                                h_csrColIndL::Ptr{Ptr{Cint}},
+                                                                h_csrValL::Ptr{Ptr{Cdouble}},
+                                                                h_nnzU::Ptr{Cint},
+                                                                h_csrRowPtrU::Ptr{Ptr{Cint}},
+                                                                h_csrColIndU::Ptr{Ptr{Cint}},
+                                                                h_csrValU::Ptr{Ptr{Cdouble}})::cusolverStatus_t
 end
 
 @checked function cusolverRfSolve(handle, P, Q, nrhs, Temp, ldt, XF, ldxf)
     initialize_context()
-    @ccall libcusolver.cusolverRfSolve(handle::cusolverRfHandle_t, P::CuPtr{Cint},
-                                       Q::CuPtr{Cint}, nrhs::Cint, Temp::CuPtr{Cdouble},
-                                       ldt::Cint, XF::CuPtr{Cdouble},
-                                       ldxf::Cint)::cusolverStatus_t
+    @gcsafe_ccall libcusolver.cusolverRfSolve(handle::cusolverRfHandle_t, P::CuPtr{Cint},
+                                              Q::CuPtr{Cint}, nrhs::Cint,
+                                              Temp::CuPtr{Cdouble}, ldt::Cint,
+                                              XF::CuPtr{Cdouble},
+                                              ldxf::Cint)::cusolverStatus_t
 end
 
 @checked function cusolverRfBatchSetupHost(batchSize, n, nnzA, h_csrRowPtrA, h_csrColIndA,
@@ -209,52 +216,53 @@ end
                                            h_csrColIndL, h_csrValL, nnzU, h_csrRowPtrU,
                                            h_csrColIndU, h_csrValU, h_P, h_Q, handle)
     initialize_context()
-    @ccall libcusolver.cusolverRfBatchSetupHost(batchSize::Cint, n::Cint, nnzA::Cint,
-                                                h_csrRowPtrA::Ptr{Cint},
-                                                h_csrColIndA::Ptr{Cint},
-                                                h_csrValA_array::Ptr{Ptr{Cdouble}},
-                                                nnzL::Cint, h_csrRowPtrL::Ptr{Cint},
-                                                h_csrColIndL::Ptr{Cint},
-                                                h_csrValL::Ptr{Cdouble}, nnzU::Cint,
-                                                h_csrRowPtrU::Ptr{Cint},
-                                                h_csrColIndU::Ptr{Cint},
-                                                h_csrValU::Ptr{Cdouble}, h_P::Ptr{Cint},
-                                                h_Q::Ptr{Cint},
-                                                handle::cusolverRfHandle_t)::cusolverStatus_t
+    @gcsafe_ccall libcusolver.cusolverRfBatchSetupHost(batchSize::Cint, n::Cint, nnzA::Cint,
+                                                       h_csrRowPtrA::Ptr{Cint},
+                                                       h_csrColIndA::Ptr{Cint},
+                                                       h_csrValA_array::Ptr{Ptr{Cdouble}},
+                                                       nnzL::Cint, h_csrRowPtrL::Ptr{Cint},
+                                                       h_csrColIndL::Ptr{Cint},
+                                                       h_csrValL::Ptr{Cdouble}, nnzU::Cint,
+                                                       h_csrRowPtrU::Ptr{Cint},
+                                                       h_csrColIndU::Ptr{Cint},
+                                                       h_csrValU::Ptr{Cdouble},
+                                                       h_P::Ptr{Cint}, h_Q::Ptr{Cint},
+                                                       handle::cusolverRfHandle_t)::cusolverStatus_t
 end
 
 @checked function cusolverRfBatchResetValues(batchSize, n, nnzA, csrRowPtrA, csrColIndA,
                                              csrValA_array, P, Q, handle)
     initialize_context()
-    @ccall libcusolver.cusolverRfBatchResetValues(batchSize::Cint, n::Cint, nnzA::Cint,
-                                                  csrRowPtrA::CuPtr{Cint},
-                                                  csrColIndA::CuPtr{Cint},
-                                                  csrValA_array::CuPtr{Ptr{Cdouble}},
-                                                  P::CuPtr{Cint}, Q::CuPtr{Cint},
-                                                  handle::cusolverRfHandle_t)::cusolverStatus_t
+    @gcsafe_ccall libcusolver.cusolverRfBatchResetValues(batchSize::Cint, n::Cint,
+                                                         nnzA::Cint,
+                                                         csrRowPtrA::CuPtr{Cint},
+                                                         csrColIndA::CuPtr{Cint},
+                                                         csrValA_array::CuPtr{Ptr{Cdouble}},
+                                                         P::CuPtr{Cint}, Q::CuPtr{Cint},
+                                                         handle::cusolverRfHandle_t)::cusolverStatus_t
 end
 
 @checked function cusolverRfBatchAnalyze(handle)
     initialize_context()
-    @ccall libcusolver.cusolverRfBatchAnalyze(handle::cusolverRfHandle_t)::cusolverStatus_t
+    @gcsafe_ccall libcusolver.cusolverRfBatchAnalyze(handle::cusolverRfHandle_t)::cusolverStatus_t
 end
 
 @checked function cusolverRfBatchRefactor(handle)
     initialize_context()
-    @ccall libcusolver.cusolverRfBatchRefactor(handle::cusolverRfHandle_t)::cusolverStatus_t
+    @gcsafe_ccall libcusolver.cusolverRfBatchRefactor(handle::cusolverRfHandle_t)::cusolverStatus_t
 end
 
 @checked function cusolverRfBatchSolve(handle, P, Q, nrhs, Temp, ldt, XF_array, ldxf)
     initialize_context()
-    @ccall libcusolver.cusolverRfBatchSolve(handle::cusolverRfHandle_t, P::CuPtr{Cint},
-                                            Q::CuPtr{Cint}, nrhs::Cint,
-                                            Temp::CuPtr{Cdouble}, ldt::Cint,
-                                            XF_array::CuPtr{Ptr{Cdouble}},
-                                            ldxf::Cint)::cusolverStatus_t
+    @gcsafe_ccall libcusolver.cusolverRfBatchSolve(handle::cusolverRfHandle_t,
+                                                   P::CuPtr{Cint}, Q::CuPtr{Cint},
+                                                   nrhs::Cint, Temp::CuPtr{Cdouble},
+                                                   ldt::Cint, XF_array::CuPtr{Ptr{Cdouble}},
+                                                   ldxf::Cint)::cusolverStatus_t
 end
 
 @checked function cusolverRfBatchZeroPivot(handle, position)
     initialize_context()
-    @ccall libcusolver.cusolverRfBatchZeroPivot(handle::cusolverRfHandle_t,
-                                                position::CuPtr{Cint})::cusolverStatus_t
+    @gcsafe_ccall libcusolver.cusolverRfBatchZeroPivot(handle::cusolverRfHandle_t,
+                                                       position::CuPtr{Cint})::cusolverStatus_t
 end

--- a/lib/cusparse/libcusparse.jl
+++ b/lib/cusparse/libcusparse.jl
@@ -142,54 +142,54 @@ end
 
 @checked function cusparseCreate(handle)
     initialize_context()
-    @ccall libcusparse.cusparseCreate(handle::Ptr{cusparseHandle_t})::cusparseStatus_t
+    @gcsafe_ccall libcusparse.cusparseCreate(handle::Ptr{cusparseHandle_t})::cusparseStatus_t
 end
 
 @checked function cusparseDestroy(handle)
     initialize_context()
-    @ccall libcusparse.cusparseDestroy(handle::cusparseHandle_t)::cusparseStatus_t
+    @gcsafe_ccall libcusparse.cusparseDestroy(handle::cusparseHandle_t)::cusparseStatus_t
 end
 
 @checked function cusparseGetVersion(handle, version)
-    @ccall libcusparse.cusparseGetVersion(handle::cusparseHandle_t,
-                                          version::Ptr{Cint})::cusparseStatus_t
+    @gcsafe_ccall libcusparse.cusparseGetVersion(handle::cusparseHandle_t,
+                                                 version::Ptr{Cint})::cusparseStatus_t
 end
 
 @checked function cusparseGetProperty(type, value)
-    @ccall libcusparse.cusparseGetProperty(type::libraryPropertyType,
-                                           value::Ptr{Cint})::cusparseStatus_t
+    @gcsafe_ccall libcusparse.cusparseGetProperty(type::libraryPropertyType,
+                                                  value::Ptr{Cint})::cusparseStatus_t
 end
 
 function cusparseGetErrorName(status)
-    @ccall libcusparse.cusparseGetErrorName(status::cusparseStatus_t)::Cstring
+    @gcsafe_ccall libcusparse.cusparseGetErrorName(status::cusparseStatus_t)::Cstring
 end
 
 function cusparseGetErrorString(status)
-    @ccall libcusparse.cusparseGetErrorString(status::cusparseStatus_t)::Cstring
+    @gcsafe_ccall libcusparse.cusparseGetErrorString(status::cusparseStatus_t)::Cstring
 end
 
 @checked function cusparseSetStream(handle, streamId)
     initialize_context()
-    @ccall libcusparse.cusparseSetStream(handle::cusparseHandle_t,
-                                         streamId::cudaStream_t)::cusparseStatus_t
+    @gcsafe_ccall libcusparse.cusparseSetStream(handle::cusparseHandle_t,
+                                                streamId::cudaStream_t)::cusparseStatus_t
 end
 
 @checked function cusparseGetStream(handle, streamId)
     initialize_context()
-    @ccall libcusparse.cusparseGetStream(handle::cusparseHandle_t,
-                                         streamId::Ptr{cudaStream_t})::cusparseStatus_t
+    @gcsafe_ccall libcusparse.cusparseGetStream(handle::cusparseHandle_t,
+                                                streamId::Ptr{cudaStream_t})::cusparseStatus_t
 end
 
 @checked function cusparseGetPointerMode(handle, mode)
     initialize_context()
-    @ccall libcusparse.cusparseGetPointerMode(handle::cusparseHandle_t,
-                                              mode::Ptr{cusparsePointerMode_t})::cusparseStatus_t
+    @gcsafe_ccall libcusparse.cusparseGetPointerMode(handle::cusparseHandle_t,
+                                                     mode::Ptr{cusparsePointerMode_t})::cusparseStatus_t
 end
 
 @checked function cusparseSetPointerMode(handle, mode)
     initialize_context()
-    @ccall libcusparse.cusparseSetPointerMode(handle::cusparseHandle_t,
-                                              mode::cusparsePointerMode_t)::cusparseStatus_t
+    @gcsafe_ccall libcusparse.cusparseSetPointerMode(handle::cusparseHandle_t,
+                                                     mode::cusparsePointerMode_t)::cusparseStatus_t
 end
 
 # typedef void ( * cusparseLoggerCallback_t ) ( int logLevel , const char * functionName , const char * message )
@@ -197,316 +197,326 @@ const cusparseLoggerCallback_t = Ptr{Cvoid}
 
 @checked function cusparseLoggerSetCallback(callback)
     initialize_context()
-    @ccall libcusparse.cusparseLoggerSetCallback(callback::cusparseLoggerCallback_t)::cusparseStatus_t
+    @gcsafe_ccall libcusparse.cusparseLoggerSetCallback(callback::cusparseLoggerCallback_t)::cusparseStatus_t
 end
 
 @checked function cusparseLoggerSetFile(file)
     initialize_context()
-    @ccall libcusparse.cusparseLoggerSetFile(file::Ptr{Libc.FILE})::cusparseStatus_t
+    @gcsafe_ccall libcusparse.cusparseLoggerSetFile(file::Ptr{Libc.FILE})::cusparseStatus_t
 end
 
 @checked function cusparseLoggerOpenFile(logFile)
     initialize_context()
-    @ccall libcusparse.cusparseLoggerOpenFile(logFile::Cstring)::cusparseStatus_t
+    @gcsafe_ccall libcusparse.cusparseLoggerOpenFile(logFile::Cstring)::cusparseStatus_t
 end
 
 @checked function cusparseLoggerSetLevel(level)
     initialize_context()
-    @ccall libcusparse.cusparseLoggerSetLevel(level::Cint)::cusparseStatus_t
+    @gcsafe_ccall libcusparse.cusparseLoggerSetLevel(level::Cint)::cusparseStatus_t
 end
 
 @checked function cusparseLoggerSetMask(mask)
     initialize_context()
-    @ccall libcusparse.cusparseLoggerSetMask(mask::Cint)::cusparseStatus_t
+    @gcsafe_ccall libcusparse.cusparseLoggerSetMask(mask::Cint)::cusparseStatus_t
 end
 
 @checked function cusparseLoggerForceDisable()
     initialize_context()
-    @ccall libcusparse.cusparseLoggerForceDisable()::cusparseStatus_t
+    @gcsafe_ccall libcusparse.cusparseLoggerForceDisable()::cusparseStatus_t
 end
 
 @checked function cusparseCreateMatDescr(descrA)
     initialize_context()
-    @ccall libcusparse.cusparseCreateMatDescr(descrA::Ptr{cusparseMatDescr_t})::cusparseStatus_t
+    @gcsafe_ccall libcusparse.cusparseCreateMatDescr(descrA::Ptr{cusparseMatDescr_t})::cusparseStatus_t
 end
 
 @checked function cusparseDestroyMatDescr(descrA)
     initialize_context()
-    @ccall libcusparse.cusparseDestroyMatDescr(descrA::cusparseMatDescr_t)::cusparseStatus_t
+    @gcsafe_ccall libcusparse.cusparseDestroyMatDescr(descrA::cusparseMatDescr_t)::cusparseStatus_t
 end
 
 @checked function cusparseSetMatType(descrA, type)
     initialize_context()
-    @ccall libcusparse.cusparseSetMatType(descrA::cusparseMatDescr_t,
-                                          type::cusparseMatrixType_t)::cusparseStatus_t
+    @gcsafe_ccall libcusparse.cusparseSetMatType(descrA::cusparseMatDescr_t,
+                                                 type::cusparseMatrixType_t)::cusparseStatus_t
 end
 
 function cusparseGetMatType(descrA)
     initialize_context()
-    @ccall libcusparse.cusparseGetMatType(descrA::cusparseMatDescr_t)::cusparseMatrixType_t
+    @gcsafe_ccall libcusparse.cusparseGetMatType(descrA::cusparseMatDescr_t)::cusparseMatrixType_t
 end
 
 @checked function cusparseSetMatFillMode(descrA, fillMode)
     initialize_context()
-    @ccall libcusparse.cusparseSetMatFillMode(descrA::cusparseMatDescr_t,
-                                              fillMode::cusparseFillMode_t)::cusparseStatus_t
+    @gcsafe_ccall libcusparse.cusparseSetMatFillMode(descrA::cusparseMatDescr_t,
+                                                     fillMode::cusparseFillMode_t)::cusparseStatus_t
 end
 
 function cusparseGetMatFillMode(descrA)
     initialize_context()
-    @ccall libcusparse.cusparseGetMatFillMode(descrA::cusparseMatDescr_t)::cusparseFillMode_t
+    @gcsafe_ccall libcusparse.cusparseGetMatFillMode(descrA::cusparseMatDescr_t)::cusparseFillMode_t
 end
 
 @checked function cusparseSetMatDiagType(descrA, diagType)
     initialize_context()
-    @ccall libcusparse.cusparseSetMatDiagType(descrA::cusparseMatDescr_t,
-                                              diagType::cusparseDiagType_t)::cusparseStatus_t
+    @gcsafe_ccall libcusparse.cusparseSetMatDiagType(descrA::cusparseMatDescr_t,
+                                                     diagType::cusparseDiagType_t)::cusparseStatus_t
 end
 
 function cusparseGetMatDiagType(descrA)
     initialize_context()
-    @ccall libcusparse.cusparseGetMatDiagType(descrA::cusparseMatDescr_t)::cusparseDiagType_t
+    @gcsafe_ccall libcusparse.cusparseGetMatDiagType(descrA::cusparseMatDescr_t)::cusparseDiagType_t
 end
 
 @checked function cusparseSetMatIndexBase(descrA, base)
     initialize_context()
-    @ccall libcusparse.cusparseSetMatIndexBase(descrA::cusparseMatDescr_t,
-                                               base::cusparseIndexBase_t)::cusparseStatus_t
+    @gcsafe_ccall libcusparse.cusparseSetMatIndexBase(descrA::cusparseMatDescr_t,
+                                                      base::cusparseIndexBase_t)::cusparseStatus_t
 end
 
 function cusparseGetMatIndexBase(descrA)
     initialize_context()
-    @ccall libcusparse.cusparseGetMatIndexBase(descrA::cusparseMatDescr_t)::cusparseIndexBase_t
+    @gcsafe_ccall libcusparse.cusparseGetMatIndexBase(descrA::cusparseMatDescr_t)::cusparseIndexBase_t
 end
 
 @checked function cusparseCreateCsric02Info(info)
     initialize_context()
-    @ccall libcusparse.cusparseCreateCsric02Info(info::Ptr{csric02Info_t})::cusparseStatus_t
+    @gcsafe_ccall libcusparse.cusparseCreateCsric02Info(info::Ptr{csric02Info_t})::cusparseStatus_t
 end
 
 @checked function cusparseDestroyCsric02Info(info)
     initialize_context()
-    @ccall libcusparse.cusparseDestroyCsric02Info(info::csric02Info_t)::cusparseStatus_t
+    @gcsafe_ccall libcusparse.cusparseDestroyCsric02Info(info::csric02Info_t)::cusparseStatus_t
 end
 
 @checked function cusparseCreateBsric02Info(info)
     initialize_context()
-    @ccall libcusparse.cusparseCreateBsric02Info(info::Ptr{bsric02Info_t})::cusparseStatus_t
+    @gcsafe_ccall libcusparse.cusparseCreateBsric02Info(info::Ptr{bsric02Info_t})::cusparseStatus_t
 end
 
 @checked function cusparseDestroyBsric02Info(info)
     initialize_context()
-    @ccall libcusparse.cusparseDestroyBsric02Info(info::bsric02Info_t)::cusparseStatus_t
+    @gcsafe_ccall libcusparse.cusparseDestroyBsric02Info(info::bsric02Info_t)::cusparseStatus_t
 end
 
 @checked function cusparseCreateCsrilu02Info(info)
     initialize_context()
-    @ccall libcusparse.cusparseCreateCsrilu02Info(info::Ptr{csrilu02Info_t})::cusparseStatus_t
+    @gcsafe_ccall libcusparse.cusparseCreateCsrilu02Info(info::Ptr{csrilu02Info_t})::cusparseStatus_t
 end
 
 @checked function cusparseDestroyCsrilu02Info(info)
     initialize_context()
-    @ccall libcusparse.cusparseDestroyCsrilu02Info(info::csrilu02Info_t)::cusparseStatus_t
+    @gcsafe_ccall libcusparse.cusparseDestroyCsrilu02Info(info::csrilu02Info_t)::cusparseStatus_t
 end
 
 @checked function cusparseCreateBsrilu02Info(info)
     initialize_context()
-    @ccall libcusparse.cusparseCreateBsrilu02Info(info::Ptr{bsrilu02Info_t})::cusparseStatus_t
+    @gcsafe_ccall libcusparse.cusparseCreateBsrilu02Info(info::Ptr{bsrilu02Info_t})::cusparseStatus_t
 end
 
 @checked function cusparseDestroyBsrilu02Info(info)
     initialize_context()
-    @ccall libcusparse.cusparseDestroyBsrilu02Info(info::bsrilu02Info_t)::cusparseStatus_t
+    @gcsafe_ccall libcusparse.cusparseDestroyBsrilu02Info(info::bsrilu02Info_t)::cusparseStatus_t
 end
 
 @checked function cusparseCreateBsrsv2Info(info)
     initialize_context()
-    @ccall libcusparse.cusparseCreateBsrsv2Info(info::Ptr{bsrsv2Info_t})::cusparseStatus_t
+    @gcsafe_ccall libcusparse.cusparseCreateBsrsv2Info(info::Ptr{bsrsv2Info_t})::cusparseStatus_t
 end
 
 @checked function cusparseDestroyBsrsv2Info(info)
     initialize_context()
-    @ccall libcusparse.cusparseDestroyBsrsv2Info(info::bsrsv2Info_t)::cusparseStatus_t
+    @gcsafe_ccall libcusparse.cusparseDestroyBsrsv2Info(info::bsrsv2Info_t)::cusparseStatus_t
 end
 
 @checked function cusparseCreateBsrsm2Info(info)
     initialize_context()
-    @ccall libcusparse.cusparseCreateBsrsm2Info(info::Ptr{bsrsm2Info_t})::cusparseStatus_t
+    @gcsafe_ccall libcusparse.cusparseCreateBsrsm2Info(info::Ptr{bsrsm2Info_t})::cusparseStatus_t
 end
 
 @checked function cusparseDestroyBsrsm2Info(info)
     initialize_context()
-    @ccall libcusparse.cusparseDestroyBsrsm2Info(info::bsrsm2Info_t)::cusparseStatus_t
+    @gcsafe_ccall libcusparse.cusparseDestroyBsrsm2Info(info::bsrsm2Info_t)::cusparseStatus_t
 end
 
 @checked function cusparseCreateCsru2csrInfo(info)
     initialize_context()
-    @ccall libcusparse.cusparseCreateCsru2csrInfo(info::Ptr{csru2csrInfo_t})::cusparseStatus_t
+    @gcsafe_ccall libcusparse.cusparseCreateCsru2csrInfo(info::Ptr{csru2csrInfo_t})::cusparseStatus_t
 end
 
 @checked function cusparseDestroyCsru2csrInfo(info)
     initialize_context()
-    @ccall libcusparse.cusparseDestroyCsru2csrInfo(info::csru2csrInfo_t)::cusparseStatus_t
+    @gcsafe_ccall libcusparse.cusparseDestroyCsru2csrInfo(info::csru2csrInfo_t)::cusparseStatus_t
 end
 
 @checked function cusparseCreateColorInfo(info)
     initialize_context()
-    @ccall libcusparse.cusparseCreateColorInfo(info::Ptr{cusparseColorInfo_t})::cusparseStatus_t
+    @gcsafe_ccall libcusparse.cusparseCreateColorInfo(info::Ptr{cusparseColorInfo_t})::cusparseStatus_t
 end
 
 @checked function cusparseDestroyColorInfo(info)
     initialize_context()
-    @ccall libcusparse.cusparseDestroyColorInfo(info::cusparseColorInfo_t)::cusparseStatus_t
+    @gcsafe_ccall libcusparse.cusparseDestroyColorInfo(info::cusparseColorInfo_t)::cusparseStatus_t
 end
 
 @checked function cusparseCreatePruneInfo(info)
     initialize_context()
-    @ccall libcusparse.cusparseCreatePruneInfo(info::Ptr{pruneInfo_t})::cusparseStatus_t
+    @gcsafe_ccall libcusparse.cusparseCreatePruneInfo(info::Ptr{pruneInfo_t})::cusparseStatus_t
 end
 
 @checked function cusparseDestroyPruneInfo(info)
     initialize_context()
-    @ccall libcusparse.cusparseDestroyPruneInfo(info::pruneInfo_t)::cusparseStatus_t
+    @gcsafe_ccall libcusparse.cusparseDestroyPruneInfo(info::pruneInfo_t)::cusparseStatus_t
 end
 
 @checked function cusparseSgemvi(handle, transA, m, n, alpha, A, lda, nnz, xVal, xInd, beta,
                                  y, idxBase, pBuffer)
     initialize_context()
-    @ccall libcusparse.cusparseSgemvi(handle::cusparseHandle_t, transA::cusparseOperation_t,
-                                      m::Cint, n::Cint, alpha::Ref{Cfloat},
-                                      A::CuPtr{Cfloat}, lda::Cint, nnz::Cint,
-                                      xVal::CuPtr{Cfloat}, xInd::CuPtr{Cint},
-                                      beta::Ref{Cfloat}, y::CuPtr{Cfloat},
-                                      idxBase::cusparseIndexBase_t,
-                                      pBuffer::CuPtr{Cvoid})::cusparseStatus_t
+    @gcsafe_ccall libcusparse.cusparseSgemvi(handle::cusparseHandle_t,
+                                             transA::cusparseOperation_t, m::Cint, n::Cint,
+                                             alpha::Ref{Cfloat}, A::CuPtr{Cfloat},
+                                             lda::Cint, nnz::Cint, xVal::CuPtr{Cfloat},
+                                             xInd::CuPtr{Cint}, beta::Ref{Cfloat},
+                                             y::CuPtr{Cfloat}, idxBase::cusparseIndexBase_t,
+                                             pBuffer::CuPtr{Cvoid})::cusparseStatus_t
 end
 
 @checked function cusparseSgemvi_bufferSize(handle, transA, m, n, nnz, pBufferSize)
     initialize_context()
-    @ccall libcusparse.cusparseSgemvi_bufferSize(handle::cusparseHandle_t,
-                                                 transA::cusparseOperation_t, m::Cint,
-                                                 n::Cint, nnz::Cint,
-                                                 pBufferSize::Ptr{Cint})::cusparseStatus_t
+    @gcsafe_ccall libcusparse.cusparseSgemvi_bufferSize(handle::cusparseHandle_t,
+                                                        transA::cusparseOperation_t,
+                                                        m::Cint, n::Cint, nnz::Cint,
+                                                        pBufferSize::Ptr{Cint})::cusparseStatus_t
 end
 
 @checked function cusparseDgemvi(handle, transA, m, n, alpha, A, lda, nnz, xVal, xInd, beta,
                                  y, idxBase, pBuffer)
     initialize_context()
-    @ccall libcusparse.cusparseDgemvi(handle::cusparseHandle_t, transA::cusparseOperation_t,
-                                      m::Cint, n::Cint, alpha::Ref{Cdouble},
-                                      A::CuPtr{Cdouble}, lda::Cint, nnz::Cint,
-                                      xVal::CuPtr{Cdouble}, xInd::CuPtr{Cint},
-                                      beta::Ref{Cdouble}, y::CuPtr{Cdouble},
-                                      idxBase::cusparseIndexBase_t,
-                                      pBuffer::CuPtr{Cvoid})::cusparseStatus_t
+    @gcsafe_ccall libcusparse.cusparseDgemvi(handle::cusparseHandle_t,
+                                             transA::cusparseOperation_t, m::Cint, n::Cint,
+                                             alpha::Ref{Cdouble}, A::CuPtr{Cdouble},
+                                             lda::Cint, nnz::Cint, xVal::CuPtr{Cdouble},
+                                             xInd::CuPtr{Cint}, beta::Ref{Cdouble},
+                                             y::CuPtr{Cdouble},
+                                             idxBase::cusparseIndexBase_t,
+                                             pBuffer::CuPtr{Cvoid})::cusparseStatus_t
 end
 
 @checked function cusparseDgemvi_bufferSize(handle, transA, m, n, nnz, pBufferSize)
     initialize_context()
-    @ccall libcusparse.cusparseDgemvi_bufferSize(handle::cusparseHandle_t,
-                                                 transA::cusparseOperation_t, m::Cint,
-                                                 n::Cint, nnz::Cint,
-                                                 pBufferSize::Ptr{Cint})::cusparseStatus_t
+    @gcsafe_ccall libcusparse.cusparseDgemvi_bufferSize(handle::cusparseHandle_t,
+                                                        transA::cusparseOperation_t,
+                                                        m::Cint, n::Cint, nnz::Cint,
+                                                        pBufferSize::Ptr{Cint})::cusparseStatus_t
 end
 
 @checked function cusparseCgemvi(handle, transA, m, n, alpha, A, lda, nnz, xVal, xInd, beta,
                                  y, idxBase, pBuffer)
     initialize_context()
-    @ccall libcusparse.cusparseCgemvi(handle::cusparseHandle_t, transA::cusparseOperation_t,
-                                      m::Cint, n::Cint, alpha::Ref{cuComplex},
-                                      A::CuPtr{cuComplex}, lda::Cint, nnz::Cint,
-                                      xVal::CuPtr{cuComplex}, xInd::CuPtr{Cint},
-                                      beta::Ref{cuComplex}, y::CuPtr{cuComplex},
-                                      idxBase::cusparseIndexBase_t,
-                                      pBuffer::CuPtr{Cvoid})::cusparseStatus_t
+    @gcsafe_ccall libcusparse.cusparseCgemvi(handle::cusparseHandle_t,
+                                             transA::cusparseOperation_t, m::Cint, n::Cint,
+                                             alpha::Ref{cuComplex}, A::CuPtr{cuComplex},
+                                             lda::Cint, nnz::Cint, xVal::CuPtr{cuComplex},
+                                             xInd::CuPtr{Cint}, beta::Ref{cuComplex},
+                                             y::CuPtr{cuComplex},
+                                             idxBase::cusparseIndexBase_t,
+                                             pBuffer::CuPtr{Cvoid})::cusparseStatus_t
 end
 
 @checked function cusparseCgemvi_bufferSize(handle, transA, m, n, nnz, pBufferSize)
     initialize_context()
-    @ccall libcusparse.cusparseCgemvi_bufferSize(handle::cusparseHandle_t,
-                                                 transA::cusparseOperation_t, m::Cint,
-                                                 n::Cint, nnz::Cint,
-                                                 pBufferSize::Ptr{Cint})::cusparseStatus_t
+    @gcsafe_ccall libcusparse.cusparseCgemvi_bufferSize(handle::cusparseHandle_t,
+                                                        transA::cusparseOperation_t,
+                                                        m::Cint, n::Cint, nnz::Cint,
+                                                        pBufferSize::Ptr{Cint})::cusparseStatus_t
 end
 
 @checked function cusparseZgemvi(handle, transA, m, n, alpha, A, lda, nnz, xVal, xInd, beta,
                                  y, idxBase, pBuffer)
     initialize_context()
-    @ccall libcusparse.cusparseZgemvi(handle::cusparseHandle_t, transA::cusparseOperation_t,
-                                      m::Cint, n::Cint, alpha::Ref{cuDoubleComplex},
-                                      A::CuPtr{cuDoubleComplex}, lda::Cint, nnz::Cint,
-                                      xVal::CuPtr{cuDoubleComplex}, xInd::CuPtr{Cint},
-                                      beta::Ref{cuDoubleComplex}, y::CuPtr{cuDoubleComplex},
-                                      idxBase::cusparseIndexBase_t,
-                                      pBuffer::CuPtr{Cvoid})::cusparseStatus_t
+    @gcsafe_ccall libcusparse.cusparseZgemvi(handle::cusparseHandle_t,
+                                             transA::cusparseOperation_t, m::Cint, n::Cint,
+                                             alpha::Ref{cuDoubleComplex},
+                                             A::CuPtr{cuDoubleComplex}, lda::Cint,
+                                             nnz::Cint, xVal::CuPtr{cuDoubleComplex},
+                                             xInd::CuPtr{Cint}, beta::Ref{cuDoubleComplex},
+                                             y::CuPtr{cuDoubleComplex},
+                                             idxBase::cusparseIndexBase_t,
+                                             pBuffer::CuPtr{Cvoid})::cusparseStatus_t
 end
 
 @checked function cusparseZgemvi_bufferSize(handle, transA, m, n, nnz, pBufferSize)
     initialize_context()
-    @ccall libcusparse.cusparseZgemvi_bufferSize(handle::cusparseHandle_t,
-                                                 transA::cusparseOperation_t, m::Cint,
-                                                 n::Cint, nnz::Cint,
-                                                 pBufferSize::Ptr{Cint})::cusparseStatus_t
+    @gcsafe_ccall libcusparse.cusparseZgemvi_bufferSize(handle::cusparseHandle_t,
+                                                        transA::cusparseOperation_t,
+                                                        m::Cint, n::Cint, nnz::Cint,
+                                                        pBufferSize::Ptr{Cint})::cusparseStatus_t
 end
 
 @checked function cusparseSbsrmv(handle, dirA, transA, mb, nb, nnzb, alpha, descrA,
                                  bsrSortedValA, bsrSortedRowPtrA, bsrSortedColIndA,
                                  blockDim, x, beta, y)
     initialize_context()
-    @ccall libcusparse.cusparseSbsrmv(handle::cusparseHandle_t, dirA::cusparseDirection_t,
-                                      transA::cusparseOperation_t, mb::Cint, nb::Cint,
-                                      nnzb::Cint, alpha::Ref{Cfloat},
-                                      descrA::cusparseMatDescr_t,
-                                      bsrSortedValA::CuPtr{Cfloat},
-                                      bsrSortedRowPtrA::CuPtr{Cint},
-                                      bsrSortedColIndA::CuPtr{Cint}, blockDim::Cint,
-                                      x::CuPtr{Cfloat}, beta::Ref{Cfloat},
-                                      y::CuPtr{Cfloat})::cusparseStatus_t
+    @gcsafe_ccall libcusparse.cusparseSbsrmv(handle::cusparseHandle_t,
+                                             dirA::cusparseDirection_t,
+                                             transA::cusparseOperation_t, mb::Cint,
+                                             nb::Cint, nnzb::Cint, alpha::Ref{Cfloat},
+                                             descrA::cusparseMatDescr_t,
+                                             bsrSortedValA::CuPtr{Cfloat},
+                                             bsrSortedRowPtrA::CuPtr{Cint},
+                                             bsrSortedColIndA::CuPtr{Cint}, blockDim::Cint,
+                                             x::CuPtr{Cfloat}, beta::Ref{Cfloat},
+                                             y::CuPtr{Cfloat})::cusparseStatus_t
 end
 
 @checked function cusparseDbsrmv(handle, dirA, transA, mb, nb, nnzb, alpha, descrA,
                                  bsrSortedValA, bsrSortedRowPtrA, bsrSortedColIndA,
                                  blockDim, x, beta, y)
     initialize_context()
-    @ccall libcusparse.cusparseDbsrmv(handle::cusparseHandle_t, dirA::cusparseDirection_t,
-                                      transA::cusparseOperation_t, mb::Cint, nb::Cint,
-                                      nnzb::Cint, alpha::Ref{Cdouble},
-                                      descrA::cusparseMatDescr_t,
-                                      bsrSortedValA::CuPtr{Cdouble},
-                                      bsrSortedRowPtrA::CuPtr{Cint},
-                                      bsrSortedColIndA::CuPtr{Cint}, blockDim::Cint,
-                                      x::CuPtr{Cdouble}, beta::Ref{Cdouble},
-                                      y::CuPtr{Cdouble})::cusparseStatus_t
+    @gcsafe_ccall libcusparse.cusparseDbsrmv(handle::cusparseHandle_t,
+                                             dirA::cusparseDirection_t,
+                                             transA::cusparseOperation_t, mb::Cint,
+                                             nb::Cint, nnzb::Cint, alpha::Ref{Cdouble},
+                                             descrA::cusparseMatDescr_t,
+                                             bsrSortedValA::CuPtr{Cdouble},
+                                             bsrSortedRowPtrA::CuPtr{Cint},
+                                             bsrSortedColIndA::CuPtr{Cint}, blockDim::Cint,
+                                             x::CuPtr{Cdouble}, beta::Ref{Cdouble},
+                                             y::CuPtr{Cdouble})::cusparseStatus_t
 end
 
 @checked function cusparseCbsrmv(handle, dirA, transA, mb, nb, nnzb, alpha, descrA,
                                  bsrSortedValA, bsrSortedRowPtrA, bsrSortedColIndA,
                                  blockDim, x, beta, y)
     initialize_context()
-    @ccall libcusparse.cusparseCbsrmv(handle::cusparseHandle_t, dirA::cusparseDirection_t,
-                                      transA::cusparseOperation_t, mb::Cint, nb::Cint,
-                                      nnzb::Cint, alpha::Ref{cuComplex},
-                                      descrA::cusparseMatDescr_t,
-                                      bsrSortedValA::CuPtr{cuComplex},
-                                      bsrSortedRowPtrA::CuPtr{Cint},
-                                      bsrSortedColIndA::CuPtr{Cint}, blockDim::Cint,
-                                      x::CuPtr{cuComplex}, beta::Ref{cuComplex},
-                                      y::CuPtr{cuComplex})::cusparseStatus_t
+    @gcsafe_ccall libcusparse.cusparseCbsrmv(handle::cusparseHandle_t,
+                                             dirA::cusparseDirection_t,
+                                             transA::cusparseOperation_t, mb::Cint,
+                                             nb::Cint, nnzb::Cint, alpha::Ref{cuComplex},
+                                             descrA::cusparseMatDescr_t,
+                                             bsrSortedValA::CuPtr{cuComplex},
+                                             bsrSortedRowPtrA::CuPtr{Cint},
+                                             bsrSortedColIndA::CuPtr{Cint}, blockDim::Cint,
+                                             x::CuPtr{cuComplex}, beta::Ref{cuComplex},
+                                             y::CuPtr{cuComplex})::cusparseStatus_t
 end
 
 @checked function cusparseZbsrmv(handle, dirA, transA, mb, nb, nnzb, alpha, descrA,
                                  bsrSortedValA, bsrSortedRowPtrA, bsrSortedColIndA,
                                  blockDim, x, beta, y)
     initialize_context()
-    @ccall libcusparse.cusparseZbsrmv(handle::cusparseHandle_t, dirA::cusparseDirection_t,
-                                      transA::cusparseOperation_t, mb::Cint, nb::Cint,
-                                      nnzb::Cint, alpha::Ref{cuDoubleComplex},
-                                      descrA::cusparseMatDescr_t,
-                                      bsrSortedValA::CuPtr{cuDoubleComplex},
-                                      bsrSortedRowPtrA::CuPtr{Cint},
-                                      bsrSortedColIndA::CuPtr{Cint}, blockDim::Cint,
-                                      x::CuPtr{cuDoubleComplex}, beta::Ref{cuDoubleComplex},
-                                      y::CuPtr{cuDoubleComplex})::cusparseStatus_t
+    @gcsafe_ccall libcusparse.cusparseZbsrmv(handle::cusparseHandle_t,
+                                             dirA::cusparseDirection_t,
+                                             transA::cusparseOperation_t, mb::Cint,
+                                             nb::Cint, nnzb::Cint,
+                                             alpha::Ref{cuDoubleComplex},
+                                             descrA::cusparseMatDescr_t,
+                                             bsrSortedValA::CuPtr{cuDoubleComplex},
+                                             bsrSortedRowPtrA::CuPtr{Cint},
+                                             bsrSortedColIndA::CuPtr{Cint}, blockDim::Cint,
+                                             x::CuPtr{cuDoubleComplex},
+                                             beta::Ref{cuDoubleComplex},
+                                             y::CuPtr{cuDoubleComplex})::cusparseStatus_t
 end
 
 @checked function cusparseSbsrxmv(handle, dirA, transA, sizeOfMask, mb, nb, nnzb, alpha,
@@ -514,17 +524,19 @@ end
                                   bsrSortedRowPtrA, bsrSortedEndPtrA, bsrSortedColIndA,
                                   blockDim, x, beta, y)
     initialize_context()
-    @ccall libcusparse.cusparseSbsrxmv(handle::cusparseHandle_t, dirA::cusparseDirection_t,
-                                       transA::cusparseOperation_t, sizeOfMask::Cint,
-                                       mb::Cint, nb::Cint, nnzb::Cint, alpha::Ref{Cfloat},
-                                       descrA::cusparseMatDescr_t,
-                                       bsrSortedValA::CuPtr{Cfloat},
-                                       bsrSortedMaskPtrA::CuPtr{Cint},
-                                       bsrSortedRowPtrA::CuPtr{Cint},
-                                       bsrSortedEndPtrA::CuPtr{Cint},
-                                       bsrSortedColIndA::CuPtr{Cint}, blockDim::Cint,
-                                       x::CuPtr{Cfloat}, beta::Ref{Cfloat},
-                                       y::CuPtr{Cfloat})::cusparseStatus_t
+    @gcsafe_ccall libcusparse.cusparseSbsrxmv(handle::cusparseHandle_t,
+                                              dirA::cusparseDirection_t,
+                                              transA::cusparseOperation_t, sizeOfMask::Cint,
+                                              mb::Cint, nb::Cint, nnzb::Cint,
+                                              alpha::Ref{Cfloat},
+                                              descrA::cusparseMatDescr_t,
+                                              bsrSortedValA::CuPtr{Cfloat},
+                                              bsrSortedMaskPtrA::CuPtr{Cint},
+                                              bsrSortedRowPtrA::CuPtr{Cint},
+                                              bsrSortedEndPtrA::CuPtr{Cint},
+                                              bsrSortedColIndA::CuPtr{Cint}, blockDim::Cint,
+                                              x::CuPtr{Cfloat}, beta::Ref{Cfloat},
+                                              y::CuPtr{Cfloat})::cusparseStatus_t
 end
 
 @checked function cusparseDbsrxmv(handle, dirA, transA, sizeOfMask, mb, nb, nnzb, alpha,
@@ -532,17 +544,19 @@ end
                                   bsrSortedRowPtrA, bsrSortedEndPtrA, bsrSortedColIndA,
                                   blockDim, x, beta, y)
     initialize_context()
-    @ccall libcusparse.cusparseDbsrxmv(handle::cusparseHandle_t, dirA::cusparseDirection_t,
-                                       transA::cusparseOperation_t, sizeOfMask::Cint,
-                                       mb::Cint, nb::Cint, nnzb::Cint, alpha::Ref{Cdouble},
-                                       descrA::cusparseMatDescr_t,
-                                       bsrSortedValA::CuPtr{Cdouble},
-                                       bsrSortedMaskPtrA::CuPtr{Cint},
-                                       bsrSortedRowPtrA::CuPtr{Cint},
-                                       bsrSortedEndPtrA::CuPtr{Cint},
-                                       bsrSortedColIndA::CuPtr{Cint}, blockDim::Cint,
-                                       x::CuPtr{Cdouble}, beta::Ref{Cdouble},
-                                       y::CuPtr{Cdouble})::cusparseStatus_t
+    @gcsafe_ccall libcusparse.cusparseDbsrxmv(handle::cusparseHandle_t,
+                                              dirA::cusparseDirection_t,
+                                              transA::cusparseOperation_t, sizeOfMask::Cint,
+                                              mb::Cint, nb::Cint, nnzb::Cint,
+                                              alpha::Ref{Cdouble},
+                                              descrA::cusparseMatDescr_t,
+                                              bsrSortedValA::CuPtr{Cdouble},
+                                              bsrSortedMaskPtrA::CuPtr{Cint},
+                                              bsrSortedRowPtrA::CuPtr{Cint},
+                                              bsrSortedEndPtrA::CuPtr{Cint},
+                                              bsrSortedColIndA::CuPtr{Cint}, blockDim::Cint,
+                                              x::CuPtr{Cdouble}, beta::Ref{Cdouble},
+                                              y::CuPtr{Cdouble})::cusparseStatus_t
 end
 
 @checked function cusparseCbsrxmv(handle, dirA, transA, sizeOfMask, mb, nb, nnzb, alpha,
@@ -550,17 +564,19 @@ end
                                   bsrSortedRowPtrA, bsrSortedEndPtrA, bsrSortedColIndA,
                                   blockDim, x, beta, y)
     initialize_context()
-    @ccall libcusparse.cusparseCbsrxmv(handle::cusparseHandle_t, dirA::cusparseDirection_t,
-                                       transA::cusparseOperation_t, sizeOfMask::Cint,
-                                       mb::Cint, nb::Cint, nnzb::Cint,
-                                       alpha::Ref{cuComplex}, descrA::cusparseMatDescr_t,
-                                       bsrSortedValA::CuPtr{cuComplex},
-                                       bsrSortedMaskPtrA::CuPtr{Cint},
-                                       bsrSortedRowPtrA::CuPtr{Cint},
-                                       bsrSortedEndPtrA::CuPtr{Cint},
-                                       bsrSortedColIndA::CuPtr{Cint}, blockDim::Cint,
-                                       x::CuPtr{cuComplex}, beta::Ref{cuComplex},
-                                       y::CuPtr{cuComplex})::cusparseStatus_t
+    @gcsafe_ccall libcusparse.cusparseCbsrxmv(handle::cusparseHandle_t,
+                                              dirA::cusparseDirection_t,
+                                              transA::cusparseOperation_t, sizeOfMask::Cint,
+                                              mb::Cint, nb::Cint, nnzb::Cint,
+                                              alpha::Ref{cuComplex},
+                                              descrA::cusparseMatDescr_t,
+                                              bsrSortedValA::CuPtr{cuComplex},
+                                              bsrSortedMaskPtrA::CuPtr{Cint},
+                                              bsrSortedRowPtrA::CuPtr{Cint},
+                                              bsrSortedEndPtrA::CuPtr{Cint},
+                                              bsrSortedColIndA::CuPtr{Cint}, blockDim::Cint,
+                                              x::CuPtr{cuComplex}, beta::Ref{cuComplex},
+                                              y::CuPtr{cuComplex})::cusparseStatus_t
 end
 
 @checked function cusparseZbsrxmv(handle, dirA, transA, sizeOfMask, mb, nb, nnzb, alpha,
@@ -568,26 +584,27 @@ end
                                   bsrSortedRowPtrA, bsrSortedEndPtrA, bsrSortedColIndA,
                                   blockDim, x, beta, y)
     initialize_context()
-    @ccall libcusparse.cusparseZbsrxmv(handle::cusparseHandle_t, dirA::cusparseDirection_t,
-                                       transA::cusparseOperation_t, sizeOfMask::Cint,
-                                       mb::Cint, nb::Cint, nnzb::Cint,
-                                       alpha::Ref{cuDoubleComplex},
-                                       descrA::cusparseMatDescr_t,
-                                       bsrSortedValA::CuPtr{cuDoubleComplex},
-                                       bsrSortedMaskPtrA::CuPtr{Cint},
-                                       bsrSortedRowPtrA::CuPtr{Cint},
-                                       bsrSortedEndPtrA::CuPtr{Cint},
-                                       bsrSortedColIndA::CuPtr{Cint}, blockDim::Cint,
-                                       x::CuPtr{cuDoubleComplex},
-                                       beta::Ref{cuDoubleComplex},
-                                       y::CuPtr{cuDoubleComplex})::cusparseStatus_t
+    @gcsafe_ccall libcusparse.cusparseZbsrxmv(handle::cusparseHandle_t,
+                                              dirA::cusparseDirection_t,
+                                              transA::cusparseOperation_t, sizeOfMask::Cint,
+                                              mb::Cint, nb::Cint, nnzb::Cint,
+                                              alpha::Ref{cuDoubleComplex},
+                                              descrA::cusparseMatDescr_t,
+                                              bsrSortedValA::CuPtr{cuDoubleComplex},
+                                              bsrSortedMaskPtrA::CuPtr{Cint},
+                                              bsrSortedRowPtrA::CuPtr{Cint},
+                                              bsrSortedEndPtrA::CuPtr{Cint},
+                                              bsrSortedColIndA::CuPtr{Cint}, blockDim::Cint,
+                                              x::CuPtr{cuDoubleComplex},
+                                              beta::Ref{cuDoubleComplex},
+                                              y::CuPtr{cuDoubleComplex})::cusparseStatus_t
 end
 
 @checked function cusparseXbsrsv2_zeroPivot(handle, info, position)
     initialize_context()
-    @ccall libcusparse.cusparseXbsrsv2_zeroPivot(handle::cusparseHandle_t,
-                                                 info::bsrsv2Info_t,
-                                                 position::Ptr{Cint})::cusparseStatus_t
+    @gcsafe_ccall libcusparse.cusparseXbsrsv2_zeroPivot(handle::cusparseHandle_t,
+                                                        info::bsrsv2Info_t,
+                                                        position::Ptr{Cint})::cusparseStatus_t
 end
 
 @checked function cusparseSbsrsv2_bufferSize(handle, dirA, transA, mb, nnzb, descrA,
@@ -595,15 +612,16 @@ end
                                              bsrSortedColIndA, blockDim, info,
                                              pBufferSizeInBytes)
     initialize_context()
-    @ccall libcusparse.cusparseSbsrsv2_bufferSize(handle::cusparseHandle_t,
-                                                  dirA::cusparseDirection_t,
-                                                  transA::cusparseOperation_t, mb::Cint,
-                                                  nnzb::Cint, descrA::cusparseMatDescr_t,
-                                                  bsrSortedValA::CuPtr{Cfloat},
-                                                  bsrSortedRowPtrA::CuPtr{Cint},
-                                                  bsrSortedColIndA::CuPtr{Cint},
-                                                  blockDim::Cint, info::bsrsv2Info_t,
-                                                  pBufferSizeInBytes::Ptr{Cint})::cusparseStatus_t
+    @gcsafe_ccall libcusparse.cusparseSbsrsv2_bufferSize(handle::cusparseHandle_t,
+                                                         dirA::cusparseDirection_t,
+                                                         transA::cusparseOperation_t,
+                                                         mb::Cint, nnzb::Cint,
+                                                         descrA::cusparseMatDescr_t,
+                                                         bsrSortedValA::CuPtr{Cfloat},
+                                                         bsrSortedRowPtrA::CuPtr{Cint},
+                                                         bsrSortedColIndA::CuPtr{Cint},
+                                                         blockDim::Cint, info::bsrsv2Info_t,
+                                                         pBufferSizeInBytes::Ptr{Cint})::cusparseStatus_t
 end
 
 @checked function cusparseDbsrsv2_bufferSize(handle, dirA, transA, mb, nnzb, descrA,
@@ -611,15 +629,16 @@ end
                                              bsrSortedColIndA, blockDim, info,
                                              pBufferSizeInBytes)
     initialize_context()
-    @ccall libcusparse.cusparseDbsrsv2_bufferSize(handle::cusparseHandle_t,
-                                                  dirA::cusparseDirection_t,
-                                                  transA::cusparseOperation_t, mb::Cint,
-                                                  nnzb::Cint, descrA::cusparseMatDescr_t,
-                                                  bsrSortedValA::CuPtr{Cdouble},
-                                                  bsrSortedRowPtrA::CuPtr{Cint},
-                                                  bsrSortedColIndA::CuPtr{Cint},
-                                                  blockDim::Cint, info::bsrsv2Info_t,
-                                                  pBufferSizeInBytes::Ptr{Cint})::cusparseStatus_t
+    @gcsafe_ccall libcusparse.cusparseDbsrsv2_bufferSize(handle::cusparseHandle_t,
+                                                         dirA::cusparseDirection_t,
+                                                         transA::cusparseOperation_t,
+                                                         mb::Cint, nnzb::Cint,
+                                                         descrA::cusparseMatDescr_t,
+                                                         bsrSortedValA::CuPtr{Cdouble},
+                                                         bsrSortedRowPtrA::CuPtr{Cint},
+                                                         bsrSortedColIndA::CuPtr{Cint},
+                                                         blockDim::Cint, info::bsrsv2Info_t,
+                                                         pBufferSizeInBytes::Ptr{Cint})::cusparseStatus_t
 end
 
 @checked function cusparseCbsrsv2_bufferSize(handle, dirA, transA, mb, nnzb, descrA,
@@ -627,15 +646,16 @@ end
                                              bsrSortedColIndA, blockDim, info,
                                              pBufferSizeInBytes)
     initialize_context()
-    @ccall libcusparse.cusparseCbsrsv2_bufferSize(handle::cusparseHandle_t,
-                                                  dirA::cusparseDirection_t,
-                                                  transA::cusparseOperation_t, mb::Cint,
-                                                  nnzb::Cint, descrA::cusparseMatDescr_t,
-                                                  bsrSortedValA::CuPtr{cuComplex},
-                                                  bsrSortedRowPtrA::CuPtr{Cint},
-                                                  bsrSortedColIndA::CuPtr{Cint},
-                                                  blockDim::Cint, info::bsrsv2Info_t,
-                                                  pBufferSizeInBytes::Ptr{Cint})::cusparseStatus_t
+    @gcsafe_ccall libcusparse.cusparseCbsrsv2_bufferSize(handle::cusparseHandle_t,
+                                                         dirA::cusparseDirection_t,
+                                                         transA::cusparseOperation_t,
+                                                         mb::Cint, nnzb::Cint,
+                                                         descrA::cusparseMatDescr_t,
+                                                         bsrSortedValA::CuPtr{cuComplex},
+                                                         bsrSortedRowPtrA::CuPtr{Cint},
+                                                         bsrSortedColIndA::CuPtr{Cint},
+                                                         blockDim::Cint, info::bsrsv2Info_t,
+                                                         pBufferSizeInBytes::Ptr{Cint})::cusparseStatus_t
 end
 
 @checked function cusparseZbsrsv2_bufferSize(handle, dirA, transA, mb, nnzb, descrA,
@@ -643,15 +663,16 @@ end
                                              bsrSortedColIndA, blockDim, info,
                                              pBufferSizeInBytes)
     initialize_context()
-    @ccall libcusparse.cusparseZbsrsv2_bufferSize(handle::cusparseHandle_t,
-                                                  dirA::cusparseDirection_t,
-                                                  transA::cusparseOperation_t, mb::Cint,
-                                                  nnzb::Cint, descrA::cusparseMatDescr_t,
-                                                  bsrSortedValA::CuPtr{cuDoubleComplex},
-                                                  bsrSortedRowPtrA::CuPtr{Cint},
-                                                  bsrSortedColIndA::CuPtr{Cint},
-                                                  blockDim::Cint, info::bsrsv2Info_t,
-                                                  pBufferSizeInBytes::Ptr{Cint})::cusparseStatus_t
+    @gcsafe_ccall libcusparse.cusparseZbsrsv2_bufferSize(handle::cusparseHandle_t,
+                                                         dirA::cusparseDirection_t,
+                                                         transA::cusparseOperation_t,
+                                                         mb::Cint, nnzb::Cint,
+                                                         descrA::cusparseMatDescr_t,
+                                                         bsrSortedValA::CuPtr{cuDoubleComplex},
+                                                         bsrSortedRowPtrA::CuPtr{Cint},
+                                                         bsrSortedColIndA::CuPtr{Cint},
+                                                         blockDim::Cint, info::bsrsv2Info_t,
+                                                         pBufferSizeInBytes::Ptr{Cint})::cusparseStatus_t
 end
 
 @checked function cusparseSbsrsv2_bufferSizeExt(handle, dirA, transA, mb, nnzb, descrA,
@@ -659,15 +680,17 @@ end
                                                 bsrSortedColIndA, blockSize, info,
                                                 pBufferSize)
     initialize_context()
-    @ccall libcusparse.cusparseSbsrsv2_bufferSizeExt(handle::cusparseHandle_t,
-                                                     dirA::cusparseDirection_t,
-                                                     transA::cusparseOperation_t, mb::Cint,
-                                                     nnzb::Cint, descrA::cusparseMatDescr_t,
-                                                     bsrSortedValA::CuPtr{Cfloat},
-                                                     bsrSortedRowPtrA::CuPtr{Cint},
-                                                     bsrSortedColIndA::CuPtr{Cint},
-                                                     blockSize::Cint, info::bsrsv2Info_t,
-                                                     pBufferSize::Ptr{Csize_t})::cusparseStatus_t
+    @gcsafe_ccall libcusparse.cusparseSbsrsv2_bufferSizeExt(handle::cusparseHandle_t,
+                                                            dirA::cusparseDirection_t,
+                                                            transA::cusparseOperation_t,
+                                                            mb::Cint, nnzb::Cint,
+                                                            descrA::cusparseMatDescr_t,
+                                                            bsrSortedValA::CuPtr{Cfloat},
+                                                            bsrSortedRowPtrA::CuPtr{Cint},
+                                                            bsrSortedColIndA::CuPtr{Cint},
+                                                            blockSize::Cint,
+                                                            info::bsrsv2Info_t,
+                                                            pBufferSize::Ptr{Csize_t})::cusparseStatus_t
 end
 
 @checked function cusparseDbsrsv2_bufferSizeExt(handle, dirA, transA, mb, nnzb, descrA,
@@ -675,15 +698,17 @@ end
                                                 bsrSortedColIndA, blockSize, info,
                                                 pBufferSize)
     initialize_context()
-    @ccall libcusparse.cusparseDbsrsv2_bufferSizeExt(handle::cusparseHandle_t,
-                                                     dirA::cusparseDirection_t,
-                                                     transA::cusparseOperation_t, mb::Cint,
-                                                     nnzb::Cint, descrA::cusparseMatDescr_t,
-                                                     bsrSortedValA::CuPtr{Cdouble},
-                                                     bsrSortedRowPtrA::CuPtr{Cint},
-                                                     bsrSortedColIndA::CuPtr{Cint},
-                                                     blockSize::Cint, info::bsrsv2Info_t,
-                                                     pBufferSize::Ptr{Csize_t})::cusparseStatus_t
+    @gcsafe_ccall libcusparse.cusparseDbsrsv2_bufferSizeExt(handle::cusparseHandle_t,
+                                                            dirA::cusparseDirection_t,
+                                                            transA::cusparseOperation_t,
+                                                            mb::Cint, nnzb::Cint,
+                                                            descrA::cusparseMatDescr_t,
+                                                            bsrSortedValA::CuPtr{Cdouble},
+                                                            bsrSortedRowPtrA::CuPtr{Cint},
+                                                            bsrSortedColIndA::CuPtr{Cint},
+                                                            blockSize::Cint,
+                                                            info::bsrsv2Info_t,
+                                                            pBufferSize::Ptr{Csize_t})::cusparseStatus_t
 end
 
 @checked function cusparseCbsrsv2_bufferSizeExt(handle, dirA, transA, mb, nnzb, descrA,
@@ -691,15 +716,17 @@ end
                                                 bsrSortedColIndA, blockSize, info,
                                                 pBufferSize)
     initialize_context()
-    @ccall libcusparse.cusparseCbsrsv2_bufferSizeExt(handle::cusparseHandle_t,
-                                                     dirA::cusparseDirection_t,
-                                                     transA::cusparseOperation_t, mb::Cint,
-                                                     nnzb::Cint, descrA::cusparseMatDescr_t,
-                                                     bsrSortedValA::CuPtr{cuComplex},
-                                                     bsrSortedRowPtrA::CuPtr{Cint},
-                                                     bsrSortedColIndA::CuPtr{Cint},
-                                                     blockSize::Cint, info::bsrsv2Info_t,
-                                                     pBufferSize::Ptr{Csize_t})::cusparseStatus_t
+    @gcsafe_ccall libcusparse.cusparseCbsrsv2_bufferSizeExt(handle::cusparseHandle_t,
+                                                            dirA::cusparseDirection_t,
+                                                            transA::cusparseOperation_t,
+                                                            mb::Cint, nnzb::Cint,
+                                                            descrA::cusparseMatDescr_t,
+                                                            bsrSortedValA::CuPtr{cuComplex},
+                                                            bsrSortedRowPtrA::CuPtr{Cint},
+                                                            bsrSortedColIndA::CuPtr{Cint},
+                                                            blockSize::Cint,
+                                                            info::bsrsv2Info_t,
+                                                            pBufferSize::Ptr{Csize_t})::cusparseStatus_t
 end
 
 @checked function cusparseZbsrsv2_bufferSizeExt(handle, dirA, transA, mb, nnzb, descrA,
@@ -707,15 +734,17 @@ end
                                                 bsrSortedColIndA, blockSize, info,
                                                 pBufferSize)
     initialize_context()
-    @ccall libcusparse.cusparseZbsrsv2_bufferSizeExt(handle::cusparseHandle_t,
-                                                     dirA::cusparseDirection_t,
-                                                     transA::cusparseOperation_t, mb::Cint,
-                                                     nnzb::Cint, descrA::cusparseMatDescr_t,
-                                                     bsrSortedValA::CuPtr{cuDoubleComplex},
-                                                     bsrSortedRowPtrA::CuPtr{Cint},
-                                                     bsrSortedColIndA::CuPtr{Cint},
-                                                     blockSize::Cint, info::bsrsv2Info_t,
-                                                     pBufferSize::Ptr{Csize_t})::cusparseStatus_t
+    @gcsafe_ccall libcusparse.cusparseZbsrsv2_bufferSizeExt(handle::cusparseHandle_t,
+                                                            dirA::cusparseDirection_t,
+                                                            transA::cusparseOperation_t,
+                                                            mb::Cint, nnzb::Cint,
+                                                            descrA::cusparseMatDescr_t,
+                                                            bsrSortedValA::CuPtr{cuDoubleComplex},
+                                                            bsrSortedRowPtrA::CuPtr{Cint},
+                                                            bsrSortedColIndA::CuPtr{Cint},
+                                                            blockSize::Cint,
+                                                            info::bsrsv2Info_t,
+                                                            pBufferSize::Ptr{Csize_t})::cusparseStatus_t
 end
 
 @checked function cusparseSbsrsv2_analysis(handle, dirA, transA, mb, nnzb, descrA,
@@ -723,16 +752,17 @@ end
                                            bsrSortedColIndA, blockDim, info, policy,
                                            pBuffer)
     initialize_context()
-    @ccall libcusparse.cusparseSbsrsv2_analysis(handle::cusparseHandle_t,
-                                                dirA::cusparseDirection_t,
-                                                transA::cusparseOperation_t, mb::Cint,
-                                                nnzb::Cint, descrA::cusparseMatDescr_t,
-                                                bsrSortedValA::CuPtr{Cfloat},
-                                                bsrSortedRowPtrA::CuPtr{Cint},
-                                                bsrSortedColIndA::CuPtr{Cint},
-                                                blockDim::Cint, info::bsrsv2Info_t,
-                                                policy::cusparseSolvePolicy_t,
-                                                pBuffer::CuPtr{Cvoid})::cusparseStatus_t
+    @gcsafe_ccall libcusparse.cusparseSbsrsv2_analysis(handle::cusparseHandle_t,
+                                                       dirA::cusparseDirection_t,
+                                                       transA::cusparseOperation_t,
+                                                       mb::Cint, nnzb::Cint,
+                                                       descrA::cusparseMatDescr_t,
+                                                       bsrSortedValA::CuPtr{Cfloat},
+                                                       bsrSortedRowPtrA::CuPtr{Cint},
+                                                       bsrSortedColIndA::CuPtr{Cint},
+                                                       blockDim::Cint, info::bsrsv2Info_t,
+                                                       policy::cusparseSolvePolicy_t,
+                                                       pBuffer::CuPtr{Cvoid})::cusparseStatus_t
 end
 
 @checked function cusparseDbsrsv2_analysis(handle, dirA, transA, mb, nnzb, descrA,
@@ -740,16 +770,17 @@ end
                                            bsrSortedColIndA, blockDim, info, policy,
                                            pBuffer)
     initialize_context()
-    @ccall libcusparse.cusparseDbsrsv2_analysis(handle::cusparseHandle_t,
-                                                dirA::cusparseDirection_t,
-                                                transA::cusparseOperation_t, mb::Cint,
-                                                nnzb::Cint, descrA::cusparseMatDescr_t,
-                                                bsrSortedValA::CuPtr{Cdouble},
-                                                bsrSortedRowPtrA::CuPtr{Cint},
-                                                bsrSortedColIndA::CuPtr{Cint},
-                                                blockDim::Cint, info::bsrsv2Info_t,
-                                                policy::cusparseSolvePolicy_t,
-                                                pBuffer::CuPtr{Cvoid})::cusparseStatus_t
+    @gcsafe_ccall libcusparse.cusparseDbsrsv2_analysis(handle::cusparseHandle_t,
+                                                       dirA::cusparseDirection_t,
+                                                       transA::cusparseOperation_t,
+                                                       mb::Cint, nnzb::Cint,
+                                                       descrA::cusparseMatDescr_t,
+                                                       bsrSortedValA::CuPtr{Cdouble},
+                                                       bsrSortedRowPtrA::CuPtr{Cint},
+                                                       bsrSortedColIndA::CuPtr{Cint},
+                                                       blockDim::Cint, info::bsrsv2Info_t,
+                                                       policy::cusparseSolvePolicy_t,
+                                                       pBuffer::CuPtr{Cvoid})::cusparseStatus_t
 end
 
 @checked function cusparseCbsrsv2_analysis(handle, dirA, transA, mb, nnzb, descrA,
@@ -757,16 +788,17 @@ end
                                            bsrSortedColIndA, blockDim, info, policy,
                                            pBuffer)
     initialize_context()
-    @ccall libcusparse.cusparseCbsrsv2_analysis(handle::cusparseHandle_t,
-                                                dirA::cusparseDirection_t,
-                                                transA::cusparseOperation_t, mb::Cint,
-                                                nnzb::Cint, descrA::cusparseMatDescr_t,
-                                                bsrSortedValA::CuPtr{cuComplex},
-                                                bsrSortedRowPtrA::CuPtr{Cint},
-                                                bsrSortedColIndA::CuPtr{Cint},
-                                                blockDim::Cint, info::bsrsv2Info_t,
-                                                policy::cusparseSolvePolicy_t,
-                                                pBuffer::CuPtr{Cvoid})::cusparseStatus_t
+    @gcsafe_ccall libcusparse.cusparseCbsrsv2_analysis(handle::cusparseHandle_t,
+                                                       dirA::cusparseDirection_t,
+                                                       transA::cusparseOperation_t,
+                                                       mb::Cint, nnzb::Cint,
+                                                       descrA::cusparseMatDescr_t,
+                                                       bsrSortedValA::CuPtr{cuComplex},
+                                                       bsrSortedRowPtrA::CuPtr{Cint},
+                                                       bsrSortedColIndA::CuPtr{Cint},
+                                                       blockDim::Cint, info::bsrsv2Info_t,
+                                                       policy::cusparseSolvePolicy_t,
+                                                       pBuffer::CuPtr{Cvoid})::cusparseStatus_t
 end
 
 @checked function cusparseZbsrsv2_analysis(handle, dirA, transA, mb, nnzb, descrA,
@@ -774,160 +806,171 @@ end
                                            bsrSortedColIndA, blockDim, info, policy,
                                            pBuffer)
     initialize_context()
-    @ccall libcusparse.cusparseZbsrsv2_analysis(handle::cusparseHandle_t,
-                                                dirA::cusparseDirection_t,
-                                                transA::cusparseOperation_t, mb::Cint,
-                                                nnzb::Cint, descrA::cusparseMatDescr_t,
-                                                bsrSortedValA::CuPtr{cuDoubleComplex},
-                                                bsrSortedRowPtrA::CuPtr{Cint},
-                                                bsrSortedColIndA::CuPtr{Cint},
-                                                blockDim::Cint, info::bsrsv2Info_t,
-                                                policy::cusparseSolvePolicy_t,
-                                                pBuffer::CuPtr{Cvoid})::cusparseStatus_t
+    @gcsafe_ccall libcusparse.cusparseZbsrsv2_analysis(handle::cusparseHandle_t,
+                                                       dirA::cusparseDirection_t,
+                                                       transA::cusparseOperation_t,
+                                                       mb::Cint, nnzb::Cint,
+                                                       descrA::cusparseMatDescr_t,
+                                                       bsrSortedValA::CuPtr{cuDoubleComplex},
+                                                       bsrSortedRowPtrA::CuPtr{Cint},
+                                                       bsrSortedColIndA::CuPtr{Cint},
+                                                       blockDim::Cint, info::bsrsv2Info_t,
+                                                       policy::cusparseSolvePolicy_t,
+                                                       pBuffer::CuPtr{Cvoid})::cusparseStatus_t
 end
 
 @checked function cusparseSbsrsv2_solve(handle, dirA, transA, mb, nnzb, alpha, descrA,
                                         bsrSortedValA, bsrSortedRowPtrA, bsrSortedColIndA,
                                         blockDim, info, f, x, policy, pBuffer)
     initialize_context()
-    @ccall libcusparse.cusparseSbsrsv2_solve(handle::cusparseHandle_t,
-                                             dirA::cusparseDirection_t,
-                                             transA::cusparseOperation_t, mb::Cint,
-                                             nnzb::Cint, alpha::Ref{Cfloat},
-                                             descrA::cusparseMatDescr_t,
-                                             bsrSortedValA::CuPtr{Cfloat},
-                                             bsrSortedRowPtrA::CuPtr{Cint},
-                                             bsrSortedColIndA::CuPtr{Cint}, blockDim::Cint,
-                                             info::bsrsv2Info_t, f::CuPtr{Cfloat},
-                                             x::CuPtr{Cfloat},
-                                             policy::cusparseSolvePolicy_t,
-                                             pBuffer::CuPtr{Cvoid})::cusparseStatus_t
+    @gcsafe_ccall libcusparse.cusparseSbsrsv2_solve(handle::cusparseHandle_t,
+                                                    dirA::cusparseDirection_t,
+                                                    transA::cusparseOperation_t, mb::Cint,
+                                                    nnzb::Cint, alpha::Ref{Cfloat},
+                                                    descrA::cusparseMatDescr_t,
+                                                    bsrSortedValA::CuPtr{Cfloat},
+                                                    bsrSortedRowPtrA::CuPtr{Cint},
+                                                    bsrSortedColIndA::CuPtr{Cint},
+                                                    blockDim::Cint, info::bsrsv2Info_t,
+                                                    f::CuPtr{Cfloat}, x::CuPtr{Cfloat},
+                                                    policy::cusparseSolvePolicy_t,
+                                                    pBuffer::CuPtr{Cvoid})::cusparseStatus_t
 end
 
 @checked function cusparseDbsrsv2_solve(handle, dirA, transA, mb, nnzb, alpha, descrA,
                                         bsrSortedValA, bsrSortedRowPtrA, bsrSortedColIndA,
                                         blockDim, info, f, x, policy, pBuffer)
     initialize_context()
-    @ccall libcusparse.cusparseDbsrsv2_solve(handle::cusparseHandle_t,
-                                             dirA::cusparseDirection_t,
-                                             transA::cusparseOperation_t, mb::Cint,
-                                             nnzb::Cint, alpha::Ref{Cdouble},
-                                             descrA::cusparseMatDescr_t,
-                                             bsrSortedValA::CuPtr{Cdouble},
-                                             bsrSortedRowPtrA::CuPtr{Cint},
-                                             bsrSortedColIndA::CuPtr{Cint}, blockDim::Cint,
-                                             info::bsrsv2Info_t, f::CuPtr{Cdouble},
-                                             x::CuPtr{Cdouble},
-                                             policy::cusparseSolvePolicy_t,
-                                             pBuffer::CuPtr{Cvoid})::cusparseStatus_t
+    @gcsafe_ccall libcusparse.cusparseDbsrsv2_solve(handle::cusparseHandle_t,
+                                                    dirA::cusparseDirection_t,
+                                                    transA::cusparseOperation_t, mb::Cint,
+                                                    nnzb::Cint, alpha::Ref{Cdouble},
+                                                    descrA::cusparseMatDescr_t,
+                                                    bsrSortedValA::CuPtr{Cdouble},
+                                                    bsrSortedRowPtrA::CuPtr{Cint},
+                                                    bsrSortedColIndA::CuPtr{Cint},
+                                                    blockDim::Cint, info::bsrsv2Info_t,
+                                                    f::CuPtr{Cdouble}, x::CuPtr{Cdouble},
+                                                    policy::cusparseSolvePolicy_t,
+                                                    pBuffer::CuPtr{Cvoid})::cusparseStatus_t
 end
 
 @checked function cusparseCbsrsv2_solve(handle, dirA, transA, mb, nnzb, alpha, descrA,
                                         bsrSortedValA, bsrSortedRowPtrA, bsrSortedColIndA,
                                         blockDim, info, f, x, policy, pBuffer)
     initialize_context()
-    @ccall libcusparse.cusparseCbsrsv2_solve(handle::cusparseHandle_t,
-                                             dirA::cusparseDirection_t,
-                                             transA::cusparseOperation_t, mb::Cint,
-                                             nnzb::Cint, alpha::Ref{cuComplex},
-                                             descrA::cusparseMatDescr_t,
-                                             bsrSortedValA::CuPtr{cuComplex},
-                                             bsrSortedRowPtrA::CuPtr{Cint},
-                                             bsrSortedColIndA::CuPtr{Cint}, blockDim::Cint,
-                                             info::bsrsv2Info_t, f::CuPtr{cuComplex},
-                                             x::CuPtr{cuComplex},
-                                             policy::cusparseSolvePolicy_t,
-                                             pBuffer::CuPtr{Cvoid})::cusparseStatus_t
+    @gcsafe_ccall libcusparse.cusparseCbsrsv2_solve(handle::cusparseHandle_t,
+                                                    dirA::cusparseDirection_t,
+                                                    transA::cusparseOperation_t, mb::Cint,
+                                                    nnzb::Cint, alpha::Ref{cuComplex},
+                                                    descrA::cusparseMatDescr_t,
+                                                    bsrSortedValA::CuPtr{cuComplex},
+                                                    bsrSortedRowPtrA::CuPtr{Cint},
+                                                    bsrSortedColIndA::CuPtr{Cint},
+                                                    blockDim::Cint, info::bsrsv2Info_t,
+                                                    f::CuPtr{cuComplex},
+                                                    x::CuPtr{cuComplex},
+                                                    policy::cusparseSolvePolicy_t,
+                                                    pBuffer::CuPtr{Cvoid})::cusparseStatus_t
 end
 
 @checked function cusparseZbsrsv2_solve(handle, dirA, transA, mb, nnzb, alpha, descrA,
                                         bsrSortedValA, bsrSortedRowPtrA, bsrSortedColIndA,
                                         blockDim, info, f, x, policy, pBuffer)
     initialize_context()
-    @ccall libcusparse.cusparseZbsrsv2_solve(handle::cusparseHandle_t,
-                                             dirA::cusparseDirection_t,
-                                             transA::cusparseOperation_t, mb::Cint,
-                                             nnzb::Cint, alpha::Ref{cuDoubleComplex},
-                                             descrA::cusparseMatDescr_t,
-                                             bsrSortedValA::CuPtr{cuDoubleComplex},
-                                             bsrSortedRowPtrA::CuPtr{Cint},
-                                             bsrSortedColIndA::CuPtr{Cint}, blockDim::Cint,
-                                             info::bsrsv2Info_t, f::CuPtr{cuDoubleComplex},
-                                             x::CuPtr{cuDoubleComplex},
-                                             policy::cusparseSolvePolicy_t,
-                                             pBuffer::CuPtr{Cvoid})::cusparseStatus_t
+    @gcsafe_ccall libcusparse.cusparseZbsrsv2_solve(handle::cusparseHandle_t,
+                                                    dirA::cusparseDirection_t,
+                                                    transA::cusparseOperation_t, mb::Cint,
+                                                    nnzb::Cint, alpha::Ref{cuDoubleComplex},
+                                                    descrA::cusparseMatDescr_t,
+                                                    bsrSortedValA::CuPtr{cuDoubleComplex},
+                                                    bsrSortedRowPtrA::CuPtr{Cint},
+                                                    bsrSortedColIndA::CuPtr{Cint},
+                                                    blockDim::Cint, info::bsrsv2Info_t,
+                                                    f::CuPtr{cuDoubleComplex},
+                                                    x::CuPtr{cuDoubleComplex},
+                                                    policy::cusparseSolvePolicy_t,
+                                                    pBuffer::CuPtr{Cvoid})::cusparseStatus_t
 end
 
 @checked function cusparseSbsrmm(handle, dirA, transA, transB, mb, n, kb, nnzb, alpha,
                                  descrA, bsrSortedValA, bsrSortedRowPtrA, bsrSortedColIndA,
                                  blockSize, B, ldb, beta, C, ldc)
     initialize_context()
-    @ccall libcusparse.cusparseSbsrmm(handle::cusparseHandle_t, dirA::cusparseDirection_t,
-                                      transA::cusparseOperation_t,
-                                      transB::cusparseOperation_t, mb::Cint, n::Cint,
-                                      kb::Cint, nnzb::Cint, alpha::Ref{Cfloat},
-                                      descrA::cusparseMatDescr_t,
-                                      bsrSortedValA::CuPtr{Cfloat},
-                                      bsrSortedRowPtrA::CuPtr{Cint},
-                                      bsrSortedColIndA::CuPtr{Cint}, blockSize::Cint,
-                                      B::CuPtr{Cfloat}, ldb::Cint, beta::Ref{Cfloat},
-                                      C::CuPtr{Cfloat}, ldc::Cint)::cusparseStatus_t
+    @gcsafe_ccall libcusparse.cusparseSbsrmm(handle::cusparseHandle_t,
+                                             dirA::cusparseDirection_t,
+                                             transA::cusparseOperation_t,
+                                             transB::cusparseOperation_t, mb::Cint, n::Cint,
+                                             kb::Cint, nnzb::Cint, alpha::Ref{Cfloat},
+                                             descrA::cusparseMatDescr_t,
+                                             bsrSortedValA::CuPtr{Cfloat},
+                                             bsrSortedRowPtrA::CuPtr{Cint},
+                                             bsrSortedColIndA::CuPtr{Cint}, blockSize::Cint,
+                                             B::CuPtr{Cfloat}, ldb::Cint, beta::Ref{Cfloat},
+                                             C::CuPtr{Cfloat}, ldc::Cint)::cusparseStatus_t
 end
 
 @checked function cusparseDbsrmm(handle, dirA, transA, transB, mb, n, kb, nnzb, alpha,
                                  descrA, bsrSortedValA, bsrSortedRowPtrA, bsrSortedColIndA,
                                  blockSize, B, ldb, beta, C, ldc)
     initialize_context()
-    @ccall libcusparse.cusparseDbsrmm(handle::cusparseHandle_t, dirA::cusparseDirection_t,
-                                      transA::cusparseOperation_t,
-                                      transB::cusparseOperation_t, mb::Cint, n::Cint,
-                                      kb::Cint, nnzb::Cint, alpha::Ref{Cdouble},
-                                      descrA::cusparseMatDescr_t,
-                                      bsrSortedValA::CuPtr{Cdouble},
-                                      bsrSortedRowPtrA::CuPtr{Cint},
-                                      bsrSortedColIndA::CuPtr{Cint}, blockSize::Cint,
-                                      B::CuPtr{Cdouble}, ldb::Cint, beta::Ref{Cdouble},
-                                      C::CuPtr{Cdouble}, ldc::Cint)::cusparseStatus_t
+    @gcsafe_ccall libcusparse.cusparseDbsrmm(handle::cusparseHandle_t,
+                                             dirA::cusparseDirection_t,
+                                             transA::cusparseOperation_t,
+                                             transB::cusparseOperation_t, mb::Cint, n::Cint,
+                                             kb::Cint, nnzb::Cint, alpha::Ref{Cdouble},
+                                             descrA::cusparseMatDescr_t,
+                                             bsrSortedValA::CuPtr{Cdouble},
+                                             bsrSortedRowPtrA::CuPtr{Cint},
+                                             bsrSortedColIndA::CuPtr{Cint}, blockSize::Cint,
+                                             B::CuPtr{Cdouble}, ldb::Cint,
+                                             beta::Ref{Cdouble}, C::CuPtr{Cdouble},
+                                             ldc::Cint)::cusparseStatus_t
 end
 
 @checked function cusparseCbsrmm(handle, dirA, transA, transB, mb, n, kb, nnzb, alpha,
                                  descrA, bsrSortedValA, bsrSortedRowPtrA, bsrSortedColIndA,
                                  blockSize, B, ldb, beta, C, ldc)
     initialize_context()
-    @ccall libcusparse.cusparseCbsrmm(handle::cusparseHandle_t, dirA::cusparseDirection_t,
-                                      transA::cusparseOperation_t,
-                                      transB::cusparseOperation_t, mb::Cint, n::Cint,
-                                      kb::Cint, nnzb::Cint, alpha::Ref{cuComplex},
-                                      descrA::cusparseMatDescr_t,
-                                      bsrSortedValA::CuPtr{cuComplex},
-                                      bsrSortedRowPtrA::CuPtr{Cint},
-                                      bsrSortedColIndA::CuPtr{Cint}, blockSize::Cint,
-                                      B::CuPtr{cuComplex}, ldb::Cint, beta::Ref{cuComplex},
-                                      C::CuPtr{cuComplex}, ldc::Cint)::cusparseStatus_t
+    @gcsafe_ccall libcusparse.cusparseCbsrmm(handle::cusparseHandle_t,
+                                             dirA::cusparseDirection_t,
+                                             transA::cusparseOperation_t,
+                                             transB::cusparseOperation_t, mb::Cint, n::Cint,
+                                             kb::Cint, nnzb::Cint, alpha::Ref{cuComplex},
+                                             descrA::cusparseMatDescr_t,
+                                             bsrSortedValA::CuPtr{cuComplex},
+                                             bsrSortedRowPtrA::CuPtr{Cint},
+                                             bsrSortedColIndA::CuPtr{Cint}, blockSize::Cint,
+                                             B::CuPtr{cuComplex}, ldb::Cint,
+                                             beta::Ref{cuComplex}, C::CuPtr{cuComplex},
+                                             ldc::Cint)::cusparseStatus_t
 end
 
 @checked function cusparseZbsrmm(handle, dirA, transA, transB, mb, n, kb, nnzb, alpha,
                                  descrA, bsrSortedValA, bsrSortedRowPtrA, bsrSortedColIndA,
                                  blockSize, B, ldb, beta, C, ldc)
     initialize_context()
-    @ccall libcusparse.cusparseZbsrmm(handle::cusparseHandle_t, dirA::cusparseDirection_t,
-                                      transA::cusparseOperation_t,
-                                      transB::cusparseOperation_t, mb::Cint, n::Cint,
-                                      kb::Cint, nnzb::Cint, alpha::Ref{cuDoubleComplex},
-                                      descrA::cusparseMatDescr_t,
-                                      bsrSortedValA::CuPtr{cuDoubleComplex},
-                                      bsrSortedRowPtrA::CuPtr{Cint},
-                                      bsrSortedColIndA::CuPtr{Cint}, blockSize::Cint,
-                                      B::CuPtr{cuDoubleComplex}, ldb::Cint,
-                                      beta::Ref{cuDoubleComplex}, C::CuPtr{cuDoubleComplex},
-                                      ldc::Cint)::cusparseStatus_t
+    @gcsafe_ccall libcusparse.cusparseZbsrmm(handle::cusparseHandle_t,
+                                             dirA::cusparseDirection_t,
+                                             transA::cusparseOperation_t,
+                                             transB::cusparseOperation_t, mb::Cint, n::Cint,
+                                             kb::Cint, nnzb::Cint,
+                                             alpha::Ref{cuDoubleComplex},
+                                             descrA::cusparseMatDescr_t,
+                                             bsrSortedValA::CuPtr{cuDoubleComplex},
+                                             bsrSortedRowPtrA::CuPtr{Cint},
+                                             bsrSortedColIndA::CuPtr{Cint}, blockSize::Cint,
+                                             B::CuPtr{cuDoubleComplex}, ldb::Cint,
+                                             beta::Ref{cuDoubleComplex},
+                                             C::CuPtr{cuDoubleComplex},
+                                             ldc::Cint)::cusparseStatus_t
 end
 
 @checked function cusparseXbsrsm2_zeroPivot(handle, info, position)
     initialize_context()
-    @ccall libcusparse.cusparseXbsrsm2_zeroPivot(handle::cusparseHandle_t,
-                                                 info::bsrsm2Info_t,
-                                                 position::Ptr{Cint})::cusparseStatus_t
+    @gcsafe_ccall libcusparse.cusparseXbsrsm2_zeroPivot(handle::cusparseHandle_t,
+                                                        info::bsrsm2Info_t,
+                                                        position::Ptr{Cint})::cusparseStatus_t
 end
 
 @checked function cusparseSbsrsm2_bufferSize(handle, dirA, transA, transXY, mb, n, nnzb,
@@ -935,17 +978,18 @@ end
                                              bsrSortedColInd, blockSize, info,
                                              pBufferSizeInBytes)
     initialize_context()
-    @ccall libcusparse.cusparseSbsrsm2_bufferSize(handle::cusparseHandle_t,
-                                                  dirA::cusparseDirection_t,
-                                                  transA::cusparseOperation_t,
-                                                  transXY::cusparseOperation_t, mb::Cint,
-                                                  n::Cint, nnzb::Cint,
-                                                  descrA::cusparseMatDescr_t,
-                                                  bsrSortedVal::CuPtr{Cfloat},
-                                                  bsrSortedRowPtr::CuPtr{Cint},
-                                                  bsrSortedColInd::CuPtr{Cint},
-                                                  blockSize::Cint, info::bsrsm2Info_t,
-                                                  pBufferSizeInBytes::Ptr{Cint})::cusparseStatus_t
+    @gcsafe_ccall libcusparse.cusparseSbsrsm2_bufferSize(handle::cusparseHandle_t,
+                                                         dirA::cusparseDirection_t,
+                                                         transA::cusparseOperation_t,
+                                                         transXY::cusparseOperation_t,
+                                                         mb::Cint, n::Cint, nnzb::Cint,
+                                                         descrA::cusparseMatDescr_t,
+                                                         bsrSortedVal::CuPtr{Cfloat},
+                                                         bsrSortedRowPtr::CuPtr{Cint},
+                                                         bsrSortedColInd::CuPtr{Cint},
+                                                         blockSize::Cint,
+                                                         info::bsrsm2Info_t,
+                                                         pBufferSizeInBytes::Ptr{Cint})::cusparseStatus_t
 end
 
 @checked function cusparseDbsrsm2_bufferSize(handle, dirA, transA, transXY, mb, n, nnzb,
@@ -953,17 +997,18 @@ end
                                              bsrSortedColInd, blockSize, info,
                                              pBufferSizeInBytes)
     initialize_context()
-    @ccall libcusparse.cusparseDbsrsm2_bufferSize(handle::cusparseHandle_t,
-                                                  dirA::cusparseDirection_t,
-                                                  transA::cusparseOperation_t,
-                                                  transXY::cusparseOperation_t, mb::Cint,
-                                                  n::Cint, nnzb::Cint,
-                                                  descrA::cusparseMatDescr_t,
-                                                  bsrSortedVal::CuPtr{Cdouble},
-                                                  bsrSortedRowPtr::CuPtr{Cint},
-                                                  bsrSortedColInd::CuPtr{Cint},
-                                                  blockSize::Cint, info::bsrsm2Info_t,
-                                                  pBufferSizeInBytes::Ptr{Cint})::cusparseStatus_t
+    @gcsafe_ccall libcusparse.cusparseDbsrsm2_bufferSize(handle::cusparseHandle_t,
+                                                         dirA::cusparseDirection_t,
+                                                         transA::cusparseOperation_t,
+                                                         transXY::cusparseOperation_t,
+                                                         mb::Cint, n::Cint, nnzb::Cint,
+                                                         descrA::cusparseMatDescr_t,
+                                                         bsrSortedVal::CuPtr{Cdouble},
+                                                         bsrSortedRowPtr::CuPtr{Cint},
+                                                         bsrSortedColInd::CuPtr{Cint},
+                                                         blockSize::Cint,
+                                                         info::bsrsm2Info_t,
+                                                         pBufferSizeInBytes::Ptr{Cint})::cusparseStatus_t
 end
 
 @checked function cusparseCbsrsm2_bufferSize(handle, dirA, transA, transXY, mb, n, nnzb,
@@ -971,17 +1016,18 @@ end
                                              bsrSortedColInd, blockSize, info,
                                              pBufferSizeInBytes)
     initialize_context()
-    @ccall libcusparse.cusparseCbsrsm2_bufferSize(handle::cusparseHandle_t,
-                                                  dirA::cusparseDirection_t,
-                                                  transA::cusparseOperation_t,
-                                                  transXY::cusparseOperation_t, mb::Cint,
-                                                  n::Cint, nnzb::Cint,
-                                                  descrA::cusparseMatDescr_t,
-                                                  bsrSortedVal::CuPtr{cuComplex},
-                                                  bsrSortedRowPtr::CuPtr{Cint},
-                                                  bsrSortedColInd::CuPtr{Cint},
-                                                  blockSize::Cint, info::bsrsm2Info_t,
-                                                  pBufferSizeInBytes::Ptr{Cint})::cusparseStatus_t
+    @gcsafe_ccall libcusparse.cusparseCbsrsm2_bufferSize(handle::cusparseHandle_t,
+                                                         dirA::cusparseDirection_t,
+                                                         transA::cusparseOperation_t,
+                                                         transXY::cusparseOperation_t,
+                                                         mb::Cint, n::Cint, nnzb::Cint,
+                                                         descrA::cusparseMatDescr_t,
+                                                         bsrSortedVal::CuPtr{cuComplex},
+                                                         bsrSortedRowPtr::CuPtr{Cint},
+                                                         bsrSortedColInd::CuPtr{Cint},
+                                                         blockSize::Cint,
+                                                         info::bsrsm2Info_t,
+                                                         pBufferSizeInBytes::Ptr{Cint})::cusparseStatus_t
 end
 
 @checked function cusparseZbsrsm2_bufferSize(handle, dirA, transA, transXY, mb, n, nnzb,
@@ -989,17 +1035,18 @@ end
                                              bsrSortedColInd, blockSize, info,
                                              pBufferSizeInBytes)
     initialize_context()
-    @ccall libcusparse.cusparseZbsrsm2_bufferSize(handle::cusparseHandle_t,
-                                                  dirA::cusparseDirection_t,
-                                                  transA::cusparseOperation_t,
-                                                  transXY::cusparseOperation_t, mb::Cint,
-                                                  n::Cint, nnzb::Cint,
-                                                  descrA::cusparseMatDescr_t,
-                                                  bsrSortedVal::CuPtr{cuDoubleComplex},
-                                                  bsrSortedRowPtr::CuPtr{Cint},
-                                                  bsrSortedColInd::CuPtr{Cint},
-                                                  blockSize::Cint, info::bsrsm2Info_t,
-                                                  pBufferSizeInBytes::Ptr{Cint})::cusparseStatus_t
+    @gcsafe_ccall libcusparse.cusparseZbsrsm2_bufferSize(handle::cusparseHandle_t,
+                                                         dirA::cusparseDirection_t,
+                                                         transA::cusparseOperation_t,
+                                                         transXY::cusparseOperation_t,
+                                                         mb::Cint, n::Cint, nnzb::Cint,
+                                                         descrA::cusparseMatDescr_t,
+                                                         bsrSortedVal::CuPtr{cuDoubleComplex},
+                                                         bsrSortedRowPtr::CuPtr{Cint},
+                                                         bsrSortedColInd::CuPtr{Cint},
+                                                         blockSize::Cint,
+                                                         info::bsrsm2Info_t,
+                                                         pBufferSizeInBytes::Ptr{Cint})::cusparseStatus_t
 end
 
 @checked function cusparseSbsrsm2_bufferSizeExt(handle, dirA, transA, transB, mb, n, nnzb,
@@ -1007,17 +1054,18 @@ end
                                                 bsrSortedColInd, blockSize, info,
                                                 pBufferSize)
     initialize_context()
-    @ccall libcusparse.cusparseSbsrsm2_bufferSizeExt(handle::cusparseHandle_t,
-                                                     dirA::cusparseDirection_t,
-                                                     transA::cusparseOperation_t,
-                                                     transB::cusparseOperation_t, mb::Cint,
-                                                     n::Cint, nnzb::Cint,
-                                                     descrA::cusparseMatDescr_t,
-                                                     bsrSortedVal::CuPtr{Cfloat},
-                                                     bsrSortedRowPtr::CuPtr{Cint},
-                                                     bsrSortedColInd::CuPtr{Cint},
-                                                     blockSize::Cint, info::bsrsm2Info_t,
-                                                     pBufferSize::CuPtr{Csize_t})::cusparseStatus_t
+    @gcsafe_ccall libcusparse.cusparseSbsrsm2_bufferSizeExt(handle::cusparseHandle_t,
+                                                            dirA::cusparseDirection_t,
+                                                            transA::cusparseOperation_t,
+                                                            transB::cusparseOperation_t,
+                                                            mb::Cint, n::Cint, nnzb::Cint,
+                                                            descrA::cusparseMatDescr_t,
+                                                            bsrSortedVal::CuPtr{Cfloat},
+                                                            bsrSortedRowPtr::CuPtr{Cint},
+                                                            bsrSortedColInd::CuPtr{Cint},
+                                                            blockSize::Cint,
+                                                            info::bsrsm2Info_t,
+                                                            pBufferSize::CuPtr{Csize_t})::cusparseStatus_t
 end
 
 @checked function cusparseDbsrsm2_bufferSizeExt(handle, dirA, transA, transB, mb, n, nnzb,
@@ -1025,17 +1073,18 @@ end
                                                 bsrSortedColInd, blockSize, info,
                                                 pBufferSize)
     initialize_context()
-    @ccall libcusparse.cusparseDbsrsm2_bufferSizeExt(handle::cusparseHandle_t,
-                                                     dirA::cusparseDirection_t,
-                                                     transA::cusparseOperation_t,
-                                                     transB::cusparseOperation_t, mb::Cint,
-                                                     n::Cint, nnzb::Cint,
-                                                     descrA::cusparseMatDescr_t,
-                                                     bsrSortedVal::CuPtr{Cdouble},
-                                                     bsrSortedRowPtr::CuPtr{Cint},
-                                                     bsrSortedColInd::CuPtr{Cint},
-                                                     blockSize::Cint, info::bsrsm2Info_t,
-                                                     pBufferSize::Ptr{Csize_t})::cusparseStatus_t
+    @gcsafe_ccall libcusparse.cusparseDbsrsm2_bufferSizeExt(handle::cusparseHandle_t,
+                                                            dirA::cusparseDirection_t,
+                                                            transA::cusparseOperation_t,
+                                                            transB::cusparseOperation_t,
+                                                            mb::Cint, n::Cint, nnzb::Cint,
+                                                            descrA::cusparseMatDescr_t,
+                                                            bsrSortedVal::CuPtr{Cdouble},
+                                                            bsrSortedRowPtr::CuPtr{Cint},
+                                                            bsrSortedColInd::CuPtr{Cint},
+                                                            blockSize::Cint,
+                                                            info::bsrsm2Info_t,
+                                                            pBufferSize::Ptr{Csize_t})::cusparseStatus_t
 end
 
 @checked function cusparseCbsrsm2_bufferSizeExt(handle, dirA, transA, transB, mb, n, nnzb,
@@ -1043,17 +1092,18 @@ end
                                                 bsrSortedColInd, blockSize, info,
                                                 pBufferSize)
     initialize_context()
-    @ccall libcusparse.cusparseCbsrsm2_bufferSizeExt(handle::cusparseHandle_t,
-                                                     dirA::cusparseDirection_t,
-                                                     transA::cusparseOperation_t,
-                                                     transB::cusparseOperation_t, mb::Cint,
-                                                     n::Cint, nnzb::Cint,
-                                                     descrA::cusparseMatDescr_t,
-                                                     bsrSortedVal::CuPtr{cuComplex},
-                                                     bsrSortedRowPtr::CuPtr{Cint},
-                                                     bsrSortedColInd::CuPtr{Cint},
-                                                     blockSize::Cint, info::bsrsm2Info_t,
-                                                     pBufferSize::Ptr{Csize_t})::cusparseStatus_t
+    @gcsafe_ccall libcusparse.cusparseCbsrsm2_bufferSizeExt(handle::cusparseHandle_t,
+                                                            dirA::cusparseDirection_t,
+                                                            transA::cusparseOperation_t,
+                                                            transB::cusparseOperation_t,
+                                                            mb::Cint, n::Cint, nnzb::Cint,
+                                                            descrA::cusparseMatDescr_t,
+                                                            bsrSortedVal::CuPtr{cuComplex},
+                                                            bsrSortedRowPtr::CuPtr{Cint},
+                                                            bsrSortedColInd::CuPtr{Cint},
+                                                            blockSize::Cint,
+                                                            info::bsrsm2Info_t,
+                                                            pBufferSize::Ptr{Csize_t})::cusparseStatus_t
 end
 
 @checked function cusparseZbsrsm2_bufferSizeExt(handle, dirA, transA, transB, mb, n, nnzb,
@@ -1061,17 +1111,18 @@ end
                                                 bsrSortedColInd, blockSize, info,
                                                 pBufferSize)
     initialize_context()
-    @ccall libcusparse.cusparseZbsrsm2_bufferSizeExt(handle::cusparseHandle_t,
-                                                     dirA::cusparseDirection_t,
-                                                     transA::cusparseOperation_t,
-                                                     transB::cusparseOperation_t, mb::Cint,
-                                                     n::Cint, nnzb::Cint,
-                                                     descrA::cusparseMatDescr_t,
-                                                     bsrSortedVal::CuPtr{cuDoubleComplex},
-                                                     bsrSortedRowPtr::CuPtr{Cint},
-                                                     bsrSortedColInd::CuPtr{Cint},
-                                                     blockSize::Cint, info::bsrsm2Info_t,
-                                                     pBufferSize::Ptr{Csize_t})::cusparseStatus_t
+    @gcsafe_ccall libcusparse.cusparseZbsrsm2_bufferSizeExt(handle::cusparseHandle_t,
+                                                            dirA::cusparseDirection_t,
+                                                            transA::cusparseOperation_t,
+                                                            transB::cusparseOperation_t,
+                                                            mb::Cint, n::Cint, nnzb::Cint,
+                                                            descrA::cusparseMatDescr_t,
+                                                            bsrSortedVal::CuPtr{cuDoubleComplex},
+                                                            bsrSortedRowPtr::CuPtr{Cint},
+                                                            bsrSortedColInd::CuPtr{Cint},
+                                                            blockSize::Cint,
+                                                            info::bsrsm2Info_t,
+                                                            pBufferSize::Ptr{Csize_t})::cusparseStatus_t
 end
 
 @checked function cusparseSbsrsm2_analysis(handle, dirA, transA, transXY, mb, n, nnzb,
@@ -1079,18 +1130,18 @@ end
                                            bsrSortedColInd, blockSize, info, policy,
                                            pBuffer)
     initialize_context()
-    @ccall libcusparse.cusparseSbsrsm2_analysis(handle::cusparseHandle_t,
-                                                dirA::cusparseDirection_t,
-                                                transA::cusparseOperation_t,
-                                                transXY::cusparseOperation_t, mb::Cint,
-                                                n::Cint, nnzb::Cint,
-                                                descrA::cusparseMatDescr_t,
-                                                bsrSortedVal::CuPtr{Cfloat},
-                                                bsrSortedRowPtr::CuPtr{Cint},
-                                                bsrSortedColInd::CuPtr{Cint},
-                                                blockSize::Cint, info::bsrsm2Info_t,
-                                                policy::cusparseSolvePolicy_t,
-                                                pBuffer::CuPtr{Cvoid})::cusparseStatus_t
+    @gcsafe_ccall libcusparse.cusparseSbsrsm2_analysis(handle::cusparseHandle_t,
+                                                       dirA::cusparseDirection_t,
+                                                       transA::cusparseOperation_t,
+                                                       transXY::cusparseOperation_t,
+                                                       mb::Cint, n::Cint, nnzb::Cint,
+                                                       descrA::cusparseMatDescr_t,
+                                                       bsrSortedVal::CuPtr{Cfloat},
+                                                       bsrSortedRowPtr::CuPtr{Cint},
+                                                       bsrSortedColInd::CuPtr{Cint},
+                                                       blockSize::Cint, info::bsrsm2Info_t,
+                                                       policy::cusparseSolvePolicy_t,
+                                                       pBuffer::CuPtr{Cvoid})::cusparseStatus_t
 end
 
 @checked function cusparseDbsrsm2_analysis(handle, dirA, transA, transXY, mb, n, nnzb,
@@ -1098,18 +1149,18 @@ end
                                            bsrSortedColInd, blockSize, info, policy,
                                            pBuffer)
     initialize_context()
-    @ccall libcusparse.cusparseDbsrsm2_analysis(handle::cusparseHandle_t,
-                                                dirA::cusparseDirection_t,
-                                                transA::cusparseOperation_t,
-                                                transXY::cusparseOperation_t, mb::Cint,
-                                                n::Cint, nnzb::Cint,
-                                                descrA::cusparseMatDescr_t,
-                                                bsrSortedVal::CuPtr{Cdouble},
-                                                bsrSortedRowPtr::CuPtr{Cint},
-                                                bsrSortedColInd::CuPtr{Cint},
-                                                blockSize::Cint, info::bsrsm2Info_t,
-                                                policy::cusparseSolvePolicy_t,
-                                                pBuffer::CuPtr{Cvoid})::cusparseStatus_t
+    @gcsafe_ccall libcusparse.cusparseDbsrsm2_analysis(handle::cusparseHandle_t,
+                                                       dirA::cusparseDirection_t,
+                                                       transA::cusparseOperation_t,
+                                                       transXY::cusparseOperation_t,
+                                                       mb::Cint, n::Cint, nnzb::Cint,
+                                                       descrA::cusparseMatDescr_t,
+                                                       bsrSortedVal::CuPtr{Cdouble},
+                                                       bsrSortedRowPtr::CuPtr{Cint},
+                                                       bsrSortedColInd::CuPtr{Cint},
+                                                       blockSize::Cint, info::bsrsm2Info_t,
+                                                       policy::cusparseSolvePolicy_t,
+                                                       pBuffer::CuPtr{Cvoid})::cusparseStatus_t
 end
 
 @checked function cusparseCbsrsm2_analysis(handle, dirA, transA, transXY, mb, n, nnzb,
@@ -1117,18 +1168,18 @@ end
                                            bsrSortedColInd, blockSize, info, policy,
                                            pBuffer)
     initialize_context()
-    @ccall libcusparse.cusparseCbsrsm2_analysis(handle::cusparseHandle_t,
-                                                dirA::cusparseDirection_t,
-                                                transA::cusparseOperation_t,
-                                                transXY::cusparseOperation_t, mb::Cint,
-                                                n::Cint, nnzb::Cint,
-                                                descrA::cusparseMatDescr_t,
-                                                bsrSortedVal::CuPtr{cuComplex},
-                                                bsrSortedRowPtr::CuPtr{Cint},
-                                                bsrSortedColInd::CuPtr{Cint},
-                                                blockSize::Cint, info::bsrsm2Info_t,
-                                                policy::cusparseSolvePolicy_t,
-                                                pBuffer::CuPtr{Cvoid})::cusparseStatus_t
+    @gcsafe_ccall libcusparse.cusparseCbsrsm2_analysis(handle::cusparseHandle_t,
+                                                       dirA::cusparseDirection_t,
+                                                       transA::cusparseOperation_t,
+                                                       transXY::cusparseOperation_t,
+                                                       mb::Cint, n::Cint, nnzb::Cint,
+                                                       descrA::cusparseMatDescr_t,
+                                                       bsrSortedVal::CuPtr{cuComplex},
+                                                       bsrSortedRowPtr::CuPtr{Cint},
+                                                       bsrSortedColInd::CuPtr{Cint},
+                                                       blockSize::Cint, info::bsrsm2Info_t,
+                                                       policy::cusparseSolvePolicy_t,
+                                                       pBuffer::CuPtr{Cvoid})::cusparseStatus_t
 end
 
 @checked function cusparseZbsrsm2_analysis(handle, dirA, transA, transXY, mb, n, nnzb,
@@ -1136,18 +1187,18 @@ end
                                            bsrSortedColInd, blockSize, info, policy,
                                            pBuffer)
     initialize_context()
-    @ccall libcusparse.cusparseZbsrsm2_analysis(handle::cusparseHandle_t,
-                                                dirA::cusparseDirection_t,
-                                                transA::cusparseOperation_t,
-                                                transXY::cusparseOperation_t, mb::Cint,
-                                                n::Cint, nnzb::Cint,
-                                                descrA::cusparseMatDescr_t,
-                                                bsrSortedVal::CuPtr{cuDoubleComplex},
-                                                bsrSortedRowPtr::CuPtr{Cint},
-                                                bsrSortedColInd::CuPtr{Cint},
-                                                blockSize::Cint, info::bsrsm2Info_t,
-                                                policy::cusparseSolvePolicy_t,
-                                                pBuffer::CuPtr{Cvoid})::cusparseStatus_t
+    @gcsafe_ccall libcusparse.cusparseZbsrsm2_analysis(handle::cusparseHandle_t,
+                                                       dirA::cusparseDirection_t,
+                                                       transA::cusparseOperation_t,
+                                                       transXY::cusparseOperation_t,
+                                                       mb::Cint, n::Cint, nnzb::Cint,
+                                                       descrA::cusparseMatDescr_t,
+                                                       bsrSortedVal::CuPtr{cuDoubleComplex},
+                                                       bsrSortedRowPtr::CuPtr{Cint},
+                                                       bsrSortedColInd::CuPtr{Cint},
+                                                       blockSize::Cint, info::bsrsm2Info_t,
+                                                       policy::cusparseSolvePolicy_t,
+                                                       pBuffer::CuPtr{Cvoid})::cusparseStatus_t
 end
 
 @checked function cusparseSbsrsm2_solve(handle, dirA, transA, transXY, mb, n, nnzb, alpha,
@@ -1155,19 +1206,20 @@ end
                                         bsrSortedColInd, blockSize, info, B, ldb, X, ldx,
                                         policy, pBuffer)
     initialize_context()
-    @ccall libcusparse.cusparseSbsrsm2_solve(handle::cusparseHandle_t,
-                                             dirA::cusparseDirection_t,
-                                             transA::cusparseOperation_t,
-                                             transXY::cusparseOperation_t, mb::Cint,
-                                             n::Cint, nnzb::Cint, alpha::Ref{Cfloat},
-                                             descrA::cusparseMatDescr_t,
-                                             bsrSortedVal::CuPtr{Cfloat},
-                                             bsrSortedRowPtr::CuPtr{Cint},
-                                             bsrSortedColInd::CuPtr{Cint}, blockSize::Cint,
-                                             info::bsrsm2Info_t, B::CuPtr{Cfloat},
-                                             ldb::Cint, X::CuPtr{Cfloat}, ldx::Cint,
-                                             policy::cusparseSolvePolicy_t,
-                                             pBuffer::CuPtr{Cvoid})::cusparseStatus_t
+    @gcsafe_ccall libcusparse.cusparseSbsrsm2_solve(handle::cusparseHandle_t,
+                                                    dirA::cusparseDirection_t,
+                                                    transA::cusparseOperation_t,
+                                                    transXY::cusparseOperation_t, mb::Cint,
+                                                    n::Cint, nnzb::Cint, alpha::Ref{Cfloat},
+                                                    descrA::cusparseMatDescr_t,
+                                                    bsrSortedVal::CuPtr{Cfloat},
+                                                    bsrSortedRowPtr::CuPtr{Cint},
+                                                    bsrSortedColInd::CuPtr{Cint},
+                                                    blockSize::Cint, info::bsrsm2Info_t,
+                                                    B::CuPtr{Cfloat}, ldb::Cint,
+                                                    X::CuPtr{Cfloat}, ldx::Cint,
+                                                    policy::cusparseSolvePolicy_t,
+                                                    pBuffer::CuPtr{Cvoid})::cusparseStatus_t
 end
 
 @checked function cusparseDbsrsm2_solve(handle, dirA, transA, transXY, mb, n, nnzb, alpha,
@@ -1175,19 +1227,21 @@ end
                                         bsrSortedColInd, blockSize, info, B, ldb, X, ldx,
                                         policy, pBuffer)
     initialize_context()
-    @ccall libcusparse.cusparseDbsrsm2_solve(handle::cusparseHandle_t,
-                                             dirA::cusparseDirection_t,
-                                             transA::cusparseOperation_t,
-                                             transXY::cusparseOperation_t, mb::Cint,
-                                             n::Cint, nnzb::Cint, alpha::Ref{Cdouble},
-                                             descrA::cusparseMatDescr_t,
-                                             bsrSortedVal::CuPtr{Cdouble},
-                                             bsrSortedRowPtr::CuPtr{Cint},
-                                             bsrSortedColInd::CuPtr{Cint}, blockSize::Cint,
-                                             info::bsrsm2Info_t, B::CuPtr{Cdouble},
-                                             ldb::Cint, X::CuPtr{Cdouble}, ldx::Cint,
-                                             policy::cusparseSolvePolicy_t,
-                                             pBuffer::CuPtr{Cvoid})::cusparseStatus_t
+    @gcsafe_ccall libcusparse.cusparseDbsrsm2_solve(handle::cusparseHandle_t,
+                                                    dirA::cusparseDirection_t,
+                                                    transA::cusparseOperation_t,
+                                                    transXY::cusparseOperation_t, mb::Cint,
+                                                    n::Cint, nnzb::Cint,
+                                                    alpha::Ref{Cdouble},
+                                                    descrA::cusparseMatDescr_t,
+                                                    bsrSortedVal::CuPtr{Cdouble},
+                                                    bsrSortedRowPtr::CuPtr{Cint},
+                                                    bsrSortedColInd::CuPtr{Cint},
+                                                    blockSize::Cint, info::bsrsm2Info_t,
+                                                    B::CuPtr{Cdouble}, ldb::Cint,
+                                                    X::CuPtr{Cdouble}, ldx::Cint,
+                                                    policy::cusparseSolvePolicy_t,
+                                                    pBuffer::CuPtr{Cvoid})::cusparseStatus_t
 end
 
 @checked function cusparseCbsrsm2_solve(handle, dirA, transA, transXY, mb, n, nnzb, alpha,
@@ -1195,19 +1249,21 @@ end
                                         bsrSortedColInd, blockSize, info, B, ldb, X, ldx,
                                         policy, pBuffer)
     initialize_context()
-    @ccall libcusparse.cusparseCbsrsm2_solve(handle::cusparseHandle_t,
-                                             dirA::cusparseDirection_t,
-                                             transA::cusparseOperation_t,
-                                             transXY::cusparseOperation_t, mb::Cint,
-                                             n::Cint, nnzb::Cint, alpha::Ref{cuComplex},
-                                             descrA::cusparseMatDescr_t,
-                                             bsrSortedVal::CuPtr{cuComplex},
-                                             bsrSortedRowPtr::CuPtr{Cint},
-                                             bsrSortedColInd::CuPtr{Cint}, blockSize::Cint,
-                                             info::bsrsm2Info_t, B::CuPtr{cuComplex},
-                                             ldb::Cint, X::CuPtr{cuComplex}, ldx::Cint,
-                                             policy::cusparseSolvePolicy_t,
-                                             pBuffer::CuPtr{Cvoid})::cusparseStatus_t
+    @gcsafe_ccall libcusparse.cusparseCbsrsm2_solve(handle::cusparseHandle_t,
+                                                    dirA::cusparseDirection_t,
+                                                    transA::cusparseOperation_t,
+                                                    transXY::cusparseOperation_t, mb::Cint,
+                                                    n::Cint, nnzb::Cint,
+                                                    alpha::Ref{cuComplex},
+                                                    descrA::cusparseMatDescr_t,
+                                                    bsrSortedVal::CuPtr{cuComplex},
+                                                    bsrSortedRowPtr::CuPtr{Cint},
+                                                    bsrSortedColInd::CuPtr{Cint},
+                                                    blockSize::Cint, info::bsrsm2Info_t,
+                                                    B::CuPtr{cuComplex}, ldb::Cint,
+                                                    X::CuPtr{cuComplex}, ldx::Cint,
+                                                    policy::cusparseSolvePolicy_t,
+                                                    pBuffer::CuPtr{Cvoid})::cusparseStatus_t
 end
 
 @checked function cusparseZbsrsm2_solve(handle, dirA, transA, transXY, mb, n, nnzb, alpha,
@@ -1215,374 +1271,399 @@ end
                                         bsrSortedColInd, blockSize, info, B, ldb, X, ldx,
                                         policy, pBuffer)
     initialize_context()
-    @ccall libcusparse.cusparseZbsrsm2_solve(handle::cusparseHandle_t,
-                                             dirA::cusparseDirection_t,
-                                             transA::cusparseOperation_t,
-                                             transXY::cusparseOperation_t, mb::Cint,
-                                             n::Cint, nnzb::Cint,
-                                             alpha::Ref{cuDoubleComplex},
-                                             descrA::cusparseMatDescr_t,
-                                             bsrSortedVal::CuPtr{cuDoubleComplex},
-                                             bsrSortedRowPtr::CuPtr{Cint},
-                                             bsrSortedColInd::CuPtr{Cint}, blockSize::Cint,
-                                             info::bsrsm2Info_t, B::CuPtr{cuDoubleComplex},
-                                             ldb::Cint, X::CuPtr{cuDoubleComplex},
-                                             ldx::Cint, policy::cusparseSolvePolicy_t,
-                                             pBuffer::CuPtr{Cvoid})::cusparseStatus_t
+    @gcsafe_ccall libcusparse.cusparseZbsrsm2_solve(handle::cusparseHandle_t,
+                                                    dirA::cusparseDirection_t,
+                                                    transA::cusparseOperation_t,
+                                                    transXY::cusparseOperation_t, mb::Cint,
+                                                    n::Cint, nnzb::Cint,
+                                                    alpha::Ref{cuDoubleComplex},
+                                                    descrA::cusparseMatDescr_t,
+                                                    bsrSortedVal::CuPtr{cuDoubleComplex},
+                                                    bsrSortedRowPtr::CuPtr{Cint},
+                                                    bsrSortedColInd::CuPtr{Cint},
+                                                    blockSize::Cint, info::bsrsm2Info_t,
+                                                    B::CuPtr{cuDoubleComplex}, ldb::Cint,
+                                                    X::CuPtr{cuDoubleComplex}, ldx::Cint,
+                                                    policy::cusparseSolvePolicy_t,
+                                                    pBuffer::CuPtr{Cvoid})::cusparseStatus_t
 end
 
 @checked function cusparseScsrilu02_numericBoost(handle, info, enable_boost, tol, boost_val)
     initialize_context()
-    @ccall libcusparse.cusparseScsrilu02_numericBoost(handle::cusparseHandle_t,
-                                                      info::csrilu02Info_t,
-                                                      enable_boost::Cint, tol::Ptr{Cdouble},
-                                                      boost_val::Ptr{Cfloat})::cusparseStatus_t
+    @gcsafe_ccall libcusparse.cusparseScsrilu02_numericBoost(handle::cusparseHandle_t,
+                                                             info::csrilu02Info_t,
+                                                             enable_boost::Cint,
+                                                             tol::Ptr{Cdouble},
+                                                             boost_val::Ptr{Cfloat})::cusparseStatus_t
 end
 
 @checked function cusparseDcsrilu02_numericBoost(handle, info, enable_boost, tol, boost_val)
     initialize_context()
-    @ccall libcusparse.cusparseDcsrilu02_numericBoost(handle::cusparseHandle_t,
-                                                      info::csrilu02Info_t,
-                                                      enable_boost::Cint, tol::Ptr{Cdouble},
-                                                      boost_val::Ptr{Cdouble})::cusparseStatus_t
+    @gcsafe_ccall libcusparse.cusparseDcsrilu02_numericBoost(handle::cusparseHandle_t,
+                                                             info::csrilu02Info_t,
+                                                             enable_boost::Cint,
+                                                             tol::Ptr{Cdouble},
+                                                             boost_val::Ptr{Cdouble})::cusparseStatus_t
 end
 
 @checked function cusparseCcsrilu02_numericBoost(handle, info, enable_boost, tol, boost_val)
     initialize_context()
-    @ccall libcusparse.cusparseCcsrilu02_numericBoost(handle::cusparseHandle_t,
-                                                      info::csrilu02Info_t,
-                                                      enable_boost::Cint, tol::Ptr{Cdouble},
-                                                      boost_val::Ptr{cuComplex})::cusparseStatus_t
+    @gcsafe_ccall libcusparse.cusparseCcsrilu02_numericBoost(handle::cusparseHandle_t,
+                                                             info::csrilu02Info_t,
+                                                             enable_boost::Cint,
+                                                             tol::Ptr{Cdouble},
+                                                             boost_val::Ptr{cuComplex})::cusparseStatus_t
 end
 
 @checked function cusparseZcsrilu02_numericBoost(handle, info, enable_boost, tol, boost_val)
     initialize_context()
-    @ccall libcusparse.cusparseZcsrilu02_numericBoost(handle::cusparseHandle_t,
-                                                      info::csrilu02Info_t,
-                                                      enable_boost::Cint, tol::Ptr{Cdouble},
-                                                      boost_val::Ptr{cuDoubleComplex})::cusparseStatus_t
+    @gcsafe_ccall libcusparse.cusparseZcsrilu02_numericBoost(handle::cusparseHandle_t,
+                                                             info::csrilu02Info_t,
+                                                             enable_boost::Cint,
+                                                             tol::Ptr{Cdouble},
+                                                             boost_val::Ptr{cuDoubleComplex})::cusparseStatus_t
 end
 
 @checked function cusparseXcsrilu02_zeroPivot(handle, info, position)
     initialize_context()
-    @ccall libcusparse.cusparseXcsrilu02_zeroPivot(handle::cusparseHandle_t,
-                                                   info::csrilu02Info_t,
-                                                   position::Ptr{Cint})::cusparseStatus_t
+    @gcsafe_ccall libcusparse.cusparseXcsrilu02_zeroPivot(handle::cusparseHandle_t,
+                                                          info::csrilu02Info_t,
+                                                          position::Ptr{Cint})::cusparseStatus_t
 end
 
 @checked function cusparseScsrilu02_bufferSize(handle, m, nnz, descrA, csrSortedValA,
                                                csrSortedRowPtrA, csrSortedColIndA, info,
                                                pBufferSizeInBytes)
     initialize_context()
-    @ccall libcusparse.cusparseScsrilu02_bufferSize(handle::cusparseHandle_t, m::Cint,
-                                                    nnz::Cint, descrA::cusparseMatDescr_t,
-                                                    csrSortedValA::CuPtr{Cfloat},
-                                                    csrSortedRowPtrA::CuPtr{Cint},
-                                                    csrSortedColIndA::CuPtr{Cint},
-                                                    info::csrilu02Info_t,
-                                                    pBufferSizeInBytes::Ptr{Cint})::cusparseStatus_t
+    @gcsafe_ccall libcusparse.cusparseScsrilu02_bufferSize(handle::cusparseHandle_t,
+                                                           m::Cint, nnz::Cint,
+                                                           descrA::cusparseMatDescr_t,
+                                                           csrSortedValA::CuPtr{Cfloat},
+                                                           csrSortedRowPtrA::CuPtr{Cint},
+                                                           csrSortedColIndA::CuPtr{Cint},
+                                                           info::csrilu02Info_t,
+                                                           pBufferSizeInBytes::Ptr{Cint})::cusparseStatus_t
 end
 
 @checked function cusparseDcsrilu02_bufferSize(handle, m, nnz, descrA, csrSortedValA,
                                                csrSortedRowPtrA, csrSortedColIndA, info,
                                                pBufferSizeInBytes)
     initialize_context()
-    @ccall libcusparse.cusparseDcsrilu02_bufferSize(handle::cusparseHandle_t, m::Cint,
-                                                    nnz::Cint, descrA::cusparseMatDescr_t,
-                                                    csrSortedValA::CuPtr{Cdouble},
-                                                    csrSortedRowPtrA::CuPtr{Cint},
-                                                    csrSortedColIndA::CuPtr{Cint},
-                                                    info::csrilu02Info_t,
-                                                    pBufferSizeInBytes::Ptr{Cint})::cusparseStatus_t
+    @gcsafe_ccall libcusparse.cusparseDcsrilu02_bufferSize(handle::cusparseHandle_t,
+                                                           m::Cint, nnz::Cint,
+                                                           descrA::cusparseMatDescr_t,
+                                                           csrSortedValA::CuPtr{Cdouble},
+                                                           csrSortedRowPtrA::CuPtr{Cint},
+                                                           csrSortedColIndA::CuPtr{Cint},
+                                                           info::csrilu02Info_t,
+                                                           pBufferSizeInBytes::Ptr{Cint})::cusparseStatus_t
 end
 
 @checked function cusparseCcsrilu02_bufferSize(handle, m, nnz, descrA, csrSortedValA,
                                                csrSortedRowPtrA, csrSortedColIndA, info,
                                                pBufferSizeInBytes)
     initialize_context()
-    @ccall libcusparse.cusparseCcsrilu02_bufferSize(handle::cusparseHandle_t, m::Cint,
-                                                    nnz::Cint, descrA::cusparseMatDescr_t,
-                                                    csrSortedValA::CuPtr{cuComplex},
-                                                    csrSortedRowPtrA::CuPtr{Cint},
-                                                    csrSortedColIndA::CuPtr{Cint},
-                                                    info::csrilu02Info_t,
-                                                    pBufferSizeInBytes::Ptr{Cint})::cusparseStatus_t
+    @gcsafe_ccall libcusparse.cusparseCcsrilu02_bufferSize(handle::cusparseHandle_t,
+                                                           m::Cint, nnz::Cint,
+                                                           descrA::cusparseMatDescr_t,
+                                                           csrSortedValA::CuPtr{cuComplex},
+                                                           csrSortedRowPtrA::CuPtr{Cint},
+                                                           csrSortedColIndA::CuPtr{Cint},
+                                                           info::csrilu02Info_t,
+                                                           pBufferSizeInBytes::Ptr{Cint})::cusparseStatus_t
 end
 
 @checked function cusparseZcsrilu02_bufferSize(handle, m, nnz, descrA, csrSortedValA,
                                                csrSortedRowPtrA, csrSortedColIndA, info,
                                                pBufferSizeInBytes)
     initialize_context()
-    @ccall libcusparse.cusparseZcsrilu02_bufferSize(handle::cusparseHandle_t, m::Cint,
-                                                    nnz::Cint, descrA::cusparseMatDescr_t,
-                                                    csrSortedValA::CuPtr{cuDoubleComplex},
-                                                    csrSortedRowPtrA::CuPtr{Cint},
-                                                    csrSortedColIndA::CuPtr{Cint},
-                                                    info::csrilu02Info_t,
-                                                    pBufferSizeInBytes::Ptr{Cint})::cusparseStatus_t
+    @gcsafe_ccall libcusparse.cusparseZcsrilu02_bufferSize(handle::cusparseHandle_t,
+                                                           m::Cint, nnz::Cint,
+                                                           descrA::cusparseMatDescr_t,
+                                                           csrSortedValA::CuPtr{cuDoubleComplex},
+                                                           csrSortedRowPtrA::CuPtr{Cint},
+                                                           csrSortedColIndA::CuPtr{Cint},
+                                                           info::csrilu02Info_t,
+                                                           pBufferSizeInBytes::Ptr{Cint})::cusparseStatus_t
 end
 
 @checked function cusparseScsrilu02_bufferSizeExt(handle, m, nnz, descrA, csrSortedVal,
                                                   csrSortedRowPtr, csrSortedColInd, info,
                                                   pBufferSize)
     initialize_context()
-    @ccall libcusparse.cusparseScsrilu02_bufferSizeExt(handle::cusparseHandle_t, m::Cint,
-                                                       nnz::Cint,
-                                                       descrA::cusparseMatDescr_t,
-                                                       csrSortedVal::CuPtr{Cfloat},
-                                                       csrSortedRowPtr::CuPtr{Cint},
-                                                       csrSortedColInd::CuPtr{Cint},
-                                                       info::csrilu02Info_t,
-                                                       pBufferSize::Ptr{Csize_t})::cusparseStatus_t
+    @gcsafe_ccall libcusparse.cusparseScsrilu02_bufferSizeExt(handle::cusparseHandle_t,
+                                                              m::Cint, nnz::Cint,
+                                                              descrA::cusparseMatDescr_t,
+                                                              csrSortedVal::CuPtr{Cfloat},
+                                                              csrSortedRowPtr::CuPtr{Cint},
+                                                              csrSortedColInd::CuPtr{Cint},
+                                                              info::csrilu02Info_t,
+                                                              pBufferSize::Ptr{Csize_t})::cusparseStatus_t
 end
 
 @checked function cusparseDcsrilu02_bufferSizeExt(handle, m, nnz, descrA, csrSortedVal,
                                                   csrSortedRowPtr, csrSortedColInd, info,
                                                   pBufferSize)
     initialize_context()
-    @ccall libcusparse.cusparseDcsrilu02_bufferSizeExt(handle::cusparseHandle_t, m::Cint,
-                                                       nnz::Cint,
-                                                       descrA::cusparseMatDescr_t,
-                                                       csrSortedVal::CuPtr{Cdouble},
-                                                       csrSortedRowPtr::CuPtr{Cint},
-                                                       csrSortedColInd::CuPtr{Cint},
-                                                       info::csrilu02Info_t,
-                                                       pBufferSize::Ptr{Csize_t})::cusparseStatus_t
+    @gcsafe_ccall libcusparse.cusparseDcsrilu02_bufferSizeExt(handle::cusparseHandle_t,
+                                                              m::Cint, nnz::Cint,
+                                                              descrA::cusparseMatDescr_t,
+                                                              csrSortedVal::CuPtr{Cdouble},
+                                                              csrSortedRowPtr::CuPtr{Cint},
+                                                              csrSortedColInd::CuPtr{Cint},
+                                                              info::csrilu02Info_t,
+                                                              pBufferSize::Ptr{Csize_t})::cusparseStatus_t
 end
 
 @checked function cusparseCcsrilu02_bufferSizeExt(handle, m, nnz, descrA, csrSortedVal,
                                                   csrSortedRowPtr, csrSortedColInd, info,
                                                   pBufferSize)
     initialize_context()
-    @ccall libcusparse.cusparseCcsrilu02_bufferSizeExt(handle::cusparseHandle_t, m::Cint,
-                                                       nnz::Cint,
-                                                       descrA::cusparseMatDescr_t,
-                                                       csrSortedVal::CuPtr{cuComplex},
-                                                       csrSortedRowPtr::CuPtr{Cint},
-                                                       csrSortedColInd::CuPtr{Cint},
-                                                       info::csrilu02Info_t,
-                                                       pBufferSize::Ptr{Csize_t})::cusparseStatus_t
+    @gcsafe_ccall libcusparse.cusparseCcsrilu02_bufferSizeExt(handle::cusparseHandle_t,
+                                                              m::Cint, nnz::Cint,
+                                                              descrA::cusparseMatDescr_t,
+                                                              csrSortedVal::CuPtr{cuComplex},
+                                                              csrSortedRowPtr::CuPtr{Cint},
+                                                              csrSortedColInd::CuPtr{Cint},
+                                                              info::csrilu02Info_t,
+                                                              pBufferSize::Ptr{Csize_t})::cusparseStatus_t
 end
 
 @checked function cusparseZcsrilu02_bufferSizeExt(handle, m, nnz, descrA, csrSortedVal,
                                                   csrSortedRowPtr, csrSortedColInd, info,
                                                   pBufferSize)
     initialize_context()
-    @ccall libcusparse.cusparseZcsrilu02_bufferSizeExt(handle::cusparseHandle_t, m::Cint,
-                                                       nnz::Cint,
-                                                       descrA::cusparseMatDescr_t,
-                                                       csrSortedVal::CuPtr{cuDoubleComplex},
-                                                       csrSortedRowPtr::CuPtr{Cint},
-                                                       csrSortedColInd::CuPtr{Cint},
-                                                       info::csrilu02Info_t,
-                                                       pBufferSize::Ptr{Csize_t})::cusparseStatus_t
+    @gcsafe_ccall libcusparse.cusparseZcsrilu02_bufferSizeExt(handle::cusparseHandle_t,
+                                                              m::Cint, nnz::Cint,
+                                                              descrA::cusparseMatDescr_t,
+                                                              csrSortedVal::CuPtr{cuDoubleComplex},
+                                                              csrSortedRowPtr::CuPtr{Cint},
+                                                              csrSortedColInd::CuPtr{Cint},
+                                                              info::csrilu02Info_t,
+                                                              pBufferSize::Ptr{Csize_t})::cusparseStatus_t
 end
 
 @checked function cusparseScsrilu02_analysis(handle, m, nnz, descrA, csrSortedValA,
                                              csrSortedRowPtrA, csrSortedColIndA, info,
                                              policy, pBuffer)
     initialize_context()
-    @ccall libcusparse.cusparseScsrilu02_analysis(handle::cusparseHandle_t, m::Cint,
-                                                  nnz::Cint, descrA::cusparseMatDescr_t,
-                                                  csrSortedValA::CuPtr{Cfloat},
-                                                  csrSortedRowPtrA::CuPtr{Cint},
-                                                  csrSortedColIndA::CuPtr{Cint},
-                                                  info::csrilu02Info_t,
-                                                  policy::cusparseSolvePolicy_t,
-                                                  pBuffer::CuPtr{Cvoid})::cusparseStatus_t
+    @gcsafe_ccall libcusparse.cusparseScsrilu02_analysis(handle::cusparseHandle_t, m::Cint,
+                                                         nnz::Cint,
+                                                         descrA::cusparseMatDescr_t,
+                                                         csrSortedValA::CuPtr{Cfloat},
+                                                         csrSortedRowPtrA::CuPtr{Cint},
+                                                         csrSortedColIndA::CuPtr{Cint},
+                                                         info::csrilu02Info_t,
+                                                         policy::cusparseSolvePolicy_t,
+                                                         pBuffer::CuPtr{Cvoid})::cusparseStatus_t
 end
 
 @checked function cusparseDcsrilu02_analysis(handle, m, nnz, descrA, csrSortedValA,
                                              csrSortedRowPtrA, csrSortedColIndA, info,
                                              policy, pBuffer)
     initialize_context()
-    @ccall libcusparse.cusparseDcsrilu02_analysis(handle::cusparseHandle_t, m::Cint,
-                                                  nnz::Cint, descrA::cusparseMatDescr_t,
-                                                  csrSortedValA::CuPtr{Cdouble},
-                                                  csrSortedRowPtrA::CuPtr{Cint},
-                                                  csrSortedColIndA::CuPtr{Cint},
-                                                  info::csrilu02Info_t,
-                                                  policy::cusparseSolvePolicy_t,
-                                                  pBuffer::CuPtr{Cvoid})::cusparseStatus_t
+    @gcsafe_ccall libcusparse.cusparseDcsrilu02_analysis(handle::cusparseHandle_t, m::Cint,
+                                                         nnz::Cint,
+                                                         descrA::cusparseMatDescr_t,
+                                                         csrSortedValA::CuPtr{Cdouble},
+                                                         csrSortedRowPtrA::CuPtr{Cint},
+                                                         csrSortedColIndA::CuPtr{Cint},
+                                                         info::csrilu02Info_t,
+                                                         policy::cusparseSolvePolicy_t,
+                                                         pBuffer::CuPtr{Cvoid})::cusparseStatus_t
 end
 
 @checked function cusparseCcsrilu02_analysis(handle, m, nnz, descrA, csrSortedValA,
                                              csrSortedRowPtrA, csrSortedColIndA, info,
                                              policy, pBuffer)
     initialize_context()
-    @ccall libcusparse.cusparseCcsrilu02_analysis(handle::cusparseHandle_t, m::Cint,
-                                                  nnz::Cint, descrA::cusparseMatDescr_t,
-                                                  csrSortedValA::CuPtr{cuComplex},
-                                                  csrSortedRowPtrA::CuPtr{Cint},
-                                                  csrSortedColIndA::CuPtr{Cint},
-                                                  info::csrilu02Info_t,
-                                                  policy::cusparseSolvePolicy_t,
-                                                  pBuffer::CuPtr{Cvoid})::cusparseStatus_t
+    @gcsafe_ccall libcusparse.cusparseCcsrilu02_analysis(handle::cusparseHandle_t, m::Cint,
+                                                         nnz::Cint,
+                                                         descrA::cusparseMatDescr_t,
+                                                         csrSortedValA::CuPtr{cuComplex},
+                                                         csrSortedRowPtrA::CuPtr{Cint},
+                                                         csrSortedColIndA::CuPtr{Cint},
+                                                         info::csrilu02Info_t,
+                                                         policy::cusparseSolvePolicy_t,
+                                                         pBuffer::CuPtr{Cvoid})::cusparseStatus_t
 end
 
 @checked function cusparseZcsrilu02_analysis(handle, m, nnz, descrA, csrSortedValA,
                                              csrSortedRowPtrA, csrSortedColIndA, info,
                                              policy, pBuffer)
     initialize_context()
-    @ccall libcusparse.cusparseZcsrilu02_analysis(handle::cusparseHandle_t, m::Cint,
-                                                  nnz::Cint, descrA::cusparseMatDescr_t,
-                                                  csrSortedValA::CuPtr{cuDoubleComplex},
-                                                  csrSortedRowPtrA::CuPtr{Cint},
-                                                  csrSortedColIndA::CuPtr{Cint},
-                                                  info::csrilu02Info_t,
-                                                  policy::cusparseSolvePolicy_t,
-                                                  pBuffer::CuPtr{Cvoid})::cusparseStatus_t
+    @gcsafe_ccall libcusparse.cusparseZcsrilu02_analysis(handle::cusparseHandle_t, m::Cint,
+                                                         nnz::Cint,
+                                                         descrA::cusparseMatDescr_t,
+                                                         csrSortedValA::CuPtr{cuDoubleComplex},
+                                                         csrSortedRowPtrA::CuPtr{Cint},
+                                                         csrSortedColIndA::CuPtr{Cint},
+                                                         info::csrilu02Info_t,
+                                                         policy::cusparseSolvePolicy_t,
+                                                         pBuffer::CuPtr{Cvoid})::cusparseStatus_t
 end
 
 @checked function cusparseScsrilu02(handle, m, nnz, descrA, csrSortedValA_valM,
                                     csrSortedRowPtrA, csrSortedColIndA, info, policy,
                                     pBuffer)
     initialize_context()
-    @ccall libcusparse.cusparseScsrilu02(handle::cusparseHandle_t, m::Cint, nnz::Cint,
-                                         descrA::cusparseMatDescr_t,
-                                         csrSortedValA_valM::CuPtr{Cfloat},
-                                         csrSortedRowPtrA::CuPtr{Cint},
-                                         csrSortedColIndA::CuPtr{Cint},
-                                         info::csrilu02Info_t,
-                                         policy::cusparseSolvePolicy_t,
-                                         pBuffer::CuPtr{Cvoid})::cusparseStatus_t
+    @gcsafe_ccall libcusparse.cusparseScsrilu02(handle::cusparseHandle_t, m::Cint,
+                                                nnz::Cint, descrA::cusparseMatDescr_t,
+                                                csrSortedValA_valM::CuPtr{Cfloat},
+                                                csrSortedRowPtrA::CuPtr{Cint},
+                                                csrSortedColIndA::CuPtr{Cint},
+                                                info::csrilu02Info_t,
+                                                policy::cusparseSolvePolicy_t,
+                                                pBuffer::CuPtr{Cvoid})::cusparseStatus_t
 end
 
 @checked function cusparseDcsrilu02(handle, m, nnz, descrA, csrSortedValA_valM,
                                     csrSortedRowPtrA, csrSortedColIndA, info, policy,
                                     pBuffer)
     initialize_context()
-    @ccall libcusparse.cusparseDcsrilu02(handle::cusparseHandle_t, m::Cint, nnz::Cint,
-                                         descrA::cusparseMatDescr_t,
-                                         csrSortedValA_valM::CuPtr{Cdouble},
-                                         csrSortedRowPtrA::CuPtr{Cint},
-                                         csrSortedColIndA::CuPtr{Cint},
-                                         info::csrilu02Info_t,
-                                         policy::cusparseSolvePolicy_t,
-                                         pBuffer::CuPtr{Cvoid})::cusparseStatus_t
+    @gcsafe_ccall libcusparse.cusparseDcsrilu02(handle::cusparseHandle_t, m::Cint,
+                                                nnz::Cint, descrA::cusparseMatDescr_t,
+                                                csrSortedValA_valM::CuPtr{Cdouble},
+                                                csrSortedRowPtrA::CuPtr{Cint},
+                                                csrSortedColIndA::CuPtr{Cint},
+                                                info::csrilu02Info_t,
+                                                policy::cusparseSolvePolicy_t,
+                                                pBuffer::CuPtr{Cvoid})::cusparseStatus_t
 end
 
 @checked function cusparseCcsrilu02(handle, m, nnz, descrA, csrSortedValA_valM,
                                     csrSortedRowPtrA, csrSortedColIndA, info, policy,
                                     pBuffer)
     initialize_context()
-    @ccall libcusparse.cusparseCcsrilu02(handle::cusparseHandle_t, m::Cint, nnz::Cint,
-                                         descrA::cusparseMatDescr_t,
-                                         csrSortedValA_valM::CuPtr{cuComplex},
-                                         csrSortedRowPtrA::CuPtr{Cint},
-                                         csrSortedColIndA::CuPtr{Cint},
-                                         info::csrilu02Info_t,
-                                         policy::cusparseSolvePolicy_t,
-                                         pBuffer::CuPtr{Cvoid})::cusparseStatus_t
+    @gcsafe_ccall libcusparse.cusparseCcsrilu02(handle::cusparseHandle_t, m::Cint,
+                                                nnz::Cint, descrA::cusparseMatDescr_t,
+                                                csrSortedValA_valM::CuPtr{cuComplex},
+                                                csrSortedRowPtrA::CuPtr{Cint},
+                                                csrSortedColIndA::CuPtr{Cint},
+                                                info::csrilu02Info_t,
+                                                policy::cusparseSolvePolicy_t,
+                                                pBuffer::CuPtr{Cvoid})::cusparseStatus_t
 end
 
 @checked function cusparseZcsrilu02(handle, m, nnz, descrA, csrSortedValA_valM,
                                     csrSortedRowPtrA, csrSortedColIndA, info, policy,
                                     pBuffer)
     initialize_context()
-    @ccall libcusparse.cusparseZcsrilu02(handle::cusparseHandle_t, m::Cint, nnz::Cint,
-                                         descrA::cusparseMatDescr_t,
-                                         csrSortedValA_valM::CuPtr{cuDoubleComplex},
-                                         csrSortedRowPtrA::CuPtr{Cint},
-                                         csrSortedColIndA::CuPtr{Cint},
-                                         info::csrilu02Info_t,
-                                         policy::cusparseSolvePolicy_t,
-                                         pBuffer::CuPtr{Cvoid})::cusparseStatus_t
+    @gcsafe_ccall libcusparse.cusparseZcsrilu02(handle::cusparseHandle_t, m::Cint,
+                                                nnz::Cint, descrA::cusparseMatDescr_t,
+                                                csrSortedValA_valM::CuPtr{cuDoubleComplex},
+                                                csrSortedRowPtrA::CuPtr{Cint},
+                                                csrSortedColIndA::CuPtr{Cint},
+                                                info::csrilu02Info_t,
+                                                policy::cusparseSolvePolicy_t,
+                                                pBuffer::CuPtr{Cvoid})::cusparseStatus_t
 end
 
 @checked function cusparseSbsrilu02_numericBoost(handle, info, enable_boost, tol, boost_val)
     initialize_context()
-    @ccall libcusparse.cusparseSbsrilu02_numericBoost(handle::cusparseHandle_t,
-                                                      info::bsrilu02Info_t,
-                                                      enable_boost::Cint, tol::Ptr{Cdouble},
-                                                      boost_val::Ptr{Cfloat})::cusparseStatus_t
+    @gcsafe_ccall libcusparse.cusparseSbsrilu02_numericBoost(handle::cusparseHandle_t,
+                                                             info::bsrilu02Info_t,
+                                                             enable_boost::Cint,
+                                                             tol::Ptr{Cdouble},
+                                                             boost_val::Ptr{Cfloat})::cusparseStatus_t
 end
 
 @checked function cusparseDbsrilu02_numericBoost(handle, info, enable_boost, tol, boost_val)
     initialize_context()
-    @ccall libcusparse.cusparseDbsrilu02_numericBoost(handle::cusparseHandle_t,
-                                                      info::bsrilu02Info_t,
-                                                      enable_boost::Cint, tol::Ptr{Cdouble},
-                                                      boost_val::Ptr{Cdouble})::cusparseStatus_t
+    @gcsafe_ccall libcusparse.cusparseDbsrilu02_numericBoost(handle::cusparseHandle_t,
+                                                             info::bsrilu02Info_t,
+                                                             enable_boost::Cint,
+                                                             tol::Ptr{Cdouble},
+                                                             boost_val::Ptr{Cdouble})::cusparseStatus_t
 end
 
 @checked function cusparseCbsrilu02_numericBoost(handle, info, enable_boost, tol, boost_val)
     initialize_context()
-    @ccall libcusparse.cusparseCbsrilu02_numericBoost(handle::cusparseHandle_t,
-                                                      info::bsrilu02Info_t,
-                                                      enable_boost::Cint, tol::Ptr{Cdouble},
-                                                      boost_val::Ptr{cuComplex})::cusparseStatus_t
+    @gcsafe_ccall libcusparse.cusparseCbsrilu02_numericBoost(handle::cusparseHandle_t,
+                                                             info::bsrilu02Info_t,
+                                                             enable_boost::Cint,
+                                                             tol::Ptr{Cdouble},
+                                                             boost_val::Ptr{cuComplex})::cusparseStatus_t
 end
 
 @checked function cusparseZbsrilu02_numericBoost(handle, info, enable_boost, tol, boost_val)
     initialize_context()
-    @ccall libcusparse.cusparseZbsrilu02_numericBoost(handle::cusparseHandle_t,
-                                                      info::bsrilu02Info_t,
-                                                      enable_boost::Cint, tol::Ptr{Cdouble},
-                                                      boost_val::Ptr{cuDoubleComplex})::cusparseStatus_t
+    @gcsafe_ccall libcusparse.cusparseZbsrilu02_numericBoost(handle::cusparseHandle_t,
+                                                             info::bsrilu02Info_t,
+                                                             enable_boost::Cint,
+                                                             tol::Ptr{Cdouble},
+                                                             boost_val::Ptr{cuDoubleComplex})::cusparseStatus_t
 end
 
 @checked function cusparseXbsrilu02_zeroPivot(handle, info, position)
     initialize_context()
-    @ccall libcusparse.cusparseXbsrilu02_zeroPivot(handle::cusparseHandle_t,
-                                                   info::bsrilu02Info_t,
-                                                   position::Ptr{Cint})::cusparseStatus_t
+    @gcsafe_ccall libcusparse.cusparseXbsrilu02_zeroPivot(handle::cusparseHandle_t,
+                                                          info::bsrilu02Info_t,
+                                                          position::Ptr{Cint})::cusparseStatus_t
 end
 
 @checked function cusparseSbsrilu02_bufferSize(handle, dirA, mb, nnzb, descrA, bsrSortedVal,
                                                bsrSortedRowPtr, bsrSortedColInd, blockDim,
                                                info, pBufferSizeInBytes)
     initialize_context()
-    @ccall libcusparse.cusparseSbsrilu02_bufferSize(handle::cusparseHandle_t,
-                                                    dirA::cusparseDirection_t, mb::Cint,
-                                                    nnzb::Cint, descrA::cusparseMatDescr_t,
-                                                    bsrSortedVal::CuPtr{Cfloat},
-                                                    bsrSortedRowPtr::CuPtr{Cint},
-                                                    bsrSortedColInd::CuPtr{Cint},
-                                                    blockDim::Cint, info::bsrilu02Info_t,
-                                                    pBufferSizeInBytes::Ptr{Cint})::cusparseStatus_t
+    @gcsafe_ccall libcusparse.cusparseSbsrilu02_bufferSize(handle::cusparseHandle_t,
+                                                           dirA::cusparseDirection_t,
+                                                           mb::Cint, nnzb::Cint,
+                                                           descrA::cusparseMatDescr_t,
+                                                           bsrSortedVal::CuPtr{Cfloat},
+                                                           bsrSortedRowPtr::CuPtr{Cint},
+                                                           bsrSortedColInd::CuPtr{Cint},
+                                                           blockDim::Cint,
+                                                           info::bsrilu02Info_t,
+                                                           pBufferSizeInBytes::Ptr{Cint})::cusparseStatus_t
 end
 
 @checked function cusparseDbsrilu02_bufferSize(handle, dirA, mb, nnzb, descrA, bsrSortedVal,
                                                bsrSortedRowPtr, bsrSortedColInd, blockDim,
                                                info, pBufferSizeInBytes)
     initialize_context()
-    @ccall libcusparse.cusparseDbsrilu02_bufferSize(handle::cusparseHandle_t,
-                                                    dirA::cusparseDirection_t, mb::Cint,
-                                                    nnzb::Cint, descrA::cusparseMatDescr_t,
-                                                    bsrSortedVal::CuPtr{Cdouble},
-                                                    bsrSortedRowPtr::CuPtr{Cint},
-                                                    bsrSortedColInd::CuPtr{Cint},
-                                                    blockDim::Cint, info::bsrilu02Info_t,
-                                                    pBufferSizeInBytes::Ptr{Cint})::cusparseStatus_t
+    @gcsafe_ccall libcusparse.cusparseDbsrilu02_bufferSize(handle::cusparseHandle_t,
+                                                           dirA::cusparseDirection_t,
+                                                           mb::Cint, nnzb::Cint,
+                                                           descrA::cusparseMatDescr_t,
+                                                           bsrSortedVal::CuPtr{Cdouble},
+                                                           bsrSortedRowPtr::CuPtr{Cint},
+                                                           bsrSortedColInd::CuPtr{Cint},
+                                                           blockDim::Cint,
+                                                           info::bsrilu02Info_t,
+                                                           pBufferSizeInBytes::Ptr{Cint})::cusparseStatus_t
 end
 
 @checked function cusparseCbsrilu02_bufferSize(handle, dirA, mb, nnzb, descrA, bsrSortedVal,
                                                bsrSortedRowPtr, bsrSortedColInd, blockDim,
                                                info, pBufferSizeInBytes)
     initialize_context()
-    @ccall libcusparse.cusparseCbsrilu02_bufferSize(handle::cusparseHandle_t,
-                                                    dirA::cusparseDirection_t, mb::Cint,
-                                                    nnzb::Cint, descrA::cusparseMatDescr_t,
-                                                    bsrSortedVal::CuPtr{cuComplex},
-                                                    bsrSortedRowPtr::CuPtr{Cint},
-                                                    bsrSortedColInd::CuPtr{Cint},
-                                                    blockDim::Cint, info::bsrilu02Info_t,
-                                                    pBufferSizeInBytes::Ptr{Cint})::cusparseStatus_t
+    @gcsafe_ccall libcusparse.cusparseCbsrilu02_bufferSize(handle::cusparseHandle_t,
+                                                           dirA::cusparseDirection_t,
+                                                           mb::Cint, nnzb::Cint,
+                                                           descrA::cusparseMatDescr_t,
+                                                           bsrSortedVal::CuPtr{cuComplex},
+                                                           bsrSortedRowPtr::CuPtr{Cint},
+                                                           bsrSortedColInd::CuPtr{Cint},
+                                                           blockDim::Cint,
+                                                           info::bsrilu02Info_t,
+                                                           pBufferSizeInBytes::Ptr{Cint})::cusparseStatus_t
 end
 
 @checked function cusparseZbsrilu02_bufferSize(handle, dirA, mb, nnzb, descrA, bsrSortedVal,
                                                bsrSortedRowPtr, bsrSortedColInd, blockDim,
                                                info, pBufferSizeInBytes)
     initialize_context()
-    @ccall libcusparse.cusparseZbsrilu02_bufferSize(handle::cusparseHandle_t,
-                                                    dirA::cusparseDirection_t, mb::Cint,
-                                                    nnzb::Cint, descrA::cusparseMatDescr_t,
-                                                    bsrSortedVal::CuPtr{cuDoubleComplex},
-                                                    bsrSortedRowPtr::CuPtr{Cint},
-                                                    bsrSortedColInd::CuPtr{Cint},
-                                                    blockDim::Cint, info::bsrilu02Info_t,
-                                                    pBufferSizeInBytes::Ptr{Cint})::cusparseStatus_t
+    @gcsafe_ccall libcusparse.cusparseZbsrilu02_bufferSize(handle::cusparseHandle_t,
+                                                           dirA::cusparseDirection_t,
+                                                           mb::Cint, nnzb::Cint,
+                                                           descrA::cusparseMatDescr_t,
+                                                           bsrSortedVal::CuPtr{cuDoubleComplex},
+                                                           bsrSortedRowPtr::CuPtr{Cint},
+                                                           bsrSortedColInd::CuPtr{Cint},
+                                                           blockDim::Cint,
+                                                           info::bsrilu02Info_t,
+                                                           pBufferSizeInBytes::Ptr{Cint})::cusparseStatus_t
 end
 
 @checked function cusparseSbsrilu02_bufferSizeExt(handle, dirA, mb, nnzb, descrA,
@@ -1590,16 +1671,16 @@ end
                                                   bsrSortedColInd, blockSize, info,
                                                   pBufferSize)
     initialize_context()
-    @ccall libcusparse.cusparseSbsrilu02_bufferSizeExt(handle::cusparseHandle_t,
-                                                       dirA::cusparseDirection_t, mb::Cint,
-                                                       nnzb::Cint,
-                                                       descrA::cusparseMatDescr_t,
-                                                       bsrSortedVal::CuPtr{Cfloat},
-                                                       bsrSortedRowPtr::CuPtr{Cint},
-                                                       bsrSortedColInd::CuPtr{Cint},
-                                                       blockSize::Cint,
-                                                       info::bsrilu02Info_t,
-                                                       pBufferSize::Ptr{Csize_t})::cusparseStatus_t
+    @gcsafe_ccall libcusparse.cusparseSbsrilu02_bufferSizeExt(handle::cusparseHandle_t,
+                                                              dirA::cusparseDirection_t,
+                                                              mb::Cint, nnzb::Cint,
+                                                              descrA::cusparseMatDescr_t,
+                                                              bsrSortedVal::CuPtr{Cfloat},
+                                                              bsrSortedRowPtr::CuPtr{Cint},
+                                                              bsrSortedColInd::CuPtr{Cint},
+                                                              blockSize::Cint,
+                                                              info::bsrilu02Info_t,
+                                                              pBufferSize::Ptr{Csize_t})::cusparseStatus_t
 end
 
 @checked function cusparseDbsrilu02_bufferSizeExt(handle, dirA, mb, nnzb, descrA,
@@ -1607,16 +1688,16 @@ end
                                                   bsrSortedColInd, blockSize, info,
                                                   pBufferSize)
     initialize_context()
-    @ccall libcusparse.cusparseDbsrilu02_bufferSizeExt(handle::cusparseHandle_t,
-                                                       dirA::cusparseDirection_t, mb::Cint,
-                                                       nnzb::Cint,
-                                                       descrA::cusparseMatDescr_t,
-                                                       bsrSortedVal::CuPtr{Cdouble},
-                                                       bsrSortedRowPtr::CuPtr{Cint},
-                                                       bsrSortedColInd::CuPtr{Cint},
-                                                       blockSize::Cint,
-                                                       info::bsrilu02Info_t,
-                                                       pBufferSize::Ptr{Csize_t})::cusparseStatus_t
+    @gcsafe_ccall libcusparse.cusparseDbsrilu02_bufferSizeExt(handle::cusparseHandle_t,
+                                                              dirA::cusparseDirection_t,
+                                                              mb::Cint, nnzb::Cint,
+                                                              descrA::cusparseMatDescr_t,
+                                                              bsrSortedVal::CuPtr{Cdouble},
+                                                              bsrSortedRowPtr::CuPtr{Cint},
+                                                              bsrSortedColInd::CuPtr{Cint},
+                                                              blockSize::Cint,
+                                                              info::bsrilu02Info_t,
+                                                              pBufferSize::Ptr{Csize_t})::cusparseStatus_t
 end
 
 @checked function cusparseCbsrilu02_bufferSizeExt(handle, dirA, mb, nnzb, descrA,
@@ -1624,16 +1705,16 @@ end
                                                   bsrSortedColInd, blockSize, info,
                                                   pBufferSize)
     initialize_context()
-    @ccall libcusparse.cusparseCbsrilu02_bufferSizeExt(handle::cusparseHandle_t,
-                                                       dirA::cusparseDirection_t, mb::Cint,
-                                                       nnzb::Cint,
-                                                       descrA::cusparseMatDescr_t,
-                                                       bsrSortedVal::CuPtr{cuComplex},
-                                                       bsrSortedRowPtr::CuPtr{Cint},
-                                                       bsrSortedColInd::CuPtr{Cint},
-                                                       blockSize::Cint,
-                                                       info::bsrilu02Info_t,
-                                                       pBufferSize::Ptr{Csize_t})::cusparseStatus_t
+    @gcsafe_ccall libcusparse.cusparseCbsrilu02_bufferSizeExt(handle::cusparseHandle_t,
+                                                              dirA::cusparseDirection_t,
+                                                              mb::Cint, nnzb::Cint,
+                                                              descrA::cusparseMatDescr_t,
+                                                              bsrSortedVal::CuPtr{cuComplex},
+                                                              bsrSortedRowPtr::CuPtr{Cint},
+                                                              bsrSortedColInd::CuPtr{Cint},
+                                                              blockSize::Cint,
+                                                              info::bsrilu02Info_t,
+                                                              pBufferSize::Ptr{Csize_t})::cusparseStatus_t
 end
 
 @checked function cusparseZbsrilu02_bufferSizeExt(handle, dirA, mb, nnzb, descrA,
@@ -1641,418 +1722,450 @@ end
                                                   bsrSortedColInd, blockSize, info,
                                                   pBufferSize)
     initialize_context()
-    @ccall libcusparse.cusparseZbsrilu02_bufferSizeExt(handle::cusparseHandle_t,
-                                                       dirA::cusparseDirection_t, mb::Cint,
-                                                       nnzb::Cint,
-                                                       descrA::cusparseMatDescr_t,
-                                                       bsrSortedVal::CuPtr{cuDoubleComplex},
-                                                       bsrSortedRowPtr::CuPtr{Cint},
-                                                       bsrSortedColInd::CuPtr{Cint},
-                                                       blockSize::Cint,
-                                                       info::bsrilu02Info_t,
-                                                       pBufferSize::Ptr{Csize_t})::cusparseStatus_t
+    @gcsafe_ccall libcusparse.cusparseZbsrilu02_bufferSizeExt(handle::cusparseHandle_t,
+                                                              dirA::cusparseDirection_t,
+                                                              mb::Cint, nnzb::Cint,
+                                                              descrA::cusparseMatDescr_t,
+                                                              bsrSortedVal::CuPtr{cuDoubleComplex},
+                                                              bsrSortedRowPtr::CuPtr{Cint},
+                                                              bsrSortedColInd::CuPtr{Cint},
+                                                              blockSize::Cint,
+                                                              info::bsrilu02Info_t,
+                                                              pBufferSize::Ptr{Csize_t})::cusparseStatus_t
 end
 
 @checked function cusparseSbsrilu02_analysis(handle, dirA, mb, nnzb, descrA, bsrSortedVal,
                                              bsrSortedRowPtr, bsrSortedColInd, blockDim,
                                              info, policy, pBuffer)
     initialize_context()
-    @ccall libcusparse.cusparseSbsrilu02_analysis(handle::cusparseHandle_t,
-                                                  dirA::cusparseDirection_t, mb::Cint,
-                                                  nnzb::Cint, descrA::cusparseMatDescr_t,
-                                                  bsrSortedVal::CuPtr{Cfloat},
-                                                  bsrSortedRowPtr::CuPtr{Cint},
-                                                  bsrSortedColInd::CuPtr{Cint},
-                                                  blockDim::Cint, info::bsrilu02Info_t,
-                                                  policy::cusparseSolvePolicy_t,
-                                                  pBuffer::CuPtr{Cvoid})::cusparseStatus_t
+    @gcsafe_ccall libcusparse.cusparseSbsrilu02_analysis(handle::cusparseHandle_t,
+                                                         dirA::cusparseDirection_t,
+                                                         mb::Cint, nnzb::Cint,
+                                                         descrA::cusparseMatDescr_t,
+                                                         bsrSortedVal::CuPtr{Cfloat},
+                                                         bsrSortedRowPtr::CuPtr{Cint},
+                                                         bsrSortedColInd::CuPtr{Cint},
+                                                         blockDim::Cint,
+                                                         info::bsrilu02Info_t,
+                                                         policy::cusparseSolvePolicy_t,
+                                                         pBuffer::CuPtr{Cvoid})::cusparseStatus_t
 end
 
 @checked function cusparseDbsrilu02_analysis(handle, dirA, mb, nnzb, descrA, bsrSortedVal,
                                              bsrSortedRowPtr, bsrSortedColInd, blockDim,
                                              info, policy, pBuffer)
     initialize_context()
-    @ccall libcusparse.cusparseDbsrilu02_analysis(handle::cusparseHandle_t,
-                                                  dirA::cusparseDirection_t, mb::Cint,
-                                                  nnzb::Cint, descrA::cusparseMatDescr_t,
-                                                  bsrSortedVal::CuPtr{Cdouble},
-                                                  bsrSortedRowPtr::CuPtr{Cint},
-                                                  bsrSortedColInd::CuPtr{Cint},
-                                                  blockDim::Cint, info::bsrilu02Info_t,
-                                                  policy::cusparseSolvePolicy_t,
-                                                  pBuffer::CuPtr{Cvoid})::cusparseStatus_t
+    @gcsafe_ccall libcusparse.cusparseDbsrilu02_analysis(handle::cusparseHandle_t,
+                                                         dirA::cusparseDirection_t,
+                                                         mb::Cint, nnzb::Cint,
+                                                         descrA::cusparseMatDescr_t,
+                                                         bsrSortedVal::CuPtr{Cdouble},
+                                                         bsrSortedRowPtr::CuPtr{Cint},
+                                                         bsrSortedColInd::CuPtr{Cint},
+                                                         blockDim::Cint,
+                                                         info::bsrilu02Info_t,
+                                                         policy::cusparseSolvePolicy_t,
+                                                         pBuffer::CuPtr{Cvoid})::cusparseStatus_t
 end
 
 @checked function cusparseCbsrilu02_analysis(handle, dirA, mb, nnzb, descrA, bsrSortedVal,
                                              bsrSortedRowPtr, bsrSortedColInd, blockDim,
                                              info, policy, pBuffer)
     initialize_context()
-    @ccall libcusparse.cusparseCbsrilu02_analysis(handle::cusparseHandle_t,
-                                                  dirA::cusparseDirection_t, mb::Cint,
-                                                  nnzb::Cint, descrA::cusparseMatDescr_t,
-                                                  bsrSortedVal::CuPtr{cuComplex},
-                                                  bsrSortedRowPtr::CuPtr{Cint},
-                                                  bsrSortedColInd::CuPtr{Cint},
-                                                  blockDim::Cint, info::bsrilu02Info_t,
-                                                  policy::cusparseSolvePolicy_t,
-                                                  pBuffer::CuPtr{Cvoid})::cusparseStatus_t
+    @gcsafe_ccall libcusparse.cusparseCbsrilu02_analysis(handle::cusparseHandle_t,
+                                                         dirA::cusparseDirection_t,
+                                                         mb::Cint, nnzb::Cint,
+                                                         descrA::cusparseMatDescr_t,
+                                                         bsrSortedVal::CuPtr{cuComplex},
+                                                         bsrSortedRowPtr::CuPtr{Cint},
+                                                         bsrSortedColInd::CuPtr{Cint},
+                                                         blockDim::Cint,
+                                                         info::bsrilu02Info_t,
+                                                         policy::cusparseSolvePolicy_t,
+                                                         pBuffer::CuPtr{Cvoid})::cusparseStatus_t
 end
 
 @checked function cusparseZbsrilu02_analysis(handle, dirA, mb, nnzb, descrA, bsrSortedVal,
                                              bsrSortedRowPtr, bsrSortedColInd, blockDim,
                                              info, policy, pBuffer)
     initialize_context()
-    @ccall libcusparse.cusparseZbsrilu02_analysis(handle::cusparseHandle_t,
-                                                  dirA::cusparseDirection_t, mb::Cint,
-                                                  nnzb::Cint, descrA::cusparseMatDescr_t,
-                                                  bsrSortedVal::CuPtr{cuDoubleComplex},
-                                                  bsrSortedRowPtr::CuPtr{Cint},
-                                                  bsrSortedColInd::CuPtr{Cint},
-                                                  blockDim::Cint, info::bsrilu02Info_t,
-                                                  policy::cusparseSolvePolicy_t,
-                                                  pBuffer::CuPtr{Cvoid})::cusparseStatus_t
+    @gcsafe_ccall libcusparse.cusparseZbsrilu02_analysis(handle::cusparseHandle_t,
+                                                         dirA::cusparseDirection_t,
+                                                         mb::Cint, nnzb::Cint,
+                                                         descrA::cusparseMatDescr_t,
+                                                         bsrSortedVal::CuPtr{cuDoubleComplex},
+                                                         bsrSortedRowPtr::CuPtr{Cint},
+                                                         bsrSortedColInd::CuPtr{Cint},
+                                                         blockDim::Cint,
+                                                         info::bsrilu02Info_t,
+                                                         policy::cusparseSolvePolicy_t,
+                                                         pBuffer::CuPtr{Cvoid})::cusparseStatus_t
 end
 
 @checked function cusparseSbsrilu02(handle, dirA, mb, nnzb, descrA, bsrSortedVal,
                                     bsrSortedRowPtr, bsrSortedColInd, blockDim, info,
                                     policy, pBuffer)
     initialize_context()
-    @ccall libcusparse.cusparseSbsrilu02(handle::cusparseHandle_t,
-                                         dirA::cusparseDirection_t, mb::Cint, nnzb::Cint,
-                                         descrA::cusparseMatDescr_t,
-                                         bsrSortedVal::CuPtr{Cfloat},
-                                         bsrSortedRowPtr::CuPtr{Cint},
-                                         bsrSortedColInd::CuPtr{Cint}, blockDim::Cint,
-                                         info::bsrilu02Info_t,
-                                         policy::cusparseSolvePolicy_t,
-                                         pBuffer::CuPtr{Cvoid})::cusparseStatus_t
+    @gcsafe_ccall libcusparse.cusparseSbsrilu02(handle::cusparseHandle_t,
+                                                dirA::cusparseDirection_t, mb::Cint,
+                                                nnzb::Cint, descrA::cusparseMatDescr_t,
+                                                bsrSortedVal::CuPtr{Cfloat},
+                                                bsrSortedRowPtr::CuPtr{Cint},
+                                                bsrSortedColInd::CuPtr{Cint},
+                                                blockDim::Cint, info::bsrilu02Info_t,
+                                                policy::cusparseSolvePolicy_t,
+                                                pBuffer::CuPtr{Cvoid})::cusparseStatus_t
 end
 
 @checked function cusparseDbsrilu02(handle, dirA, mb, nnzb, descrA, bsrSortedVal,
                                     bsrSortedRowPtr, bsrSortedColInd, blockDim, info,
                                     policy, pBuffer)
     initialize_context()
-    @ccall libcusparse.cusparseDbsrilu02(handle::cusparseHandle_t,
-                                         dirA::cusparseDirection_t, mb::Cint, nnzb::Cint,
-                                         descrA::cusparseMatDescr_t,
-                                         bsrSortedVal::CuPtr{Cdouble},
-                                         bsrSortedRowPtr::CuPtr{Cint},
-                                         bsrSortedColInd::CuPtr{Cint}, blockDim::Cint,
-                                         info::bsrilu02Info_t,
-                                         policy::cusparseSolvePolicy_t,
-                                         pBuffer::CuPtr{Cvoid})::cusparseStatus_t
+    @gcsafe_ccall libcusparse.cusparseDbsrilu02(handle::cusparseHandle_t,
+                                                dirA::cusparseDirection_t, mb::Cint,
+                                                nnzb::Cint, descrA::cusparseMatDescr_t,
+                                                bsrSortedVal::CuPtr{Cdouble},
+                                                bsrSortedRowPtr::CuPtr{Cint},
+                                                bsrSortedColInd::CuPtr{Cint},
+                                                blockDim::Cint, info::bsrilu02Info_t,
+                                                policy::cusparseSolvePolicy_t,
+                                                pBuffer::CuPtr{Cvoid})::cusparseStatus_t
 end
 
 @checked function cusparseCbsrilu02(handle, dirA, mb, nnzb, descrA, bsrSortedVal,
                                     bsrSortedRowPtr, bsrSortedColInd, blockDim, info,
                                     policy, pBuffer)
     initialize_context()
-    @ccall libcusparse.cusparseCbsrilu02(handle::cusparseHandle_t,
-                                         dirA::cusparseDirection_t, mb::Cint, nnzb::Cint,
-                                         descrA::cusparseMatDescr_t,
-                                         bsrSortedVal::CuPtr{cuComplex},
-                                         bsrSortedRowPtr::CuPtr{Cint},
-                                         bsrSortedColInd::CuPtr{Cint}, blockDim::Cint,
-                                         info::bsrilu02Info_t,
-                                         policy::cusparseSolvePolicy_t,
-                                         pBuffer::CuPtr{Cvoid})::cusparseStatus_t
+    @gcsafe_ccall libcusparse.cusparseCbsrilu02(handle::cusparseHandle_t,
+                                                dirA::cusparseDirection_t, mb::Cint,
+                                                nnzb::Cint, descrA::cusparseMatDescr_t,
+                                                bsrSortedVal::CuPtr{cuComplex},
+                                                bsrSortedRowPtr::CuPtr{Cint},
+                                                bsrSortedColInd::CuPtr{Cint},
+                                                blockDim::Cint, info::bsrilu02Info_t,
+                                                policy::cusparseSolvePolicy_t,
+                                                pBuffer::CuPtr{Cvoid})::cusparseStatus_t
 end
 
 @checked function cusparseZbsrilu02(handle, dirA, mb, nnzb, descrA, bsrSortedVal,
                                     bsrSortedRowPtr, bsrSortedColInd, blockDim, info,
                                     policy, pBuffer)
     initialize_context()
-    @ccall libcusparse.cusparseZbsrilu02(handle::cusparseHandle_t,
-                                         dirA::cusparseDirection_t, mb::Cint, nnzb::Cint,
-                                         descrA::cusparseMatDescr_t,
-                                         bsrSortedVal::CuPtr{cuDoubleComplex},
-                                         bsrSortedRowPtr::CuPtr{Cint},
-                                         bsrSortedColInd::CuPtr{Cint}, blockDim::Cint,
-                                         info::bsrilu02Info_t,
-                                         policy::cusparseSolvePolicy_t,
-                                         pBuffer::CuPtr{Cvoid})::cusparseStatus_t
+    @gcsafe_ccall libcusparse.cusparseZbsrilu02(handle::cusparseHandle_t,
+                                                dirA::cusparseDirection_t, mb::Cint,
+                                                nnzb::Cint, descrA::cusparseMatDescr_t,
+                                                bsrSortedVal::CuPtr{cuDoubleComplex},
+                                                bsrSortedRowPtr::CuPtr{Cint},
+                                                bsrSortedColInd::CuPtr{Cint},
+                                                blockDim::Cint, info::bsrilu02Info_t,
+                                                policy::cusparseSolvePolicy_t,
+                                                pBuffer::CuPtr{Cvoid})::cusparseStatus_t
 end
 
 @checked function cusparseXcsric02_zeroPivot(handle, info, position)
     initialize_context()
-    @ccall libcusparse.cusparseXcsric02_zeroPivot(handle::cusparseHandle_t,
-                                                  info::csric02Info_t,
-                                                  position::Ptr{Cint})::cusparseStatus_t
+    @gcsafe_ccall libcusparse.cusparseXcsric02_zeroPivot(handle::cusparseHandle_t,
+                                                         info::csric02Info_t,
+                                                         position::Ptr{Cint})::cusparseStatus_t
 end
 
 @checked function cusparseScsric02_bufferSize(handle, m, nnz, descrA, csrSortedValA,
                                               csrSortedRowPtrA, csrSortedColIndA, info,
                                               pBufferSizeInBytes)
     initialize_context()
-    @ccall libcusparse.cusparseScsric02_bufferSize(handle::cusparseHandle_t, m::Cint,
-                                                   nnz::Cint, descrA::cusparseMatDescr_t,
-                                                   csrSortedValA::CuPtr{Cfloat},
-                                                   csrSortedRowPtrA::CuPtr{Cint},
-                                                   csrSortedColIndA::CuPtr{Cint},
-                                                   info::csric02Info_t,
-                                                   pBufferSizeInBytes::Ptr{Cint})::cusparseStatus_t
+    @gcsafe_ccall libcusparse.cusparseScsric02_bufferSize(handle::cusparseHandle_t, m::Cint,
+                                                          nnz::Cint,
+                                                          descrA::cusparseMatDescr_t,
+                                                          csrSortedValA::CuPtr{Cfloat},
+                                                          csrSortedRowPtrA::CuPtr{Cint},
+                                                          csrSortedColIndA::CuPtr{Cint},
+                                                          info::csric02Info_t,
+                                                          pBufferSizeInBytes::Ptr{Cint})::cusparseStatus_t
 end
 
 @checked function cusparseDcsric02_bufferSize(handle, m, nnz, descrA, csrSortedValA,
                                               csrSortedRowPtrA, csrSortedColIndA, info,
                                               pBufferSizeInBytes)
     initialize_context()
-    @ccall libcusparse.cusparseDcsric02_bufferSize(handle::cusparseHandle_t, m::Cint,
-                                                   nnz::Cint, descrA::cusparseMatDescr_t,
-                                                   csrSortedValA::CuPtr{Cdouble},
-                                                   csrSortedRowPtrA::CuPtr{Cint},
-                                                   csrSortedColIndA::CuPtr{Cint},
-                                                   info::csric02Info_t,
-                                                   pBufferSizeInBytes::Ptr{Cint})::cusparseStatus_t
+    @gcsafe_ccall libcusparse.cusparseDcsric02_bufferSize(handle::cusparseHandle_t, m::Cint,
+                                                          nnz::Cint,
+                                                          descrA::cusparseMatDescr_t,
+                                                          csrSortedValA::CuPtr{Cdouble},
+                                                          csrSortedRowPtrA::CuPtr{Cint},
+                                                          csrSortedColIndA::CuPtr{Cint},
+                                                          info::csric02Info_t,
+                                                          pBufferSizeInBytes::Ptr{Cint})::cusparseStatus_t
 end
 
 @checked function cusparseCcsric02_bufferSize(handle, m, nnz, descrA, csrSortedValA,
                                               csrSortedRowPtrA, csrSortedColIndA, info,
                                               pBufferSizeInBytes)
     initialize_context()
-    @ccall libcusparse.cusparseCcsric02_bufferSize(handle::cusparseHandle_t, m::Cint,
-                                                   nnz::Cint, descrA::cusparseMatDescr_t,
-                                                   csrSortedValA::CuPtr{cuComplex},
-                                                   csrSortedRowPtrA::CuPtr{Cint},
-                                                   csrSortedColIndA::CuPtr{Cint},
-                                                   info::csric02Info_t,
-                                                   pBufferSizeInBytes::Ptr{Cint})::cusparseStatus_t
+    @gcsafe_ccall libcusparse.cusparseCcsric02_bufferSize(handle::cusparseHandle_t, m::Cint,
+                                                          nnz::Cint,
+                                                          descrA::cusparseMatDescr_t,
+                                                          csrSortedValA::CuPtr{cuComplex},
+                                                          csrSortedRowPtrA::CuPtr{Cint},
+                                                          csrSortedColIndA::CuPtr{Cint},
+                                                          info::csric02Info_t,
+                                                          pBufferSizeInBytes::Ptr{Cint})::cusparseStatus_t
 end
 
 @checked function cusparseZcsric02_bufferSize(handle, m, nnz, descrA, csrSortedValA,
                                               csrSortedRowPtrA, csrSortedColIndA, info,
                                               pBufferSizeInBytes)
     initialize_context()
-    @ccall libcusparse.cusparseZcsric02_bufferSize(handle::cusparseHandle_t, m::Cint,
-                                                   nnz::Cint, descrA::cusparseMatDescr_t,
-                                                   csrSortedValA::CuPtr{cuDoubleComplex},
-                                                   csrSortedRowPtrA::CuPtr{Cint},
-                                                   csrSortedColIndA::CuPtr{Cint},
-                                                   info::csric02Info_t,
-                                                   pBufferSizeInBytes::Ptr{Cint})::cusparseStatus_t
+    @gcsafe_ccall libcusparse.cusparseZcsric02_bufferSize(handle::cusparseHandle_t, m::Cint,
+                                                          nnz::Cint,
+                                                          descrA::cusparseMatDescr_t,
+                                                          csrSortedValA::CuPtr{cuDoubleComplex},
+                                                          csrSortedRowPtrA::CuPtr{Cint},
+                                                          csrSortedColIndA::CuPtr{Cint},
+                                                          info::csric02Info_t,
+                                                          pBufferSizeInBytes::Ptr{Cint})::cusparseStatus_t
 end
 
 @checked function cusparseScsric02_bufferSizeExt(handle, m, nnz, descrA, csrSortedVal,
                                                  csrSortedRowPtr, csrSortedColInd, info,
                                                  pBufferSize)
     initialize_context()
-    @ccall libcusparse.cusparseScsric02_bufferSizeExt(handle::cusparseHandle_t, m::Cint,
-                                                      nnz::Cint, descrA::cusparseMatDescr_t,
-                                                      csrSortedVal::CuPtr{Cfloat},
-                                                      csrSortedRowPtr::CuPtr{Cint},
-                                                      csrSortedColInd::CuPtr{Cint},
-                                                      info::csric02Info_t,
-                                                      pBufferSize::Ptr{Csize_t})::cusparseStatus_t
+    @gcsafe_ccall libcusparse.cusparseScsric02_bufferSizeExt(handle::cusparseHandle_t,
+                                                             m::Cint, nnz::Cint,
+                                                             descrA::cusparseMatDescr_t,
+                                                             csrSortedVal::CuPtr{Cfloat},
+                                                             csrSortedRowPtr::CuPtr{Cint},
+                                                             csrSortedColInd::CuPtr{Cint},
+                                                             info::csric02Info_t,
+                                                             pBufferSize::Ptr{Csize_t})::cusparseStatus_t
 end
 
 @checked function cusparseDcsric02_bufferSizeExt(handle, m, nnz, descrA, csrSortedVal,
                                                  csrSortedRowPtr, csrSortedColInd, info,
                                                  pBufferSize)
     initialize_context()
-    @ccall libcusparse.cusparseDcsric02_bufferSizeExt(handle::cusparseHandle_t, m::Cint,
-                                                      nnz::Cint, descrA::cusparseMatDescr_t,
-                                                      csrSortedVal::CuPtr{Cdouble},
-                                                      csrSortedRowPtr::CuPtr{Cint},
-                                                      csrSortedColInd::CuPtr{Cint},
-                                                      info::csric02Info_t,
-                                                      pBufferSize::Ptr{Csize_t})::cusparseStatus_t
+    @gcsafe_ccall libcusparse.cusparseDcsric02_bufferSizeExt(handle::cusparseHandle_t,
+                                                             m::Cint, nnz::Cint,
+                                                             descrA::cusparseMatDescr_t,
+                                                             csrSortedVal::CuPtr{Cdouble},
+                                                             csrSortedRowPtr::CuPtr{Cint},
+                                                             csrSortedColInd::CuPtr{Cint},
+                                                             info::csric02Info_t,
+                                                             pBufferSize::Ptr{Csize_t})::cusparseStatus_t
 end
 
 @checked function cusparseCcsric02_bufferSizeExt(handle, m, nnz, descrA, csrSortedVal,
                                                  csrSortedRowPtr, csrSortedColInd, info,
                                                  pBufferSize)
     initialize_context()
-    @ccall libcusparse.cusparseCcsric02_bufferSizeExt(handle::cusparseHandle_t, m::Cint,
-                                                      nnz::Cint, descrA::cusparseMatDescr_t,
-                                                      csrSortedVal::CuPtr{cuComplex},
-                                                      csrSortedRowPtr::CuPtr{Cint},
-                                                      csrSortedColInd::CuPtr{Cint},
-                                                      info::csric02Info_t,
-                                                      pBufferSize::Ptr{Csize_t})::cusparseStatus_t
+    @gcsafe_ccall libcusparse.cusparseCcsric02_bufferSizeExt(handle::cusparseHandle_t,
+                                                             m::Cint, nnz::Cint,
+                                                             descrA::cusparseMatDescr_t,
+                                                             csrSortedVal::CuPtr{cuComplex},
+                                                             csrSortedRowPtr::CuPtr{Cint},
+                                                             csrSortedColInd::CuPtr{Cint},
+                                                             info::csric02Info_t,
+                                                             pBufferSize::Ptr{Csize_t})::cusparseStatus_t
 end
 
 @checked function cusparseZcsric02_bufferSizeExt(handle, m, nnz, descrA, csrSortedVal,
                                                  csrSortedRowPtr, csrSortedColInd, info,
                                                  pBufferSize)
     initialize_context()
-    @ccall libcusparse.cusparseZcsric02_bufferSizeExt(handle::cusparseHandle_t, m::Cint,
-                                                      nnz::Cint, descrA::cusparseMatDescr_t,
-                                                      csrSortedVal::CuPtr{cuDoubleComplex},
-                                                      csrSortedRowPtr::CuPtr{Cint},
-                                                      csrSortedColInd::CuPtr{Cint},
-                                                      info::csric02Info_t,
-                                                      pBufferSize::Ptr{Csize_t})::cusparseStatus_t
+    @gcsafe_ccall libcusparse.cusparseZcsric02_bufferSizeExt(handle::cusparseHandle_t,
+                                                             m::Cint, nnz::Cint,
+                                                             descrA::cusparseMatDescr_t,
+                                                             csrSortedVal::CuPtr{cuDoubleComplex},
+                                                             csrSortedRowPtr::CuPtr{Cint},
+                                                             csrSortedColInd::CuPtr{Cint},
+                                                             info::csric02Info_t,
+                                                             pBufferSize::Ptr{Csize_t})::cusparseStatus_t
 end
 
 @checked function cusparseScsric02_analysis(handle, m, nnz, descrA, csrSortedValA,
                                             csrSortedRowPtrA, csrSortedColIndA, info,
                                             policy, pBuffer)
     initialize_context()
-    @ccall libcusparse.cusparseScsric02_analysis(handle::cusparseHandle_t, m::Cint,
-                                                 nnz::Cint, descrA::cusparseMatDescr_t,
-                                                 csrSortedValA::CuPtr{Cfloat},
-                                                 csrSortedRowPtrA::CuPtr{Cint},
-                                                 csrSortedColIndA::CuPtr{Cint},
-                                                 info::csric02Info_t,
-                                                 policy::cusparseSolvePolicy_t,
-                                                 pBuffer::CuPtr{Cvoid})::cusparseStatus_t
+    @gcsafe_ccall libcusparse.cusparseScsric02_analysis(handle::cusparseHandle_t, m::Cint,
+                                                        nnz::Cint,
+                                                        descrA::cusparseMatDescr_t,
+                                                        csrSortedValA::CuPtr{Cfloat},
+                                                        csrSortedRowPtrA::CuPtr{Cint},
+                                                        csrSortedColIndA::CuPtr{Cint},
+                                                        info::csric02Info_t,
+                                                        policy::cusparseSolvePolicy_t,
+                                                        pBuffer::CuPtr{Cvoid})::cusparseStatus_t
 end
 
 @checked function cusparseDcsric02_analysis(handle, m, nnz, descrA, csrSortedValA,
                                             csrSortedRowPtrA, csrSortedColIndA, info,
                                             policy, pBuffer)
     initialize_context()
-    @ccall libcusparse.cusparseDcsric02_analysis(handle::cusparseHandle_t, m::Cint,
-                                                 nnz::Cint, descrA::cusparseMatDescr_t,
-                                                 csrSortedValA::CuPtr{Cdouble},
-                                                 csrSortedRowPtrA::CuPtr{Cint},
-                                                 csrSortedColIndA::CuPtr{Cint},
-                                                 info::csric02Info_t,
-                                                 policy::cusparseSolvePolicy_t,
-                                                 pBuffer::CuPtr{Cvoid})::cusparseStatus_t
+    @gcsafe_ccall libcusparse.cusparseDcsric02_analysis(handle::cusparseHandle_t, m::Cint,
+                                                        nnz::Cint,
+                                                        descrA::cusparseMatDescr_t,
+                                                        csrSortedValA::CuPtr{Cdouble},
+                                                        csrSortedRowPtrA::CuPtr{Cint},
+                                                        csrSortedColIndA::CuPtr{Cint},
+                                                        info::csric02Info_t,
+                                                        policy::cusparseSolvePolicy_t,
+                                                        pBuffer::CuPtr{Cvoid})::cusparseStatus_t
 end
 
 @checked function cusparseCcsric02_analysis(handle, m, nnz, descrA, csrSortedValA,
                                             csrSortedRowPtrA, csrSortedColIndA, info,
                                             policy, pBuffer)
     initialize_context()
-    @ccall libcusparse.cusparseCcsric02_analysis(handle::cusparseHandle_t, m::Cint,
-                                                 nnz::Cint, descrA::cusparseMatDescr_t,
-                                                 csrSortedValA::CuPtr{cuComplex},
-                                                 csrSortedRowPtrA::CuPtr{Cint},
-                                                 csrSortedColIndA::CuPtr{Cint},
-                                                 info::csric02Info_t,
-                                                 policy::cusparseSolvePolicy_t,
-                                                 pBuffer::CuPtr{Cvoid})::cusparseStatus_t
+    @gcsafe_ccall libcusparse.cusparseCcsric02_analysis(handle::cusparseHandle_t, m::Cint,
+                                                        nnz::Cint,
+                                                        descrA::cusparseMatDescr_t,
+                                                        csrSortedValA::CuPtr{cuComplex},
+                                                        csrSortedRowPtrA::CuPtr{Cint},
+                                                        csrSortedColIndA::CuPtr{Cint},
+                                                        info::csric02Info_t,
+                                                        policy::cusparseSolvePolicy_t,
+                                                        pBuffer::CuPtr{Cvoid})::cusparseStatus_t
 end
 
 @checked function cusparseZcsric02_analysis(handle, m, nnz, descrA, csrSortedValA,
                                             csrSortedRowPtrA, csrSortedColIndA, info,
                                             policy, pBuffer)
     initialize_context()
-    @ccall libcusparse.cusparseZcsric02_analysis(handle::cusparseHandle_t, m::Cint,
-                                                 nnz::Cint, descrA::cusparseMatDescr_t,
-                                                 csrSortedValA::CuPtr{cuDoubleComplex},
-                                                 csrSortedRowPtrA::CuPtr{Cint},
-                                                 csrSortedColIndA::CuPtr{Cint},
-                                                 info::csric02Info_t,
-                                                 policy::cusparseSolvePolicy_t,
-                                                 pBuffer::CuPtr{Cvoid})::cusparseStatus_t
+    @gcsafe_ccall libcusparse.cusparseZcsric02_analysis(handle::cusparseHandle_t, m::Cint,
+                                                        nnz::Cint,
+                                                        descrA::cusparseMatDescr_t,
+                                                        csrSortedValA::CuPtr{cuDoubleComplex},
+                                                        csrSortedRowPtrA::CuPtr{Cint},
+                                                        csrSortedColIndA::CuPtr{Cint},
+                                                        info::csric02Info_t,
+                                                        policy::cusparseSolvePolicy_t,
+                                                        pBuffer::CuPtr{Cvoid})::cusparseStatus_t
 end
 
 @checked function cusparseScsric02(handle, m, nnz, descrA, csrSortedValA_valM,
                                    csrSortedRowPtrA, csrSortedColIndA, info, policy,
                                    pBuffer)
     initialize_context()
-    @ccall libcusparse.cusparseScsric02(handle::cusparseHandle_t, m::Cint, nnz::Cint,
-                                        descrA::cusparseMatDescr_t,
-                                        csrSortedValA_valM::CuPtr{Cfloat},
-                                        csrSortedRowPtrA::CuPtr{Cint},
-                                        csrSortedColIndA::CuPtr{Cint}, info::csric02Info_t,
-                                        policy::cusparseSolvePolicy_t,
-                                        pBuffer::CuPtr{Cvoid})::cusparseStatus_t
+    @gcsafe_ccall libcusparse.cusparseScsric02(handle::cusparseHandle_t, m::Cint, nnz::Cint,
+                                               descrA::cusparseMatDescr_t,
+                                               csrSortedValA_valM::CuPtr{Cfloat},
+                                               csrSortedRowPtrA::CuPtr{Cint},
+                                               csrSortedColIndA::CuPtr{Cint},
+                                               info::csric02Info_t,
+                                               policy::cusparseSolvePolicy_t,
+                                               pBuffer::CuPtr{Cvoid})::cusparseStatus_t
 end
 
 @checked function cusparseDcsric02(handle, m, nnz, descrA, csrSortedValA_valM,
                                    csrSortedRowPtrA, csrSortedColIndA, info, policy,
                                    pBuffer)
     initialize_context()
-    @ccall libcusparse.cusparseDcsric02(handle::cusparseHandle_t, m::Cint, nnz::Cint,
-                                        descrA::cusparseMatDescr_t,
-                                        csrSortedValA_valM::CuPtr{Cdouble},
-                                        csrSortedRowPtrA::CuPtr{Cint},
-                                        csrSortedColIndA::CuPtr{Cint}, info::csric02Info_t,
-                                        policy::cusparseSolvePolicy_t,
-                                        pBuffer::CuPtr{Cvoid})::cusparseStatus_t
+    @gcsafe_ccall libcusparse.cusparseDcsric02(handle::cusparseHandle_t, m::Cint, nnz::Cint,
+                                               descrA::cusparseMatDescr_t,
+                                               csrSortedValA_valM::CuPtr{Cdouble},
+                                               csrSortedRowPtrA::CuPtr{Cint},
+                                               csrSortedColIndA::CuPtr{Cint},
+                                               info::csric02Info_t,
+                                               policy::cusparseSolvePolicy_t,
+                                               pBuffer::CuPtr{Cvoid})::cusparseStatus_t
 end
 
 @checked function cusparseCcsric02(handle, m, nnz, descrA, csrSortedValA_valM,
                                    csrSortedRowPtrA, csrSortedColIndA, info, policy,
                                    pBuffer)
     initialize_context()
-    @ccall libcusparse.cusparseCcsric02(handle::cusparseHandle_t, m::Cint, nnz::Cint,
-                                        descrA::cusparseMatDescr_t,
-                                        csrSortedValA_valM::CuPtr{cuComplex},
-                                        csrSortedRowPtrA::CuPtr{Cint},
-                                        csrSortedColIndA::CuPtr{Cint}, info::csric02Info_t,
-                                        policy::cusparseSolvePolicy_t,
-                                        pBuffer::CuPtr{Cvoid})::cusparseStatus_t
+    @gcsafe_ccall libcusparse.cusparseCcsric02(handle::cusparseHandle_t, m::Cint, nnz::Cint,
+                                               descrA::cusparseMatDescr_t,
+                                               csrSortedValA_valM::CuPtr{cuComplex},
+                                               csrSortedRowPtrA::CuPtr{Cint},
+                                               csrSortedColIndA::CuPtr{Cint},
+                                               info::csric02Info_t,
+                                               policy::cusparseSolvePolicy_t,
+                                               pBuffer::CuPtr{Cvoid})::cusparseStatus_t
 end
 
 @checked function cusparseZcsric02(handle, m, nnz, descrA, csrSortedValA_valM,
                                    csrSortedRowPtrA, csrSortedColIndA, info, policy,
                                    pBuffer)
     initialize_context()
-    @ccall libcusparse.cusparseZcsric02(handle::cusparseHandle_t, m::Cint, nnz::Cint,
-                                        descrA::cusparseMatDescr_t,
-                                        csrSortedValA_valM::CuPtr{cuDoubleComplex},
-                                        csrSortedRowPtrA::CuPtr{Cint},
-                                        csrSortedColIndA::CuPtr{Cint}, info::csric02Info_t,
-                                        policy::cusparseSolvePolicy_t,
-                                        pBuffer::CuPtr{Cvoid})::cusparseStatus_t
+    @gcsafe_ccall libcusparse.cusparseZcsric02(handle::cusparseHandle_t, m::Cint, nnz::Cint,
+                                               descrA::cusparseMatDescr_t,
+                                               csrSortedValA_valM::CuPtr{cuDoubleComplex},
+                                               csrSortedRowPtrA::CuPtr{Cint},
+                                               csrSortedColIndA::CuPtr{Cint},
+                                               info::csric02Info_t,
+                                               policy::cusparseSolvePolicy_t,
+                                               pBuffer::CuPtr{Cvoid})::cusparseStatus_t
 end
 
 @checked function cusparseXbsric02_zeroPivot(handle, info, position)
     initialize_context()
-    @ccall libcusparse.cusparseXbsric02_zeroPivot(handle::cusparseHandle_t,
-                                                  info::bsric02Info_t,
-                                                  position::Ptr{Cint})::cusparseStatus_t
+    @gcsafe_ccall libcusparse.cusparseXbsric02_zeroPivot(handle::cusparseHandle_t,
+                                                         info::bsric02Info_t,
+                                                         position::Ptr{Cint})::cusparseStatus_t
 end
 
 @checked function cusparseSbsric02_bufferSize(handle, dirA, mb, nnzb, descrA, bsrSortedVal,
                                               bsrSortedRowPtr, bsrSortedColInd, blockDim,
                                               info, pBufferSizeInBytes)
     initialize_context()
-    @ccall libcusparse.cusparseSbsric02_bufferSize(handle::cusparseHandle_t,
-                                                   dirA::cusparseDirection_t, mb::Cint,
-                                                   nnzb::Cint, descrA::cusparseMatDescr_t,
-                                                   bsrSortedVal::CuPtr{Cfloat},
-                                                   bsrSortedRowPtr::CuPtr{Cint},
-                                                   bsrSortedColInd::CuPtr{Cint},
-                                                   blockDim::Cint, info::bsric02Info_t,
-                                                   pBufferSizeInBytes::Ptr{Cint})::cusparseStatus_t
+    @gcsafe_ccall libcusparse.cusparseSbsric02_bufferSize(handle::cusparseHandle_t,
+                                                          dirA::cusparseDirection_t,
+                                                          mb::Cint, nnzb::Cint,
+                                                          descrA::cusparseMatDescr_t,
+                                                          bsrSortedVal::CuPtr{Cfloat},
+                                                          bsrSortedRowPtr::CuPtr{Cint},
+                                                          bsrSortedColInd::CuPtr{Cint},
+                                                          blockDim::Cint,
+                                                          info::bsric02Info_t,
+                                                          pBufferSizeInBytes::Ptr{Cint})::cusparseStatus_t
 end
 
 @checked function cusparseDbsric02_bufferSize(handle, dirA, mb, nnzb, descrA, bsrSortedVal,
                                               bsrSortedRowPtr, bsrSortedColInd, blockDim,
                                               info, pBufferSizeInBytes)
     initialize_context()
-    @ccall libcusparse.cusparseDbsric02_bufferSize(handle::cusparseHandle_t,
-                                                   dirA::cusparseDirection_t, mb::Cint,
-                                                   nnzb::Cint, descrA::cusparseMatDescr_t,
-                                                   bsrSortedVal::CuPtr{Cdouble},
-                                                   bsrSortedRowPtr::CuPtr{Cint},
-                                                   bsrSortedColInd::CuPtr{Cint},
-                                                   blockDim::Cint, info::bsric02Info_t,
-                                                   pBufferSizeInBytes::Ptr{Cint})::cusparseStatus_t
+    @gcsafe_ccall libcusparse.cusparseDbsric02_bufferSize(handle::cusparseHandle_t,
+                                                          dirA::cusparseDirection_t,
+                                                          mb::Cint, nnzb::Cint,
+                                                          descrA::cusparseMatDescr_t,
+                                                          bsrSortedVal::CuPtr{Cdouble},
+                                                          bsrSortedRowPtr::CuPtr{Cint},
+                                                          bsrSortedColInd::CuPtr{Cint},
+                                                          blockDim::Cint,
+                                                          info::bsric02Info_t,
+                                                          pBufferSizeInBytes::Ptr{Cint})::cusparseStatus_t
 end
 
 @checked function cusparseCbsric02_bufferSize(handle, dirA, mb, nnzb, descrA, bsrSortedVal,
                                               bsrSortedRowPtr, bsrSortedColInd, blockDim,
                                               info, pBufferSizeInBytes)
     initialize_context()
-    @ccall libcusparse.cusparseCbsric02_bufferSize(handle::cusparseHandle_t,
-                                                   dirA::cusparseDirection_t, mb::Cint,
-                                                   nnzb::Cint, descrA::cusparseMatDescr_t,
-                                                   bsrSortedVal::CuPtr{cuComplex},
-                                                   bsrSortedRowPtr::CuPtr{Cint},
-                                                   bsrSortedColInd::CuPtr{Cint},
-                                                   blockDim::Cint, info::bsric02Info_t,
-                                                   pBufferSizeInBytes::Ptr{Cint})::cusparseStatus_t
+    @gcsafe_ccall libcusparse.cusparseCbsric02_bufferSize(handle::cusparseHandle_t,
+                                                          dirA::cusparseDirection_t,
+                                                          mb::Cint, nnzb::Cint,
+                                                          descrA::cusparseMatDescr_t,
+                                                          bsrSortedVal::CuPtr{cuComplex},
+                                                          bsrSortedRowPtr::CuPtr{Cint},
+                                                          bsrSortedColInd::CuPtr{Cint},
+                                                          blockDim::Cint,
+                                                          info::bsric02Info_t,
+                                                          pBufferSizeInBytes::Ptr{Cint})::cusparseStatus_t
 end
 
 @checked function cusparseZbsric02_bufferSize(handle, dirA, mb, nnzb, descrA, bsrSortedVal,
                                               bsrSortedRowPtr, bsrSortedColInd, blockDim,
                                               info, pBufferSizeInBytes)
     initialize_context()
-    @ccall libcusparse.cusparseZbsric02_bufferSize(handle::cusparseHandle_t,
-                                                   dirA::cusparseDirection_t, mb::Cint,
-                                                   nnzb::Cint, descrA::cusparseMatDescr_t,
-                                                   bsrSortedVal::CuPtr{cuDoubleComplex},
-                                                   bsrSortedRowPtr::CuPtr{Cint},
-                                                   bsrSortedColInd::CuPtr{Cint},
-                                                   blockDim::Cint, info::bsric02Info_t,
-                                                   pBufferSizeInBytes::Ptr{Cint})::cusparseStatus_t
+    @gcsafe_ccall libcusparse.cusparseZbsric02_bufferSize(handle::cusparseHandle_t,
+                                                          dirA::cusparseDirection_t,
+                                                          mb::Cint, nnzb::Cint,
+                                                          descrA::cusparseMatDescr_t,
+                                                          bsrSortedVal::CuPtr{cuDoubleComplex},
+                                                          bsrSortedRowPtr::CuPtr{Cint},
+                                                          bsrSortedColInd::CuPtr{Cint},
+                                                          blockDim::Cint,
+                                                          info::bsric02Info_t,
+                                                          pBufferSizeInBytes::Ptr{Cint})::cusparseStatus_t
 end
 
 @checked function cusparseSbsric02_bufferSizeExt(handle, dirA, mb, nnzb, descrA,
@@ -2060,15 +2173,16 @@ end
                                                  bsrSortedColInd, blockSize, info,
                                                  pBufferSize)
     initialize_context()
-    @ccall libcusparse.cusparseSbsric02_bufferSizeExt(handle::cusparseHandle_t,
-                                                      dirA::cusparseDirection_t, mb::Cint,
-                                                      nnzb::Cint,
-                                                      descrA::cusparseMatDescr_t,
-                                                      bsrSortedVal::CuPtr{Cfloat},
-                                                      bsrSortedRowPtr::CuPtr{Cint},
-                                                      bsrSortedColInd::CuPtr{Cint},
-                                                      blockSize::Cint, info::bsric02Info_t,
-                                                      pBufferSize::Ptr{Csize_t})::cusparseStatus_t
+    @gcsafe_ccall libcusparse.cusparseSbsric02_bufferSizeExt(handle::cusparseHandle_t,
+                                                             dirA::cusparseDirection_t,
+                                                             mb::Cint, nnzb::Cint,
+                                                             descrA::cusparseMatDescr_t,
+                                                             bsrSortedVal::CuPtr{Cfloat},
+                                                             bsrSortedRowPtr::CuPtr{Cint},
+                                                             bsrSortedColInd::CuPtr{Cint},
+                                                             blockSize::Cint,
+                                                             info::bsric02Info_t,
+                                                             pBufferSize::Ptr{Csize_t})::cusparseStatus_t
 end
 
 @checked function cusparseDbsric02_bufferSizeExt(handle, dirA, mb, nnzb, descrA,
@@ -2076,15 +2190,16 @@ end
                                                  bsrSortedColInd, blockSize, info,
                                                  pBufferSize)
     initialize_context()
-    @ccall libcusparse.cusparseDbsric02_bufferSizeExt(handle::cusparseHandle_t,
-                                                      dirA::cusparseDirection_t, mb::Cint,
-                                                      nnzb::Cint,
-                                                      descrA::cusparseMatDescr_t,
-                                                      bsrSortedVal::CuPtr{Cdouble},
-                                                      bsrSortedRowPtr::CuPtr{Cint},
-                                                      bsrSortedColInd::CuPtr{Cint},
-                                                      blockSize::Cint, info::bsric02Info_t,
-                                                      pBufferSize::Ptr{Csize_t})::cusparseStatus_t
+    @gcsafe_ccall libcusparse.cusparseDbsric02_bufferSizeExt(handle::cusparseHandle_t,
+                                                             dirA::cusparseDirection_t,
+                                                             mb::Cint, nnzb::Cint,
+                                                             descrA::cusparseMatDescr_t,
+                                                             bsrSortedVal::CuPtr{Cdouble},
+                                                             bsrSortedRowPtr::CuPtr{Cint},
+                                                             bsrSortedColInd::CuPtr{Cint},
+                                                             blockSize::Cint,
+                                                             info::bsric02Info_t,
+                                                             pBufferSize::Ptr{Csize_t})::cusparseStatus_t
 end
 
 @checked function cusparseCbsric02_bufferSizeExt(handle, dirA, mb, nnzb, descrA,
@@ -2092,15 +2207,16 @@ end
                                                  bsrSortedColInd, blockSize, info,
                                                  pBufferSize)
     initialize_context()
-    @ccall libcusparse.cusparseCbsric02_bufferSizeExt(handle::cusparseHandle_t,
-                                                      dirA::cusparseDirection_t, mb::Cint,
-                                                      nnzb::Cint,
-                                                      descrA::cusparseMatDescr_t,
-                                                      bsrSortedVal::CuPtr{cuComplex},
-                                                      bsrSortedRowPtr::CuPtr{Cint},
-                                                      bsrSortedColInd::CuPtr{Cint},
-                                                      blockSize::Cint, info::bsric02Info_t,
-                                                      pBufferSize::Ptr{Csize_t})::cusparseStatus_t
+    @gcsafe_ccall libcusparse.cusparseCbsric02_bufferSizeExt(handle::cusparseHandle_t,
+                                                             dirA::cusparseDirection_t,
+                                                             mb::Cint, nnzb::Cint,
+                                                             descrA::cusparseMatDescr_t,
+                                                             bsrSortedVal::CuPtr{cuComplex},
+                                                             bsrSortedRowPtr::CuPtr{Cint},
+                                                             bsrSortedColInd::CuPtr{Cint},
+                                                             blockSize::Cint,
+                                                             info::bsric02Info_t,
+                                                             pBufferSize::Ptr{Csize_t})::cusparseStatus_t
 end
 
 @checked function cusparseZbsric02_bufferSizeExt(handle, dirA, mb, nnzb, descrA,
@@ -2108,599 +2224,666 @@ end
                                                  bsrSortedColInd, blockSize, info,
                                                  pBufferSize)
     initialize_context()
-    @ccall libcusparse.cusparseZbsric02_bufferSizeExt(handle::cusparseHandle_t,
-                                                      dirA::cusparseDirection_t, mb::Cint,
-                                                      nnzb::Cint,
-                                                      descrA::cusparseMatDescr_t,
-                                                      bsrSortedVal::CuPtr{cuDoubleComplex},
-                                                      bsrSortedRowPtr::CuPtr{Cint},
-                                                      bsrSortedColInd::CuPtr{Cint},
-                                                      blockSize::Cint, info::bsric02Info_t,
-                                                      pBufferSize::Ptr{Csize_t})::cusparseStatus_t
+    @gcsafe_ccall libcusparse.cusparseZbsric02_bufferSizeExt(handle::cusparseHandle_t,
+                                                             dirA::cusparseDirection_t,
+                                                             mb::Cint, nnzb::Cint,
+                                                             descrA::cusparseMatDescr_t,
+                                                             bsrSortedVal::CuPtr{cuDoubleComplex},
+                                                             bsrSortedRowPtr::CuPtr{Cint},
+                                                             bsrSortedColInd::CuPtr{Cint},
+                                                             blockSize::Cint,
+                                                             info::bsric02Info_t,
+                                                             pBufferSize::Ptr{Csize_t})::cusparseStatus_t
 end
 
 @checked function cusparseSbsric02_analysis(handle, dirA, mb, nnzb, descrA, bsrSortedVal,
                                             bsrSortedRowPtr, bsrSortedColInd, blockDim,
                                             info, policy, pInputBuffer)
     initialize_context()
-    @ccall libcusparse.cusparseSbsric02_analysis(handle::cusparseHandle_t,
-                                                 dirA::cusparseDirection_t, mb::Cint,
-                                                 nnzb::Cint, descrA::cusparseMatDescr_t,
-                                                 bsrSortedVal::CuPtr{Cfloat},
-                                                 bsrSortedRowPtr::CuPtr{Cint},
-                                                 bsrSortedColInd::CuPtr{Cint},
-                                                 blockDim::Cint, info::bsric02Info_t,
-                                                 policy::cusparseSolvePolicy_t,
-                                                 pInputBuffer::CuPtr{Cvoid})::cusparseStatus_t
+    @gcsafe_ccall libcusparse.cusparseSbsric02_analysis(handle::cusparseHandle_t,
+                                                        dirA::cusparseDirection_t, mb::Cint,
+                                                        nnzb::Cint,
+                                                        descrA::cusparseMatDescr_t,
+                                                        bsrSortedVal::CuPtr{Cfloat},
+                                                        bsrSortedRowPtr::CuPtr{Cint},
+                                                        bsrSortedColInd::CuPtr{Cint},
+                                                        blockDim::Cint, info::bsric02Info_t,
+                                                        policy::cusparseSolvePolicy_t,
+                                                        pInputBuffer::CuPtr{Cvoid})::cusparseStatus_t
 end
 
 @checked function cusparseDbsric02_analysis(handle, dirA, mb, nnzb, descrA, bsrSortedVal,
                                             bsrSortedRowPtr, bsrSortedColInd, blockDim,
                                             info, policy, pInputBuffer)
     initialize_context()
-    @ccall libcusparse.cusparseDbsric02_analysis(handle::cusparseHandle_t,
-                                                 dirA::cusparseDirection_t, mb::Cint,
-                                                 nnzb::Cint, descrA::cusparseMatDescr_t,
-                                                 bsrSortedVal::CuPtr{Cdouble},
-                                                 bsrSortedRowPtr::CuPtr{Cint},
-                                                 bsrSortedColInd::CuPtr{Cint},
-                                                 blockDim::Cint, info::bsric02Info_t,
-                                                 policy::cusparseSolvePolicy_t,
-                                                 pInputBuffer::CuPtr{Cvoid})::cusparseStatus_t
+    @gcsafe_ccall libcusparse.cusparseDbsric02_analysis(handle::cusparseHandle_t,
+                                                        dirA::cusparseDirection_t, mb::Cint,
+                                                        nnzb::Cint,
+                                                        descrA::cusparseMatDescr_t,
+                                                        bsrSortedVal::CuPtr{Cdouble},
+                                                        bsrSortedRowPtr::CuPtr{Cint},
+                                                        bsrSortedColInd::CuPtr{Cint},
+                                                        blockDim::Cint, info::bsric02Info_t,
+                                                        policy::cusparseSolvePolicy_t,
+                                                        pInputBuffer::CuPtr{Cvoid})::cusparseStatus_t
 end
 
 @checked function cusparseCbsric02_analysis(handle, dirA, mb, nnzb, descrA, bsrSortedVal,
                                             bsrSortedRowPtr, bsrSortedColInd, blockDim,
                                             info, policy, pInputBuffer)
     initialize_context()
-    @ccall libcusparse.cusparseCbsric02_analysis(handle::cusparseHandle_t,
-                                                 dirA::cusparseDirection_t, mb::Cint,
-                                                 nnzb::Cint, descrA::cusparseMatDescr_t,
-                                                 bsrSortedVal::CuPtr{cuComplex},
-                                                 bsrSortedRowPtr::CuPtr{Cint},
-                                                 bsrSortedColInd::CuPtr{Cint},
-                                                 blockDim::Cint, info::bsric02Info_t,
-                                                 policy::cusparseSolvePolicy_t,
-                                                 pInputBuffer::CuPtr{Cvoid})::cusparseStatus_t
+    @gcsafe_ccall libcusparse.cusparseCbsric02_analysis(handle::cusparseHandle_t,
+                                                        dirA::cusparseDirection_t, mb::Cint,
+                                                        nnzb::Cint,
+                                                        descrA::cusparseMatDescr_t,
+                                                        bsrSortedVal::CuPtr{cuComplex},
+                                                        bsrSortedRowPtr::CuPtr{Cint},
+                                                        bsrSortedColInd::CuPtr{Cint},
+                                                        blockDim::Cint, info::bsric02Info_t,
+                                                        policy::cusparseSolvePolicy_t,
+                                                        pInputBuffer::CuPtr{Cvoid})::cusparseStatus_t
 end
 
 @checked function cusparseZbsric02_analysis(handle, dirA, mb, nnzb, descrA, bsrSortedVal,
                                             bsrSortedRowPtr, bsrSortedColInd, blockDim,
                                             info, policy, pInputBuffer)
     initialize_context()
-    @ccall libcusparse.cusparseZbsric02_analysis(handle::cusparseHandle_t,
-                                                 dirA::cusparseDirection_t, mb::Cint,
-                                                 nnzb::Cint, descrA::cusparseMatDescr_t,
-                                                 bsrSortedVal::CuPtr{cuDoubleComplex},
-                                                 bsrSortedRowPtr::CuPtr{Cint},
-                                                 bsrSortedColInd::CuPtr{Cint},
-                                                 blockDim::Cint, info::bsric02Info_t,
-                                                 policy::cusparseSolvePolicy_t,
-                                                 pInputBuffer::CuPtr{Cvoid})::cusparseStatus_t
+    @gcsafe_ccall libcusparse.cusparseZbsric02_analysis(handle::cusparseHandle_t,
+                                                        dirA::cusparseDirection_t, mb::Cint,
+                                                        nnzb::Cint,
+                                                        descrA::cusparseMatDescr_t,
+                                                        bsrSortedVal::CuPtr{cuDoubleComplex},
+                                                        bsrSortedRowPtr::CuPtr{Cint},
+                                                        bsrSortedColInd::CuPtr{Cint},
+                                                        blockDim::Cint, info::bsric02Info_t,
+                                                        policy::cusparseSolvePolicy_t,
+                                                        pInputBuffer::CuPtr{Cvoid})::cusparseStatus_t
 end
 
 @checked function cusparseSbsric02(handle, dirA, mb, nnzb, descrA, bsrSortedVal,
                                    bsrSortedRowPtr, bsrSortedColInd, blockDim, info, policy,
                                    pBuffer)
     initialize_context()
-    @ccall libcusparse.cusparseSbsric02(handle::cusparseHandle_t, dirA::cusparseDirection_t,
-                                        mb::Cint, nnzb::Cint, descrA::cusparseMatDescr_t,
-                                        bsrSortedVal::CuPtr{Cfloat},
-                                        bsrSortedRowPtr::CuPtr{Cint},
-                                        bsrSortedColInd::CuPtr{Cint}, blockDim::Cint,
-                                        info::bsric02Info_t, policy::cusparseSolvePolicy_t,
-                                        pBuffer::CuPtr{Cvoid})::cusparseStatus_t
+    @gcsafe_ccall libcusparse.cusparseSbsric02(handle::cusparseHandle_t,
+                                               dirA::cusparseDirection_t, mb::Cint,
+                                               nnzb::Cint, descrA::cusparseMatDescr_t,
+                                               bsrSortedVal::CuPtr{Cfloat},
+                                               bsrSortedRowPtr::CuPtr{Cint},
+                                               bsrSortedColInd::CuPtr{Cint}, blockDim::Cint,
+                                               info::bsric02Info_t,
+                                               policy::cusparseSolvePolicy_t,
+                                               pBuffer::CuPtr{Cvoid})::cusparseStatus_t
 end
 
 @checked function cusparseDbsric02(handle, dirA, mb, nnzb, descrA, bsrSortedVal,
                                    bsrSortedRowPtr, bsrSortedColInd, blockDim, info, policy,
                                    pBuffer)
     initialize_context()
-    @ccall libcusparse.cusparseDbsric02(handle::cusparseHandle_t, dirA::cusparseDirection_t,
-                                        mb::Cint, nnzb::Cint, descrA::cusparseMatDescr_t,
-                                        bsrSortedVal::CuPtr{Cdouble},
-                                        bsrSortedRowPtr::CuPtr{Cint},
-                                        bsrSortedColInd::CuPtr{Cint}, blockDim::Cint,
-                                        info::bsric02Info_t, policy::cusparseSolvePolicy_t,
-                                        pBuffer::CuPtr{Cvoid})::cusparseStatus_t
+    @gcsafe_ccall libcusparse.cusparseDbsric02(handle::cusparseHandle_t,
+                                               dirA::cusparseDirection_t, mb::Cint,
+                                               nnzb::Cint, descrA::cusparseMatDescr_t,
+                                               bsrSortedVal::CuPtr{Cdouble},
+                                               bsrSortedRowPtr::CuPtr{Cint},
+                                               bsrSortedColInd::CuPtr{Cint}, blockDim::Cint,
+                                               info::bsric02Info_t,
+                                               policy::cusparseSolvePolicy_t,
+                                               pBuffer::CuPtr{Cvoid})::cusparseStatus_t
 end
 
 @checked function cusparseCbsric02(handle, dirA, mb, nnzb, descrA, bsrSortedVal,
                                    bsrSortedRowPtr, bsrSortedColInd, blockDim, info, policy,
                                    pBuffer)
     initialize_context()
-    @ccall libcusparse.cusparseCbsric02(handle::cusparseHandle_t, dirA::cusparseDirection_t,
-                                        mb::Cint, nnzb::Cint, descrA::cusparseMatDescr_t,
-                                        bsrSortedVal::CuPtr{cuComplex},
-                                        bsrSortedRowPtr::CuPtr{Cint},
-                                        bsrSortedColInd::CuPtr{Cint}, blockDim::Cint,
-                                        info::bsric02Info_t, policy::cusparseSolvePolicy_t,
-                                        pBuffer::CuPtr{Cvoid})::cusparseStatus_t
+    @gcsafe_ccall libcusparse.cusparseCbsric02(handle::cusparseHandle_t,
+                                               dirA::cusparseDirection_t, mb::Cint,
+                                               nnzb::Cint, descrA::cusparseMatDescr_t,
+                                               bsrSortedVal::CuPtr{cuComplex},
+                                               bsrSortedRowPtr::CuPtr{Cint},
+                                               bsrSortedColInd::CuPtr{Cint}, blockDim::Cint,
+                                               info::bsric02Info_t,
+                                               policy::cusparseSolvePolicy_t,
+                                               pBuffer::CuPtr{Cvoid})::cusparseStatus_t
 end
 
 @checked function cusparseZbsric02(handle, dirA, mb, nnzb, descrA, bsrSortedVal,
                                    bsrSortedRowPtr, bsrSortedColInd, blockDim, info, policy,
                                    pBuffer)
     initialize_context()
-    @ccall libcusparse.cusparseZbsric02(handle::cusparseHandle_t, dirA::cusparseDirection_t,
-                                        mb::Cint, nnzb::Cint, descrA::cusparseMatDescr_t,
-                                        bsrSortedVal::CuPtr{cuDoubleComplex},
-                                        bsrSortedRowPtr::CuPtr{Cint},
-                                        bsrSortedColInd::CuPtr{Cint}, blockDim::Cint,
-                                        info::bsric02Info_t, policy::cusparseSolvePolicy_t,
-                                        pBuffer::CuPtr{Cvoid})::cusparseStatus_t
+    @gcsafe_ccall libcusparse.cusparseZbsric02(handle::cusparseHandle_t,
+                                               dirA::cusparseDirection_t, mb::Cint,
+                                               nnzb::Cint, descrA::cusparseMatDescr_t,
+                                               bsrSortedVal::CuPtr{cuDoubleComplex},
+                                               bsrSortedRowPtr::CuPtr{Cint},
+                                               bsrSortedColInd::CuPtr{Cint}, blockDim::Cint,
+                                               info::bsric02Info_t,
+                                               policy::cusparseSolvePolicy_t,
+                                               pBuffer::CuPtr{Cvoid})::cusparseStatus_t
 end
 
 @checked function cusparseSgtsv2_bufferSizeExt(handle, m, n, dl, d, du, B, ldb,
                                                bufferSizeInBytes)
     initialize_context()
-    @ccall libcusparse.cusparseSgtsv2_bufferSizeExt(handle::cusparseHandle_t, m::Cint,
-                                                    n::Cint, dl::CuPtr{Cfloat},
-                                                    d::CuPtr{Cfloat}, du::CuPtr{Cfloat},
-                                                    B::CuPtr{Cfloat}, ldb::Cint,
-                                                    bufferSizeInBytes::Ptr{Csize_t})::cusparseStatus_t
+    @gcsafe_ccall libcusparse.cusparseSgtsv2_bufferSizeExt(handle::cusparseHandle_t,
+                                                           m::Cint, n::Cint,
+                                                           dl::CuPtr{Cfloat},
+                                                           d::CuPtr{Cfloat},
+                                                           du::CuPtr{Cfloat},
+                                                           B::CuPtr{Cfloat}, ldb::Cint,
+                                                           bufferSizeInBytes::Ptr{Csize_t})::cusparseStatus_t
 end
 
 @checked function cusparseDgtsv2_bufferSizeExt(handle, m, n, dl, d, du, B, ldb,
                                                bufferSizeInBytes)
     initialize_context()
-    @ccall libcusparse.cusparseDgtsv2_bufferSizeExt(handle::cusparseHandle_t, m::Cint,
-                                                    n::Cint, dl::CuPtr{Cdouble},
-                                                    d::CuPtr{Cdouble}, du::CuPtr{Cdouble},
-                                                    B::CuPtr{Cdouble}, ldb::Cint,
-                                                    bufferSizeInBytes::Ptr{Csize_t})::cusparseStatus_t
+    @gcsafe_ccall libcusparse.cusparseDgtsv2_bufferSizeExt(handle::cusparseHandle_t,
+                                                           m::Cint, n::Cint,
+                                                           dl::CuPtr{Cdouble},
+                                                           d::CuPtr{Cdouble},
+                                                           du::CuPtr{Cdouble},
+                                                           B::CuPtr{Cdouble}, ldb::Cint,
+                                                           bufferSizeInBytes::Ptr{Csize_t})::cusparseStatus_t
 end
 
 @checked function cusparseCgtsv2_bufferSizeExt(handle, m, n, dl, d, du, B, ldb,
                                                bufferSizeInBytes)
     initialize_context()
-    @ccall libcusparse.cusparseCgtsv2_bufferSizeExt(handle::cusparseHandle_t, m::Cint,
-                                                    n::Cint, dl::CuPtr{cuComplex},
-                                                    d::CuPtr{cuComplex},
-                                                    du::CuPtr{cuComplex},
-                                                    B::CuPtr{cuComplex}, ldb::Cint,
-                                                    bufferSizeInBytes::Ptr{Csize_t})::cusparseStatus_t
+    @gcsafe_ccall libcusparse.cusparseCgtsv2_bufferSizeExt(handle::cusparseHandle_t,
+                                                           m::Cint, n::Cint,
+                                                           dl::CuPtr{cuComplex},
+                                                           d::CuPtr{cuComplex},
+                                                           du::CuPtr{cuComplex},
+                                                           B::CuPtr{cuComplex}, ldb::Cint,
+                                                           bufferSizeInBytes::Ptr{Csize_t})::cusparseStatus_t
 end
 
 @checked function cusparseZgtsv2_bufferSizeExt(handle, m, n, dl, d, du, B, ldb,
                                                bufferSizeInBytes)
     initialize_context()
-    @ccall libcusparse.cusparseZgtsv2_bufferSizeExt(handle::cusparseHandle_t, m::Cint,
-                                                    n::Cint, dl::CuPtr{cuDoubleComplex},
-                                                    d::CuPtr{cuDoubleComplex},
-                                                    du::CuPtr{cuDoubleComplex},
-                                                    B::CuPtr{cuDoubleComplex}, ldb::Cint,
-                                                    bufferSizeInBytes::Ptr{Csize_t})::cusparseStatus_t
+    @gcsafe_ccall libcusparse.cusparseZgtsv2_bufferSizeExt(handle::cusparseHandle_t,
+                                                           m::Cint, n::Cint,
+                                                           dl::CuPtr{cuDoubleComplex},
+                                                           d::CuPtr{cuDoubleComplex},
+                                                           du::CuPtr{cuDoubleComplex},
+                                                           B::CuPtr{cuDoubleComplex},
+                                                           ldb::Cint,
+                                                           bufferSizeInBytes::Ptr{Csize_t})::cusparseStatus_t
 end
 
 @checked function cusparseSgtsv2(handle, m, n, dl, d, du, B, ldb, pBuffer)
     initialize_context()
-    @ccall libcusparse.cusparseSgtsv2(handle::cusparseHandle_t, m::Cint, n::Cint,
-                                      dl::CuPtr{Cfloat}, d::CuPtr{Cfloat},
-                                      du::CuPtr{Cfloat}, B::CuPtr{Cfloat}, ldb::Cint,
-                                      pBuffer::CuPtr{Cvoid})::cusparseStatus_t
+    @gcsafe_ccall libcusparse.cusparseSgtsv2(handle::cusparseHandle_t, m::Cint, n::Cint,
+                                             dl::CuPtr{Cfloat}, d::CuPtr{Cfloat},
+                                             du::CuPtr{Cfloat}, B::CuPtr{Cfloat}, ldb::Cint,
+                                             pBuffer::CuPtr{Cvoid})::cusparseStatus_t
 end
 
 @checked function cusparseDgtsv2(handle, m, n, dl, d, du, B, ldb, pBuffer)
     initialize_context()
-    @ccall libcusparse.cusparseDgtsv2(handle::cusparseHandle_t, m::Cint, n::Cint,
-                                      dl::CuPtr{Cdouble}, d::CuPtr{Cdouble},
-                                      du::CuPtr{Cdouble}, B::CuPtr{Cdouble}, ldb::Cint,
-                                      pBuffer::CuPtr{Cvoid})::cusparseStatus_t
+    @gcsafe_ccall libcusparse.cusparseDgtsv2(handle::cusparseHandle_t, m::Cint, n::Cint,
+                                             dl::CuPtr{Cdouble}, d::CuPtr{Cdouble},
+                                             du::CuPtr{Cdouble}, B::CuPtr{Cdouble},
+                                             ldb::Cint,
+                                             pBuffer::CuPtr{Cvoid})::cusparseStatus_t
 end
 
 @checked function cusparseCgtsv2(handle, m, n, dl, d, du, B, ldb, pBuffer)
     initialize_context()
-    @ccall libcusparse.cusparseCgtsv2(handle::cusparseHandle_t, m::Cint, n::Cint,
-                                      dl::CuPtr{cuComplex}, d::CuPtr{cuComplex},
-                                      du::CuPtr{cuComplex}, B::CuPtr{cuComplex}, ldb::Cint,
-                                      pBuffer::CuPtr{Cvoid})::cusparseStatus_t
+    @gcsafe_ccall libcusparse.cusparseCgtsv2(handle::cusparseHandle_t, m::Cint, n::Cint,
+                                             dl::CuPtr{cuComplex}, d::CuPtr{cuComplex},
+                                             du::CuPtr{cuComplex}, B::CuPtr{cuComplex},
+                                             ldb::Cint,
+                                             pBuffer::CuPtr{Cvoid})::cusparseStatus_t
 end
 
 @checked function cusparseZgtsv2(handle, m, n, dl, d, du, B, ldb, pBuffer)
     initialize_context()
-    @ccall libcusparse.cusparseZgtsv2(handle::cusparseHandle_t, m::Cint, n::Cint,
-                                      dl::CuPtr{cuDoubleComplex}, d::CuPtr{cuDoubleComplex},
-                                      du::CuPtr{cuDoubleComplex}, B::CuPtr{cuDoubleComplex},
-                                      ldb::Cint, pBuffer::CuPtr{Cvoid})::cusparseStatus_t
+    @gcsafe_ccall libcusparse.cusparseZgtsv2(handle::cusparseHandle_t, m::Cint, n::Cint,
+                                             dl::CuPtr{cuDoubleComplex},
+                                             d::CuPtr{cuDoubleComplex},
+                                             du::CuPtr{cuDoubleComplex},
+                                             B::CuPtr{cuDoubleComplex}, ldb::Cint,
+                                             pBuffer::CuPtr{Cvoid})::cusparseStatus_t
 end
 
 @checked function cusparseSgtsv2_nopivot_bufferSizeExt(handle, m, n, dl, d, du, B, ldb,
                                                        bufferSizeInBytes)
     initialize_context()
-    @ccall libcusparse.cusparseSgtsv2_nopivot_bufferSizeExt(handle::cusparseHandle_t,
-                                                            m::Cint, n::Cint,
-                                                            dl::CuPtr{Cfloat},
-                                                            d::CuPtr{Cfloat},
-                                                            du::CuPtr{Cfloat},
-                                                            B::CuPtr{Cfloat}, ldb::Cint,
-                                                            bufferSizeInBytes::Ptr{Csize_t})::cusparseStatus_t
+    @gcsafe_ccall libcusparse.cusparseSgtsv2_nopivot_bufferSizeExt(handle::cusparseHandle_t,
+                                                                   m::Cint, n::Cint,
+                                                                   dl::CuPtr{Cfloat},
+                                                                   d::CuPtr{Cfloat},
+                                                                   du::CuPtr{Cfloat},
+                                                                   B::CuPtr{Cfloat},
+                                                                   ldb::Cint,
+                                                                   bufferSizeInBytes::Ptr{Csize_t})::cusparseStatus_t
 end
 
 @checked function cusparseDgtsv2_nopivot_bufferSizeExt(handle, m, n, dl, d, du, B, ldb,
                                                        bufferSizeInBytes)
     initialize_context()
-    @ccall libcusparse.cusparseDgtsv2_nopivot_bufferSizeExt(handle::cusparseHandle_t,
-                                                            m::Cint, n::Cint,
-                                                            dl::CuPtr{Cdouble},
-                                                            d::CuPtr{Cdouble},
-                                                            du::CuPtr{Cdouble},
-                                                            B::CuPtr{Cdouble}, ldb::Cint,
-                                                            bufferSizeInBytes::Ptr{Csize_t})::cusparseStatus_t
+    @gcsafe_ccall libcusparse.cusparseDgtsv2_nopivot_bufferSizeExt(handle::cusparseHandle_t,
+                                                                   m::Cint, n::Cint,
+                                                                   dl::CuPtr{Cdouble},
+                                                                   d::CuPtr{Cdouble},
+                                                                   du::CuPtr{Cdouble},
+                                                                   B::CuPtr{Cdouble},
+                                                                   ldb::Cint,
+                                                                   bufferSizeInBytes::Ptr{Csize_t})::cusparseStatus_t
 end
 
 @checked function cusparseCgtsv2_nopivot_bufferSizeExt(handle, m, n, dl, d, du, B, ldb,
                                                        bufferSizeInBytes)
     initialize_context()
-    @ccall libcusparse.cusparseCgtsv2_nopivot_bufferSizeExt(handle::cusparseHandle_t,
-                                                            m::Cint, n::Cint,
-                                                            dl::CuPtr{cuComplex},
-                                                            d::CuPtr{cuComplex},
-                                                            du::CuPtr{cuComplex},
-                                                            B::CuPtr{cuComplex}, ldb::Cint,
-                                                            bufferSizeInBytes::Ptr{Csize_t})::cusparseStatus_t
+    @gcsafe_ccall libcusparse.cusparseCgtsv2_nopivot_bufferSizeExt(handle::cusparseHandle_t,
+                                                                   m::Cint, n::Cint,
+                                                                   dl::CuPtr{cuComplex},
+                                                                   d::CuPtr{cuComplex},
+                                                                   du::CuPtr{cuComplex},
+                                                                   B::CuPtr{cuComplex},
+                                                                   ldb::Cint,
+                                                                   bufferSizeInBytes::Ptr{Csize_t})::cusparseStatus_t
 end
 
 @checked function cusparseZgtsv2_nopivot_bufferSizeExt(handle, m, n, dl, d, du, B, ldb,
                                                        bufferSizeInBytes)
     initialize_context()
-    @ccall libcusparse.cusparseZgtsv2_nopivot_bufferSizeExt(handle::cusparseHandle_t,
-                                                            m::Cint, n::Cint,
-                                                            dl::CuPtr{cuDoubleComplex},
-                                                            d::CuPtr{cuDoubleComplex},
-                                                            du::CuPtr{cuDoubleComplex},
-                                                            B::CuPtr{cuDoubleComplex},
-                                                            ldb::Cint,
-                                                            bufferSizeInBytes::Ptr{Csize_t})::cusparseStatus_t
+    @gcsafe_ccall libcusparse.cusparseZgtsv2_nopivot_bufferSizeExt(handle::cusparseHandle_t,
+                                                                   m::Cint, n::Cint,
+                                                                   dl::CuPtr{cuDoubleComplex},
+                                                                   d::CuPtr{cuDoubleComplex},
+                                                                   du::CuPtr{cuDoubleComplex},
+                                                                   B::CuPtr{cuDoubleComplex},
+                                                                   ldb::Cint,
+                                                                   bufferSizeInBytes::Ptr{Csize_t})::cusparseStatus_t
 end
 
 @checked function cusparseSgtsv2_nopivot(handle, m, n, dl, d, du, B, ldb, pBuffer)
     initialize_context()
-    @ccall libcusparse.cusparseSgtsv2_nopivot(handle::cusparseHandle_t, m::Cint, n::Cint,
-                                              dl::CuPtr{Cfloat}, d::CuPtr{Cfloat},
-                                              du::CuPtr{Cfloat}, B::CuPtr{Cfloat},
-                                              ldb::Cint,
-                                              pBuffer::CuPtr{Cvoid})::cusparseStatus_t
+    @gcsafe_ccall libcusparse.cusparseSgtsv2_nopivot(handle::cusparseHandle_t, m::Cint,
+                                                     n::Cint, dl::CuPtr{Cfloat},
+                                                     d::CuPtr{Cfloat}, du::CuPtr{Cfloat},
+                                                     B::CuPtr{Cfloat}, ldb::Cint,
+                                                     pBuffer::CuPtr{Cvoid})::cusparseStatus_t
 end
 
 @checked function cusparseDgtsv2_nopivot(handle, m, n, dl, d, du, B, ldb, pBuffer)
     initialize_context()
-    @ccall libcusparse.cusparseDgtsv2_nopivot(handle::cusparseHandle_t, m::Cint, n::Cint,
-                                              dl::CuPtr{Cdouble}, d::CuPtr{Cdouble},
-                                              du::CuPtr{Cdouble}, B::CuPtr{Cdouble},
-                                              ldb::Cint,
-                                              pBuffer::CuPtr{Cvoid})::cusparseStatus_t
+    @gcsafe_ccall libcusparse.cusparseDgtsv2_nopivot(handle::cusparseHandle_t, m::Cint,
+                                                     n::Cint, dl::CuPtr{Cdouble},
+                                                     d::CuPtr{Cdouble}, du::CuPtr{Cdouble},
+                                                     B::CuPtr{Cdouble}, ldb::Cint,
+                                                     pBuffer::CuPtr{Cvoid})::cusparseStatus_t
 end
 
 @checked function cusparseCgtsv2_nopivot(handle, m, n, dl, d, du, B, ldb, pBuffer)
     initialize_context()
-    @ccall libcusparse.cusparseCgtsv2_nopivot(handle::cusparseHandle_t, m::Cint, n::Cint,
-                                              dl::CuPtr{cuComplex}, d::CuPtr{cuComplex},
-                                              du::CuPtr{cuComplex}, B::CuPtr{cuComplex},
-                                              ldb::Cint,
-                                              pBuffer::CuPtr{Cvoid})::cusparseStatus_t
+    @gcsafe_ccall libcusparse.cusparseCgtsv2_nopivot(handle::cusparseHandle_t, m::Cint,
+                                                     n::Cint, dl::CuPtr{cuComplex},
+                                                     d::CuPtr{cuComplex},
+                                                     du::CuPtr{cuComplex},
+                                                     B::CuPtr{cuComplex}, ldb::Cint,
+                                                     pBuffer::CuPtr{Cvoid})::cusparseStatus_t
 end
 
 @checked function cusparseZgtsv2_nopivot(handle, m, n, dl, d, du, B, ldb, pBuffer)
     initialize_context()
-    @ccall libcusparse.cusparseZgtsv2_nopivot(handle::cusparseHandle_t, m::Cint, n::Cint,
-                                              dl::CuPtr{cuDoubleComplex},
-                                              d::CuPtr{cuDoubleComplex},
-                                              du::CuPtr{cuDoubleComplex},
-                                              B::CuPtr{cuDoubleComplex}, ldb::Cint,
-                                              pBuffer::CuPtr{Cvoid})::cusparseStatus_t
+    @gcsafe_ccall libcusparse.cusparseZgtsv2_nopivot(handle::cusparseHandle_t, m::Cint,
+                                                     n::Cint, dl::CuPtr{cuDoubleComplex},
+                                                     d::CuPtr{cuDoubleComplex},
+                                                     du::CuPtr{cuDoubleComplex},
+                                                     B::CuPtr{cuDoubleComplex}, ldb::Cint,
+                                                     pBuffer::CuPtr{Cvoid})::cusparseStatus_t
 end
 
 @checked function cusparseSgtsv2StridedBatch_bufferSizeExt(handle, m, dl, d, du, x,
                                                            batchCount, batchStride,
                                                            bufferSizeInBytes)
     initialize_context()
-    @ccall libcusparse.cusparseSgtsv2StridedBatch_bufferSizeExt(handle::cusparseHandle_t,
-                                                                m::Cint, dl::CuPtr{Cfloat},
-                                                                d::CuPtr{Cfloat},
-                                                                du::CuPtr{Cfloat},
-                                                                x::CuPtr{Cfloat},
-                                                                batchCount::Cint,
-                                                                batchStride::Cint,
-                                                                bufferSizeInBytes::Ptr{Csize_t})::cusparseStatus_t
+    @gcsafe_ccall libcusparse.cusparseSgtsv2StridedBatch_bufferSizeExt(handle::cusparseHandle_t,
+                                                                       m::Cint,
+                                                                       dl::CuPtr{Cfloat},
+                                                                       d::CuPtr{Cfloat},
+                                                                       du::CuPtr{Cfloat},
+                                                                       x::CuPtr{Cfloat},
+                                                                       batchCount::Cint,
+                                                                       batchStride::Cint,
+                                                                       bufferSizeInBytes::Ptr{Csize_t})::cusparseStatus_t
 end
 
 @checked function cusparseDgtsv2StridedBatch_bufferSizeExt(handle, m, dl, d, du, x,
                                                            batchCount, batchStride,
                                                            bufferSizeInBytes)
     initialize_context()
-    @ccall libcusparse.cusparseDgtsv2StridedBatch_bufferSizeExt(handle::cusparseHandle_t,
-                                                                m::Cint, dl::CuPtr{Cdouble},
-                                                                d::CuPtr{Cdouble},
-                                                                du::CuPtr{Cdouble},
-                                                                x::CuPtr{Cdouble},
-                                                                batchCount::Cint,
-                                                                batchStride::Cint,
-                                                                bufferSizeInBytes::Ptr{Csize_t})::cusparseStatus_t
+    @gcsafe_ccall libcusparse.cusparseDgtsv2StridedBatch_bufferSizeExt(handle::cusparseHandle_t,
+                                                                       m::Cint,
+                                                                       dl::CuPtr{Cdouble},
+                                                                       d::CuPtr{Cdouble},
+                                                                       du::CuPtr{Cdouble},
+                                                                       x::CuPtr{Cdouble},
+                                                                       batchCount::Cint,
+                                                                       batchStride::Cint,
+                                                                       bufferSizeInBytes::Ptr{Csize_t})::cusparseStatus_t
 end
 
 @checked function cusparseCgtsv2StridedBatch_bufferSizeExt(handle, m, dl, d, du, x,
                                                            batchCount, batchStride,
                                                            bufferSizeInBytes)
     initialize_context()
-    @ccall libcusparse.cusparseCgtsv2StridedBatch_bufferSizeExt(handle::cusparseHandle_t,
-                                                                m::Cint,
-                                                                dl::CuPtr{cuComplex},
-                                                                d::CuPtr{cuComplex},
-                                                                du::CuPtr{cuComplex},
-                                                                x::CuPtr{cuComplex},
-                                                                batchCount::Cint,
-                                                                batchStride::Cint,
-                                                                bufferSizeInBytes::Ptr{Csize_t})::cusparseStatus_t
+    @gcsafe_ccall libcusparse.cusparseCgtsv2StridedBatch_bufferSizeExt(handle::cusparseHandle_t,
+                                                                       m::Cint,
+                                                                       dl::CuPtr{cuComplex},
+                                                                       d::CuPtr{cuComplex},
+                                                                       du::CuPtr{cuComplex},
+                                                                       x::CuPtr{cuComplex},
+                                                                       batchCount::Cint,
+                                                                       batchStride::Cint,
+                                                                       bufferSizeInBytes::Ptr{Csize_t})::cusparseStatus_t
 end
 
 @checked function cusparseZgtsv2StridedBatch_bufferSizeExt(handle, m, dl, d, du, x,
                                                            batchCount, batchStride,
                                                            bufferSizeInBytes)
     initialize_context()
-    @ccall libcusparse.cusparseZgtsv2StridedBatch_bufferSizeExt(handle::cusparseHandle_t,
-                                                                m::Cint,
-                                                                dl::CuPtr{cuDoubleComplex},
-                                                                d::CuPtr{cuDoubleComplex},
-                                                                du::CuPtr{cuDoubleComplex},
-                                                                x::CuPtr{cuDoubleComplex},
-                                                                batchCount::Cint,
-                                                                batchStride::Cint,
-                                                                bufferSizeInBytes::Ptr{Csize_t})::cusparseStatus_t
+    @gcsafe_ccall libcusparse.cusparseZgtsv2StridedBatch_bufferSizeExt(handle::cusparseHandle_t,
+                                                                       m::Cint,
+                                                                       dl::CuPtr{cuDoubleComplex},
+                                                                       d::CuPtr{cuDoubleComplex},
+                                                                       du::CuPtr{cuDoubleComplex},
+                                                                       x::CuPtr{cuDoubleComplex},
+                                                                       batchCount::Cint,
+                                                                       batchStride::Cint,
+                                                                       bufferSizeInBytes::Ptr{Csize_t})::cusparseStatus_t
 end
 
 @checked function cusparseSgtsv2StridedBatch(handle, m, dl, d, du, x, batchCount,
                                              batchStride, pBuffer)
     initialize_context()
-    @ccall libcusparse.cusparseSgtsv2StridedBatch(handle::cusparseHandle_t, m::Cint,
-                                                  dl::CuPtr{Cfloat}, d::CuPtr{Cfloat},
-                                                  du::CuPtr{Cfloat}, x::CuPtr{Cfloat},
-                                                  batchCount::Cint, batchStride::Cint,
-                                                  pBuffer::CuPtr{Cvoid})::cusparseStatus_t
+    @gcsafe_ccall libcusparse.cusparseSgtsv2StridedBatch(handle::cusparseHandle_t, m::Cint,
+                                                         dl::CuPtr{Cfloat},
+                                                         d::CuPtr{Cfloat},
+                                                         du::CuPtr{Cfloat},
+                                                         x::CuPtr{Cfloat}, batchCount::Cint,
+                                                         batchStride::Cint,
+                                                         pBuffer::CuPtr{Cvoid})::cusparseStatus_t
 end
 
 @checked function cusparseDgtsv2StridedBatch(handle, m, dl, d, du, x, batchCount,
                                              batchStride, pBuffer)
     initialize_context()
-    @ccall libcusparse.cusparseDgtsv2StridedBatch(handle::cusparseHandle_t, m::Cint,
-                                                  dl::CuPtr{Cdouble}, d::CuPtr{Cdouble},
-                                                  du::CuPtr{Cdouble}, x::CuPtr{Cdouble},
-                                                  batchCount::Cint, batchStride::Cint,
-                                                  pBuffer::CuPtr{Cvoid})::cusparseStatus_t
+    @gcsafe_ccall libcusparse.cusparseDgtsv2StridedBatch(handle::cusparseHandle_t, m::Cint,
+                                                         dl::CuPtr{Cdouble},
+                                                         d::CuPtr{Cdouble},
+                                                         du::CuPtr{Cdouble},
+                                                         x::CuPtr{Cdouble},
+                                                         batchCount::Cint,
+                                                         batchStride::Cint,
+                                                         pBuffer::CuPtr{Cvoid})::cusparseStatus_t
 end
 
 @checked function cusparseCgtsv2StridedBatch(handle, m, dl, d, du, x, batchCount,
                                              batchStride, pBuffer)
     initialize_context()
-    @ccall libcusparse.cusparseCgtsv2StridedBatch(handle::cusparseHandle_t, m::Cint,
-                                                  dl::CuPtr{cuComplex}, d::CuPtr{cuComplex},
-                                                  du::CuPtr{cuComplex}, x::CuPtr{cuComplex},
-                                                  batchCount::Cint, batchStride::Cint,
-                                                  pBuffer::CuPtr{Cvoid})::cusparseStatus_t
+    @gcsafe_ccall libcusparse.cusparseCgtsv2StridedBatch(handle::cusparseHandle_t, m::Cint,
+                                                         dl::CuPtr{cuComplex},
+                                                         d::CuPtr{cuComplex},
+                                                         du::CuPtr{cuComplex},
+                                                         x::CuPtr{cuComplex},
+                                                         batchCount::Cint,
+                                                         batchStride::Cint,
+                                                         pBuffer::CuPtr{Cvoid})::cusparseStatus_t
 end
 
 @checked function cusparseZgtsv2StridedBatch(handle, m, dl, d, du, x, batchCount,
                                              batchStride, pBuffer)
     initialize_context()
-    @ccall libcusparse.cusparseZgtsv2StridedBatch(handle::cusparseHandle_t, m::Cint,
-                                                  dl::CuPtr{cuDoubleComplex},
-                                                  d::CuPtr{cuDoubleComplex},
-                                                  du::CuPtr{cuDoubleComplex},
-                                                  x::CuPtr{cuDoubleComplex},
-                                                  batchCount::Cint, batchStride::Cint,
-                                                  pBuffer::CuPtr{Cvoid})::cusparseStatus_t
+    @gcsafe_ccall libcusparse.cusparseZgtsv2StridedBatch(handle::cusparseHandle_t, m::Cint,
+                                                         dl::CuPtr{cuDoubleComplex},
+                                                         d::CuPtr{cuDoubleComplex},
+                                                         du::CuPtr{cuDoubleComplex},
+                                                         x::CuPtr{cuDoubleComplex},
+                                                         batchCount::Cint,
+                                                         batchStride::Cint,
+                                                         pBuffer::CuPtr{Cvoid})::cusparseStatus_t
 end
 
 @checked function cusparseSgtsvInterleavedBatch_bufferSizeExt(handle, algo, m, dl, d, du, x,
                                                               batchCount,
                                                               pBufferSizeInBytes)
     initialize_context()
-    @ccall libcusparse.cusparseSgtsvInterleavedBatch_bufferSizeExt(handle::cusparseHandle_t,
-                                                                   algo::Cint, m::Cint,
-                                                                   dl::CuPtr{Cfloat},
-                                                                   d::CuPtr{Cfloat},
-                                                                   du::CuPtr{Cfloat},
-                                                                   x::CuPtr{Cfloat},
-                                                                   batchCount::Cint,
-                                                                   pBufferSizeInBytes::Ptr{Csize_t})::cusparseStatus_t
+    @gcsafe_ccall libcusparse.cusparseSgtsvInterleavedBatch_bufferSizeExt(handle::cusparseHandle_t,
+                                                                          algo::Cint,
+                                                                          m::Cint,
+                                                                          dl::CuPtr{Cfloat},
+                                                                          d::CuPtr{Cfloat},
+                                                                          du::CuPtr{Cfloat},
+                                                                          x::CuPtr{Cfloat},
+                                                                          batchCount::Cint,
+                                                                          pBufferSizeInBytes::Ptr{Csize_t})::cusparseStatus_t
 end
 
 @checked function cusparseDgtsvInterleavedBatch_bufferSizeExt(handle, algo, m, dl, d, du, x,
                                                               batchCount,
                                                               pBufferSizeInBytes)
     initialize_context()
-    @ccall libcusparse.cusparseDgtsvInterleavedBatch_bufferSizeExt(handle::cusparseHandle_t,
-                                                                   algo::Cint, m::Cint,
-                                                                   dl::CuPtr{Cdouble},
-                                                                   d::CuPtr{Cdouble},
-                                                                   du::CuPtr{Cdouble},
-                                                                   x::CuPtr{Cdouble},
-                                                                   batchCount::Cint,
-                                                                   pBufferSizeInBytes::Ptr{Csize_t})::cusparseStatus_t
+    @gcsafe_ccall libcusparse.cusparseDgtsvInterleavedBatch_bufferSizeExt(handle::cusparseHandle_t,
+                                                                          algo::Cint,
+                                                                          m::Cint,
+                                                                          dl::CuPtr{Cdouble},
+                                                                          d::CuPtr{Cdouble},
+                                                                          du::CuPtr{Cdouble},
+                                                                          x::CuPtr{Cdouble},
+                                                                          batchCount::Cint,
+                                                                          pBufferSizeInBytes::Ptr{Csize_t})::cusparseStatus_t
 end
 
 @checked function cusparseCgtsvInterleavedBatch_bufferSizeExt(handle, algo, m, dl, d, du, x,
                                                               batchCount,
                                                               pBufferSizeInBytes)
     initialize_context()
-    @ccall libcusparse.cusparseCgtsvInterleavedBatch_bufferSizeExt(handle::cusparseHandle_t,
-                                                                   algo::Cint, m::Cint,
-                                                                   dl::CuPtr{cuComplex},
-                                                                   d::CuPtr{cuComplex},
-                                                                   du::CuPtr{cuComplex},
-                                                                   x::CuPtr{cuComplex},
-                                                                   batchCount::Cint,
-                                                                   pBufferSizeInBytes::Ptr{Csize_t})::cusparseStatus_t
+    @gcsafe_ccall libcusparse.cusparseCgtsvInterleavedBatch_bufferSizeExt(handle::cusparseHandle_t,
+                                                                          algo::Cint,
+                                                                          m::Cint,
+                                                                          dl::CuPtr{cuComplex},
+                                                                          d::CuPtr{cuComplex},
+                                                                          du::CuPtr{cuComplex},
+                                                                          x::CuPtr{cuComplex},
+                                                                          batchCount::Cint,
+                                                                          pBufferSizeInBytes::Ptr{Csize_t})::cusparseStatus_t
 end
 
 @checked function cusparseZgtsvInterleavedBatch_bufferSizeExt(handle, algo, m, dl, d, du, x,
                                                               batchCount,
                                                               pBufferSizeInBytes)
     initialize_context()
-    @ccall libcusparse.cusparseZgtsvInterleavedBatch_bufferSizeExt(handle::cusparseHandle_t,
-                                                                   algo::Cint, m::Cint,
-                                                                   dl::CuPtr{cuDoubleComplex},
-                                                                   d::CuPtr{cuDoubleComplex},
-                                                                   du::CuPtr{cuDoubleComplex},
-                                                                   x::CuPtr{cuDoubleComplex},
-                                                                   batchCount::Cint,
-                                                                   pBufferSizeInBytes::Ptr{Csize_t})::cusparseStatus_t
+    @gcsafe_ccall libcusparse.cusparseZgtsvInterleavedBatch_bufferSizeExt(handle::cusparseHandle_t,
+                                                                          algo::Cint,
+                                                                          m::Cint,
+                                                                          dl::CuPtr{cuDoubleComplex},
+                                                                          d::CuPtr{cuDoubleComplex},
+                                                                          du::CuPtr{cuDoubleComplex},
+                                                                          x::CuPtr{cuDoubleComplex},
+                                                                          batchCount::Cint,
+                                                                          pBufferSizeInBytes::Ptr{Csize_t})::cusparseStatus_t
 end
 
 @checked function cusparseSgtsvInterleavedBatch(handle, algo, m, dl, d, du, x, batchCount,
                                                 pBuffer)
     initialize_context()
-    @ccall libcusparse.cusparseSgtsvInterleavedBatch(handle::cusparseHandle_t, algo::Cint,
-                                                     m::Cint, dl::CuPtr{Cfloat},
-                                                     d::CuPtr{Cfloat}, du::CuPtr{Cfloat},
-                                                     x::CuPtr{Cfloat}, batchCount::Cint,
-                                                     pBuffer::CuPtr{Cvoid})::cusparseStatus_t
+    @gcsafe_ccall libcusparse.cusparseSgtsvInterleavedBatch(handle::cusparseHandle_t,
+                                                            algo::Cint, m::Cint,
+                                                            dl::CuPtr{Cfloat},
+                                                            d::CuPtr{Cfloat},
+                                                            du::CuPtr{Cfloat},
+                                                            x::CuPtr{Cfloat},
+                                                            batchCount::Cint,
+                                                            pBuffer::CuPtr{Cvoid})::cusparseStatus_t
 end
 
 @checked function cusparseDgtsvInterleavedBatch(handle, algo, m, dl, d, du, x, batchCount,
                                                 pBuffer)
     initialize_context()
-    @ccall libcusparse.cusparseDgtsvInterleavedBatch(handle::cusparseHandle_t, algo::Cint,
-                                                     m::Cint, dl::CuPtr{Cdouble},
-                                                     d::CuPtr{Cdouble}, du::CuPtr{Cdouble},
-                                                     x::CuPtr{Cdouble}, batchCount::Cint,
-                                                     pBuffer::CuPtr{Cvoid})::cusparseStatus_t
+    @gcsafe_ccall libcusparse.cusparseDgtsvInterleavedBatch(handle::cusparseHandle_t,
+                                                            algo::Cint, m::Cint,
+                                                            dl::CuPtr{Cdouble},
+                                                            d::CuPtr{Cdouble},
+                                                            du::CuPtr{Cdouble},
+                                                            x::CuPtr{Cdouble},
+                                                            batchCount::Cint,
+                                                            pBuffer::CuPtr{Cvoid})::cusparseStatus_t
 end
 
 @checked function cusparseCgtsvInterleavedBatch(handle, algo, m, dl, d, du, x, batchCount,
                                                 pBuffer)
     initialize_context()
-    @ccall libcusparse.cusparseCgtsvInterleavedBatch(handle::cusparseHandle_t, algo::Cint,
-                                                     m::Cint, dl::CuPtr{cuComplex},
-                                                     d::CuPtr{cuComplex},
-                                                     du::CuPtr{cuComplex},
-                                                     x::CuPtr{cuComplex}, batchCount::Cint,
-                                                     pBuffer::CuPtr{Cvoid})::cusparseStatus_t
+    @gcsafe_ccall libcusparse.cusparseCgtsvInterleavedBatch(handle::cusparseHandle_t,
+                                                            algo::Cint, m::Cint,
+                                                            dl::CuPtr{cuComplex},
+                                                            d::CuPtr{cuComplex},
+                                                            du::CuPtr{cuComplex},
+                                                            x::CuPtr{cuComplex},
+                                                            batchCount::Cint,
+                                                            pBuffer::CuPtr{Cvoid})::cusparseStatus_t
 end
 
 @checked function cusparseZgtsvInterleavedBatch(handle, algo, m, dl, d, du, x, batchCount,
                                                 pBuffer)
     initialize_context()
-    @ccall libcusparse.cusparseZgtsvInterleavedBatch(handle::cusparseHandle_t, algo::Cint,
-                                                     m::Cint, dl::CuPtr{cuDoubleComplex},
-                                                     d::CuPtr{cuDoubleComplex},
-                                                     du::CuPtr{cuDoubleComplex},
-                                                     x::CuPtr{cuDoubleComplex},
-                                                     batchCount::Cint,
-                                                     pBuffer::CuPtr{Cvoid})::cusparseStatus_t
+    @gcsafe_ccall libcusparse.cusparseZgtsvInterleavedBatch(handle::cusparseHandle_t,
+                                                            algo::Cint, m::Cint,
+                                                            dl::CuPtr{cuDoubleComplex},
+                                                            d::CuPtr{cuDoubleComplex},
+                                                            du::CuPtr{cuDoubleComplex},
+                                                            x::CuPtr{cuDoubleComplex},
+                                                            batchCount::Cint,
+                                                            pBuffer::CuPtr{Cvoid})::cusparseStatus_t
 end
 
 @checked function cusparseSgpsvInterleavedBatch_bufferSizeExt(handle, algo, m, ds, dl, d,
                                                               du, dw, x, batchCount,
                                                               pBufferSizeInBytes)
     initialize_context()
-    @ccall libcusparse.cusparseSgpsvInterleavedBatch_bufferSizeExt(handle::cusparseHandle_t,
-                                                                   algo::Cint, m::Cint,
-                                                                   ds::CuPtr{Cfloat},
-                                                                   dl::CuPtr{Cfloat},
-                                                                   d::CuPtr{Cfloat},
-                                                                   du::CuPtr{Cfloat},
-                                                                   dw::CuPtr{Cfloat},
-                                                                   x::CuPtr{Cfloat},
-                                                                   batchCount::Cint,
-                                                                   pBufferSizeInBytes::Ptr{Csize_t})::cusparseStatus_t
+    @gcsafe_ccall libcusparse.cusparseSgpsvInterleavedBatch_bufferSizeExt(handle::cusparseHandle_t,
+                                                                          algo::Cint,
+                                                                          m::Cint,
+                                                                          ds::CuPtr{Cfloat},
+                                                                          dl::CuPtr{Cfloat},
+                                                                          d::CuPtr{Cfloat},
+                                                                          du::CuPtr{Cfloat},
+                                                                          dw::CuPtr{Cfloat},
+                                                                          x::CuPtr{Cfloat},
+                                                                          batchCount::Cint,
+                                                                          pBufferSizeInBytes::Ptr{Csize_t})::cusparseStatus_t
 end
 
 @checked function cusparseDgpsvInterleavedBatch_bufferSizeExt(handle, algo, m, ds, dl, d,
                                                               du, dw, x, batchCount,
                                                               pBufferSizeInBytes)
     initialize_context()
-    @ccall libcusparse.cusparseDgpsvInterleavedBatch_bufferSizeExt(handle::cusparseHandle_t,
-                                                                   algo::Cint, m::Cint,
-                                                                   ds::CuPtr{Cdouble},
-                                                                   dl::CuPtr{Cdouble},
-                                                                   d::CuPtr{Cdouble},
-                                                                   du::CuPtr{Cdouble},
-                                                                   dw::CuPtr{Cdouble},
-                                                                   x::CuPtr{Cdouble},
-                                                                   batchCount::Cint,
-                                                                   pBufferSizeInBytes::Ptr{Csize_t})::cusparseStatus_t
+    @gcsafe_ccall libcusparse.cusparseDgpsvInterleavedBatch_bufferSizeExt(handle::cusparseHandle_t,
+                                                                          algo::Cint,
+                                                                          m::Cint,
+                                                                          ds::CuPtr{Cdouble},
+                                                                          dl::CuPtr{Cdouble},
+                                                                          d::CuPtr{Cdouble},
+                                                                          du::CuPtr{Cdouble},
+                                                                          dw::CuPtr{Cdouble},
+                                                                          x::CuPtr{Cdouble},
+                                                                          batchCount::Cint,
+                                                                          pBufferSizeInBytes::Ptr{Csize_t})::cusparseStatus_t
 end
 
 @checked function cusparseCgpsvInterleavedBatch_bufferSizeExt(handle, algo, m, ds, dl, d,
                                                               du, dw, x, batchCount,
                                                               pBufferSizeInBytes)
     initialize_context()
-    @ccall libcusparse.cusparseCgpsvInterleavedBatch_bufferSizeExt(handle::cusparseHandle_t,
-                                                                   algo::Cint, m::Cint,
-                                                                   ds::CuPtr{cuComplex},
-                                                                   dl::CuPtr{cuComplex},
-                                                                   d::CuPtr{cuComplex},
-                                                                   du::CuPtr{cuComplex},
-                                                                   dw::CuPtr{cuComplex},
-                                                                   x::CuPtr{cuComplex},
-                                                                   batchCount::Cint,
-                                                                   pBufferSizeInBytes::Ptr{Csize_t})::cusparseStatus_t
+    @gcsafe_ccall libcusparse.cusparseCgpsvInterleavedBatch_bufferSizeExt(handle::cusparseHandle_t,
+                                                                          algo::Cint,
+                                                                          m::Cint,
+                                                                          ds::CuPtr{cuComplex},
+                                                                          dl::CuPtr{cuComplex},
+                                                                          d::CuPtr{cuComplex},
+                                                                          du::CuPtr{cuComplex},
+                                                                          dw::CuPtr{cuComplex},
+                                                                          x::CuPtr{cuComplex},
+                                                                          batchCount::Cint,
+                                                                          pBufferSizeInBytes::Ptr{Csize_t})::cusparseStatus_t
 end
 
 @checked function cusparseZgpsvInterleavedBatch_bufferSizeExt(handle, algo, m, ds, dl, d,
                                                               du, dw, x, batchCount,
                                                               pBufferSizeInBytes)
     initialize_context()
-    @ccall libcusparse.cusparseZgpsvInterleavedBatch_bufferSizeExt(handle::cusparseHandle_t,
-                                                                   algo::Cint, m::Cint,
-                                                                   ds::CuPtr{cuDoubleComplex},
-                                                                   dl::CuPtr{cuDoubleComplex},
-                                                                   d::CuPtr{cuDoubleComplex},
-                                                                   du::CuPtr{cuDoubleComplex},
-                                                                   dw::CuPtr{cuDoubleComplex},
-                                                                   x::CuPtr{cuDoubleComplex},
-                                                                   batchCount::Cint,
-                                                                   pBufferSizeInBytes::Ptr{Csize_t})::cusparseStatus_t
+    @gcsafe_ccall libcusparse.cusparseZgpsvInterleavedBatch_bufferSizeExt(handle::cusparseHandle_t,
+                                                                          algo::Cint,
+                                                                          m::Cint,
+                                                                          ds::CuPtr{cuDoubleComplex},
+                                                                          dl::CuPtr{cuDoubleComplex},
+                                                                          d::CuPtr{cuDoubleComplex},
+                                                                          du::CuPtr{cuDoubleComplex},
+                                                                          dw::CuPtr{cuDoubleComplex},
+                                                                          x::CuPtr{cuDoubleComplex},
+                                                                          batchCount::Cint,
+                                                                          pBufferSizeInBytes::Ptr{Csize_t})::cusparseStatus_t
 end
 
 @checked function cusparseSgpsvInterleavedBatch(handle, algo, m, ds, dl, d, du, dw, x,
                                                 batchCount, pBuffer)
     initialize_context()
-    @ccall libcusparse.cusparseSgpsvInterleavedBatch(handle::cusparseHandle_t, algo::Cint,
-                                                     m::Cint, ds::CuPtr{Cfloat},
-                                                     dl::CuPtr{Cfloat}, d::CuPtr{Cfloat},
-                                                     du::CuPtr{Cfloat}, dw::CuPtr{Cfloat},
-                                                     x::CuPtr{Cfloat}, batchCount::Cint,
-                                                     pBuffer::CuPtr{Cvoid})::cusparseStatus_t
+    @gcsafe_ccall libcusparse.cusparseSgpsvInterleavedBatch(handle::cusparseHandle_t,
+                                                            algo::Cint, m::Cint,
+                                                            ds::CuPtr{Cfloat},
+                                                            dl::CuPtr{Cfloat},
+                                                            d::CuPtr{Cfloat},
+                                                            du::CuPtr{Cfloat},
+                                                            dw::CuPtr{Cfloat},
+                                                            x::CuPtr{Cfloat},
+                                                            batchCount::Cint,
+                                                            pBuffer::CuPtr{Cvoid})::cusparseStatus_t
 end
 
 @checked function cusparseDgpsvInterleavedBatch(handle, algo, m, ds, dl, d, du, dw, x,
                                                 batchCount, pBuffer)
     initialize_context()
-    @ccall libcusparse.cusparseDgpsvInterleavedBatch(handle::cusparseHandle_t, algo::Cint,
-                                                     m::Cint, ds::CuPtr{Cdouble},
-                                                     dl::CuPtr{Cdouble}, d::CuPtr{Cdouble},
-                                                     du::CuPtr{Cdouble}, dw::CuPtr{Cdouble},
-                                                     x::CuPtr{Cdouble}, batchCount::Cint,
-                                                     pBuffer::CuPtr{Cvoid})::cusparseStatus_t
+    @gcsafe_ccall libcusparse.cusparseDgpsvInterleavedBatch(handle::cusparseHandle_t,
+                                                            algo::Cint, m::Cint,
+                                                            ds::CuPtr{Cdouble},
+                                                            dl::CuPtr{Cdouble},
+                                                            d::CuPtr{Cdouble},
+                                                            du::CuPtr{Cdouble},
+                                                            dw::CuPtr{Cdouble},
+                                                            x::CuPtr{Cdouble},
+                                                            batchCount::Cint,
+                                                            pBuffer::CuPtr{Cvoid})::cusparseStatus_t
 end
 
 @checked function cusparseCgpsvInterleavedBatch(handle, algo, m, ds, dl, d, du, dw, x,
                                                 batchCount, pBuffer)
     initialize_context()
-    @ccall libcusparse.cusparseCgpsvInterleavedBatch(handle::cusparseHandle_t, algo::Cint,
-                                                     m::Cint, ds::CuPtr{cuComplex},
-                                                     dl::CuPtr{cuComplex},
-                                                     d::CuPtr{cuComplex},
-                                                     du::CuPtr{cuComplex},
-                                                     dw::CuPtr{cuComplex},
-                                                     x::CuPtr{cuComplex}, batchCount::Cint,
-                                                     pBuffer::CuPtr{Cvoid})::cusparseStatus_t
+    @gcsafe_ccall libcusparse.cusparseCgpsvInterleavedBatch(handle::cusparseHandle_t,
+                                                            algo::Cint, m::Cint,
+                                                            ds::CuPtr{cuComplex},
+                                                            dl::CuPtr{cuComplex},
+                                                            d::CuPtr{cuComplex},
+                                                            du::CuPtr{cuComplex},
+                                                            dw::CuPtr{cuComplex},
+                                                            x::CuPtr{cuComplex},
+                                                            batchCount::Cint,
+                                                            pBuffer::CuPtr{Cvoid})::cusparseStatus_t
 end
 
 @checked function cusparseZgpsvInterleavedBatch(handle, algo, m, ds, dl, d, du, dw, x,
                                                 batchCount, pBuffer)
     initialize_context()
-    @ccall libcusparse.cusparseZgpsvInterleavedBatch(handle::cusparseHandle_t, algo::Cint,
-                                                     m::Cint, ds::CuPtr{cuDoubleComplex},
-                                                     dl::CuPtr{cuDoubleComplex},
-                                                     d::CuPtr{cuDoubleComplex},
-                                                     du::CuPtr{cuDoubleComplex},
-                                                     dw::CuPtr{cuDoubleComplex},
-                                                     x::CuPtr{cuDoubleComplex},
-                                                     batchCount::Cint,
-                                                     pBuffer::CuPtr{Cvoid})::cusparseStatus_t
+    @gcsafe_ccall libcusparse.cusparseZgpsvInterleavedBatch(handle::cusparseHandle_t,
+                                                            algo::Cint, m::Cint,
+                                                            ds::CuPtr{cuDoubleComplex},
+                                                            dl::CuPtr{cuDoubleComplex},
+                                                            d::CuPtr{cuDoubleComplex},
+                                                            du::CuPtr{cuDoubleComplex},
+                                                            dw::CuPtr{cuDoubleComplex},
+                                                            x::CuPtr{cuDoubleComplex},
+                                                            batchCount::Cint,
+                                                            pBuffer::CuPtr{Cvoid})::cusparseStatus_t
 end
 
 @checked function cusparseScsrgeam2_bufferSizeExt(handle, m, n, alpha, descrA, nnzA,
@@ -2711,24 +2894,25 @@ end
                                                   csrSortedRowPtrC, csrSortedColIndC,
                                                   pBufferSizeInBytes)
     initialize_context()
-    @ccall libcusparse.cusparseScsrgeam2_bufferSizeExt(handle::cusparseHandle_t, m::Cint,
-                                                       n::Cint, alpha::Ref{Cfloat},
-                                                       descrA::cusparseMatDescr_t,
-                                                       nnzA::Cint,
-                                                       csrSortedValA::CuPtr{Cfloat},
-                                                       csrSortedRowPtrA::CuPtr{Cint},
-                                                       csrSortedColIndA::CuPtr{Cint},
-                                                       beta::Ref{Cfloat},
-                                                       descrB::cusparseMatDescr_t,
-                                                       nnzB::Cint,
-                                                       csrSortedValB::CuPtr{Cfloat},
-                                                       csrSortedRowPtrB::CuPtr{Cint},
-                                                       csrSortedColIndB::CuPtr{Cint},
-                                                       descrC::cusparseMatDescr_t,
-                                                       csrSortedValC::CuPtr{Cfloat},
-                                                       csrSortedRowPtrC::CuPtr{Cint},
-                                                       csrSortedColIndC::CuPtr{Cint},
-                                                       pBufferSizeInBytes::Ptr{Csize_t})::cusparseStatus_t
+    @gcsafe_ccall libcusparse.cusparseScsrgeam2_bufferSizeExt(handle::cusparseHandle_t,
+                                                              m::Cint, n::Cint,
+                                                              alpha::Ref{Cfloat},
+                                                              descrA::cusparseMatDescr_t,
+                                                              nnzA::Cint,
+                                                              csrSortedValA::CuPtr{Cfloat},
+                                                              csrSortedRowPtrA::CuPtr{Cint},
+                                                              csrSortedColIndA::CuPtr{Cint},
+                                                              beta::Ref{Cfloat},
+                                                              descrB::cusparseMatDescr_t,
+                                                              nnzB::Cint,
+                                                              csrSortedValB::CuPtr{Cfloat},
+                                                              csrSortedRowPtrB::CuPtr{Cint},
+                                                              csrSortedColIndB::CuPtr{Cint},
+                                                              descrC::cusparseMatDescr_t,
+                                                              csrSortedValC::CuPtr{Cfloat},
+                                                              csrSortedRowPtrC::CuPtr{Cint},
+                                                              csrSortedColIndC::CuPtr{Cint},
+                                                              pBufferSizeInBytes::Ptr{Csize_t})::cusparseStatus_t
 end
 
 @checked function cusparseDcsrgeam2_bufferSizeExt(handle, m, n, alpha, descrA, nnzA,
@@ -2739,24 +2923,25 @@ end
                                                   csrSortedRowPtrC, csrSortedColIndC,
                                                   pBufferSizeInBytes)
     initialize_context()
-    @ccall libcusparse.cusparseDcsrgeam2_bufferSizeExt(handle::cusparseHandle_t, m::Cint,
-                                                       n::Cint, alpha::Ref{Cdouble},
-                                                       descrA::cusparseMatDescr_t,
-                                                       nnzA::Cint,
-                                                       csrSortedValA::CuPtr{Cdouble},
-                                                       csrSortedRowPtrA::CuPtr{Cint},
-                                                       csrSortedColIndA::CuPtr{Cint},
-                                                       beta::Ref{Cdouble},
-                                                       descrB::cusparseMatDescr_t,
-                                                       nnzB::Cint,
-                                                       csrSortedValB::CuPtr{Cdouble},
-                                                       csrSortedRowPtrB::CuPtr{Cint},
-                                                       csrSortedColIndB::CuPtr{Cint},
-                                                       descrC::cusparseMatDescr_t,
-                                                       csrSortedValC::CuPtr{Cdouble},
-                                                       csrSortedRowPtrC::CuPtr{Cint},
-                                                       csrSortedColIndC::CuPtr{Cint},
-                                                       pBufferSizeInBytes::Ptr{Csize_t})::cusparseStatus_t
+    @gcsafe_ccall libcusparse.cusparseDcsrgeam2_bufferSizeExt(handle::cusparseHandle_t,
+                                                              m::Cint, n::Cint,
+                                                              alpha::Ref{Cdouble},
+                                                              descrA::cusparseMatDescr_t,
+                                                              nnzA::Cint,
+                                                              csrSortedValA::CuPtr{Cdouble},
+                                                              csrSortedRowPtrA::CuPtr{Cint},
+                                                              csrSortedColIndA::CuPtr{Cint},
+                                                              beta::Ref{Cdouble},
+                                                              descrB::cusparseMatDescr_t,
+                                                              nnzB::Cint,
+                                                              csrSortedValB::CuPtr{Cdouble},
+                                                              csrSortedRowPtrB::CuPtr{Cint},
+                                                              csrSortedColIndB::CuPtr{Cint},
+                                                              descrC::cusparseMatDescr_t,
+                                                              csrSortedValC::CuPtr{Cdouble},
+                                                              csrSortedRowPtrC::CuPtr{Cint},
+                                                              csrSortedColIndC::CuPtr{Cint},
+                                                              pBufferSizeInBytes::Ptr{Csize_t})::cusparseStatus_t
 end
 
 @checked function cusparseCcsrgeam2_bufferSizeExt(handle, m, n, alpha, descrA, nnzA,
@@ -2767,24 +2952,25 @@ end
                                                   csrSortedRowPtrC, csrSortedColIndC,
                                                   pBufferSizeInBytes)
     initialize_context()
-    @ccall libcusparse.cusparseCcsrgeam2_bufferSizeExt(handle::cusparseHandle_t, m::Cint,
-                                                       n::Cint, alpha::Ref{cuComplex},
-                                                       descrA::cusparseMatDescr_t,
-                                                       nnzA::Cint,
-                                                       csrSortedValA::CuPtr{cuComplex},
-                                                       csrSortedRowPtrA::CuPtr{Cint},
-                                                       csrSortedColIndA::CuPtr{Cint},
-                                                       beta::Ref{cuComplex},
-                                                       descrB::cusparseMatDescr_t,
-                                                       nnzB::Cint,
-                                                       csrSortedValB::CuPtr{cuComplex},
-                                                       csrSortedRowPtrB::CuPtr{Cint},
-                                                       csrSortedColIndB::CuPtr{Cint},
-                                                       descrC::cusparseMatDescr_t,
-                                                       csrSortedValC::CuPtr{cuComplex},
-                                                       csrSortedRowPtrC::CuPtr{Cint},
-                                                       csrSortedColIndC::CuPtr{Cint},
-                                                       pBufferSizeInBytes::Ptr{Csize_t})::cusparseStatus_t
+    @gcsafe_ccall libcusparse.cusparseCcsrgeam2_bufferSizeExt(handle::cusparseHandle_t,
+                                                              m::Cint, n::Cint,
+                                                              alpha::Ref{cuComplex},
+                                                              descrA::cusparseMatDescr_t,
+                                                              nnzA::Cint,
+                                                              csrSortedValA::CuPtr{cuComplex},
+                                                              csrSortedRowPtrA::CuPtr{Cint},
+                                                              csrSortedColIndA::CuPtr{Cint},
+                                                              beta::Ref{cuComplex},
+                                                              descrB::cusparseMatDescr_t,
+                                                              nnzB::Cint,
+                                                              csrSortedValB::CuPtr{cuComplex},
+                                                              csrSortedRowPtrB::CuPtr{Cint},
+                                                              csrSortedColIndB::CuPtr{Cint},
+                                                              descrC::cusparseMatDescr_t,
+                                                              csrSortedValC::CuPtr{cuComplex},
+                                                              csrSortedRowPtrC::CuPtr{Cint},
+                                                              csrSortedColIndC::CuPtr{Cint},
+                                                              pBufferSizeInBytes::Ptr{Csize_t})::cusparseStatus_t
 end
 
 @checked function cusparseZcsrgeam2_bufferSizeExt(handle, m, n, alpha, descrA, nnzA,
@@ -2795,24 +2981,25 @@ end
                                                   csrSortedRowPtrC, csrSortedColIndC,
                                                   pBufferSizeInBytes)
     initialize_context()
-    @ccall libcusparse.cusparseZcsrgeam2_bufferSizeExt(handle::cusparseHandle_t, m::Cint,
-                                                       n::Cint, alpha::Ref{cuDoubleComplex},
-                                                       descrA::cusparseMatDescr_t,
-                                                       nnzA::Cint,
-                                                       csrSortedValA::CuPtr{cuDoubleComplex},
-                                                       csrSortedRowPtrA::CuPtr{Cint},
-                                                       csrSortedColIndA::CuPtr{Cint},
-                                                       beta::Ref{cuDoubleComplex},
-                                                       descrB::cusparseMatDescr_t,
-                                                       nnzB::Cint,
-                                                       csrSortedValB::CuPtr{cuDoubleComplex},
-                                                       csrSortedRowPtrB::CuPtr{Cint},
-                                                       csrSortedColIndB::CuPtr{Cint},
-                                                       descrC::cusparseMatDescr_t,
-                                                       csrSortedValC::CuPtr{cuDoubleComplex},
-                                                       csrSortedRowPtrC::CuPtr{Cint},
-                                                       csrSortedColIndC::CuPtr{Cint},
-                                                       pBufferSizeInBytes::Ptr{Csize_t})::cusparseStatus_t
+    @gcsafe_ccall libcusparse.cusparseZcsrgeam2_bufferSizeExt(handle::cusparseHandle_t,
+                                                              m::Cint, n::Cint,
+                                                              alpha::Ref{cuDoubleComplex},
+                                                              descrA::cusparseMatDescr_t,
+                                                              nnzA::Cint,
+                                                              csrSortedValA::CuPtr{cuDoubleComplex},
+                                                              csrSortedRowPtrA::CuPtr{Cint},
+                                                              csrSortedColIndA::CuPtr{Cint},
+                                                              beta::Ref{cuDoubleComplex},
+                                                              descrB::cusparseMatDescr_t,
+                                                              nnzB::Cint,
+                                                              csrSortedValB::CuPtr{cuDoubleComplex},
+                                                              csrSortedRowPtrB::CuPtr{Cint},
+                                                              csrSortedColIndB::CuPtr{Cint},
+                                                              descrC::cusparseMatDescr_t,
+                                                              csrSortedValC::CuPtr{cuDoubleComplex},
+                                                              csrSortedRowPtrC::CuPtr{Cint},
+                                                              csrSortedColIndC::CuPtr{Cint},
+                                                              pBufferSizeInBytes::Ptr{Csize_t})::cusparseStatus_t
 end
 
 @checked function cusparseXcsrgeam2Nnz(handle, m, n, descrA, nnzA, csrSortedRowPtrA,
@@ -2820,17 +3007,18 @@ end
                                        csrSortedColIndB, descrC, csrSortedRowPtrC,
                                        nnzTotalDevHostPtr, workspace)
     initialize_context()
-    @ccall libcusparse.cusparseXcsrgeam2Nnz(handle::cusparseHandle_t, m::Cint, n::Cint,
-                                            descrA::cusparseMatDescr_t, nnzA::Cint,
-                                            csrSortedRowPtrA::CuPtr{Cint},
-                                            csrSortedColIndA::CuPtr{Cint},
-                                            descrB::cusparseMatDescr_t, nnzB::Cint,
-                                            csrSortedRowPtrB::CuPtr{Cint},
-                                            csrSortedColIndB::CuPtr{Cint},
-                                            descrC::cusparseMatDescr_t,
-                                            csrSortedRowPtrC::CuPtr{Cint},
-                                            nnzTotalDevHostPtr::PtrOrCuPtr{Cint},
-                                            workspace::CuPtr{Cvoid})::cusparseStatus_t
+    @gcsafe_ccall libcusparse.cusparseXcsrgeam2Nnz(handle::cusparseHandle_t, m::Cint,
+                                                   n::Cint, descrA::cusparseMatDescr_t,
+                                                   nnzA::Cint,
+                                                   csrSortedRowPtrA::CuPtr{Cint},
+                                                   csrSortedColIndA::CuPtr{Cint},
+                                                   descrB::cusparseMatDescr_t, nnzB::Cint,
+                                                   csrSortedRowPtrB::CuPtr{Cint},
+                                                   csrSortedColIndB::CuPtr{Cint},
+                                                   descrC::cusparseMatDescr_t,
+                                                   csrSortedRowPtrC::CuPtr{Cint},
+                                                   nnzTotalDevHostPtr::PtrOrCuPtr{Cint},
+                                                   workspace::CuPtr{Cvoid})::cusparseStatus_t
 end
 
 @checked function cusparseScsrgeam2(handle, m, n, alpha, descrA, nnzA, csrSortedValA,
@@ -2839,20 +3027,22 @@ end
                                     descrC, csrSortedValC, csrSortedRowPtrC,
                                     csrSortedColIndC, pBuffer)
     initialize_context()
-    @ccall libcusparse.cusparseScsrgeam2(handle::cusparseHandle_t, m::Cint, n::Cint,
-                                         alpha::Ref{Cfloat}, descrA::cusparseMatDescr_t,
-                                         nnzA::Cint, csrSortedValA::CuPtr{Cfloat},
-                                         csrSortedRowPtrA::CuPtr{Cint},
-                                         csrSortedColIndA::CuPtr{Cint}, beta::Ref{Cfloat},
-                                         descrB::cusparseMatDescr_t, nnzB::Cint,
-                                         csrSortedValB::CuPtr{Cfloat},
-                                         csrSortedRowPtrB::CuPtr{Cint},
-                                         csrSortedColIndB::CuPtr{Cint},
-                                         descrC::cusparseMatDescr_t,
-                                         csrSortedValC::CuPtr{Cfloat},
-                                         csrSortedRowPtrC::CuPtr{Cint},
-                                         csrSortedColIndC::CuPtr{Cint},
-                                         pBuffer::CuPtr{Cvoid})::cusparseStatus_t
+    @gcsafe_ccall libcusparse.cusparseScsrgeam2(handle::cusparseHandle_t, m::Cint, n::Cint,
+                                                alpha::Ref{Cfloat},
+                                                descrA::cusparseMatDescr_t, nnzA::Cint,
+                                                csrSortedValA::CuPtr{Cfloat},
+                                                csrSortedRowPtrA::CuPtr{Cint},
+                                                csrSortedColIndA::CuPtr{Cint},
+                                                beta::Ref{Cfloat},
+                                                descrB::cusparseMatDescr_t, nnzB::Cint,
+                                                csrSortedValB::CuPtr{Cfloat},
+                                                csrSortedRowPtrB::CuPtr{Cint},
+                                                csrSortedColIndB::CuPtr{Cint},
+                                                descrC::cusparseMatDescr_t,
+                                                csrSortedValC::CuPtr{Cfloat},
+                                                csrSortedRowPtrC::CuPtr{Cint},
+                                                csrSortedColIndC::CuPtr{Cint},
+                                                pBuffer::CuPtr{Cvoid})::cusparseStatus_t
 end
 
 @checked function cusparseDcsrgeam2(handle, m, n, alpha, descrA, nnzA, csrSortedValA,
@@ -2861,20 +3051,22 @@ end
                                     descrC, csrSortedValC, csrSortedRowPtrC,
                                     csrSortedColIndC, pBuffer)
     initialize_context()
-    @ccall libcusparse.cusparseDcsrgeam2(handle::cusparseHandle_t, m::Cint, n::Cint,
-                                         alpha::Ref{Cdouble}, descrA::cusparseMatDescr_t,
-                                         nnzA::Cint, csrSortedValA::CuPtr{Cdouble},
-                                         csrSortedRowPtrA::CuPtr{Cint},
-                                         csrSortedColIndA::CuPtr{Cint}, beta::Ref{Cdouble},
-                                         descrB::cusparseMatDescr_t, nnzB::Cint,
-                                         csrSortedValB::CuPtr{Cdouble},
-                                         csrSortedRowPtrB::CuPtr{Cint},
-                                         csrSortedColIndB::CuPtr{Cint},
-                                         descrC::cusparseMatDescr_t,
-                                         csrSortedValC::CuPtr{Cdouble},
-                                         csrSortedRowPtrC::CuPtr{Cint},
-                                         csrSortedColIndC::CuPtr{Cint},
-                                         pBuffer::CuPtr{Cvoid})::cusparseStatus_t
+    @gcsafe_ccall libcusparse.cusparseDcsrgeam2(handle::cusparseHandle_t, m::Cint, n::Cint,
+                                                alpha::Ref{Cdouble},
+                                                descrA::cusparseMatDescr_t, nnzA::Cint,
+                                                csrSortedValA::CuPtr{Cdouble},
+                                                csrSortedRowPtrA::CuPtr{Cint},
+                                                csrSortedColIndA::CuPtr{Cint},
+                                                beta::Ref{Cdouble},
+                                                descrB::cusparseMatDescr_t, nnzB::Cint,
+                                                csrSortedValB::CuPtr{Cdouble},
+                                                csrSortedRowPtrB::CuPtr{Cint},
+                                                csrSortedColIndB::CuPtr{Cint},
+                                                descrC::cusparseMatDescr_t,
+                                                csrSortedValC::CuPtr{Cdouble},
+                                                csrSortedRowPtrC::CuPtr{Cint},
+                                                csrSortedColIndC::CuPtr{Cint},
+                                                pBuffer::CuPtr{Cvoid})::cusparseStatus_t
 end
 
 @checked function cusparseCcsrgeam2(handle, m, n, alpha, descrA, nnzA, csrSortedValA,
@@ -2883,20 +3075,22 @@ end
                                     descrC, csrSortedValC, csrSortedRowPtrC,
                                     csrSortedColIndC, pBuffer)
     initialize_context()
-    @ccall libcusparse.cusparseCcsrgeam2(handle::cusparseHandle_t, m::Cint, n::Cint,
-                                         alpha::Ref{cuComplex}, descrA::cusparseMatDescr_t,
-                                         nnzA::Cint, csrSortedValA::CuPtr{cuComplex},
-                                         csrSortedRowPtrA::CuPtr{Cint},
-                                         csrSortedColIndA::CuPtr{Cint},
-                                         beta::Ref{cuComplex}, descrB::cusparseMatDescr_t,
-                                         nnzB::Cint, csrSortedValB::CuPtr{cuComplex},
-                                         csrSortedRowPtrB::CuPtr{Cint},
-                                         csrSortedColIndB::CuPtr{Cint},
-                                         descrC::cusparseMatDescr_t,
-                                         csrSortedValC::CuPtr{cuComplex},
-                                         csrSortedRowPtrC::CuPtr{Cint},
-                                         csrSortedColIndC::CuPtr{Cint},
-                                         pBuffer::CuPtr{Cvoid})::cusparseStatus_t
+    @gcsafe_ccall libcusparse.cusparseCcsrgeam2(handle::cusparseHandle_t, m::Cint, n::Cint,
+                                                alpha::Ref{cuComplex},
+                                                descrA::cusparseMatDescr_t, nnzA::Cint,
+                                                csrSortedValA::CuPtr{cuComplex},
+                                                csrSortedRowPtrA::CuPtr{Cint},
+                                                csrSortedColIndA::CuPtr{Cint},
+                                                beta::Ref{cuComplex},
+                                                descrB::cusparseMatDescr_t, nnzB::Cint,
+                                                csrSortedValB::CuPtr{cuComplex},
+                                                csrSortedRowPtrB::CuPtr{Cint},
+                                                csrSortedColIndB::CuPtr{Cint},
+                                                descrC::cusparseMatDescr_t,
+                                                csrSortedValC::CuPtr{cuComplex},
+                                                csrSortedRowPtrC::CuPtr{Cint},
+                                                csrSortedColIndC::CuPtr{Cint},
+                                                pBuffer::CuPtr{Cvoid})::cusparseStatus_t
 end
 
 @checked function cusparseZcsrgeam2(handle, m, n, alpha, descrA, nnzA, csrSortedValA,
@@ -2905,160 +3099,171 @@ end
                                     descrC, csrSortedValC, csrSortedRowPtrC,
                                     csrSortedColIndC, pBuffer)
     initialize_context()
-    @ccall libcusparse.cusparseZcsrgeam2(handle::cusparseHandle_t, m::Cint, n::Cint,
-                                         alpha::Ref{cuDoubleComplex},
-                                         descrA::cusparseMatDescr_t, nnzA::Cint,
-                                         csrSortedValA::CuPtr{cuDoubleComplex},
-                                         csrSortedRowPtrA::CuPtr{Cint},
-                                         csrSortedColIndA::CuPtr{Cint},
-                                         beta::Ref{cuDoubleComplex},
-                                         descrB::cusparseMatDescr_t, nnzB::Cint,
-                                         csrSortedValB::CuPtr{cuDoubleComplex},
-                                         csrSortedRowPtrB::CuPtr{Cint},
-                                         csrSortedColIndB::CuPtr{Cint},
-                                         descrC::cusparseMatDescr_t,
-                                         csrSortedValC::CuPtr{cuDoubleComplex},
-                                         csrSortedRowPtrC::CuPtr{Cint},
-                                         csrSortedColIndC::CuPtr{Cint},
-                                         pBuffer::CuPtr{Cvoid})::cusparseStatus_t
+    @gcsafe_ccall libcusparse.cusparseZcsrgeam2(handle::cusparseHandle_t, m::Cint, n::Cint,
+                                                alpha::Ref{cuDoubleComplex},
+                                                descrA::cusparseMatDescr_t, nnzA::Cint,
+                                                csrSortedValA::CuPtr{cuDoubleComplex},
+                                                csrSortedRowPtrA::CuPtr{Cint},
+                                                csrSortedColIndA::CuPtr{Cint},
+                                                beta::Ref{cuDoubleComplex},
+                                                descrB::cusparseMatDescr_t, nnzB::Cint,
+                                                csrSortedValB::CuPtr{cuDoubleComplex},
+                                                csrSortedRowPtrB::CuPtr{Cint},
+                                                csrSortedColIndB::CuPtr{Cint},
+                                                descrC::cusparseMatDescr_t,
+                                                csrSortedValC::CuPtr{cuDoubleComplex},
+                                                csrSortedRowPtrC::CuPtr{Cint},
+                                                csrSortedColIndC::CuPtr{Cint},
+                                                pBuffer::CuPtr{Cvoid})::cusparseStatus_t
 end
 
 @checked function cusparseScsrcolor(handle, m, nnz, descrA, csrSortedValA, csrSortedRowPtrA,
                                     csrSortedColIndA, fractionToColor, ncolors, coloring,
                                     reordering, info)
     initialize_context()
-    @ccall libcusparse.cusparseScsrcolor(handle::cusparseHandle_t, m::Cint, nnz::Cint,
-                                         descrA::cusparseMatDescr_t,
-                                         csrSortedValA::CuPtr{Cfloat},
-                                         csrSortedRowPtrA::CuPtr{Cint},
-                                         csrSortedColIndA::CuPtr{Cint},
-                                         fractionToColor::Ptr{Cfloat}, ncolors::Ptr{Cint},
-                                         coloring::CuPtr{Cint}, reordering::CuPtr{Cint},
-                                         info::cusparseColorInfo_t)::cusparseStatus_t
+    @gcsafe_ccall libcusparse.cusparseScsrcolor(handle::cusparseHandle_t, m::Cint,
+                                                nnz::Cint, descrA::cusparseMatDescr_t,
+                                                csrSortedValA::CuPtr{Cfloat},
+                                                csrSortedRowPtrA::CuPtr{Cint},
+                                                csrSortedColIndA::CuPtr{Cint},
+                                                fractionToColor::Ptr{Cfloat},
+                                                ncolors::Ptr{Cint}, coloring::CuPtr{Cint},
+                                                reordering::CuPtr{Cint},
+                                                info::cusparseColorInfo_t)::cusparseStatus_t
 end
 
 @checked function cusparseDcsrcolor(handle, m, nnz, descrA, csrSortedValA, csrSortedRowPtrA,
                                     csrSortedColIndA, fractionToColor, ncolors, coloring,
                                     reordering, info)
     initialize_context()
-    @ccall libcusparse.cusparseDcsrcolor(handle::cusparseHandle_t, m::Cint, nnz::Cint,
-                                         descrA::cusparseMatDescr_t,
-                                         csrSortedValA::CuPtr{Cdouble},
-                                         csrSortedRowPtrA::CuPtr{Cint},
-                                         csrSortedColIndA::CuPtr{Cint},
-                                         fractionToColor::Ptr{Cdouble}, ncolors::Ptr{Cint},
-                                         coloring::CuPtr{Cint}, reordering::CuPtr{Cint},
-                                         info::cusparseColorInfo_t)::cusparseStatus_t
+    @gcsafe_ccall libcusparse.cusparseDcsrcolor(handle::cusparseHandle_t, m::Cint,
+                                                nnz::Cint, descrA::cusparseMatDescr_t,
+                                                csrSortedValA::CuPtr{Cdouble},
+                                                csrSortedRowPtrA::CuPtr{Cint},
+                                                csrSortedColIndA::CuPtr{Cint},
+                                                fractionToColor::Ptr{Cdouble},
+                                                ncolors::Ptr{Cint}, coloring::CuPtr{Cint},
+                                                reordering::CuPtr{Cint},
+                                                info::cusparseColorInfo_t)::cusparseStatus_t
 end
 
 @checked function cusparseCcsrcolor(handle, m, nnz, descrA, csrSortedValA, csrSortedRowPtrA,
                                     csrSortedColIndA, fractionToColor, ncolors, coloring,
                                     reordering, info)
     initialize_context()
-    @ccall libcusparse.cusparseCcsrcolor(handle::cusparseHandle_t, m::Cint, nnz::Cint,
-                                         descrA::cusparseMatDescr_t,
-                                         csrSortedValA::CuPtr{cuComplex},
-                                         csrSortedRowPtrA::CuPtr{Cint},
-                                         csrSortedColIndA::CuPtr{Cint},
-                                         fractionToColor::Ptr{Cfloat}, ncolors::Ptr{Cint},
-                                         coloring::CuPtr{Cint}, reordering::CuPtr{Cint},
-                                         info::cusparseColorInfo_t)::cusparseStatus_t
+    @gcsafe_ccall libcusparse.cusparseCcsrcolor(handle::cusparseHandle_t, m::Cint,
+                                                nnz::Cint, descrA::cusparseMatDescr_t,
+                                                csrSortedValA::CuPtr{cuComplex},
+                                                csrSortedRowPtrA::CuPtr{Cint},
+                                                csrSortedColIndA::CuPtr{Cint},
+                                                fractionToColor::Ptr{Cfloat},
+                                                ncolors::Ptr{Cint}, coloring::CuPtr{Cint},
+                                                reordering::CuPtr{Cint},
+                                                info::cusparseColorInfo_t)::cusparseStatus_t
 end
 
 @checked function cusparseZcsrcolor(handle, m, nnz, descrA, csrSortedValA, csrSortedRowPtrA,
                                     csrSortedColIndA, fractionToColor, ncolors, coloring,
                                     reordering, info)
     initialize_context()
-    @ccall libcusparse.cusparseZcsrcolor(handle::cusparseHandle_t, m::Cint, nnz::Cint,
-                                         descrA::cusparseMatDescr_t,
-                                         csrSortedValA::CuPtr{cuDoubleComplex},
-                                         csrSortedRowPtrA::CuPtr{Cint},
-                                         csrSortedColIndA::CuPtr{Cint},
-                                         fractionToColor::Ptr{Cdouble}, ncolors::Ptr{Cint},
-                                         coloring::CuPtr{Cint}, reordering::CuPtr{Cint},
-                                         info::cusparseColorInfo_t)::cusparseStatus_t
+    @gcsafe_ccall libcusparse.cusparseZcsrcolor(handle::cusparseHandle_t, m::Cint,
+                                                nnz::Cint, descrA::cusparseMatDescr_t,
+                                                csrSortedValA::CuPtr{cuDoubleComplex},
+                                                csrSortedRowPtrA::CuPtr{Cint},
+                                                csrSortedColIndA::CuPtr{Cint},
+                                                fractionToColor::Ptr{Cdouble},
+                                                ncolors::Ptr{Cint}, coloring::CuPtr{Cint},
+                                                reordering::CuPtr{Cint},
+                                                info::cusparseColorInfo_t)::cusparseStatus_t
 end
 
 @checked function cusparseSnnz(handle, dirA, m, n, descrA, A, lda, nnzPerRowCol,
                                nnzTotalDevHostPtr)
     initialize_context()
-    @ccall libcusparse.cusparseSnnz(handle::cusparseHandle_t, dirA::cusparseDirection_t,
-                                    m::Cint, n::Cint, descrA::cusparseMatDescr_t,
-                                    A::CuPtr{Cfloat}, lda::Cint, nnzPerRowCol::CuPtr{Cint},
-                                    nnzTotalDevHostPtr::PtrOrCuPtr{Cint})::cusparseStatus_t
+    @gcsafe_ccall libcusparse.cusparseSnnz(handle::cusparseHandle_t,
+                                           dirA::cusparseDirection_t, m::Cint, n::Cint,
+                                           descrA::cusparseMatDescr_t, A::CuPtr{Cfloat},
+                                           lda::Cint, nnzPerRowCol::CuPtr{Cint},
+                                           nnzTotalDevHostPtr::PtrOrCuPtr{Cint})::cusparseStatus_t
 end
 
 @checked function cusparseDnnz(handle, dirA, m, n, descrA, A, lda, nnzPerRowCol,
                                nnzTotalDevHostPtr)
     initialize_context()
-    @ccall libcusparse.cusparseDnnz(handle::cusparseHandle_t, dirA::cusparseDirection_t,
-                                    m::Cint, n::Cint, descrA::cusparseMatDescr_t,
-                                    A::CuPtr{Cdouble}, lda::Cint, nnzPerRowCol::CuPtr{Cint},
-                                    nnzTotalDevHostPtr::PtrOrCuPtr{Cint})::cusparseStatus_t
+    @gcsafe_ccall libcusparse.cusparseDnnz(handle::cusparseHandle_t,
+                                           dirA::cusparseDirection_t, m::Cint, n::Cint,
+                                           descrA::cusparseMatDescr_t, A::CuPtr{Cdouble},
+                                           lda::Cint, nnzPerRowCol::CuPtr{Cint},
+                                           nnzTotalDevHostPtr::PtrOrCuPtr{Cint})::cusparseStatus_t
 end
 
 @checked function cusparseCnnz(handle, dirA, m, n, descrA, A, lda, nnzPerRowCol,
                                nnzTotalDevHostPtr)
     initialize_context()
-    @ccall libcusparse.cusparseCnnz(handle::cusparseHandle_t, dirA::cusparseDirection_t,
-                                    m::Cint, n::Cint, descrA::cusparseMatDescr_t,
-                                    A::CuPtr{cuComplex}, lda::Cint,
-                                    nnzPerRowCol::CuPtr{Cint},
-                                    nnzTotalDevHostPtr::PtrOrCuPtr{Cint})::cusparseStatus_t
+    @gcsafe_ccall libcusparse.cusparseCnnz(handle::cusparseHandle_t,
+                                           dirA::cusparseDirection_t, m::Cint, n::Cint,
+                                           descrA::cusparseMatDescr_t, A::CuPtr{cuComplex},
+                                           lda::Cint, nnzPerRowCol::CuPtr{Cint},
+                                           nnzTotalDevHostPtr::PtrOrCuPtr{Cint})::cusparseStatus_t
 end
 
 @checked function cusparseZnnz(handle, dirA, m, n, descrA, A, lda, nnzPerRowCol,
                                nnzTotalDevHostPtr)
     initialize_context()
-    @ccall libcusparse.cusparseZnnz(handle::cusparseHandle_t, dirA::cusparseDirection_t,
-                                    m::Cint, n::Cint, descrA::cusparseMatDescr_t,
-                                    A::CuPtr{cuDoubleComplex}, lda::Cint,
-                                    nnzPerRowCol::CuPtr{Cint},
-                                    nnzTotalDevHostPtr::PtrOrCuPtr{Cint})::cusparseStatus_t
+    @gcsafe_ccall libcusparse.cusparseZnnz(handle::cusparseHandle_t,
+                                           dirA::cusparseDirection_t, m::Cint, n::Cint,
+                                           descrA::cusparseMatDescr_t,
+                                           A::CuPtr{cuDoubleComplex}, lda::Cint,
+                                           nnzPerRowCol::CuPtr{Cint},
+                                           nnzTotalDevHostPtr::PtrOrCuPtr{Cint})::cusparseStatus_t
 end
 
 @checked function cusparseSnnz_compress(handle, m, descr, csrSortedValA, csrSortedRowPtrA,
                                         nnzPerRow, nnzC, tol)
     initialize_context()
-    @ccall libcusparse.cusparseSnnz_compress(handle::cusparseHandle_t, m::Cint,
-                                             descr::cusparseMatDescr_t,
-                                             csrSortedValA::CuPtr{Cfloat},
-                                             csrSortedRowPtrA::CuPtr{Cint},
-                                             nnzPerRow::CuPtr{Cint}, nnzC::PtrOrCuPtr{Cint},
-                                             tol::Cfloat)::cusparseStatus_t
+    @gcsafe_ccall libcusparse.cusparseSnnz_compress(handle::cusparseHandle_t, m::Cint,
+                                                    descr::cusparseMatDescr_t,
+                                                    csrSortedValA::CuPtr{Cfloat},
+                                                    csrSortedRowPtrA::CuPtr{Cint},
+                                                    nnzPerRow::CuPtr{Cint},
+                                                    nnzC::PtrOrCuPtr{Cint},
+                                                    tol::Cfloat)::cusparseStatus_t
 end
 
 @checked function cusparseDnnz_compress(handle, m, descr, csrSortedValA, csrSortedRowPtrA,
                                         nnzPerRow, nnzC, tol)
     initialize_context()
-    @ccall libcusparse.cusparseDnnz_compress(handle::cusparseHandle_t, m::Cint,
-                                             descr::cusparseMatDescr_t,
-                                             csrSortedValA::CuPtr{Cdouble},
-                                             csrSortedRowPtrA::CuPtr{Cint},
-                                             nnzPerRow::CuPtr{Cint}, nnzC::PtrOrCuPtr{Cint},
-                                             tol::Cdouble)::cusparseStatus_t
+    @gcsafe_ccall libcusparse.cusparseDnnz_compress(handle::cusparseHandle_t, m::Cint,
+                                                    descr::cusparseMatDescr_t,
+                                                    csrSortedValA::CuPtr{Cdouble},
+                                                    csrSortedRowPtrA::CuPtr{Cint},
+                                                    nnzPerRow::CuPtr{Cint},
+                                                    nnzC::PtrOrCuPtr{Cint},
+                                                    tol::Cdouble)::cusparseStatus_t
 end
 
 @checked function cusparseCnnz_compress(handle, m, descr, csrSortedValA, csrSortedRowPtrA,
                                         nnzPerRow, nnzC, tol)
     initialize_context()
-    @ccall libcusparse.cusparseCnnz_compress(handle::cusparseHandle_t, m::Cint,
-                                             descr::cusparseMatDescr_t,
-                                             csrSortedValA::CuPtr{cuComplex},
-                                             csrSortedRowPtrA::CuPtr{Cint},
-                                             nnzPerRow::CuPtr{Cint}, nnzC::PtrOrCuPtr{Cint},
-                                             tol::cuComplex)::cusparseStatus_t
+    @gcsafe_ccall libcusparse.cusparseCnnz_compress(handle::cusparseHandle_t, m::Cint,
+                                                    descr::cusparseMatDescr_t,
+                                                    csrSortedValA::CuPtr{cuComplex},
+                                                    csrSortedRowPtrA::CuPtr{Cint},
+                                                    nnzPerRow::CuPtr{Cint},
+                                                    nnzC::PtrOrCuPtr{Cint},
+                                                    tol::cuComplex)::cusparseStatus_t
 end
 
 @checked function cusparseZnnz_compress(handle, m, descr, csrSortedValA, csrSortedRowPtrA,
                                         nnzPerRow, nnzC, tol)
     initialize_context()
-    @ccall libcusparse.cusparseZnnz_compress(handle::cusparseHandle_t, m::Cint,
-                                             descr::cusparseMatDescr_t,
-                                             csrSortedValA::CuPtr{cuDoubleComplex},
-                                             csrSortedRowPtrA::CuPtr{Cint},
-                                             nnzPerRow::CuPtr{Cint}, nnzC::PtrOrCuPtr{Cint},
-                                             tol::cuDoubleComplex)::cusparseStatus_t
+    @gcsafe_ccall libcusparse.cusparseZnnz_compress(handle::cusparseHandle_t, m::Cint,
+                                                    descr::cusparseMatDescr_t,
+                                                    csrSortedValA::CuPtr{cuDoubleComplex},
+                                                    csrSortedRowPtrA::CuPtr{Cint},
+                                                    nnzPerRow::CuPtr{Cint},
+                                                    nnzC::PtrOrCuPtr{Cint},
+                                                    tol::cuDoubleComplex)::cusparseStatus_t
 end
 
 @checked function cusparseScsr2csr_compress(handle, m, n, descrA, csrSortedValA,
@@ -3066,16 +3271,16 @@ end
                                             nnzPerRow, csrSortedValC, csrSortedColIndC,
                                             csrSortedRowPtrC, tol)
     initialize_context()
-    @ccall libcusparse.cusparseScsr2csr_compress(handle::cusparseHandle_t, m::Cint, n::Cint,
-                                                 descrA::cusparseMatDescr_t,
-                                                 csrSortedValA::CuPtr{Cfloat},
-                                                 csrSortedColIndA::CuPtr{Cint},
-                                                 csrSortedRowPtrA::CuPtr{Cint}, nnzA::Cint,
-                                                 nnzPerRow::CuPtr{Cint},
-                                                 csrSortedValC::CuPtr{Cfloat},
-                                                 csrSortedColIndC::CuPtr{Cint},
-                                                 csrSortedRowPtrC::CuPtr{Cint},
-                                                 tol::Cfloat)::cusparseStatus_t
+    @gcsafe_ccall libcusparse.cusparseScsr2csr_compress(handle::cusparseHandle_t, m::Cint,
+                                                        n::Cint, descrA::cusparseMatDescr_t,
+                                                        csrSortedValA::CuPtr{Cfloat},
+                                                        csrSortedColIndA::CuPtr{Cint},
+                                                        csrSortedRowPtrA::CuPtr{Cint},
+                                                        nnzA::Cint, nnzPerRow::CuPtr{Cint},
+                                                        csrSortedValC::CuPtr{Cfloat},
+                                                        csrSortedColIndC::CuPtr{Cint},
+                                                        csrSortedRowPtrC::CuPtr{Cint},
+                                                        tol::Cfloat)::cusparseStatus_t
 end
 
 @checked function cusparseDcsr2csr_compress(handle, m, n, descrA, csrSortedValA,
@@ -3083,16 +3288,16 @@ end
                                             nnzPerRow, csrSortedValC, csrSortedColIndC,
                                             csrSortedRowPtrC, tol)
     initialize_context()
-    @ccall libcusparse.cusparseDcsr2csr_compress(handle::cusparseHandle_t, m::Cint, n::Cint,
-                                                 descrA::cusparseMatDescr_t,
-                                                 csrSortedValA::CuPtr{Cdouble},
-                                                 csrSortedColIndA::CuPtr{Cint},
-                                                 csrSortedRowPtrA::CuPtr{Cint}, nnzA::Cint,
-                                                 nnzPerRow::CuPtr{Cint},
-                                                 csrSortedValC::CuPtr{Cdouble},
-                                                 csrSortedColIndC::CuPtr{Cint},
-                                                 csrSortedRowPtrC::CuPtr{Cint},
-                                                 tol::Cdouble)::cusparseStatus_t
+    @gcsafe_ccall libcusparse.cusparseDcsr2csr_compress(handle::cusparseHandle_t, m::Cint,
+                                                        n::Cint, descrA::cusparseMatDescr_t,
+                                                        csrSortedValA::CuPtr{Cdouble},
+                                                        csrSortedColIndA::CuPtr{Cint},
+                                                        csrSortedRowPtrA::CuPtr{Cint},
+                                                        nnzA::Cint, nnzPerRow::CuPtr{Cint},
+                                                        csrSortedValC::CuPtr{Cdouble},
+                                                        csrSortedColIndC::CuPtr{Cint},
+                                                        csrSortedRowPtrC::CuPtr{Cint},
+                                                        tol::Cdouble)::cusparseStatus_t
 end
 
 @checked function cusparseCcsr2csr_compress(handle, m, n, descrA, csrSortedValA,
@@ -3100,16 +3305,16 @@ end
                                             nnzPerRow, csrSortedValC, csrSortedColIndC,
                                             csrSortedRowPtrC, tol)
     initialize_context()
-    @ccall libcusparse.cusparseCcsr2csr_compress(handle::cusparseHandle_t, m::Cint, n::Cint,
-                                                 descrA::cusparseMatDescr_t,
-                                                 csrSortedValA::CuPtr{cuComplex},
-                                                 csrSortedColIndA::CuPtr{Cint},
-                                                 csrSortedRowPtrA::CuPtr{Cint}, nnzA::Cint,
-                                                 nnzPerRow::CuPtr{Cint},
-                                                 csrSortedValC::CuPtr{cuComplex},
-                                                 csrSortedColIndC::CuPtr{Cint},
-                                                 csrSortedRowPtrC::CuPtr{Cint},
-                                                 tol::cuComplex)::cusparseStatus_t
+    @gcsafe_ccall libcusparse.cusparseCcsr2csr_compress(handle::cusparseHandle_t, m::Cint,
+                                                        n::Cint, descrA::cusparseMatDescr_t,
+                                                        csrSortedValA::CuPtr{cuComplex},
+                                                        csrSortedColIndA::CuPtr{Cint},
+                                                        csrSortedRowPtrA::CuPtr{Cint},
+                                                        nnzA::Cint, nnzPerRow::CuPtr{Cint},
+                                                        csrSortedValC::CuPtr{cuComplex},
+                                                        csrSortedColIndC::CuPtr{Cint},
+                                                        csrSortedRowPtrC::CuPtr{Cint},
+                                                        tol::cuComplex)::cusparseStatus_t
 end
 
 @checked function cusparseZcsr2csr_compress(handle, m, n, descrA, csrSortedValA,
@@ -3117,165 +3322,175 @@ end
                                             nnzPerRow, csrSortedValC, csrSortedColIndC,
                                             csrSortedRowPtrC, tol)
     initialize_context()
-    @ccall libcusparse.cusparseZcsr2csr_compress(handle::cusparseHandle_t, m::Cint, n::Cint,
-                                                 descrA::cusparseMatDescr_t,
-                                                 csrSortedValA::CuPtr{cuDoubleComplex},
-                                                 csrSortedColIndA::CuPtr{Cint},
-                                                 csrSortedRowPtrA::CuPtr{Cint}, nnzA::Cint,
-                                                 nnzPerRow::CuPtr{Cint},
-                                                 csrSortedValC::CuPtr{cuDoubleComplex},
-                                                 csrSortedColIndC::CuPtr{Cint},
-                                                 csrSortedRowPtrC::CuPtr{Cint},
-                                                 tol::cuDoubleComplex)::cusparseStatus_t
+    @gcsafe_ccall libcusparse.cusparseZcsr2csr_compress(handle::cusparseHandle_t, m::Cint,
+                                                        n::Cint, descrA::cusparseMatDescr_t,
+                                                        csrSortedValA::CuPtr{cuDoubleComplex},
+                                                        csrSortedColIndA::CuPtr{Cint},
+                                                        csrSortedRowPtrA::CuPtr{Cint},
+                                                        nnzA::Cint, nnzPerRow::CuPtr{Cint},
+                                                        csrSortedValC::CuPtr{cuDoubleComplex},
+                                                        csrSortedColIndC::CuPtr{Cint},
+                                                        csrSortedRowPtrC::CuPtr{Cint},
+                                                        tol::cuDoubleComplex)::cusparseStatus_t
 end
 
 @checked function cusparseXcoo2csr(handle, cooRowInd, nnz, m, csrSortedRowPtr, idxBase)
     initialize_context()
-    @ccall libcusparse.cusparseXcoo2csr(handle::cusparseHandle_t, cooRowInd::CuPtr{Cint},
-                                        nnz::Cint, m::Cint, csrSortedRowPtr::CuPtr{Cint},
-                                        idxBase::cusparseIndexBase_t)::cusparseStatus_t
+    @gcsafe_ccall libcusparse.cusparseXcoo2csr(handle::cusparseHandle_t,
+                                               cooRowInd::CuPtr{Cint}, nnz::Cint, m::Cint,
+                                               csrSortedRowPtr::CuPtr{Cint},
+                                               idxBase::cusparseIndexBase_t)::cusparseStatus_t
 end
 
 @checked function cusparseXcsr2coo(handle, csrSortedRowPtr, nnz, m, cooRowInd, idxBase)
     initialize_context()
-    @ccall libcusparse.cusparseXcsr2coo(handle::cusparseHandle_t,
-                                        csrSortedRowPtr::CuPtr{Cint}, nnz::Cint, m::Cint,
-                                        cooRowInd::CuPtr{Cint},
-                                        idxBase::cusparseIndexBase_t)::cusparseStatus_t
+    @gcsafe_ccall libcusparse.cusparseXcsr2coo(handle::cusparseHandle_t,
+                                               csrSortedRowPtr::CuPtr{Cint}, nnz::Cint,
+                                               m::Cint, cooRowInd::CuPtr{Cint},
+                                               idxBase::cusparseIndexBase_t)::cusparseStatus_t
 end
 
 @checked function cusparseXcsr2bsrNnz(handle, dirA, m, n, descrA, csrSortedRowPtrA,
                                       csrSortedColIndA, blockDim, descrC, bsrSortedRowPtrC,
                                       nnzTotalDevHostPtr)
     initialize_context()
-    @ccall libcusparse.cusparseXcsr2bsrNnz(handle::cusparseHandle_t,
-                                           dirA::cusparseDirection_t, m::Cint, n::Cint,
-                                           descrA::cusparseMatDescr_t,
-                                           csrSortedRowPtrA::CuPtr{Cint},
-                                           csrSortedColIndA::CuPtr{Cint}, blockDim::Cint,
-                                           descrC::cusparseMatDescr_t,
-                                           bsrSortedRowPtrC::CuPtr{Cint},
-                                           nnzTotalDevHostPtr::PtrOrCuPtr{Cint})::cusparseStatus_t
+    @gcsafe_ccall libcusparse.cusparseXcsr2bsrNnz(handle::cusparseHandle_t,
+                                                  dirA::cusparseDirection_t, m::Cint,
+                                                  n::Cint, descrA::cusparseMatDescr_t,
+                                                  csrSortedRowPtrA::CuPtr{Cint},
+                                                  csrSortedColIndA::CuPtr{Cint},
+                                                  blockDim::Cint,
+                                                  descrC::cusparseMatDescr_t,
+                                                  bsrSortedRowPtrC::CuPtr{Cint},
+                                                  nnzTotalDevHostPtr::PtrOrCuPtr{Cint})::cusparseStatus_t
 end
 
 @checked function cusparseScsr2bsr(handle, dirA, m, n, descrA, csrSortedValA,
                                    csrSortedRowPtrA, csrSortedColIndA, blockDim, descrC,
                                    bsrSortedValC, bsrSortedRowPtrC, bsrSortedColIndC)
     initialize_context()
-    @ccall libcusparse.cusparseScsr2bsr(handle::cusparseHandle_t, dirA::cusparseDirection_t,
-                                        m::Cint, n::Cint, descrA::cusparseMatDescr_t,
-                                        csrSortedValA::CuPtr{Cfloat},
-                                        csrSortedRowPtrA::CuPtr{Cint},
-                                        csrSortedColIndA::CuPtr{Cint}, blockDim::Cint,
-                                        descrC::cusparseMatDescr_t,
-                                        bsrSortedValC::CuPtr{Cfloat},
-                                        bsrSortedRowPtrC::CuPtr{Cint},
-                                        bsrSortedColIndC::CuPtr{Cint})::cusparseStatus_t
+    @gcsafe_ccall libcusparse.cusparseScsr2bsr(handle::cusparseHandle_t,
+                                               dirA::cusparseDirection_t, m::Cint, n::Cint,
+                                               descrA::cusparseMatDescr_t,
+                                               csrSortedValA::CuPtr{Cfloat},
+                                               csrSortedRowPtrA::CuPtr{Cint},
+                                               csrSortedColIndA::CuPtr{Cint},
+                                               blockDim::Cint, descrC::cusparseMatDescr_t,
+                                               bsrSortedValC::CuPtr{Cfloat},
+                                               bsrSortedRowPtrC::CuPtr{Cint},
+                                               bsrSortedColIndC::CuPtr{Cint})::cusparseStatus_t
 end
 
 @checked function cusparseDcsr2bsr(handle, dirA, m, n, descrA, csrSortedValA,
                                    csrSortedRowPtrA, csrSortedColIndA, blockDim, descrC,
                                    bsrSortedValC, bsrSortedRowPtrC, bsrSortedColIndC)
     initialize_context()
-    @ccall libcusparse.cusparseDcsr2bsr(handle::cusparseHandle_t, dirA::cusparseDirection_t,
-                                        m::Cint, n::Cint, descrA::cusparseMatDescr_t,
-                                        csrSortedValA::CuPtr{Cdouble},
-                                        csrSortedRowPtrA::CuPtr{Cint},
-                                        csrSortedColIndA::CuPtr{Cint}, blockDim::Cint,
-                                        descrC::cusparseMatDescr_t,
-                                        bsrSortedValC::CuPtr{Cdouble},
-                                        bsrSortedRowPtrC::CuPtr{Cint},
-                                        bsrSortedColIndC::CuPtr{Cint})::cusparseStatus_t
+    @gcsafe_ccall libcusparse.cusparseDcsr2bsr(handle::cusparseHandle_t,
+                                               dirA::cusparseDirection_t, m::Cint, n::Cint,
+                                               descrA::cusparseMatDescr_t,
+                                               csrSortedValA::CuPtr{Cdouble},
+                                               csrSortedRowPtrA::CuPtr{Cint},
+                                               csrSortedColIndA::CuPtr{Cint},
+                                               blockDim::Cint, descrC::cusparseMatDescr_t,
+                                               bsrSortedValC::CuPtr{Cdouble},
+                                               bsrSortedRowPtrC::CuPtr{Cint},
+                                               bsrSortedColIndC::CuPtr{Cint})::cusparseStatus_t
 end
 
 @checked function cusparseCcsr2bsr(handle, dirA, m, n, descrA, csrSortedValA,
                                    csrSortedRowPtrA, csrSortedColIndA, blockDim, descrC,
                                    bsrSortedValC, bsrSortedRowPtrC, bsrSortedColIndC)
     initialize_context()
-    @ccall libcusparse.cusparseCcsr2bsr(handle::cusparseHandle_t, dirA::cusparseDirection_t,
-                                        m::Cint, n::Cint, descrA::cusparseMatDescr_t,
-                                        csrSortedValA::CuPtr{cuComplex},
-                                        csrSortedRowPtrA::CuPtr{Cint},
-                                        csrSortedColIndA::CuPtr{Cint}, blockDim::Cint,
-                                        descrC::cusparseMatDescr_t,
-                                        bsrSortedValC::CuPtr{cuComplex},
-                                        bsrSortedRowPtrC::CuPtr{Cint},
-                                        bsrSortedColIndC::CuPtr{Cint})::cusparseStatus_t
+    @gcsafe_ccall libcusparse.cusparseCcsr2bsr(handle::cusparseHandle_t,
+                                               dirA::cusparseDirection_t, m::Cint, n::Cint,
+                                               descrA::cusparseMatDescr_t,
+                                               csrSortedValA::CuPtr{cuComplex},
+                                               csrSortedRowPtrA::CuPtr{Cint},
+                                               csrSortedColIndA::CuPtr{Cint},
+                                               blockDim::Cint, descrC::cusparseMatDescr_t,
+                                               bsrSortedValC::CuPtr{cuComplex},
+                                               bsrSortedRowPtrC::CuPtr{Cint},
+                                               bsrSortedColIndC::CuPtr{Cint})::cusparseStatus_t
 end
 
 @checked function cusparseZcsr2bsr(handle, dirA, m, n, descrA, csrSortedValA,
                                    csrSortedRowPtrA, csrSortedColIndA, blockDim, descrC,
                                    bsrSortedValC, bsrSortedRowPtrC, bsrSortedColIndC)
     initialize_context()
-    @ccall libcusparse.cusparseZcsr2bsr(handle::cusparseHandle_t, dirA::cusparseDirection_t,
-                                        m::Cint, n::Cint, descrA::cusparseMatDescr_t,
-                                        csrSortedValA::CuPtr{cuDoubleComplex},
-                                        csrSortedRowPtrA::CuPtr{Cint},
-                                        csrSortedColIndA::CuPtr{Cint}, blockDim::Cint,
-                                        descrC::cusparseMatDescr_t,
-                                        bsrSortedValC::CuPtr{cuDoubleComplex},
-                                        bsrSortedRowPtrC::CuPtr{Cint},
-                                        bsrSortedColIndC::CuPtr{Cint})::cusparseStatus_t
+    @gcsafe_ccall libcusparse.cusparseZcsr2bsr(handle::cusparseHandle_t,
+                                               dirA::cusparseDirection_t, m::Cint, n::Cint,
+                                               descrA::cusparseMatDescr_t,
+                                               csrSortedValA::CuPtr{cuDoubleComplex},
+                                               csrSortedRowPtrA::CuPtr{Cint},
+                                               csrSortedColIndA::CuPtr{Cint},
+                                               blockDim::Cint, descrC::cusparseMatDescr_t,
+                                               bsrSortedValC::CuPtr{cuDoubleComplex},
+                                               bsrSortedRowPtrC::CuPtr{Cint},
+                                               bsrSortedColIndC::CuPtr{Cint})::cusparseStatus_t
 end
 
 @checked function cusparseSbsr2csr(handle, dirA, mb, nb, descrA, bsrSortedValA,
                                    bsrSortedRowPtrA, bsrSortedColIndA, blockDim, descrC,
                                    csrSortedValC, csrSortedRowPtrC, csrSortedColIndC)
     initialize_context()
-    @ccall libcusparse.cusparseSbsr2csr(handle::cusparseHandle_t, dirA::cusparseDirection_t,
-                                        mb::Cint, nb::Cint, descrA::cusparseMatDescr_t,
-                                        bsrSortedValA::CuPtr{Cfloat},
-                                        bsrSortedRowPtrA::CuPtr{Cint},
-                                        bsrSortedColIndA::CuPtr{Cint}, blockDim::Cint,
-                                        descrC::cusparseMatDescr_t,
-                                        csrSortedValC::CuPtr{Cfloat},
-                                        csrSortedRowPtrC::CuPtr{Cint},
-                                        csrSortedColIndC::CuPtr{Cint})::cusparseStatus_t
+    @gcsafe_ccall libcusparse.cusparseSbsr2csr(handle::cusparseHandle_t,
+                                               dirA::cusparseDirection_t, mb::Cint,
+                                               nb::Cint, descrA::cusparseMatDescr_t,
+                                               bsrSortedValA::CuPtr{Cfloat},
+                                               bsrSortedRowPtrA::CuPtr{Cint},
+                                               bsrSortedColIndA::CuPtr{Cint},
+                                               blockDim::Cint, descrC::cusparseMatDescr_t,
+                                               csrSortedValC::CuPtr{Cfloat},
+                                               csrSortedRowPtrC::CuPtr{Cint},
+                                               csrSortedColIndC::CuPtr{Cint})::cusparseStatus_t
 end
 
 @checked function cusparseDbsr2csr(handle, dirA, mb, nb, descrA, bsrSortedValA,
                                    bsrSortedRowPtrA, bsrSortedColIndA, blockDim, descrC,
                                    csrSortedValC, csrSortedRowPtrC, csrSortedColIndC)
     initialize_context()
-    @ccall libcusparse.cusparseDbsr2csr(handle::cusparseHandle_t, dirA::cusparseDirection_t,
-                                        mb::Cint, nb::Cint, descrA::cusparseMatDescr_t,
-                                        bsrSortedValA::CuPtr{Cdouble},
-                                        bsrSortedRowPtrA::CuPtr{Cint},
-                                        bsrSortedColIndA::CuPtr{Cint}, blockDim::Cint,
-                                        descrC::cusparseMatDescr_t,
-                                        csrSortedValC::CuPtr{Cdouble},
-                                        csrSortedRowPtrC::CuPtr{Cint},
-                                        csrSortedColIndC::CuPtr{Cint})::cusparseStatus_t
+    @gcsafe_ccall libcusparse.cusparseDbsr2csr(handle::cusparseHandle_t,
+                                               dirA::cusparseDirection_t, mb::Cint,
+                                               nb::Cint, descrA::cusparseMatDescr_t,
+                                               bsrSortedValA::CuPtr{Cdouble},
+                                               bsrSortedRowPtrA::CuPtr{Cint},
+                                               bsrSortedColIndA::CuPtr{Cint},
+                                               blockDim::Cint, descrC::cusparseMatDescr_t,
+                                               csrSortedValC::CuPtr{Cdouble},
+                                               csrSortedRowPtrC::CuPtr{Cint},
+                                               csrSortedColIndC::CuPtr{Cint})::cusparseStatus_t
 end
 
 @checked function cusparseCbsr2csr(handle, dirA, mb, nb, descrA, bsrSortedValA,
                                    bsrSortedRowPtrA, bsrSortedColIndA, blockDim, descrC,
                                    csrSortedValC, csrSortedRowPtrC, csrSortedColIndC)
     initialize_context()
-    @ccall libcusparse.cusparseCbsr2csr(handle::cusparseHandle_t, dirA::cusparseDirection_t,
-                                        mb::Cint, nb::Cint, descrA::cusparseMatDescr_t,
-                                        bsrSortedValA::CuPtr{cuComplex},
-                                        bsrSortedRowPtrA::CuPtr{Cint},
-                                        bsrSortedColIndA::CuPtr{Cint}, blockDim::Cint,
-                                        descrC::cusparseMatDescr_t,
-                                        csrSortedValC::CuPtr{cuComplex},
-                                        csrSortedRowPtrC::CuPtr{Cint},
-                                        csrSortedColIndC::CuPtr{Cint})::cusparseStatus_t
+    @gcsafe_ccall libcusparse.cusparseCbsr2csr(handle::cusparseHandle_t,
+                                               dirA::cusparseDirection_t, mb::Cint,
+                                               nb::Cint, descrA::cusparseMatDescr_t,
+                                               bsrSortedValA::CuPtr{cuComplex},
+                                               bsrSortedRowPtrA::CuPtr{Cint},
+                                               bsrSortedColIndA::CuPtr{Cint},
+                                               blockDim::Cint, descrC::cusparseMatDescr_t,
+                                               csrSortedValC::CuPtr{cuComplex},
+                                               csrSortedRowPtrC::CuPtr{Cint},
+                                               csrSortedColIndC::CuPtr{Cint})::cusparseStatus_t
 end
 
 @checked function cusparseZbsr2csr(handle, dirA, mb, nb, descrA, bsrSortedValA,
                                    bsrSortedRowPtrA, bsrSortedColIndA, blockDim, descrC,
                                    csrSortedValC, csrSortedRowPtrC, csrSortedColIndC)
     initialize_context()
-    @ccall libcusparse.cusparseZbsr2csr(handle::cusparseHandle_t, dirA::cusparseDirection_t,
-                                        mb::Cint, nb::Cint, descrA::cusparseMatDescr_t,
-                                        bsrSortedValA::CuPtr{cuDoubleComplex},
-                                        bsrSortedRowPtrA::CuPtr{Cint},
-                                        bsrSortedColIndA::CuPtr{Cint}, blockDim::Cint,
-                                        descrC::cusparseMatDescr_t,
-                                        csrSortedValC::CuPtr{cuDoubleComplex},
-                                        csrSortedRowPtrC::CuPtr{Cint},
-                                        csrSortedColIndC::CuPtr{Cint})::cusparseStatus_t
+    @gcsafe_ccall libcusparse.cusparseZbsr2csr(handle::cusparseHandle_t,
+                                               dirA::cusparseDirection_t, mb::Cint,
+                                               nb::Cint, descrA::cusparseMatDescr_t,
+                                               bsrSortedValA::CuPtr{cuDoubleComplex},
+                                               bsrSortedRowPtrA::CuPtr{Cint},
+                                               bsrSortedColIndA::CuPtr{Cint},
+                                               blockDim::Cint, descrC::cusparseMatDescr_t,
+                                               csrSortedValC::CuPtr{cuDoubleComplex},
+                                               csrSortedRowPtrC::CuPtr{Cint},
+                                               csrSortedColIndC::CuPtr{Cint})::cusparseStatus_t
 end
 
 @checked function cusparseSgebsr2gebsc_bufferSize(handle, mb, nb, nnzb, bsrSortedVal,
@@ -3283,13 +3498,15 @@ end
                                                   rowBlockDim, colBlockDim,
                                                   pBufferSizeInBytes)
     initialize_context()
-    @ccall libcusparse.cusparseSgebsr2gebsc_bufferSize(handle::cusparseHandle_t, mb::Cint,
-                                                       nb::Cint, nnzb::Cint,
-                                                       bsrSortedVal::CuPtr{Cfloat},
-                                                       bsrSortedRowPtr::CuPtr{Cint},
-                                                       bsrSortedColInd::CuPtr{Cint},
-                                                       rowBlockDim::Cint, colBlockDim::Cint,
-                                                       pBufferSizeInBytes::Ptr{Cint})::cusparseStatus_t
+    @gcsafe_ccall libcusparse.cusparseSgebsr2gebsc_bufferSize(handle::cusparseHandle_t,
+                                                              mb::Cint, nb::Cint,
+                                                              nnzb::Cint,
+                                                              bsrSortedVal::CuPtr{Cfloat},
+                                                              bsrSortedRowPtr::CuPtr{Cint},
+                                                              bsrSortedColInd::CuPtr{Cint},
+                                                              rowBlockDim::Cint,
+                                                              colBlockDim::Cint,
+                                                              pBufferSizeInBytes::Ptr{Cint})::cusparseStatus_t
 end
 
 @checked function cusparseDgebsr2gebsc_bufferSize(handle, mb, nb, nnzb, bsrSortedVal,
@@ -3297,13 +3514,15 @@ end
                                                   rowBlockDim, colBlockDim,
                                                   pBufferSizeInBytes)
     initialize_context()
-    @ccall libcusparse.cusparseDgebsr2gebsc_bufferSize(handle::cusparseHandle_t, mb::Cint,
-                                                       nb::Cint, nnzb::Cint,
-                                                       bsrSortedVal::CuPtr{Cdouble},
-                                                       bsrSortedRowPtr::CuPtr{Cint},
-                                                       bsrSortedColInd::CuPtr{Cint},
-                                                       rowBlockDim::Cint, colBlockDim::Cint,
-                                                       pBufferSizeInBytes::Ptr{Cint})::cusparseStatus_t
+    @gcsafe_ccall libcusparse.cusparseDgebsr2gebsc_bufferSize(handle::cusparseHandle_t,
+                                                              mb::Cint, nb::Cint,
+                                                              nnzb::Cint,
+                                                              bsrSortedVal::CuPtr{Cdouble},
+                                                              bsrSortedRowPtr::CuPtr{Cint},
+                                                              bsrSortedColInd::CuPtr{Cint},
+                                                              rowBlockDim::Cint,
+                                                              colBlockDim::Cint,
+                                                              pBufferSizeInBytes::Ptr{Cint})::cusparseStatus_t
 end
 
 @checked function cusparseCgebsr2gebsc_bufferSize(handle, mb, nb, nnzb, bsrSortedVal,
@@ -3311,13 +3530,15 @@ end
                                                   rowBlockDim, colBlockDim,
                                                   pBufferSizeInBytes)
     initialize_context()
-    @ccall libcusparse.cusparseCgebsr2gebsc_bufferSize(handle::cusparseHandle_t, mb::Cint,
-                                                       nb::Cint, nnzb::Cint,
-                                                       bsrSortedVal::CuPtr{cuComplex},
-                                                       bsrSortedRowPtr::CuPtr{Cint},
-                                                       bsrSortedColInd::CuPtr{Cint},
-                                                       rowBlockDim::Cint, colBlockDim::Cint,
-                                                       pBufferSizeInBytes::Ptr{Cint})::cusparseStatus_t
+    @gcsafe_ccall libcusparse.cusparseCgebsr2gebsc_bufferSize(handle::cusparseHandle_t,
+                                                              mb::Cint, nb::Cint,
+                                                              nnzb::Cint,
+                                                              bsrSortedVal::CuPtr{cuComplex},
+                                                              bsrSortedRowPtr::CuPtr{Cint},
+                                                              bsrSortedColInd::CuPtr{Cint},
+                                                              rowBlockDim::Cint,
+                                                              colBlockDim::Cint,
+                                                              pBufferSizeInBytes::Ptr{Cint})::cusparseStatus_t
 end
 
 @checked function cusparseZgebsr2gebsc_bufferSize(handle, mb, nb, nnzb, bsrSortedVal,
@@ -3325,145 +3546,162 @@ end
                                                   rowBlockDim, colBlockDim,
                                                   pBufferSizeInBytes)
     initialize_context()
-    @ccall libcusparse.cusparseZgebsr2gebsc_bufferSize(handle::cusparseHandle_t, mb::Cint,
-                                                       nb::Cint, nnzb::Cint,
-                                                       bsrSortedVal::CuPtr{cuDoubleComplex},
-                                                       bsrSortedRowPtr::CuPtr{Cint},
-                                                       bsrSortedColInd::CuPtr{Cint},
-                                                       rowBlockDim::Cint, colBlockDim::Cint,
-                                                       pBufferSizeInBytes::Ptr{Cint})::cusparseStatus_t
+    @gcsafe_ccall libcusparse.cusparseZgebsr2gebsc_bufferSize(handle::cusparseHandle_t,
+                                                              mb::Cint, nb::Cint,
+                                                              nnzb::Cint,
+                                                              bsrSortedVal::CuPtr{cuDoubleComplex},
+                                                              bsrSortedRowPtr::CuPtr{Cint},
+                                                              bsrSortedColInd::CuPtr{Cint},
+                                                              rowBlockDim::Cint,
+                                                              colBlockDim::Cint,
+                                                              pBufferSizeInBytes::Ptr{Cint})::cusparseStatus_t
 end
 
 @checked function cusparseSgebsr2gebsc_bufferSizeExt(handle, mb, nb, nnzb, bsrSortedVal,
                                                      bsrSortedRowPtr, bsrSortedColInd,
                                                      rowBlockDim, colBlockDim, pBufferSize)
     initialize_context()
-    @ccall libcusparse.cusparseSgebsr2gebsc_bufferSizeExt(handle::cusparseHandle_t,
-                                                          mb::Cint, nb::Cint, nnzb::Cint,
-                                                          bsrSortedVal::CuPtr{Cfloat},
-                                                          bsrSortedRowPtr::CuPtr{Cint},
-                                                          bsrSortedColInd::CuPtr{Cint},
-                                                          rowBlockDim::Cint,
-                                                          colBlockDim::Cint,
-                                                          pBufferSize::Ptr{Csize_t})::cusparseStatus_t
+    @gcsafe_ccall libcusparse.cusparseSgebsr2gebsc_bufferSizeExt(handle::cusparseHandle_t,
+                                                                 mb::Cint, nb::Cint,
+                                                                 nnzb::Cint,
+                                                                 bsrSortedVal::CuPtr{Cfloat},
+                                                                 bsrSortedRowPtr::CuPtr{Cint},
+                                                                 bsrSortedColInd::CuPtr{Cint},
+                                                                 rowBlockDim::Cint,
+                                                                 colBlockDim::Cint,
+                                                                 pBufferSize::Ptr{Csize_t})::cusparseStatus_t
 end
 
 @checked function cusparseDgebsr2gebsc_bufferSizeExt(handle, mb, nb, nnzb, bsrSortedVal,
                                                      bsrSortedRowPtr, bsrSortedColInd,
                                                      rowBlockDim, colBlockDim, pBufferSize)
     initialize_context()
-    @ccall libcusparse.cusparseDgebsr2gebsc_bufferSizeExt(handle::cusparseHandle_t,
-                                                          mb::Cint, nb::Cint, nnzb::Cint,
-                                                          bsrSortedVal::CuPtr{Cdouble},
-                                                          bsrSortedRowPtr::CuPtr{Cint},
-                                                          bsrSortedColInd::CuPtr{Cint},
-                                                          rowBlockDim::Cint,
-                                                          colBlockDim::Cint,
-                                                          pBufferSize::Ptr{Csize_t})::cusparseStatus_t
+    @gcsafe_ccall libcusparse.cusparseDgebsr2gebsc_bufferSizeExt(handle::cusparseHandle_t,
+                                                                 mb::Cint, nb::Cint,
+                                                                 nnzb::Cint,
+                                                                 bsrSortedVal::CuPtr{Cdouble},
+                                                                 bsrSortedRowPtr::CuPtr{Cint},
+                                                                 bsrSortedColInd::CuPtr{Cint},
+                                                                 rowBlockDim::Cint,
+                                                                 colBlockDim::Cint,
+                                                                 pBufferSize::Ptr{Csize_t})::cusparseStatus_t
 end
 
 @checked function cusparseCgebsr2gebsc_bufferSizeExt(handle, mb, nb, nnzb, bsrSortedVal,
                                                      bsrSortedRowPtr, bsrSortedColInd,
                                                      rowBlockDim, colBlockDim, pBufferSize)
     initialize_context()
-    @ccall libcusparse.cusparseCgebsr2gebsc_bufferSizeExt(handle::cusparseHandle_t,
-                                                          mb::Cint, nb::Cint, nnzb::Cint,
-                                                          bsrSortedVal::CuPtr{cuComplex},
-                                                          bsrSortedRowPtr::CuPtr{Cint},
-                                                          bsrSortedColInd::CuPtr{Cint},
-                                                          rowBlockDim::Cint,
-                                                          colBlockDim::Cint,
-                                                          pBufferSize::Ptr{Csize_t})::cusparseStatus_t
+    @gcsafe_ccall libcusparse.cusparseCgebsr2gebsc_bufferSizeExt(handle::cusparseHandle_t,
+                                                                 mb::Cint, nb::Cint,
+                                                                 nnzb::Cint,
+                                                                 bsrSortedVal::CuPtr{cuComplex},
+                                                                 bsrSortedRowPtr::CuPtr{Cint},
+                                                                 bsrSortedColInd::CuPtr{Cint},
+                                                                 rowBlockDim::Cint,
+                                                                 colBlockDim::Cint,
+                                                                 pBufferSize::Ptr{Csize_t})::cusparseStatus_t
 end
 
 @checked function cusparseZgebsr2gebsc_bufferSizeExt(handle, mb, nb, nnzb, bsrSortedVal,
                                                      bsrSortedRowPtr, bsrSortedColInd,
                                                      rowBlockDim, colBlockDim, pBufferSize)
     initialize_context()
-    @ccall libcusparse.cusparseZgebsr2gebsc_bufferSizeExt(handle::cusparseHandle_t,
-                                                          mb::Cint, nb::Cint, nnzb::Cint,
-                                                          bsrSortedVal::CuPtr{cuDoubleComplex},
-                                                          bsrSortedRowPtr::CuPtr{Cint},
-                                                          bsrSortedColInd::CuPtr{Cint},
-                                                          rowBlockDim::Cint,
-                                                          colBlockDim::Cint,
-                                                          pBufferSize::Ptr{Csize_t})::cusparseStatus_t
+    @gcsafe_ccall libcusparse.cusparseZgebsr2gebsc_bufferSizeExt(handle::cusparseHandle_t,
+                                                                 mb::Cint, nb::Cint,
+                                                                 nnzb::Cint,
+                                                                 bsrSortedVal::CuPtr{cuDoubleComplex},
+                                                                 bsrSortedRowPtr::CuPtr{Cint},
+                                                                 bsrSortedColInd::CuPtr{Cint},
+                                                                 rowBlockDim::Cint,
+                                                                 colBlockDim::Cint,
+                                                                 pBufferSize::Ptr{Csize_t})::cusparseStatus_t
 end
 
 @checked function cusparseSgebsr2gebsc(handle, mb, nb, nnzb, bsrSortedVal, bsrSortedRowPtr,
                                        bsrSortedColInd, rowBlockDim, colBlockDim, bscVal,
                                        bscRowInd, bscColPtr, copyValues, idxBase, pBuffer)
     initialize_context()
-    @ccall libcusparse.cusparseSgebsr2gebsc(handle::cusparseHandle_t, mb::Cint, nb::Cint,
-                                            nnzb::Cint, bsrSortedVal::CuPtr{Cfloat},
-                                            bsrSortedRowPtr::CuPtr{Cint},
-                                            bsrSortedColInd::CuPtr{Cint}, rowBlockDim::Cint,
-                                            colBlockDim::Cint, bscVal::CuPtr{Cfloat},
-                                            bscRowInd::CuPtr{Cint}, bscColPtr::CuPtr{Cint},
-                                            copyValues::cusparseAction_t,
-                                            idxBase::cusparseIndexBase_t,
-                                            pBuffer::CuPtr{Cvoid})::cusparseStatus_t
+    @gcsafe_ccall libcusparse.cusparseSgebsr2gebsc(handle::cusparseHandle_t, mb::Cint,
+                                                   nb::Cint, nnzb::Cint,
+                                                   bsrSortedVal::CuPtr{Cfloat},
+                                                   bsrSortedRowPtr::CuPtr{Cint},
+                                                   bsrSortedColInd::CuPtr{Cint},
+                                                   rowBlockDim::Cint, colBlockDim::Cint,
+                                                   bscVal::CuPtr{Cfloat},
+                                                   bscRowInd::CuPtr{Cint},
+                                                   bscColPtr::CuPtr{Cint},
+                                                   copyValues::cusparseAction_t,
+                                                   idxBase::cusparseIndexBase_t,
+                                                   pBuffer::CuPtr{Cvoid})::cusparseStatus_t
 end
 
 @checked function cusparseDgebsr2gebsc(handle, mb, nb, nnzb, bsrSortedVal, bsrSortedRowPtr,
                                        bsrSortedColInd, rowBlockDim, colBlockDim, bscVal,
                                        bscRowInd, bscColPtr, copyValues, idxBase, pBuffer)
     initialize_context()
-    @ccall libcusparse.cusparseDgebsr2gebsc(handle::cusparseHandle_t, mb::Cint, nb::Cint,
-                                            nnzb::Cint, bsrSortedVal::CuPtr{Cdouble},
-                                            bsrSortedRowPtr::CuPtr{Cint},
-                                            bsrSortedColInd::CuPtr{Cint}, rowBlockDim::Cint,
-                                            colBlockDim::Cint, bscVal::CuPtr{Cdouble},
-                                            bscRowInd::CuPtr{Cint}, bscColPtr::CuPtr{Cint},
-                                            copyValues::cusparseAction_t,
-                                            idxBase::cusparseIndexBase_t,
-                                            pBuffer::CuPtr{Cvoid})::cusparseStatus_t
+    @gcsafe_ccall libcusparse.cusparseDgebsr2gebsc(handle::cusparseHandle_t, mb::Cint,
+                                                   nb::Cint, nnzb::Cint,
+                                                   bsrSortedVal::CuPtr{Cdouble},
+                                                   bsrSortedRowPtr::CuPtr{Cint},
+                                                   bsrSortedColInd::CuPtr{Cint},
+                                                   rowBlockDim::Cint, colBlockDim::Cint,
+                                                   bscVal::CuPtr{Cdouble},
+                                                   bscRowInd::CuPtr{Cint},
+                                                   bscColPtr::CuPtr{Cint},
+                                                   copyValues::cusparseAction_t,
+                                                   idxBase::cusparseIndexBase_t,
+                                                   pBuffer::CuPtr{Cvoid})::cusparseStatus_t
 end
 
 @checked function cusparseCgebsr2gebsc(handle, mb, nb, nnzb, bsrSortedVal, bsrSortedRowPtr,
                                        bsrSortedColInd, rowBlockDim, colBlockDim, bscVal,
                                        bscRowInd, bscColPtr, copyValues, idxBase, pBuffer)
     initialize_context()
-    @ccall libcusparse.cusparseCgebsr2gebsc(handle::cusparseHandle_t, mb::Cint, nb::Cint,
-                                            nnzb::Cint, bsrSortedVal::CuPtr{cuComplex},
-                                            bsrSortedRowPtr::CuPtr{Cint},
-                                            bsrSortedColInd::CuPtr{Cint}, rowBlockDim::Cint,
-                                            colBlockDim::Cint, bscVal::CuPtr{cuComplex},
-                                            bscRowInd::CuPtr{Cint}, bscColPtr::CuPtr{Cint},
-                                            copyValues::cusparseAction_t,
-                                            idxBase::cusparseIndexBase_t,
-                                            pBuffer::CuPtr{Cvoid})::cusparseStatus_t
+    @gcsafe_ccall libcusparse.cusparseCgebsr2gebsc(handle::cusparseHandle_t, mb::Cint,
+                                                   nb::Cint, nnzb::Cint,
+                                                   bsrSortedVal::CuPtr{cuComplex},
+                                                   bsrSortedRowPtr::CuPtr{Cint},
+                                                   bsrSortedColInd::CuPtr{Cint},
+                                                   rowBlockDim::Cint, colBlockDim::Cint,
+                                                   bscVal::CuPtr{cuComplex},
+                                                   bscRowInd::CuPtr{Cint},
+                                                   bscColPtr::CuPtr{Cint},
+                                                   copyValues::cusparseAction_t,
+                                                   idxBase::cusparseIndexBase_t,
+                                                   pBuffer::CuPtr{Cvoid})::cusparseStatus_t
 end
 
 @checked function cusparseZgebsr2gebsc(handle, mb, nb, nnzb, bsrSortedVal, bsrSortedRowPtr,
                                        bsrSortedColInd, rowBlockDim, colBlockDim, bscVal,
                                        bscRowInd, bscColPtr, copyValues, idxBase, pBuffer)
     initialize_context()
-    @ccall libcusparse.cusparseZgebsr2gebsc(handle::cusparseHandle_t, mb::Cint, nb::Cint,
-                                            nnzb::Cint,
-                                            bsrSortedVal::CuPtr{cuDoubleComplex},
-                                            bsrSortedRowPtr::CuPtr{Cint},
-                                            bsrSortedColInd::CuPtr{Cint}, rowBlockDim::Cint,
-                                            colBlockDim::Cint,
-                                            bscVal::CuPtr{cuDoubleComplex},
-                                            bscRowInd::CuPtr{Cint}, bscColPtr::CuPtr{Cint},
-                                            copyValues::cusparseAction_t,
-                                            idxBase::cusparseIndexBase_t,
-                                            pBuffer::CuPtr{Cvoid})::cusparseStatus_t
+    @gcsafe_ccall libcusparse.cusparseZgebsr2gebsc(handle::cusparseHandle_t, mb::Cint,
+                                                   nb::Cint, nnzb::Cint,
+                                                   bsrSortedVal::CuPtr{cuDoubleComplex},
+                                                   bsrSortedRowPtr::CuPtr{Cint},
+                                                   bsrSortedColInd::CuPtr{Cint},
+                                                   rowBlockDim::Cint, colBlockDim::Cint,
+                                                   bscVal::CuPtr{cuDoubleComplex},
+                                                   bscRowInd::CuPtr{Cint},
+                                                   bscColPtr::CuPtr{Cint},
+                                                   copyValues::cusparseAction_t,
+                                                   idxBase::cusparseIndexBase_t,
+                                                   pBuffer::CuPtr{Cvoid})::cusparseStatus_t
 end
 
 @checked function cusparseXgebsr2csr(handle, dirA, mb, nb, descrA, bsrSortedRowPtrA,
                                      bsrSortedColIndA, rowBlockDim, colBlockDim, descrC,
                                      csrSortedRowPtrC, csrSortedColIndC)
     initialize_context()
-    @ccall libcusparse.cusparseXgebsr2csr(handle::cusparseHandle_t,
-                                          dirA::cusparseDirection_t, mb::Cint, nb::Cint,
-                                          descrA::cusparseMatDescr_t,
-                                          bsrSortedRowPtrA::CuPtr{Cint},
-                                          bsrSortedColIndA::CuPtr{Cint}, rowBlockDim::Cint,
-                                          colBlockDim::Cint, descrC::cusparseMatDescr_t,
-                                          csrSortedRowPtrC::CuPtr{Cint},
-                                          csrSortedColIndC::CuPtr{Cint})::cusparseStatus_t
+    @gcsafe_ccall libcusparse.cusparseXgebsr2csr(handle::cusparseHandle_t,
+                                                 dirA::cusparseDirection_t, mb::Cint,
+                                                 nb::Cint, descrA::cusparseMatDescr_t,
+                                                 bsrSortedRowPtrA::CuPtr{Cint},
+                                                 bsrSortedColIndA::CuPtr{Cint},
+                                                 rowBlockDim::Cint, colBlockDim::Cint,
+                                                 descrC::cusparseMatDescr_t,
+                                                 csrSortedRowPtrC::CuPtr{Cint},
+                                                 csrSortedColIndC::CuPtr{Cint})::cusparseStatus_t
 end
 
 @checked function cusparseSgebsr2csr(handle, dirA, mb, nb, descrA, bsrSortedValA,
@@ -3471,16 +3709,17 @@ end
                                      colBlockDim, descrC, csrSortedValC, csrSortedRowPtrC,
                                      csrSortedColIndC)
     initialize_context()
-    @ccall libcusparse.cusparseSgebsr2csr(handle::cusparseHandle_t,
-                                          dirA::cusparseDirection_t, mb::Cint, nb::Cint,
-                                          descrA::cusparseMatDescr_t,
-                                          bsrSortedValA::CuPtr{Cfloat},
-                                          bsrSortedRowPtrA::CuPtr{Cint},
-                                          bsrSortedColIndA::CuPtr{Cint}, rowBlockDim::Cint,
-                                          colBlockDim::Cint, descrC::cusparseMatDescr_t,
-                                          csrSortedValC::CuPtr{Cfloat},
-                                          csrSortedRowPtrC::CuPtr{Cint},
-                                          csrSortedColIndC::CuPtr{Cint})::cusparseStatus_t
+    @gcsafe_ccall libcusparse.cusparseSgebsr2csr(handle::cusparseHandle_t,
+                                                 dirA::cusparseDirection_t, mb::Cint,
+                                                 nb::Cint, descrA::cusparseMatDescr_t,
+                                                 bsrSortedValA::CuPtr{Cfloat},
+                                                 bsrSortedRowPtrA::CuPtr{Cint},
+                                                 bsrSortedColIndA::CuPtr{Cint},
+                                                 rowBlockDim::Cint, colBlockDim::Cint,
+                                                 descrC::cusparseMatDescr_t,
+                                                 csrSortedValC::CuPtr{Cfloat},
+                                                 csrSortedRowPtrC::CuPtr{Cint},
+                                                 csrSortedColIndC::CuPtr{Cint})::cusparseStatus_t
 end
 
 @checked function cusparseDgebsr2csr(handle, dirA, mb, nb, descrA, bsrSortedValA,
@@ -3488,16 +3727,17 @@ end
                                      colBlockDim, descrC, csrSortedValC, csrSortedRowPtrC,
                                      csrSortedColIndC)
     initialize_context()
-    @ccall libcusparse.cusparseDgebsr2csr(handle::cusparseHandle_t,
-                                          dirA::cusparseDirection_t, mb::Cint, nb::Cint,
-                                          descrA::cusparseMatDescr_t,
-                                          bsrSortedValA::CuPtr{Cdouble},
-                                          bsrSortedRowPtrA::CuPtr{Cint},
-                                          bsrSortedColIndA::CuPtr{Cint}, rowBlockDim::Cint,
-                                          colBlockDim::Cint, descrC::cusparseMatDescr_t,
-                                          csrSortedValC::CuPtr{Cdouble},
-                                          csrSortedRowPtrC::CuPtr{Cint},
-                                          csrSortedColIndC::CuPtr{Cint})::cusparseStatus_t
+    @gcsafe_ccall libcusparse.cusparseDgebsr2csr(handle::cusparseHandle_t,
+                                                 dirA::cusparseDirection_t, mb::Cint,
+                                                 nb::Cint, descrA::cusparseMatDescr_t,
+                                                 bsrSortedValA::CuPtr{Cdouble},
+                                                 bsrSortedRowPtrA::CuPtr{Cint},
+                                                 bsrSortedColIndA::CuPtr{Cint},
+                                                 rowBlockDim::Cint, colBlockDim::Cint,
+                                                 descrC::cusparseMatDescr_t,
+                                                 csrSortedValC::CuPtr{Cdouble},
+                                                 csrSortedRowPtrC::CuPtr{Cint},
+                                                 csrSortedColIndC::CuPtr{Cint})::cusparseStatus_t
 end
 
 @checked function cusparseCgebsr2csr(handle, dirA, mb, nb, descrA, bsrSortedValA,
@@ -3505,16 +3745,17 @@ end
                                      colBlockDim, descrC, csrSortedValC, csrSortedRowPtrC,
                                      csrSortedColIndC)
     initialize_context()
-    @ccall libcusparse.cusparseCgebsr2csr(handle::cusparseHandle_t,
-                                          dirA::cusparseDirection_t, mb::Cint, nb::Cint,
-                                          descrA::cusparseMatDescr_t,
-                                          bsrSortedValA::CuPtr{cuComplex},
-                                          bsrSortedRowPtrA::CuPtr{Cint},
-                                          bsrSortedColIndA::CuPtr{Cint}, rowBlockDim::Cint,
-                                          colBlockDim::Cint, descrC::cusparseMatDescr_t,
-                                          csrSortedValC::CuPtr{cuComplex},
-                                          csrSortedRowPtrC::CuPtr{Cint},
-                                          csrSortedColIndC::CuPtr{Cint})::cusparseStatus_t
+    @gcsafe_ccall libcusparse.cusparseCgebsr2csr(handle::cusparseHandle_t,
+                                                 dirA::cusparseDirection_t, mb::Cint,
+                                                 nb::Cint, descrA::cusparseMatDescr_t,
+                                                 bsrSortedValA::CuPtr{cuComplex},
+                                                 bsrSortedRowPtrA::CuPtr{Cint},
+                                                 bsrSortedColIndA::CuPtr{Cint},
+                                                 rowBlockDim::Cint, colBlockDim::Cint,
+                                                 descrC::cusparseMatDescr_t,
+                                                 csrSortedValC::CuPtr{cuComplex},
+                                                 csrSortedRowPtrC::CuPtr{Cint},
+                                                 csrSortedColIndC::CuPtr{Cint})::cusparseStatus_t
 end
 
 @checked function cusparseZgebsr2csr(handle, dirA, mb, nb, descrA, bsrSortedValA,
@@ -3522,16 +3763,17 @@ end
                                      colBlockDim, descrC, csrSortedValC, csrSortedRowPtrC,
                                      csrSortedColIndC)
     initialize_context()
-    @ccall libcusparse.cusparseZgebsr2csr(handle::cusparseHandle_t,
-                                          dirA::cusparseDirection_t, mb::Cint, nb::Cint,
-                                          descrA::cusparseMatDescr_t,
-                                          bsrSortedValA::CuPtr{cuDoubleComplex},
-                                          bsrSortedRowPtrA::CuPtr{Cint},
-                                          bsrSortedColIndA::CuPtr{Cint}, rowBlockDim::Cint,
-                                          colBlockDim::Cint, descrC::cusparseMatDescr_t,
-                                          csrSortedValC::CuPtr{cuDoubleComplex},
-                                          csrSortedRowPtrC::CuPtr{Cint},
-                                          csrSortedColIndC::CuPtr{Cint})::cusparseStatus_t
+    @gcsafe_ccall libcusparse.cusparseZgebsr2csr(handle::cusparseHandle_t,
+                                                 dirA::cusparseDirection_t, mb::Cint,
+                                                 nb::Cint, descrA::cusparseMatDescr_t,
+                                                 bsrSortedValA::CuPtr{cuDoubleComplex},
+                                                 bsrSortedRowPtrA::CuPtr{Cint},
+                                                 bsrSortedColIndA::CuPtr{Cint},
+                                                 rowBlockDim::Cint, colBlockDim::Cint,
+                                                 descrC::cusparseMatDescr_t,
+                                                 csrSortedValC::CuPtr{cuDoubleComplex},
+                                                 csrSortedRowPtrC::CuPtr{Cint},
+                                                 csrSortedColIndC::CuPtr{Cint})::cusparseStatus_t
 end
 
 @checked function cusparseScsr2gebsr_bufferSize(handle, dirA, m, n, descrA, csrSortedValA,
@@ -3539,14 +3781,16 @@ end
                                                 rowBlockDim, colBlockDim,
                                                 pBufferSizeInBytes)
     initialize_context()
-    @ccall libcusparse.cusparseScsr2gebsr_bufferSize(handle::cusparseHandle_t,
-                                                     dirA::cusparseDirection_t, m::Cint,
-                                                     n::Cint, descrA::cusparseMatDescr_t,
-                                                     csrSortedValA::CuPtr{Cfloat},
-                                                     csrSortedRowPtrA::CuPtr{Cint},
-                                                     csrSortedColIndA::CuPtr{Cint},
-                                                     rowBlockDim::Cint, colBlockDim::Cint,
-                                                     pBufferSizeInBytes::Ptr{Cint})::cusparseStatus_t
+    @gcsafe_ccall libcusparse.cusparseScsr2gebsr_bufferSize(handle::cusparseHandle_t,
+                                                            dirA::cusparseDirection_t,
+                                                            m::Cint, n::Cint,
+                                                            descrA::cusparseMatDescr_t,
+                                                            csrSortedValA::CuPtr{Cfloat},
+                                                            csrSortedRowPtrA::CuPtr{Cint},
+                                                            csrSortedColIndA::CuPtr{Cint},
+                                                            rowBlockDim::Cint,
+                                                            colBlockDim::Cint,
+                                                            pBufferSizeInBytes::Ptr{Cint})::cusparseStatus_t
 end
 
 @checked function cusparseDcsr2gebsr_bufferSize(handle, dirA, m, n, descrA, csrSortedValA,
@@ -3554,14 +3798,16 @@ end
                                                 rowBlockDim, colBlockDim,
                                                 pBufferSizeInBytes)
     initialize_context()
-    @ccall libcusparse.cusparseDcsr2gebsr_bufferSize(handle::cusparseHandle_t,
-                                                     dirA::cusparseDirection_t, m::Cint,
-                                                     n::Cint, descrA::cusparseMatDescr_t,
-                                                     csrSortedValA::CuPtr{Cdouble},
-                                                     csrSortedRowPtrA::CuPtr{Cint},
-                                                     csrSortedColIndA::CuPtr{Cint},
-                                                     rowBlockDim::Cint, colBlockDim::Cint,
-                                                     pBufferSizeInBytes::Ptr{Cint})::cusparseStatus_t
+    @gcsafe_ccall libcusparse.cusparseDcsr2gebsr_bufferSize(handle::cusparseHandle_t,
+                                                            dirA::cusparseDirection_t,
+                                                            m::Cint, n::Cint,
+                                                            descrA::cusparseMatDescr_t,
+                                                            csrSortedValA::CuPtr{Cdouble},
+                                                            csrSortedRowPtrA::CuPtr{Cint},
+                                                            csrSortedColIndA::CuPtr{Cint},
+                                                            rowBlockDim::Cint,
+                                                            colBlockDim::Cint,
+                                                            pBufferSizeInBytes::Ptr{Cint})::cusparseStatus_t
 end
 
 @checked function cusparseCcsr2gebsr_bufferSize(handle, dirA, m, n, descrA, csrSortedValA,
@@ -3569,14 +3815,16 @@ end
                                                 rowBlockDim, colBlockDim,
                                                 pBufferSizeInBytes)
     initialize_context()
-    @ccall libcusparse.cusparseCcsr2gebsr_bufferSize(handle::cusparseHandle_t,
-                                                     dirA::cusparseDirection_t, m::Cint,
-                                                     n::Cint, descrA::cusparseMatDescr_t,
-                                                     csrSortedValA::CuPtr{cuComplex},
-                                                     csrSortedRowPtrA::CuPtr{Cint},
-                                                     csrSortedColIndA::CuPtr{Cint},
-                                                     rowBlockDim::Cint, colBlockDim::Cint,
-                                                     pBufferSizeInBytes::Ptr{Cint})::cusparseStatus_t
+    @gcsafe_ccall libcusparse.cusparseCcsr2gebsr_bufferSize(handle::cusparseHandle_t,
+                                                            dirA::cusparseDirection_t,
+                                                            m::Cint, n::Cint,
+                                                            descrA::cusparseMatDescr_t,
+                                                            csrSortedValA::CuPtr{cuComplex},
+                                                            csrSortedRowPtrA::CuPtr{Cint},
+                                                            csrSortedColIndA::CuPtr{Cint},
+                                                            rowBlockDim::Cint,
+                                                            colBlockDim::Cint,
+                                                            pBufferSizeInBytes::Ptr{Cint})::cusparseStatus_t
 end
 
 @checked function cusparseZcsr2gebsr_bufferSize(handle, dirA, m, n, descrA, csrSortedValA,
@@ -3584,14 +3832,16 @@ end
                                                 rowBlockDim, colBlockDim,
                                                 pBufferSizeInBytes)
     initialize_context()
-    @ccall libcusparse.cusparseZcsr2gebsr_bufferSize(handle::cusparseHandle_t,
-                                                     dirA::cusparseDirection_t, m::Cint,
-                                                     n::Cint, descrA::cusparseMatDescr_t,
-                                                     csrSortedValA::CuPtr{cuDoubleComplex},
-                                                     csrSortedRowPtrA::CuPtr{Cint},
-                                                     csrSortedColIndA::CuPtr{Cint},
-                                                     rowBlockDim::Cint, colBlockDim::Cint,
-                                                     pBufferSizeInBytes::Ptr{Cint})::cusparseStatus_t
+    @gcsafe_ccall libcusparse.cusparseZcsr2gebsr_bufferSize(handle::cusparseHandle_t,
+                                                            dirA::cusparseDirection_t,
+                                                            m::Cint, n::Cint,
+                                                            descrA::cusparseMatDescr_t,
+                                                            csrSortedValA::CuPtr{cuDoubleComplex},
+                                                            csrSortedRowPtrA::CuPtr{Cint},
+                                                            csrSortedColIndA::CuPtr{Cint},
+                                                            rowBlockDim::Cint,
+                                                            colBlockDim::Cint,
+                                                            pBufferSizeInBytes::Ptr{Cint})::cusparseStatus_t
 end
 
 @checked function cusparseScsr2gebsr_bufferSizeExt(handle, dirA, m, n, descrA,
@@ -3599,15 +3849,16 @@ end
                                                    csrSortedColIndA, rowBlockDim,
                                                    colBlockDim, pBufferSize)
     initialize_context()
-    @ccall libcusparse.cusparseScsr2gebsr_bufferSizeExt(handle::cusparseHandle_t,
-                                                        dirA::cusparseDirection_t, m::Cint,
-                                                        n::Cint, descrA::cusparseMatDescr_t,
-                                                        csrSortedValA::CuPtr{Cfloat},
-                                                        csrSortedRowPtrA::CuPtr{Cint},
-                                                        csrSortedColIndA::CuPtr{Cint},
-                                                        rowBlockDim::Cint,
-                                                        colBlockDim::Cint,
-                                                        pBufferSize::Ptr{Csize_t})::cusparseStatus_t
+    @gcsafe_ccall libcusparse.cusparseScsr2gebsr_bufferSizeExt(handle::cusparseHandle_t,
+                                                               dirA::cusparseDirection_t,
+                                                               m::Cint, n::Cint,
+                                                               descrA::cusparseMatDescr_t,
+                                                               csrSortedValA::CuPtr{Cfloat},
+                                                               csrSortedRowPtrA::CuPtr{Cint},
+                                                               csrSortedColIndA::CuPtr{Cint},
+                                                               rowBlockDim::Cint,
+                                                               colBlockDim::Cint,
+                                                               pBufferSize::Ptr{Csize_t})::cusparseStatus_t
 end
 
 @checked function cusparseDcsr2gebsr_bufferSizeExt(handle, dirA, m, n, descrA,
@@ -3615,15 +3866,16 @@ end
                                                    csrSortedColIndA, rowBlockDim,
                                                    colBlockDim, pBufferSize)
     initialize_context()
-    @ccall libcusparse.cusparseDcsr2gebsr_bufferSizeExt(handle::cusparseHandle_t,
-                                                        dirA::cusparseDirection_t, m::Cint,
-                                                        n::Cint, descrA::cusparseMatDescr_t,
-                                                        csrSortedValA::CuPtr{Cdouble},
-                                                        csrSortedRowPtrA::CuPtr{Cint},
-                                                        csrSortedColIndA::CuPtr{Cint},
-                                                        rowBlockDim::Cint,
-                                                        colBlockDim::Cint,
-                                                        pBufferSize::Ptr{Csize_t})::cusparseStatus_t
+    @gcsafe_ccall libcusparse.cusparseDcsr2gebsr_bufferSizeExt(handle::cusparseHandle_t,
+                                                               dirA::cusparseDirection_t,
+                                                               m::Cint, n::Cint,
+                                                               descrA::cusparseMatDescr_t,
+                                                               csrSortedValA::CuPtr{Cdouble},
+                                                               csrSortedRowPtrA::CuPtr{Cint},
+                                                               csrSortedColIndA::CuPtr{Cint},
+                                                               rowBlockDim::Cint,
+                                                               colBlockDim::Cint,
+                                                               pBufferSize::Ptr{Csize_t})::cusparseStatus_t
 end
 
 @checked function cusparseCcsr2gebsr_bufferSizeExt(handle, dirA, m, n, descrA,
@@ -3631,15 +3883,16 @@ end
                                                    csrSortedColIndA, rowBlockDim,
                                                    colBlockDim, pBufferSize)
     initialize_context()
-    @ccall libcusparse.cusparseCcsr2gebsr_bufferSizeExt(handle::cusparseHandle_t,
-                                                        dirA::cusparseDirection_t, m::Cint,
-                                                        n::Cint, descrA::cusparseMatDescr_t,
-                                                        csrSortedValA::CuPtr{cuComplex},
-                                                        csrSortedRowPtrA::CuPtr{Cint},
-                                                        csrSortedColIndA::CuPtr{Cint},
-                                                        rowBlockDim::Cint,
-                                                        colBlockDim::Cint,
-                                                        pBufferSize::Ptr{Csize_t})::cusparseStatus_t
+    @gcsafe_ccall libcusparse.cusparseCcsr2gebsr_bufferSizeExt(handle::cusparseHandle_t,
+                                                               dirA::cusparseDirection_t,
+                                                               m::Cint, n::Cint,
+                                                               descrA::cusparseMatDescr_t,
+                                                               csrSortedValA::CuPtr{cuComplex},
+                                                               csrSortedRowPtrA::CuPtr{Cint},
+                                                               csrSortedColIndA::CuPtr{Cint},
+                                                               rowBlockDim::Cint,
+                                                               colBlockDim::Cint,
+                                                               pBufferSize::Ptr{Csize_t})::cusparseStatus_t
 end
 
 @checked function cusparseZcsr2gebsr_bufferSizeExt(handle, dirA, m, n, descrA,
@@ -3647,15 +3900,16 @@ end
                                                    csrSortedColIndA, rowBlockDim,
                                                    colBlockDim, pBufferSize)
     initialize_context()
-    @ccall libcusparse.cusparseZcsr2gebsr_bufferSizeExt(handle::cusparseHandle_t,
-                                                        dirA::cusparseDirection_t, m::Cint,
-                                                        n::Cint, descrA::cusparseMatDescr_t,
-                                                        csrSortedValA::CuPtr{cuDoubleComplex},
-                                                        csrSortedRowPtrA::CuPtr{Cint},
-                                                        csrSortedColIndA::CuPtr{Cint},
-                                                        rowBlockDim::Cint,
-                                                        colBlockDim::Cint,
-                                                        pBufferSize::Ptr{Csize_t})::cusparseStatus_t
+    @gcsafe_ccall libcusparse.cusparseZcsr2gebsr_bufferSizeExt(handle::cusparseHandle_t,
+                                                               dirA::cusparseDirection_t,
+                                                               m::Cint, n::Cint,
+                                                               descrA::cusparseMatDescr_t,
+                                                               csrSortedValA::CuPtr{cuDoubleComplex},
+                                                               csrSortedRowPtrA::CuPtr{Cint},
+                                                               csrSortedColIndA::CuPtr{Cint},
+                                                               rowBlockDim::Cint,
+                                                               colBlockDim::Cint,
+                                                               pBufferSize::Ptr{Csize_t})::cusparseStatus_t
 end
 
 @checked function cusparseXcsr2gebsrNnz(handle, dirA, m, n, descrA, csrSortedRowPtrA,
@@ -3663,16 +3917,16 @@ end
                                         rowBlockDim, colBlockDim, nnzTotalDevHostPtr,
                                         pBuffer)
     initialize_context()
-    @ccall libcusparse.cusparseXcsr2gebsrNnz(handle::cusparseHandle_t,
-                                             dirA::cusparseDirection_t, m::Cint, n::Cint,
-                                             descrA::cusparseMatDescr_t,
-                                             csrSortedRowPtrA::CuPtr{Cint},
-                                             csrSortedColIndA::CuPtr{Cint},
-                                             descrC::cusparseMatDescr_t,
-                                             bsrSortedRowPtrC::CuPtr{Cint},
-                                             rowBlockDim::Cint, colBlockDim::Cint,
-                                             nnzTotalDevHostPtr::PtrOrCuPtr{Cint},
-                                             pBuffer::CuPtr{Cvoid})::cusparseStatus_t
+    @gcsafe_ccall libcusparse.cusparseXcsr2gebsrNnz(handle::cusparseHandle_t,
+                                                    dirA::cusparseDirection_t, m::Cint,
+                                                    n::Cint, descrA::cusparseMatDescr_t,
+                                                    csrSortedRowPtrA::CuPtr{Cint},
+                                                    csrSortedColIndA::CuPtr{Cint},
+                                                    descrC::cusparseMatDescr_t,
+                                                    bsrSortedRowPtrC::CuPtr{Cint},
+                                                    rowBlockDim::Cint, colBlockDim::Cint,
+                                                    nnzTotalDevHostPtr::PtrOrCuPtr{Cint},
+                                                    pBuffer::CuPtr{Cvoid})::cusparseStatus_t
 end
 
 @checked function cusparseScsr2gebsr(handle, dirA, m, n, descrA, csrSortedValA,
@@ -3680,18 +3934,18 @@ end
                                      bsrSortedValC, bsrSortedRowPtrC, bsrSortedColIndC,
                                      rowBlockDim, colBlockDim, pBuffer)
     initialize_context()
-    @ccall libcusparse.cusparseScsr2gebsr(handle::cusparseHandle_t,
-                                          dirA::cusparseDirection_t, m::Cint, n::Cint,
-                                          descrA::cusparseMatDescr_t,
-                                          csrSortedValA::CuPtr{Cfloat},
-                                          csrSortedRowPtrA::CuPtr{Cint},
-                                          csrSortedColIndA::CuPtr{Cint},
-                                          descrC::cusparseMatDescr_t,
-                                          bsrSortedValC::CuPtr{Cfloat},
-                                          bsrSortedRowPtrC::CuPtr{Cint},
-                                          bsrSortedColIndC::CuPtr{Cint}, rowBlockDim::Cint,
-                                          colBlockDim::Cint,
-                                          pBuffer::CuPtr{Cvoid})::cusparseStatus_t
+    @gcsafe_ccall libcusparse.cusparseScsr2gebsr(handle::cusparseHandle_t,
+                                                 dirA::cusparseDirection_t, m::Cint,
+                                                 n::Cint, descrA::cusparseMatDescr_t,
+                                                 csrSortedValA::CuPtr{Cfloat},
+                                                 csrSortedRowPtrA::CuPtr{Cint},
+                                                 csrSortedColIndA::CuPtr{Cint},
+                                                 descrC::cusparseMatDescr_t,
+                                                 bsrSortedValC::CuPtr{Cfloat},
+                                                 bsrSortedRowPtrC::CuPtr{Cint},
+                                                 bsrSortedColIndC::CuPtr{Cint},
+                                                 rowBlockDim::Cint, colBlockDim::Cint,
+                                                 pBuffer::CuPtr{Cvoid})::cusparseStatus_t
 end
 
 @checked function cusparseDcsr2gebsr(handle, dirA, m, n, descrA, csrSortedValA,
@@ -3699,18 +3953,18 @@ end
                                      bsrSortedValC, bsrSortedRowPtrC, bsrSortedColIndC,
                                      rowBlockDim, colBlockDim, pBuffer)
     initialize_context()
-    @ccall libcusparse.cusparseDcsr2gebsr(handle::cusparseHandle_t,
-                                          dirA::cusparseDirection_t, m::Cint, n::Cint,
-                                          descrA::cusparseMatDescr_t,
-                                          csrSortedValA::CuPtr{Cdouble},
-                                          csrSortedRowPtrA::CuPtr{Cint},
-                                          csrSortedColIndA::CuPtr{Cint},
-                                          descrC::cusparseMatDescr_t,
-                                          bsrSortedValC::CuPtr{Cdouble},
-                                          bsrSortedRowPtrC::CuPtr{Cint},
-                                          bsrSortedColIndC::CuPtr{Cint}, rowBlockDim::Cint,
-                                          colBlockDim::Cint,
-                                          pBuffer::CuPtr{Cvoid})::cusparseStatus_t
+    @gcsafe_ccall libcusparse.cusparseDcsr2gebsr(handle::cusparseHandle_t,
+                                                 dirA::cusparseDirection_t, m::Cint,
+                                                 n::Cint, descrA::cusparseMatDescr_t,
+                                                 csrSortedValA::CuPtr{Cdouble},
+                                                 csrSortedRowPtrA::CuPtr{Cint},
+                                                 csrSortedColIndA::CuPtr{Cint},
+                                                 descrC::cusparseMatDescr_t,
+                                                 bsrSortedValC::CuPtr{Cdouble},
+                                                 bsrSortedRowPtrC::CuPtr{Cint},
+                                                 bsrSortedColIndC::CuPtr{Cint},
+                                                 rowBlockDim::Cint, colBlockDim::Cint,
+                                                 pBuffer::CuPtr{Cvoid})::cusparseStatus_t
 end
 
 @checked function cusparseCcsr2gebsr(handle, dirA, m, n, descrA, csrSortedValA,
@@ -3718,18 +3972,18 @@ end
                                      bsrSortedValC, bsrSortedRowPtrC, bsrSortedColIndC,
                                      rowBlockDim, colBlockDim, pBuffer)
     initialize_context()
-    @ccall libcusparse.cusparseCcsr2gebsr(handle::cusparseHandle_t,
-                                          dirA::cusparseDirection_t, m::Cint, n::Cint,
-                                          descrA::cusparseMatDescr_t,
-                                          csrSortedValA::CuPtr{cuComplex},
-                                          csrSortedRowPtrA::CuPtr{Cint},
-                                          csrSortedColIndA::CuPtr{Cint},
-                                          descrC::cusparseMatDescr_t,
-                                          bsrSortedValC::CuPtr{cuComplex},
-                                          bsrSortedRowPtrC::CuPtr{Cint},
-                                          bsrSortedColIndC::CuPtr{Cint}, rowBlockDim::Cint,
-                                          colBlockDim::Cint,
-                                          pBuffer::CuPtr{Cvoid})::cusparseStatus_t
+    @gcsafe_ccall libcusparse.cusparseCcsr2gebsr(handle::cusparseHandle_t,
+                                                 dirA::cusparseDirection_t, m::Cint,
+                                                 n::Cint, descrA::cusparseMatDescr_t,
+                                                 csrSortedValA::CuPtr{cuComplex},
+                                                 csrSortedRowPtrA::CuPtr{Cint},
+                                                 csrSortedColIndA::CuPtr{Cint},
+                                                 descrC::cusparseMatDescr_t,
+                                                 bsrSortedValC::CuPtr{cuComplex},
+                                                 bsrSortedRowPtrC::CuPtr{Cint},
+                                                 bsrSortedColIndC::CuPtr{Cint},
+                                                 rowBlockDim::Cint, colBlockDim::Cint,
+                                                 pBuffer::CuPtr{Cvoid})::cusparseStatus_t
 end
 
 @checked function cusparseZcsr2gebsr(handle, dirA, m, n, descrA, csrSortedValA,
@@ -3737,18 +3991,18 @@ end
                                      bsrSortedValC, bsrSortedRowPtrC, bsrSortedColIndC,
                                      rowBlockDim, colBlockDim, pBuffer)
     initialize_context()
-    @ccall libcusparse.cusparseZcsr2gebsr(handle::cusparseHandle_t,
-                                          dirA::cusparseDirection_t, m::Cint, n::Cint,
-                                          descrA::cusparseMatDescr_t,
-                                          csrSortedValA::CuPtr{cuDoubleComplex},
-                                          csrSortedRowPtrA::CuPtr{Cint},
-                                          csrSortedColIndA::CuPtr{Cint},
-                                          descrC::cusparseMatDescr_t,
-                                          bsrSortedValC::CuPtr{cuDoubleComplex},
-                                          bsrSortedRowPtrC::CuPtr{Cint},
-                                          bsrSortedColIndC::CuPtr{Cint}, rowBlockDim::Cint,
-                                          colBlockDim::Cint,
-                                          pBuffer::CuPtr{Cvoid})::cusparseStatus_t
+    @gcsafe_ccall libcusparse.cusparseZcsr2gebsr(handle::cusparseHandle_t,
+                                                 dirA::cusparseDirection_t, m::Cint,
+                                                 n::Cint, descrA::cusparseMatDescr_t,
+                                                 csrSortedValA::CuPtr{cuDoubleComplex},
+                                                 csrSortedRowPtrA::CuPtr{Cint},
+                                                 csrSortedColIndA::CuPtr{Cint},
+                                                 descrC::cusparseMatDescr_t,
+                                                 bsrSortedValC::CuPtr{cuDoubleComplex},
+                                                 bsrSortedRowPtrC::CuPtr{Cint},
+                                                 bsrSortedColIndC::CuPtr{Cint},
+                                                 rowBlockDim::Cint, colBlockDim::Cint,
+                                                 pBuffer::CuPtr{Cvoid})::cusparseStatus_t
 end
 
 @checked function cusparseSgebsr2gebsr_bufferSize(handle, dirA, mb, nb, nnzb, descrA,
@@ -3757,18 +4011,19 @@ end
                                                   colBlockDimA, rowBlockDimC, colBlockDimC,
                                                   pBufferSizeInBytes)
     initialize_context()
-    @ccall libcusparse.cusparseSgebsr2gebsr_bufferSize(handle::cusparseHandle_t,
-                                                       dirA::cusparseDirection_t, mb::Cint,
-                                                       nb::Cint, nnzb::Cint,
-                                                       descrA::cusparseMatDescr_t,
-                                                       bsrSortedValA::CuPtr{Cfloat},
-                                                       bsrSortedRowPtrA::CuPtr{Cint},
-                                                       bsrSortedColIndA::CuPtr{Cint},
-                                                       rowBlockDimA::Cint,
-                                                       colBlockDimA::Cint,
-                                                       rowBlockDimC::Cint,
-                                                       colBlockDimC::Cint,
-                                                       pBufferSizeInBytes::Ptr{Cint})::cusparseStatus_t
+    @gcsafe_ccall libcusparse.cusparseSgebsr2gebsr_bufferSize(handle::cusparseHandle_t,
+                                                              dirA::cusparseDirection_t,
+                                                              mb::Cint, nb::Cint,
+                                                              nnzb::Cint,
+                                                              descrA::cusparseMatDescr_t,
+                                                              bsrSortedValA::CuPtr{Cfloat},
+                                                              bsrSortedRowPtrA::CuPtr{Cint},
+                                                              bsrSortedColIndA::CuPtr{Cint},
+                                                              rowBlockDimA::Cint,
+                                                              colBlockDimA::Cint,
+                                                              rowBlockDimC::Cint,
+                                                              colBlockDimC::Cint,
+                                                              pBufferSizeInBytes::Ptr{Cint})::cusparseStatus_t
 end
 
 @checked function cusparseDgebsr2gebsr_bufferSize(handle, dirA, mb, nb, nnzb, descrA,
@@ -3777,18 +4032,19 @@ end
                                                   colBlockDimA, rowBlockDimC, colBlockDimC,
                                                   pBufferSizeInBytes)
     initialize_context()
-    @ccall libcusparse.cusparseDgebsr2gebsr_bufferSize(handle::cusparseHandle_t,
-                                                       dirA::cusparseDirection_t, mb::Cint,
-                                                       nb::Cint, nnzb::Cint,
-                                                       descrA::cusparseMatDescr_t,
-                                                       bsrSortedValA::CuPtr{Cdouble},
-                                                       bsrSortedRowPtrA::CuPtr{Cint},
-                                                       bsrSortedColIndA::CuPtr{Cint},
-                                                       rowBlockDimA::Cint,
-                                                       colBlockDimA::Cint,
-                                                       rowBlockDimC::Cint,
-                                                       colBlockDimC::Cint,
-                                                       pBufferSizeInBytes::Ptr{Cint})::cusparseStatus_t
+    @gcsafe_ccall libcusparse.cusparseDgebsr2gebsr_bufferSize(handle::cusparseHandle_t,
+                                                              dirA::cusparseDirection_t,
+                                                              mb::Cint, nb::Cint,
+                                                              nnzb::Cint,
+                                                              descrA::cusparseMatDescr_t,
+                                                              bsrSortedValA::CuPtr{Cdouble},
+                                                              bsrSortedRowPtrA::CuPtr{Cint},
+                                                              bsrSortedColIndA::CuPtr{Cint},
+                                                              rowBlockDimA::Cint,
+                                                              colBlockDimA::Cint,
+                                                              rowBlockDimC::Cint,
+                                                              colBlockDimC::Cint,
+                                                              pBufferSizeInBytes::Ptr{Cint})::cusparseStatus_t
 end
 
 @checked function cusparseCgebsr2gebsr_bufferSize(handle, dirA, mb, nb, nnzb, descrA,
@@ -3797,18 +4053,19 @@ end
                                                   colBlockDimA, rowBlockDimC, colBlockDimC,
                                                   pBufferSizeInBytes)
     initialize_context()
-    @ccall libcusparse.cusparseCgebsr2gebsr_bufferSize(handle::cusparseHandle_t,
-                                                       dirA::cusparseDirection_t, mb::Cint,
-                                                       nb::Cint, nnzb::Cint,
-                                                       descrA::cusparseMatDescr_t,
-                                                       bsrSortedValA::CuPtr{cuComplex},
-                                                       bsrSortedRowPtrA::CuPtr{Cint},
-                                                       bsrSortedColIndA::CuPtr{Cint},
-                                                       rowBlockDimA::Cint,
-                                                       colBlockDimA::Cint,
-                                                       rowBlockDimC::Cint,
-                                                       colBlockDimC::Cint,
-                                                       pBufferSizeInBytes::Ptr{Cint})::cusparseStatus_t
+    @gcsafe_ccall libcusparse.cusparseCgebsr2gebsr_bufferSize(handle::cusparseHandle_t,
+                                                              dirA::cusparseDirection_t,
+                                                              mb::Cint, nb::Cint,
+                                                              nnzb::Cint,
+                                                              descrA::cusparseMatDescr_t,
+                                                              bsrSortedValA::CuPtr{cuComplex},
+                                                              bsrSortedRowPtrA::CuPtr{Cint},
+                                                              bsrSortedColIndA::CuPtr{Cint},
+                                                              rowBlockDimA::Cint,
+                                                              colBlockDimA::Cint,
+                                                              rowBlockDimC::Cint,
+                                                              colBlockDimC::Cint,
+                                                              pBufferSizeInBytes::Ptr{Cint})::cusparseStatus_t
 end
 
 @checked function cusparseZgebsr2gebsr_bufferSize(handle, dirA, mb, nb, nnzb, descrA,
@@ -3817,18 +4074,19 @@ end
                                                   colBlockDimA, rowBlockDimC, colBlockDimC,
                                                   pBufferSizeInBytes)
     initialize_context()
-    @ccall libcusparse.cusparseZgebsr2gebsr_bufferSize(handle::cusparseHandle_t,
-                                                       dirA::cusparseDirection_t, mb::Cint,
-                                                       nb::Cint, nnzb::Cint,
-                                                       descrA::cusparseMatDescr_t,
-                                                       bsrSortedValA::CuPtr{cuDoubleComplex},
-                                                       bsrSortedRowPtrA::CuPtr{Cint},
-                                                       bsrSortedColIndA::CuPtr{Cint},
-                                                       rowBlockDimA::Cint,
-                                                       colBlockDimA::Cint,
-                                                       rowBlockDimC::Cint,
-                                                       colBlockDimC::Cint,
-                                                       pBufferSizeInBytes::Ptr{Cint})::cusparseStatus_t
+    @gcsafe_ccall libcusparse.cusparseZgebsr2gebsr_bufferSize(handle::cusparseHandle_t,
+                                                              dirA::cusparseDirection_t,
+                                                              mb::Cint, nb::Cint,
+                                                              nnzb::Cint,
+                                                              descrA::cusparseMatDescr_t,
+                                                              bsrSortedValA::CuPtr{cuDoubleComplex},
+                                                              bsrSortedRowPtrA::CuPtr{Cint},
+                                                              bsrSortedColIndA::CuPtr{Cint},
+                                                              rowBlockDimA::Cint,
+                                                              colBlockDimA::Cint,
+                                                              rowBlockDimC::Cint,
+                                                              colBlockDimC::Cint,
+                                                              pBufferSizeInBytes::Ptr{Cint})::cusparseStatus_t
 end
 
 @checked function cusparseSgebsr2gebsr_bufferSizeExt(handle, dirA, mb, nb, nnzb, descrA,
@@ -3837,18 +4095,19 @@ end
                                                      colBlockDimA, rowBlockDimC,
                                                      colBlockDimC, pBufferSize)
     initialize_context()
-    @ccall libcusparse.cusparseSgebsr2gebsr_bufferSizeExt(handle::cusparseHandle_t,
-                                                          dirA::cusparseDirection_t,
-                                                          mb::Cint, nb::Cint, nnzb::Cint,
-                                                          descrA::cusparseMatDescr_t,
-                                                          bsrSortedValA::CuPtr{Cfloat},
-                                                          bsrSortedRowPtrA::CuPtr{Cint},
-                                                          bsrSortedColIndA::CuPtr{Cint},
-                                                          rowBlockDimA::Cint,
-                                                          colBlockDimA::Cint,
-                                                          rowBlockDimC::Cint,
-                                                          colBlockDimC::Cint,
-                                                          pBufferSize::Ptr{Csize_t})::cusparseStatus_t
+    @gcsafe_ccall libcusparse.cusparseSgebsr2gebsr_bufferSizeExt(handle::cusparseHandle_t,
+                                                                 dirA::cusparseDirection_t,
+                                                                 mb::Cint, nb::Cint,
+                                                                 nnzb::Cint,
+                                                                 descrA::cusparseMatDescr_t,
+                                                                 bsrSortedValA::CuPtr{Cfloat},
+                                                                 bsrSortedRowPtrA::CuPtr{Cint},
+                                                                 bsrSortedColIndA::CuPtr{Cint},
+                                                                 rowBlockDimA::Cint,
+                                                                 colBlockDimA::Cint,
+                                                                 rowBlockDimC::Cint,
+                                                                 colBlockDimC::Cint,
+                                                                 pBufferSize::Ptr{Csize_t})::cusparseStatus_t
 end
 
 @checked function cusparseDgebsr2gebsr_bufferSizeExt(handle, dirA, mb, nb, nnzb, descrA,
@@ -3857,18 +4116,19 @@ end
                                                      colBlockDimA, rowBlockDimC,
                                                      colBlockDimC, pBufferSize)
     initialize_context()
-    @ccall libcusparse.cusparseDgebsr2gebsr_bufferSizeExt(handle::cusparseHandle_t,
-                                                          dirA::cusparseDirection_t,
-                                                          mb::Cint, nb::Cint, nnzb::Cint,
-                                                          descrA::cusparseMatDescr_t,
-                                                          bsrSortedValA::CuPtr{Cdouble},
-                                                          bsrSortedRowPtrA::CuPtr{Cint},
-                                                          bsrSortedColIndA::CuPtr{Cint},
-                                                          rowBlockDimA::Cint,
-                                                          colBlockDimA::Cint,
-                                                          rowBlockDimC::Cint,
-                                                          colBlockDimC::Cint,
-                                                          pBufferSize::Ptr{Csize_t})::cusparseStatus_t
+    @gcsafe_ccall libcusparse.cusparseDgebsr2gebsr_bufferSizeExt(handle::cusparseHandle_t,
+                                                                 dirA::cusparseDirection_t,
+                                                                 mb::Cint, nb::Cint,
+                                                                 nnzb::Cint,
+                                                                 descrA::cusparseMatDescr_t,
+                                                                 bsrSortedValA::CuPtr{Cdouble},
+                                                                 bsrSortedRowPtrA::CuPtr{Cint},
+                                                                 bsrSortedColIndA::CuPtr{Cint},
+                                                                 rowBlockDimA::Cint,
+                                                                 colBlockDimA::Cint,
+                                                                 rowBlockDimC::Cint,
+                                                                 colBlockDimC::Cint,
+                                                                 pBufferSize::Ptr{Csize_t})::cusparseStatus_t
 end
 
 @checked function cusparseCgebsr2gebsr_bufferSizeExt(handle, dirA, mb, nb, nnzb, descrA,
@@ -3877,18 +4137,19 @@ end
                                                      colBlockDimA, rowBlockDimC,
                                                      colBlockDimC, pBufferSize)
     initialize_context()
-    @ccall libcusparse.cusparseCgebsr2gebsr_bufferSizeExt(handle::cusparseHandle_t,
-                                                          dirA::cusparseDirection_t,
-                                                          mb::Cint, nb::Cint, nnzb::Cint,
-                                                          descrA::cusparseMatDescr_t,
-                                                          bsrSortedValA::CuPtr{cuComplex},
-                                                          bsrSortedRowPtrA::CuPtr{Cint},
-                                                          bsrSortedColIndA::CuPtr{Cint},
-                                                          rowBlockDimA::Cint,
-                                                          colBlockDimA::Cint,
-                                                          rowBlockDimC::Cint,
-                                                          colBlockDimC::Cint,
-                                                          pBufferSize::Ptr{Csize_t})::cusparseStatus_t
+    @gcsafe_ccall libcusparse.cusparseCgebsr2gebsr_bufferSizeExt(handle::cusparseHandle_t,
+                                                                 dirA::cusparseDirection_t,
+                                                                 mb::Cint, nb::Cint,
+                                                                 nnzb::Cint,
+                                                                 descrA::cusparseMatDescr_t,
+                                                                 bsrSortedValA::CuPtr{cuComplex},
+                                                                 bsrSortedRowPtrA::CuPtr{Cint},
+                                                                 bsrSortedColIndA::CuPtr{Cint},
+                                                                 rowBlockDimA::Cint,
+                                                                 colBlockDimA::Cint,
+                                                                 rowBlockDimC::Cint,
+                                                                 colBlockDimC::Cint,
+                                                                 pBufferSize::Ptr{Csize_t})::cusparseStatus_t
 end
 
 @checked function cusparseZgebsr2gebsr_bufferSizeExt(handle, dirA, mb, nb, nnzb, descrA,
@@ -3897,18 +4158,19 @@ end
                                                      colBlockDimA, rowBlockDimC,
                                                      colBlockDimC, pBufferSize)
     initialize_context()
-    @ccall libcusparse.cusparseZgebsr2gebsr_bufferSizeExt(handle::cusparseHandle_t,
-                                                          dirA::cusparseDirection_t,
-                                                          mb::Cint, nb::Cint, nnzb::Cint,
-                                                          descrA::cusparseMatDescr_t,
-                                                          bsrSortedValA::CuPtr{cuDoubleComplex},
-                                                          bsrSortedRowPtrA::CuPtr{Cint},
-                                                          bsrSortedColIndA::CuPtr{Cint},
-                                                          rowBlockDimA::Cint,
-                                                          colBlockDimA::Cint,
-                                                          rowBlockDimC::Cint,
-                                                          colBlockDimC::Cint,
-                                                          pBufferSize::Ptr{Csize_t})::cusparseStatus_t
+    @gcsafe_ccall libcusparse.cusparseZgebsr2gebsr_bufferSizeExt(handle::cusparseHandle_t,
+                                                                 dirA::cusparseDirection_t,
+                                                                 mb::Cint, nb::Cint,
+                                                                 nnzb::Cint,
+                                                                 descrA::cusparseMatDescr_t,
+                                                                 bsrSortedValA::CuPtr{cuDoubleComplex},
+                                                                 bsrSortedRowPtrA::CuPtr{Cint},
+                                                                 bsrSortedColIndA::CuPtr{Cint},
+                                                                 rowBlockDimA::Cint,
+                                                                 colBlockDimA::Cint,
+                                                                 rowBlockDimC::Cint,
+                                                                 colBlockDimC::Cint,
+                                                                 pBufferSize::Ptr{Csize_t})::cusparseStatus_t
 end
 
 @checked function cusparseXgebsr2gebsrNnz(handle, dirA, mb, nb, nnzb, descrA,
@@ -3917,18 +4179,20 @@ end
                                           rowBlockDimC, colBlockDimC, nnzTotalDevHostPtr,
                                           pBuffer)
     initialize_context()
-    @ccall libcusparse.cusparseXgebsr2gebsrNnz(handle::cusparseHandle_t,
-                                               dirA::cusparseDirection_t, mb::Cint,
-                                               nb::Cint, nnzb::Cint,
-                                               descrA::cusparseMatDescr_t,
-                                               bsrSortedRowPtrA::CuPtr{Cint},
-                                               bsrSortedColIndA::CuPtr{Cint},
-                                               rowBlockDimA::Cint, colBlockDimA::Cint,
-                                               descrC::cusparseMatDescr_t,
-                                               bsrSortedRowPtrC::CuPtr{Cint},
-                                               rowBlockDimC::Cint, colBlockDimC::Cint,
-                                               nnzTotalDevHostPtr::PtrOrCuPtr{Cint},
-                                               pBuffer::CuPtr{Cvoid})::cusparseStatus_t
+    @gcsafe_ccall libcusparse.cusparseXgebsr2gebsrNnz(handle::cusparseHandle_t,
+                                                      dirA::cusparseDirection_t, mb::Cint,
+                                                      nb::Cint, nnzb::Cint,
+                                                      descrA::cusparseMatDescr_t,
+                                                      bsrSortedRowPtrA::CuPtr{Cint},
+                                                      bsrSortedColIndA::CuPtr{Cint},
+                                                      rowBlockDimA::Cint,
+                                                      colBlockDimA::Cint,
+                                                      descrC::cusparseMatDescr_t,
+                                                      bsrSortedRowPtrC::CuPtr{Cint},
+                                                      rowBlockDimC::Cint,
+                                                      colBlockDimC::Cint,
+                                                      nnzTotalDevHostPtr::PtrOrCuPtr{Cint},
+                                                      pBuffer::CuPtr{Cvoid})::cusparseStatus_t
 end
 
 @checked function cusparseSgebsr2gebsr(handle, dirA, mb, nb, nnzb, descrA, bsrSortedValA,
@@ -3937,19 +4201,20 @@ end
                                        bsrSortedRowPtrC, bsrSortedColIndC, rowBlockDimC,
                                        colBlockDimC, pBuffer)
     initialize_context()
-    @ccall libcusparse.cusparseSgebsr2gebsr(handle::cusparseHandle_t,
-                                            dirA::cusparseDirection_t, mb::Cint, nb::Cint,
-                                            nnzb::Cint, descrA::cusparseMatDescr_t,
-                                            bsrSortedValA::CuPtr{Cfloat},
-                                            bsrSortedRowPtrA::CuPtr{Cint},
-                                            bsrSortedColIndA::CuPtr{Cint},
-                                            rowBlockDimA::Cint, colBlockDimA::Cint,
-                                            descrC::cusparseMatDescr_t,
-                                            bsrSortedValC::CuPtr{Cfloat},
-                                            bsrSortedRowPtrC::CuPtr{Cint},
-                                            bsrSortedColIndC::CuPtr{Cint},
-                                            rowBlockDimC::Cint, colBlockDimC::Cint,
-                                            pBuffer::CuPtr{Cvoid})::cusparseStatus_t
+    @gcsafe_ccall libcusparse.cusparseSgebsr2gebsr(handle::cusparseHandle_t,
+                                                   dirA::cusparseDirection_t, mb::Cint,
+                                                   nb::Cint, nnzb::Cint,
+                                                   descrA::cusparseMatDescr_t,
+                                                   bsrSortedValA::CuPtr{Cfloat},
+                                                   bsrSortedRowPtrA::CuPtr{Cint},
+                                                   bsrSortedColIndA::CuPtr{Cint},
+                                                   rowBlockDimA::Cint, colBlockDimA::Cint,
+                                                   descrC::cusparseMatDescr_t,
+                                                   bsrSortedValC::CuPtr{Cfloat},
+                                                   bsrSortedRowPtrC::CuPtr{Cint},
+                                                   bsrSortedColIndC::CuPtr{Cint},
+                                                   rowBlockDimC::Cint, colBlockDimC::Cint,
+                                                   pBuffer::CuPtr{Cvoid})::cusparseStatus_t
 end
 
 @checked function cusparseDgebsr2gebsr(handle, dirA, mb, nb, nnzb, descrA, bsrSortedValA,
@@ -3958,19 +4223,20 @@ end
                                        bsrSortedRowPtrC, bsrSortedColIndC, rowBlockDimC,
                                        colBlockDimC, pBuffer)
     initialize_context()
-    @ccall libcusparse.cusparseDgebsr2gebsr(handle::cusparseHandle_t,
-                                            dirA::cusparseDirection_t, mb::Cint, nb::Cint,
-                                            nnzb::Cint, descrA::cusparseMatDescr_t,
-                                            bsrSortedValA::CuPtr{Cdouble},
-                                            bsrSortedRowPtrA::CuPtr{Cint},
-                                            bsrSortedColIndA::CuPtr{Cint},
-                                            rowBlockDimA::Cint, colBlockDimA::Cint,
-                                            descrC::cusparseMatDescr_t,
-                                            bsrSortedValC::CuPtr{Cdouble},
-                                            bsrSortedRowPtrC::CuPtr{Cint},
-                                            bsrSortedColIndC::CuPtr{Cint},
-                                            rowBlockDimC::Cint, colBlockDimC::Cint,
-                                            pBuffer::CuPtr{Cvoid})::cusparseStatus_t
+    @gcsafe_ccall libcusparse.cusparseDgebsr2gebsr(handle::cusparseHandle_t,
+                                                   dirA::cusparseDirection_t, mb::Cint,
+                                                   nb::Cint, nnzb::Cint,
+                                                   descrA::cusparseMatDescr_t,
+                                                   bsrSortedValA::CuPtr{Cdouble},
+                                                   bsrSortedRowPtrA::CuPtr{Cint},
+                                                   bsrSortedColIndA::CuPtr{Cint},
+                                                   rowBlockDimA::Cint, colBlockDimA::Cint,
+                                                   descrC::cusparseMatDescr_t,
+                                                   bsrSortedValC::CuPtr{Cdouble},
+                                                   bsrSortedRowPtrC::CuPtr{Cint},
+                                                   bsrSortedColIndC::CuPtr{Cint},
+                                                   rowBlockDimC::Cint, colBlockDimC::Cint,
+                                                   pBuffer::CuPtr{Cvoid})::cusparseStatus_t
 end
 
 @checked function cusparseCgebsr2gebsr(handle, dirA, mb, nb, nnzb, descrA, bsrSortedValA,
@@ -3979,19 +4245,20 @@ end
                                        bsrSortedRowPtrC, bsrSortedColIndC, rowBlockDimC,
                                        colBlockDimC, pBuffer)
     initialize_context()
-    @ccall libcusparse.cusparseCgebsr2gebsr(handle::cusparseHandle_t,
-                                            dirA::cusparseDirection_t, mb::Cint, nb::Cint,
-                                            nnzb::Cint, descrA::cusparseMatDescr_t,
-                                            bsrSortedValA::CuPtr{cuComplex},
-                                            bsrSortedRowPtrA::CuPtr{Cint},
-                                            bsrSortedColIndA::CuPtr{Cint},
-                                            rowBlockDimA::Cint, colBlockDimA::Cint,
-                                            descrC::cusparseMatDescr_t,
-                                            bsrSortedValC::CuPtr{cuComplex},
-                                            bsrSortedRowPtrC::CuPtr{Cint},
-                                            bsrSortedColIndC::CuPtr{Cint},
-                                            rowBlockDimC::Cint, colBlockDimC::Cint,
-                                            pBuffer::CuPtr{Cvoid})::cusparseStatus_t
+    @gcsafe_ccall libcusparse.cusparseCgebsr2gebsr(handle::cusparseHandle_t,
+                                                   dirA::cusparseDirection_t, mb::Cint,
+                                                   nb::Cint, nnzb::Cint,
+                                                   descrA::cusparseMatDescr_t,
+                                                   bsrSortedValA::CuPtr{cuComplex},
+                                                   bsrSortedRowPtrA::CuPtr{Cint},
+                                                   bsrSortedColIndA::CuPtr{Cint},
+                                                   rowBlockDimA::Cint, colBlockDimA::Cint,
+                                                   descrC::cusparseMatDescr_t,
+                                                   bsrSortedValC::CuPtr{cuComplex},
+                                                   bsrSortedRowPtrC::CuPtr{Cint},
+                                                   bsrSortedColIndC::CuPtr{Cint},
+                                                   rowBlockDimC::Cint, colBlockDimC::Cint,
+                                                   pBuffer::CuPtr{Cvoid})::cusparseStatus_t
 end
 
 @checked function cusparseZgebsr2gebsr(handle, dirA, mb, nb, nnzb, descrA, bsrSortedValA,
@@ -4000,222 +4267,241 @@ end
                                        bsrSortedRowPtrC, bsrSortedColIndC, rowBlockDimC,
                                        colBlockDimC, pBuffer)
     initialize_context()
-    @ccall libcusparse.cusparseZgebsr2gebsr(handle::cusparseHandle_t,
-                                            dirA::cusparseDirection_t, mb::Cint, nb::Cint,
-                                            nnzb::Cint, descrA::cusparseMatDescr_t,
-                                            bsrSortedValA::CuPtr{cuDoubleComplex},
-                                            bsrSortedRowPtrA::CuPtr{Cint},
-                                            bsrSortedColIndA::CuPtr{Cint},
-                                            rowBlockDimA::Cint, colBlockDimA::Cint,
-                                            descrC::cusparseMatDescr_t,
-                                            bsrSortedValC::CuPtr{cuDoubleComplex},
-                                            bsrSortedRowPtrC::CuPtr{Cint},
-                                            bsrSortedColIndC::CuPtr{Cint},
-                                            rowBlockDimC::Cint, colBlockDimC::Cint,
-                                            pBuffer::CuPtr{Cvoid})::cusparseStatus_t
+    @gcsafe_ccall libcusparse.cusparseZgebsr2gebsr(handle::cusparseHandle_t,
+                                                   dirA::cusparseDirection_t, mb::Cint,
+                                                   nb::Cint, nnzb::Cint,
+                                                   descrA::cusparseMatDescr_t,
+                                                   bsrSortedValA::CuPtr{cuDoubleComplex},
+                                                   bsrSortedRowPtrA::CuPtr{Cint},
+                                                   bsrSortedColIndA::CuPtr{Cint},
+                                                   rowBlockDimA::Cint, colBlockDimA::Cint,
+                                                   descrC::cusparseMatDescr_t,
+                                                   bsrSortedValC::CuPtr{cuDoubleComplex},
+                                                   bsrSortedRowPtrC::CuPtr{Cint},
+                                                   bsrSortedColIndC::CuPtr{Cint},
+                                                   rowBlockDimC::Cint, colBlockDimC::Cint,
+                                                   pBuffer::CuPtr{Cvoid})::cusparseStatus_t
 end
 
 @checked function cusparseCreateIdentityPermutation(handle, n, p)
     initialize_context()
-    @ccall libcusparse.cusparseCreateIdentityPermutation(handle::cusparseHandle_t, n::Cint,
-                                                         p::CuPtr{Cint})::cusparseStatus_t
+    @gcsafe_ccall libcusparse.cusparseCreateIdentityPermutation(handle::cusparseHandle_t,
+                                                                n::Cint,
+                                                                p::CuPtr{Cint})::cusparseStatus_t
 end
 
 @checked function cusparseXcoosort_bufferSizeExt(handle, m, n, nnz, cooRowsA, cooColsA,
                                                  pBufferSizeInBytes)
     initialize_context()
-    @ccall libcusparse.cusparseXcoosort_bufferSizeExt(handle::cusparseHandle_t, m::Cint,
-                                                      n::Cint, nnz::Cint,
-                                                      cooRowsA::CuPtr{Cint},
-                                                      cooColsA::CuPtr{Cint},
-                                                      pBufferSizeInBytes::Ptr{Csize_t})::cusparseStatus_t
+    @gcsafe_ccall libcusparse.cusparseXcoosort_bufferSizeExt(handle::cusparseHandle_t,
+                                                             m::Cint, n::Cint, nnz::Cint,
+                                                             cooRowsA::CuPtr{Cint},
+                                                             cooColsA::CuPtr{Cint},
+                                                             pBufferSizeInBytes::Ptr{Csize_t})::cusparseStatus_t
 end
 
 @checked function cusparseXcoosortByRow(handle, m, n, nnz, cooRowsA, cooColsA, P, pBuffer)
     initialize_context()
-    @ccall libcusparse.cusparseXcoosortByRow(handle::cusparseHandle_t, m::Cint, n::Cint,
-                                             nnz::Cint, cooRowsA::CuPtr{Cint},
-                                             cooColsA::CuPtr{Cint}, P::CuPtr{Cint},
-                                             pBuffer::CuPtr{Cvoid})::cusparseStatus_t
+    @gcsafe_ccall libcusparse.cusparseXcoosortByRow(handle::cusparseHandle_t, m::Cint,
+                                                    n::Cint, nnz::Cint,
+                                                    cooRowsA::CuPtr{Cint},
+                                                    cooColsA::CuPtr{Cint}, P::CuPtr{Cint},
+                                                    pBuffer::CuPtr{Cvoid})::cusparseStatus_t
 end
 
 @checked function cusparseXcoosortByColumn(handle, m, n, nnz, cooRowsA, cooColsA, P,
                                            pBuffer)
     initialize_context()
-    @ccall libcusparse.cusparseXcoosortByColumn(handle::cusparseHandle_t, m::Cint, n::Cint,
-                                                nnz::Cint, cooRowsA::CuPtr{Cint},
-                                                cooColsA::CuPtr{Cint}, P::CuPtr{Cint},
-                                                pBuffer::CuPtr{Cvoid})::cusparseStatus_t
+    @gcsafe_ccall libcusparse.cusparseXcoosortByColumn(handle::cusparseHandle_t, m::Cint,
+                                                       n::Cint, nnz::Cint,
+                                                       cooRowsA::CuPtr{Cint},
+                                                       cooColsA::CuPtr{Cint},
+                                                       P::CuPtr{Cint},
+                                                       pBuffer::CuPtr{Cvoid})::cusparseStatus_t
 end
 
 @checked function cusparseXcsrsort_bufferSizeExt(handle, m, n, nnz, csrRowPtrA, csrColIndA,
                                                  pBufferSizeInBytes)
     initialize_context()
-    @ccall libcusparse.cusparseXcsrsort_bufferSizeExt(handle::cusparseHandle_t, m::Cint,
-                                                      n::Cint, nnz::Cint,
-                                                      csrRowPtrA::CuPtr{Cint},
-                                                      csrColIndA::CuPtr{Cint},
-                                                      pBufferSizeInBytes::Ptr{Csize_t})::cusparseStatus_t
+    @gcsafe_ccall libcusparse.cusparseXcsrsort_bufferSizeExt(handle::cusparseHandle_t,
+                                                             m::Cint, n::Cint, nnz::Cint,
+                                                             csrRowPtrA::CuPtr{Cint},
+                                                             csrColIndA::CuPtr{Cint},
+                                                             pBufferSizeInBytes::Ptr{Csize_t})::cusparseStatus_t
 end
 
 @checked function cusparseXcsrsort(handle, m, n, nnz, descrA, csrRowPtrA, csrColIndA, P,
                                    pBuffer)
     initialize_context()
-    @ccall libcusparse.cusparseXcsrsort(handle::cusparseHandle_t, m::Cint, n::Cint,
-                                        nnz::Cint, descrA::cusparseMatDescr_t,
-                                        csrRowPtrA::CuPtr{Cint}, csrColIndA::CuPtr{Cint},
-                                        P::CuPtr{Cint},
-                                        pBuffer::CuPtr{Cvoid})::cusparseStatus_t
+    @gcsafe_ccall libcusparse.cusparseXcsrsort(handle::cusparseHandle_t, m::Cint, n::Cint,
+                                               nnz::Cint, descrA::cusparseMatDescr_t,
+                                               csrRowPtrA::CuPtr{Cint},
+                                               csrColIndA::CuPtr{Cint}, P::CuPtr{Cint},
+                                               pBuffer::CuPtr{Cvoid})::cusparseStatus_t
 end
 
 @checked function cusparseXcscsort_bufferSizeExt(handle, m, n, nnz, cscColPtrA, cscRowIndA,
                                                  pBufferSizeInBytes)
     initialize_context()
-    @ccall libcusparse.cusparseXcscsort_bufferSizeExt(handle::cusparseHandle_t, m::Cint,
-                                                      n::Cint, nnz::Cint,
-                                                      cscColPtrA::CuPtr{Cint},
-                                                      cscRowIndA::CuPtr{Cint},
-                                                      pBufferSizeInBytes::Ptr{Csize_t})::cusparseStatus_t
+    @gcsafe_ccall libcusparse.cusparseXcscsort_bufferSizeExt(handle::cusparseHandle_t,
+                                                             m::Cint, n::Cint, nnz::Cint,
+                                                             cscColPtrA::CuPtr{Cint},
+                                                             cscRowIndA::CuPtr{Cint},
+                                                             pBufferSizeInBytes::Ptr{Csize_t})::cusparseStatus_t
 end
 
 @checked function cusparseXcscsort(handle, m, n, nnz, descrA, cscColPtrA, cscRowIndA, P,
                                    pBuffer)
     initialize_context()
-    @ccall libcusparse.cusparseXcscsort(handle::cusparseHandle_t, m::Cint, n::Cint,
-                                        nnz::Cint, descrA::cusparseMatDescr_t,
-                                        cscColPtrA::CuPtr{Cint}, cscRowIndA::CuPtr{Cint},
-                                        P::CuPtr{Cint},
-                                        pBuffer::CuPtr{Cvoid})::cusparseStatus_t
+    @gcsafe_ccall libcusparse.cusparseXcscsort(handle::cusparseHandle_t, m::Cint, n::Cint,
+                                               nnz::Cint, descrA::cusparseMatDescr_t,
+                                               cscColPtrA::CuPtr{Cint},
+                                               cscRowIndA::CuPtr{Cint}, P::CuPtr{Cint},
+                                               pBuffer::CuPtr{Cvoid})::cusparseStatus_t
 end
 
 @checked function cusparseScsru2csr_bufferSizeExt(handle, m, n, nnz, csrVal, csrRowPtr,
                                                   csrColInd, info, pBufferSizeInBytes)
     initialize_context()
-    @ccall libcusparse.cusparseScsru2csr_bufferSizeExt(handle::cusparseHandle_t, m::Cint,
-                                                       n::Cint, nnz::Cint,
-                                                       csrVal::CuPtr{Cfloat},
-                                                       csrRowPtr::CuPtr{Cint},
-                                                       csrColInd::CuPtr{Cint},
-                                                       info::csru2csrInfo_t,
-                                                       pBufferSizeInBytes::Ptr{Csize_t})::cusparseStatus_t
+    @gcsafe_ccall libcusparse.cusparseScsru2csr_bufferSizeExt(handle::cusparseHandle_t,
+                                                              m::Cint, n::Cint, nnz::Cint,
+                                                              csrVal::CuPtr{Cfloat},
+                                                              csrRowPtr::CuPtr{Cint},
+                                                              csrColInd::CuPtr{Cint},
+                                                              info::csru2csrInfo_t,
+                                                              pBufferSizeInBytes::Ptr{Csize_t})::cusparseStatus_t
 end
 
 @checked function cusparseDcsru2csr_bufferSizeExt(handle, m, n, nnz, csrVal, csrRowPtr,
                                                   csrColInd, info, pBufferSizeInBytes)
     initialize_context()
-    @ccall libcusparse.cusparseDcsru2csr_bufferSizeExt(handle::cusparseHandle_t, m::Cint,
-                                                       n::Cint, nnz::Cint,
-                                                       csrVal::CuPtr{Cdouble},
-                                                       csrRowPtr::CuPtr{Cint},
-                                                       csrColInd::CuPtr{Cint},
-                                                       info::csru2csrInfo_t,
-                                                       pBufferSizeInBytes::Ptr{Csize_t})::cusparseStatus_t
+    @gcsafe_ccall libcusparse.cusparseDcsru2csr_bufferSizeExt(handle::cusparseHandle_t,
+                                                              m::Cint, n::Cint, nnz::Cint,
+                                                              csrVal::CuPtr{Cdouble},
+                                                              csrRowPtr::CuPtr{Cint},
+                                                              csrColInd::CuPtr{Cint},
+                                                              info::csru2csrInfo_t,
+                                                              pBufferSizeInBytes::Ptr{Csize_t})::cusparseStatus_t
 end
 
 @checked function cusparseCcsru2csr_bufferSizeExt(handle, m, n, nnz, csrVal, csrRowPtr,
                                                   csrColInd, info, pBufferSizeInBytes)
     initialize_context()
-    @ccall libcusparse.cusparseCcsru2csr_bufferSizeExt(handle::cusparseHandle_t, m::Cint,
-                                                       n::Cint, nnz::Cint,
-                                                       csrVal::CuPtr{cuComplex},
-                                                       csrRowPtr::CuPtr{Cint},
-                                                       csrColInd::CuPtr{Cint},
-                                                       info::csru2csrInfo_t,
-                                                       pBufferSizeInBytes::Ptr{Csize_t})::cusparseStatus_t
+    @gcsafe_ccall libcusparse.cusparseCcsru2csr_bufferSizeExt(handle::cusparseHandle_t,
+                                                              m::Cint, n::Cint, nnz::Cint,
+                                                              csrVal::CuPtr{cuComplex},
+                                                              csrRowPtr::CuPtr{Cint},
+                                                              csrColInd::CuPtr{Cint},
+                                                              info::csru2csrInfo_t,
+                                                              pBufferSizeInBytes::Ptr{Csize_t})::cusparseStatus_t
 end
 
 @checked function cusparseZcsru2csr_bufferSizeExt(handle, m, n, nnz, csrVal, csrRowPtr,
                                                   csrColInd, info, pBufferSizeInBytes)
     initialize_context()
-    @ccall libcusparse.cusparseZcsru2csr_bufferSizeExt(handle::cusparseHandle_t, m::Cint,
-                                                       n::Cint, nnz::Cint,
-                                                       csrVal::CuPtr{cuDoubleComplex},
-                                                       csrRowPtr::CuPtr{Cint},
-                                                       csrColInd::CuPtr{Cint},
-                                                       info::csru2csrInfo_t,
-                                                       pBufferSizeInBytes::Ptr{Csize_t})::cusparseStatus_t
+    @gcsafe_ccall libcusparse.cusparseZcsru2csr_bufferSizeExt(handle::cusparseHandle_t,
+                                                              m::Cint, n::Cint, nnz::Cint,
+                                                              csrVal::CuPtr{cuDoubleComplex},
+                                                              csrRowPtr::CuPtr{Cint},
+                                                              csrColInd::CuPtr{Cint},
+                                                              info::csru2csrInfo_t,
+                                                              pBufferSizeInBytes::Ptr{Csize_t})::cusparseStatus_t
 end
 
 @checked function cusparseScsru2csr(handle, m, n, nnz, descrA, csrVal, csrRowPtr, csrColInd,
                                     info, pBuffer)
     initialize_context()
-    @ccall libcusparse.cusparseScsru2csr(handle::cusparseHandle_t, m::Cint, n::Cint,
-                                         nnz::Cint, descrA::cusparseMatDescr_t,
-                                         csrVal::CuPtr{Cfloat}, csrRowPtr::CuPtr{Cint},
-                                         csrColInd::CuPtr{Cint}, info::csru2csrInfo_t,
-                                         pBuffer::CuPtr{Cvoid})::cusparseStatus_t
+    @gcsafe_ccall libcusparse.cusparseScsru2csr(handle::cusparseHandle_t, m::Cint, n::Cint,
+                                                nnz::Cint, descrA::cusparseMatDescr_t,
+                                                csrVal::CuPtr{Cfloat},
+                                                csrRowPtr::CuPtr{Cint},
+                                                csrColInd::CuPtr{Cint},
+                                                info::csru2csrInfo_t,
+                                                pBuffer::CuPtr{Cvoid})::cusparseStatus_t
 end
 
 @checked function cusparseDcsru2csr(handle, m, n, nnz, descrA, csrVal, csrRowPtr, csrColInd,
                                     info, pBuffer)
     initialize_context()
-    @ccall libcusparse.cusparseDcsru2csr(handle::cusparseHandle_t, m::Cint, n::Cint,
-                                         nnz::Cint, descrA::cusparseMatDescr_t,
-                                         csrVal::CuPtr{Cdouble}, csrRowPtr::CuPtr{Cint},
-                                         csrColInd::CuPtr{Cint}, info::csru2csrInfo_t,
-                                         pBuffer::CuPtr{Cvoid})::cusparseStatus_t
+    @gcsafe_ccall libcusparse.cusparseDcsru2csr(handle::cusparseHandle_t, m::Cint, n::Cint,
+                                                nnz::Cint, descrA::cusparseMatDescr_t,
+                                                csrVal::CuPtr{Cdouble},
+                                                csrRowPtr::CuPtr{Cint},
+                                                csrColInd::CuPtr{Cint},
+                                                info::csru2csrInfo_t,
+                                                pBuffer::CuPtr{Cvoid})::cusparseStatus_t
 end
 
 @checked function cusparseCcsru2csr(handle, m, n, nnz, descrA, csrVal, csrRowPtr, csrColInd,
                                     info, pBuffer)
     initialize_context()
-    @ccall libcusparse.cusparseCcsru2csr(handle::cusparseHandle_t, m::Cint, n::Cint,
-                                         nnz::Cint, descrA::cusparseMatDescr_t,
-                                         csrVal::CuPtr{cuComplex}, csrRowPtr::CuPtr{Cint},
-                                         csrColInd::CuPtr{Cint}, info::csru2csrInfo_t,
-                                         pBuffer::CuPtr{Cvoid})::cusparseStatus_t
+    @gcsafe_ccall libcusparse.cusparseCcsru2csr(handle::cusparseHandle_t, m::Cint, n::Cint,
+                                                nnz::Cint, descrA::cusparseMatDescr_t,
+                                                csrVal::CuPtr{cuComplex},
+                                                csrRowPtr::CuPtr{Cint},
+                                                csrColInd::CuPtr{Cint},
+                                                info::csru2csrInfo_t,
+                                                pBuffer::CuPtr{Cvoid})::cusparseStatus_t
 end
 
 @checked function cusparseZcsru2csr(handle, m, n, nnz, descrA, csrVal, csrRowPtr, csrColInd,
                                     info, pBuffer)
     initialize_context()
-    @ccall libcusparse.cusparseZcsru2csr(handle::cusparseHandle_t, m::Cint, n::Cint,
-                                         nnz::Cint, descrA::cusparseMatDescr_t,
-                                         csrVal::CuPtr{cuDoubleComplex},
-                                         csrRowPtr::CuPtr{Cint}, csrColInd::CuPtr{Cint},
-                                         info::csru2csrInfo_t,
-                                         pBuffer::CuPtr{Cvoid})::cusparseStatus_t
+    @gcsafe_ccall libcusparse.cusparseZcsru2csr(handle::cusparseHandle_t, m::Cint, n::Cint,
+                                                nnz::Cint, descrA::cusparseMatDescr_t,
+                                                csrVal::CuPtr{cuDoubleComplex},
+                                                csrRowPtr::CuPtr{Cint},
+                                                csrColInd::CuPtr{Cint},
+                                                info::csru2csrInfo_t,
+                                                pBuffer::CuPtr{Cvoid})::cusparseStatus_t
 end
 
 @checked function cusparseScsr2csru(handle, m, n, nnz, descrA, csrVal, csrRowPtr, csrColInd,
                                     info, pBuffer)
     initialize_context()
-    @ccall libcusparse.cusparseScsr2csru(handle::cusparseHandle_t, m::Cint, n::Cint,
-                                         nnz::Cint, descrA::cusparseMatDescr_t,
-                                         csrVal::CuPtr{Cfloat}, csrRowPtr::CuPtr{Cint},
-                                         csrColInd::CuPtr{Cint}, info::csru2csrInfo_t,
-                                         pBuffer::CuPtr{Cvoid})::cusparseStatus_t
+    @gcsafe_ccall libcusparse.cusparseScsr2csru(handle::cusparseHandle_t, m::Cint, n::Cint,
+                                                nnz::Cint, descrA::cusparseMatDescr_t,
+                                                csrVal::CuPtr{Cfloat},
+                                                csrRowPtr::CuPtr{Cint},
+                                                csrColInd::CuPtr{Cint},
+                                                info::csru2csrInfo_t,
+                                                pBuffer::CuPtr{Cvoid})::cusparseStatus_t
 end
 
 @checked function cusparseDcsr2csru(handle, m, n, nnz, descrA, csrVal, csrRowPtr, csrColInd,
                                     info, pBuffer)
     initialize_context()
-    @ccall libcusparse.cusparseDcsr2csru(handle::cusparseHandle_t, m::Cint, n::Cint,
-                                         nnz::Cint, descrA::cusparseMatDescr_t,
-                                         csrVal::CuPtr{Cdouble}, csrRowPtr::CuPtr{Cint},
-                                         csrColInd::CuPtr{Cint}, info::csru2csrInfo_t,
-                                         pBuffer::CuPtr{Cvoid})::cusparseStatus_t
+    @gcsafe_ccall libcusparse.cusparseDcsr2csru(handle::cusparseHandle_t, m::Cint, n::Cint,
+                                                nnz::Cint, descrA::cusparseMatDescr_t,
+                                                csrVal::CuPtr{Cdouble},
+                                                csrRowPtr::CuPtr{Cint},
+                                                csrColInd::CuPtr{Cint},
+                                                info::csru2csrInfo_t,
+                                                pBuffer::CuPtr{Cvoid})::cusparseStatus_t
 end
 
 @checked function cusparseCcsr2csru(handle, m, n, nnz, descrA, csrVal, csrRowPtr, csrColInd,
                                     info, pBuffer)
     initialize_context()
-    @ccall libcusparse.cusparseCcsr2csru(handle::cusparseHandle_t, m::Cint, n::Cint,
-                                         nnz::Cint, descrA::cusparseMatDescr_t,
-                                         csrVal::CuPtr{cuComplex}, csrRowPtr::CuPtr{Cint},
-                                         csrColInd::CuPtr{Cint}, info::csru2csrInfo_t,
-                                         pBuffer::CuPtr{Cvoid})::cusparseStatus_t
+    @gcsafe_ccall libcusparse.cusparseCcsr2csru(handle::cusparseHandle_t, m::Cint, n::Cint,
+                                                nnz::Cint, descrA::cusparseMatDescr_t,
+                                                csrVal::CuPtr{cuComplex},
+                                                csrRowPtr::CuPtr{Cint},
+                                                csrColInd::CuPtr{Cint},
+                                                info::csru2csrInfo_t,
+                                                pBuffer::CuPtr{Cvoid})::cusparseStatus_t
 end
 
 @checked function cusparseZcsr2csru(handle, m, n, nnz, descrA, csrVal, csrRowPtr, csrColInd,
                                     info, pBuffer)
     initialize_context()
-    @ccall libcusparse.cusparseZcsr2csru(handle::cusparseHandle_t, m::Cint, n::Cint,
-                                         nnz::Cint, descrA::cusparseMatDescr_t,
-                                         csrVal::CuPtr{cuDoubleComplex},
-                                         csrRowPtr::CuPtr{Cint}, csrColInd::CuPtr{Cint},
-                                         info::csru2csrInfo_t,
-                                         pBuffer::CuPtr{Cvoid})::cusparseStatus_t
+    @gcsafe_ccall libcusparse.cusparseZcsr2csru(handle::cusparseHandle_t, m::Cint, n::Cint,
+                                                nnz::Cint, descrA::cusparseMatDescr_t,
+                                                csrVal::CuPtr{cuDoubleComplex},
+                                                csrRowPtr::CuPtr{Cint},
+                                                csrColInd::CuPtr{Cint},
+                                                info::csru2csrInfo_t,
+                                                pBuffer::CuPtr{Cvoid})::cusparseStatus_t
 end
 
 @checked function cusparseSpruneDense2csr_bufferSizeExt(handle, m, n, A, lda, threshold,
@@ -4223,15 +4509,16 @@ end
                                                         csrSortedRowPtrC, csrSortedColIndC,
                                                         pBufferSizeInBytes)
     initialize_context()
-    @ccall libcusparse.cusparseSpruneDense2csr_bufferSizeExt(handle::cusparseHandle_t,
-                                                             m::Cint, n::Cint,
-                                                             A::CuPtr{Cfloat}, lda::Cint,
-                                                             threshold::Ptr{Cfloat},
-                                                             descrC::cusparseMatDescr_t,
-                                                             csrSortedValC::CuPtr{Cfloat},
-                                                             csrSortedRowPtrC::CuPtr{Cint},
-                                                             csrSortedColIndC::CuPtr{Cint},
-                                                             pBufferSizeInBytes::Ptr{Csize_t})::cusparseStatus_t
+    @gcsafe_ccall libcusparse.cusparseSpruneDense2csr_bufferSizeExt(handle::cusparseHandle_t,
+                                                                    m::Cint, n::Cint,
+                                                                    A::CuPtr{Cfloat},
+                                                                    lda::Cint,
+                                                                    threshold::Ptr{Cfloat},
+                                                                    descrC::cusparseMatDescr_t,
+                                                                    csrSortedValC::CuPtr{Cfloat},
+                                                                    csrSortedRowPtrC::CuPtr{Cint},
+                                                                    csrSortedColIndC::CuPtr{Cint},
+                                                                    pBufferSizeInBytes::Ptr{Csize_t})::cusparseStatus_t
 end
 
 @checked function cusparseDpruneDense2csr_bufferSizeExt(handle, m, n, A, lda, threshold,
@@ -4239,67 +4526,68 @@ end
                                                         csrSortedRowPtrC, csrSortedColIndC,
                                                         pBufferSizeInBytes)
     initialize_context()
-    @ccall libcusparse.cusparseDpruneDense2csr_bufferSizeExt(handle::cusparseHandle_t,
-                                                             m::Cint, n::Cint,
-                                                             A::CuPtr{Cdouble}, lda::Cint,
-                                                             threshold::Ptr{Cdouble},
-                                                             descrC::cusparseMatDescr_t,
-                                                             csrSortedValC::CuPtr{Cdouble},
-                                                             csrSortedRowPtrC::CuPtr{Cint},
-                                                             csrSortedColIndC::CuPtr{Cint},
-                                                             pBufferSizeInBytes::Ptr{Csize_t})::cusparseStatus_t
+    @gcsafe_ccall libcusparse.cusparseDpruneDense2csr_bufferSizeExt(handle::cusparseHandle_t,
+                                                                    m::Cint, n::Cint,
+                                                                    A::CuPtr{Cdouble},
+                                                                    lda::Cint,
+                                                                    threshold::Ptr{Cdouble},
+                                                                    descrC::cusparseMatDescr_t,
+                                                                    csrSortedValC::CuPtr{Cdouble},
+                                                                    csrSortedRowPtrC::CuPtr{Cint},
+                                                                    csrSortedColIndC::CuPtr{Cint},
+                                                                    pBufferSizeInBytes::Ptr{Csize_t})::cusparseStatus_t
 end
 
 @checked function cusparseSpruneDense2csrNnz(handle, m, n, A, lda, threshold, descrC,
                                              csrRowPtrC, nnzTotalDevHostPtr, pBuffer)
     initialize_context()
-    @ccall libcusparse.cusparseSpruneDense2csrNnz(handle::cusparseHandle_t, m::Cint,
-                                                  n::Cint, A::CuPtr{Cfloat}, lda::Cint,
-                                                  threshold::Ptr{Cfloat},
-                                                  descrC::cusparseMatDescr_t,
-                                                  csrRowPtrC::CuPtr{Cint},
-                                                  nnzTotalDevHostPtr::PtrOrCuPtr{Cint},
-                                                  pBuffer::CuPtr{Cvoid})::cusparseStatus_t
+    @gcsafe_ccall libcusparse.cusparseSpruneDense2csrNnz(handle::cusparseHandle_t, m::Cint,
+                                                         n::Cint, A::CuPtr{Cfloat},
+                                                         lda::Cint, threshold::Ptr{Cfloat},
+                                                         descrC::cusparseMatDescr_t,
+                                                         csrRowPtrC::CuPtr{Cint},
+                                                         nnzTotalDevHostPtr::PtrOrCuPtr{Cint},
+                                                         pBuffer::CuPtr{Cvoid})::cusparseStatus_t
 end
 
 @checked function cusparseDpruneDense2csrNnz(handle, m, n, A, lda, threshold, descrC,
                                              csrSortedRowPtrC, nnzTotalDevHostPtr, pBuffer)
     initialize_context()
-    @ccall libcusparse.cusparseDpruneDense2csrNnz(handle::cusparseHandle_t, m::Cint,
-                                                  n::Cint, A::CuPtr{Cdouble}, lda::Cint,
-                                                  threshold::Ptr{Cdouble},
-                                                  descrC::cusparseMatDescr_t,
-                                                  csrSortedRowPtrC::CuPtr{Cint},
-                                                  nnzTotalDevHostPtr::PtrOrCuPtr{Cint},
-                                                  pBuffer::CuPtr{Cvoid})::cusparseStatus_t
+    @gcsafe_ccall libcusparse.cusparseDpruneDense2csrNnz(handle::cusparseHandle_t, m::Cint,
+                                                         n::Cint, A::CuPtr{Cdouble},
+                                                         lda::Cint, threshold::Ptr{Cdouble},
+                                                         descrC::cusparseMatDescr_t,
+                                                         csrSortedRowPtrC::CuPtr{Cint},
+                                                         nnzTotalDevHostPtr::PtrOrCuPtr{Cint},
+                                                         pBuffer::CuPtr{Cvoid})::cusparseStatus_t
 end
 
 @checked function cusparseSpruneDense2csr(handle, m, n, A, lda, threshold, descrC,
                                           csrSortedValC, csrSortedRowPtrC, csrSortedColIndC,
                                           pBuffer)
     initialize_context()
-    @ccall libcusparse.cusparseSpruneDense2csr(handle::cusparseHandle_t, m::Cint, n::Cint,
-                                               A::CuPtr{Cfloat}, lda::Cint,
-                                               threshold::Ptr{Cfloat},
-                                               descrC::cusparseMatDescr_t,
-                                               csrSortedValC::CuPtr{Cfloat},
-                                               csrSortedRowPtrC::CuPtr{Cint},
-                                               csrSortedColIndC::CuPtr{Cint},
-                                               pBuffer::CuPtr{Cvoid})::cusparseStatus_t
+    @gcsafe_ccall libcusparse.cusparseSpruneDense2csr(handle::cusparseHandle_t, m::Cint,
+                                                      n::Cint, A::CuPtr{Cfloat}, lda::Cint,
+                                                      threshold::Ptr{Cfloat},
+                                                      descrC::cusparseMatDescr_t,
+                                                      csrSortedValC::CuPtr{Cfloat},
+                                                      csrSortedRowPtrC::CuPtr{Cint},
+                                                      csrSortedColIndC::CuPtr{Cint},
+                                                      pBuffer::CuPtr{Cvoid})::cusparseStatus_t
 end
 
 @checked function cusparseDpruneDense2csr(handle, m, n, A, lda, threshold, descrC,
                                           csrSortedValC, csrSortedRowPtrC, csrSortedColIndC,
                                           pBuffer)
     initialize_context()
-    @ccall libcusparse.cusparseDpruneDense2csr(handle::cusparseHandle_t, m::Cint, n::Cint,
-                                               A::CuPtr{Cdouble}, lda::Cint,
-                                               threshold::Ptr{Cdouble},
-                                               descrC::cusparseMatDescr_t,
-                                               csrSortedValC::CuPtr{Cdouble},
-                                               csrSortedRowPtrC::CuPtr{Cint},
-                                               csrSortedColIndC::CuPtr{Cint},
-                                               pBuffer::CuPtr{Cvoid})::cusparseStatus_t
+    @gcsafe_ccall libcusparse.cusparseDpruneDense2csr(handle::cusparseHandle_t, m::Cint,
+                                                      n::Cint, A::CuPtr{Cdouble}, lda::Cint,
+                                                      threshold::Ptr{Cdouble},
+                                                      descrC::cusparseMatDescr_t,
+                                                      csrSortedValC::CuPtr{Cdouble},
+                                                      csrSortedRowPtrC::CuPtr{Cint},
+                                                      csrSortedColIndC::CuPtr{Cint},
+                                                      pBuffer::CuPtr{Cvoid})::cusparseStatus_t
 end
 
 @checked function cusparseSpruneCsr2csr_bufferSizeExt(handle, m, n, nnzA, descrA,
@@ -4308,18 +4596,19 @@ end
                                                       csrSortedValC, csrSortedRowPtrC,
                                                       csrSortedColIndC, pBufferSizeInBytes)
     initialize_context()
-    @ccall libcusparse.cusparseSpruneCsr2csr_bufferSizeExt(handle::cusparseHandle_t,
-                                                           m::Cint, n::Cint, nnzA::Cint,
-                                                           descrA::cusparseMatDescr_t,
-                                                           csrSortedValA::CuPtr{Cfloat},
-                                                           csrSortedRowPtrA::CuPtr{Cint},
-                                                           csrSortedColIndA::CuPtr{Cint},
-                                                           threshold::Ptr{Cfloat},
-                                                           descrC::cusparseMatDescr_t,
-                                                           csrSortedValC::CuPtr{Cfloat},
-                                                           csrSortedRowPtrC::CuPtr{Cint},
-                                                           csrSortedColIndC::CuPtr{Cint},
-                                                           pBufferSizeInBytes::Ptr{Csize_t})::cusparseStatus_t
+    @gcsafe_ccall libcusparse.cusparseSpruneCsr2csr_bufferSizeExt(handle::cusparseHandle_t,
+                                                                  m::Cint, n::Cint,
+                                                                  nnzA::Cint,
+                                                                  descrA::cusparseMatDescr_t,
+                                                                  csrSortedValA::CuPtr{Cfloat},
+                                                                  csrSortedRowPtrA::CuPtr{Cint},
+                                                                  csrSortedColIndA::CuPtr{Cint},
+                                                                  threshold::Ptr{Cfloat},
+                                                                  descrC::cusparseMatDescr_t,
+                                                                  csrSortedValC::CuPtr{Cfloat},
+                                                                  csrSortedRowPtrC::CuPtr{Cint},
+                                                                  csrSortedColIndC::CuPtr{Cint},
+                                                                  pBufferSizeInBytes::Ptr{Csize_t})::cusparseStatus_t
 end
 
 @checked function cusparseDpruneCsr2csr_bufferSizeExt(handle, m, n, nnzA, descrA,
@@ -4328,18 +4617,19 @@ end
                                                       csrSortedValC, csrSortedRowPtrC,
                                                       csrSortedColIndC, pBufferSizeInBytes)
     initialize_context()
-    @ccall libcusparse.cusparseDpruneCsr2csr_bufferSizeExt(handle::cusparseHandle_t,
-                                                           m::Cint, n::Cint, nnzA::Cint,
-                                                           descrA::cusparseMatDescr_t,
-                                                           csrSortedValA::CuPtr{Cdouble},
-                                                           csrSortedRowPtrA::CuPtr{Cint},
-                                                           csrSortedColIndA::CuPtr{Cint},
-                                                           threshold::Ptr{Cdouble},
-                                                           descrC::cusparseMatDescr_t,
-                                                           csrSortedValC::CuPtr{Cdouble},
-                                                           csrSortedRowPtrC::CuPtr{Cint},
-                                                           csrSortedColIndC::CuPtr{Cint},
-                                                           pBufferSizeInBytes::Ptr{Csize_t})::cusparseStatus_t
+    @gcsafe_ccall libcusparse.cusparseDpruneCsr2csr_bufferSizeExt(handle::cusparseHandle_t,
+                                                                  m::Cint, n::Cint,
+                                                                  nnzA::Cint,
+                                                                  descrA::cusparseMatDescr_t,
+                                                                  csrSortedValA::CuPtr{Cdouble},
+                                                                  csrSortedRowPtrA::CuPtr{Cint},
+                                                                  csrSortedColIndA::CuPtr{Cint},
+                                                                  threshold::Ptr{Cdouble},
+                                                                  descrC::cusparseMatDescr_t,
+                                                                  csrSortedValC::CuPtr{Cdouble},
+                                                                  csrSortedRowPtrC::CuPtr{Cint},
+                                                                  csrSortedColIndC::CuPtr{Cint},
+                                                                  pBufferSizeInBytes::Ptr{Csize_t})::cusparseStatus_t
 end
 
 @checked function cusparseSpruneCsr2csrNnz(handle, m, n, nnzA, descrA, csrSortedValA,
@@ -4347,16 +4637,17 @@ end
                                            descrC, csrSortedRowPtrC, nnzTotalDevHostPtr,
                                            pBuffer)
     initialize_context()
-    @ccall libcusparse.cusparseSpruneCsr2csrNnz(handle::cusparseHandle_t, m::Cint, n::Cint,
-                                                nnzA::Cint, descrA::cusparseMatDescr_t,
-                                                csrSortedValA::CuPtr{Cfloat},
-                                                csrSortedRowPtrA::CuPtr{Cint},
-                                                csrSortedColIndA::CuPtr{Cint},
-                                                threshold::Ptr{Cfloat},
-                                                descrC::cusparseMatDescr_t,
-                                                csrSortedRowPtrC::CuPtr{Cint},
-                                                nnzTotalDevHostPtr::PtrOrCuPtr{Cint},
-                                                pBuffer::CuPtr{Cvoid})::cusparseStatus_t
+    @gcsafe_ccall libcusparse.cusparseSpruneCsr2csrNnz(handle::cusparseHandle_t, m::Cint,
+                                                       n::Cint, nnzA::Cint,
+                                                       descrA::cusparseMatDescr_t,
+                                                       csrSortedValA::CuPtr{Cfloat},
+                                                       csrSortedRowPtrA::CuPtr{Cint},
+                                                       csrSortedColIndA::CuPtr{Cint},
+                                                       threshold::Ptr{Cfloat},
+                                                       descrC::cusparseMatDescr_t,
+                                                       csrSortedRowPtrC::CuPtr{Cint},
+                                                       nnzTotalDevHostPtr::PtrOrCuPtr{Cint},
+                                                       pBuffer::CuPtr{Cvoid})::cusparseStatus_t
 end
 
 @checked function cusparseDpruneCsr2csrNnz(handle, m, n, nnzA, descrA, csrSortedValA,
@@ -4364,16 +4655,17 @@ end
                                            descrC, csrSortedRowPtrC, nnzTotalDevHostPtr,
                                            pBuffer)
     initialize_context()
-    @ccall libcusparse.cusparseDpruneCsr2csrNnz(handle::cusparseHandle_t, m::Cint, n::Cint,
-                                                nnzA::Cint, descrA::cusparseMatDescr_t,
-                                                csrSortedValA::CuPtr{Cdouble},
-                                                csrSortedRowPtrA::CuPtr{Cint},
-                                                csrSortedColIndA::CuPtr{Cint},
-                                                threshold::Ptr{Cdouble},
-                                                descrC::cusparseMatDescr_t,
-                                                csrSortedRowPtrC::CuPtr{Cint},
-                                                nnzTotalDevHostPtr::PtrOrCuPtr{Cint},
-                                                pBuffer::CuPtr{Cvoid})::cusparseStatus_t
+    @gcsafe_ccall libcusparse.cusparseDpruneCsr2csrNnz(handle::cusparseHandle_t, m::Cint,
+                                                       n::Cint, nnzA::Cint,
+                                                       descrA::cusparseMatDescr_t,
+                                                       csrSortedValA::CuPtr{Cdouble},
+                                                       csrSortedRowPtrA::CuPtr{Cint},
+                                                       csrSortedColIndA::CuPtr{Cint},
+                                                       threshold::Ptr{Cdouble},
+                                                       descrC::cusparseMatDescr_t,
+                                                       csrSortedRowPtrC::CuPtr{Cint},
+                                                       nnzTotalDevHostPtr::PtrOrCuPtr{Cint},
+                                                       pBuffer::CuPtr{Cvoid})::cusparseStatus_t
 end
 
 @checked function cusparseSpruneCsr2csr(handle, m, n, nnzA, descrA, csrSortedValA,
@@ -4381,17 +4673,18 @@ end
                                         descrC, csrSortedValC, csrSortedRowPtrC,
                                         csrSortedColIndC, pBuffer)
     initialize_context()
-    @ccall libcusparse.cusparseSpruneCsr2csr(handle::cusparseHandle_t, m::Cint, n::Cint,
-                                             nnzA::Cint, descrA::cusparseMatDescr_t,
-                                             csrSortedValA::CuPtr{Cfloat},
-                                             csrSortedRowPtrA::CuPtr{Cint},
-                                             csrSortedColIndA::CuPtr{Cint},
-                                             threshold::Ptr{Cfloat},
-                                             descrC::cusparseMatDescr_t,
-                                             csrSortedValC::CuPtr{Cfloat},
-                                             csrSortedRowPtrC::CuPtr{Cint},
-                                             csrSortedColIndC::CuPtr{Cint},
-                                             pBuffer::CuPtr{Cvoid})::cusparseStatus_t
+    @gcsafe_ccall libcusparse.cusparseSpruneCsr2csr(handle::cusparseHandle_t, m::Cint,
+                                                    n::Cint, nnzA::Cint,
+                                                    descrA::cusparseMatDescr_t,
+                                                    csrSortedValA::CuPtr{Cfloat},
+                                                    csrSortedRowPtrA::CuPtr{Cint},
+                                                    csrSortedColIndA::CuPtr{Cint},
+                                                    threshold::Ptr{Cfloat},
+                                                    descrC::cusparseMatDescr_t,
+                                                    csrSortedValC::CuPtr{Cfloat},
+                                                    csrSortedRowPtrC::CuPtr{Cint},
+                                                    csrSortedColIndC::CuPtr{Cint},
+                                                    pBuffer::CuPtr{Cvoid})::cusparseStatus_t
 end
 
 @checked function cusparseDpruneCsr2csr(handle, m, n, nnzA, descrA, csrSortedValA,
@@ -4399,17 +4692,18 @@ end
                                         descrC, csrSortedValC, csrSortedRowPtrC,
                                         csrSortedColIndC, pBuffer)
     initialize_context()
-    @ccall libcusparse.cusparseDpruneCsr2csr(handle::cusparseHandle_t, m::Cint, n::Cint,
-                                             nnzA::Cint, descrA::cusparseMatDescr_t,
-                                             csrSortedValA::CuPtr{Cdouble},
-                                             csrSortedRowPtrA::CuPtr{Cint},
-                                             csrSortedColIndA::CuPtr{Cint},
-                                             threshold::Ptr{Cdouble},
-                                             descrC::cusparseMatDescr_t,
-                                             csrSortedValC::CuPtr{Cdouble},
-                                             csrSortedRowPtrC::CuPtr{Cint},
-                                             csrSortedColIndC::CuPtr{Cint},
-                                             pBuffer::CuPtr{Cvoid})::cusparseStatus_t
+    @gcsafe_ccall libcusparse.cusparseDpruneCsr2csr(handle::cusparseHandle_t, m::Cint,
+                                                    n::Cint, nnzA::Cint,
+                                                    descrA::cusparseMatDescr_t,
+                                                    csrSortedValA::CuPtr{Cdouble},
+                                                    csrSortedRowPtrA::CuPtr{Cint},
+                                                    csrSortedColIndA::CuPtr{Cint},
+                                                    threshold::Ptr{Cdouble},
+                                                    descrC::cusparseMatDescr_t,
+                                                    csrSortedValC::CuPtr{Cdouble},
+                                                    csrSortedRowPtrC::CuPtr{Cint},
+                                                    csrSortedColIndC::CuPtr{Cint},
+                                                    pBuffer::CuPtr{Cvoid})::cusparseStatus_t
 end
 
 @checked function cusparseSpruneDense2csrByPercentage_bufferSizeExt(handle, m, n, A, lda,
@@ -4419,17 +4713,18 @@ end
                                                                     csrSortedColIndC, info,
                                                                     pBufferSizeInBytes)
     initialize_context()
-    @ccall libcusparse.cusparseSpruneDense2csrByPercentage_bufferSizeExt(handle::cusparseHandle_t,
-                                                                         m::Cint, n::Cint,
-                                                                         A::CuPtr{Cfloat},
-                                                                         lda::Cint,
-                                                                         percentage::Cfloat,
-                                                                         descrC::cusparseMatDescr_t,
-                                                                         csrSortedValC::CuPtr{Cfloat},
-                                                                         csrSortedRowPtrC::CuPtr{Cint},
-                                                                         csrSortedColIndC::CuPtr{Cint},
-                                                                         info::pruneInfo_t,
-                                                                         pBufferSizeInBytes::Ptr{Csize_t})::cusparseStatus_t
+    @gcsafe_ccall libcusparse.cusparseSpruneDense2csrByPercentage_bufferSizeExt(handle::cusparseHandle_t,
+                                                                                m::Cint,
+                                                                                n::Cint,
+                                                                                A::CuPtr{Cfloat},
+                                                                                lda::Cint,
+                                                                                percentage::Cfloat,
+                                                                                descrC::cusparseMatDescr_t,
+                                                                                csrSortedValC::CuPtr{Cfloat},
+                                                                                csrSortedRowPtrC::CuPtr{Cint},
+                                                                                csrSortedColIndC::CuPtr{Cint},
+                                                                                info::pruneInfo_t,
+                                                                                pBufferSizeInBytes::Ptr{Csize_t})::cusparseStatus_t
 end
 
 @checked function cusparseDpruneDense2csrByPercentage_bufferSizeExt(handle, m, n, A, lda,
@@ -4439,47 +4734,50 @@ end
                                                                     csrSortedColIndC, info,
                                                                     pBufferSizeInBytes)
     initialize_context()
-    @ccall libcusparse.cusparseDpruneDense2csrByPercentage_bufferSizeExt(handle::cusparseHandle_t,
-                                                                         m::Cint, n::Cint,
-                                                                         A::CuPtr{Cdouble},
-                                                                         lda::Cint,
-                                                                         percentage::Cfloat,
-                                                                         descrC::cusparseMatDescr_t,
-                                                                         csrSortedValC::CuPtr{Cdouble},
-                                                                         csrSortedRowPtrC::CuPtr{Cint},
-                                                                         csrSortedColIndC::CuPtr{Cint},
-                                                                         info::pruneInfo_t,
-                                                                         pBufferSizeInBytes::Ptr{Csize_t})::cusparseStatus_t
+    @gcsafe_ccall libcusparse.cusparseDpruneDense2csrByPercentage_bufferSizeExt(handle::cusparseHandle_t,
+                                                                                m::Cint,
+                                                                                n::Cint,
+                                                                                A::CuPtr{Cdouble},
+                                                                                lda::Cint,
+                                                                                percentage::Cfloat,
+                                                                                descrC::cusparseMatDescr_t,
+                                                                                csrSortedValC::CuPtr{Cdouble},
+                                                                                csrSortedRowPtrC::CuPtr{Cint},
+                                                                                csrSortedColIndC::CuPtr{Cint},
+                                                                                info::pruneInfo_t,
+                                                                                pBufferSizeInBytes::Ptr{Csize_t})::cusparseStatus_t
 end
 
 @checked function cusparseSpruneDense2csrNnzByPercentage(handle, m, n, A, lda, percentage,
                                                          descrC, csrRowPtrC,
                                                          nnzTotalDevHostPtr, info, pBuffer)
     initialize_context()
-    @ccall libcusparse.cusparseSpruneDense2csrNnzByPercentage(handle::cusparseHandle_t,
-                                                              m::Cint, n::Cint,
-                                                              A::CuPtr{Cfloat}, lda::Cint,
-                                                              percentage::Cfloat,
-                                                              descrC::cusparseMatDescr_t,
-                                                              csrRowPtrC::CuPtr{Cint},
-                                                              nnzTotalDevHostPtr::PtrOrCuPtr{Cint},
-                                                              info::pruneInfo_t,
-                                                              pBuffer::CuPtr{Cvoid})::cusparseStatus_t
+    @gcsafe_ccall libcusparse.cusparseSpruneDense2csrNnzByPercentage(handle::cusparseHandle_t,
+                                                                     m::Cint, n::Cint,
+                                                                     A::CuPtr{Cfloat},
+                                                                     lda::Cint,
+                                                                     percentage::Cfloat,
+                                                                     descrC::cusparseMatDescr_t,
+                                                                     csrRowPtrC::CuPtr{Cint},
+                                                                     nnzTotalDevHostPtr::PtrOrCuPtr{Cint},
+                                                                     info::pruneInfo_t,
+                                                                     pBuffer::CuPtr{Cvoid})::cusparseStatus_t
 end
 
 @checked function cusparseDpruneDense2csrNnzByPercentage(handle, m, n, A, lda, percentage,
                                                          descrC, csrRowPtrC,
                                                          nnzTotalDevHostPtr, info, pBuffer)
     initialize_context()
-    @ccall libcusparse.cusparseDpruneDense2csrNnzByPercentage(handle::cusparseHandle_t,
-                                                              m::Cint, n::Cint,
-                                                              A::CuPtr{Cdouble}, lda::Cint,
-                                                              percentage::Cfloat,
-                                                              descrC::cusparseMatDescr_t,
-                                                              csrRowPtrC::CuPtr{Cint},
-                                                              nnzTotalDevHostPtr::PtrOrCuPtr{Cint},
-                                                              info::pruneInfo_t,
-                                                              pBuffer::CuPtr{Cvoid})::cusparseStatus_t
+    @gcsafe_ccall libcusparse.cusparseDpruneDense2csrNnzByPercentage(handle::cusparseHandle_t,
+                                                                     m::Cint, n::Cint,
+                                                                     A::CuPtr{Cdouble},
+                                                                     lda::Cint,
+                                                                     percentage::Cfloat,
+                                                                     descrC::cusparseMatDescr_t,
+                                                                     csrRowPtrC::CuPtr{Cint},
+                                                                     nnzTotalDevHostPtr::PtrOrCuPtr{Cint},
+                                                                     info::pruneInfo_t,
+                                                                     pBuffer::CuPtr{Cvoid})::cusparseStatus_t
 end
 
 @checked function cusparseSpruneDense2csrByPercentage(handle, m, n, A, lda, percentage,
@@ -4487,16 +4785,17 @@ end
                                                       csrSortedRowPtrC, csrSortedColIndC,
                                                       info, pBuffer)
     initialize_context()
-    @ccall libcusparse.cusparseSpruneDense2csrByPercentage(handle::cusparseHandle_t,
-                                                           m::Cint, n::Cint,
-                                                           A::CuPtr{Cfloat}, lda::Cint,
-                                                           percentage::Cfloat,
-                                                           descrC::cusparseMatDescr_t,
-                                                           csrSortedValC::CuPtr{Cfloat},
-                                                           csrSortedRowPtrC::CuPtr{Cint},
-                                                           csrSortedColIndC::CuPtr{Cint},
-                                                           info::pruneInfo_t,
-                                                           pBuffer::CuPtr{Cvoid})::cusparseStatus_t
+    @gcsafe_ccall libcusparse.cusparseSpruneDense2csrByPercentage(handle::cusparseHandle_t,
+                                                                  m::Cint, n::Cint,
+                                                                  A::CuPtr{Cfloat},
+                                                                  lda::Cint,
+                                                                  percentage::Cfloat,
+                                                                  descrC::cusparseMatDescr_t,
+                                                                  csrSortedValC::CuPtr{Cfloat},
+                                                                  csrSortedRowPtrC::CuPtr{Cint},
+                                                                  csrSortedColIndC::CuPtr{Cint},
+                                                                  info::pruneInfo_t,
+                                                                  pBuffer::CuPtr{Cvoid})::cusparseStatus_t
 end
 
 @checked function cusparseDpruneDense2csrByPercentage(handle, m, n, A, lda, percentage,
@@ -4504,16 +4803,17 @@ end
                                                       csrSortedRowPtrC, csrSortedColIndC,
                                                       info, pBuffer)
     initialize_context()
-    @ccall libcusparse.cusparseDpruneDense2csrByPercentage(handle::cusparseHandle_t,
-                                                           m::Cint, n::Cint,
-                                                           A::CuPtr{Cdouble}, lda::Cint,
-                                                           percentage::Cfloat,
-                                                           descrC::cusparseMatDescr_t,
-                                                           csrSortedValC::CuPtr{Cdouble},
-                                                           csrSortedRowPtrC::CuPtr{Cint},
-                                                           csrSortedColIndC::CuPtr{Cint},
-                                                           info::pruneInfo_t,
-                                                           pBuffer::CuPtr{Cvoid})::cusparseStatus_t
+    @gcsafe_ccall libcusparse.cusparseDpruneDense2csrByPercentage(handle::cusparseHandle_t,
+                                                                  m::Cint, n::Cint,
+                                                                  A::CuPtr{Cdouble},
+                                                                  lda::Cint,
+                                                                  percentage::Cfloat,
+                                                                  descrC::cusparseMatDescr_t,
+                                                                  csrSortedValC::CuPtr{Cdouble},
+                                                                  csrSortedRowPtrC::CuPtr{Cint},
+                                                                  csrSortedColIndC::CuPtr{Cint},
+                                                                  info::pruneInfo_t,
+                                                                  pBuffer::CuPtr{Cvoid})::cusparseStatus_t
 end
 
 @checked function cusparseSpruneCsr2csrByPercentage_bufferSizeExt(handle, m, n, nnzA,
@@ -4526,20 +4826,21 @@ end
                                                                   csrSortedColIndC, info,
                                                                   pBufferSizeInBytes)
     initialize_context()
-    @ccall libcusparse.cusparseSpruneCsr2csrByPercentage_bufferSizeExt(handle::cusparseHandle_t,
-                                                                       m::Cint, n::Cint,
-                                                                       nnzA::Cint,
-                                                                       descrA::cusparseMatDescr_t,
-                                                                       csrSortedValA::CuPtr{Cfloat},
-                                                                       csrSortedRowPtrA::CuPtr{Cint},
-                                                                       csrSortedColIndA::CuPtr{Cint},
-                                                                       percentage::Cfloat,
-                                                                       descrC::cusparseMatDescr_t,
-                                                                       csrSortedValC::CuPtr{Cfloat},
-                                                                       csrSortedRowPtrC::CuPtr{Cint},
-                                                                       csrSortedColIndC::CuPtr{Cint},
-                                                                       info::pruneInfo_t,
-                                                                       pBufferSizeInBytes::Ptr{Csize_t})::cusparseStatus_t
+    @gcsafe_ccall libcusparse.cusparseSpruneCsr2csrByPercentage_bufferSizeExt(handle::cusparseHandle_t,
+                                                                              m::Cint,
+                                                                              n::Cint,
+                                                                              nnzA::Cint,
+                                                                              descrA::cusparseMatDescr_t,
+                                                                              csrSortedValA::CuPtr{Cfloat},
+                                                                              csrSortedRowPtrA::CuPtr{Cint},
+                                                                              csrSortedColIndA::CuPtr{Cint},
+                                                                              percentage::Cfloat,
+                                                                              descrC::cusparseMatDescr_t,
+                                                                              csrSortedValC::CuPtr{Cfloat},
+                                                                              csrSortedRowPtrC::CuPtr{Cint},
+                                                                              csrSortedColIndC::CuPtr{Cint},
+                                                                              info::pruneInfo_t,
+                                                                              pBufferSizeInBytes::Ptr{Csize_t})::cusparseStatus_t
 end
 
 @checked function cusparseDpruneCsr2csrByPercentage_bufferSizeExt(handle, m, n, nnzA,
@@ -4552,20 +4853,21 @@ end
                                                                   csrSortedColIndC, info,
                                                                   pBufferSizeInBytes)
     initialize_context()
-    @ccall libcusparse.cusparseDpruneCsr2csrByPercentage_bufferSizeExt(handle::cusparseHandle_t,
-                                                                       m::Cint, n::Cint,
-                                                                       nnzA::Cint,
-                                                                       descrA::cusparseMatDescr_t,
-                                                                       csrSortedValA::CuPtr{Cdouble},
-                                                                       csrSortedRowPtrA::CuPtr{Cint},
-                                                                       csrSortedColIndA::CuPtr{Cint},
-                                                                       percentage::Cfloat,
-                                                                       descrC::cusparseMatDescr_t,
-                                                                       csrSortedValC::CuPtr{Cdouble},
-                                                                       csrSortedRowPtrC::CuPtr{Cint},
-                                                                       csrSortedColIndC::CuPtr{Cint},
-                                                                       info::pruneInfo_t,
-                                                                       pBufferSizeInBytes::Ptr{Csize_t})::cusparseStatus_t
+    @gcsafe_ccall libcusparse.cusparseDpruneCsr2csrByPercentage_bufferSizeExt(handle::cusparseHandle_t,
+                                                                              m::Cint,
+                                                                              n::Cint,
+                                                                              nnzA::Cint,
+                                                                              descrA::cusparseMatDescr_t,
+                                                                              csrSortedValA::CuPtr{Cdouble},
+                                                                              csrSortedRowPtrA::CuPtr{Cint},
+                                                                              csrSortedColIndA::CuPtr{Cint},
+                                                                              percentage::Cfloat,
+                                                                              descrC::cusparseMatDescr_t,
+                                                                              csrSortedValC::CuPtr{Cdouble},
+                                                                              csrSortedRowPtrC::CuPtr{Cint},
+                                                                              csrSortedColIndC::CuPtr{Cint},
+                                                                              info::pruneInfo_t,
+                                                                              pBufferSizeInBytes::Ptr{Csize_t})::cusparseStatus_t
 end
 
 @checked function cusparseSpruneCsr2csrNnzByPercentage(handle, m, n, nnzA, descrA,
@@ -4574,18 +4876,19 @@ end
                                                        csrSortedRowPtrC, nnzTotalDevHostPtr,
                                                        info, pBuffer)
     initialize_context()
-    @ccall libcusparse.cusparseSpruneCsr2csrNnzByPercentage(handle::cusparseHandle_t,
-                                                            m::Cint, n::Cint, nnzA::Cint,
-                                                            descrA::cusparseMatDescr_t,
-                                                            csrSortedValA::CuPtr{Cfloat},
-                                                            csrSortedRowPtrA::CuPtr{Cint},
-                                                            csrSortedColIndA::CuPtr{Cint},
-                                                            percentage::Cfloat,
-                                                            descrC::cusparseMatDescr_t,
-                                                            csrSortedRowPtrC::CuPtr{Cint},
-                                                            nnzTotalDevHostPtr::PtrOrCuPtr{Cint},
-                                                            info::pruneInfo_t,
-                                                            pBuffer::CuPtr{Cvoid})::cusparseStatus_t
+    @gcsafe_ccall libcusparse.cusparseSpruneCsr2csrNnzByPercentage(handle::cusparseHandle_t,
+                                                                   m::Cint, n::Cint,
+                                                                   nnzA::Cint,
+                                                                   descrA::cusparseMatDescr_t,
+                                                                   csrSortedValA::CuPtr{Cfloat},
+                                                                   csrSortedRowPtrA::CuPtr{Cint},
+                                                                   csrSortedColIndA::CuPtr{Cint},
+                                                                   percentage::Cfloat,
+                                                                   descrC::cusparseMatDescr_t,
+                                                                   csrSortedRowPtrC::CuPtr{Cint},
+                                                                   nnzTotalDevHostPtr::PtrOrCuPtr{Cint},
+                                                                   info::pruneInfo_t,
+                                                                   pBuffer::CuPtr{Cvoid})::cusparseStatus_t
 end
 
 @checked function cusparseDpruneCsr2csrNnzByPercentage(handle, m, n, nnzA, descrA,
@@ -4594,18 +4897,19 @@ end
                                                        csrSortedRowPtrC, nnzTotalDevHostPtr,
                                                        info, pBuffer)
     initialize_context()
-    @ccall libcusparse.cusparseDpruneCsr2csrNnzByPercentage(handle::cusparseHandle_t,
-                                                            m::Cint, n::Cint, nnzA::Cint,
-                                                            descrA::cusparseMatDescr_t,
-                                                            csrSortedValA::CuPtr{Cdouble},
-                                                            csrSortedRowPtrA::CuPtr{Cint},
-                                                            csrSortedColIndA::CuPtr{Cint},
-                                                            percentage::Cfloat,
-                                                            descrC::cusparseMatDescr_t,
-                                                            csrSortedRowPtrC::CuPtr{Cint},
-                                                            nnzTotalDevHostPtr::PtrOrCuPtr{Cint},
-                                                            info::pruneInfo_t,
-                                                            pBuffer::CuPtr{Cvoid})::cusparseStatus_t
+    @gcsafe_ccall libcusparse.cusparseDpruneCsr2csrNnzByPercentage(handle::cusparseHandle_t,
+                                                                   m::Cint, n::Cint,
+                                                                   nnzA::Cint,
+                                                                   descrA::cusparseMatDescr_t,
+                                                                   csrSortedValA::CuPtr{Cdouble},
+                                                                   csrSortedRowPtrA::CuPtr{Cint},
+                                                                   csrSortedColIndA::CuPtr{Cint},
+                                                                   percentage::Cfloat,
+                                                                   descrC::cusparseMatDescr_t,
+                                                                   csrSortedRowPtrC::CuPtr{Cint},
+                                                                   nnzTotalDevHostPtr::PtrOrCuPtr{Cint},
+                                                                   info::pruneInfo_t,
+                                                                   pBuffer::CuPtr{Cvoid})::cusparseStatus_t
 end
 
 @checked function cusparseSpruneCsr2csrByPercentage(handle, m, n, nnzA, descrA,
@@ -4614,19 +4918,20 @@ end
                                                     csrSortedValC, csrSortedRowPtrC,
                                                     csrSortedColIndC, info, pBuffer)
     initialize_context()
-    @ccall libcusparse.cusparseSpruneCsr2csrByPercentage(handle::cusparseHandle_t, m::Cint,
-                                                         n::Cint, nnzA::Cint,
-                                                         descrA::cusparseMatDescr_t,
-                                                         csrSortedValA::CuPtr{Cfloat},
-                                                         csrSortedRowPtrA::CuPtr{Cint},
-                                                         csrSortedColIndA::CuPtr{Cint},
-                                                         percentage::Cfloat,
-                                                         descrC::cusparseMatDescr_t,
-                                                         csrSortedValC::CuPtr{Cfloat},
-                                                         csrSortedRowPtrC::CuPtr{Cint},
-                                                         csrSortedColIndC::CuPtr{Cint},
-                                                         info::pruneInfo_t,
-                                                         pBuffer::CuPtr{Cvoid})::cusparseStatus_t
+    @gcsafe_ccall libcusparse.cusparseSpruneCsr2csrByPercentage(handle::cusparseHandle_t,
+                                                                m::Cint, n::Cint,
+                                                                nnzA::Cint,
+                                                                descrA::cusparseMatDescr_t,
+                                                                csrSortedValA::CuPtr{Cfloat},
+                                                                csrSortedRowPtrA::CuPtr{Cint},
+                                                                csrSortedColIndA::CuPtr{Cint},
+                                                                percentage::Cfloat,
+                                                                descrC::cusparseMatDescr_t,
+                                                                csrSortedValC::CuPtr{Cfloat},
+                                                                csrSortedRowPtrC::CuPtr{Cint},
+                                                                csrSortedColIndC::CuPtr{Cint},
+                                                                info::pruneInfo_t,
+                                                                pBuffer::CuPtr{Cvoid})::cusparseStatus_t
 end
 
 @checked function cusparseDpruneCsr2csrByPercentage(handle, m, n, nnzA, descrA,
@@ -4635,19 +4940,20 @@ end
                                                     csrSortedValC, csrSortedRowPtrC,
                                                     csrSortedColIndC, info, pBuffer)
     initialize_context()
-    @ccall libcusparse.cusparseDpruneCsr2csrByPercentage(handle::cusparseHandle_t, m::Cint,
-                                                         n::Cint, nnzA::Cint,
-                                                         descrA::cusparseMatDescr_t,
-                                                         csrSortedValA::CuPtr{Cdouble},
-                                                         csrSortedRowPtrA::CuPtr{Cint},
-                                                         csrSortedColIndA::CuPtr{Cint},
-                                                         percentage::Cfloat,
-                                                         descrC::cusparseMatDescr_t,
-                                                         csrSortedValC::CuPtr{Cdouble},
-                                                         csrSortedRowPtrC::CuPtr{Cint},
-                                                         csrSortedColIndC::CuPtr{Cint},
-                                                         info::pruneInfo_t,
-                                                         pBuffer::CuPtr{Cvoid})::cusparseStatus_t
+    @gcsafe_ccall libcusparse.cusparseDpruneCsr2csrByPercentage(handle::cusparseHandle_t,
+                                                                m::Cint, n::Cint,
+                                                                nnzA::Cint,
+                                                                descrA::cusparseMatDescr_t,
+                                                                csrSortedValA::CuPtr{Cdouble},
+                                                                csrSortedRowPtrA::CuPtr{Cint},
+                                                                csrSortedColIndA::CuPtr{Cint},
+                                                                percentage::Cfloat,
+                                                                descrC::cusparseMatDescr_t,
+                                                                csrSortedValC::CuPtr{Cdouble},
+                                                                csrSortedRowPtrC::CuPtr{Cint},
+                                                                csrSortedColIndC::CuPtr{Cint},
+                                                                info::pruneInfo_t,
+                                                                pBuffer::CuPtr{Cvoid})::cusparseStatus_t
 end
 
 @cenum cusparseCsr2CscAlg_t::UInt32 begin
@@ -4659,15 +4965,18 @@ end
                                      cscVal, cscColPtr, cscRowInd, valType, copyValues,
                                      idxBase, alg, buffer)
     initialize_context()
-    @ccall libcusparse.cusparseCsr2cscEx2(handle::cusparseHandle_t, m::Cint, n::Cint,
-                                          nnz::Cint, csrVal::CuPtr{Cvoid},
-                                          csrRowPtr::CuPtr{Cint}, csrColInd::CuPtr{Cint},
-                                          cscVal::CuPtr{Cvoid}, cscColPtr::CuPtr{Cint},
-                                          cscRowInd::CuPtr{Cint}, valType::cudaDataType,
-                                          copyValues::cusparseAction_t,
-                                          idxBase::cusparseIndexBase_t,
-                                          alg::cusparseCsr2CscAlg_t,
-                                          buffer::CuPtr{Cvoid})::cusparseStatus_t
+    @gcsafe_ccall libcusparse.cusparseCsr2cscEx2(handle::cusparseHandle_t, m::Cint, n::Cint,
+                                                 nnz::Cint, csrVal::CuPtr{Cvoid},
+                                                 csrRowPtr::CuPtr{Cint},
+                                                 csrColInd::CuPtr{Cint},
+                                                 cscVal::CuPtr{Cvoid},
+                                                 cscColPtr::CuPtr{Cint},
+                                                 cscRowInd::CuPtr{Cint},
+                                                 valType::cudaDataType,
+                                                 copyValues::cusparseAction_t,
+                                                 idxBase::cusparseIndexBase_t,
+                                                 alg::cusparseCsr2CscAlg_t,
+                                                 buffer::CuPtr{Cvoid})::cusparseStatus_t
 end
 
 @checked function cusparseCsr2cscEx2_bufferSize(handle, m, n, nnz, csrVal, csrRowPtr,
@@ -4675,19 +4984,19 @@ end
                                                 valType, copyValues, idxBase, alg,
                                                 bufferSize)
     initialize_context()
-    @ccall libcusparse.cusparseCsr2cscEx2_bufferSize(handle::cusparseHandle_t, m::Cint,
-                                                     n::Cint, nnz::Cint,
-                                                     csrVal::CuPtr{Cvoid},
-                                                     csrRowPtr::CuPtr{Cint},
-                                                     csrColInd::CuPtr{Cint},
-                                                     cscVal::CuPtr{Cvoid},
-                                                     cscColPtr::CuPtr{Cint},
-                                                     cscRowInd::CuPtr{Cint},
-                                                     valType::cudaDataType,
-                                                     copyValues::cusparseAction_t,
-                                                     idxBase::cusparseIndexBase_t,
-                                                     alg::cusparseCsr2CscAlg_t,
-                                                     bufferSize::Ptr{Csize_t})::cusparseStatus_t
+    @gcsafe_ccall libcusparse.cusparseCsr2cscEx2_bufferSize(handle::cusparseHandle_t,
+                                                            m::Cint, n::Cint, nnz::Cint,
+                                                            csrVal::CuPtr{Cvoid},
+                                                            csrRowPtr::CuPtr{Cint},
+                                                            csrColInd::CuPtr{Cint},
+                                                            cscVal::CuPtr{Cvoid},
+                                                            cscColPtr::CuPtr{Cint},
+                                                            cscRowInd::CuPtr{Cint},
+                                                            valType::cudaDataType,
+                                                            copyValues::cusparseAction_t,
+                                                            idxBase::cusparseIndexBase_t,
+                                                            alg::cusparseCsr2CscAlg_t,
+                                                            bufferSize::Ptr{Csize_t})::cusparseStatus_t
 end
 
 @cenum cusparseFormat_t::UInt32 begin
@@ -4737,200 +5046,204 @@ const cusparseConstDnMatDescr_t = Ptr{cusparseDnMatDescr}
 @checked function cusparseCreateSpVec(spVecDescr, size, nnz, indices, values, idxType,
                                       idxBase, valueType)
     initialize_context()
-    @ccall libcusparse.cusparseCreateSpVec(spVecDescr::Ptr{cusparseSpVecDescr_t},
-                                           size::Int64, nnz::Int64, indices::CuPtr{Cvoid},
-                                           values::CuPtr{Cvoid},
-                                           idxType::cusparseIndexType_t,
-                                           idxBase::cusparseIndexBase_t,
-                                           valueType::cudaDataType)::cusparseStatus_t
+    @gcsafe_ccall libcusparse.cusparseCreateSpVec(spVecDescr::Ptr{cusparseSpVecDescr_t},
+                                                  size::Int64, nnz::Int64,
+                                                  indices::CuPtr{Cvoid},
+                                                  values::CuPtr{Cvoid},
+                                                  idxType::cusparseIndexType_t,
+                                                  idxBase::cusparseIndexBase_t,
+                                                  valueType::cudaDataType)::cusparseStatus_t
 end
 
 @checked function cusparseCreateConstSpVec(spVecDescr, size, nnz, indices, values, idxType,
                                            idxBase, valueType)
     initialize_context()
-    @ccall libcusparse.cusparseCreateConstSpVec(spVecDescr::Ptr{cusparseConstSpVecDescr_t},
-                                                size::Int64, nnz::Int64,
-                                                indices::Ptr{Cvoid}, values::Ptr{Cvoid},
-                                                idxType::cusparseIndexType_t,
-                                                idxBase::cusparseIndexBase_t,
-                                                valueType::cudaDataType)::cusparseStatus_t
+    @gcsafe_ccall libcusparse.cusparseCreateConstSpVec(spVecDescr::Ptr{cusparseConstSpVecDescr_t},
+                                                       size::Int64, nnz::Int64,
+                                                       indices::Ptr{Cvoid},
+                                                       values::Ptr{Cvoid},
+                                                       idxType::cusparseIndexType_t,
+                                                       idxBase::cusparseIndexBase_t,
+                                                       valueType::cudaDataType)::cusparseStatus_t
 end
 
 @checked function cusparseDestroySpVec(spVecDescr)
     initialize_context()
-    @ccall libcusparse.cusparseDestroySpVec(spVecDescr::cusparseConstSpVecDescr_t)::cusparseStatus_t
+    @gcsafe_ccall libcusparse.cusparseDestroySpVec(spVecDescr::cusparseConstSpVecDescr_t)::cusparseStatus_t
 end
 
 @checked function cusparseSpVecGet(spVecDescr, size, nnz, indices, values, idxType, idxBase,
                                    valueType)
     initialize_context()
-    @ccall libcusparse.cusparseSpVecGet(spVecDescr::cusparseSpVecDescr_t, size::Ptr{Int64},
-                                        nnz::Ptr{Int64}, indices::CuPtr{Ptr{Cvoid}},
-                                        values::CuPtr{Ptr{Cvoid}},
-                                        idxType::Ptr{cusparseIndexType_t},
-                                        idxBase::Ptr{cusparseIndexBase_t},
-                                        valueType::Ptr{cudaDataType})::cusparseStatus_t
+    @gcsafe_ccall libcusparse.cusparseSpVecGet(spVecDescr::cusparseSpVecDescr_t,
+                                               size::Ptr{Int64}, nnz::Ptr{Int64},
+                                               indices::CuPtr{Ptr{Cvoid}},
+                                               values::CuPtr{Ptr{Cvoid}},
+                                               idxType::Ptr{cusparseIndexType_t},
+                                               idxBase::Ptr{cusparseIndexBase_t},
+                                               valueType::Ptr{cudaDataType})::cusparseStatus_t
 end
 
 @checked function cusparseConstSpVecGet(spVecDescr, size, nnz, indices, values, idxType,
                                         idxBase, valueType)
     initialize_context()
-    @ccall libcusparse.cusparseConstSpVecGet(spVecDescr::cusparseConstSpVecDescr_t,
-                                             size::Ptr{Int64}, nnz::Ptr{Int64},
-                                             indices::Ptr{Ptr{Cvoid}},
-                                             values::Ptr{Ptr{Cvoid}},
-                                             idxType::Ptr{cusparseIndexType_t},
-                                             idxBase::Ptr{cusparseIndexBase_t},
-                                             valueType::Ptr{cudaDataType})::cusparseStatus_t
+    @gcsafe_ccall libcusparse.cusparseConstSpVecGet(spVecDescr::cusparseConstSpVecDescr_t,
+                                                    size::Ptr{Int64}, nnz::Ptr{Int64},
+                                                    indices::Ptr{Ptr{Cvoid}},
+                                                    values::Ptr{Ptr{Cvoid}},
+                                                    idxType::Ptr{cusparseIndexType_t},
+                                                    idxBase::Ptr{cusparseIndexBase_t},
+                                                    valueType::Ptr{cudaDataType})::cusparseStatus_t
 end
 
 @checked function cusparseSpVecGetIndexBase(spVecDescr, idxBase)
     initialize_context()
-    @ccall libcusparse.cusparseSpVecGetIndexBase(spVecDescr::cusparseConstSpVecDescr_t,
-                                                 idxBase::Ptr{cusparseIndexBase_t})::cusparseStatus_t
+    @gcsafe_ccall libcusparse.cusparseSpVecGetIndexBase(spVecDescr::cusparseConstSpVecDescr_t,
+                                                        idxBase::Ptr{cusparseIndexBase_t})::cusparseStatus_t
 end
 
 @checked function cusparseSpVecGetValues(spVecDescr, values)
     initialize_context()
-    @ccall libcusparse.cusparseSpVecGetValues(spVecDescr::cusparseSpVecDescr_t,
-                                              values::CuPtr{Ptr{Cvoid}})::cusparseStatus_t
+    @gcsafe_ccall libcusparse.cusparseSpVecGetValues(spVecDescr::cusparseSpVecDescr_t,
+                                                     values::CuPtr{Ptr{Cvoid}})::cusparseStatus_t
 end
 
 @checked function cusparseConstSpVecGetValues(spVecDescr, values)
     initialize_context()
-    @ccall libcusparse.cusparseConstSpVecGetValues(spVecDescr::cusparseConstSpVecDescr_t,
-                                                   values::Ptr{Ptr{Cvoid}})::cusparseStatus_t
+    @gcsafe_ccall libcusparse.cusparseConstSpVecGetValues(spVecDescr::cusparseConstSpVecDescr_t,
+                                                          values::Ptr{Ptr{Cvoid}})::cusparseStatus_t
 end
 
 @checked function cusparseSpVecSetValues(spVecDescr, values)
     initialize_context()
-    @ccall libcusparse.cusparseSpVecSetValues(spVecDescr::cusparseSpVecDescr_t,
-                                              values::CuPtr{Cvoid})::cusparseStatus_t
+    @gcsafe_ccall libcusparse.cusparseSpVecSetValues(spVecDescr::cusparseSpVecDescr_t,
+                                                     values::CuPtr{Cvoid})::cusparseStatus_t
 end
 
 @checked function cusparseCreateDnVec(dnVecDescr, size, values, valueType)
     initialize_context()
-    @ccall libcusparse.cusparseCreateDnVec(dnVecDescr::Ptr{cusparseDnVecDescr_t},
-                                           size::Int64, values::CuPtr{Cvoid},
-                                           valueType::cudaDataType)::cusparseStatus_t
+    @gcsafe_ccall libcusparse.cusparseCreateDnVec(dnVecDescr::Ptr{cusparseDnVecDescr_t},
+                                                  size::Int64, values::CuPtr{Cvoid},
+                                                  valueType::cudaDataType)::cusparseStatus_t
 end
 
 @checked function cusparseCreateConstDnVec(dnVecDescr, size, values, valueType)
     initialize_context()
-    @ccall libcusparse.cusparseCreateConstDnVec(dnVecDescr::Ptr{cusparseConstDnVecDescr_t},
-                                                size::Int64, values::Ptr{Cvoid},
-                                                valueType::cudaDataType)::cusparseStatus_t
+    @gcsafe_ccall libcusparse.cusparseCreateConstDnVec(dnVecDescr::Ptr{cusparseConstDnVecDescr_t},
+                                                       size::Int64, values::Ptr{Cvoid},
+                                                       valueType::cudaDataType)::cusparseStatus_t
 end
 
 @checked function cusparseDestroyDnVec(dnVecDescr)
     initialize_context()
-    @ccall libcusparse.cusparseDestroyDnVec(dnVecDescr::cusparseConstDnVecDescr_t)::cusparseStatus_t
+    @gcsafe_ccall libcusparse.cusparseDestroyDnVec(dnVecDescr::cusparseConstDnVecDescr_t)::cusparseStatus_t
 end
 
 @checked function cusparseDnVecGet(dnVecDescr, size, values, valueType)
     initialize_context()
-    @ccall libcusparse.cusparseDnVecGet(dnVecDescr::cusparseDnVecDescr_t, size::Ptr{Int64},
-                                        values::CuPtr{Ptr{Cvoid}},
-                                        valueType::Ptr{cudaDataType})::cusparseStatus_t
+    @gcsafe_ccall libcusparse.cusparseDnVecGet(dnVecDescr::cusparseDnVecDescr_t,
+                                               size::Ptr{Int64}, values::CuPtr{Ptr{Cvoid}},
+                                               valueType::Ptr{cudaDataType})::cusparseStatus_t
 end
 
 @checked function cusparseConstDnVecGet(dnVecDescr, size, values, valueType)
     initialize_context()
-    @ccall libcusparse.cusparseConstDnVecGet(dnVecDescr::cusparseConstDnVecDescr_t,
-                                             size::Ptr{Int64}, values::Ptr{Ptr{Cvoid}},
-                                             valueType::Ptr{cudaDataType})::cusparseStatus_t
+    @gcsafe_ccall libcusparse.cusparseConstDnVecGet(dnVecDescr::cusparseConstDnVecDescr_t,
+                                                    size::Ptr{Int64},
+                                                    values::Ptr{Ptr{Cvoid}},
+                                                    valueType::Ptr{cudaDataType})::cusparseStatus_t
 end
 
 @checked function cusparseDnVecGetValues(dnVecDescr, values)
     initialize_context()
-    @ccall libcusparse.cusparseDnVecGetValues(dnVecDescr::cusparseDnVecDescr_t,
-                                              values::CuPtr{Ptr{Cvoid}})::cusparseStatus_t
+    @gcsafe_ccall libcusparse.cusparseDnVecGetValues(dnVecDescr::cusparseDnVecDescr_t,
+                                                     values::CuPtr{Ptr{Cvoid}})::cusparseStatus_t
 end
 
 @checked function cusparseConstDnVecGetValues(dnVecDescr, values)
     initialize_context()
-    @ccall libcusparse.cusparseConstDnVecGetValues(dnVecDescr::cusparseConstDnVecDescr_t,
-                                                   values::Ptr{Ptr{Cvoid}})::cusparseStatus_t
+    @gcsafe_ccall libcusparse.cusparseConstDnVecGetValues(dnVecDescr::cusparseConstDnVecDescr_t,
+                                                          values::Ptr{Ptr{Cvoid}})::cusparseStatus_t
 end
 
 @checked function cusparseDnVecSetValues(dnVecDescr, values)
     initialize_context()
-    @ccall libcusparse.cusparseDnVecSetValues(dnVecDescr::cusparseDnVecDescr_t,
-                                              values::CuPtr{Cvoid})::cusparseStatus_t
+    @gcsafe_ccall libcusparse.cusparseDnVecSetValues(dnVecDescr::cusparseDnVecDescr_t,
+                                                     values::CuPtr{Cvoid})::cusparseStatus_t
 end
 
 @checked function cusparseDestroySpMat(spMatDescr)
     initialize_context()
-    @ccall libcusparse.cusparseDestroySpMat(spMatDescr::cusparseConstSpMatDescr_t)::cusparseStatus_t
+    @gcsafe_ccall libcusparse.cusparseDestroySpMat(spMatDescr::cusparseConstSpMatDescr_t)::cusparseStatus_t
 end
 
 @checked function cusparseSpMatGetFormat(spMatDescr, format)
     initialize_context()
-    @ccall libcusparse.cusparseSpMatGetFormat(spMatDescr::cusparseConstSpMatDescr_t,
-                                              format::Ptr{cusparseFormat_t})::cusparseStatus_t
+    @gcsafe_ccall libcusparse.cusparseSpMatGetFormat(spMatDescr::cusparseConstSpMatDescr_t,
+                                                     format::Ptr{cusparseFormat_t})::cusparseStatus_t
 end
 
 @checked function cusparseSpMatGetIndexBase(spMatDescr, idxBase)
     initialize_context()
-    @ccall libcusparse.cusparseSpMatGetIndexBase(spMatDescr::cusparseConstSpMatDescr_t,
-                                                 idxBase::Ptr{cusparseIndexBase_t})::cusparseStatus_t
+    @gcsafe_ccall libcusparse.cusparseSpMatGetIndexBase(spMatDescr::cusparseConstSpMatDescr_t,
+                                                        idxBase::Ptr{cusparseIndexBase_t})::cusparseStatus_t
 end
 
 @checked function cusparseSpMatGetValues(spMatDescr, values)
     initialize_context()
-    @ccall libcusparse.cusparseSpMatGetValues(spMatDescr::cusparseSpMatDescr_t,
-                                              values::CuPtr{Ptr{Cvoid}})::cusparseStatus_t
+    @gcsafe_ccall libcusparse.cusparseSpMatGetValues(spMatDescr::cusparseSpMatDescr_t,
+                                                     values::CuPtr{Ptr{Cvoid}})::cusparseStatus_t
 end
 
 @checked function cusparseConstSpMatGetValues(spMatDescr, values)
     initialize_context()
-    @ccall libcusparse.cusparseConstSpMatGetValues(spMatDescr::cusparseConstSpMatDescr_t,
-                                                   values::Ptr{Ptr{Cvoid}})::cusparseStatus_t
+    @gcsafe_ccall libcusparse.cusparseConstSpMatGetValues(spMatDescr::cusparseConstSpMatDescr_t,
+                                                          values::Ptr{Ptr{Cvoid}})::cusparseStatus_t
 end
 
 @checked function cusparseSpMatSetValues(spMatDescr, values)
     initialize_context()
-    @ccall libcusparse.cusparseSpMatSetValues(spMatDescr::cusparseSpMatDescr_t,
-                                              values::CuPtr{Cvoid})::cusparseStatus_t
+    @gcsafe_ccall libcusparse.cusparseSpMatSetValues(spMatDescr::cusparseSpMatDescr_t,
+                                                     values::CuPtr{Cvoid})::cusparseStatus_t
 end
 
 @checked function cusparseSpMatGetSize(spMatDescr, rows, cols, nnz)
     initialize_context()
-    @ccall libcusparse.cusparseSpMatGetSize(spMatDescr::cusparseConstSpMatDescr_t,
-                                            rows::Ptr{Int64}, cols::Ptr{Int64},
-                                            nnz::Ptr{Int64})::cusparseStatus_t
+    @gcsafe_ccall libcusparse.cusparseSpMatGetSize(spMatDescr::cusparseConstSpMatDescr_t,
+                                                   rows::Ptr{Int64}, cols::Ptr{Int64},
+                                                   nnz::Ptr{Int64})::cusparseStatus_t
 end
 
 @checked function cusparseSpMatGetStridedBatch(spMatDescr, batchCount)
     initialize_context()
-    @ccall libcusparse.cusparseSpMatGetStridedBatch(spMatDescr::cusparseConstSpMatDescr_t,
-                                                    batchCount::Ptr{Cint})::cusparseStatus_t
+    @gcsafe_ccall libcusparse.cusparseSpMatGetStridedBatch(spMatDescr::cusparseConstSpMatDescr_t,
+                                                           batchCount::Ptr{Cint})::cusparseStatus_t
 end
 
 @checked function cusparseCooSetStridedBatch(spMatDescr, batchCount, batchStride)
     initialize_context()
-    @ccall libcusparse.cusparseCooSetStridedBatch(spMatDescr::cusparseSpMatDescr_t,
-                                                  batchCount::Cint,
-                                                  batchStride::Int64)::cusparseStatus_t
+    @gcsafe_ccall libcusparse.cusparseCooSetStridedBatch(spMatDescr::cusparseSpMatDescr_t,
+                                                         batchCount::Cint,
+                                                         batchStride::Int64)::cusparseStatus_t
 end
 
 @checked function cusparseCsrSetStridedBatch(spMatDescr, batchCount, offsetsBatchStride,
                                              columnsValuesBatchStride)
     initialize_context()
-    @ccall libcusparse.cusparseCsrSetStridedBatch(spMatDescr::cusparseSpMatDescr_t,
-                                                  batchCount::Cint,
-                                                  offsetsBatchStride::Int64,
-                                                  columnsValuesBatchStride::Int64)::cusparseStatus_t
+    @gcsafe_ccall libcusparse.cusparseCsrSetStridedBatch(spMatDescr::cusparseSpMatDescr_t,
+                                                         batchCount::Cint,
+                                                         offsetsBatchStride::Int64,
+                                                         columnsValuesBatchStride::Int64)::cusparseStatus_t
 end
 
 @checked function cusparseBsrSetStridedBatch(spMatDescr, batchCount, offsetsBatchStride,
                                              columnsBatchStride, ValuesBatchStride)
     initialize_context()
-    @ccall libcusparse.cusparseBsrSetStridedBatch(spMatDescr::cusparseSpMatDescr_t,
-                                                  batchCount::Cint,
-                                                  offsetsBatchStride::Int64,
-                                                  columnsBatchStride::Int64,
-                                                  ValuesBatchStride::Int64)::cusparseStatus_t
+    @gcsafe_ccall libcusparse.cusparseBsrSetStridedBatch(spMatDescr::cusparseSpMatDescr_t,
+                                                         batchCount::Cint,
+                                                         offsetsBatchStride::Int64,
+                                                         columnsBatchStride::Int64,
+                                                         ValuesBatchStride::Int64)::cusparseStatus_t
 end
 
 @cenum cusparseSpMatAttribute_t::UInt32 begin
@@ -4940,150 +5253,158 @@ end
 
 @checked function cusparseSpMatGetAttribute(spMatDescr, attribute, data, dataSize)
     initialize_context()
-    @ccall libcusparse.cusparseSpMatGetAttribute(spMatDescr::cusparseConstSpMatDescr_t,
-                                                 attribute::cusparseSpMatAttribute_t,
-                                                 data::Ptr{Cvoid},
-                                                 dataSize::Csize_t)::cusparseStatus_t
+    @gcsafe_ccall libcusparse.cusparseSpMatGetAttribute(spMatDescr::cusparseConstSpMatDescr_t,
+                                                        attribute::cusparseSpMatAttribute_t,
+                                                        data::Ptr{Cvoid},
+                                                        dataSize::Csize_t)::cusparseStatus_t
 end
 
 @checked function cusparseSpMatSetAttribute(spMatDescr, attribute, data, dataSize)
     initialize_context()
-    @ccall libcusparse.cusparseSpMatSetAttribute(spMatDescr::cusparseSpMatDescr_t,
-                                                 attribute::cusparseSpMatAttribute_t,
-                                                 data::Ptr{Cvoid},
-                                                 dataSize::Csize_t)::cusparseStatus_t
+    @gcsafe_ccall libcusparse.cusparseSpMatSetAttribute(spMatDescr::cusparseSpMatDescr_t,
+                                                        attribute::cusparseSpMatAttribute_t,
+                                                        data::Ptr{Cvoid},
+                                                        dataSize::Csize_t)::cusparseStatus_t
 end
 
 @checked function cusparseCreateCsr(spMatDescr, rows, cols, nnz, csrRowOffsets, csrColInd,
                                     csrValues, csrRowOffsetsType, csrColIndType, idxBase,
                                     valueType)
     initialize_context()
-    @ccall libcusparse.cusparseCreateCsr(spMatDescr::Ptr{cusparseSpMatDescr_t}, rows::Int64,
-                                         cols::Int64, nnz::Int64,
-                                         csrRowOffsets::CuPtr{Cvoid},
-                                         csrColInd::CuPtr{Cvoid}, csrValues::CuPtr{Cvoid},
-                                         csrRowOffsetsType::cusparseIndexType_t,
-                                         csrColIndType::cusparseIndexType_t,
-                                         idxBase::cusparseIndexBase_t,
-                                         valueType::cudaDataType)::cusparseStatus_t
+    @gcsafe_ccall libcusparse.cusparseCreateCsr(spMatDescr::Ptr{cusparseSpMatDescr_t},
+                                                rows::Int64, cols::Int64, nnz::Int64,
+                                                csrRowOffsets::CuPtr{Cvoid},
+                                                csrColInd::CuPtr{Cvoid},
+                                                csrValues::CuPtr{Cvoid},
+                                                csrRowOffsetsType::cusparseIndexType_t,
+                                                csrColIndType::cusparseIndexType_t,
+                                                idxBase::cusparseIndexBase_t,
+                                                valueType::cudaDataType)::cusparseStatus_t
 end
 
 @checked function cusparseCreateConstCsr(spMatDescr, rows, cols, nnz, csrRowOffsets,
                                          csrColInd, csrValues, csrRowOffsetsType,
                                          csrColIndType, idxBase, valueType)
     initialize_context()
-    @ccall libcusparse.cusparseCreateConstCsr(spMatDescr::Ptr{cusparseConstSpMatDescr_t},
-                                              rows::Int64, cols::Int64, nnz::Int64,
-                                              csrRowOffsets::Ptr{Cvoid},
-                                              csrColInd::Ptr{Cvoid}, csrValues::Ptr{Cvoid},
-                                              csrRowOffsetsType::cusparseIndexType_t,
-                                              csrColIndType::cusparseIndexType_t,
-                                              idxBase::cusparseIndexBase_t,
-                                              valueType::cudaDataType)::cusparseStatus_t
+    @gcsafe_ccall libcusparse.cusparseCreateConstCsr(spMatDescr::Ptr{cusparseConstSpMatDescr_t},
+                                                     rows::Int64, cols::Int64, nnz::Int64,
+                                                     csrRowOffsets::Ptr{Cvoid},
+                                                     csrColInd::Ptr{Cvoid},
+                                                     csrValues::Ptr{Cvoid},
+                                                     csrRowOffsetsType::cusparseIndexType_t,
+                                                     csrColIndType::cusparseIndexType_t,
+                                                     idxBase::cusparseIndexBase_t,
+                                                     valueType::cudaDataType)::cusparseStatus_t
 end
 
 @checked function cusparseCreateCsc(spMatDescr, rows, cols, nnz, cscColOffsets, cscRowInd,
                                     cscValues, cscColOffsetsType, cscRowIndType, idxBase,
                                     valueType)
     initialize_context()
-    @ccall libcusparse.cusparseCreateCsc(spMatDescr::Ptr{cusparseSpMatDescr_t}, rows::Int64,
-                                         cols::Int64, nnz::Int64,
-                                         cscColOffsets::CuPtr{Cvoid},
-                                         cscRowInd::CuPtr{Cvoid}, cscValues::CuPtr{Cvoid},
-                                         cscColOffsetsType::cusparseIndexType_t,
-                                         cscRowIndType::cusparseIndexType_t,
-                                         idxBase::cusparseIndexBase_t,
-                                         valueType::cudaDataType)::cusparseStatus_t
+    @gcsafe_ccall libcusparse.cusparseCreateCsc(spMatDescr::Ptr{cusparseSpMatDescr_t},
+                                                rows::Int64, cols::Int64, nnz::Int64,
+                                                cscColOffsets::CuPtr{Cvoid},
+                                                cscRowInd::CuPtr{Cvoid},
+                                                cscValues::CuPtr{Cvoid},
+                                                cscColOffsetsType::cusparseIndexType_t,
+                                                cscRowIndType::cusparseIndexType_t,
+                                                idxBase::cusparseIndexBase_t,
+                                                valueType::cudaDataType)::cusparseStatus_t
 end
 
 @checked function cusparseCreateConstCsc(spMatDescr, rows, cols, nnz, cscColOffsets,
                                          cscRowInd, cscValues, cscColOffsetsType,
                                          cscRowIndType, idxBase, valueType)
     initialize_context()
-    @ccall libcusparse.cusparseCreateConstCsc(spMatDescr::Ptr{cusparseConstSpMatDescr_t},
-                                              rows::Int64, cols::Int64, nnz::Int64,
-                                              cscColOffsets::Ptr{Cvoid},
-                                              cscRowInd::Ptr{Cvoid}, cscValues::Ptr{Cvoid},
-                                              cscColOffsetsType::cusparseIndexType_t,
-                                              cscRowIndType::cusparseIndexType_t,
-                                              idxBase::cusparseIndexBase_t,
-                                              valueType::cudaDataType)::cusparseStatus_t
+    @gcsafe_ccall libcusparse.cusparseCreateConstCsc(spMatDescr::Ptr{cusparseConstSpMatDescr_t},
+                                                     rows::Int64, cols::Int64, nnz::Int64,
+                                                     cscColOffsets::Ptr{Cvoid},
+                                                     cscRowInd::Ptr{Cvoid},
+                                                     cscValues::Ptr{Cvoid},
+                                                     cscColOffsetsType::cusparseIndexType_t,
+                                                     cscRowIndType::cusparseIndexType_t,
+                                                     idxBase::cusparseIndexBase_t,
+                                                     valueType::cudaDataType)::cusparseStatus_t
 end
 
 @checked function cusparseCsrGet(spMatDescr, rows, cols, nnz, csrRowOffsets, csrColInd,
                                  csrValues, csrRowOffsetsType, csrColIndType, idxBase,
                                  valueType)
     initialize_context()
-    @ccall libcusparse.cusparseCsrGet(spMatDescr::cusparseSpMatDescr_t, rows::Ptr{Int64},
-                                      cols::Ptr{Int64}, nnz::Ptr{Int64},
-                                      csrRowOffsets::CuPtr{Ptr{Cvoid}},
-                                      csrColInd::CuPtr{Ptr{Cvoid}},
-                                      csrValues::CuPtr{Ptr{Cvoid}},
-                                      csrRowOffsetsType::Ptr{cusparseIndexType_t},
-                                      csrColIndType::Ptr{cusparseIndexType_t},
-                                      idxBase::Ptr{cusparseIndexBase_t},
-                                      valueType::Ptr{cudaDataType})::cusparseStatus_t
+    @gcsafe_ccall libcusparse.cusparseCsrGet(spMatDescr::cusparseSpMatDescr_t,
+                                             rows::Ptr{Int64}, cols::Ptr{Int64},
+                                             nnz::Ptr{Int64},
+                                             csrRowOffsets::CuPtr{Ptr{Cvoid}},
+                                             csrColInd::CuPtr{Ptr{Cvoid}},
+                                             csrValues::CuPtr{Ptr{Cvoid}},
+                                             csrRowOffsetsType::Ptr{cusparseIndexType_t},
+                                             csrColIndType::Ptr{cusparseIndexType_t},
+                                             idxBase::Ptr{cusparseIndexBase_t},
+                                             valueType::Ptr{cudaDataType})::cusparseStatus_t
 end
 
 @checked function cusparseConstCsrGet(spMatDescr, rows, cols, nnz, csrRowOffsets, csrColInd,
                                       csrValues, csrRowOffsetsType, csrColIndType, idxBase,
                                       valueType)
     initialize_context()
-    @ccall libcusparse.cusparseConstCsrGet(spMatDescr::cusparseConstSpMatDescr_t,
-                                           rows::Ptr{Int64}, cols::Ptr{Int64},
-                                           nnz::Ptr{Int64}, csrRowOffsets::Ptr{Ptr{Cvoid}},
-                                           csrColInd::Ptr{Ptr{Cvoid}},
-                                           csrValues::Ptr{Ptr{Cvoid}},
-                                           csrRowOffsetsType::Ptr{cusparseIndexType_t},
-                                           csrColIndType::Ptr{cusparseIndexType_t},
-                                           idxBase::Ptr{cusparseIndexBase_t},
-                                           valueType::Ptr{cudaDataType})::cusparseStatus_t
+    @gcsafe_ccall libcusparse.cusparseConstCsrGet(spMatDescr::cusparseConstSpMatDescr_t,
+                                                  rows::Ptr{Int64}, cols::Ptr{Int64},
+                                                  nnz::Ptr{Int64},
+                                                  csrRowOffsets::Ptr{Ptr{Cvoid}},
+                                                  csrColInd::Ptr{Ptr{Cvoid}},
+                                                  csrValues::Ptr{Ptr{Cvoid}},
+                                                  csrRowOffsetsType::Ptr{cusparseIndexType_t},
+                                                  csrColIndType::Ptr{cusparseIndexType_t},
+                                                  idxBase::Ptr{cusparseIndexBase_t},
+                                                  valueType::Ptr{cudaDataType})::cusparseStatus_t
 end
 
 @checked function cusparseCscGet(spMatDescr, rows, cols, nnz, cscColOffsets, cscRowInd,
                                  cscValues, cscColOffsetsType, cscRowIndType, idxBase,
                                  valueType)
     initialize_context()
-    @ccall libcusparse.cusparseCscGet(spMatDescr::cusparseSpMatDescr_t, rows::Ptr{Int64},
-                                      cols::Ptr{Int64}, nnz::Ptr{Int64},
-                                      cscColOffsets::Ptr{Ptr{Cvoid}},
-                                      cscRowInd::Ptr{Ptr{Cvoid}},
-                                      cscValues::Ptr{Ptr{Cvoid}},
-                                      cscColOffsetsType::Ptr{cusparseIndexType_t},
-                                      cscRowIndType::Ptr{cusparseIndexType_t},
-                                      idxBase::Ptr{cusparseIndexBase_t},
-                                      valueType::Ptr{cudaDataType})::cusparseStatus_t
+    @gcsafe_ccall libcusparse.cusparseCscGet(spMatDescr::cusparseSpMatDescr_t,
+                                             rows::Ptr{Int64}, cols::Ptr{Int64},
+                                             nnz::Ptr{Int64},
+                                             cscColOffsets::Ptr{Ptr{Cvoid}},
+                                             cscRowInd::Ptr{Ptr{Cvoid}},
+                                             cscValues::Ptr{Ptr{Cvoid}},
+                                             cscColOffsetsType::Ptr{cusparseIndexType_t},
+                                             cscRowIndType::Ptr{cusparseIndexType_t},
+                                             idxBase::Ptr{cusparseIndexBase_t},
+                                             valueType::Ptr{cudaDataType})::cusparseStatus_t
 end
 
 @checked function cusparseConstCscGet(spMatDescr, rows, cols, nnz, cscColOffsets, cscRowInd,
                                       cscValues, cscColOffsetsType, cscRowIndType, idxBase,
                                       valueType)
     initialize_context()
-    @ccall libcusparse.cusparseConstCscGet(spMatDescr::cusparseConstSpMatDescr_t,
-                                           rows::Ptr{Int64}, cols::Ptr{Int64},
-                                           nnz::Ptr{Int64}, cscColOffsets::Ptr{Ptr{Cvoid}},
-                                           cscRowInd::Ptr{Ptr{Cvoid}},
-                                           cscValues::Ptr{Ptr{Cvoid}},
-                                           cscColOffsetsType::Ptr{cusparseIndexType_t},
-                                           cscRowIndType::Ptr{cusparseIndexType_t},
-                                           idxBase::Ptr{cusparseIndexBase_t},
-                                           valueType::Ptr{cudaDataType})::cusparseStatus_t
+    @gcsafe_ccall libcusparse.cusparseConstCscGet(spMatDescr::cusparseConstSpMatDescr_t,
+                                                  rows::Ptr{Int64}, cols::Ptr{Int64},
+                                                  nnz::Ptr{Int64},
+                                                  cscColOffsets::Ptr{Ptr{Cvoid}},
+                                                  cscRowInd::Ptr{Ptr{Cvoid}},
+                                                  cscValues::Ptr{Ptr{Cvoid}},
+                                                  cscColOffsetsType::Ptr{cusparseIndexType_t},
+                                                  cscRowIndType::Ptr{cusparseIndexType_t},
+                                                  idxBase::Ptr{cusparseIndexBase_t},
+                                                  valueType::Ptr{cudaDataType})::cusparseStatus_t
 end
 
 @checked function cusparseCsrSetPointers(spMatDescr, csrRowOffsets, csrColInd, csrValues)
     initialize_context()
-    @ccall libcusparse.cusparseCsrSetPointers(spMatDescr::cusparseSpMatDescr_t,
-                                              csrRowOffsets::CuPtr{Cvoid},
-                                              csrColInd::CuPtr{Cvoid},
-                                              csrValues::CuPtr{Cvoid})::cusparseStatus_t
+    @gcsafe_ccall libcusparse.cusparseCsrSetPointers(spMatDescr::cusparseSpMatDescr_t,
+                                                     csrRowOffsets::CuPtr{Cvoid},
+                                                     csrColInd::CuPtr{Cvoid},
+                                                     csrValues::CuPtr{Cvoid})::cusparseStatus_t
 end
 
 @checked function cusparseCscSetPointers(spMatDescr, cscColOffsets, cscRowInd, cscValues)
     initialize_context()
-    @ccall libcusparse.cusparseCscSetPointers(spMatDescr::cusparseSpMatDescr_t,
-                                              cscColOffsets::CuPtr{Cvoid},
-                                              cscRowInd::CuPtr{Cvoid},
-                                              cscValues::CuPtr{Cvoid})::cusparseStatus_t
+    @gcsafe_ccall libcusparse.cusparseCscSetPointers(spMatDescr::cusparseSpMatDescr_t,
+                                                     cscColOffsets::CuPtr{Cvoid},
+                                                     cscRowInd::CuPtr{Cvoid},
+                                                     cscValues::CuPtr{Cvoid})::cusparseStatus_t
 end
 
 @checked function cusparseCreateBsr(spMatDescr, brows, bcols, bnnz, rowBlockSize,
@@ -5091,16 +5412,17 @@ end
                                     bsrRowOffsetsType, bsrColIndType, idxBase, valueType,
                                     order)
     initialize_context()
-    @ccall libcusparse.cusparseCreateBsr(spMatDescr::Ptr{cusparseSpMatDescr_t},
-                                         brows::Int64, bcols::Int64, bnnz::Int64,
-                                         rowBlockSize::Int64, colBlockSize::Int64,
-                                         bsrRowOffsets::Ptr{Cvoid}, bsrColInd::Ptr{Cvoid},
-                                         bsrValues::Ptr{Cvoid},
-                                         bsrRowOffsetsType::cusparseIndexType_t,
-                                         bsrColIndType::cusparseIndexType_t,
-                                         idxBase::cusparseIndexBase_t,
-                                         valueType::cudaDataType,
-                                         order::cusparseOrder_t)::cusparseStatus_t
+    @gcsafe_ccall libcusparse.cusparseCreateBsr(spMatDescr::Ptr{cusparseSpMatDescr_t},
+                                                brows::Int64, bcols::Int64, bnnz::Int64,
+                                                rowBlockSize::Int64, colBlockSize::Int64,
+                                                bsrRowOffsets::Ptr{Cvoid},
+                                                bsrColInd::Ptr{Cvoid},
+                                                bsrValues::Ptr{Cvoid},
+                                                bsrRowOffsetsType::cusparseIndexType_t,
+                                                bsrColIndType::cusparseIndexType_t,
+                                                idxBase::cusparseIndexBase_t,
+                                                valueType::cudaDataType,
+                                                order::cusparseOrder_t)::cusparseStatus_t
 end
 
 @checked function cusparseCreateConstBsr(spMatDescr, brows, bcols, bnnz, rowBlockDim,
@@ -5108,129 +5430,137 @@ end
                                          bsrRowOffsetsType, bsrColIndType, idxBase,
                                          valueType, order)
     initialize_context()
-    @ccall libcusparse.cusparseCreateConstBsr(spMatDescr::Ptr{cusparseConstSpMatDescr_t},
-                                              brows::Int64, bcols::Int64, bnnz::Int64,
-                                              rowBlockDim::Int64, colBlockDim::Int64,
-                                              bsrRowOffsets::Ptr{Cvoid},
-                                              bsrColInd::Ptr{Cvoid}, bsrValues::Ptr{Cvoid},
-                                              bsrRowOffsetsType::cusparseIndexType_t,
-                                              bsrColIndType::cusparseIndexType_t,
-                                              idxBase::cusparseIndexBase_t,
-                                              valueType::cudaDataType,
-                                              order::cusparseOrder_t)::cusparseStatus_t
+    @gcsafe_ccall libcusparse.cusparseCreateConstBsr(spMatDescr::Ptr{cusparseConstSpMatDescr_t},
+                                                     brows::Int64, bcols::Int64,
+                                                     bnnz::Int64, rowBlockDim::Int64,
+                                                     colBlockDim::Int64,
+                                                     bsrRowOffsets::Ptr{Cvoid},
+                                                     bsrColInd::Ptr{Cvoid},
+                                                     bsrValues::Ptr{Cvoid},
+                                                     bsrRowOffsetsType::cusparseIndexType_t,
+                                                     bsrColIndType::cusparseIndexType_t,
+                                                     idxBase::cusparseIndexBase_t,
+                                                     valueType::cudaDataType,
+                                                     order::cusparseOrder_t)::cusparseStatus_t
 end
 
 @checked function cusparseCreateCoo(spMatDescr, rows, cols, nnz, cooRowInd, cooColInd,
                                     cooValues, cooIdxType, idxBase, valueType)
     initialize_context()
-    @ccall libcusparse.cusparseCreateCoo(spMatDescr::Ptr{cusparseSpMatDescr_t}, rows::Int64,
-                                         cols::Int64, nnz::Int64, cooRowInd::CuPtr{Cvoid},
-                                         cooColInd::CuPtr{Cvoid}, cooValues::CuPtr{Cvoid},
-                                         cooIdxType::cusparseIndexType_t,
-                                         idxBase::cusparseIndexBase_t,
-                                         valueType::cudaDataType)::cusparseStatus_t
+    @gcsafe_ccall libcusparse.cusparseCreateCoo(spMatDescr::Ptr{cusparseSpMatDescr_t},
+                                                rows::Int64, cols::Int64, nnz::Int64,
+                                                cooRowInd::CuPtr{Cvoid},
+                                                cooColInd::CuPtr{Cvoid},
+                                                cooValues::CuPtr{Cvoid},
+                                                cooIdxType::cusparseIndexType_t,
+                                                idxBase::cusparseIndexBase_t,
+                                                valueType::cudaDataType)::cusparseStatus_t
 end
 
 @checked function cusparseCreateConstCoo(spMatDescr, rows, cols, nnz, cooRowInd, cooColInd,
                                          cooValues, cooIdxType, idxBase, valueType)
     initialize_context()
-    @ccall libcusparse.cusparseCreateConstCoo(spMatDescr::Ptr{cusparseConstSpMatDescr_t},
-                                              rows::Int64, cols::Int64, nnz::Int64,
-                                              cooRowInd::Ptr{Cvoid}, cooColInd::Ptr{Cvoid},
-                                              cooValues::Ptr{Cvoid},
-                                              cooIdxType::cusparseIndexType_t,
-                                              idxBase::cusparseIndexBase_t,
-                                              valueType::cudaDataType)::cusparseStatus_t
+    @gcsafe_ccall libcusparse.cusparseCreateConstCoo(spMatDescr::Ptr{cusparseConstSpMatDescr_t},
+                                                     rows::Int64, cols::Int64, nnz::Int64,
+                                                     cooRowInd::Ptr{Cvoid},
+                                                     cooColInd::Ptr{Cvoid},
+                                                     cooValues::Ptr{Cvoid},
+                                                     cooIdxType::cusparseIndexType_t,
+                                                     idxBase::cusparseIndexBase_t,
+                                                     valueType::cudaDataType)::cusparseStatus_t
 end
 
 @checked function cusparseCooGet(spMatDescr, rows, cols, nnz, cooRowInd, cooColInd,
                                  cooValues, idxType, idxBase, valueType)
     initialize_context()
-    @ccall libcusparse.cusparseCooGet(spMatDescr::cusparseSpMatDescr_t, rows::Ptr{Int64},
-                                      cols::Ptr{Int64}, nnz::Ptr{Int64},
-                                      cooRowInd::CuPtr{Ptr{Cvoid}},
-                                      cooColInd::CuPtr{Ptr{Cvoid}},
-                                      cooValues::CuPtr{Ptr{Cvoid}},
-                                      idxType::Ptr{cusparseIndexType_t},
-                                      idxBase::Ptr{cusparseIndexBase_t},
-                                      valueType::Ptr{cudaDataType})::cusparseStatus_t
+    @gcsafe_ccall libcusparse.cusparseCooGet(spMatDescr::cusparseSpMatDescr_t,
+                                             rows::Ptr{Int64}, cols::Ptr{Int64},
+                                             nnz::Ptr{Int64}, cooRowInd::CuPtr{Ptr{Cvoid}},
+                                             cooColInd::CuPtr{Ptr{Cvoid}},
+                                             cooValues::CuPtr{Ptr{Cvoid}},
+                                             idxType::Ptr{cusparseIndexType_t},
+                                             idxBase::Ptr{cusparseIndexBase_t},
+                                             valueType::Ptr{cudaDataType})::cusparseStatus_t
 end
 
 @checked function cusparseConstCooGet(spMatDescr, rows, cols, nnz, cooRowInd, cooColInd,
                                       cooValues, idxType, idxBase, valueType)
     initialize_context()
-    @ccall libcusparse.cusparseConstCooGet(spMatDescr::cusparseConstSpMatDescr_t,
-                                           rows::Ptr{Int64}, cols::Ptr{Int64},
-                                           nnz::Ptr{Int64}, cooRowInd::Ptr{Ptr{Cvoid}},
-                                           cooColInd::Ptr{Ptr{Cvoid}},
-                                           cooValues::Ptr{Ptr{Cvoid}},
-                                           idxType::Ptr{cusparseIndexType_t},
-                                           idxBase::Ptr{cusparseIndexBase_t},
-                                           valueType::Ptr{cudaDataType})::cusparseStatus_t
+    @gcsafe_ccall libcusparse.cusparseConstCooGet(spMatDescr::cusparseConstSpMatDescr_t,
+                                                  rows::Ptr{Int64}, cols::Ptr{Int64},
+                                                  nnz::Ptr{Int64},
+                                                  cooRowInd::Ptr{Ptr{Cvoid}},
+                                                  cooColInd::Ptr{Ptr{Cvoid}},
+                                                  cooValues::Ptr{Ptr{Cvoid}},
+                                                  idxType::Ptr{cusparseIndexType_t},
+                                                  idxBase::Ptr{cusparseIndexBase_t},
+                                                  valueType::Ptr{cudaDataType})::cusparseStatus_t
 end
 
 @checked function cusparseCooSetPointers(spMatDescr, cooRows, cooColumns, cooValues)
     initialize_context()
-    @ccall libcusparse.cusparseCooSetPointers(spMatDescr::cusparseSpMatDescr_t,
-                                              cooRows::CuPtr{Cvoid},
-                                              cooColumns::CuPtr{Cvoid},
-                                              cooValues::CuPtr{Cvoid})::cusparseStatus_t
+    @gcsafe_ccall libcusparse.cusparseCooSetPointers(spMatDescr::cusparseSpMatDescr_t,
+                                                     cooRows::CuPtr{Cvoid},
+                                                     cooColumns::CuPtr{Cvoid},
+                                                     cooValues::CuPtr{Cvoid})::cusparseStatus_t
 end
 
 @checked function cusparseCreateBlockedEll(spMatDescr, rows, cols, ellBlockSize, ellCols,
                                            ellColInd, ellValue, ellIdxType, idxBase,
                                            valueType)
     initialize_context()
-    @ccall libcusparse.cusparseCreateBlockedEll(spMatDescr::Ptr{cusparseSpMatDescr_t},
-                                                rows::Int64, cols::Int64,
-                                                ellBlockSize::Int64, ellCols::Int64,
-                                                ellColInd::CuPtr{Cvoid},
-                                                ellValue::CuPtr{Cvoid},
-                                                ellIdxType::cusparseIndexType_t,
-                                                idxBase::cusparseIndexBase_t,
-                                                valueType::cudaDataType)::cusparseStatus_t
+    @gcsafe_ccall libcusparse.cusparseCreateBlockedEll(spMatDescr::Ptr{cusparseSpMatDescr_t},
+                                                       rows::Int64, cols::Int64,
+                                                       ellBlockSize::Int64, ellCols::Int64,
+                                                       ellColInd::CuPtr{Cvoid},
+                                                       ellValue::CuPtr{Cvoid},
+                                                       ellIdxType::cusparseIndexType_t,
+                                                       idxBase::cusparseIndexBase_t,
+                                                       valueType::cudaDataType)::cusparseStatus_t
 end
 
 @checked function cusparseCreateConstBlockedEll(spMatDescr, rows, cols, ellBlockSize,
                                                 ellCols, ellColInd, ellValue, ellIdxType,
                                                 idxBase, valueType)
     initialize_context()
-    @ccall libcusparse.cusparseCreateConstBlockedEll(spMatDescr::Ptr{cusparseConstSpMatDescr_t},
-                                                     rows::Int64, cols::Int64,
-                                                     ellBlockSize::Int64, ellCols::Int64,
-                                                     ellColInd::Ptr{Cvoid},
-                                                     ellValue::Ptr{Cvoid},
-                                                     ellIdxType::cusparseIndexType_t,
-                                                     idxBase::cusparseIndexBase_t,
-                                                     valueType::cudaDataType)::cusparseStatus_t
+    @gcsafe_ccall libcusparse.cusparseCreateConstBlockedEll(spMatDescr::Ptr{cusparseConstSpMatDescr_t},
+                                                            rows::Int64, cols::Int64,
+                                                            ellBlockSize::Int64,
+                                                            ellCols::Int64,
+                                                            ellColInd::Ptr{Cvoid},
+                                                            ellValue::Ptr{Cvoid},
+                                                            ellIdxType::cusparseIndexType_t,
+                                                            idxBase::cusparseIndexBase_t,
+                                                            valueType::cudaDataType)::cusparseStatus_t
 end
 
 @checked function cusparseBlockedEllGet(spMatDescr, rows, cols, ellBlockSize, ellCols,
                                         ellColInd, ellValue, ellIdxType, idxBase, valueType)
     initialize_context()
-    @ccall libcusparse.cusparseBlockedEllGet(spMatDescr::cusparseSpMatDescr_t,
-                                             rows::Ptr{Int64}, cols::Ptr{Int64},
-                                             ellBlockSize::Ptr{Int64}, ellCols::Ptr{Int64},
-                                             ellColInd::CuPtr{Ptr{Cvoid}},
-                                             ellValue::CuPtr{Ptr{Cvoid}},
-                                             ellIdxType::Ptr{cusparseIndexType_t},
-                                             idxBase::Ptr{cusparseIndexBase_t},
-                                             valueType::Ptr{cudaDataType})::cusparseStatus_t
+    @gcsafe_ccall libcusparse.cusparseBlockedEllGet(spMatDescr::cusparseSpMatDescr_t,
+                                                    rows::Ptr{Int64}, cols::Ptr{Int64},
+                                                    ellBlockSize::Ptr{Int64},
+                                                    ellCols::Ptr{Int64},
+                                                    ellColInd::CuPtr{Ptr{Cvoid}},
+                                                    ellValue::CuPtr{Ptr{Cvoid}},
+                                                    ellIdxType::Ptr{cusparseIndexType_t},
+                                                    idxBase::Ptr{cusparseIndexBase_t},
+                                                    valueType::Ptr{cudaDataType})::cusparseStatus_t
 end
 
 @checked function cusparseConstBlockedEllGet(spMatDescr, rows, cols, ellBlockSize, ellCols,
                                              ellColInd, ellValue, ellIdxType, idxBase,
                                              valueType)
     initialize_context()
-    @ccall libcusparse.cusparseConstBlockedEllGet(spMatDescr::cusparseConstSpMatDescr_t,
-                                                  rows::Ptr{Int64}, cols::Ptr{Int64},
-                                                  ellBlockSize::Ptr{Int64},
-                                                  ellCols::Ptr{Int64},
-                                                  ellColInd::Ptr{Ptr{Cvoid}},
-                                                  ellValue::Ptr{Ptr{Cvoid}},
-                                                  ellIdxType::Ptr{cusparseIndexType_t},
-                                                  idxBase::Ptr{cusparseIndexBase_t},
-                                                  valueType::Ptr{cudaDataType})::cusparseStatus_t
+    @gcsafe_ccall libcusparse.cusparseConstBlockedEllGet(spMatDescr::cusparseConstSpMatDescr_t,
+                                                         rows::Ptr{Int64}, cols::Ptr{Int64},
+                                                         ellBlockSize::Ptr{Int64},
+                                                         ellCols::Ptr{Int64},
+                                                         ellColInd::Ptr{Ptr{Cvoid}},
+                                                         ellValue::Ptr{Ptr{Cvoid}},
+                                                         ellIdxType::Ptr{cusparseIndexType_t},
+                                                         idxBase::Ptr{cusparseIndexBase_t},
+                                                         valueType::Ptr{cudaDataType})::cusparseStatus_t
 end
 
 @checked function cusparseCreateSlicedEll(spMatDescr, rows, cols, nnz, sellValuesSize,
@@ -5238,16 +5568,17 @@ end
                                           sellValues, sellSliceOffsetsType, sellColIndType,
                                           idxBase, valueType)
     initialize_context()
-    @ccall libcusparse.cusparseCreateSlicedEll(spMatDescr::Ptr{cusparseSpMatDescr_t},
-                                               rows::Int64, cols::Int64, nnz::Int64,
-                                               sellValuesSize::Int64, sliceSize::Int64,
-                                               sellSliceOffsets::Ptr{Cvoid},
-                                               sellColInd::Ptr{Cvoid},
-                                               sellValues::Ptr{Cvoid},
-                                               sellSliceOffsetsType::cusparseIndexType_t,
-                                               sellColIndType::cusparseIndexType_t,
-                                               idxBase::cusparseIndexBase_t,
-                                               valueType::cudaDataType)::cusparseStatus_t
+    @gcsafe_ccall libcusparse.cusparseCreateSlicedEll(spMatDescr::Ptr{cusparseSpMatDescr_t},
+                                                      rows::Int64, cols::Int64, nnz::Int64,
+                                                      sellValuesSize::Int64,
+                                                      sliceSize::Int64,
+                                                      sellSliceOffsets::Ptr{Cvoid},
+                                                      sellColInd::Ptr{Cvoid},
+                                                      sellValues::Ptr{Cvoid},
+                                                      sellSliceOffsetsType::cusparseIndexType_t,
+                                                      sellColIndType::cusparseIndexType_t,
+                                                      idxBase::cusparseIndexBase_t,
+                                                      valueType::cudaDataType)::cusparseStatus_t
 end
 
 @checked function cusparseCreateConstSlicedEll(spMatDescr, rows, cols, nnz, sellValuesSize,
@@ -5255,137 +5586,147 @@ end
                                                sellValues, sellSliceOffsetsType,
                                                sellColIndType, idxBase, valueType)
     initialize_context()
-    @ccall libcusparse.cusparseCreateConstSlicedEll(spMatDescr::Ptr{cusparseConstSpMatDescr_t},
-                                                    rows::Int64, cols::Int64, nnz::Int64,
-                                                    sellValuesSize::Int64, sliceSize::Int64,
-                                                    sellSliceOffsets::Ptr{Cvoid},
-                                                    sellColInd::Ptr{Cvoid},
-                                                    sellValues::Ptr{Cvoid},
-                                                    sellSliceOffsetsType::cusparseIndexType_t,
-                                                    sellColIndType::cusparseIndexType_t,
-                                                    idxBase::cusparseIndexBase_t,
-                                                    valueType::cudaDataType)::cusparseStatus_t
+    @gcsafe_ccall libcusparse.cusparseCreateConstSlicedEll(spMatDescr::Ptr{cusparseConstSpMatDescr_t},
+                                                           rows::Int64, cols::Int64,
+                                                           nnz::Int64,
+                                                           sellValuesSize::Int64,
+                                                           sliceSize::Int64,
+                                                           sellSliceOffsets::Ptr{Cvoid},
+                                                           sellColInd::Ptr{Cvoid},
+                                                           sellValues::Ptr{Cvoid},
+                                                           sellSliceOffsetsType::cusparseIndexType_t,
+                                                           sellColIndType::cusparseIndexType_t,
+                                                           idxBase::cusparseIndexBase_t,
+                                                           valueType::cudaDataType)::cusparseStatus_t
 end
 
 @checked function cusparseCreateDnMat(dnMatDescr, rows, cols, ld, values, valueType, order)
     initialize_context()
-    @ccall libcusparse.cusparseCreateDnMat(dnMatDescr::Ptr{cusparseDnMatDescr_t},
-                                           rows::Int64, cols::Int64, ld::Int64,
-                                           values::CuPtr{Cvoid}, valueType::cudaDataType,
-                                           order::cusparseOrder_t)::cusparseStatus_t
+    @gcsafe_ccall libcusparse.cusparseCreateDnMat(dnMatDescr::Ptr{cusparseDnMatDescr_t},
+                                                  rows::Int64, cols::Int64, ld::Int64,
+                                                  values::CuPtr{Cvoid},
+                                                  valueType::cudaDataType,
+                                                  order::cusparseOrder_t)::cusparseStatus_t
 end
 
 @checked function cusparseCreateConstDnMat(dnMatDescr, rows, cols, ld, values, valueType,
                                            order)
     initialize_context()
-    @ccall libcusparse.cusparseCreateConstDnMat(dnMatDescr::Ptr{cusparseConstDnMatDescr_t},
-                                                rows::Int64, cols::Int64, ld::Int64,
-                                                values::Ptr{Cvoid}, valueType::cudaDataType,
-                                                order::cusparseOrder_t)::cusparseStatus_t
+    @gcsafe_ccall libcusparse.cusparseCreateConstDnMat(dnMatDescr::Ptr{cusparseConstDnMatDescr_t},
+                                                       rows::Int64, cols::Int64, ld::Int64,
+                                                       values::Ptr{Cvoid},
+                                                       valueType::cudaDataType,
+                                                       order::cusparseOrder_t)::cusparseStatus_t
 end
 
 @checked function cusparseDestroyDnMat(dnMatDescr)
     initialize_context()
-    @ccall libcusparse.cusparseDestroyDnMat(dnMatDescr::cusparseConstDnMatDescr_t)::cusparseStatus_t
+    @gcsafe_ccall libcusparse.cusparseDestroyDnMat(dnMatDescr::cusparseConstDnMatDescr_t)::cusparseStatus_t
 end
 
 @checked function cusparseDnMatGet(dnMatDescr, rows, cols, ld, values, type, order)
     initialize_context()
-    @ccall libcusparse.cusparseDnMatGet(dnMatDescr::cusparseDnMatDescr_t, rows::Ptr{Int64},
-                                        cols::Ptr{Int64}, ld::Ptr{Int64},
-                                        values::CuPtr{Ptr{Cvoid}}, type::Ptr{cudaDataType},
-                                        order::Ptr{cusparseOrder_t})::cusparseStatus_t
+    @gcsafe_ccall libcusparse.cusparseDnMatGet(dnMatDescr::cusparseDnMatDescr_t,
+                                               rows::Ptr{Int64}, cols::Ptr{Int64},
+                                               ld::Ptr{Int64}, values::CuPtr{Ptr{Cvoid}},
+                                               type::Ptr{cudaDataType},
+                                               order::Ptr{cusparseOrder_t})::cusparseStatus_t
 end
 
 @checked function cusparseConstDnMatGet(dnMatDescr, rows, cols, ld, values, type, order)
     initialize_context()
-    @ccall libcusparse.cusparseConstDnMatGet(dnMatDescr::cusparseConstDnMatDescr_t,
-                                             rows::Ptr{Int64}, cols::Ptr{Int64},
-                                             ld::Ptr{Int64}, values::Ptr{Ptr{Cvoid}},
-                                             type::Ptr{cudaDataType},
-                                             order::Ptr{cusparseOrder_t})::cusparseStatus_t
+    @gcsafe_ccall libcusparse.cusparseConstDnMatGet(dnMatDescr::cusparseConstDnMatDescr_t,
+                                                    rows::Ptr{Int64}, cols::Ptr{Int64},
+                                                    ld::Ptr{Int64}, values::Ptr{Ptr{Cvoid}},
+                                                    type::Ptr{cudaDataType},
+                                                    order::Ptr{cusparseOrder_t})::cusparseStatus_t
 end
 
 @checked function cusparseDnMatGetValues(dnMatDescr, values)
     initialize_context()
-    @ccall libcusparse.cusparseDnMatGetValues(dnMatDescr::cusparseDnMatDescr_t,
-                                              values::CuPtr{Ptr{Cvoid}})::cusparseStatus_t
+    @gcsafe_ccall libcusparse.cusparseDnMatGetValues(dnMatDescr::cusparseDnMatDescr_t,
+                                                     values::CuPtr{Ptr{Cvoid}})::cusparseStatus_t
 end
 
 @checked function cusparseConstDnMatGetValues(dnMatDescr, values)
     initialize_context()
-    @ccall libcusparse.cusparseConstDnMatGetValues(dnMatDescr::cusparseConstDnMatDescr_t,
-                                                   values::Ptr{Ptr{Cvoid}})::cusparseStatus_t
+    @gcsafe_ccall libcusparse.cusparseConstDnMatGetValues(dnMatDescr::cusparseConstDnMatDescr_t,
+                                                          values::Ptr{Ptr{Cvoid}})::cusparseStatus_t
 end
 
 @checked function cusparseDnMatSetValues(dnMatDescr, values)
     initialize_context()
-    @ccall libcusparse.cusparseDnMatSetValues(dnMatDescr::cusparseDnMatDescr_t,
-                                              values::CuPtr{Cvoid})::cusparseStatus_t
+    @gcsafe_ccall libcusparse.cusparseDnMatSetValues(dnMatDescr::cusparseDnMatDescr_t,
+                                                     values::CuPtr{Cvoid})::cusparseStatus_t
 end
 
 @checked function cusparseDnMatSetStridedBatch(dnMatDescr, batchCount, batchStride)
     initialize_context()
-    @ccall libcusparse.cusparseDnMatSetStridedBatch(dnMatDescr::cusparseDnMatDescr_t,
-                                                    batchCount::Cint,
-                                                    batchStride::Int64)::cusparseStatus_t
+    @gcsafe_ccall libcusparse.cusparseDnMatSetStridedBatch(dnMatDescr::cusparseDnMatDescr_t,
+                                                           batchCount::Cint,
+                                                           batchStride::Int64)::cusparseStatus_t
 end
 
 @checked function cusparseDnMatGetStridedBatch(dnMatDescr, batchCount, batchStride)
     initialize_context()
-    @ccall libcusparse.cusparseDnMatGetStridedBatch(dnMatDescr::cusparseConstDnMatDescr_t,
-                                                    batchCount::Ptr{Cint},
-                                                    batchStride::Ptr{Int64})::cusparseStatus_t
+    @gcsafe_ccall libcusparse.cusparseDnMatGetStridedBatch(dnMatDescr::cusparseConstDnMatDescr_t,
+                                                           batchCount::Ptr{Cint},
+                                                           batchStride::Ptr{Int64})::cusparseStatus_t
 end
 
 @checked function cusparseAxpby(handle, alpha, vecX, beta, vecY)
     initialize_context()
-    @ccall libcusparse.cusparseAxpby(handle::cusparseHandle_t, alpha::PtrOrCuPtr{Cvoid},
-                                     vecX::cusparseConstSpVecDescr_t,
-                                     beta::PtrOrCuPtr{Cvoid},
-                                     vecY::cusparseDnVecDescr_t)::cusparseStatus_t
+    @gcsafe_ccall libcusparse.cusparseAxpby(handle::cusparseHandle_t,
+                                            alpha::PtrOrCuPtr{Cvoid},
+                                            vecX::cusparseConstSpVecDescr_t,
+                                            beta::PtrOrCuPtr{Cvoid},
+                                            vecY::cusparseDnVecDescr_t)::cusparseStatus_t
 end
 
 @checked function cusparseGather(handle, vecY, vecX)
     initialize_context()
-    @ccall libcusparse.cusparseGather(handle::cusparseHandle_t,
-                                      vecY::cusparseConstDnVecDescr_t,
-                                      vecX::cusparseSpVecDescr_t)::cusparseStatus_t
+    @gcsafe_ccall libcusparse.cusparseGather(handle::cusparseHandle_t,
+                                             vecY::cusparseConstDnVecDescr_t,
+                                             vecX::cusparseSpVecDescr_t)::cusparseStatus_t
 end
 
 @checked function cusparseScatter(handle, vecX, vecY)
     initialize_context()
-    @ccall libcusparse.cusparseScatter(handle::cusparseHandle_t,
-                                       vecX::cusparseConstSpVecDescr_t,
-                                       vecY::cusparseDnVecDescr_t)::cusparseStatus_t
+    @gcsafe_ccall libcusparse.cusparseScatter(handle::cusparseHandle_t,
+                                              vecX::cusparseConstSpVecDescr_t,
+                                              vecY::cusparseDnVecDescr_t)::cusparseStatus_t
 end
 
 @checked function cusparseRot(handle, c_coeff, s_coeff, vecX, vecY)
     initialize_context()
-    @ccall libcusparse.cusparseRot(handle::cusparseHandle_t, c_coeff::PtrOrCuPtr{Cvoid},
-                                   s_coeff::PtrOrCuPtr{Cvoid}, vecX::cusparseSpVecDescr_t,
-                                   vecY::cusparseDnVecDescr_t)::cusparseStatus_t
+    @gcsafe_ccall libcusparse.cusparseRot(handle::cusparseHandle_t,
+                                          c_coeff::PtrOrCuPtr{Cvoid},
+                                          s_coeff::PtrOrCuPtr{Cvoid},
+                                          vecX::cusparseSpVecDescr_t,
+                                          vecY::cusparseDnVecDescr_t)::cusparseStatus_t
 end
 
 @checked function cusparseSpVV_bufferSize(handle, opX, vecX, vecY, result, computeType,
                                           bufferSize)
     initialize_context()
-    @ccall libcusparse.cusparseSpVV_bufferSize(handle::cusparseHandle_t,
-                                               opX::cusparseOperation_t,
-                                               vecX::cusparseConstSpVecDescr_t,
-                                               vecY::cusparseConstDnVecDescr_t,
-                                               result::PtrOrCuPtr{Cvoid},
-                                               computeType::cudaDataType,
-                                               bufferSize::Ptr{Csize_t})::cusparseStatus_t
+    @gcsafe_ccall libcusparse.cusparseSpVV_bufferSize(handle::cusparseHandle_t,
+                                                      opX::cusparseOperation_t,
+                                                      vecX::cusparseConstSpVecDescr_t,
+                                                      vecY::cusparseConstDnVecDescr_t,
+                                                      result::PtrOrCuPtr{Cvoid},
+                                                      computeType::cudaDataType,
+                                                      bufferSize::Ptr{Csize_t})::cusparseStatus_t
 end
 
 @checked function cusparseSpVV(handle, opX, vecX, vecY, result, computeType, externalBuffer)
     initialize_context()
-    @ccall libcusparse.cusparseSpVV(handle::cusparseHandle_t, opX::cusparseOperation_t,
-                                    vecX::cusparseConstSpVecDescr_t,
-                                    vecY::cusparseConstDnVecDescr_t,
-                                    result::PtrOrCuPtr{Cvoid}, computeType::cudaDataType,
-                                    externalBuffer::CuPtr{Cvoid})::cusparseStatus_t
+    @gcsafe_ccall libcusparse.cusparseSpVV(handle::cusparseHandle_t,
+                                           opX::cusparseOperation_t,
+                                           vecX::cusparseConstSpVecDescr_t,
+                                           vecY::cusparseConstDnVecDescr_t,
+                                           result::PtrOrCuPtr{Cvoid},
+                                           computeType::cudaDataType,
+                                           externalBuffer::CuPtr{Cvoid})::cusparseStatus_t
 end
 
 @cenum cusparseSparseToDenseAlg_t::UInt32 begin
@@ -5394,20 +5735,20 @@ end
 
 @checked function cusparseSparseToDense_bufferSize(handle, matA, matB, alg, bufferSize)
     initialize_context()
-    @ccall libcusparse.cusparseSparseToDense_bufferSize(handle::cusparseHandle_t,
-                                                        matA::cusparseConstSpMatDescr_t,
-                                                        matB::cusparseDnMatDescr_t,
-                                                        alg::cusparseSparseToDenseAlg_t,
-                                                        bufferSize::Ptr{Csize_t})::cusparseStatus_t
+    @gcsafe_ccall libcusparse.cusparseSparseToDense_bufferSize(handle::cusparseHandle_t,
+                                                               matA::cusparseConstSpMatDescr_t,
+                                                               matB::cusparseDnMatDescr_t,
+                                                               alg::cusparseSparseToDenseAlg_t,
+                                                               bufferSize::Ptr{Csize_t})::cusparseStatus_t
 end
 
 @checked function cusparseSparseToDense(handle, matA, matB, alg, externalBuffer)
     initialize_context()
-    @ccall libcusparse.cusparseSparseToDense(handle::cusparseHandle_t,
-                                             matA::cusparseConstSpMatDescr_t,
-                                             matB::cusparseDnMatDescr_t,
-                                             alg::cusparseSparseToDenseAlg_t,
-                                             externalBuffer::CuPtr{Cvoid})::cusparseStatus_t
+    @gcsafe_ccall libcusparse.cusparseSparseToDense(handle::cusparseHandle_t,
+                                                    matA::cusparseConstSpMatDescr_t,
+                                                    matB::cusparseDnMatDescr_t,
+                                                    alg::cusparseSparseToDenseAlg_t,
+                                                    externalBuffer::CuPtr{Cvoid})::cusparseStatus_t
 end
 
 @cenum cusparseDenseToSparseAlg_t::UInt32 begin
@@ -5416,29 +5757,29 @@ end
 
 @checked function cusparseDenseToSparse_bufferSize(handle, matA, matB, alg, bufferSize)
     initialize_context()
-    @ccall libcusparse.cusparseDenseToSparse_bufferSize(handle::cusparseHandle_t,
-                                                        matA::cusparseConstDnMatDescr_t,
-                                                        matB::cusparseSpMatDescr_t,
-                                                        alg::cusparseDenseToSparseAlg_t,
-                                                        bufferSize::Ptr{Csize_t})::cusparseStatus_t
+    @gcsafe_ccall libcusparse.cusparseDenseToSparse_bufferSize(handle::cusparseHandle_t,
+                                                               matA::cusparseConstDnMatDescr_t,
+                                                               matB::cusparseSpMatDescr_t,
+                                                               alg::cusparseDenseToSparseAlg_t,
+                                                               bufferSize::Ptr{Csize_t})::cusparseStatus_t
 end
 
 @checked function cusparseDenseToSparse_analysis(handle, matA, matB, alg, externalBuffer)
     initialize_context()
-    @ccall libcusparse.cusparseDenseToSparse_analysis(handle::cusparseHandle_t,
-                                                      matA::cusparseConstDnMatDescr_t,
-                                                      matB::cusparseSpMatDescr_t,
-                                                      alg::cusparseDenseToSparseAlg_t,
-                                                      externalBuffer::CuPtr{Cvoid})::cusparseStatus_t
+    @gcsafe_ccall libcusparse.cusparseDenseToSparse_analysis(handle::cusparseHandle_t,
+                                                             matA::cusparseConstDnMatDescr_t,
+                                                             matB::cusparseSpMatDescr_t,
+                                                             alg::cusparseDenseToSparseAlg_t,
+                                                             externalBuffer::CuPtr{Cvoid})::cusparseStatus_t
 end
 
 @checked function cusparseDenseToSparse_convert(handle, matA, matB, alg, externalBuffer)
     initialize_context()
-    @ccall libcusparse.cusparseDenseToSparse_convert(handle::cusparseHandle_t,
-                                                     matA::cusparseConstDnMatDescr_t,
-                                                     matB::cusparseSpMatDescr_t,
-                                                     alg::cusparseDenseToSparseAlg_t,
-                                                     externalBuffer::CuPtr{Cvoid})::cusparseStatus_t
+    @gcsafe_ccall libcusparse.cusparseDenseToSparse_convert(handle::cusparseHandle_t,
+                                                            matA::cusparseConstDnMatDescr_t,
+                                                            matB::cusparseSpMatDescr_t,
+                                                            alg::cusparseDenseToSparseAlg_t,
+                                                            externalBuffer::CuPtr{Cvoid})::cusparseStatus_t
 end
 
 @cenum cusparseSpMVAlg_t::UInt32 begin
@@ -5453,26 +5794,31 @@ end
 @checked function cusparseSpMV(handle, opA, alpha, matA, vecX, beta, vecY, computeType, alg,
                                externalBuffer)
     initialize_context()
-    @ccall libcusparse.cusparseSpMV(handle::cusparseHandle_t, opA::cusparseOperation_t,
-                                    alpha::PtrOrCuPtr{Cvoid},
-                                    matA::cusparseConstSpMatDescr_t,
-                                    vecX::cusparseConstDnVecDescr_t,
-                                    beta::PtrOrCuPtr{Cvoid}, vecY::cusparseDnVecDescr_t,
-                                    computeType::cudaDataType, alg::cusparseSpMVAlg_t,
-                                    externalBuffer::CuPtr{Cvoid})::cusparseStatus_t
+    @gcsafe_ccall libcusparse.cusparseSpMV(handle::cusparseHandle_t,
+                                           opA::cusparseOperation_t,
+                                           alpha::PtrOrCuPtr{Cvoid},
+                                           matA::cusparseConstSpMatDescr_t,
+                                           vecX::cusparseConstDnVecDescr_t,
+                                           beta::PtrOrCuPtr{Cvoid},
+                                           vecY::cusparseDnVecDescr_t,
+                                           computeType::cudaDataType,
+                                           alg::cusparseSpMVAlg_t,
+                                           externalBuffer::CuPtr{Cvoid})::cusparseStatus_t
 end
 
 @checked function cusparseSpMV_bufferSize(handle, opA, alpha, matA, vecX, beta, vecY,
                                           computeType, alg, bufferSize)
     initialize_context()
-    @ccall libcusparse.cusparseSpMV_bufferSize(handle::cusparseHandle_t,
-                                               opA::cusparseOperation_t, alpha::Ptr{Cvoid},
-                                               matA::cusparseConstSpMatDescr_t,
-                                               vecX::cusparseConstDnVecDescr_t,
-                                               beta::Ptr{Cvoid}, vecY::cusparseDnVecDescr_t,
-                                               computeType::cudaDataType,
-                                               alg::cusparseSpMVAlg_t,
-                                               bufferSize::Ptr{Csize_t})::cusparseStatus_t
+    @gcsafe_ccall libcusparse.cusparseSpMV_bufferSize(handle::cusparseHandle_t,
+                                                      opA::cusparseOperation_t,
+                                                      alpha::Ptr{Cvoid},
+                                                      matA::cusparseConstSpMatDescr_t,
+                                                      vecX::cusparseConstDnVecDescr_t,
+                                                      beta::Ptr{Cvoid},
+                                                      vecY::cusparseDnVecDescr_t,
+                                                      computeType::cudaDataType,
+                                                      alg::cusparseSpMVAlg_t,
+                                                      bufferSize::Ptr{Csize_t})::cusparseStatus_t
 end
 
 @cenum cusparseSpSVAlg_t::UInt32 begin
@@ -5490,60 +5836,64 @@ const cusparseSpSVDescr_t = Ptr{cusparseSpSVDescr}
 
 @checked function cusparseSpSV_createDescr(descr)
     initialize_context()
-    @ccall libcusparse.cusparseSpSV_createDescr(descr::Ptr{cusparseSpSVDescr_t})::cusparseStatus_t
+    @gcsafe_ccall libcusparse.cusparseSpSV_createDescr(descr::Ptr{cusparseSpSVDescr_t})::cusparseStatus_t
 end
 
 @checked function cusparseSpSV_destroyDescr(descr)
     initialize_context()
-    @ccall libcusparse.cusparseSpSV_destroyDescr(descr::cusparseSpSVDescr_t)::cusparseStatus_t
+    @gcsafe_ccall libcusparse.cusparseSpSV_destroyDescr(descr::cusparseSpSVDescr_t)::cusparseStatus_t
 end
 
 @checked function cusparseSpSV_bufferSize(handle, opA, alpha, matA, vecX, vecY, computeType,
                                           alg, spsvDescr, bufferSize)
     initialize_context()
-    @ccall libcusparse.cusparseSpSV_bufferSize(handle::cusparseHandle_t,
-                                               opA::cusparseOperation_t, alpha::Ptr{Cvoid},
-                                               matA::cusparseConstSpMatDescr_t,
-                                               vecX::cusparseConstDnVecDescr_t,
-                                               vecY::cusparseDnVecDescr_t,
-                                               computeType::cudaDataType,
-                                               alg::cusparseSpSVAlg_t,
-                                               spsvDescr::cusparseSpSVDescr_t,
-                                               bufferSize::Ptr{Csize_t})::cusparseStatus_t
+    @gcsafe_ccall libcusparse.cusparseSpSV_bufferSize(handle::cusparseHandle_t,
+                                                      opA::cusparseOperation_t,
+                                                      alpha::Ptr{Cvoid},
+                                                      matA::cusparseConstSpMatDescr_t,
+                                                      vecX::cusparseConstDnVecDescr_t,
+                                                      vecY::cusparseDnVecDescr_t,
+                                                      computeType::cudaDataType,
+                                                      alg::cusparseSpSVAlg_t,
+                                                      spsvDescr::cusparseSpSVDescr_t,
+                                                      bufferSize::Ptr{Csize_t})::cusparseStatus_t
 end
 
 @checked function cusparseSpSV_analysis(handle, opA, alpha, matA, vecX, vecY, computeType,
                                         alg, spsvDescr, externalBuffer)
     initialize_context()
-    @ccall libcusparse.cusparseSpSV_analysis(handle::cusparseHandle_t,
-                                             opA::cusparseOperation_t, alpha::Ptr{Cvoid},
-                                             matA::cusparseConstSpMatDescr_t,
-                                             vecX::cusparseConstDnVecDescr_t,
-                                             vecY::cusparseDnVecDescr_t,
-                                             computeType::cudaDataType,
-                                             alg::cusparseSpSVAlg_t,
-                                             spsvDescr::cusparseSpSVDescr_t,
-                                             externalBuffer::CuPtr{Cvoid})::cusparseStatus_t
+    @gcsafe_ccall libcusparse.cusparseSpSV_analysis(handle::cusparseHandle_t,
+                                                    opA::cusparseOperation_t,
+                                                    alpha::Ptr{Cvoid},
+                                                    matA::cusparseConstSpMatDescr_t,
+                                                    vecX::cusparseConstDnVecDescr_t,
+                                                    vecY::cusparseDnVecDescr_t,
+                                                    computeType::cudaDataType,
+                                                    alg::cusparseSpSVAlg_t,
+                                                    spsvDescr::cusparseSpSVDescr_t,
+                                                    externalBuffer::CuPtr{Cvoid})::cusparseStatus_t
 end
 
 @checked function cusparseSpSV_solve(handle, opA, alpha, matA, vecX, vecY, computeType, alg,
                                      spsvDescr)
     initialize_context()
-    @ccall libcusparse.cusparseSpSV_solve(handle::cusparseHandle_t,
-                                          opA::cusparseOperation_t, alpha::Ptr{Cvoid},
-                                          matA::cusparseConstSpMatDescr_t,
-                                          vecX::cusparseConstDnVecDescr_t,
-                                          vecY::cusparseDnVecDescr_t,
-                                          computeType::cudaDataType, alg::cusparseSpSVAlg_t,
-                                          spsvDescr::cusparseSpSVDescr_t)::cusparseStatus_t
+    @gcsafe_ccall libcusparse.cusparseSpSV_solve(handle::cusparseHandle_t,
+                                                 opA::cusparseOperation_t,
+                                                 alpha::Ptr{Cvoid},
+                                                 matA::cusparseConstSpMatDescr_t,
+                                                 vecX::cusparseConstDnVecDescr_t,
+                                                 vecY::cusparseDnVecDescr_t,
+                                                 computeType::cudaDataType,
+                                                 alg::cusparseSpSVAlg_t,
+                                                 spsvDescr::cusparseSpSVDescr_t)::cusparseStatus_t
 end
 
 @checked function cusparseSpSV_updateMatrix(handle, spsvDescr, newValues, updatePart)
     initialize_context()
-    @ccall libcusparse.cusparseSpSV_updateMatrix(handle::cusparseHandle_t,
-                                                 spsvDescr::cusparseSpSVDescr_t,
-                                                 newValues::CuPtr{Cvoid},
-                                                 updatePart::cusparseSpSVUpdate_t)::cusparseStatus_t
+    @gcsafe_ccall libcusparse.cusparseSpSV_updateMatrix(handle::cusparseHandle_t,
+                                                        spsvDescr::cusparseSpSVDescr_t,
+                                                        newValues::CuPtr{Cvoid},
+                                                        updatePart::cusparseSpSVUpdate_t)::cusparseStatus_t
 end
 
 @cenum cusparseSpSMAlg_t::UInt32 begin
@@ -5556,55 +5906,59 @@ const cusparseSpSMDescr_t = Ptr{cusparseSpSMDescr}
 
 @checked function cusparseSpSM_createDescr(descr)
     initialize_context()
-    @ccall libcusparse.cusparseSpSM_createDescr(descr::Ptr{cusparseSpSMDescr_t})::cusparseStatus_t
+    @gcsafe_ccall libcusparse.cusparseSpSM_createDescr(descr::Ptr{cusparseSpSMDescr_t})::cusparseStatus_t
 end
 
 @checked function cusparseSpSM_destroyDescr(descr)
     initialize_context()
-    @ccall libcusparse.cusparseSpSM_destroyDescr(descr::cusparseSpSMDescr_t)::cusparseStatus_t
+    @gcsafe_ccall libcusparse.cusparseSpSM_destroyDescr(descr::cusparseSpSMDescr_t)::cusparseStatus_t
 end
 
 @checked function cusparseSpSM_bufferSize(handle, opA, opB, alpha, matA, matB, matC,
                                           computeType, alg, spsmDescr, bufferSize)
     initialize_context()
-    @ccall libcusparse.cusparseSpSM_bufferSize(handle::cusparseHandle_t,
-                                               opA::cusparseOperation_t,
-                                               opB::cusparseOperation_t, alpha::Ptr{Cvoid},
-                                               matA::cusparseConstSpMatDescr_t,
-                                               matB::cusparseConstDnMatDescr_t,
-                                               matC::cusparseDnMatDescr_t,
-                                               computeType::cudaDataType,
-                                               alg::cusparseSpSMAlg_t,
-                                               spsmDescr::cusparseSpSMDescr_t,
-                                               bufferSize::Ptr{Csize_t})::cusparseStatus_t
+    @gcsafe_ccall libcusparse.cusparseSpSM_bufferSize(handle::cusparseHandle_t,
+                                                      opA::cusparseOperation_t,
+                                                      opB::cusparseOperation_t,
+                                                      alpha::Ptr{Cvoid},
+                                                      matA::cusparseConstSpMatDescr_t,
+                                                      matB::cusparseConstDnMatDescr_t,
+                                                      matC::cusparseDnMatDescr_t,
+                                                      computeType::cudaDataType,
+                                                      alg::cusparseSpSMAlg_t,
+                                                      spsmDescr::cusparseSpSMDescr_t,
+                                                      bufferSize::Ptr{Csize_t})::cusparseStatus_t
 end
 
 @checked function cusparseSpSM_analysis(handle, opA, opB, alpha, matA, matB, matC,
                                         computeType, alg, spsmDescr, externalBuffer)
     initialize_context()
-    @ccall libcusparse.cusparseSpSM_analysis(handle::cusparseHandle_t,
-                                             opA::cusparseOperation_t,
-                                             opB::cusparseOperation_t, alpha::Ptr{Cvoid},
-                                             matA::cusparseConstSpMatDescr_t,
-                                             matB::cusparseConstDnMatDescr_t,
-                                             matC::cusparseDnMatDescr_t,
-                                             computeType::cudaDataType,
-                                             alg::cusparseSpSMAlg_t,
-                                             spsmDescr::cusparseSpSMDescr_t,
-                                             externalBuffer::CuPtr{Cvoid})::cusparseStatus_t
+    @gcsafe_ccall libcusparse.cusparseSpSM_analysis(handle::cusparseHandle_t,
+                                                    opA::cusparseOperation_t,
+                                                    opB::cusparseOperation_t,
+                                                    alpha::Ptr{Cvoid},
+                                                    matA::cusparseConstSpMatDescr_t,
+                                                    matB::cusparseConstDnMatDescr_t,
+                                                    matC::cusparseDnMatDescr_t,
+                                                    computeType::cudaDataType,
+                                                    alg::cusparseSpSMAlg_t,
+                                                    spsmDescr::cusparseSpSMDescr_t,
+                                                    externalBuffer::CuPtr{Cvoid})::cusparseStatus_t
 end
 
 @checked function cusparseSpSM_solve(handle, opA, opB, alpha, matA, matB, matC, computeType,
                                      alg, spsmDescr)
     initialize_context()
-    @ccall libcusparse.cusparseSpSM_solve(handle::cusparseHandle_t,
-                                          opA::cusparseOperation_t,
-                                          opB::cusparseOperation_t, alpha::Ptr{Cvoid},
-                                          matA::cusparseConstSpMatDescr_t,
-                                          matB::cusparseConstDnMatDescr_t,
-                                          matC::cusparseDnMatDescr_t,
-                                          computeType::cudaDataType, alg::cusparseSpSMAlg_t,
-                                          spsmDescr::cusparseSpSMDescr_t)::cusparseStatus_t
+    @gcsafe_ccall libcusparse.cusparseSpSM_solve(handle::cusparseHandle_t,
+                                                 opA::cusparseOperation_t,
+                                                 opB::cusparseOperation_t,
+                                                 alpha::Ptr{Cvoid},
+                                                 matA::cusparseConstSpMatDescr_t,
+                                                 matB::cusparseConstDnMatDescr_t,
+                                                 matC::cusparseDnMatDescr_t,
+                                                 computeType::cudaDataType,
+                                                 alg::cusparseSpSMAlg_t,
+                                                 spsmDescr::cusparseSpSMDescr_t)::cusparseStatus_t
 end
 
 @cenum cusparseSpMMAlg_t::UInt32 begin
@@ -5622,45 +5976,49 @@ end
 @checked function cusparseSpMM_bufferSize(handle, opA, opB, alpha, matA, matB, beta, matC,
                                           computeType, alg, bufferSize)
     initialize_context()
-    @ccall libcusparse.cusparseSpMM_bufferSize(handle::cusparseHandle_t,
-                                               opA::cusparseOperation_t,
-                                               opB::cusparseOperation_t,
-                                               alpha::PtrOrCuPtr{Cvoid},
-                                               matA::cusparseConstSpMatDescr_t,
-                                               matB::cusparseConstDnMatDescr_t,
-                                               beta::PtrOrCuPtr{Cvoid},
-                                               matC::cusparseDnMatDescr_t,
-                                               computeType::cudaDataType,
-                                               alg::cusparseSpMMAlg_t,
-                                               bufferSize::Ptr{Csize_t})::cusparseStatus_t
+    @gcsafe_ccall libcusparse.cusparseSpMM_bufferSize(handle::cusparseHandle_t,
+                                                      opA::cusparseOperation_t,
+                                                      opB::cusparseOperation_t,
+                                                      alpha::PtrOrCuPtr{Cvoid},
+                                                      matA::cusparseConstSpMatDescr_t,
+                                                      matB::cusparseConstDnMatDescr_t,
+                                                      beta::PtrOrCuPtr{Cvoid},
+                                                      matC::cusparseDnMatDescr_t,
+                                                      computeType::cudaDataType,
+                                                      alg::cusparseSpMMAlg_t,
+                                                      bufferSize::Ptr{Csize_t})::cusparseStatus_t
 end
 
 @checked function cusparseSpMM_preprocess(handle, opA, opB, alpha, matA, matB, beta, matC,
                                           computeType, alg, externalBuffer)
     initialize_context()
-    @ccall libcusparse.cusparseSpMM_preprocess(handle::cusparseHandle_t,
-                                               opA::cusparseOperation_t,
-                                               opB::cusparseOperation_t,
-                                               alpha::PtrOrCuPtr{Cvoid},
-                                               matA::cusparseConstSpMatDescr_t,
-                                               matB::cusparseConstDnMatDescr_t,
-                                               beta::PtrOrCuPtr{Cvoid},
-                                               matC::cusparseDnMatDescr_t,
-                                               computeType::cudaDataType,
-                                               alg::cusparseSpMMAlg_t,
-                                               externalBuffer::CuPtr{Cvoid})::cusparseStatus_t
+    @gcsafe_ccall libcusparse.cusparseSpMM_preprocess(handle::cusparseHandle_t,
+                                                      opA::cusparseOperation_t,
+                                                      opB::cusparseOperation_t,
+                                                      alpha::PtrOrCuPtr{Cvoid},
+                                                      matA::cusparseConstSpMatDescr_t,
+                                                      matB::cusparseConstDnMatDescr_t,
+                                                      beta::PtrOrCuPtr{Cvoid},
+                                                      matC::cusparseDnMatDescr_t,
+                                                      computeType::cudaDataType,
+                                                      alg::cusparseSpMMAlg_t,
+                                                      externalBuffer::CuPtr{Cvoid})::cusparseStatus_t
 end
 
 @checked function cusparseSpMM(handle, opA, opB, alpha, matA, matB, beta, matC, computeType,
                                alg, externalBuffer)
     initialize_context()
-    @ccall libcusparse.cusparseSpMM(handle::cusparseHandle_t, opA::cusparseOperation_t,
-                                    opB::cusparseOperation_t, alpha::PtrOrCuPtr{Cvoid},
-                                    matA::cusparseConstSpMatDescr_t,
-                                    matB::cusparseConstDnMatDescr_t,
-                                    beta::PtrOrCuPtr{Cvoid}, matC::cusparseDnMatDescr_t,
-                                    computeType::cudaDataType, alg::cusparseSpMMAlg_t,
-                                    externalBuffer::CuPtr{Cvoid})::cusparseStatus_t
+    @gcsafe_ccall libcusparse.cusparseSpMM(handle::cusparseHandle_t,
+                                           opA::cusparseOperation_t,
+                                           opB::cusparseOperation_t,
+                                           alpha::PtrOrCuPtr{Cvoid},
+                                           matA::cusparseConstSpMatDescr_t,
+                                           matB::cusparseConstDnMatDescr_t,
+                                           beta::PtrOrCuPtr{Cvoid},
+                                           matC::cusparseDnMatDescr_t,
+                                           computeType::cudaDataType,
+                                           alg::cusparseSpMMAlg_t,
+                                           externalBuffer::CuPtr{Cvoid})::cusparseStatus_t
 end
 
 @cenum cusparseSpGEMMAlg_t::UInt32 begin
@@ -5678,19 +6036,66 @@ const cusparseSpGEMMDescr_t = Ptr{cusparseSpGEMMDescr}
 
 @checked function cusparseSpGEMM_createDescr(descr)
     initialize_context()
-    @ccall libcusparse.cusparseSpGEMM_createDescr(descr::Ptr{cusparseSpGEMMDescr_t})::cusparseStatus_t
+    @gcsafe_ccall libcusparse.cusparseSpGEMM_createDescr(descr::Ptr{cusparseSpGEMMDescr_t})::cusparseStatus_t
 end
 
 @checked function cusparseSpGEMM_destroyDescr(descr)
     initialize_context()
-    @ccall libcusparse.cusparseSpGEMM_destroyDescr(descr::cusparseSpGEMMDescr_t)::cusparseStatus_t
+    @gcsafe_ccall libcusparse.cusparseSpGEMM_destroyDescr(descr::cusparseSpGEMMDescr_t)::cusparseStatus_t
 end
 
 @checked function cusparseSpGEMM_workEstimation(handle, opA, opB, alpha, matA, matB, beta,
                                                 matC, computeType, alg, spgemmDescr,
                                                 bufferSize1, externalBuffer1)
     initialize_context()
-    @ccall libcusparse.cusparseSpGEMM_workEstimation(handle::cusparseHandle_t,
+    @gcsafe_ccall libcusparse.cusparseSpGEMM_workEstimation(handle::cusparseHandle_t,
+                                                            opA::cusparseOperation_t,
+                                                            opB::cusparseOperation_t,
+                                                            alpha::PtrOrCuPtr{Cvoid},
+                                                            matA::cusparseConstSpMatDescr_t,
+                                                            matB::cusparseConstSpMatDescr_t,
+                                                            beta::PtrOrCuPtr{Cvoid},
+                                                            matC::cusparseSpMatDescr_t,
+                                                            computeType::cudaDataType,
+                                                            alg::cusparseSpGEMMAlg_t,
+                                                            spgemmDescr::cusparseSpGEMMDescr_t,
+                                                            bufferSize1::Ptr{Csize_t},
+                                                            externalBuffer1::CuPtr{Cvoid})::cusparseStatus_t
+end
+
+@checked function cusparseSpGEMM_getNumProducts(spgemmDescr, num_prods)
+    initialize_context()
+    @gcsafe_ccall libcusparse.cusparseSpGEMM_getNumProducts(spgemmDescr::cusparseSpGEMMDescr_t,
+                                                            num_prods::Ptr{Int64})::cusparseStatus_t
+end
+
+@checked function cusparseSpGEMM_estimateMemory(handle, opA, opB, alpha, matA, matB, beta,
+                                                matC, computeType, alg, spgemmDescr,
+                                                chunk_fraction, bufferSize3,
+                                                externalBuffer3, bufferSize2)
+    initialize_context()
+    @gcsafe_ccall libcusparse.cusparseSpGEMM_estimateMemory(handle::cusparseHandle_t,
+                                                            opA::cusparseOperation_t,
+                                                            opB::cusparseOperation_t,
+                                                            alpha::Ptr{Cvoid},
+                                                            matA::cusparseConstSpMatDescr_t,
+                                                            matB::cusparseConstSpMatDescr_t,
+                                                            beta::Ptr{Cvoid},
+                                                            matC::cusparseSpMatDescr_t,
+                                                            computeType::cudaDataType,
+                                                            alg::cusparseSpGEMMAlg_t,
+                                                            spgemmDescr::cusparseSpGEMMDescr_t,
+                                                            chunk_fraction::Cfloat,
+                                                            bufferSize3::Ptr{Csize_t},
+                                                            externalBuffer3::Ptr{Cvoid},
+                                                            bufferSize2::Ptr{Csize_t})::cusparseStatus_t
+end
+
+@checked function cusparseSpGEMM_compute(handle, opA, opB, alpha, matA, matB, beta, matC,
+                                         computeType, alg, spgemmDescr, bufferSize2,
+                                         externalBuffer2)
+    initialize_context()
+    @gcsafe_ccall libcusparse.cusparseSpGEMM_compute(handle::cusparseHandle_t,
                                                      opA::cusparseOperation_t,
                                                      opB::cusparseOperation_t,
                                                      alpha::PtrOrCuPtr{Cvoid},
@@ -5701,87 +6106,40 @@ end
                                                      computeType::cudaDataType,
                                                      alg::cusparseSpGEMMAlg_t,
                                                      spgemmDescr::cusparseSpGEMMDescr_t,
-                                                     bufferSize1::Ptr{Csize_t},
-                                                     externalBuffer1::CuPtr{Cvoid})::cusparseStatus_t
-end
-
-@checked function cusparseSpGEMM_getNumProducts(spgemmDescr, num_prods)
-    initialize_context()
-    @ccall libcusparse.cusparseSpGEMM_getNumProducts(spgemmDescr::cusparseSpGEMMDescr_t,
-                                                     num_prods::Ptr{Int64})::cusparseStatus_t
-end
-
-@checked function cusparseSpGEMM_estimateMemory(handle, opA, opB, alpha, matA, matB, beta,
-                                                matC, computeType, alg, spgemmDescr,
-                                                chunk_fraction, bufferSize3,
-                                                externalBuffer3, bufferSize2)
-    initialize_context()
-    @ccall libcusparse.cusparseSpGEMM_estimateMemory(handle::cusparseHandle_t,
-                                                     opA::cusparseOperation_t,
-                                                     opB::cusparseOperation_t,
-                                                     alpha::Ptr{Cvoid},
-                                                     matA::cusparseConstSpMatDescr_t,
-                                                     matB::cusparseConstSpMatDescr_t,
-                                                     beta::Ptr{Cvoid},
-                                                     matC::cusparseSpMatDescr_t,
-                                                     computeType::cudaDataType,
-                                                     alg::cusparseSpGEMMAlg_t,
-                                                     spgemmDescr::cusparseSpGEMMDescr_t,
-                                                     chunk_fraction::Cfloat,
-                                                     bufferSize3::Ptr{Csize_t},
-                                                     externalBuffer3::Ptr{Cvoid},
-                                                     bufferSize2::Ptr{Csize_t})::cusparseStatus_t
-end
-
-@checked function cusparseSpGEMM_compute(handle, opA, opB, alpha, matA, matB, beta, matC,
-                                         computeType, alg, spgemmDescr, bufferSize2,
-                                         externalBuffer2)
-    initialize_context()
-    @ccall libcusparse.cusparseSpGEMM_compute(handle::cusparseHandle_t,
-                                              opA::cusparseOperation_t,
-                                              opB::cusparseOperation_t,
-                                              alpha::PtrOrCuPtr{Cvoid},
-                                              matA::cusparseConstSpMatDescr_t,
-                                              matB::cusparseConstSpMatDescr_t,
-                                              beta::PtrOrCuPtr{Cvoid},
-                                              matC::cusparseSpMatDescr_t,
-                                              computeType::cudaDataType,
-                                              alg::cusparseSpGEMMAlg_t,
-                                              spgemmDescr::cusparseSpGEMMDescr_t,
-                                              bufferSize2::Ptr{Csize_t},
-                                              externalBuffer2::CuPtr{Cvoid})::cusparseStatus_t
+                                                     bufferSize2::Ptr{Csize_t},
+                                                     externalBuffer2::CuPtr{Cvoid})::cusparseStatus_t
 end
 
 @checked function cusparseSpGEMM_copy(handle, opA, opB, alpha, matA, matB, beta, matC,
                                       computeType, alg, spgemmDescr)
     initialize_context()
-    @ccall libcusparse.cusparseSpGEMM_copy(handle::cusparseHandle_t,
-                                           opA::cusparseOperation_t,
-                                           opB::cusparseOperation_t,
-                                           alpha::PtrOrCuPtr{Cvoid},
-                                           matA::cusparseConstSpMatDescr_t,
-                                           matB::cusparseConstSpMatDescr_t,
-                                           beta::PtrOrCuPtr{Cvoid},
-                                           matC::cusparseSpMatDescr_t,
-                                           computeType::cudaDataType,
-                                           alg::cusparseSpGEMMAlg_t,
-                                           spgemmDescr::cusparseSpGEMMDescr_t)::cusparseStatus_t
+    @gcsafe_ccall libcusparse.cusparseSpGEMM_copy(handle::cusparseHandle_t,
+                                                  opA::cusparseOperation_t,
+                                                  opB::cusparseOperation_t,
+                                                  alpha::PtrOrCuPtr{Cvoid},
+                                                  matA::cusparseConstSpMatDescr_t,
+                                                  matB::cusparseConstSpMatDescr_t,
+                                                  beta::PtrOrCuPtr{Cvoid},
+                                                  matC::cusparseSpMatDescr_t,
+                                                  computeType::cudaDataType,
+                                                  alg::cusparseSpGEMMAlg_t,
+                                                  spgemmDescr::cusparseSpGEMMDescr_t)::cusparseStatus_t
 end
 
 @checked function cusparseSpGEMMreuse_workEstimation(handle, opA, opB, matA, matB, matC,
                                                      alg, spgemmDescr, bufferSize1,
                                                      externalBuffer1)
     initialize_context()
-    @ccall libcusparse.cusparseSpGEMMreuse_workEstimation(handle::cusparseHandle_t,
-                                                          opA::cusparseOperation_t,
-                                                          opB::cusparseOperation_t,
-                                                          matA::cusparseConstSpMatDescr_t,
-                                                          matB::cusparseConstSpMatDescr_t,
-                                                          matC::cusparseSpMatDescr_t,
-                                                          alg::cusparseSpGEMMAlg_t,
-                                                          spgemmDescr::cusparseSpGEMMDescr_t,
-                                                          bufferSize1::Ptr{Csize_t},
-                                                          externalBuffer1::CuPtr{Cvoid})::cusparseStatus_t
+    @gcsafe_ccall libcusparse.cusparseSpGEMMreuse_workEstimation(handle::cusparseHandle_t,
+                                                                 opA::cusparseOperation_t,
+                                                                 opB::cusparseOperation_t,
+                                                                 matA::cusparseConstSpMatDescr_t,
+                                                                 matB::cusparseConstSpMatDescr_t,
+                                                                 matC::cusparseSpMatDescr_t,
+                                                                 alg::cusparseSpGEMMAlg_t,
+                                                                 spgemmDescr::cusparseSpGEMMDescr_t,
+                                                                 bufferSize1::Ptr{Csize_t},
+                                                                 externalBuffer1::CuPtr{Cvoid})::cusparseStatus_t
 end
 
 @checked function cusparseSpGEMMreuse_nnz(handle, opA, opB, matA, matB, matC, alg,
@@ -5789,51 +6147,51 @@ end
                                           bufferSize3, externalBuffer3, bufferSize4,
                                           externalBuffer4)
     initialize_context()
-    @ccall libcusparse.cusparseSpGEMMreuse_nnz(handle::cusparseHandle_t,
-                                               opA::cusparseOperation_t,
-                                               opB::cusparseOperation_t,
-                                               matA::cusparseConstSpMatDescr_t,
-                                               matB::cusparseConstSpMatDescr_t,
-                                               matC::cusparseSpMatDescr_t,
-                                               alg::cusparseSpGEMMAlg_t,
-                                               spgemmDescr::cusparseSpGEMMDescr_t,
-                                               bufferSize2::Ptr{Csize_t},
-                                               externalBuffer2::CuPtr{Cvoid},
-                                               bufferSize3::Ptr{Csize_t},
-                                               externalBuffer3::CuPtr{Cvoid},
-                                               bufferSize4::Ptr{Csize_t},
-                                               externalBuffer4::CuPtr{Cvoid})::cusparseStatus_t
+    @gcsafe_ccall libcusparse.cusparseSpGEMMreuse_nnz(handle::cusparseHandle_t,
+                                                      opA::cusparseOperation_t,
+                                                      opB::cusparseOperation_t,
+                                                      matA::cusparseConstSpMatDescr_t,
+                                                      matB::cusparseConstSpMatDescr_t,
+                                                      matC::cusparseSpMatDescr_t,
+                                                      alg::cusparseSpGEMMAlg_t,
+                                                      spgemmDescr::cusparseSpGEMMDescr_t,
+                                                      bufferSize2::Ptr{Csize_t},
+                                                      externalBuffer2::CuPtr{Cvoid},
+                                                      bufferSize3::Ptr{Csize_t},
+                                                      externalBuffer3::CuPtr{Cvoid},
+                                                      bufferSize4::Ptr{Csize_t},
+                                                      externalBuffer4::CuPtr{Cvoid})::cusparseStatus_t
 end
 
 @checked function cusparseSpGEMMreuse_copy(handle, opA, opB, matA, matB, matC, alg,
                                            spgemmDescr, bufferSize5, externalBuffer5)
     initialize_context()
-    @ccall libcusparse.cusparseSpGEMMreuse_copy(handle::cusparseHandle_t,
-                                                opA::cusparseOperation_t,
-                                                opB::cusparseOperation_t,
-                                                matA::cusparseConstSpMatDescr_t,
-                                                matB::cusparseConstSpMatDescr_t,
-                                                matC::cusparseSpMatDescr_t,
-                                                alg::cusparseSpGEMMAlg_t,
-                                                spgemmDescr::cusparseSpGEMMDescr_t,
-                                                bufferSize5::Ptr{Csize_t},
-                                                externalBuffer5::CuPtr{Cvoid})::cusparseStatus_t
+    @gcsafe_ccall libcusparse.cusparseSpGEMMreuse_copy(handle::cusparseHandle_t,
+                                                       opA::cusparseOperation_t,
+                                                       opB::cusparseOperation_t,
+                                                       matA::cusparseConstSpMatDescr_t,
+                                                       matB::cusparseConstSpMatDescr_t,
+                                                       matC::cusparseSpMatDescr_t,
+                                                       alg::cusparseSpGEMMAlg_t,
+                                                       spgemmDescr::cusparseSpGEMMDescr_t,
+                                                       bufferSize5::Ptr{Csize_t},
+                                                       externalBuffer5::CuPtr{Cvoid})::cusparseStatus_t
 end
 
 @checked function cusparseSpGEMMreuse_compute(handle, opA, opB, alpha, matA, matB, beta,
                                               matC, computeType, alg, spgemmDescr)
     initialize_context()
-    @ccall libcusparse.cusparseSpGEMMreuse_compute(handle::cusparseHandle_t,
-                                                   opA::cusparseOperation_t,
-                                                   opB::cusparseOperation_t,
-                                                   alpha::Ptr{Cvoid},
-                                                   matA::cusparseConstSpMatDescr_t,
-                                                   matB::cusparseConstSpMatDescr_t,
-                                                   beta::Ptr{Cvoid},
-                                                   matC::cusparseSpMatDescr_t,
-                                                   computeType::cudaDataType,
-                                                   alg::cusparseSpGEMMAlg_t,
-                                                   spgemmDescr::cusparseSpGEMMDescr_t)::cusparseStatus_t
+    @gcsafe_ccall libcusparse.cusparseSpGEMMreuse_compute(handle::cusparseHandle_t,
+                                                          opA::cusparseOperation_t,
+                                                          opB::cusparseOperation_t,
+                                                          alpha::Ptr{Cvoid},
+                                                          matA::cusparseConstSpMatDescr_t,
+                                                          matB::cusparseConstSpMatDescr_t,
+                                                          beta::Ptr{Cvoid},
+                                                          matC::cusparseSpMatDescr_t,
+                                                          computeType::cudaDataType,
+                                                          alg::cusparseSpGEMMAlg_t,
+                                                          spgemmDescr::cusparseSpGEMMDescr_t)::cusparseStatus_t
 end
 
 @cenum cusparseSDDMMAlg_t::UInt32 begin
@@ -5843,45 +6201,49 @@ end
 @checked function cusparseSDDMM_bufferSize(handle, opA, opB, alpha, matA, matB, beta, matC,
                                            computeType, alg, bufferSize)
     initialize_context()
-    @ccall libcusparse.cusparseSDDMM_bufferSize(handle::cusparseHandle_t,
-                                                opA::cusparseOperation_t,
-                                                opB::cusparseOperation_t,
-                                                alpha::PtrOrCuPtr{Cvoid},
-                                                matA::cusparseConstDnMatDescr_t,
-                                                matB::cusparseConstDnMatDescr_t,
-                                                beta::PtrOrCuPtr{Cvoid},
-                                                matC::cusparseSpMatDescr_t,
-                                                computeType::cudaDataType,
-                                                alg::cusparseSDDMMAlg_t,
-                                                bufferSize::Ptr{Csize_t})::cusparseStatus_t
+    @gcsafe_ccall libcusparse.cusparseSDDMM_bufferSize(handle::cusparseHandle_t,
+                                                       opA::cusparseOperation_t,
+                                                       opB::cusparseOperation_t,
+                                                       alpha::PtrOrCuPtr{Cvoid},
+                                                       matA::cusparseConstDnMatDescr_t,
+                                                       matB::cusparseConstDnMatDescr_t,
+                                                       beta::PtrOrCuPtr{Cvoid},
+                                                       matC::cusparseSpMatDescr_t,
+                                                       computeType::cudaDataType,
+                                                       alg::cusparseSDDMMAlg_t,
+                                                       bufferSize::Ptr{Csize_t})::cusparseStatus_t
 end
 
 @checked function cusparseSDDMM_preprocess(handle, opA, opB, alpha, matA, matB, beta, matC,
                                            computeType, alg, externalBuffer)
     initialize_context()
-    @ccall libcusparse.cusparseSDDMM_preprocess(handle::cusparseHandle_t,
-                                                opA::cusparseOperation_t,
-                                                opB::cusparseOperation_t,
-                                                alpha::PtrOrCuPtr{Cvoid},
-                                                matA::cusparseConstDnMatDescr_t,
-                                                matB::cusparseConstDnMatDescr_t,
-                                                beta::PtrOrCuPtr{Cvoid},
-                                                matC::cusparseSpMatDescr_t,
-                                                computeType::cudaDataType,
-                                                alg::cusparseSDDMMAlg_t,
-                                                externalBuffer::CuPtr{Cvoid})::cusparseStatus_t
+    @gcsafe_ccall libcusparse.cusparseSDDMM_preprocess(handle::cusparseHandle_t,
+                                                       opA::cusparseOperation_t,
+                                                       opB::cusparseOperation_t,
+                                                       alpha::PtrOrCuPtr{Cvoid},
+                                                       matA::cusparseConstDnMatDescr_t,
+                                                       matB::cusparseConstDnMatDescr_t,
+                                                       beta::PtrOrCuPtr{Cvoid},
+                                                       matC::cusparseSpMatDescr_t,
+                                                       computeType::cudaDataType,
+                                                       alg::cusparseSDDMMAlg_t,
+                                                       externalBuffer::CuPtr{Cvoid})::cusparseStatus_t
 end
 
 @checked function cusparseSDDMM(handle, opA, opB, alpha, matA, matB, beta, matC,
                                 computeType, alg, externalBuffer)
     initialize_context()
-    @ccall libcusparse.cusparseSDDMM(handle::cusparseHandle_t, opA::cusparseOperation_t,
-                                     opB::cusparseOperation_t, alpha::PtrOrCuPtr{Cvoid},
-                                     matA::cusparseConstDnMatDescr_t,
-                                     matB::cusparseConstDnMatDescr_t,
-                                     beta::PtrOrCuPtr{Cvoid}, matC::cusparseSpMatDescr_t,
-                                     computeType::cudaDataType, alg::cusparseSDDMMAlg_t,
-                                     externalBuffer::CuPtr{Cvoid})::cusparseStatus_t
+    @gcsafe_ccall libcusparse.cusparseSDDMM(handle::cusparseHandle_t,
+                                            opA::cusparseOperation_t,
+                                            opB::cusparseOperation_t,
+                                            alpha::PtrOrCuPtr{Cvoid},
+                                            matA::cusparseConstDnMatDescr_t,
+                                            matB::cusparseConstDnMatDescr_t,
+                                            beta::PtrOrCuPtr{Cvoid},
+                                            matC::cusparseSpMatDescr_t,
+                                            computeType::cudaDataType,
+                                            alg::cusparseSDDMMAlg_t,
+                                            externalBuffer::CuPtr{Cvoid})::cusparseStatus_t
 end
 
 mutable struct cusparseSpMMOpPlan end
@@ -5898,33 +6260,33 @@ end
                                             mulOperationBufferSize, epilogueNvvmBuffer,
                                             epilogueBufferSize, SpMMWorkspaceSize)
     initialize_context()
-    @ccall libcusparse.cusparseSpMMOp_createPlan(handle::cusparseHandle_t,
-                                                 plan::Ptr{cusparseSpMMOpPlan_t},
-                                                 opA::cusparseOperation_t,
-                                                 opB::cusparseOperation_t,
-                                                 matA::cusparseConstSpMatDescr_t,
-                                                 matB::cusparseConstDnMatDescr_t,
-                                                 matC::cusparseDnMatDescr_t,
-                                                 computeType::cudaDataType,
-                                                 alg::cusparseSpMMOpAlg_t,
-                                                 addOperationNvvmBuffer::Ptr{Cvoid},
-                                                 addOperationBufferSize::Csize_t,
-                                                 mulOperationNvvmBuffer::Ptr{Cvoid},
-                                                 mulOperationBufferSize::Csize_t,
-                                                 epilogueNvvmBuffer::Ptr{Cvoid},
-                                                 epilogueBufferSize::Csize_t,
-                                                 SpMMWorkspaceSize::Ptr{Csize_t})::cusparseStatus_t
+    @gcsafe_ccall libcusparse.cusparseSpMMOp_createPlan(handle::cusparseHandle_t,
+                                                        plan::Ptr{cusparseSpMMOpPlan_t},
+                                                        opA::cusparseOperation_t,
+                                                        opB::cusparseOperation_t,
+                                                        matA::cusparseConstSpMatDescr_t,
+                                                        matB::cusparseConstDnMatDescr_t,
+                                                        matC::cusparseDnMatDescr_t,
+                                                        computeType::cudaDataType,
+                                                        alg::cusparseSpMMOpAlg_t,
+                                                        addOperationNvvmBuffer::Ptr{Cvoid},
+                                                        addOperationBufferSize::Csize_t,
+                                                        mulOperationNvvmBuffer::Ptr{Cvoid},
+                                                        mulOperationBufferSize::Csize_t,
+                                                        epilogueNvvmBuffer::Ptr{Cvoid},
+                                                        epilogueBufferSize::Csize_t,
+                                                        SpMMWorkspaceSize::Ptr{Csize_t})::cusparseStatus_t
 end
 
 @checked function cusparseSpMMOp(plan, externalBuffer)
     initialize_context()
-    @ccall libcusparse.cusparseSpMMOp(plan::cusparseSpMMOpPlan_t,
-                                      externalBuffer::CuPtr{Cvoid})::cusparseStatus_t
+    @gcsafe_ccall libcusparse.cusparseSpMMOp(plan::cusparseSpMMOpPlan_t,
+                                             externalBuffer::CuPtr{Cvoid})::cusparseStatus_t
 end
 
 @checked function cusparseSpMMOp_destroyPlan(plan)
     initialize_context()
-    @ccall libcusparse.cusparseSpMMOp_destroyPlan(plan::cusparseSpMMOpPlan_t)::cusparseStatus_t
+    @gcsafe_ccall libcusparse.cusparseSpMMOp_destroyPlan(plan::cusparseSpMMOpPlan_t)::cusparseStatus_t
 end
 
 # Float16 functionality is only enabled when using C++ (defining __cplusplus breaks things)

--- a/lib/custatevec/src/cuStateVec.jl
+++ b/lib/custatevec/src/cuStateVec.jl
@@ -88,6 +88,11 @@ end
 ## logging
 
 function log_message(log_level, function_name, message)
+    # see @gcsafe_ccall documentation
+    @static if VERSION < v"1.9"
+        GC.safepoint()
+    end
+
     function_name = unsafe_string(function_name)
     message = unsafe_string(message)
     output = if isempty(message)

--- a/lib/custatevec/src/cuStateVec.jl
+++ b/lib/custatevec/src/cuStateVec.jl
@@ -12,6 +12,13 @@ else
     import cuQuantum_jll
 end
 
+# XXX: cuStateVec depends on cuTENSOR 1, while GC-safe ccalls were introduced in CUDA 5.3
+#      which is only compatible with cuTENSOR 2. So disable that functionality for now.
+const var"@gcsafe_ccall" = var"@ccall"
+macro gcunsafe_callback(expr)
+    esc(expr)
+end
+
 
 export has_custatevec
 

--- a/lib/custatevec/src/cuStateVec.jl
+++ b/lib/custatevec/src/cuStateVec.jl
@@ -87,12 +87,7 @@ end
 
 ## logging
 
-function log_message(log_level, function_name, message)
-    # see @gcsafe_ccall documentation
-    @static if VERSION < v"1.9"
-        GC.safepoint()
-    end
-
+@gcunsafe_callback function log_message(log_level, function_name, message)
     function_name = unsafe_string(function_name)
     message = unsafe_string(message)
     output = if isempty(message)

--- a/lib/custatevec/src/libcustatevec.jl
+++ b/lib/custatevec/src/libcustatevec.jl
@@ -130,210 +130,218 @@ end
 
 @checked function custatevecCreate(handle)
     initialize_context()
-    @ccall libcustatevec.custatevecCreate(handle::Ptr{custatevecHandle_t})::custatevecStatus_t
+    @gcsafe_ccall libcustatevec.custatevecCreate(handle::Ptr{custatevecHandle_t})::custatevecStatus_t
 end
 
 @checked function custatevecDestroy(handle)
     initialize_context()
-    @ccall libcustatevec.custatevecDestroy(handle::custatevecHandle_t)::custatevecStatus_t
+    @gcsafe_ccall libcustatevec.custatevecDestroy(handle::custatevecHandle_t)::custatevecStatus_t
 end
 
 @checked function custatevecGetDefaultWorkspaceSize(handle, workspaceSizeInBytes)
     initialize_context()
-    @ccall libcustatevec.custatevecGetDefaultWorkspaceSize(handle::custatevecHandle_t,
-                                                           workspaceSizeInBytes::Ptr{Csize_t})::custatevecStatus_t
+    @gcsafe_ccall libcustatevec.custatevecGetDefaultWorkspaceSize(handle::custatevecHandle_t,
+                                                                  workspaceSizeInBytes::Ptr{Csize_t})::custatevecStatus_t
 end
 
 @checked function custatevecSetWorkspace(handle, workspace, workspaceSizeInBytes)
     initialize_context()
-    @ccall libcustatevec.custatevecSetWorkspace(handle::custatevecHandle_t,
-                                                workspace::CuPtr{Cvoid},
-                                                workspaceSizeInBytes::Csize_t)::custatevecStatus_t
+    @gcsafe_ccall libcustatevec.custatevecSetWorkspace(handle::custatevecHandle_t,
+                                                       workspace::CuPtr{Cvoid},
+                                                       workspaceSizeInBytes::Csize_t)::custatevecStatus_t
 end
 
 function custatevecGetErrorName(status)
     initialize_context()
-    @ccall libcustatevec.custatevecGetErrorName(status::custatevecStatus_t)::Cstring
+    @gcsafe_ccall libcustatevec.custatevecGetErrorName(status::custatevecStatus_t)::Cstring
 end
 
 function custatevecGetErrorString(status)
-    @ccall libcustatevec.custatevecGetErrorString(status::custatevecStatus_t)::Cstring
+    @gcsafe_ccall libcustatevec.custatevecGetErrorString(status::custatevecStatus_t)::Cstring
 end
 
 @checked function custatevecGetProperty(type, value)
     initialize_context()
-    @ccall libcustatevec.custatevecGetProperty(type::libraryPropertyType,
-                                               value::Ptr{Int32})::custatevecStatus_t
+    @gcsafe_ccall libcustatevec.custatevecGetProperty(type::libraryPropertyType,
+                                                      value::Ptr{Int32})::custatevecStatus_t
 end
 
 # no prototype is found for this function at custatevec.h:521:8, please use with caution
 function custatevecGetVersion()
-    @ccall libcustatevec.custatevecGetVersion()::Csize_t
+    @gcsafe_ccall libcustatevec.custatevecGetVersion()::Csize_t
 end
 
 @checked function custatevecSetStream(handle, streamId)
     initialize_context()
-    @ccall libcustatevec.custatevecSetStream(handle::custatevecHandle_t,
-                                             streamId::cudaStream_t)::custatevecStatus_t
+    @gcsafe_ccall libcustatevec.custatevecSetStream(handle::custatevecHandle_t,
+                                                    streamId::cudaStream_t)::custatevecStatus_t
 end
 
 @checked function custatevecGetStream(handle, streamId)
     initialize_context()
-    @ccall libcustatevec.custatevecGetStream(handle::custatevecHandle_t,
-                                             streamId::Ptr{cudaStream_t})::custatevecStatus_t
+    @gcsafe_ccall libcustatevec.custatevecGetStream(handle::custatevecHandle_t,
+                                                    streamId::Ptr{cudaStream_t})::custatevecStatus_t
 end
 
 @checked function custatevecLoggerSetCallback(callback)
-    @ccall libcustatevec.custatevecLoggerSetCallback(callback::custatevecLoggerCallback_t)::custatevecStatus_t
+    @gcsafe_ccall libcustatevec.custatevecLoggerSetCallback(callback::custatevecLoggerCallback_t)::custatevecStatus_t
 end
 
 @checked function custatevecLoggerSetCallbackData(callback, userData)
     initialize_context()
-    @ccall libcustatevec.custatevecLoggerSetCallbackData(callback::custatevecLoggerCallbackData_t,
-                                                         userData::Ptr{Cvoid})::custatevecStatus_t
+    @gcsafe_ccall libcustatevec.custatevecLoggerSetCallbackData(callback::custatevecLoggerCallbackData_t,
+                                                                userData::Ptr{Cvoid})::custatevecStatus_t
 end
 
 @checked function custatevecLoggerSetFile(file)
-    @ccall libcustatevec.custatevecLoggerSetFile(file::Ptr{Libc.FILE})::custatevecStatus_t
+    @gcsafe_ccall libcustatevec.custatevecLoggerSetFile(file::Ptr{Libc.FILE})::custatevecStatus_t
 end
 
 @checked function custatevecLoggerOpenFile(logFile)
-    @ccall libcustatevec.custatevecLoggerOpenFile(logFile::Cstring)::custatevecStatus_t
+    @gcsafe_ccall libcustatevec.custatevecLoggerOpenFile(logFile::Cstring)::custatevecStatus_t
 end
 
 @checked function custatevecLoggerSetLevel(level)
     initialize_context()
-    @ccall libcustatevec.custatevecLoggerSetLevel(level::Int32)::custatevecStatus_t
+    @gcsafe_ccall libcustatevec.custatevecLoggerSetLevel(level::Int32)::custatevecStatus_t
 end
 
 @checked function custatevecLoggerSetMask(mask)
-    @ccall libcustatevec.custatevecLoggerSetMask(mask::Int32)::custatevecStatus_t
+    @gcsafe_ccall libcustatevec.custatevecLoggerSetMask(mask::Int32)::custatevecStatus_t
 end
 
 # no prototype is found for this function at custatevec.h:621:1, please use with caution
 @checked function custatevecLoggerForceDisable()
-    @ccall libcustatevec.custatevecLoggerForceDisable()::custatevecStatus_t
+    @gcsafe_ccall libcustatevec.custatevecLoggerForceDisable()::custatevecStatus_t
 end
 
 @checked function custatevecGetDeviceMemHandler(handle, handler)
     initialize_context()
-    @ccall libcustatevec.custatevecGetDeviceMemHandler(handle::custatevecHandle_t,
-                                                       handler::Ptr{custatevecDeviceMemHandler_t})::custatevecStatus_t
+    @gcsafe_ccall libcustatevec.custatevecGetDeviceMemHandler(handle::custatevecHandle_t,
+                                                              handler::Ptr{custatevecDeviceMemHandler_t})::custatevecStatus_t
 end
 
 @checked function custatevecSetDeviceMemHandler(handle, handler)
     initialize_context()
-    @ccall libcustatevec.custatevecSetDeviceMemHandler(handle::custatevecHandle_t,
-                                                       handler::Ptr{custatevecDeviceMemHandler_t})::custatevecStatus_t
+    @gcsafe_ccall libcustatevec.custatevecSetDeviceMemHandler(handle::custatevecHandle_t,
+                                                              handler::Ptr{custatevecDeviceMemHandler_t})::custatevecStatus_t
 end
 
 @checked function custatevecAbs2SumOnZBasis(handle, sv, svDataType, nIndexBits, abs2sum0,
                                             abs2sum1, basisBits, nBasisBits)
     initialize_context()
-    @ccall libcustatevec.custatevecAbs2SumOnZBasis(handle::custatevecHandle_t,
-                                                   sv::CuPtr{Cvoid},
-                                                   svDataType::cudaDataType_t,
-                                                   nIndexBits::UInt32,
-                                                   abs2sum0::Ptr{Cdouble},
-                                                   abs2sum1::Ptr{Cdouble},
-                                                   basisBits::Ptr{Int32},
-                                                   nBasisBits::UInt32)::custatevecStatus_t
+    @gcsafe_ccall libcustatevec.custatevecAbs2SumOnZBasis(handle::custatevecHandle_t,
+                                                          sv::CuPtr{Cvoid},
+                                                          svDataType::cudaDataType_t,
+                                                          nIndexBits::UInt32,
+                                                          abs2sum0::Ptr{Cdouble},
+                                                          abs2sum1::Ptr{Cdouble},
+                                                          basisBits::Ptr{Int32},
+                                                          nBasisBits::UInt32)::custatevecStatus_t
 end
 
 @checked function custatevecAbs2SumArray(handle, sv, svDataType, nIndexBits, abs2sum,
                                          bitOrdering, bitOrderingLen, maskBitString,
                                          maskOrdering, maskLen)
     initialize_context()
-    @ccall libcustatevec.custatevecAbs2SumArray(handle::custatevecHandle_t,
-                                                sv::CuPtr{Cvoid},
-                                                svDataType::cudaDataType_t,
-                                                nIndexBits::UInt32, abs2sum::Ptr{Cdouble},
-                                                bitOrdering::Ptr{Int32},
-                                                bitOrderingLen::UInt32,
-                                                maskBitString::Ptr{Int32},
-                                                maskOrdering::Ptr{Int32},
-                                                maskLen::UInt32)::custatevecStatus_t
+    @gcsafe_ccall libcustatevec.custatevecAbs2SumArray(handle::custatevecHandle_t,
+                                                       sv::CuPtr{Cvoid},
+                                                       svDataType::cudaDataType_t,
+                                                       nIndexBits::UInt32,
+                                                       abs2sum::Ptr{Cdouble},
+                                                       bitOrdering::Ptr{Int32},
+                                                       bitOrderingLen::UInt32,
+                                                       maskBitString::Ptr{Int32},
+                                                       maskOrdering::Ptr{Int32},
+                                                       maskLen::UInt32)::custatevecStatus_t
 end
 
 @checked function custatevecCollapseOnZBasis(handle, sv, svDataType, nIndexBits, parity,
                                              basisBits, nBasisBits, norm)
     initialize_context()
-    @ccall libcustatevec.custatevecCollapseOnZBasis(handle::custatevecHandle_t,
-                                                    sv::CuPtr{Cvoid},
-                                                    svDataType::cudaDataType_t,
-                                                    nIndexBits::UInt32, parity::Int32,
-                                                    basisBits::Ptr{Int32},
-                                                    nBasisBits::UInt32,
-                                                    norm::Cdouble)::custatevecStatus_t
+    @gcsafe_ccall libcustatevec.custatevecCollapseOnZBasis(handle::custatevecHandle_t,
+                                                           sv::CuPtr{Cvoid},
+                                                           svDataType::cudaDataType_t,
+                                                           nIndexBits::UInt32,
+                                                           parity::Int32,
+                                                           basisBits::Ptr{Int32},
+                                                           nBasisBits::UInt32,
+                                                           norm::Cdouble)::custatevecStatus_t
 end
 
 @checked function custatevecCollapseByBitString(handle, sv, svDataType, nIndexBits,
                                                 bitString, bitOrdering, bitStringLen, norm)
     initialize_context()
-    @ccall libcustatevec.custatevecCollapseByBitString(handle::custatevecHandle_t,
+    @gcsafe_ccall libcustatevec.custatevecCollapseByBitString(handle::custatevecHandle_t,
+                                                              sv::CuPtr{Cvoid},
+                                                              svDataType::cudaDataType_t,
+                                                              nIndexBits::UInt32,
+                                                              bitString::Ptr{Int32},
+                                                              bitOrdering::Ptr{Int32},
+                                                              bitStringLen::UInt32,
+                                                              norm::Cdouble)::custatevecStatus_t
+end
+
+@checked function custatevecMeasureOnZBasis(handle, sv, svDataType, nIndexBits, parity,
+                                            basisBits, nBasisBits, randnum, collapse)
+    initialize_context()
+    @gcsafe_ccall libcustatevec.custatevecMeasureOnZBasis(handle::custatevecHandle_t,
+                                                          sv::CuPtr{Cvoid},
+                                                          svDataType::cudaDataType_t,
+                                                          nIndexBits::UInt32,
+                                                          parity::Ptr{Int32},
+                                                          basisBits::Ptr{Int32},
+                                                          nBasisBits::UInt32,
+                                                          randnum::Cdouble,
+                                                          collapse::custatevecCollapseOp_t)::custatevecStatus_t
+end
+
+@checked function custatevecBatchMeasure(handle, sv, svDataType, nIndexBits, bitString,
+                                         bitOrdering, bitStringLen, randnum, collapse)
+    initialize_context()
+    @gcsafe_ccall libcustatevec.custatevecBatchMeasure(handle::custatevecHandle_t,
                                                        sv::CuPtr{Cvoid},
                                                        svDataType::cudaDataType_t,
                                                        nIndexBits::UInt32,
                                                        bitString::Ptr{Int32},
                                                        bitOrdering::Ptr{Int32},
                                                        bitStringLen::UInt32,
-                                                       norm::Cdouble)::custatevecStatus_t
-end
-
-@checked function custatevecMeasureOnZBasis(handle, sv, svDataType, nIndexBits, parity,
-                                            basisBits, nBasisBits, randnum, collapse)
-    initialize_context()
-    @ccall libcustatevec.custatevecMeasureOnZBasis(handle::custatevecHandle_t,
-                                                   sv::CuPtr{Cvoid},
-                                                   svDataType::cudaDataType_t,
-                                                   nIndexBits::UInt32, parity::Ptr{Int32},
-                                                   basisBits::Ptr{Int32},
-                                                   nBasisBits::UInt32, randnum::Cdouble,
-                                                   collapse::custatevecCollapseOp_t)::custatevecStatus_t
-end
-
-@checked function custatevecBatchMeasure(handle, sv, svDataType, nIndexBits, bitString,
-                                         bitOrdering, bitStringLen, randnum, collapse)
-    initialize_context()
-    @ccall libcustatevec.custatevecBatchMeasure(handle::custatevecHandle_t,
-                                                sv::CuPtr{Cvoid},
-                                                svDataType::cudaDataType_t,
-                                                nIndexBits::UInt32, bitString::Ptr{Int32},
-                                                bitOrdering::Ptr{Int32},
-                                                bitStringLen::UInt32, randnum::Cdouble,
-                                                collapse::custatevecCollapseOp_t)::custatevecStatus_t
+                                                       randnum::Cdouble,
+                                                       collapse::custatevecCollapseOp_t)::custatevecStatus_t
 end
 
 @checked function custatevecBatchMeasureWithOffset(handle, sv, svDataType, nIndexBits,
                                                    bitString, bitOrdering, bitStringLen,
                                                    randnum, collapse, offset, abs2sum)
     initialize_context()
-    @ccall libcustatevec.custatevecBatchMeasureWithOffset(handle::custatevecHandle_t,
-                                                          sv::CuPtr{Cvoid},
-                                                          svDataType::cudaDataType_t,
-                                                          nIndexBits::UInt32,
-                                                          bitString::Ptr{Int32},
-                                                          bitOrdering::Ptr{Int32},
-                                                          bitStringLen::UInt32,
-                                                          randnum::Cdouble,
-                                                          collapse::custatevecCollapseOp_t,
-                                                          offset::Cdouble,
-                                                          abs2sum::Cdouble)::custatevecStatus_t
+    @gcsafe_ccall libcustatevec.custatevecBatchMeasureWithOffset(handle::custatevecHandle_t,
+                                                                 sv::CuPtr{Cvoid},
+                                                                 svDataType::cudaDataType_t,
+                                                                 nIndexBits::UInt32,
+                                                                 bitString::Ptr{Int32},
+                                                                 bitOrdering::Ptr{Int32},
+                                                                 bitStringLen::UInt32,
+                                                                 randnum::Cdouble,
+                                                                 collapse::custatevecCollapseOp_t,
+                                                                 offset::Cdouble,
+                                                                 abs2sum::Cdouble)::custatevecStatus_t
 end
 
 @checked function custatevecApplyPauliRotation(handle, sv, svDataType, nIndexBits, theta,
                                                paulis, targets, nTargets, controls,
                                                controlBitValues, nControls)
     initialize_context()
-    @ccall libcustatevec.custatevecApplyPauliRotation(handle::custatevecHandle_t,
-                                                      sv::CuPtr{Cvoid},
-                                                      svDataType::cudaDataType_t,
-                                                      nIndexBits::UInt32, theta::Cdouble,
-                                                      paulis::Ptr{custatevecPauli_t},
-                                                      targets::Ptr{Int32}, nTargets::UInt32,
-                                                      controls::Ptr{Int32},
-                                                      controlBitValues::Ptr{Int32},
-                                                      nControls::UInt32)::custatevecStatus_t
+    @gcsafe_ccall libcustatevec.custatevecApplyPauliRotation(handle::custatevecHandle_t,
+                                                             sv::CuPtr{Cvoid},
+                                                             svDataType::cudaDataType_t,
+                                                             nIndexBits::UInt32,
+                                                             theta::Cdouble,
+                                                             paulis::Ptr{custatevecPauli_t},
+                                                             targets::Ptr{Int32},
+                                                             nTargets::UInt32,
+                                                             controls::Ptr{Int32},
+                                                             controlBitValues::Ptr{Int32},
+                                                             nControls::UInt32)::custatevecStatus_t
 end
 
 @checked function custatevecApplyMatrixGetWorkspaceSize(handle, svDataType, nIndexBits,
@@ -342,17 +350,17 @@ end
                                                         computeType,
                                                         extraWorkspaceSizeInBytes)
     initialize_context()
-    @ccall libcustatevec.custatevecApplyMatrixGetWorkspaceSize(handle::custatevecHandle_t,
-                                                               svDataType::cudaDataType_t,
-                                                               nIndexBits::UInt32,
-                                                               matrix::PtrOrCuPtr{Cvoid},
-                                                               matrixDataType::cudaDataType_t,
-                                                               layout::custatevecMatrixLayout_t,
-                                                               adjoint::Int32,
-                                                               nTargets::UInt32,
-                                                               nControls::UInt32,
-                                                               computeType::custatevecComputeType_t,
-                                                               extraWorkspaceSizeInBytes::Ptr{Csize_t})::custatevecStatus_t
+    @gcsafe_ccall libcustatevec.custatevecApplyMatrixGetWorkspaceSize(handle::custatevecHandle_t,
+                                                                      svDataType::cudaDataType_t,
+                                                                      nIndexBits::UInt32,
+                                                                      matrix::PtrOrCuPtr{Cvoid},
+                                                                      matrixDataType::cudaDataType_t,
+                                                                      layout::custatevecMatrixLayout_t,
+                                                                      adjoint::Int32,
+                                                                      nTargets::UInt32,
+                                                                      nControls::UInt32,
+                                                                      computeType::custatevecComputeType_t,
+                                                                      extraWorkspaceSizeInBytes::Ptr{Csize_t})::custatevecStatus_t
 end
 
 @checked function custatevecApplyMatrix(handle, sv, svDataType, nIndexBits, matrix,
@@ -360,19 +368,21 @@ end
                                         controls, controlBitValues, nControls, computeType,
                                         extraWorkspace, extraWorkspaceSizeInBytes)
     initialize_context()
-    @ccall libcustatevec.custatevecApplyMatrix(handle::custatevecHandle_t, sv::CuPtr{Cvoid},
-                                               svDataType::cudaDataType_t,
-                                               nIndexBits::UInt32,
-                                               matrix::PtrOrCuPtr{Cvoid},
-                                               matrixDataType::cudaDataType_t,
-                                               layout::custatevecMatrixLayout_t,
-                                               adjoint::Int32, targets::Ptr{Int32},
-                                               nTargets::UInt32, controls::Ptr{Int32},
-                                               controlBitValues::Ptr{Int32},
-                                               nControls::UInt32,
-                                               computeType::custatevecComputeType_t,
-                                               extraWorkspace::CuPtr{Cvoid},
-                                               extraWorkspaceSizeInBytes::Csize_t)::custatevecStatus_t
+    @gcsafe_ccall libcustatevec.custatevecApplyMatrix(handle::custatevecHandle_t,
+                                                      sv::CuPtr{Cvoid},
+                                                      svDataType::cudaDataType_t,
+                                                      nIndexBits::UInt32,
+                                                      matrix::PtrOrCuPtr{Cvoid},
+                                                      matrixDataType::cudaDataType_t,
+                                                      layout::custatevecMatrixLayout_t,
+                                                      adjoint::Int32, targets::Ptr{Int32},
+                                                      nTargets::UInt32,
+                                                      controls::Ptr{Int32},
+                                                      controlBitValues::Ptr{Int32},
+                                                      nControls::UInt32,
+                                                      computeType::custatevecComputeType_t,
+                                                      extraWorkspace::CuPtr{Cvoid},
+                                                      extraWorkspaceSizeInBytes::Csize_t)::custatevecStatus_t
 end
 
 @checked function custatevecComputeExpectationGetWorkspaceSize(handle, svDataType,
@@ -381,15 +391,15 @@ end
                                                                nBasisBits, computeType,
                                                                extraWorkspaceSizeInBytes)
     initialize_context()
-    @ccall libcustatevec.custatevecComputeExpectationGetWorkspaceSize(handle::custatevecHandle_t,
-                                                                      svDataType::cudaDataType_t,
-                                                                      nIndexBits::UInt32,
-                                                                      matrix::PtrOrCuPtr{Cvoid},
-                                                                      matrixDataType::cudaDataType_t,
-                                                                      layout::custatevecMatrixLayout_t,
-                                                                      nBasisBits::UInt32,
-                                                                      computeType::custatevecComputeType_t,
-                                                                      extraWorkspaceSizeInBytes::Ptr{Csize_t})::custatevecStatus_t
+    @gcsafe_ccall libcustatevec.custatevecComputeExpectationGetWorkspaceSize(handle::custatevecHandle_t,
+                                                                             svDataType::cudaDataType_t,
+                                                                             nIndexBits::UInt32,
+                                                                             matrix::PtrOrCuPtr{Cvoid},
+                                                                             matrixDataType::cudaDataType_t,
+                                                                             layout::custatevecMatrixLayout_t,
+                                                                             nBasisBits::UInt32,
+                                                                             computeType::custatevecComputeType_t,
+                                                                             extraWorkspaceSizeInBytes::Ptr{Csize_t})::custatevecStatus_t
 end
 
 @checked function custatevecComputeExpectation(handle, sv, svDataType, nIndexBits,
@@ -398,76 +408,78 @@ end
                                                basisBits, nBasisBits, computeType,
                                                extraWorkspace, extraWorkspaceSizeInBytes)
     initialize_context()
-    @ccall libcustatevec.custatevecComputeExpectation(handle::custatevecHandle_t,
-                                                      sv::CuPtr{Cvoid},
-                                                      svDataType::cudaDataType_t,
-                                                      nIndexBits::UInt32,
-                                                      expectationValue::Ptr{Cvoid},
-                                                      expectationDataType::cudaDataType_t,
-                                                      residualNorm::Ptr{Cdouble},
-                                                      matrix::PtrOrCuPtr{Cvoid},
-                                                      matrixDataType::cudaDataType_t,
-                                                      layout::custatevecMatrixLayout_t,
-                                                      basisBits::Ptr{Int32},
-                                                      nBasisBits::UInt32,
-                                                      computeType::custatevecComputeType_t,
-                                                      extraWorkspace::CuPtr{Cvoid},
-                                                      extraWorkspaceSizeInBytes::Csize_t)::custatevecStatus_t
+    @gcsafe_ccall libcustatevec.custatevecComputeExpectation(handle::custatevecHandle_t,
+                                                             sv::CuPtr{Cvoid},
+                                                             svDataType::cudaDataType_t,
+                                                             nIndexBits::UInt32,
+                                                             expectationValue::Ptr{Cvoid},
+                                                             expectationDataType::cudaDataType_t,
+                                                             residualNorm::Ptr{Cdouble},
+                                                             matrix::PtrOrCuPtr{Cvoid},
+                                                             matrixDataType::cudaDataType_t,
+                                                             layout::custatevecMatrixLayout_t,
+                                                             basisBits::Ptr{Int32},
+                                                             nBasisBits::UInt32,
+                                                             computeType::custatevecComputeType_t,
+                                                             extraWorkspace::CuPtr{Cvoid},
+                                                             extraWorkspaceSizeInBytes::Csize_t)::custatevecStatus_t
 end
 
 @checked function custatevecSamplerCreate(handle, sv, svDataType, nIndexBits, sampler,
                                           nMaxShots, extraWorkspaceSizeInBytes)
     initialize_context()
-    @ccall libcustatevec.custatevecSamplerCreate(handle::custatevecHandle_t,
-                                                 sv::CuPtr{Cvoid},
-                                                 svDataType::cudaDataType_t,
-                                                 nIndexBits::UInt32,
-                                                 sampler::Ptr{custatevecSamplerDescriptor_t},
-                                                 nMaxShots::UInt32,
-                                                 extraWorkspaceSizeInBytes::Ptr{Csize_t})::custatevecStatus_t
+    @gcsafe_ccall libcustatevec.custatevecSamplerCreate(handle::custatevecHandle_t,
+                                                        sv::CuPtr{Cvoid},
+                                                        svDataType::cudaDataType_t,
+                                                        nIndexBits::UInt32,
+                                                        sampler::Ptr{custatevecSamplerDescriptor_t},
+                                                        nMaxShots::UInt32,
+                                                        extraWorkspaceSizeInBytes::Ptr{Csize_t})::custatevecStatus_t
 end
 
 @checked function custatevecSamplerDestroy(sampler)
     initialize_context()
-    @ccall libcustatevec.custatevecSamplerDestroy(sampler::custatevecSamplerDescriptor_t)::custatevecStatus_t
+    @gcsafe_ccall libcustatevec.custatevecSamplerDestroy(sampler::custatevecSamplerDescriptor_t)::custatevecStatus_t
 end
 
 @checked function custatevecSamplerPreprocess(handle, sampler, extraWorkspace,
                                               extraWorkspaceSizeInBytes)
     initialize_context()
-    @ccall libcustatevec.custatevecSamplerPreprocess(handle::custatevecHandle_t,
-                                                     sampler::custatevecSamplerDescriptor_t,
-                                                     extraWorkspace::CuPtr{Cvoid},
-                                                     extraWorkspaceSizeInBytes::Csize_t)::custatevecStatus_t
+    @gcsafe_ccall libcustatevec.custatevecSamplerPreprocess(handle::custatevecHandle_t,
+                                                            sampler::custatevecSamplerDescriptor_t,
+                                                            extraWorkspace::CuPtr{Cvoid},
+                                                            extraWorkspaceSizeInBytes::Csize_t)::custatevecStatus_t
 end
 
 @checked function custatevecSamplerGetSquaredNorm(handle, sampler, norm)
     initialize_context()
-    @ccall libcustatevec.custatevecSamplerGetSquaredNorm(handle::custatevecHandle_t,
-                                                         sampler::custatevecSamplerDescriptor_t,
-                                                         norm::Ptr{Cdouble})::custatevecStatus_t
+    @gcsafe_ccall libcustatevec.custatevecSamplerGetSquaredNorm(handle::custatevecHandle_t,
+                                                                sampler::custatevecSamplerDescriptor_t,
+                                                                norm::Ptr{Cdouble})::custatevecStatus_t
 end
 
 @checked function custatevecSamplerApplySubSVOffset(handle, sampler, subSVOrd, nSubSVs,
                                                     offset, norm)
     initialize_context()
-    @ccall libcustatevec.custatevecSamplerApplySubSVOffset(handle::custatevecHandle_t,
-                                                           sampler::custatevecSamplerDescriptor_t,
-                                                           subSVOrd::Int32, nSubSVs::UInt32,
-                                                           offset::Cdouble,
-                                                           norm::Cdouble)::custatevecStatus_t
+    @gcsafe_ccall libcustatevec.custatevecSamplerApplySubSVOffset(handle::custatevecHandle_t,
+                                                                  sampler::custatevecSamplerDescriptor_t,
+                                                                  subSVOrd::Int32,
+                                                                  nSubSVs::UInt32,
+                                                                  offset::Cdouble,
+                                                                  norm::Cdouble)::custatevecStatus_t
 end
 
 @checked function custatevecSamplerSample(handle, sampler, bitStrings, bitOrdering,
                                           bitStringLen, randnums, nShots, output)
     initialize_context()
-    @ccall libcustatevec.custatevecSamplerSample(handle::custatevecHandle_t,
-                                                 sampler::custatevecSamplerDescriptor_t,
-                                                 bitStrings::Ptr{custatevecIndex_t},
-                                                 bitOrdering::Ptr{Int32},
-                                                 bitStringLen::UInt32,
-                                                 randnums::Ptr{Cdouble}, nShots::UInt32,
-                                                 output::custatevecSamplerOutput_t)::custatevecStatus_t
+    @gcsafe_ccall libcustatevec.custatevecSamplerSample(handle::custatevecHandle_t,
+                                                        sampler::custatevecSamplerDescriptor_t,
+                                                        bitStrings::Ptr{custatevecIndex_t},
+                                                        bitOrdering::Ptr{Int32},
+                                                        bitStringLen::UInt32,
+                                                        randnums::Ptr{Cdouble},
+                                                        nShots::UInt32,
+                                                        output::custatevecSamplerOutput_t)::custatevecStatus_t
 end
 
 @checked function custatevecApplyGeneralizedPermutationMatrixGetWorkspaceSize(handle,
@@ -481,16 +493,16 @@ end
                                                                               nControls,
                                                                               extraWorkspaceSizeInBytes)
     initialize_context()
-    @ccall libcustatevec.custatevecApplyGeneralizedPermutationMatrixGetWorkspaceSize(handle::custatevecHandle_t,
-                                                                                     svDataType::cudaDataType_t,
-                                                                                     nIndexBits::UInt32,
-                                                                                     permutation::PtrOrCuPtr{custatevecIndex_t},
-                                                                                     diagonals::CuPtr{Cvoid},
-                                                                                     diagonalsDataType::cudaDataType_t,
-                                                                                     targets::Ptr{Int32},
-                                                                                     nTargets::UInt32,
-                                                                                     nControls::UInt32,
-                                                                                     extraWorkspaceSizeInBytes::Ptr{Csize_t})::custatevecStatus_t
+    @gcsafe_ccall libcustatevec.custatevecApplyGeneralizedPermutationMatrixGetWorkspaceSize(handle::custatevecHandle_t,
+                                                                                            svDataType::cudaDataType_t,
+                                                                                            nIndexBits::UInt32,
+                                                                                            permutation::PtrOrCuPtr{custatevecIndex_t},
+                                                                                            diagonals::CuPtr{Cvoid},
+                                                                                            diagonalsDataType::cudaDataType_t,
+                                                                                            targets::Ptr{Int32},
+                                                                                            nTargets::UInt32,
+                                                                                            nControls::UInt32,
+                                                                                            extraWorkspaceSizeInBytes::Ptr{Csize_t})::custatevecStatus_t
 end
 
 @checked function custatevecApplyGeneralizedPermutationMatrix(handle, sv, svDataType,
@@ -501,21 +513,21 @@ end
                                                               nControls, extraWorkspace,
                                                               extraWorkspaceSizeInBytes)
     initialize_context()
-    @ccall libcustatevec.custatevecApplyGeneralizedPermutationMatrix(handle::custatevecHandle_t,
-                                                                     sv::CuPtr{Cvoid},
-                                                                     svDataType::cudaDataType_t,
-                                                                     nIndexBits::UInt32,
-                                                                     permutation::PtrOrCuPtr{custatevecIndex_t},
-                                                                     diagonals::PtrOrCuPtr{Cvoid},
-                                                                     diagonalsDataType::cudaDataType_t,
-                                                                     adjoint::Int32,
-                                                                     targets::Ptr{Int32},
-                                                                     nTargets::UInt32,
-                                                                     controls::Ptr{Int32},
-                                                                     controlBitValues::Ptr{Int32},
-                                                                     nControls::UInt32,
-                                                                     extraWorkspace::PtrOrCuPtr{Cvoid},
-                                                                     extraWorkspaceSizeInBytes::Csize_t)::custatevecStatus_t
+    @gcsafe_ccall libcustatevec.custatevecApplyGeneralizedPermutationMatrix(handle::custatevecHandle_t,
+                                                                            sv::CuPtr{Cvoid},
+                                                                            svDataType::cudaDataType_t,
+                                                                            nIndexBits::UInt32,
+                                                                            permutation::PtrOrCuPtr{custatevecIndex_t},
+                                                                            diagonals::PtrOrCuPtr{Cvoid},
+                                                                            diagonalsDataType::cudaDataType_t,
+                                                                            adjoint::Int32,
+                                                                            targets::Ptr{Int32},
+                                                                            nTargets::UInt32,
+                                                                            controls::Ptr{Int32},
+                                                                            controlBitValues::Ptr{Int32},
+                                                                            nControls::UInt32,
+                                                                            extraWorkspace::PtrOrCuPtr{Cvoid},
+                                                                            extraWorkspaceSizeInBytes::Csize_t)::custatevecStatus_t
 end
 
 @checked function custatevecComputeExpectationsOnPauliBasis(handle, sv, svDataType,
@@ -524,31 +536,32 @@ end
                                                             nPauliOperatorArrays,
                                                             basisBitsArray, nBasisBitsArray)
     initialize_context()
-    @ccall libcustatevec.custatevecComputeExpectationsOnPauliBasis(handle::custatevecHandle_t,
-                                                                   sv::CuPtr{Cvoid},
-                                                                   svDataType::cudaDataType_t,
-                                                                   nIndexBits::UInt32,
-                                                                   expectationValues::Ptr{Cdouble},
-                                                                   pauliOperatorsArray::Ptr{Ptr{custatevecPauli_t}},
-                                                                   nPauliOperatorArrays::UInt32,
-                                                                   basisBitsArray::Ptr{Ptr{Int32}},
-                                                                   nBasisBitsArray::Ptr{UInt32})::custatevecStatus_t
+    @gcsafe_ccall libcustatevec.custatevecComputeExpectationsOnPauliBasis(handle::custatevecHandle_t,
+                                                                          sv::CuPtr{Cvoid},
+                                                                          svDataType::cudaDataType_t,
+                                                                          nIndexBits::UInt32,
+                                                                          expectationValues::Ptr{Cdouble},
+                                                                          pauliOperatorsArray::Ptr{Ptr{custatevecPauli_t}},
+                                                                          nPauliOperatorArrays::UInt32,
+                                                                          basisBitsArray::Ptr{Ptr{Int32}},
+                                                                          nBasisBitsArray::Ptr{UInt32})::custatevecStatus_t
 end
 
 @checked function custatevecAccessorCreate(handle, sv, svDataType, nIndexBits, accessor,
                                            bitOrdering, bitOrderingLen, maskBitString,
                                            maskOrdering, maskLen, extraWorkspaceSizeInBytes)
     initialize_context()
-    @ccall libcustatevec.custatevecAccessorCreate(handle::custatevecHandle_t,
-                                                  sv::CuPtr{Cvoid},
-                                                  svDataType::cudaDataType_t,
-                                                  nIndexBits::UInt32,
-                                                  accessor::Ptr{custatevecAccessorDescriptor_t},
-                                                  bitOrdering::Ptr{Int32},
-                                                  bitOrderingLen::UInt32,
-                                                  maskBitString::Ptr{Int32},
-                                                  maskOrdering::Ptr{Int32}, maskLen::UInt32,
-                                                  extraWorkspaceSizeInBytes::Ptr{Csize_t})::custatevecStatus_t
+    @gcsafe_ccall libcustatevec.custatevecAccessorCreate(handle::custatevecHandle_t,
+                                                         sv::CuPtr{Cvoid},
+                                                         svDataType::cudaDataType_t,
+                                                         nIndexBits::UInt32,
+                                                         accessor::Ptr{custatevecAccessorDescriptor_t},
+                                                         bitOrdering::Ptr{Int32},
+                                                         bitOrderingLen::UInt32,
+                                                         maskBitString::Ptr{Int32},
+                                                         maskOrdering::Ptr{Int32},
+                                                         maskLen::UInt32,
+                                                         extraWorkspaceSizeInBytes::Ptr{Csize_t})::custatevecStatus_t
 end
 
 @checked function custatevecAccessorCreateView(handle, sv, svDataType, nIndexBits, accessor,
@@ -556,62 +569,63 @@ end
                                                maskOrdering, maskLen,
                                                extraWorkspaceSizeInBytes)
     initialize_context()
-    @ccall libcustatevec.custatevecAccessorCreateView(handle::custatevecHandle_t,
-                                                      sv::CuPtr{Cvoid},
-                                                      svDataType::cudaDataType_t,
-                                                      nIndexBits::UInt32,
-                                                      accessor::Ptr{custatevecAccessorDescriptor_t},
-                                                      bitOrdering::Ptr{Int32},
-                                                      bitOrderingLen::UInt32,
-                                                      maskBitString::Ptr{Int32},
-                                                      maskOrdering::Ptr{Int32},
-                                                      maskLen::UInt32,
-                                                      extraWorkspaceSizeInBytes::Ptr{Csize_t})::custatevecStatus_t
+    @gcsafe_ccall libcustatevec.custatevecAccessorCreateView(handle::custatevecHandle_t,
+                                                             sv::CuPtr{Cvoid},
+                                                             svDataType::cudaDataType_t,
+                                                             nIndexBits::UInt32,
+                                                             accessor::Ptr{custatevecAccessorDescriptor_t},
+                                                             bitOrdering::Ptr{Int32},
+                                                             bitOrderingLen::UInt32,
+                                                             maskBitString::Ptr{Int32},
+                                                             maskOrdering::Ptr{Int32},
+                                                             maskLen::UInt32,
+                                                             extraWorkspaceSizeInBytes::Ptr{Csize_t})::custatevecStatus_t
 end
 
 @checked function custatevecAccessorDestroy(accessor)
     initialize_context()
-    @ccall libcustatevec.custatevecAccessorDestroy(accessor::custatevecAccessorDescriptor_t)::custatevecStatus_t
+    @gcsafe_ccall libcustatevec.custatevecAccessorDestroy(accessor::custatevecAccessorDescriptor_t)::custatevecStatus_t
 end
 
 @checked function custatevecAccessorSetExtraWorkspace(handle, accessor, extraWorkspace,
                                                       extraWorkspaceSizeInBytes)
     initialize_context()
-    @ccall libcustatevec.custatevecAccessorSetExtraWorkspace(handle::custatevecHandle_t,
-                                                             accessor::custatevecAccessorDescriptor_t,
-                                                             extraWorkspace::Ptr{Cvoid},
-                                                             extraWorkspaceSizeInBytes::Csize_t)::custatevecStatus_t
+    @gcsafe_ccall libcustatevec.custatevecAccessorSetExtraWorkspace(handle::custatevecHandle_t,
+                                                                    accessor::custatevecAccessorDescriptor_t,
+                                                                    extraWorkspace::Ptr{Cvoid},
+                                                                    extraWorkspaceSizeInBytes::Csize_t)::custatevecStatus_t
 end
 
 @checked function custatevecAccessorGet(handle, accessor, externalBuffer, _begin, _end)
     initialize_context()
-    @ccall libcustatevec.custatevecAccessorGet(handle::custatevecHandle_t,
-                                               accessor::custatevecAccessorDescriptor_t,
-                                               externalBuffer::Ptr{Cvoid},
-                                               _begin::custatevecIndex_t,
-                                               _end::custatevecIndex_t)::custatevecStatus_t
+    @gcsafe_ccall libcustatevec.custatevecAccessorGet(handle::custatevecHandle_t,
+                                                      accessor::custatevecAccessorDescriptor_t,
+                                                      externalBuffer::Ptr{Cvoid},
+                                                      _begin::custatevecIndex_t,
+                                                      _end::custatevecIndex_t)::custatevecStatus_t
 end
 
 @checked function custatevecAccessorSet(handle, accessor, externalBuffer, _begin, _end)
     initialize_context()
-    @ccall libcustatevec.custatevecAccessorSet(handle::custatevecHandle_t,
-                                               accessor::custatevecAccessorDescriptor_t,
-                                               externalBuffer::Ptr{Cvoid},
-                                               _begin::custatevecIndex_t,
-                                               _end::custatevecIndex_t)::custatevecStatus_t
+    @gcsafe_ccall libcustatevec.custatevecAccessorSet(handle::custatevecHandle_t,
+                                                      accessor::custatevecAccessorDescriptor_t,
+                                                      externalBuffer::Ptr{Cvoid},
+                                                      _begin::custatevecIndex_t,
+                                                      _end::custatevecIndex_t)::custatevecStatus_t
 end
 
 @checked function custatevecSwapIndexBits(handle, sv, svDataType, nIndexBits, bitSwaps,
                                           nBitSwaps, maskBitString, maskOrdering, maskLen)
     initialize_context()
-    @ccall libcustatevec.custatevecSwapIndexBits(handle::custatevecHandle_t,
-                                                 sv::CuPtr{Cvoid},
-                                                 svDataType::cudaDataType_t,
-                                                 nIndexBits::UInt32, bitSwaps::Ptr{int2},
-                                                 nBitSwaps::UInt32,
-                                                 maskBitString::Ptr{Int32},
-                                                 maskOrdering::Ptr{Int32},
-                                                 maskLen::UInt32)::custatevecStatus_t
+    @gcsafe_ccall libcustatevec.custatevecSwapIndexBits(handle::custatevecHandle_t,
+                                                        sv::CuPtr{Cvoid},
+                                                        svDataType::cudaDataType_t,
+                                                        nIndexBits::UInt32,
+                                                        bitSwaps::Ptr{int2},
+                                                        nBitSwaps::UInt32,
+                                                        maskBitString::Ptr{Int32},
+                                                        maskOrdering::Ptr{Int32},
+                                                        maskLen::UInt32)::custatevecStatus_t
 end
 
 @checked function custatevecTestMatrixTypeGetWorkspaceSize(handle, matrixType, matrix,
@@ -619,15 +633,15 @@ end
                                                            adjoint, computeType,
                                                            extraWorkspaceSizeInBytes)
     initialize_context()
-    @ccall libcustatevec.custatevecTestMatrixTypeGetWorkspaceSize(handle::custatevecHandle_t,
-                                                                  matrixType::custatevecMatrixType_t,
-                                                                  matrix::PtrOrCuPtr{Cvoid},
-                                                                  matrixDataType::cudaDataType_t,
-                                                                  layout::custatevecMatrixLayout_t,
-                                                                  nTargets::UInt32,
-                                                                  adjoint::Int32,
-                                                                  computeType::custatevecComputeType_t,
-                                                                  extraWorkspaceSizeInBytes::Ptr{Csize_t})::custatevecStatus_t
+    @gcsafe_ccall libcustatevec.custatevecTestMatrixTypeGetWorkspaceSize(handle::custatevecHandle_t,
+                                                                         matrixType::custatevecMatrixType_t,
+                                                                         matrix::PtrOrCuPtr{Cvoid},
+                                                                         matrixDataType::cudaDataType_t,
+                                                                         layout::custatevecMatrixLayout_t,
+                                                                         nTargets::UInt32,
+                                                                         adjoint::Int32,
+                                                                         computeType::custatevecComputeType_t,
+                                                                         extraWorkspaceSizeInBytes::Ptr{Csize_t})::custatevecStatus_t
 end
 
 @checked function custatevecTestMatrixType(handle, residualNorm, matrixType, matrix,
@@ -635,26 +649,26 @@ end
                                            computeType, extraWorkspace,
                                            extraWorkspaceSizeInBytes)
     initialize_context()
-    @ccall libcustatevec.custatevecTestMatrixType(handle::custatevecHandle_t,
-                                                  residualNorm::Ptr{Cdouble},
-                                                  matrixType::custatevecMatrixType_t,
-                                                  matrix::PtrOrCuPtr{Cvoid},
-                                                  matrixDataType::cudaDataType_t,
-                                                  layout::custatevecMatrixLayout_t,
-                                                  nTargets::UInt32, adjoint::Int32,
-                                                  computeType::custatevecComputeType_t,
-                                                  extraWorkspace::PtrOrCuPtr{Cvoid},
-                                                  extraWorkspaceSizeInBytes::Csize_t)::custatevecStatus_t
+    @gcsafe_ccall libcustatevec.custatevecTestMatrixType(handle::custatevecHandle_t,
+                                                         residualNorm::Ptr{Cdouble},
+                                                         matrixType::custatevecMatrixType_t,
+                                                         matrix::PtrOrCuPtr{Cvoid},
+                                                         matrixDataType::cudaDataType_t,
+                                                         layout::custatevecMatrixLayout_t,
+                                                         nTargets::UInt32, adjoint::Int32,
+                                                         computeType::custatevecComputeType_t,
+                                                         extraWorkspace::PtrOrCuPtr{Cvoid},
+                                                         extraWorkspaceSizeInBytes::Csize_t)::custatevecStatus_t
 end
 
 @checked function custatevecInitializeStateVector(handle, sv, svDataType, nIndexBits,
                                                   svType)
     initialize_context()
-    @ccall libcustatevec.custatevecInitializeStateVector(handle::custatevecHandle_t,
-                                                         sv::Ptr{Cvoid},
-                                                         svDataType::cudaDataType_t,
-                                                         nIndexBits::UInt32,
-                                                         svType::custatevecStateVectorType_t)::custatevecStatus_t
+    @gcsafe_ccall libcustatevec.custatevecInitializeStateVector(handle::custatevecHandle_t,
+                                                                sv::Ptr{Cvoid},
+                                                                svDataType::cudaDataType_t,
+                                                                nIndexBits::UInt32,
+                                                                svType::custatevecStateVectorType_t)::custatevecStatus_t
 end
 
 @checked function custatevecMultiDeviceSwapIndexBits(handles, nHandles, subSVs, svDataType,
@@ -663,18 +677,18 @@ end
                                                      maskBitString, maskOrdering, maskLen,
                                                      deviceNetworkType)
     initialize_context()
-    @ccall libcustatevec.custatevecMultiDeviceSwapIndexBits(handles::Ptr{custatevecHandle_t},
-                                                            nHandles::UInt32,
-                                                            subSVs::Ptr{Ptr{Cvoid}},
-                                                            svDataType::cudaDataType_t,
-                                                            nGlobalIndexBits::UInt32,
-                                                            nLocalIndexBits::UInt32,
-                                                            indexBitSwaps::Ptr{int2},
-                                                            nIndexBitSwaps::UInt32,
-                                                            maskBitString::Ptr{Int32},
-                                                            maskOrdering::Ptr{Int32},
-                                                            maskLen::UInt32,
-                                                            deviceNetworkType::custatevecDeviceNetworkType_t)::custatevecStatus_t
+    @gcsafe_ccall libcustatevec.custatevecMultiDeviceSwapIndexBits(handles::Ptr{custatevecHandle_t},
+                                                                   nHandles::UInt32,
+                                                                   subSVs::Ptr{Ptr{Cvoid}},
+                                                                   svDataType::cudaDataType_t,
+                                                                   nGlobalIndexBits::UInt32,
+                                                                   nLocalIndexBits::UInt32,
+                                                                   indexBitSwaps::Ptr{int2},
+                                                                   nIndexBitSwaps::UInt32,
+                                                                   maskBitString::Ptr{Int32},
+                                                                   maskOrdering::Ptr{Int32},
+                                                                   maskLen::UInt32,
+                                                                   deviceNetworkType::custatevecDeviceNetworkType_t)::custatevecStatus_t
 end
 
 mutable struct custatevecCommunicator_t end
@@ -718,32 +732,32 @@ const custatevecSVSwapWorkerDescriptor_t = Ptr{custatevecSVSwapWorker_t}
 @checked function custatevecCommunicatorCreate(handle, communicator, communicatorType,
                                                soname)
     initialize_context()
-    @ccall libcustatevec.custatevecCommunicatorCreate(handle::custatevecHandle_t,
-                                                      communicator::Ptr{custatevecCommunicatorDescriptor_t},
-                                                      communicatorType::custatevecCommunicatorType_t,
-                                                      soname::Cstring)::custatevecStatus_t
+    @gcsafe_ccall libcustatevec.custatevecCommunicatorCreate(handle::custatevecHandle_t,
+                                                             communicator::Ptr{custatevecCommunicatorDescriptor_t},
+                                                             communicatorType::custatevecCommunicatorType_t,
+                                                             soname::Cstring)::custatevecStatus_t
 end
 
 @checked function custatevecCommunicatorDestroy(handle, communicator)
     initialize_context()
-    @ccall libcustatevec.custatevecCommunicatorDestroy(handle::custatevecHandle_t,
-                                                       communicator::custatevecCommunicatorDescriptor_t)::custatevecStatus_t
+    @gcsafe_ccall libcustatevec.custatevecCommunicatorDestroy(handle::custatevecHandle_t,
+                                                              communicator::custatevecCommunicatorDescriptor_t)::custatevecStatus_t
 end
 
 @checked function custatevecDistIndexBitSwapSchedulerCreate(handle, scheduler,
                                                             nGlobalIndexBits,
                                                             nLocalIndexBits)
     initialize_context()
-    @ccall libcustatevec.custatevecDistIndexBitSwapSchedulerCreate(handle::custatevecHandle_t,
-                                                                   scheduler::Ptr{custatevecDistIndexBitSwapSchedulerDescriptor_t},
-                                                                   nGlobalIndexBits::UInt32,
-                                                                   nLocalIndexBits::UInt32)::custatevecStatus_t
+    @gcsafe_ccall libcustatevec.custatevecDistIndexBitSwapSchedulerCreate(handle::custatevecHandle_t,
+                                                                          scheduler::Ptr{custatevecDistIndexBitSwapSchedulerDescriptor_t},
+                                                                          nGlobalIndexBits::UInt32,
+                                                                          nLocalIndexBits::UInt32)::custatevecStatus_t
 end
 
 @checked function custatevecDistIndexBitSwapSchedulerDestroy(handle, scheduler)
     initialize_context()
-    @ccall libcustatevec.custatevecDistIndexBitSwapSchedulerDestroy(handle::custatevecHandle_t,
-                                                                    scheduler::custatevecDistIndexBitSwapSchedulerDescriptor_t)::custatevecStatus_t
+    @gcsafe_ccall libcustatevec.custatevecDistIndexBitSwapSchedulerDestroy(handle::custatevecHandle_t,
+                                                                           scheduler::custatevecDistIndexBitSwapSchedulerDescriptor_t)::custatevecStatus_t
 end
 
 @checked function custatevecDistIndexBitSwapSchedulerSetIndexBitSwaps(handle, scheduler,
@@ -753,14 +767,14 @@ end
                                                                       maskOrdering, maskLen,
                                                                       nSwapBatches)
     initialize_context()
-    @ccall libcustatevec.custatevecDistIndexBitSwapSchedulerSetIndexBitSwaps(handle::custatevecHandle_t,
-                                                                             scheduler::custatevecDistIndexBitSwapSchedulerDescriptor_t,
-                                                                             indexBitSwaps::Ptr{int2},
-                                                                             nIndexBitSwaps::UInt32,
-                                                                             maskBitString::Ptr{Int32},
-                                                                             maskOrdering::Ptr{Int32},
-                                                                             maskLen::UInt32,
-                                                                             nSwapBatches::Ptr{UInt32})::custatevecStatus_t
+    @gcsafe_ccall libcustatevec.custatevecDistIndexBitSwapSchedulerSetIndexBitSwaps(handle::custatevecHandle_t,
+                                                                                    scheduler::custatevecDistIndexBitSwapSchedulerDescriptor_t,
+                                                                                    indexBitSwaps::Ptr{int2},
+                                                                                    nIndexBitSwaps::UInt32,
+                                                                                    maskBitString::Ptr{Int32},
+                                                                                    maskOrdering::Ptr{Int32},
+                                                                                    maskLen::UInt32,
+                                                                                    nSwapBatches::Ptr{UInt32})::custatevecStatus_t
 end
 
 @checked function custatevecDistIndexBitSwapSchedulerGetParameters(handle, scheduler,
@@ -768,11 +782,11 @@ end
                                                                    orgSubSVIndex,
                                                                    parameters)
     initialize_context()
-    @ccall libcustatevec.custatevecDistIndexBitSwapSchedulerGetParameters(handle::custatevecHandle_t,
-                                                                          scheduler::custatevecDistIndexBitSwapSchedulerDescriptor_t,
-                                                                          swapBatchIndex::Int32,
-                                                                          orgSubSVIndex::Int32,
-                                                                          parameters::Ptr{custatevecSVSwapParameters_t})::custatevecStatus_t
+    @gcsafe_ccall libcustatevec.custatevecDistIndexBitSwapSchedulerGetParameters(handle::custatevecHandle_t,
+                                                                                 scheduler::custatevecDistIndexBitSwapSchedulerDescriptor_t,
+                                                                                 swapBatchIndex::Int32,
+                                                                                 orgSubSVIndex::Int32,
+                                                                                 parameters::Ptr{custatevecSVSwapParameters_t})::custatevecStatus_t
 end
 
 @checked function custatevecSVSwapWorkerCreate(handle, svSwapWorker, communicator, orgSubSV,
@@ -780,71 +794,71 @@ end
                                                extraWorkspaceSizeInBytes,
                                                minTransferWorkspaceSizeInBytes)
     initialize_context()
-    @ccall libcustatevec.custatevecSVSwapWorkerCreate(handle::custatevecHandle_t,
-                                                      svSwapWorker::Ptr{custatevecSVSwapWorkerDescriptor_t},
-                                                      communicator::custatevecCommunicatorDescriptor_t,
-                                                      orgSubSV::Ptr{Cvoid},
-                                                      orgSubSVIndex::Int32,
-                                                      orgEvent::cudaEvent_t,
-                                                      svDataType::cudaDataType_t,
-                                                      stream::cudaStream_t,
-                                                      extraWorkspaceSizeInBytes::Ptr{Csize_t},
-                                                      minTransferWorkspaceSizeInBytes::Ptr{Csize_t})::custatevecStatus_t
+    @gcsafe_ccall libcustatevec.custatevecSVSwapWorkerCreate(handle::custatevecHandle_t,
+                                                             svSwapWorker::Ptr{custatevecSVSwapWorkerDescriptor_t},
+                                                             communicator::custatevecCommunicatorDescriptor_t,
+                                                             orgSubSV::Ptr{Cvoid},
+                                                             orgSubSVIndex::Int32,
+                                                             orgEvent::cudaEvent_t,
+                                                             svDataType::cudaDataType_t,
+                                                             stream::cudaStream_t,
+                                                             extraWorkspaceSizeInBytes::Ptr{Csize_t},
+                                                             minTransferWorkspaceSizeInBytes::Ptr{Csize_t})::custatevecStatus_t
 end
 
 @checked function custatevecSVSwapWorkerDestroy(handle, svSwapWorker)
     initialize_context()
-    @ccall libcustatevec.custatevecSVSwapWorkerDestroy(handle::custatevecHandle_t,
-                                                       svSwapWorker::custatevecSVSwapWorkerDescriptor_t)::custatevecStatus_t
+    @gcsafe_ccall libcustatevec.custatevecSVSwapWorkerDestroy(handle::custatevecHandle_t,
+                                                              svSwapWorker::custatevecSVSwapWorkerDescriptor_t)::custatevecStatus_t
 end
 
 @checked function custatevecSVSwapWorkerSetExtraWorkspace(handle, svSwapWorker,
                                                           extraWorkspace,
                                                           extraWorkspaceSizeInBytes)
     initialize_context()
-    @ccall libcustatevec.custatevecSVSwapWorkerSetExtraWorkspace(handle::custatevecHandle_t,
-                                                                 svSwapWorker::custatevecSVSwapWorkerDescriptor_t,
-                                                                 extraWorkspace::Ptr{Cvoid},
-                                                                 extraWorkspaceSizeInBytes::Csize_t)::custatevecStatus_t
+    @gcsafe_ccall libcustatevec.custatevecSVSwapWorkerSetExtraWorkspace(handle::custatevecHandle_t,
+                                                                        svSwapWorker::custatevecSVSwapWorkerDescriptor_t,
+                                                                        extraWorkspace::Ptr{Cvoid},
+                                                                        extraWorkspaceSizeInBytes::Csize_t)::custatevecStatus_t
 end
 
 @checked function custatevecSVSwapWorkerSetTransferWorkspace(handle, svSwapWorker,
                                                              transferWorkspace,
                                                              transferWorkspaceSizeInBytes)
     initialize_context()
-    @ccall libcustatevec.custatevecSVSwapWorkerSetTransferWorkspace(handle::custatevecHandle_t,
-                                                                    svSwapWorker::custatevecSVSwapWorkerDescriptor_t,
-                                                                    transferWorkspace::Ptr{Cvoid},
-                                                                    transferWorkspaceSizeInBytes::Csize_t)::custatevecStatus_t
+    @gcsafe_ccall libcustatevec.custatevecSVSwapWorkerSetTransferWorkspace(handle::custatevecHandle_t,
+                                                                           svSwapWorker::custatevecSVSwapWorkerDescriptor_t,
+                                                                           transferWorkspace::Ptr{Cvoid},
+                                                                           transferWorkspaceSizeInBytes::Csize_t)::custatevecStatus_t
 end
 
 @checked function custatevecSVSwapWorkerSetSubSVsP2P(handle, svSwapWorker, dstSubSVsP2P,
                                                      dstSubSVIndicesP2P, dstEvents,
                                                      nDstSubSVsP2P)
     initialize_context()
-    @ccall libcustatevec.custatevecSVSwapWorkerSetSubSVsP2P(handle::custatevecHandle_t,
-                                                            svSwapWorker::custatevecSVSwapWorkerDescriptor_t,
-                                                            dstSubSVsP2P::Ptr{Ptr{Cvoid}},
-                                                            dstSubSVIndicesP2P::Ptr{Int32},
-                                                            dstEvents::Ptr{cudaEvent_t},
-                                                            nDstSubSVsP2P::UInt32)::custatevecStatus_t
+    @gcsafe_ccall libcustatevec.custatevecSVSwapWorkerSetSubSVsP2P(handle::custatevecHandle_t,
+                                                                   svSwapWorker::custatevecSVSwapWorkerDescriptor_t,
+                                                                   dstSubSVsP2P::Ptr{Ptr{Cvoid}},
+                                                                   dstSubSVIndicesP2P::Ptr{Int32},
+                                                                   dstEvents::Ptr{cudaEvent_t},
+                                                                   nDstSubSVsP2P::UInt32)::custatevecStatus_t
 end
 
 @checked function custatevecSVSwapWorkerSetParameters(handle, svSwapWorker, parameters,
                                                       peer)
     initialize_context()
-    @ccall libcustatevec.custatevecSVSwapWorkerSetParameters(handle::custatevecHandle_t,
-                                                             svSwapWorker::custatevecSVSwapWorkerDescriptor_t,
-                                                             parameters::Ptr{custatevecSVSwapParameters_t},
-                                                             peer::Cint)::custatevecStatus_t
+    @gcsafe_ccall libcustatevec.custatevecSVSwapWorkerSetParameters(handle::custatevecHandle_t,
+                                                                    svSwapWorker::custatevecSVSwapWorkerDescriptor_t,
+                                                                    parameters::Ptr{custatevecSVSwapParameters_t},
+                                                                    peer::Cint)::custatevecStatus_t
 end
 
 @checked function custatevecSVSwapWorkerExecute(handle, svSwapWorker, _begin, _end)
     initialize_context()
-    @ccall libcustatevec.custatevecSVSwapWorkerExecute(handle::custatevecHandle_t,
-                                                       svSwapWorker::custatevecSVSwapWorkerDescriptor_t,
-                                                       _begin::custatevecIndex_t,
-                                                       _end::custatevecIndex_t)::custatevecStatus_t
+    @gcsafe_ccall libcustatevec.custatevecSVSwapWorkerExecute(handle::custatevecHandle_t,
+                                                              svSwapWorker::custatevecSVSwapWorkerDescriptor_t,
+                                                              _begin::custatevecIndex_t,
+                                                              _end::custatevecIndex_t)::custatevecStatus_t
 end
 
 @checked function custatevecApplyMatrixBatchedGetWorkspaceSize(handle, svDataType,
@@ -856,22 +870,22 @@ end
                                                                computeType,
                                                                extraWorkspaceSizeInBytes)
     initialize_context()
-    @ccall libcustatevec.custatevecApplyMatrixBatchedGetWorkspaceSize(handle::custatevecHandle_t,
-                                                                      svDataType::cudaDataType_t,
-                                                                      nIndexBits::UInt32,
-                                                                      nSVs::UInt32,
-                                                                      svStride::custatevecIndex_t,
-                                                                      mapType::custatevecMatrixMapType_t,
-                                                                      matrixIndices::Ptr{Int32},
-                                                                      matrices::PtrOrCuPtr{Cvoid},
-                                                                      matrixDataType::cudaDataType_t,
-                                                                      layout::custatevecMatrixLayout_t,
-                                                                      adjoint::Int32,
-                                                                      nMatrices::UInt32,
-                                                                      nTargets::UInt32,
-                                                                      nControls::UInt32,
-                                                                      computeType::custatevecComputeType_t,
-                                                                      extraWorkspaceSizeInBytes::Ptr{Csize_t})::custatevecStatus_t
+    @gcsafe_ccall libcustatevec.custatevecApplyMatrixBatchedGetWorkspaceSize(handle::custatevecHandle_t,
+                                                                             svDataType::cudaDataType_t,
+                                                                             nIndexBits::UInt32,
+                                                                             nSVs::UInt32,
+                                                                             svStride::custatevecIndex_t,
+                                                                             mapType::custatevecMatrixMapType_t,
+                                                                             matrixIndices::Ptr{Int32},
+                                                                             matrices::PtrOrCuPtr{Cvoid},
+                                                                             matrixDataType::cudaDataType_t,
+                                                                             layout::custatevecMatrixLayout_t,
+                                                                             adjoint::Int32,
+                                                                             nMatrices::UInt32,
+                                                                             nTargets::UInt32,
+                                                                             nControls::UInt32,
+                                                                             computeType::custatevecComputeType_t,
+                                                                             extraWorkspaceSizeInBytes::Ptr{Csize_t})::custatevecStatus_t
 end
 
 @checked function custatevecApplyMatrixBatched(handle, batchedSv, svDataType, nIndexBits,
@@ -881,24 +895,27 @@ end
                                                controlBitValues, nControls, computeType,
                                                extraWorkspace, extraWorkspaceSizeInBytes)
     initialize_context()
-    @ccall libcustatevec.custatevecApplyMatrixBatched(handle::custatevecHandle_t,
-                                                      batchedSv::CuPtr{Cvoid},
-                                                      svDataType::cudaDataType_t,
-                                                      nIndexBits::UInt32, nSVs::UInt32,
-                                                      svStride::custatevecIndex_t,
-                                                      mapType::custatevecMatrixMapType_t,
-                                                      matrixIndices::Ptr{Int32},
-                                                      matrices::PtrOrCuPtr{Cvoid},
-                                                      matrixDataType::cudaDataType_t,
-                                                      layout::custatevecMatrixLayout_t,
-                                                      adjoint::Int32, nMatrices::UInt32,
-                                                      targets::Ptr{Int32}, nTargets::UInt32,
-                                                      controls::Ptr{Int32},
-                                                      controlBitValues::Ptr{Int32},
-                                                      nControls::UInt32,
-                                                      computeType::custatevecComputeType_t,
-                                                      extraWorkspace::CuPtr{Cvoid},
-                                                      extraWorkspaceSizeInBytes::Csize_t)::custatevecStatus_t
+    @gcsafe_ccall libcustatevec.custatevecApplyMatrixBatched(handle::custatevecHandle_t,
+                                                             batchedSv::CuPtr{Cvoid},
+                                                             svDataType::cudaDataType_t,
+                                                             nIndexBits::UInt32,
+                                                             nSVs::UInt32,
+                                                             svStride::custatevecIndex_t,
+                                                             mapType::custatevecMatrixMapType_t,
+                                                             matrixIndices::Ptr{Int32},
+                                                             matrices::PtrOrCuPtr{Cvoid},
+                                                             matrixDataType::cudaDataType_t,
+                                                             layout::custatevecMatrixLayout_t,
+                                                             adjoint::Int32,
+                                                             nMatrices::UInt32,
+                                                             targets::Ptr{Int32},
+                                                             nTargets::UInt32,
+                                                             controls::Ptr{Int32},
+                                                             controlBitValues::Ptr{Int32},
+                                                             nControls::UInt32,
+                                                             computeType::custatevecComputeType_t,
+                                                             extraWorkspace::CuPtr{Cvoid},
+                                                             extraWorkspaceSizeInBytes::Csize_t)::custatevecStatus_t
 end
 
 @checked function custatevecAbs2SumArrayBatched(handle, batchedSv, svDataType, nIndexBits,
@@ -907,29 +924,30 @@ end
                                                 bitOrderingLen, maskBitStrings,
                                                 maskOrdering, maskLen)
     initialize_context()
-    @ccall libcustatevec.custatevecAbs2SumArrayBatched(handle::custatevecHandle_t,
-                                                       batchedSv::CuPtr{Cvoid},
-                                                       svDataType::cudaDataType_t,
-                                                       nIndexBits::UInt32, nSVs::UInt32,
-                                                       svStride::custatevecIndex_t,
-                                                       abs2sumArrays::Ptr{Cdouble},
-                                                       abs2sumArrayStride::custatevecIndex_t,
-                                                       bitOrdering::Ptr{Int32},
-                                                       bitOrderingLen::UInt32,
-                                                       maskBitStrings::Ptr{custatevecIndex_t},
-                                                       maskOrdering::Ptr{Int32},
-                                                       maskLen::UInt32)::custatevecStatus_t
+    @gcsafe_ccall libcustatevec.custatevecAbs2SumArrayBatched(handle::custatevecHandle_t,
+                                                              batchedSv::CuPtr{Cvoid},
+                                                              svDataType::cudaDataType_t,
+                                                              nIndexBits::UInt32,
+                                                              nSVs::UInt32,
+                                                              svStride::custatevecIndex_t,
+                                                              abs2sumArrays::Ptr{Cdouble},
+                                                              abs2sumArrayStride::custatevecIndex_t,
+                                                              bitOrdering::Ptr{Int32},
+                                                              bitOrderingLen::UInt32,
+                                                              maskBitStrings::Ptr{custatevecIndex_t},
+                                                              maskOrdering::Ptr{Int32},
+                                                              maskLen::UInt32)::custatevecStatus_t
 end
 
 @checked function custatevecCollapseByBitStringBatchedGetWorkspaceSize(handle, nSVs,
                                                                        bitStrings, norms,
                                                                        extraWorkspaceSizeInBytes)
     initialize_context()
-    @ccall libcustatevec.custatevecCollapseByBitStringBatchedGetWorkspaceSize(handle::custatevecHandle_t,
-                                                                              nSVs::UInt32,
-                                                                              bitStrings::Ptr{custatevecIndex_t},
-                                                                              norms::Ptr{Cdouble},
-                                                                              extraWorkspaceSizeInBytes::Ptr{Csize_t})::custatevecStatus_t
+    @gcsafe_ccall libcustatevec.custatevecCollapseByBitStringBatchedGetWorkspaceSize(handle::custatevecHandle_t,
+                                                                                     nSVs::UInt32,
+                                                                                     bitStrings::Ptr{custatevecIndex_t},
+                                                                                     norms::Ptr{Cdouble},
+                                                                                     extraWorkspaceSizeInBytes::Ptr{Csize_t})::custatevecStatus_t
 end
 
 @checked function custatevecCollapseByBitStringBatched(handle, batchedSv, svDataType,
@@ -938,34 +956,34 @@ end
                                                        bitStringLen, norms, extraWorkspace,
                                                        extraWorkspaceSizeInBytes)
     initialize_context()
-    @ccall libcustatevec.custatevecCollapseByBitStringBatched(handle::custatevecHandle_t,
-                                                              batchedSv::CuPtr{Cvoid},
-                                                              svDataType::cudaDataType_t,
-                                                              nIndexBits::UInt32,
-                                                              nSVs::UInt32,
-                                                              svStride::custatevecIndex_t,
-                                                              bitStrings::Ptr{custatevecIndex_t},
-                                                              bitOrdering::Ptr{Int32},
-                                                              bitStringLen::UInt32,
-                                                              norms::Ptr{Cdouble},
-                                                              extraWorkspace::PtrOrCuPtr{Cvoid},
-                                                              extraWorkspaceSizeInBytes::Csize_t)::custatevecStatus_t
+    @gcsafe_ccall libcustatevec.custatevecCollapseByBitStringBatched(handle::custatevecHandle_t,
+                                                                     batchedSv::CuPtr{Cvoid},
+                                                                     svDataType::cudaDataType_t,
+                                                                     nIndexBits::UInt32,
+                                                                     nSVs::UInt32,
+                                                                     svStride::custatevecIndex_t,
+                                                                     bitStrings::Ptr{custatevecIndex_t},
+                                                                     bitOrdering::Ptr{Int32},
+                                                                     bitStringLen::UInt32,
+                                                                     norms::Ptr{Cdouble},
+                                                                     extraWorkspace::PtrOrCuPtr{Cvoid},
+                                                                     extraWorkspaceSizeInBytes::Csize_t)::custatevecStatus_t
 end
 
 @checked function custatevecMeasureBatched(handle, batchedSv, svDataType, nIndexBits, nSVs,
                                            svStride, bitStrings, bitOrdering, bitStringLen,
                                            randnums, collapse)
     initialize_context()
-    @ccall libcustatevec.custatevecMeasureBatched(handle::custatevecHandle_t,
-                                                  batchedSv::CuPtr{Cvoid},
-                                                  svDataType::cudaDataType_t,
-                                                  nIndexBits::UInt32, nSVs::UInt32,
-                                                  svStride::custatevecIndex_t,
-                                                  bitStrings::Ptr{custatevecIndex_t},
-                                                  bitOrdering::Ptr{Int32},
-                                                  bitStringLen::UInt32,
-                                                  randnums::Ptr{Cdouble},
-                                                  collapse::custatevecCollapseOp_t)::custatevecStatus_t
+    @gcsafe_ccall libcustatevec.custatevecMeasureBatched(handle::custatevecHandle_t,
+                                                         batchedSv::CuPtr{Cvoid},
+                                                         svDataType::cudaDataType_t,
+                                                         nIndexBits::UInt32, nSVs::UInt32,
+                                                         svStride::custatevecIndex_t,
+                                                         bitStrings::Ptr{custatevecIndex_t},
+                                                         bitOrdering::Ptr{Int32},
+                                                         bitStringLen::UInt32,
+                                                         randnums::Ptr{Cdouble},
+                                                         collapse::custatevecCollapseOp_t)::custatevecStatus_t
 end
 
 mutable struct custatevecSubSVMigratorDescriptor end
@@ -975,30 +993,30 @@ const custatevecSubSVMigratorDescriptor_t = Ptr{custatevecSubSVMigratorDescripto
 @checked function custatevecSubSVMigratorCreate(handle, migrator, deviceSlots, svDataType,
                                                 nDeviceSlots, nLocalIndexBits)
     initialize_context()
-    @ccall libcustatevec.custatevecSubSVMigratorCreate(handle::custatevecHandle_t,
-                                                       migrator::Ptr{custatevecSubSVMigratorDescriptor_t},
-                                                       deviceSlots::Ptr{Cvoid},
-                                                       svDataType::cudaDataType_t,
-                                                       nDeviceSlots::Cint,
-                                                       nLocalIndexBits::Cint)::custatevecStatus_t
+    @gcsafe_ccall libcustatevec.custatevecSubSVMigratorCreate(handle::custatevecHandle_t,
+                                                              migrator::Ptr{custatevecSubSVMigratorDescriptor_t},
+                                                              deviceSlots::Ptr{Cvoid},
+                                                              svDataType::cudaDataType_t,
+                                                              nDeviceSlots::Cint,
+                                                              nLocalIndexBits::Cint)::custatevecStatus_t
 end
 
 @checked function custatevecSubSVMigratorDestroy(handle, migrator)
     initialize_context()
-    @ccall libcustatevec.custatevecSubSVMigratorDestroy(handle::custatevecHandle_t,
-                                                        migrator::custatevecSubSVMigratorDescriptor_t)::custatevecStatus_t
+    @gcsafe_ccall libcustatevec.custatevecSubSVMigratorDestroy(handle::custatevecHandle_t,
+                                                               migrator::custatevecSubSVMigratorDescriptor_t)::custatevecStatus_t
 end
 
 @checked function custatevecSubSVMigratorMigrate(handle, migrator, deviceSlotIndex,
                                                  srcSubSV, dstSubSV, _begin, _end)
     initialize_context()
-    @ccall libcustatevec.custatevecSubSVMigratorMigrate(handle::custatevecHandle_t,
-                                                        migrator::custatevecSubSVMigratorDescriptor_t,
-                                                        deviceSlotIndex::Cint,
-                                                        srcSubSV::Ptr{Cvoid},
-                                                        dstSubSV::Ptr{Cvoid},
-                                                        _begin::custatevecIndex_t,
-                                                        _end::custatevecIndex_t)::custatevecStatus_t
+    @gcsafe_ccall libcustatevec.custatevecSubSVMigratorMigrate(handle::custatevecHandle_t,
+                                                               migrator::custatevecSubSVMigratorDescriptor_t,
+                                                               deviceSlotIndex::Cint,
+                                                               srcSubSV::Ptr{Cvoid},
+                                                               dstSubSV::Ptr{Cvoid},
+                                                               _begin::custatevecIndex_t,
+                                                               _end::custatevecIndex_t)::custatevecStatus_t
 end
 
 const CUSTATEVEC_ALLOCATOR_NAME_LEN = 64

--- a/lib/cutensor/Project.toml
+++ b/lib/cutensor/Project.toml
@@ -1,7 +1,7 @@
 name = "cuTENSOR"
 uuid = "011b41b2-24ef-40a8-b3eb-fa098493e9e1"
 authors = ["Tim Besard <tim.besard@gmail.com>"]
-version = "2.0"
+version = "2.1"
 
 [deps]
 CEnum = "fa961155-64e5-5f13-b03f-caf6b980ea82"
@@ -12,7 +12,7 @@ LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 
 [compat]
 CEnum = "0.2, 0.3, 0.4, 0.5"
-CUDA = "~5.1, ~5.2"
+CUDA = "~5.3"
 CUDA_Runtime_Discovery = "0.2"
 CUTENSOR_jll = "~2.0"
 julia = "1.8"

--- a/lib/cutensor/src/cuTENSOR.jl
+++ b/lib/cutensor/src/cuTENSOR.jl
@@ -71,6 +71,11 @@ end
 ## logging
 
 function log_message(log_level, function_name, message)
+    # see @gcsafe_ccall documentation
+    @static if VERSION < v"1.9"
+        GC.safepoint()
+    end
+
     function_name = unsafe_string(function_name)
     message = unsafe_string(message)
     output = if isempty(message)

--- a/lib/cutensor/src/cuTENSOR.jl
+++ b/lib/cutensor/src/cuTENSOR.jl
@@ -70,12 +70,7 @@ end
 
 ## logging
 
-function log_message(log_level, function_name, message)
-    # see @gcsafe_ccall documentation
-    @static if VERSION < v"1.9"
-        GC.safepoint()
-    end
-
+@gcunsafe_callback function log_message(log_level, function_name, message)
     function_name = unsafe_string(function_name)
     message = unsafe_string(message)
     output = if isempty(message)

--- a/lib/cutensor/src/libcutensor.jl
+++ b/lib/cutensor/src/libcutensor.jl
@@ -194,66 +194,156 @@ const cutensorLoggerCallback_t = Ptr{Cvoid}
 
 @checked function cutensorCreate(handle)
     initialize_context()
-    @ccall libcutensor.cutensorCreate(handle::Ptr{cutensorHandle_t})::cutensorStatus_t
+    @gcsafe_ccall libcutensor.cutensorCreate(handle::Ptr{cutensorHandle_t})::cutensorStatus_t
 end
 
 @checked function cutensorDestroy(handle)
     initialize_context()
-    @ccall libcutensor.cutensorDestroy(handle::cutensorHandle_t)::cutensorStatus_t
+    @gcsafe_ccall libcutensor.cutensorDestroy(handle::cutensorHandle_t)::cutensorStatus_t
 end
 
 @checked function cutensorHandleResizePlanCache(handle, numEntries)
     initialize_context()
-    @ccall libcutensor.cutensorHandleResizePlanCache(handle::cutensorHandle_t,
-                                                     numEntries::UInt32)::cutensorStatus_t
+    @gcsafe_ccall libcutensor.cutensorHandleResizePlanCache(handle::cutensorHandle_t,
+                                                            numEntries::UInt32)::cutensorStatus_t
 end
 
 @checked function cutensorHandleWritePlanCacheToFile(handle, filename)
     initialize_context()
-    @ccall libcutensor.cutensorHandleWritePlanCacheToFile(handle::cutensorHandle_t,
-                                                          filename::Ptr{Cchar})::cutensorStatus_t
+    @gcsafe_ccall libcutensor.cutensorHandleWritePlanCacheToFile(handle::cutensorHandle_t,
+                                                                 filename::Ptr{Cchar})::cutensorStatus_t
 end
 
 @checked function cutensorHandleReadPlanCacheFromFile(handle, filename, numCachelinesRead)
     initialize_context()
-    @ccall libcutensor.cutensorHandleReadPlanCacheFromFile(handle::cutensorHandle_t,
-                                                           filename::Ptr{Cchar},
-                                                           numCachelinesRead::Ptr{UInt32})::cutensorStatus_t
+    @gcsafe_ccall libcutensor.cutensorHandleReadPlanCacheFromFile(handle::cutensorHandle_t,
+                                                                  filename::Ptr{Cchar},
+                                                                  numCachelinesRead::Ptr{UInt32})::cutensorStatus_t
 end
 
 @checked function cutensorWriteKernelCacheToFile(handle, filename)
     initialize_context()
-    @ccall libcutensor.cutensorWriteKernelCacheToFile(handle::cutensorHandle_t,
-                                                      filename::Ptr{Cchar})::cutensorStatus_t
+    @gcsafe_ccall libcutensor.cutensorWriteKernelCacheToFile(handle::cutensorHandle_t,
+                                                             filename::Ptr{Cchar})::cutensorStatus_t
 end
 
 @checked function cutensorReadKernelCacheFromFile(handle, filename)
     initialize_context()
-    @ccall libcutensor.cutensorReadKernelCacheFromFile(handle::cutensorHandle_t,
-                                                       filename::Ptr{Cchar})::cutensorStatus_t
+    @gcsafe_ccall libcutensor.cutensorReadKernelCacheFromFile(handle::cutensorHandle_t,
+                                                              filename::Ptr{Cchar})::cutensorStatus_t
 end
 
 @checked function cutensorCreateTensorDescriptor(handle, desc, numModes, extent, stride,
                                                  dataType, alignmentRequirement)
     initialize_context()
-    @ccall libcutensor.cutensorCreateTensorDescriptor(handle::cutensorHandle_t,
-                                                      desc::Ptr{cutensorTensorDescriptor_t},
-                                                      numModes::UInt32, extent::Ptr{Int64},
-                                                      stride::Ptr{Int64},
-                                                      dataType::cutensorDataType_t,
-                                                      alignmentRequirement::UInt32)::cutensorStatus_t
+    @gcsafe_ccall libcutensor.cutensorCreateTensorDescriptor(handle::cutensorHandle_t,
+                                                             desc::Ptr{cutensorTensorDescriptor_t},
+                                                             numModes::UInt32,
+                                                             extent::Ptr{Int64},
+                                                             stride::Ptr{Int64},
+                                                             dataType::cutensorDataType_t,
+                                                             alignmentRequirement::UInt32)::cutensorStatus_t
 end
 
 @checked function cutensorDestroyTensorDescriptor(desc)
     initialize_context()
-    @ccall libcutensor.cutensorDestroyTensorDescriptor(desc::cutensorTensorDescriptor_t)::cutensorStatus_t
+    @gcsafe_ccall libcutensor.cutensorDestroyTensorDescriptor(desc::cutensorTensorDescriptor_t)::cutensorStatus_t
 end
 
 @checked function cutensorCreateElementwiseTrinary(handle, desc, descA, modeA, opA, descB,
                                                    modeB, opB, descC, modeC, opC, descD,
                                                    modeD, opAB, opABC, descCompute)
     initialize_context()
-    @ccall libcutensor.cutensorCreateElementwiseTrinary(handle::cutensorHandle_t,
+    @gcsafe_ccall libcutensor.cutensorCreateElementwiseTrinary(handle::cutensorHandle_t,
+                                                               desc::Ptr{cutensorOperationDescriptor_t},
+                                                               descA::cutensorTensorDescriptor_t,
+                                                               modeA::Ptr{Int32},
+                                                               opA::cutensorOperator_t,
+                                                               descB::cutensorTensorDescriptor_t,
+                                                               modeB::Ptr{Int32},
+                                                               opB::cutensorOperator_t,
+                                                               descC::cutensorTensorDescriptor_t,
+                                                               modeC::Ptr{Int32},
+                                                               opC::cutensorOperator_t,
+                                                               descD::cutensorTensorDescriptor_t,
+                                                               modeD::Ptr{Int32},
+                                                               opAB::cutensorOperator_t,
+                                                               opABC::cutensorOperator_t,
+                                                               descCompute::cutensorComputeDescriptor_t)::cutensorStatus_t
+end
+
+@checked function cutensorElementwiseTrinaryExecute(handle, plan, alpha, A, beta, B, gamma,
+                                                    C, D, stream)
+    initialize_context()
+    @gcsafe_ccall libcutensor.cutensorElementwiseTrinaryExecute(handle::cutensorHandle_t,
+                                                                plan::cutensorPlan_t,
+                                                                alpha::Ptr{Cvoid},
+                                                                A::CuPtr{Cvoid},
+                                                                beta::Ptr{Cvoid},
+                                                                B::CuPtr{Cvoid},
+                                                                gamma::Ptr{Cvoid},
+                                                                C::CuPtr{Cvoid},
+                                                                D::CuPtr{Cvoid},
+                                                                stream::cudaStream_t)::cutensorStatus_t
+end
+
+@checked function cutensorCreateElementwiseBinary(handle, desc, descA, modeA, opA, descC,
+                                                  modeC, opC, descD, modeD, opAC,
+                                                  descCompute)
+    initialize_context()
+    @gcsafe_ccall libcutensor.cutensorCreateElementwiseBinary(handle::cutensorHandle_t,
+                                                              desc::Ptr{cutensorOperationDescriptor_t},
+                                                              descA::cutensorTensorDescriptor_t,
+                                                              modeA::Ptr{Int32},
+                                                              opA::cutensorOperator_t,
+                                                              descC::cutensorTensorDescriptor_t,
+                                                              modeC::Ptr{Int32},
+                                                              opC::cutensorOperator_t,
+                                                              descD::cutensorTensorDescriptor_t,
+                                                              modeD::Ptr{Int32},
+                                                              opAC::cutensorOperator_t,
+                                                              descCompute::cutensorComputeDescriptor_t)::cutensorStatus_t
+end
+
+@checked function cutensorElementwiseBinaryExecute(handle, plan, alpha, A, gamma, C, D,
+                                                   stream)
+    initialize_context()
+    @gcsafe_ccall libcutensor.cutensorElementwiseBinaryExecute(handle::cutensorHandle_t,
+                                                               plan::cutensorPlan_t,
+                                                               alpha::Ptr{Cvoid},
+                                                               A::CuPtr{Cvoid},
+                                                               gamma::Ptr{Cvoid},
+                                                               C::CuPtr{Cvoid},
+                                                               D::CuPtr{Cvoid},
+                                                               stream::cudaStream_t)::cutensorStatus_t
+end
+
+@checked function cutensorCreatePermutation(handle, desc, descA, modeA, opA, descB, modeB,
+                                            descCompute)
+    initialize_context()
+    @gcsafe_ccall libcutensor.cutensorCreatePermutation(handle::cutensorHandle_t,
+                                                        desc::Ptr{cutensorOperationDescriptor_t},
+                                                        descA::cutensorTensorDescriptor_t,
+                                                        modeA::Ptr{Int32},
+                                                        opA::cutensorOperator_t,
+                                                        descB::cutensorTensorDescriptor_t,
+                                                        modeB::Ptr{Int32},
+                                                        descCompute::cutensorComputeDescriptor_t)::cutensorStatus_t
+end
+
+@checked function cutensorPermute(handle, plan, alpha, A, B, stream)
+    initialize_context()
+    @gcsafe_ccall libcutensor.cutensorPermute(handle::cutensorHandle_t,
+                                              plan::cutensorPlan_t, alpha::Ptr{Cvoid},
+                                              A::CuPtr{Cvoid}, B::CuPtr{Cvoid},
+                                              stream::cudaStream_t)::cutensorStatus_t
+end
+
+@checked function cutensorCreateContraction(handle, desc, descA, modeA, opA, descB, modeB,
+                                            opB, descC, modeC, opC, descD, modeD,
+                                            descCompute)
+    initialize_context()
+    @gcsafe_ccall libcutensor.cutensorCreateContraction(handle::cutensorHandle_t,
                                                         desc::Ptr{cutensorOperationDescriptor_t},
                                                         descA::cutensorTensorDescriptor_t,
                                                         modeA::Ptr{Int32},
@@ -266,246 +356,172 @@ end
                                                         opC::cutensorOperator_t,
                                                         descD::cutensorTensorDescriptor_t,
                                                         modeD::Ptr{Int32},
-                                                        opAB::cutensorOperator_t,
-                                                        opABC::cutensorOperator_t,
                                                         descCompute::cutensorComputeDescriptor_t)::cutensorStatus_t
-end
-
-@checked function cutensorElementwiseTrinaryExecute(handle, plan, alpha, A, beta, B, gamma,
-                                                    C, D, stream)
-    initialize_context()
-    @ccall libcutensor.cutensorElementwiseTrinaryExecute(handle::cutensorHandle_t,
-                                                         plan::cutensorPlan_t,
-                                                         alpha::Ptr{Cvoid}, A::CuPtr{Cvoid},
-                                                         beta::Ptr{Cvoid}, B::CuPtr{Cvoid},
-                                                         gamma::Ptr{Cvoid}, C::CuPtr{Cvoid},
-                                                         D::CuPtr{Cvoid},
-                                                         stream::cudaStream_t)::cutensorStatus_t
-end
-
-@checked function cutensorCreateElementwiseBinary(handle, desc, descA, modeA, opA, descC,
-                                                  modeC, opC, descD, modeD, opAC,
-                                                  descCompute)
-    initialize_context()
-    @ccall libcutensor.cutensorCreateElementwiseBinary(handle::cutensorHandle_t,
-                                                       desc::Ptr{cutensorOperationDescriptor_t},
-                                                       descA::cutensorTensorDescriptor_t,
-                                                       modeA::Ptr{Int32},
-                                                       opA::cutensorOperator_t,
-                                                       descC::cutensorTensorDescriptor_t,
-                                                       modeC::Ptr{Int32},
-                                                       opC::cutensorOperator_t,
-                                                       descD::cutensorTensorDescriptor_t,
-                                                       modeD::Ptr{Int32},
-                                                       opAC::cutensorOperator_t,
-                                                       descCompute::cutensorComputeDescriptor_t)::cutensorStatus_t
-end
-
-@checked function cutensorElementwiseBinaryExecute(handle, plan, alpha, A, gamma, C, D,
-                                                   stream)
-    initialize_context()
-    @ccall libcutensor.cutensorElementwiseBinaryExecute(handle::cutensorHandle_t,
-                                                        plan::cutensorPlan_t,
-                                                        alpha::Ptr{Cvoid}, A::CuPtr{Cvoid},
-                                                        gamma::Ptr{Cvoid}, C::CuPtr{Cvoid},
-                                                        D::CuPtr{Cvoid},
-                                                        stream::cudaStream_t)::cutensorStatus_t
-end
-
-@checked function cutensorCreatePermutation(handle, desc, descA, modeA, opA, descB, modeB,
-                                            descCompute)
-    initialize_context()
-    @ccall libcutensor.cutensorCreatePermutation(handle::cutensorHandle_t,
-                                                 desc::Ptr{cutensorOperationDescriptor_t},
-                                                 descA::cutensorTensorDescriptor_t,
-                                                 modeA::Ptr{Int32}, opA::cutensorOperator_t,
-                                                 descB::cutensorTensorDescriptor_t,
-                                                 modeB::Ptr{Int32},
-                                                 descCompute::cutensorComputeDescriptor_t)::cutensorStatus_t
-end
-
-@checked function cutensorPermute(handle, plan, alpha, A, B, stream)
-    initialize_context()
-    @ccall libcutensor.cutensorPermute(handle::cutensorHandle_t, plan::cutensorPlan_t,
-                                       alpha::Ptr{Cvoid}, A::CuPtr{Cvoid}, B::CuPtr{Cvoid},
-                                       stream::cudaStream_t)::cutensorStatus_t
-end
-
-@checked function cutensorCreateContraction(handle, desc, descA, modeA, opA, descB, modeB,
-                                            opB, descC, modeC, opC, descD, modeD,
-                                            descCompute)
-    initialize_context()
-    @ccall libcutensor.cutensorCreateContraction(handle::cutensorHandle_t,
-                                                 desc::Ptr{cutensorOperationDescriptor_t},
-                                                 descA::cutensorTensorDescriptor_t,
-                                                 modeA::Ptr{Int32}, opA::cutensorOperator_t,
-                                                 descB::cutensorTensorDescriptor_t,
-                                                 modeB::Ptr{Int32}, opB::cutensorOperator_t,
-                                                 descC::cutensorTensorDescriptor_t,
-                                                 modeC::Ptr{Int32}, opC::cutensorOperator_t,
-                                                 descD::cutensorTensorDescriptor_t,
-                                                 modeD::Ptr{Int32},
-                                                 descCompute::cutensorComputeDescriptor_t)::cutensorStatus_t
 end
 
 @checked function cutensorDestroyOperationDescriptor(desc)
     initialize_context()
-    @ccall libcutensor.cutensorDestroyOperationDescriptor(desc::cutensorOperationDescriptor_t)::cutensorStatus_t
+    @gcsafe_ccall libcutensor.cutensorDestroyOperationDescriptor(desc::cutensorOperationDescriptor_t)::cutensorStatus_t
 end
 
 @checked function cutensorOperationDescriptorSetAttribute(handle, desc, attr, buf,
                                                           sizeInBytes)
     initialize_context()
-    @ccall libcutensor.cutensorOperationDescriptorSetAttribute(handle::cutensorHandle_t,
-                                                               desc::cutensorOperationDescriptor_t,
-                                                               attr::cutensorOperationDescriptorAttribute_t,
-                                                               buf::Ptr{Cvoid},
-                                                               sizeInBytes::Csize_t)::cutensorStatus_t
+    @gcsafe_ccall libcutensor.cutensorOperationDescriptorSetAttribute(handle::cutensorHandle_t,
+                                                                      desc::cutensorOperationDescriptor_t,
+                                                                      attr::cutensorOperationDescriptorAttribute_t,
+                                                                      buf::Ptr{Cvoid},
+                                                                      sizeInBytes::Csize_t)::cutensorStatus_t
 end
 
 @checked function cutensorOperationDescriptorGetAttribute(handle, desc, attr, buf,
                                                           sizeInBytes)
     initialize_context()
-    @ccall libcutensor.cutensorOperationDescriptorGetAttribute(handle::cutensorHandle_t,
-                                                               desc::cutensorOperationDescriptor_t,
-                                                               attr::cutensorOperationDescriptorAttribute_t,
-                                                               buf::Ptr{Cvoid},
-                                                               sizeInBytes::Csize_t)::cutensorStatus_t
+    @gcsafe_ccall libcutensor.cutensorOperationDescriptorGetAttribute(handle::cutensorHandle_t,
+                                                                      desc::cutensorOperationDescriptor_t,
+                                                                      attr::cutensorOperationDescriptorAttribute_t,
+                                                                      buf::Ptr{Cvoid},
+                                                                      sizeInBytes::Csize_t)::cutensorStatus_t
 end
 
 @checked function cutensorCreatePlanPreference(handle, pref, algo, jitMode)
     initialize_context()
-    @ccall libcutensor.cutensorCreatePlanPreference(handle::cutensorHandle_t,
-                                                    pref::Ptr{cutensorPlanPreference_t},
-                                                    algo::cutensorAlgo_t,
-                                                    jitMode::cutensorJitMode_t)::cutensorStatus_t
+    @gcsafe_ccall libcutensor.cutensorCreatePlanPreference(handle::cutensorHandle_t,
+                                                           pref::Ptr{cutensorPlanPreference_t},
+                                                           algo::cutensorAlgo_t,
+                                                           jitMode::cutensorJitMode_t)::cutensorStatus_t
 end
 
 @checked function cutensorDestroyPlanPreference(pref)
     initialize_context()
-    @ccall libcutensor.cutensorDestroyPlanPreference(pref::cutensorPlanPreference_t)::cutensorStatus_t
+    @gcsafe_ccall libcutensor.cutensorDestroyPlanPreference(pref::cutensorPlanPreference_t)::cutensorStatus_t
 end
 
 @checked function cutensorPlanPreferenceSetAttribute(handle, pref, attr, buf, sizeInBytes)
     initialize_context()
-    @ccall libcutensor.cutensorPlanPreferenceSetAttribute(handle::cutensorHandle_t,
-                                                          pref::cutensorPlanPreference_t,
-                                                          attr::cutensorPlanPreferenceAttribute_t,
-                                                          buf::Ptr{Cvoid},
-                                                          sizeInBytes::Csize_t)::cutensorStatus_t
+    @gcsafe_ccall libcutensor.cutensorPlanPreferenceSetAttribute(handle::cutensorHandle_t,
+                                                                 pref::cutensorPlanPreference_t,
+                                                                 attr::cutensorPlanPreferenceAttribute_t,
+                                                                 buf::Ptr{Cvoid},
+                                                                 sizeInBytes::Csize_t)::cutensorStatus_t
 end
 
 @checked function cutensorPlanGetAttribute(handle, plan, attr, buf, sizeInBytes)
     initialize_context()
-    @ccall libcutensor.cutensorPlanGetAttribute(handle::cutensorHandle_t,
-                                                plan::cutensorPlan_t,
-                                                attr::cutensorPlanAttribute_t,
-                                                buf::Ptr{Cvoid},
-                                                sizeInBytes::Csize_t)::cutensorStatus_t
+    @gcsafe_ccall libcutensor.cutensorPlanGetAttribute(handle::cutensorHandle_t,
+                                                       plan::cutensorPlan_t,
+                                                       attr::cutensorPlanAttribute_t,
+                                                       buf::Ptr{Cvoid},
+                                                       sizeInBytes::Csize_t)::cutensorStatus_t
 end
 
 @checked function cutensorEstimateWorkspaceSize(handle, desc, planPref, workspacePref,
                                                 workspaceSizeEstimate)
     initialize_context()
-    @ccall libcutensor.cutensorEstimateWorkspaceSize(handle::cutensorHandle_t,
-                                                     desc::cutensorOperationDescriptor_t,
-                                                     planPref::cutensorPlanPreference_t,
-                                                     workspacePref::cutensorWorksizePreference_t,
-                                                     workspaceSizeEstimate::Ptr{UInt64})::cutensorStatus_t
+    @gcsafe_ccall libcutensor.cutensorEstimateWorkspaceSize(handle::cutensorHandle_t,
+                                                            desc::cutensorOperationDescriptor_t,
+                                                            planPref::cutensorPlanPreference_t,
+                                                            workspacePref::cutensorWorksizePreference_t,
+                                                            workspaceSizeEstimate::Ptr{UInt64})::cutensorStatus_t
 end
 
 @checked function cutensorCreatePlan(handle, plan, desc, pref, workspaceSizeLimit)
     initialize_context()
-    @ccall libcutensor.cutensorCreatePlan(handle::cutensorHandle_t,
-                                          plan::Ptr{cutensorPlan_t},
-                                          desc::cutensorOperationDescriptor_t,
-                                          pref::cutensorPlanPreference_t,
-                                          workspaceSizeLimit::UInt64)::cutensorStatus_t
+    @gcsafe_ccall libcutensor.cutensorCreatePlan(handle::cutensorHandle_t,
+                                                 plan::Ptr{cutensorPlan_t},
+                                                 desc::cutensorOperationDescriptor_t,
+                                                 pref::cutensorPlanPreference_t,
+                                                 workspaceSizeLimit::UInt64)::cutensorStatus_t
 end
 
 @checked function cutensorDestroyPlan(plan)
     initialize_context()
-    @ccall libcutensor.cutensorDestroyPlan(plan::cutensorPlan_t)::cutensorStatus_t
+    @gcsafe_ccall libcutensor.cutensorDestroyPlan(plan::cutensorPlan_t)::cutensorStatus_t
 end
 
 @checked function cutensorContract(handle, plan, alpha, A, B, beta, C, D, workspace,
                                    workspaceSize, stream)
     initialize_context()
-    @ccall libcutensor.cutensorContract(handle::cutensorHandle_t, plan::cutensorPlan_t,
-                                        alpha::Ptr{Cvoid}, A::CuPtr{Cvoid}, B::CuPtr{Cvoid},
-                                        beta::Ptr{Cvoid}, C::CuPtr{Cvoid}, D::CuPtr{Cvoid},
-                                        workspace::CuPtr{Cvoid}, workspaceSize::UInt64,
-                                        stream::cudaStream_t)::cutensorStatus_t
+    @gcsafe_ccall libcutensor.cutensorContract(handle::cutensorHandle_t,
+                                               plan::cutensorPlan_t, alpha::Ptr{Cvoid},
+                                               A::CuPtr{Cvoid}, B::CuPtr{Cvoid},
+                                               beta::Ptr{Cvoid}, C::CuPtr{Cvoid},
+                                               D::CuPtr{Cvoid}, workspace::CuPtr{Cvoid},
+                                               workspaceSize::UInt64,
+                                               stream::cudaStream_t)::cutensorStatus_t
 end
 
 @checked function cutensorCreateReduction(handle, desc, descA, modeA, opA, descC, modeC,
                                           opC, descD, modeD, opReduce, descCompute)
     initialize_context()
-    @ccall libcutensor.cutensorCreateReduction(handle::cutensorHandle_t,
-                                               desc::Ptr{cutensorOperationDescriptor_t},
-                                               descA::cutensorTensorDescriptor_t,
-                                               modeA::Ptr{Int32}, opA::cutensorOperator_t,
-                                               descC::cutensorTensorDescriptor_t,
-                                               modeC::Ptr{Int32}, opC::cutensorOperator_t,
-                                               descD::cutensorTensorDescriptor_t,
-                                               modeD::Ptr{Int32},
-                                               opReduce::cutensorOperator_t,
-                                               descCompute::cutensorComputeDescriptor_t)::cutensorStatus_t
+    @gcsafe_ccall libcutensor.cutensorCreateReduction(handle::cutensorHandle_t,
+                                                      desc::Ptr{cutensorOperationDescriptor_t},
+                                                      descA::cutensorTensorDescriptor_t,
+                                                      modeA::Ptr{Int32},
+                                                      opA::cutensorOperator_t,
+                                                      descC::cutensorTensorDescriptor_t,
+                                                      modeC::Ptr{Int32},
+                                                      opC::cutensorOperator_t,
+                                                      descD::cutensorTensorDescriptor_t,
+                                                      modeD::Ptr{Int32},
+                                                      opReduce::cutensorOperator_t,
+                                                      descCompute::cutensorComputeDescriptor_t)::cutensorStatus_t
 end
 
 @checked function cutensorReduce(handle, plan, alpha, A, beta, C, D, workspace,
                                  workspaceSize, stream)
     initialize_context()
-    @ccall libcutensor.cutensorReduce(handle::cutensorHandle_t, plan::cutensorPlan_t,
-                                      alpha::Ptr{Cvoid}, A::CuPtr{Cvoid}, beta::Ptr{Cvoid},
-                                      C::CuPtr{Cvoid}, D::CuPtr{Cvoid},
-                                      workspace::CuPtr{Cvoid}, workspaceSize::UInt64,
-                                      stream::cudaStream_t)::cutensorStatus_t
+    @gcsafe_ccall libcutensor.cutensorReduce(handle::cutensorHandle_t, plan::cutensorPlan_t,
+                                             alpha::Ptr{Cvoid}, A::CuPtr{Cvoid},
+                                             beta::Ptr{Cvoid}, C::CuPtr{Cvoid},
+                                             D::CuPtr{Cvoid}, workspace::CuPtr{Cvoid},
+                                             workspaceSize::UInt64,
+                                             stream::cudaStream_t)::cutensorStatus_t
 end
 
 function cutensorGetErrorString(error)
-    @ccall libcutensor.cutensorGetErrorString(error::cutensorStatus_t)::Cstring
+    @gcsafe_ccall libcutensor.cutensorGetErrorString(error::cutensorStatus_t)::Cstring
 end
 
 # no prototype is found for this function at cutensor.h:980:8, please use with caution
 function cutensorGetVersion()
-    @ccall libcutensor.cutensorGetVersion()::Csize_t
+    @gcsafe_ccall libcutensor.cutensorGetVersion()::Csize_t
 end
 
 # no prototype is found for this function at cutensor.h:986:8, please use with caution
 function cutensorGetCudartVersion()
-    @ccall libcutensor.cutensorGetCudartVersion()::Csize_t
+    @gcsafe_ccall libcutensor.cutensorGetCudartVersion()::Csize_t
 end
 
 @checked function cutensorLoggerSetCallback(callback)
     initialize_context()
-    @ccall libcutensor.cutensorLoggerSetCallback(callback::cutensorLoggerCallback_t)::cutensorStatus_t
+    @gcsafe_ccall libcutensor.cutensorLoggerSetCallback(callback::cutensorLoggerCallback_t)::cutensorStatus_t
 end
 
 @checked function cutensorLoggerSetFile(file)
     initialize_context()
-    @ccall libcutensor.cutensorLoggerSetFile(file::Ptr{Libc.FILE})::cutensorStatus_t
+    @gcsafe_ccall libcutensor.cutensorLoggerSetFile(file::Ptr{Libc.FILE})::cutensorStatus_t
 end
 
 @checked function cutensorLoggerOpenFile(logFile)
     initialize_context()
-    @ccall libcutensor.cutensorLoggerOpenFile(logFile::Cstring)::cutensorStatus_t
+    @gcsafe_ccall libcutensor.cutensorLoggerOpenFile(logFile::Cstring)::cutensorStatus_t
 end
 
 @checked function cutensorLoggerSetLevel(level)
     initialize_context()
-    @ccall libcutensor.cutensorLoggerSetLevel(level::Int32)::cutensorStatus_t
+    @gcsafe_ccall libcutensor.cutensorLoggerSetLevel(level::Int32)::cutensorStatus_t
 end
 
 @checked function cutensorLoggerSetMask(mask)
     initialize_context()
-    @ccall libcutensor.cutensorLoggerSetMask(mask::Int32)::cutensorStatus_t
+    @gcsafe_ccall libcutensor.cutensorLoggerSetMask(mask::Int32)::cutensorStatus_t
 end
 
 # no prototype is found for this function at cutensor.h:1034:18, please use with caution
 @checked function cutensorLoggerForceDisable()
     initialize_context()
-    @ccall libcutensor.cutensorLoggerForceDisable()::cutensorStatus_t
+    @gcsafe_ccall libcutensor.cutensorLoggerForceDisable()::cutensorStatus_t
 end
 
 # Skipping MacroDefinition: CUTENSOR_EXTERN extern

--- a/lib/cutensornet/src/cuTensorNet.jl
+++ b/lib/cutensornet/src/cuTensorNet.jl
@@ -89,6 +89,11 @@ end
 ## logging
 
 function log_message(log_level, function_name, message)
+    # see @gcsafe_ccall documentation
+    @static if VERSION < v"1.9"
+        GC.safepoint()
+    end
+
     function_name = unsafe_string(function_name)
     message = unsafe_string(message)
     output = if isempty(message)

--- a/lib/cutensornet/src/cuTensorNet.jl
+++ b/lib/cutensornet/src/cuTensorNet.jl
@@ -16,6 +16,13 @@ else
     import cuQuantum_jll
 end
 
+# XXX: cuTensorNet depends on cuTENSOR 1, while GC-safe ccalls were introduced in CUDA 5.3
+#      which is only compatible with cuTENSOR 2. So disable that functionality for now.
+const var"@gcsafe_ccall" = var"@ccall"
+macro gcunsafe_callback(expr)
+    esc(expr)
+end
+
 
 export has_cutensornet
 

--- a/lib/cutensornet/src/cuTensorNet.jl
+++ b/lib/cutensornet/src/cuTensorNet.jl
@@ -88,12 +88,7 @@ end
 
 ## logging
 
-function log_message(log_level, function_name, message)
-    # see @gcsafe_ccall documentation
-    @static if VERSION < v"1.9"
-        GC.safepoint()
-    end
-
+@gcunsafe_callback function log_message(log_level, function_name, message)
     function_name = unsafe_string(function_name)
     message = unsafe_string(message)
     output = if isempty(message)

--- a/lib/cutensornet/src/libcutensornet.jl
+++ b/lib/cutensornet/src/libcutensornet.jl
@@ -334,12 +334,12 @@ const cutensornetLoggerCallbackData_t = Ptr{Cvoid}
 
 @checked function cutensornetCreate(handle)
     initialize_context()
-    @ccall libcutensornet.cutensornetCreate(handle::Ptr{cutensornetHandle_t})::cutensornetStatus_t
+    @gcsafe_ccall libcutensornet.cutensornetCreate(handle::Ptr{cutensornetHandle_t})::cutensornetStatus_t
 end
 
 @checked function cutensornetDestroy(handle)
     initialize_context()
-    @ccall libcutensornet.cutensornetDestroy(handle::cutensornetHandle_t)::cutensornetStatus_t
+    @gcsafe_ccall libcutensornet.cutensornetDestroy(handle::cutensornetHandle_t)::cutensornetStatus_t
 end
 
 @checked function cutensornetCreateNetworkDescriptor(handle, numInputs, numModesIn,
@@ -348,264 +348,264 @@ end
                                                      stridesOut, modesOut, dataType,
                                                      computeType, descNet)
     initialize_context()
-    @ccall libcutensornet.cutensornetCreateNetworkDescriptor(handle::cutensornetHandle_t,
-                                                             numInputs::Int32,
-                                                             numModesIn::Ptr{Int32},
-                                                             extentsIn::Ptr{Ptr{Int64}},
-                                                             stridesIn::Ptr{Ptr{Int64}},
-                                                             modesIn::Ptr{Ptr{Int32}},
-                                                             qualifiersIn::Ptr{cutensornetTensorQualifiers_t},
-                                                             numModesOut::Int32,
-                                                             extentsOut::Ptr{Int64},
-                                                             stridesOut::Ptr{Int64},
-                                                             modesOut::Ptr{Int32},
-                                                             dataType::cudaDataType_t,
-                                                             computeType::cutensornetComputeType_t,
-                                                             descNet::Ptr{cutensornetNetworkDescriptor_t})::cutensornetStatus_t
+    @gcsafe_ccall libcutensornet.cutensornetCreateNetworkDescriptor(handle::cutensornetHandle_t,
+                                                                    numInputs::Int32,
+                                                                    numModesIn::Ptr{Int32},
+                                                                    extentsIn::Ptr{Ptr{Int64}},
+                                                                    stridesIn::Ptr{Ptr{Int64}},
+                                                                    modesIn::Ptr{Ptr{Int32}},
+                                                                    qualifiersIn::Ptr{cutensornetTensorQualifiers_t},
+                                                                    numModesOut::Int32,
+                                                                    extentsOut::Ptr{Int64},
+                                                                    stridesOut::Ptr{Int64},
+                                                                    modesOut::Ptr{Int32},
+                                                                    dataType::cudaDataType_t,
+                                                                    computeType::cutensornetComputeType_t,
+                                                                    descNet::Ptr{cutensornetNetworkDescriptor_t})::cutensornetStatus_t
 end
 
 @checked function cutensornetDestroyNetworkDescriptor(desc)
     initialize_context()
-    @ccall libcutensornet.cutensornetDestroyNetworkDescriptor(desc::cutensornetNetworkDescriptor_t)::cutensornetStatus_t
+    @gcsafe_ccall libcutensornet.cutensornetDestroyNetworkDescriptor(desc::cutensornetNetworkDescriptor_t)::cutensornetStatus_t
 end
 
 @checked function cutensornetNetworkGetAttribute(handle, networkDesc, attr, buf,
                                                  sizeInBytes)
     initialize_context()
-    @ccall libcutensornet.cutensornetNetworkGetAttribute(handle::cutensornetHandle_t,
-                                                         networkDesc::cutensornetNetworkDescriptor_t,
-                                                         attr::cutensornetNetworkAttributes_t,
-                                                         buf::Ptr{Cvoid},
-                                                         sizeInBytes::Csize_t)::cutensornetStatus_t
+    @gcsafe_ccall libcutensornet.cutensornetNetworkGetAttribute(handle::cutensornetHandle_t,
+                                                                networkDesc::cutensornetNetworkDescriptor_t,
+                                                                attr::cutensornetNetworkAttributes_t,
+                                                                buf::Ptr{Cvoid},
+                                                                sizeInBytes::Csize_t)::cutensornetStatus_t
 end
 
 @checked function cutensornetNetworkSetAttribute(handle, networkDesc, attr, buf,
                                                  sizeInBytes)
     initialize_context()
-    @ccall libcutensornet.cutensornetNetworkSetAttribute(handle::cutensornetHandle_t,
-                                                         networkDesc::cutensornetNetworkDescriptor_t,
-                                                         attr::cutensornetNetworkAttributes_t,
-                                                         buf::Ptr{Cvoid},
-                                                         sizeInBytes::Csize_t)::cutensornetStatus_t
+    @gcsafe_ccall libcutensornet.cutensornetNetworkSetAttribute(handle::cutensornetHandle_t,
+                                                                networkDesc::cutensornetNetworkDescriptor_t,
+                                                                attr::cutensornetNetworkAttributes_t,
+                                                                buf::Ptr{Cvoid},
+                                                                sizeInBytes::Csize_t)::cutensornetStatus_t
 end
 
 @checked function cutensornetGetOutputTensorDetails(handle, descNet, numModes, dataSize,
                                                     modeLabels, extents, strides)
     initialize_context()
-    @ccall libcutensornet.cutensornetGetOutputTensorDetails(handle::cutensornetHandle_t,
-                                                            descNet::cutensornetNetworkDescriptor_t,
-                                                            numModes::Ptr{Int32},
-                                                            dataSize::Ptr{Csize_t},
-                                                            modeLabels::Ptr{Int32},
-                                                            extents::Ptr{Int64},
-                                                            strides::Ptr{Int64})::cutensornetStatus_t
+    @gcsafe_ccall libcutensornet.cutensornetGetOutputTensorDetails(handle::cutensornetHandle_t,
+                                                                   descNet::cutensornetNetworkDescriptor_t,
+                                                                   numModes::Ptr{Int32},
+                                                                   dataSize::Ptr{Csize_t},
+                                                                   modeLabels::Ptr{Int32},
+                                                                   extents::Ptr{Int64},
+                                                                   strides::Ptr{Int64})::cutensornetStatus_t
 end
 
 @checked function cutensornetGetOutputTensorDescriptor(handle, descNet, outputTensorDesc)
     initialize_context()
-    @ccall libcutensornet.cutensornetGetOutputTensorDescriptor(handle::cutensornetHandle_t,
-                                                               descNet::cutensornetNetworkDescriptor_t,
-                                                               outputTensorDesc::Ptr{cutensornetTensorDescriptor_t})::cutensornetStatus_t
+    @gcsafe_ccall libcutensornet.cutensornetGetOutputTensorDescriptor(handle::cutensornetHandle_t,
+                                                                      descNet::cutensornetNetworkDescriptor_t,
+                                                                      outputTensorDesc::Ptr{cutensornetTensorDescriptor_t})::cutensornetStatus_t
 end
 
 @checked function cutensornetGetTensorDetails(handle, tensorDesc, numModes, dataSize,
                                               modeLabels, extents, strides)
     initialize_context()
-    @ccall libcutensornet.cutensornetGetTensorDetails(handle::cutensornetHandle_t,
-                                                      tensorDesc::cutensornetTensorDescriptor_t,
-                                                      numModes::Ptr{Int32},
-                                                      dataSize::Ptr{Csize_t},
-                                                      modeLabels::Ptr{Int32},
-                                                      extents::Ptr{Int64},
-                                                      strides::Ptr{Int64})::cutensornetStatus_t
+    @gcsafe_ccall libcutensornet.cutensornetGetTensorDetails(handle::cutensornetHandle_t,
+                                                             tensorDesc::cutensornetTensorDescriptor_t,
+                                                             numModes::Ptr{Int32},
+                                                             dataSize::Ptr{Csize_t},
+                                                             modeLabels::Ptr{Int32},
+                                                             extents::Ptr{Int64},
+                                                             strides::Ptr{Int64})::cutensornetStatus_t
 end
 
 @checked function cutensornetCreateWorkspaceDescriptor(handle, workDesc)
     initialize_context()
-    @ccall libcutensornet.cutensornetCreateWorkspaceDescriptor(handle::cutensornetHandle_t,
-                                                               workDesc::Ptr{cutensornetWorkspaceDescriptor_t})::cutensornetStatus_t
+    @gcsafe_ccall libcutensornet.cutensornetCreateWorkspaceDescriptor(handle::cutensornetHandle_t,
+                                                                      workDesc::Ptr{cutensornetWorkspaceDescriptor_t})::cutensornetStatus_t
 end
 
 @checked function cutensornetWorkspaceComputeSizes(handle, descNet, optimizerInfo, workDesc)
     initialize_context()
-    @ccall libcutensornet.cutensornetWorkspaceComputeSizes(handle::cutensornetHandle_t,
-                                                           descNet::cutensornetNetworkDescriptor_t,
-                                                           optimizerInfo::cutensornetContractionOptimizerInfo_t,
-                                                           workDesc::cutensornetWorkspaceDescriptor_t)::cutensornetStatus_t
+    @gcsafe_ccall libcutensornet.cutensornetWorkspaceComputeSizes(handle::cutensornetHandle_t,
+                                                                  descNet::cutensornetNetworkDescriptor_t,
+                                                                  optimizerInfo::cutensornetContractionOptimizerInfo_t,
+                                                                  workDesc::cutensornetWorkspaceDescriptor_t)::cutensornetStatus_t
 end
 
 @checked function cutensornetWorkspaceComputeContractionSizes(handle, descNet,
                                                               optimizerInfo, workDesc)
     initialize_context()
-    @ccall libcutensornet.cutensornetWorkspaceComputeContractionSizes(handle::cutensornetHandle_t,
-                                                                      descNet::cutensornetNetworkDescriptor_t,
-                                                                      optimizerInfo::cutensornetContractionOptimizerInfo_t,
-                                                                      workDesc::cutensornetWorkspaceDescriptor_t)::cutensornetStatus_t
+    @gcsafe_ccall libcutensornet.cutensornetWorkspaceComputeContractionSizes(handle::cutensornetHandle_t,
+                                                                             descNet::cutensornetNetworkDescriptor_t,
+                                                                             optimizerInfo::cutensornetContractionOptimizerInfo_t,
+                                                                             workDesc::cutensornetWorkspaceDescriptor_t)::cutensornetStatus_t
 end
 
 @checked function cutensornetWorkspaceGetSize(handle, workDesc, workPref, memSpace,
                                               workspaceSize)
     initialize_context()
-    @ccall libcutensornet.cutensornetWorkspaceGetSize(handle::cutensornetHandle_t,
-                                                      workDesc::cutensornetWorkspaceDescriptor_t,
-                                                      workPref::cutensornetWorksizePref_t,
-                                                      memSpace::cutensornetMemspace_t,
-                                                      workspaceSize::Ptr{UInt64})::cutensornetStatus_t
+    @gcsafe_ccall libcutensornet.cutensornetWorkspaceGetSize(handle::cutensornetHandle_t,
+                                                             workDesc::cutensornetWorkspaceDescriptor_t,
+                                                             workPref::cutensornetWorksizePref_t,
+                                                             memSpace::cutensornetMemspace_t,
+                                                             workspaceSize::Ptr{UInt64})::cutensornetStatus_t
 end
 
 @checked function cutensornetWorkspaceGetMemorySize(handle, workDesc, workPref, memSpace,
                                                     workKind, memorySize)
     initialize_context()
-    @ccall libcutensornet.cutensornetWorkspaceGetMemorySize(handle::cutensornetHandle_t,
-                                                            workDesc::cutensornetWorkspaceDescriptor_t,
-                                                            workPref::cutensornetWorksizePref_t,
-                                                            memSpace::cutensornetMemspace_t,
-                                                            workKind::cutensornetWorkspaceKind_t,
-                                                            memorySize::Ptr{Int64})::cutensornetStatus_t
+    @gcsafe_ccall libcutensornet.cutensornetWorkspaceGetMemorySize(handle::cutensornetHandle_t,
+                                                                   workDesc::cutensornetWorkspaceDescriptor_t,
+                                                                   workPref::cutensornetWorksizePref_t,
+                                                                   memSpace::cutensornetMemspace_t,
+                                                                   workKind::cutensornetWorkspaceKind_t,
+                                                                   memorySize::Ptr{Int64})::cutensornetStatus_t
 end
 
 @checked function cutensornetWorkspaceSet(handle, workDesc, memSpace, workspacePtr,
                                           workspaceSize)
     initialize_context()
-    @ccall libcutensornet.cutensornetWorkspaceSet(handle::cutensornetHandle_t,
-                                                  workDesc::cutensornetWorkspaceDescriptor_t,
-                                                  memSpace::cutensornetMemspace_t,
-                                                  workspacePtr::PtrOrCuPtr{Cvoid},
-                                                  workspaceSize::UInt64)::cutensornetStatus_t
+    @gcsafe_ccall libcutensornet.cutensornetWorkspaceSet(handle::cutensornetHandle_t,
+                                                         workDesc::cutensornetWorkspaceDescriptor_t,
+                                                         memSpace::cutensornetMemspace_t,
+                                                         workspacePtr::PtrOrCuPtr{Cvoid},
+                                                         workspaceSize::UInt64)::cutensornetStatus_t
 end
 
 @checked function cutensornetWorkspaceSetMemory(handle, workDesc, memSpace, workKind,
                                                 memoryPtr, memorySize)
     initialize_context()
-    @ccall libcutensornet.cutensornetWorkspaceSetMemory(handle::cutensornetHandle_t,
-                                                        workDesc::cutensornetWorkspaceDescriptor_t,
-                                                        memSpace::cutensornetMemspace_t,
-                                                        workKind::cutensornetWorkspaceKind_t,
-                                                        memoryPtr::Ptr{Cvoid},
-                                                        memorySize::Int64)::cutensornetStatus_t
+    @gcsafe_ccall libcutensornet.cutensornetWorkspaceSetMemory(handle::cutensornetHandle_t,
+                                                               workDesc::cutensornetWorkspaceDescriptor_t,
+                                                               memSpace::cutensornetMemspace_t,
+                                                               workKind::cutensornetWorkspaceKind_t,
+                                                               memoryPtr::Ptr{Cvoid},
+                                                               memorySize::Int64)::cutensornetStatus_t
 end
 
 @checked function cutensornetWorkspaceGet(handle, workDesc, memSpace, workspacePtr,
                                           workspaceSize)
     initialize_context()
-    @ccall libcutensornet.cutensornetWorkspaceGet(handle::cutensornetHandle_t,
-                                                  workDesc::cutensornetWorkspaceDescriptor_t,
-                                                  memSpace::cutensornetMemspace_t,
-                                                  workspacePtr::Ptr{Ptr{Cvoid}},
-                                                  workspaceSize::Ptr{UInt64})::cutensornetStatus_t
+    @gcsafe_ccall libcutensornet.cutensornetWorkspaceGet(handle::cutensornetHandle_t,
+                                                         workDesc::cutensornetWorkspaceDescriptor_t,
+                                                         memSpace::cutensornetMemspace_t,
+                                                         workspacePtr::Ptr{Ptr{Cvoid}},
+                                                         workspaceSize::Ptr{UInt64})::cutensornetStatus_t
 end
 
 @checked function cutensornetWorkspaceGetMemory(handle, workDesc, memSpace, workKind,
                                                 memoryPtr, memorySize)
     initialize_context()
-    @ccall libcutensornet.cutensornetWorkspaceGetMemory(handle::cutensornetHandle_t,
-                                                        workDesc::cutensornetWorkspaceDescriptor_t,
-                                                        memSpace::cutensornetMemspace_t,
-                                                        workKind::cutensornetWorkspaceKind_t,
-                                                        memoryPtr::Ptr{Ptr{Cvoid}},
-                                                        memorySize::Ptr{Int64})::cutensornetStatus_t
+    @gcsafe_ccall libcutensornet.cutensornetWorkspaceGetMemory(handle::cutensornetHandle_t,
+                                                               workDesc::cutensornetWorkspaceDescriptor_t,
+                                                               memSpace::cutensornetMemspace_t,
+                                                               workKind::cutensornetWorkspaceKind_t,
+                                                               memoryPtr::Ptr{Ptr{Cvoid}},
+                                                               memorySize::Ptr{Int64})::cutensornetStatus_t
 end
 
 @checked function cutensornetWorkspacePurgeCache(handle, workDesc, memSpace)
     initialize_context()
-    @ccall libcutensornet.cutensornetWorkspacePurgeCache(handle::cutensornetHandle_t,
-                                                         workDesc::cutensornetWorkspaceDescriptor_t,
-                                                         memSpace::cutensornetMemspace_t)::cutensornetStatus_t
+    @gcsafe_ccall libcutensornet.cutensornetWorkspacePurgeCache(handle::cutensornetHandle_t,
+                                                                workDesc::cutensornetWorkspaceDescriptor_t,
+                                                                memSpace::cutensornetMemspace_t)::cutensornetStatus_t
 end
 
 @checked function cutensornetDestroyWorkspaceDescriptor(desc)
     initialize_context()
-    @ccall libcutensornet.cutensornetDestroyWorkspaceDescriptor(desc::cutensornetWorkspaceDescriptor_t)::cutensornetStatus_t
+    @gcsafe_ccall libcutensornet.cutensornetDestroyWorkspaceDescriptor(desc::cutensornetWorkspaceDescriptor_t)::cutensornetStatus_t
 end
 
 @checked function cutensornetCreateContractionOptimizerConfig(handle, optimizerConfig)
     initialize_context()
-    @ccall libcutensornet.cutensornetCreateContractionOptimizerConfig(handle::cutensornetHandle_t,
-                                                                      optimizerConfig::Ptr{cutensornetContractionOptimizerConfig_t})::cutensornetStatus_t
+    @gcsafe_ccall libcutensornet.cutensornetCreateContractionOptimizerConfig(handle::cutensornetHandle_t,
+                                                                             optimizerConfig::Ptr{cutensornetContractionOptimizerConfig_t})::cutensornetStatus_t
 end
 
 @checked function cutensornetDestroyContractionOptimizerConfig(optimizerConfig)
     initialize_context()
-    @ccall libcutensornet.cutensornetDestroyContractionOptimizerConfig(optimizerConfig::cutensornetContractionOptimizerConfig_t)::cutensornetStatus_t
+    @gcsafe_ccall libcutensornet.cutensornetDestroyContractionOptimizerConfig(optimizerConfig::cutensornetContractionOptimizerConfig_t)::cutensornetStatus_t
 end
 
 @checked function cutensornetContractionOptimizerConfigGetAttribute(handle, optimizerConfig,
                                                                     attr, buf, sizeInBytes)
     initialize_context()
-    @ccall libcutensornet.cutensornetContractionOptimizerConfigGetAttribute(handle::cutensornetHandle_t,
-                                                                            optimizerConfig::cutensornetContractionOptimizerConfig_t,
-                                                                            attr::cutensornetContractionOptimizerConfigAttributes_t,
-                                                                            buf::Ptr{Cvoid},
-                                                                            sizeInBytes::Csize_t)::cutensornetStatus_t
+    @gcsafe_ccall libcutensornet.cutensornetContractionOptimizerConfigGetAttribute(handle::cutensornetHandle_t,
+                                                                                   optimizerConfig::cutensornetContractionOptimizerConfig_t,
+                                                                                   attr::cutensornetContractionOptimizerConfigAttributes_t,
+                                                                                   buf::Ptr{Cvoid},
+                                                                                   sizeInBytes::Csize_t)::cutensornetStatus_t
 end
 
 @checked function cutensornetContractionOptimizerConfigSetAttribute(handle, optimizerConfig,
                                                                     attr, buf, sizeInBytes)
     initialize_context()
-    @ccall libcutensornet.cutensornetContractionOptimizerConfigSetAttribute(handle::cutensornetHandle_t,
-                                                                            optimizerConfig::cutensornetContractionOptimizerConfig_t,
-                                                                            attr::cutensornetContractionOptimizerConfigAttributes_t,
-                                                                            buf::Ptr{Cvoid},
-                                                                            sizeInBytes::Csize_t)::cutensornetStatus_t
+    @gcsafe_ccall libcutensornet.cutensornetContractionOptimizerConfigSetAttribute(handle::cutensornetHandle_t,
+                                                                                   optimizerConfig::cutensornetContractionOptimizerConfig_t,
+                                                                                   attr::cutensornetContractionOptimizerConfigAttributes_t,
+                                                                                   buf::Ptr{Cvoid},
+                                                                                   sizeInBytes::Csize_t)::cutensornetStatus_t
 end
 
 @checked function cutensornetDestroyContractionOptimizerInfo(optimizerInfo)
     initialize_context()
-    @ccall libcutensornet.cutensornetDestroyContractionOptimizerInfo(optimizerInfo::cutensornetContractionOptimizerInfo_t)::cutensornetStatus_t
+    @gcsafe_ccall libcutensornet.cutensornetDestroyContractionOptimizerInfo(optimizerInfo::cutensornetContractionOptimizerInfo_t)::cutensornetStatus_t
 end
 
 @checked function cutensornetCreateContractionOptimizerInfo(handle, descNet, optimizerInfo)
     initialize_context()
-    @ccall libcutensornet.cutensornetCreateContractionOptimizerInfo(handle::cutensornetHandle_t,
-                                                                    descNet::cutensornetNetworkDescriptor_t,
-                                                                    optimizerInfo::Ptr{cutensornetContractionOptimizerInfo_t})::cutensornetStatus_t
+    @gcsafe_ccall libcutensornet.cutensornetCreateContractionOptimizerInfo(handle::cutensornetHandle_t,
+                                                                           descNet::cutensornetNetworkDescriptor_t,
+                                                                           optimizerInfo::Ptr{cutensornetContractionOptimizerInfo_t})::cutensornetStatus_t
 end
 
 @checked function cutensornetContractionOptimize(handle, descNet, optimizerConfig,
                                                  workspaceSizeConstraint, optimizerInfo)
     initialize_context()
-    @ccall libcutensornet.cutensornetContractionOptimize(handle::cutensornetHandle_t,
-                                                         descNet::cutensornetNetworkDescriptor_t,
-                                                         optimizerConfig::cutensornetContractionOptimizerConfig_t,
-                                                         workspaceSizeConstraint::UInt64,
-                                                         optimizerInfo::cutensornetContractionOptimizerInfo_t)::cutensornetStatus_t
+    @gcsafe_ccall libcutensornet.cutensornetContractionOptimize(handle::cutensornetHandle_t,
+                                                                descNet::cutensornetNetworkDescriptor_t,
+                                                                optimizerConfig::cutensornetContractionOptimizerConfig_t,
+                                                                workspaceSizeConstraint::UInt64,
+                                                                optimizerInfo::cutensornetContractionOptimizerInfo_t)::cutensornetStatus_t
 end
 
 @checked function cutensornetContractionOptimizerInfoGetAttribute(handle, optimizerInfo,
                                                                   attr, buf, sizeInBytes)
     initialize_context()
-    @ccall libcutensornet.cutensornetContractionOptimizerInfoGetAttribute(handle::cutensornetHandle_t,
-                                                                          optimizerInfo::cutensornetContractionOptimizerInfo_t,
-                                                                          attr::cutensornetContractionOptimizerInfoAttributes_t,
-                                                                          buf::Ptr{Cvoid},
-                                                                          sizeInBytes::Csize_t)::cutensornetStatus_t
+    @gcsafe_ccall libcutensornet.cutensornetContractionOptimizerInfoGetAttribute(handle::cutensornetHandle_t,
+                                                                                 optimizerInfo::cutensornetContractionOptimizerInfo_t,
+                                                                                 attr::cutensornetContractionOptimizerInfoAttributes_t,
+                                                                                 buf::Ptr{Cvoid},
+                                                                                 sizeInBytes::Csize_t)::cutensornetStatus_t
 end
 
 @checked function cutensornetContractionOptimizerInfoSetAttribute(handle, optimizerInfo,
                                                                   attr, buf, sizeInBytes)
     initialize_context()
-    @ccall libcutensornet.cutensornetContractionOptimizerInfoSetAttribute(handle::cutensornetHandle_t,
-                                                                          optimizerInfo::cutensornetContractionOptimizerInfo_t,
-                                                                          attr::cutensornetContractionOptimizerInfoAttributes_t,
-                                                                          buf::Ptr{Cvoid},
-                                                                          sizeInBytes::Csize_t)::cutensornetStatus_t
+    @gcsafe_ccall libcutensornet.cutensornetContractionOptimizerInfoSetAttribute(handle::cutensornetHandle_t,
+                                                                                 optimizerInfo::cutensornetContractionOptimizerInfo_t,
+                                                                                 attr::cutensornetContractionOptimizerInfoAttributes_t,
+                                                                                 buf::Ptr{Cvoid},
+                                                                                 sizeInBytes::Csize_t)::cutensornetStatus_t
 end
 
 @checked function cutensornetContractionOptimizerInfoGetPackedSize(handle, optimizerInfo,
                                                                    sizeInBytes)
     initialize_context()
-    @ccall libcutensornet.cutensornetContractionOptimizerInfoGetPackedSize(handle::cutensornetHandle_t,
-                                                                           optimizerInfo::cutensornetContractionOptimizerInfo_t,
-                                                                           sizeInBytes::Ptr{Csize_t})::cutensornetStatus_t
+    @gcsafe_ccall libcutensornet.cutensornetContractionOptimizerInfoGetPackedSize(handle::cutensornetHandle_t,
+                                                                                  optimizerInfo::cutensornetContractionOptimizerInfo_t,
+                                                                                  sizeInBytes::Ptr{Csize_t})::cutensornetStatus_t
 end
 
 @checked function cutensornetContractionOptimizerInfoPackData(handle, optimizerInfo, buffer,
                                                               sizeInBytes)
     initialize_context()
-    @ccall libcutensornet.cutensornetContractionOptimizerInfoPackData(handle::cutensornetHandle_t,
-                                                                      optimizerInfo::cutensornetContractionOptimizerInfo_t,
-                                                                      buffer::Ptr{Cvoid},
-                                                                      sizeInBytes::Csize_t)::cutensornetStatus_t
+    @gcsafe_ccall libcutensornet.cutensornetContractionOptimizerInfoPackData(handle::cutensornetHandle_t,
+                                                                             optimizerInfo::cutensornetContractionOptimizerInfo_t,
+                                                                             buffer::Ptr{Cvoid},
+                                                                             sizeInBytes::Csize_t)::cutensornetStatus_t
 end
 
 @checked function cutensornetCreateContractionOptimizerInfoFromPackedData(handle, descNet,
@@ -613,54 +613,54 @@ end
                                                                           sizeInBytes,
                                                                           optimizerInfo)
     initialize_context()
-    @ccall libcutensornet.cutensornetCreateContractionOptimizerInfoFromPackedData(handle::cutensornetHandle_t,
-                                                                                  descNet::cutensornetNetworkDescriptor_t,
-                                                                                  buffer::Ptr{Cvoid},
-                                                                                  sizeInBytes::Csize_t,
-                                                                                  optimizerInfo::Ptr{cutensornetContractionOptimizerInfo_t})::cutensornetStatus_t
+    @gcsafe_ccall libcutensornet.cutensornetCreateContractionOptimizerInfoFromPackedData(handle::cutensornetHandle_t,
+                                                                                         descNet::cutensornetNetworkDescriptor_t,
+                                                                                         buffer::Ptr{Cvoid},
+                                                                                         sizeInBytes::Csize_t,
+                                                                                         optimizerInfo::Ptr{cutensornetContractionOptimizerInfo_t})::cutensornetStatus_t
 end
 
 @checked function cutensornetUpdateContractionOptimizerInfoFromPackedData(handle, buffer,
                                                                           sizeInBytes,
                                                                           optimizerInfo)
     initialize_context()
-    @ccall libcutensornet.cutensornetUpdateContractionOptimizerInfoFromPackedData(handle::cutensornetHandle_t,
-                                                                                  buffer::Ptr{Cvoid},
-                                                                                  sizeInBytes::Csize_t,
-                                                                                  optimizerInfo::cutensornetContractionOptimizerInfo_t)::cutensornetStatus_t
+    @gcsafe_ccall libcutensornet.cutensornetUpdateContractionOptimizerInfoFromPackedData(handle::cutensornetHandle_t,
+                                                                                         buffer::Ptr{Cvoid},
+                                                                                         sizeInBytes::Csize_t,
+                                                                                         optimizerInfo::cutensornetContractionOptimizerInfo_t)::cutensornetStatus_t
 end
 
 @checked function cutensornetCreateContractionPlan(handle, descNet, optimizerInfo, workDesc,
                                                    plan)
     initialize_context()
-    @ccall libcutensornet.cutensornetCreateContractionPlan(handle::cutensornetHandle_t,
-                                                           descNet::cutensornetNetworkDescriptor_t,
-                                                           optimizerInfo::cutensornetContractionOptimizerInfo_t,
-                                                           workDesc::cutensornetWorkspaceDescriptor_t,
-                                                           plan::Ptr{cutensornetContractionPlan_t})::cutensornetStatus_t
+    @gcsafe_ccall libcutensornet.cutensornetCreateContractionPlan(handle::cutensornetHandle_t,
+                                                                  descNet::cutensornetNetworkDescriptor_t,
+                                                                  optimizerInfo::cutensornetContractionOptimizerInfo_t,
+                                                                  workDesc::cutensornetWorkspaceDescriptor_t,
+                                                                  plan::Ptr{cutensornetContractionPlan_t})::cutensornetStatus_t
 end
 
 @checked function cutensornetDestroyContractionPlan(plan)
     initialize_context()
-    @ccall libcutensornet.cutensornetDestroyContractionPlan(plan::cutensornetContractionPlan_t)::cutensornetStatus_t
+    @gcsafe_ccall libcutensornet.cutensornetDestroyContractionPlan(plan::cutensornetContractionPlan_t)::cutensornetStatus_t
 end
 
 @checked function cutensornetContractionAutotune(handle, plan, rawDataIn, rawDataOut,
                                                  workDesc, pref, stream)
     initialize_context()
-    @ccall libcutensornet.cutensornetContractionAutotune(handle::cutensornetHandle_t,
-                                                         plan::cutensornetContractionPlan_t,
-                                                         rawDataIn::Ptr{CuPtr{Cvoid}},
-                                                         rawDataOut::CuPtr{Cvoid},
-                                                         workDesc::cutensornetWorkspaceDescriptor_t,
-                                                         pref::cutensornetContractionAutotunePreference_t,
-                                                         stream::cudaStream_t)::cutensornetStatus_t
+    @gcsafe_ccall libcutensornet.cutensornetContractionAutotune(handle::cutensornetHandle_t,
+                                                                plan::cutensornetContractionPlan_t,
+                                                                rawDataIn::Ptr{CuPtr{Cvoid}},
+                                                                rawDataOut::CuPtr{Cvoid},
+                                                                workDesc::cutensornetWorkspaceDescriptor_t,
+                                                                pref::cutensornetContractionAutotunePreference_t,
+                                                                stream::cudaStream_t)::cutensornetStatus_t
 end
 
 @checked function cutensornetCreateContractionAutotunePreference(handle, autotunePreference)
     initialize_context()
-    @ccall libcutensornet.cutensornetCreateContractionAutotunePreference(handle::cutensornetHandle_t,
-                                                                         autotunePreference::Ptr{cutensornetContractionAutotunePreference_t})::cutensornetStatus_t
+    @gcsafe_ccall libcutensornet.cutensornetCreateContractionAutotunePreference(handle::cutensornetHandle_t,
+                                                                                autotunePreference::Ptr{cutensornetContractionAutotunePreference_t})::cutensornetStatus_t
 end
 
 @checked function cutensornetContractionAutotunePreferenceGetAttribute(handle,
@@ -668,11 +668,11 @@ end
                                                                        attr, buf,
                                                                        sizeInBytes)
     initialize_context()
-    @ccall libcutensornet.cutensornetContractionAutotunePreferenceGetAttribute(handle::cutensornetHandle_t,
-                                                                               autotunePreference::cutensornetContractionAutotunePreference_t,
-                                                                               attr::cutensornetContractionAutotunePreferenceAttributes_t,
-                                                                               buf::Ptr{Cvoid},
-                                                                               sizeInBytes::Csize_t)::cutensornetStatus_t
+    @gcsafe_ccall libcutensornet.cutensornetContractionAutotunePreferenceGetAttribute(handle::cutensornetHandle_t,
+                                                                                      autotunePreference::cutensornetContractionAutotunePreference_t,
+                                                                                      attr::cutensornetContractionAutotunePreferenceAttributes_t,
+                                                                                      buf::Ptr{Cvoid},
+                                                                                      sizeInBytes::Csize_t)::cutensornetStatus_t
 end
 
 @checked function cutensornetContractionAutotunePreferenceSetAttribute(handle,
@@ -680,199 +680,199 @@ end
                                                                        attr, buf,
                                                                        sizeInBytes)
     initialize_context()
-    @ccall libcutensornet.cutensornetContractionAutotunePreferenceSetAttribute(handle::cutensornetHandle_t,
-                                                                               autotunePreference::cutensornetContractionAutotunePreference_t,
-                                                                               attr::cutensornetContractionAutotunePreferenceAttributes_t,
-                                                                               buf::Ptr{Cvoid},
-                                                                               sizeInBytes::Csize_t)::cutensornetStatus_t
+    @gcsafe_ccall libcutensornet.cutensornetContractionAutotunePreferenceSetAttribute(handle::cutensornetHandle_t,
+                                                                                      autotunePreference::cutensornetContractionAutotunePreference_t,
+                                                                                      attr::cutensornetContractionAutotunePreferenceAttributes_t,
+                                                                                      buf::Ptr{Cvoid},
+                                                                                      sizeInBytes::Csize_t)::cutensornetStatus_t
 end
 
 @checked function cutensornetDestroyContractionAutotunePreference(autotunePreference)
     initialize_context()
-    @ccall libcutensornet.cutensornetDestroyContractionAutotunePreference(autotunePreference::cutensornetContractionAutotunePreference_t)::cutensornetStatus_t
+    @gcsafe_ccall libcutensornet.cutensornetDestroyContractionAutotunePreference(autotunePreference::cutensornetContractionAutotunePreference_t)::cutensornetStatus_t
 end
 
 @checked function cutensornetContraction(handle, plan, rawDataIn, rawDataOut, workDesc,
                                          sliceId, stream)
     initialize_context()
-    @ccall libcutensornet.cutensornetContraction(handle::cutensornetHandle_t,
-                                                 plan::cutensornetContractionPlan_t,
-                                                 rawDataIn::Ptr{CuPtr{Cvoid}},
-                                                 rawDataOut::CuPtr{Cvoid},
-                                                 workDesc::cutensornetWorkspaceDescriptor_t,
-                                                 sliceId::Int64,
-                                                 stream::cudaStream_t)::cutensornetStatus_t
+    @gcsafe_ccall libcutensornet.cutensornetContraction(handle::cutensornetHandle_t,
+                                                        plan::cutensornetContractionPlan_t,
+                                                        rawDataIn::Ptr{CuPtr{Cvoid}},
+                                                        rawDataOut::CuPtr{Cvoid},
+                                                        workDesc::cutensornetWorkspaceDescriptor_t,
+                                                        sliceId::Int64,
+                                                        stream::cudaStream_t)::cutensornetStatus_t
 end
 
 @checked function cutensornetCreateSliceGroupFromIDRange(handle, sliceIdStart, sliceIdStop,
                                                          sliceIdStep, sliceGroup)
     initialize_context()
-    @ccall libcutensornet.cutensornetCreateSliceGroupFromIDRange(handle::cutensornetHandle_t,
-                                                                 sliceIdStart::Int64,
-                                                                 sliceIdStop::Int64,
-                                                                 sliceIdStep::Int64,
-                                                                 sliceGroup::Ptr{cutensornetSliceGroup_t})::cutensornetStatus_t
+    @gcsafe_ccall libcutensornet.cutensornetCreateSliceGroupFromIDRange(handle::cutensornetHandle_t,
+                                                                        sliceIdStart::Int64,
+                                                                        sliceIdStop::Int64,
+                                                                        sliceIdStep::Int64,
+                                                                        sliceGroup::Ptr{cutensornetSliceGroup_t})::cutensornetStatus_t
 end
 
 @checked function cutensornetCreateSliceGroupFromIDs(handle, beginIDSequence, endIDSequence,
                                                      sliceGroup)
     initialize_context()
-    @ccall libcutensornet.cutensornetCreateSliceGroupFromIDs(handle::cutensornetHandle_t,
-                                                             beginIDSequence::Ptr{Int64},
-                                                             endIDSequence::Ptr{Int64},
-                                                             sliceGroup::Ptr{cutensornetSliceGroup_t})::cutensornetStatus_t
+    @gcsafe_ccall libcutensornet.cutensornetCreateSliceGroupFromIDs(handle::cutensornetHandle_t,
+                                                                    beginIDSequence::Ptr{Int64},
+                                                                    endIDSequence::Ptr{Int64},
+                                                                    sliceGroup::Ptr{cutensornetSliceGroup_t})::cutensornetStatus_t
 end
 
 @checked function cutensornetDestroySliceGroup(sliceGroup)
     initialize_context()
-    @ccall libcutensornet.cutensornetDestroySliceGroup(sliceGroup::cutensornetSliceGroup_t)::cutensornetStatus_t
+    @gcsafe_ccall libcutensornet.cutensornetDestroySliceGroup(sliceGroup::cutensornetSliceGroup_t)::cutensornetStatus_t
 end
 
 @checked function cutensornetContractSlices(handle, plan, rawDataIn, rawDataOut,
                                             accumulateOutput, workDesc, sliceGroup, stream)
     initialize_context()
-    @ccall libcutensornet.cutensornetContractSlices(handle::cutensornetHandle_t,
-                                                    plan::cutensornetContractionPlan_t,
-                                                    rawDataIn::Ptr{CuPtr{Cvoid}},
-                                                    rawDataOut::CuPtr{Cvoid},
-                                                    accumulateOutput::Int32,
-                                                    workDesc::cutensornetWorkspaceDescriptor_t,
-                                                    sliceGroup::cutensornetSliceGroup_t,
-                                                    stream::cudaStream_t)::cutensornetStatus_t
+    @gcsafe_ccall libcutensornet.cutensornetContractSlices(handle::cutensornetHandle_t,
+                                                           plan::cutensornetContractionPlan_t,
+                                                           rawDataIn::Ptr{CuPtr{Cvoid}},
+                                                           rawDataOut::CuPtr{Cvoid},
+                                                           accumulateOutput::Int32,
+                                                           workDesc::cutensornetWorkspaceDescriptor_t,
+                                                           sliceGroup::cutensornetSliceGroup_t,
+                                                           stream::cudaStream_t)::cutensornetStatus_t
 end
 
 @checked function cutensornetComputeGradientsBackward(handle, plan, rawDataIn,
                                                       outputGradient, gradients,
                                                       accumulateOutput, workDesc, stream)
     initialize_context()
-    @ccall libcutensornet.cutensornetComputeGradientsBackward(handle::cutensornetHandle_t,
-                                                              plan::cutensornetContractionPlan_t,
-                                                              rawDataIn::Ptr{Ptr{Cvoid}},
-                                                              outputGradient::Ptr{Cvoid},
-                                                              gradients::Ptr{Ptr{Cvoid}},
-                                                              accumulateOutput::Int32,
-                                                              workDesc::cutensornetWorkspaceDescriptor_t,
-                                                              stream::cudaStream_t)::cutensornetStatus_t
+    @gcsafe_ccall libcutensornet.cutensornetComputeGradientsBackward(handle::cutensornetHandle_t,
+                                                                     plan::cutensornetContractionPlan_t,
+                                                                     rawDataIn::Ptr{Ptr{Cvoid}},
+                                                                     outputGradient::Ptr{Cvoid},
+                                                                     gradients::Ptr{Ptr{Cvoid}},
+                                                                     accumulateOutput::Int32,
+                                                                     workDesc::cutensornetWorkspaceDescriptor_t,
+                                                                     stream::cudaStream_t)::cutensornetStatus_t
 end
 
 @checked function cutensornetCreateTensorDescriptor(handle, numModes, extents, strides,
                                                     modes, dataType, descTensor)
     initialize_context()
-    @ccall libcutensornet.cutensornetCreateTensorDescriptor(handle::cutensornetHandle_t,
-                                                            numModes::Int32,
-                                                            extents::Ptr{Int64},
-                                                            strides::Ptr{Int64},
-                                                            modes::Ptr{Int32},
-                                                            dataType::cudaDataType_t,
-                                                            descTensor::Ptr{cutensornetTensorDescriptor_t})::cutensornetStatus_t
+    @gcsafe_ccall libcutensornet.cutensornetCreateTensorDescriptor(handle::cutensornetHandle_t,
+                                                                   numModes::Int32,
+                                                                   extents::Ptr{Int64},
+                                                                   strides::Ptr{Int64},
+                                                                   modes::Ptr{Int32},
+                                                                   dataType::cudaDataType_t,
+                                                                   descTensor::Ptr{cutensornetTensorDescriptor_t})::cutensornetStatus_t
 end
 
 @checked function cutensornetDestroyTensorDescriptor(descTensor)
     initialize_context()
-    @ccall libcutensornet.cutensornetDestroyTensorDescriptor(descTensor::cutensornetTensorDescriptor_t)::cutensornetStatus_t
+    @gcsafe_ccall libcutensornet.cutensornetDestroyTensorDescriptor(descTensor::cutensornetTensorDescriptor_t)::cutensornetStatus_t
 end
 
 @checked function cutensornetCreateTensorSVDConfig(handle, svdConfig)
     initialize_context()
-    @ccall libcutensornet.cutensornetCreateTensorSVDConfig(handle::cutensornetHandle_t,
-                                                           svdConfig::Ptr{cutensornetTensorSVDConfig_t})::cutensornetStatus_t
+    @gcsafe_ccall libcutensornet.cutensornetCreateTensorSVDConfig(handle::cutensornetHandle_t,
+                                                                  svdConfig::Ptr{cutensornetTensorSVDConfig_t})::cutensornetStatus_t
 end
 
 @checked function cutensornetDestroyTensorSVDConfig(svdConfig)
     initialize_context()
-    @ccall libcutensornet.cutensornetDestroyTensorSVDConfig(svdConfig::cutensornetTensorSVDConfig_t)::cutensornetStatus_t
+    @gcsafe_ccall libcutensornet.cutensornetDestroyTensorSVDConfig(svdConfig::cutensornetTensorSVDConfig_t)::cutensornetStatus_t
 end
 
 @checked function cutensornetTensorSVDConfigGetAttribute(handle, svdConfig, attr, buf,
                                                          sizeInBytes)
     initialize_context()
-    @ccall libcutensornet.cutensornetTensorSVDConfigGetAttribute(handle::cutensornetHandle_t,
-                                                                 svdConfig::cutensornetTensorSVDConfig_t,
-                                                                 attr::cutensornetTensorSVDConfigAttributes_t,
-                                                                 buf::Ptr{Cvoid},
-                                                                 sizeInBytes::Csize_t)::cutensornetStatus_t
+    @gcsafe_ccall libcutensornet.cutensornetTensorSVDConfigGetAttribute(handle::cutensornetHandle_t,
+                                                                        svdConfig::cutensornetTensorSVDConfig_t,
+                                                                        attr::cutensornetTensorSVDConfigAttributes_t,
+                                                                        buf::Ptr{Cvoid},
+                                                                        sizeInBytes::Csize_t)::cutensornetStatus_t
 end
 
 @checked function cutensornetTensorSVDConfigSetAttribute(handle, svdConfig, attr, buf,
                                                          sizeInBytes)
     initialize_context()
-    @ccall libcutensornet.cutensornetTensorSVDConfigSetAttribute(handle::cutensornetHandle_t,
-                                                                 svdConfig::cutensornetTensorSVDConfig_t,
-                                                                 attr::cutensornetTensorSVDConfigAttributes_t,
-                                                                 buf::Ptr{Cvoid},
-                                                                 sizeInBytes::Csize_t)::cutensornetStatus_t
+    @gcsafe_ccall libcutensornet.cutensornetTensorSVDConfigSetAttribute(handle::cutensornetHandle_t,
+                                                                        svdConfig::cutensornetTensorSVDConfig_t,
+                                                                        attr::cutensornetTensorSVDConfigAttributes_t,
+                                                                        buf::Ptr{Cvoid},
+                                                                        sizeInBytes::Csize_t)::cutensornetStatus_t
 end
 
 @checked function cutensornetWorkspaceComputeSVDSizes(handle, descTensorIn, descTensorU,
                                                       descTensorV, svdConfig, workDesc)
     initialize_context()
-    @ccall libcutensornet.cutensornetWorkspaceComputeSVDSizes(handle::cutensornetHandle_t,
-                                                              descTensorIn::cutensornetTensorDescriptor_t,
-                                                              descTensorU::cutensornetTensorDescriptor_t,
-                                                              descTensorV::cutensornetTensorDescriptor_t,
-                                                              svdConfig::cutensornetTensorSVDConfig_t,
-                                                              workDesc::cutensornetWorkspaceDescriptor_t)::cutensornetStatus_t
+    @gcsafe_ccall libcutensornet.cutensornetWorkspaceComputeSVDSizes(handle::cutensornetHandle_t,
+                                                                     descTensorIn::cutensornetTensorDescriptor_t,
+                                                                     descTensorU::cutensornetTensorDescriptor_t,
+                                                                     descTensorV::cutensornetTensorDescriptor_t,
+                                                                     svdConfig::cutensornetTensorSVDConfig_t,
+                                                                     workDesc::cutensornetWorkspaceDescriptor_t)::cutensornetStatus_t
 end
 
 @checked function cutensornetWorkspaceComputeQRSizes(handle, descTensorIn, descTensorQ,
                                                      descTensorR, workDesc)
     initialize_context()
-    @ccall libcutensornet.cutensornetWorkspaceComputeQRSizes(handle::cutensornetHandle_t,
-                                                             descTensorIn::cutensornetTensorDescriptor_t,
-                                                             descTensorQ::cutensornetTensorDescriptor_t,
-                                                             descTensorR::cutensornetTensorDescriptor_t,
-                                                             workDesc::cutensornetWorkspaceDescriptor_t)::cutensornetStatus_t
+    @gcsafe_ccall libcutensornet.cutensornetWorkspaceComputeQRSizes(handle::cutensornetHandle_t,
+                                                                    descTensorIn::cutensornetTensorDescriptor_t,
+                                                                    descTensorQ::cutensornetTensorDescriptor_t,
+                                                                    descTensorR::cutensornetTensorDescriptor_t,
+                                                                    workDesc::cutensornetWorkspaceDescriptor_t)::cutensornetStatus_t
 end
 
 @checked function cutensornetCreateTensorSVDInfo(handle, svdInfo)
     initialize_context()
-    @ccall libcutensornet.cutensornetCreateTensorSVDInfo(handle::cutensornetHandle_t,
-                                                         svdInfo::Ptr{cutensornetTensorSVDInfo_t})::cutensornetStatus_t
+    @gcsafe_ccall libcutensornet.cutensornetCreateTensorSVDInfo(handle::cutensornetHandle_t,
+                                                                svdInfo::Ptr{cutensornetTensorSVDInfo_t})::cutensornetStatus_t
 end
 
 @checked function cutensornetTensorSVDInfoGetAttribute(handle, svdInfo, attr, buf,
                                                        sizeInBytes)
     initialize_context()
-    @ccall libcutensornet.cutensornetTensorSVDInfoGetAttribute(handle::cutensornetHandle_t,
-                                                               svdInfo::cutensornetTensorSVDInfo_t,
-                                                               attr::cutensornetTensorSVDInfoAttributes_t,
-                                                               buf::Ptr{Cvoid},
-                                                               sizeInBytes::Csize_t)::cutensornetStatus_t
+    @gcsafe_ccall libcutensornet.cutensornetTensorSVDInfoGetAttribute(handle::cutensornetHandle_t,
+                                                                      svdInfo::cutensornetTensorSVDInfo_t,
+                                                                      attr::cutensornetTensorSVDInfoAttributes_t,
+                                                                      buf::Ptr{Cvoid},
+                                                                      sizeInBytes::Csize_t)::cutensornetStatus_t
 end
 
 @checked function cutensornetDestroyTensorSVDInfo(svdInfo)
     initialize_context()
-    @ccall libcutensornet.cutensornetDestroyTensorSVDInfo(svdInfo::cutensornetTensorSVDInfo_t)::cutensornetStatus_t
+    @gcsafe_ccall libcutensornet.cutensornetDestroyTensorSVDInfo(svdInfo::cutensornetTensorSVDInfo_t)::cutensornetStatus_t
 end
 
 @checked function cutensornetTensorSVD(handle, descTensorIn, rawDataIn, descTensorU, u, s,
                                        descTensorV, v, svdConfig, svdInfo, workDesc, stream)
     initialize_context()
-    @ccall libcutensornet.cutensornetTensorSVD(handle::cutensornetHandle_t,
-                                               descTensorIn::cutensornetTensorDescriptor_t,
-                                               rawDataIn::CuPtr{Cvoid},
-                                               descTensorU::cutensornetTensorDescriptor_t,
-                                               u::CuPtr{Cvoid}, s::CuPtr{Cvoid},
-                                               descTensorV::cutensornetTensorDescriptor_t,
-                                               v::CuPtr{Cvoid},
-                                               svdConfig::cutensornetTensorSVDConfig_t,
-                                               svdInfo::cutensornetTensorSVDInfo_t,
-                                               workDesc::cutensornetWorkspaceDescriptor_t,
-                                               stream::cudaStream_t)::cutensornetStatus_t
+    @gcsafe_ccall libcutensornet.cutensornetTensorSVD(handle::cutensornetHandle_t,
+                                                      descTensorIn::cutensornetTensorDescriptor_t,
+                                                      rawDataIn::CuPtr{Cvoid},
+                                                      descTensorU::cutensornetTensorDescriptor_t,
+                                                      u::CuPtr{Cvoid}, s::CuPtr{Cvoid},
+                                                      descTensorV::cutensornetTensorDescriptor_t,
+                                                      v::CuPtr{Cvoid},
+                                                      svdConfig::cutensornetTensorSVDConfig_t,
+                                                      svdInfo::cutensornetTensorSVDInfo_t,
+                                                      workDesc::cutensornetWorkspaceDescriptor_t,
+                                                      stream::cudaStream_t)::cutensornetStatus_t
 end
 
 @checked function cutensornetTensorQR(handle, descTensorIn, rawDataIn, descTensorQ, q,
                                       descTensorR, r, workDesc, stream)
     initialize_context()
-    @ccall libcutensornet.cutensornetTensorQR(handle::cutensornetHandle_t,
-                                              descTensorIn::cutensornetTensorDescriptor_t,
-                                              rawDataIn::CuPtr{Cvoid},
-                                              descTensorQ::cutensornetTensorDescriptor_t,
-                                              q::CuPtr{Cvoid},
-                                              descTensorR::cutensornetTensorDescriptor_t,
-                                              r::CuPtr{Cvoid},
-                                              workDesc::cutensornetWorkspaceDescriptor_t,
-                                              stream::cudaStream_t)::cutensornetStatus_t
+    @gcsafe_ccall libcutensornet.cutensornetTensorQR(handle::cutensornetHandle_t,
+                                                     descTensorIn::cutensornetTensorDescriptor_t,
+                                                     rawDataIn::CuPtr{Cvoid},
+                                                     descTensorQ::cutensornetTensorDescriptor_t,
+                                                     q::CuPtr{Cvoid},
+                                                     descTensorR::cutensornetTensorDescriptor_t,
+                                                     r::CuPtr{Cvoid},
+                                                     workDesc::cutensornetWorkspaceDescriptor_t,
+                                                     stream::cudaStream_t)::cutensornetStatus_t
 end
 
 @checked function cutensornetWorkspaceComputeGateSplitSizes(handle, descTensorInA,
@@ -881,16 +881,16 @@ end
                                                             gateAlgo, svdConfig,
                                                             computeType, workDesc)
     initialize_context()
-    @ccall libcutensornet.cutensornetWorkspaceComputeGateSplitSizes(handle::cutensornetHandle_t,
-                                                                    descTensorInA::cutensornetTensorDescriptor_t,
-                                                                    descTensorInB::cutensornetTensorDescriptor_t,
-                                                                    descTensorInG::cutensornetTensorDescriptor_t,
-                                                                    descTensorU::cutensornetTensorDescriptor_t,
-                                                                    descTensorV::cutensornetTensorDescriptor_t,
-                                                                    gateAlgo::cutensornetGateSplitAlgo_t,
-                                                                    svdConfig::cutensornetTensorSVDConfig_t,
-                                                                    computeType::cutensornetComputeType_t,
-                                                                    workDesc::cutensornetWorkspaceDescriptor_t)::cutensornetStatus_t
+    @gcsafe_ccall libcutensornet.cutensornetWorkspaceComputeGateSplitSizes(handle::cutensornetHandle_t,
+                                                                           descTensorInA::cutensornetTensorDescriptor_t,
+                                                                           descTensorInB::cutensornetTensorDescriptor_t,
+                                                                           descTensorInG::cutensornetTensorDescriptor_t,
+                                                                           descTensorU::cutensornetTensorDescriptor_t,
+                                                                           descTensorV::cutensornetTensorDescriptor_t,
+                                                                           gateAlgo::cutensornetGateSplitAlgo_t,
+                                                                           svdConfig::cutensornetTensorSVDConfig_t,
+                                                                           computeType::cutensornetComputeType_t,
+                                                                           workDesc::cutensornetWorkspaceDescriptor_t)::cutensornetStatus_t
 end
 
 @checked function cutensornetGateSplit(handle, descTensorInA, rawDataInA, descTensorInB,
@@ -898,210 +898,210 @@ end
                                        u, s, descTensorV, v, gateAlgo, svdConfig,
                                        computeType, svdInfo, workDesc, stream)
     initialize_context()
-    @ccall libcutensornet.cutensornetGateSplit(handle::cutensornetHandle_t,
-                                               descTensorInA::cutensornetTensorDescriptor_t,
-                                               rawDataInA::CuPtr{Cvoid},
-                                               descTensorInB::cutensornetTensorDescriptor_t,
-                                               rawDataInB::CuPtr{Cvoid},
-                                               descTensorInG::cutensornetTensorDescriptor_t,
-                                               rawDataInG::CuPtr{Cvoid},
-                                               descTensorU::cutensornetTensorDescriptor_t,
-                                               u::CuPtr{Cvoid}, s::CuPtr{Cvoid},
-                                               descTensorV::cutensornetTensorDescriptor_t,
-                                               v::CuPtr{Cvoid},
-                                               gateAlgo::cutensornetGateSplitAlgo_t,
-                                               svdConfig::cutensornetTensorSVDConfig_t,
-                                               computeType::cutensornetComputeType_t,
-                                               svdInfo::cutensornetTensorSVDInfo_t,
-                                               workDesc::cutensornetWorkspaceDescriptor_t,
-                                               stream::cudaStream_t)::cutensornetStatus_t
+    @gcsafe_ccall libcutensornet.cutensornetGateSplit(handle::cutensornetHandle_t,
+                                                      descTensorInA::cutensornetTensorDescriptor_t,
+                                                      rawDataInA::CuPtr{Cvoid},
+                                                      descTensorInB::cutensornetTensorDescriptor_t,
+                                                      rawDataInB::CuPtr{Cvoid},
+                                                      descTensorInG::cutensornetTensorDescriptor_t,
+                                                      rawDataInG::CuPtr{Cvoid},
+                                                      descTensorU::cutensornetTensorDescriptor_t,
+                                                      u::CuPtr{Cvoid}, s::CuPtr{Cvoid},
+                                                      descTensorV::cutensornetTensorDescriptor_t,
+                                                      v::CuPtr{Cvoid},
+                                                      gateAlgo::cutensornetGateSplitAlgo_t,
+                                                      svdConfig::cutensornetTensorSVDConfig_t,
+                                                      computeType::cutensornetComputeType_t,
+                                                      svdInfo::cutensornetTensorSVDInfo_t,
+                                                      workDesc::cutensornetWorkspaceDescriptor_t,
+                                                      stream::cudaStream_t)::cutensornetStatus_t
 end
 
 @checked function cutensornetGetDeviceMemHandler(handle, devMemHandler)
     initialize_context()
-    @ccall libcutensornet.cutensornetGetDeviceMemHandler(handle::cutensornetHandle_t,
-                                                         devMemHandler::Ptr{cutensornetDeviceMemHandler_t})::cutensornetStatus_t
+    @gcsafe_ccall libcutensornet.cutensornetGetDeviceMemHandler(handle::cutensornetHandle_t,
+                                                                devMemHandler::Ptr{cutensornetDeviceMemHandler_t})::cutensornetStatus_t
 end
 
 @checked function cutensornetSetDeviceMemHandler(handle, devMemHandler)
     initialize_context()
-    @ccall libcutensornet.cutensornetSetDeviceMemHandler(handle::cutensornetHandle_t,
-                                                         devMemHandler::Ptr{cutensornetDeviceMemHandler_t})::cutensornetStatus_t
+    @gcsafe_ccall libcutensornet.cutensornetSetDeviceMemHandler(handle::cutensornetHandle_t,
+                                                                devMemHandler::Ptr{cutensornetDeviceMemHandler_t})::cutensornetStatus_t
 end
 
 @checked function cutensornetLoggerSetCallback(callback)
-    @ccall libcutensornet.cutensornetLoggerSetCallback(callback::cutensornetLoggerCallback_t)::cutensornetStatus_t
+    @gcsafe_ccall libcutensornet.cutensornetLoggerSetCallback(callback::cutensornetLoggerCallback_t)::cutensornetStatus_t
 end
 
 @checked function cutensornetLoggerSetCallbackData(callback, userData)
     initialize_context()
-    @ccall libcutensornet.cutensornetLoggerSetCallbackData(callback::cutensornetLoggerCallbackData_t,
-                                                           userData::Ptr{Cvoid})::cutensornetStatus_t
+    @gcsafe_ccall libcutensornet.cutensornetLoggerSetCallbackData(callback::cutensornetLoggerCallbackData_t,
+                                                                  userData::Ptr{Cvoid})::cutensornetStatus_t
 end
 
 @checked function cutensornetLoggerSetFile(file)
-    @ccall libcutensornet.cutensornetLoggerSetFile(file::Ptr{Libc.FILE})::cutensornetStatus_t
+    @gcsafe_ccall libcutensornet.cutensornetLoggerSetFile(file::Ptr{Libc.FILE})::cutensornetStatus_t
 end
 
 @checked function cutensornetLoggerOpenFile(logFile)
-    @ccall libcutensornet.cutensornetLoggerOpenFile(logFile::Cstring)::cutensornetStatus_t
+    @gcsafe_ccall libcutensornet.cutensornetLoggerOpenFile(logFile::Cstring)::cutensornetStatus_t
 end
 
 @checked function cutensornetLoggerSetLevel(level)
     initialize_context()
-    @ccall libcutensornet.cutensornetLoggerSetLevel(level::Int32)::cutensornetStatus_t
+    @gcsafe_ccall libcutensornet.cutensornetLoggerSetLevel(level::Int32)::cutensornetStatus_t
 end
 
 @checked function cutensornetLoggerSetMask(mask)
-    @ccall libcutensornet.cutensornetLoggerSetMask(mask::Int32)::cutensornetStatus_t
+    @gcsafe_ccall libcutensornet.cutensornetLoggerSetMask(mask::Int32)::cutensornetStatus_t
 end
 
 # no prototype is found for this function at cutensornet.h:1262:21, please use with caution
 @checked function cutensornetLoggerForceDisable()
-    @ccall libcutensornet.cutensornetLoggerForceDisable()::cutensornetStatus_t
+    @gcsafe_ccall libcutensornet.cutensornetLoggerForceDisable()::cutensornetStatus_t
 end
 
 # no prototype is found for this function at cutensornet.h:1267:8, please use with caution
 function cutensornetGetVersion()
-    @ccall libcutensornet.cutensornetGetVersion()::Csize_t
+    @gcsafe_ccall libcutensornet.cutensornetGetVersion()::Csize_t
 end
 
 # no prototype is found for this function at cutensornet.h:1273:8, please use with caution
 function cutensornetGetCudartVersion()
-    @ccall libcutensornet.cutensornetGetCudartVersion()::Csize_t
+    @gcsafe_ccall libcutensornet.cutensornetGetCudartVersion()::Csize_t
 end
 
 function cutensornetGetErrorString(error)
-    @ccall libcutensornet.cutensornetGetErrorString(error::cutensornetStatus_t)::Cstring
+    @gcsafe_ccall libcutensornet.cutensornetGetErrorString(error::cutensornetStatus_t)::Cstring
 end
 
 @checked function cutensornetDistributedResetConfiguration(handle, commPtr, commSize)
     initialize_context()
-    @ccall libcutensornet.cutensornetDistributedResetConfiguration(handle::cutensornetHandle_t,
-                                                                   commPtr::Ptr{Cvoid},
-                                                                   commSize::Csize_t)::cutensornetStatus_t
+    @gcsafe_ccall libcutensornet.cutensornetDistributedResetConfiguration(handle::cutensornetHandle_t,
+                                                                          commPtr::Ptr{Cvoid},
+                                                                          commSize::Csize_t)::cutensornetStatus_t
 end
 
 @checked function cutensornetDistributedGetNumRanks(handle, numRanks)
     initialize_context()
-    @ccall libcutensornet.cutensornetDistributedGetNumRanks(handle::cutensornetHandle_t,
-                                                            numRanks::Ptr{Int32})::cutensornetStatus_t
+    @gcsafe_ccall libcutensornet.cutensornetDistributedGetNumRanks(handle::cutensornetHandle_t,
+                                                                   numRanks::Ptr{Int32})::cutensornetStatus_t
 end
 
 @checked function cutensornetDistributedGetProcRank(handle, procRank)
     initialize_context()
-    @ccall libcutensornet.cutensornetDistributedGetProcRank(handle::cutensornetHandle_t,
-                                                            procRank::Ptr{Int32})::cutensornetStatus_t
+    @gcsafe_ccall libcutensornet.cutensornetDistributedGetProcRank(handle::cutensornetHandle_t,
+                                                                   procRank::Ptr{Int32})::cutensornetStatus_t
 end
 
 @checked function cutensornetDistributedSynchronize(handle)
     initialize_context()
-    @ccall libcutensornet.cutensornetDistributedSynchronize(handle::cutensornetHandle_t)::cutensornetStatus_t
+    @gcsafe_ccall libcutensornet.cutensornetDistributedSynchronize(handle::cutensornetHandle_t)::cutensornetStatus_t
 end
 
 @checked function cutensornetCreateState(handle, purity, numStateModes, stateModeExtents,
                                          dataType, tensorNetworkState)
     initialize_context()
-    @ccall libcutensornet.cutensornetCreateState(handle::cutensornetHandle_t,
-                                                 purity::cutensornetStatePurity_t,
-                                                 numStateModes::Int32,
-                                                 stateModeExtents::Ptr{Int64},
-                                                 dataType::cudaDataType_t,
-                                                 tensorNetworkState::Ptr{cutensornetState_t})::cutensornetStatus_t
+    @gcsafe_ccall libcutensornet.cutensornetCreateState(handle::cutensornetHandle_t,
+                                                        purity::cutensornetStatePurity_t,
+                                                        numStateModes::Int32,
+                                                        stateModeExtents::Ptr{Int64},
+                                                        dataType::cudaDataType_t,
+                                                        tensorNetworkState::Ptr{cutensornetState_t})::cutensornetStatus_t
 end
 
 @checked function cutensornetStateApplyTensor(handle, tensorNetworkState, numStateModes,
                                               stateModes, tensorData, tensorModeStrides,
                                               immutable, adjoint, unitary, tensorId)
     initialize_context()
-    @ccall libcutensornet.cutensornetStateApplyTensor(handle::cutensornetHandle_t,
-                                                      tensorNetworkState::cutensornetState_t,
-                                                      numStateModes::Int32,
-                                                      stateModes::Ptr{Int32},
-                                                      tensorData::Ptr{Cvoid},
-                                                      tensorModeStrides::Ptr{Int64},
-                                                      immutable::Int32, adjoint::Int32,
-                                                      unitary::Int32,
-                                                      tensorId::Ptr{Int64})::cutensornetStatus_t
+    @gcsafe_ccall libcutensornet.cutensornetStateApplyTensor(handle::cutensornetHandle_t,
+                                                             tensorNetworkState::cutensornetState_t,
+                                                             numStateModes::Int32,
+                                                             stateModes::Ptr{Int32},
+                                                             tensorData::Ptr{Cvoid},
+                                                             tensorModeStrides::Ptr{Int64},
+                                                             immutable::Int32,
+                                                             adjoint::Int32, unitary::Int32,
+                                                             tensorId::Ptr{Int64})::cutensornetStatus_t
 end
 
 @checked function cutensornetStateUpdateTensor(handle, tensorNetworkState, tensorId,
                                                tensorData, unitary)
     initialize_context()
-    @ccall libcutensornet.cutensornetStateUpdateTensor(handle::cutensornetHandle_t,
-                                                       tensorNetworkState::cutensornetState_t,
-                                                       tensorId::Int64,
-                                                       tensorData::Ptr{Cvoid},
-                                                       unitary::Int32)::cutensornetStatus_t
+    @gcsafe_ccall libcutensornet.cutensornetStateUpdateTensor(handle::cutensornetHandle_t,
+                                                              tensorNetworkState::cutensornetState_t,
+                                                              tensorId::Int64,
+                                                              tensorData::Ptr{Cvoid},
+                                                              unitary::Int32)::cutensornetStatus_t
 end
 
 @checked function cutensornetStateFinalizeMPS(handle, tensorNetworkState, boundaryCondition,
                                               extentsOut, stridesOut)
     initialize_context()
-    @ccall libcutensornet.cutensornetStateFinalizeMPS(handle::cutensornetHandle_t,
-                                                      tensorNetworkState::cutensornetState_t,
-                                                      boundaryCondition::cutensornetBoundaryCondition_t,
-                                                      extentsOut::Ptr{Ptr{Int64}},
-                                                      stridesOut::Ptr{Ptr{Int64}})::cutensornetStatus_t
+    @gcsafe_ccall libcutensornet.cutensornetStateFinalizeMPS(handle::cutensornetHandle_t,
+                                                             tensorNetworkState::cutensornetState_t,
+                                                             boundaryCondition::cutensornetBoundaryCondition_t,
+                                                             extentsOut::Ptr{Ptr{Int64}},
+                                                             stridesOut::Ptr{Ptr{Int64}})::cutensornetStatus_t
 end
 
 @checked function cutensornetStateConfigure(handle, tensorNetworkState, attribute,
                                             attributeValue, attributeSize)
     initialize_context()
-    @ccall libcutensornet.cutensornetStateConfigure(handle::cutensornetHandle_t,
-                                                    tensorNetworkState::cutensornetState_t,
-                                                    attribute::cutensornetStateAttributes_t,
-                                                    attributeValue::Ptr{Cvoid},
-                                                    attributeSize::Csize_t)::cutensornetStatus_t
+    @gcsafe_ccall libcutensornet.cutensornetStateConfigure(handle::cutensornetHandle_t,
+                                                           tensorNetworkState::cutensornetState_t,
+                                                           attribute::cutensornetStateAttributes_t,
+                                                           attributeValue::Ptr{Cvoid},
+                                                           attributeSize::Csize_t)::cutensornetStatus_t
 end
 
 @checked function cutensornetStatePrepare(handle, tensorNetworkState,
                                           maxWorkspaceSizeDevice, workDesc, cudaStream)
     initialize_context()
-    @ccall libcutensornet.cutensornetStatePrepare(handle::cutensornetHandle_t,
-                                                  tensorNetworkState::cutensornetState_t,
-                                                  maxWorkspaceSizeDevice::Csize_t,
-                                                  workDesc::cutensornetWorkspaceDescriptor_t,
-                                                  cudaStream::cudaStream_t)::cutensornetStatus_t
+    @gcsafe_ccall libcutensornet.cutensornetStatePrepare(handle::cutensornetHandle_t,
+                                                         tensorNetworkState::cutensornetState_t,
+                                                         maxWorkspaceSizeDevice::Csize_t,
+                                                         workDesc::cutensornetWorkspaceDescriptor_t,
+                                                         cudaStream::cudaStream_t)::cutensornetStatus_t
 end
 
 @checked function cutensornetStateCompute(handle, tensorNetworkState, workDesc, extentsOut,
                                           stridesOut, stateTensorsOut, cudaStream)
     initialize_context()
-    @ccall libcutensornet.cutensornetStateCompute(handle::cutensornetHandle_t,
-                                                  tensorNetworkState::cutensornetState_t,
-                                                  workDesc::cutensornetWorkspaceDescriptor_t,
-                                                  extentsOut::Ptr{Ptr{Int64}},
-                                                  stridesOut::Ptr{Ptr{Int64}},
-                                                  stateTensorsOut::Ptr{Ptr{Cvoid}},
-                                                  cudaStream::cudaStream_t)::cutensornetStatus_t
+    @gcsafe_ccall libcutensornet.cutensornetStateCompute(handle::cutensornetHandle_t,
+                                                         tensorNetworkState::cutensornetState_t,
+                                                         workDesc::cutensornetWorkspaceDescriptor_t,
+                                                         extentsOut::Ptr{Ptr{Int64}},
+                                                         stridesOut::Ptr{Ptr{Int64}},
+                                                         stateTensorsOut::Ptr{Ptr{Cvoid}},
+                                                         cudaStream::cudaStream_t)::cutensornetStatus_t
 end
 
 @checked function cutensornetGetOutputStateDetails(handle, tensorNetworkState,
                                                    numTensorsOut, numModesOut, extentsOut,
                                                    stridesOut)
     initialize_context()
-    @ccall libcutensornet.cutensornetGetOutputStateDetails(handle::cutensornetHandle_t,
-                                                           tensorNetworkState::cutensornetState_t,
-                                                           numTensorsOut::Ptr{Int32},
-                                                           numModesOut::Ptr{Int32},
-                                                           extentsOut::Ptr{Ptr{Int64}},
-                                                           stridesOut::Ptr{Ptr{Int64}})::cutensornetStatus_t
+    @gcsafe_ccall libcutensornet.cutensornetGetOutputStateDetails(handle::cutensornetHandle_t,
+                                                                  tensorNetworkState::cutensornetState_t,
+                                                                  numTensorsOut::Ptr{Int32},
+                                                                  numModesOut::Ptr{Int32},
+                                                                  extentsOut::Ptr{Ptr{Int64}},
+                                                                  stridesOut::Ptr{Ptr{Int64}})::cutensornetStatus_t
 end
 
 @checked function cutensornetDestroyState(tensorNetworkState)
     initialize_context()
-    @ccall libcutensornet.cutensornetDestroyState(tensorNetworkState::cutensornetState_t)::cutensornetStatus_t
+    @gcsafe_ccall libcutensornet.cutensornetDestroyState(tensorNetworkState::cutensornetState_t)::cutensornetStatus_t
 end
 
 @checked function cutensornetCreateNetworkOperator(handle, numStateModes, stateModeExtents,
                                                    dataType, tensorNetworkOperator)
     initialize_context()
-    @ccall libcutensornet.cutensornetCreateNetworkOperator(handle::cutensornetHandle_t,
-                                                           numStateModes::Int32,
-                                                           stateModeExtents::Ptr{Int64},
-                                                           dataType::cudaDataType_t,
-                                                           tensorNetworkOperator::Ptr{cutensornetNetworkOperator_t})::cutensornetStatus_t
+    @gcsafe_ccall libcutensornet.cutensornetCreateNetworkOperator(handle::cutensornetHandle_t,
+                                                                  numStateModes::Int32,
+                                                                  stateModeExtents::Ptr{Int64},
+                                                                  dataType::cudaDataType_t,
+                                                                  tensorNetworkOperator::Ptr{cutensornetNetworkOperator_t})::cutensornetStatus_t
 end
 
 @checked function cutensornetNetworkOperatorAppendProduct(handle, tensorNetworkOperator,
@@ -1109,117 +1109,117 @@ end
                                                           stateModes, tensorModeStrides,
                                                           tensorData, componentId)
     initialize_context()
-    @ccall libcutensornet.cutensornetNetworkOperatorAppendProduct(handle::cutensornetHandle_t,
-                                                                  tensorNetworkOperator::cutensornetNetworkOperator_t,
-                                                                  coefficient::cuDoubleComplex,
-                                                                  numTensors::Int32,
-                                                                  numModes::Ptr{Int32},
-                                                                  stateModes::Ptr{Ptr{Int32}},
-                                                                  tensorModeStrides::Ptr{Ptr{Int64}},
-                                                                  tensorData::Ptr{Ptr{Cvoid}},
-                                                                  componentId::Ptr{Int64})::cutensornetStatus_t
+    @gcsafe_ccall libcutensornet.cutensornetNetworkOperatorAppendProduct(handle::cutensornetHandle_t,
+                                                                         tensorNetworkOperator::cutensornetNetworkOperator_t,
+                                                                         coefficient::cuDoubleComplex,
+                                                                         numTensors::Int32,
+                                                                         numModes::Ptr{Int32},
+                                                                         stateModes::Ptr{Ptr{Int32}},
+                                                                         tensorModeStrides::Ptr{Ptr{Int64}},
+                                                                         tensorData::Ptr{Ptr{Cvoid}},
+                                                                         componentId::Ptr{Int64})::cutensornetStatus_t
 end
 
 @checked function cutensornetDestroyNetworkOperator(tensorNetworkOperator)
     initialize_context()
-    @ccall libcutensornet.cutensornetDestroyNetworkOperator(tensorNetworkOperator::cutensornetNetworkOperator_t)::cutensornetStatus_t
+    @gcsafe_ccall libcutensornet.cutensornetDestroyNetworkOperator(tensorNetworkOperator::cutensornetNetworkOperator_t)::cutensornetStatus_t
 end
 
 @checked function cutensornetCreateAccessor(handle, tensorNetworkState, numProjectedModes,
                                             projectedModes, amplitudesTensorStrides,
                                             tensorNetworkAccessor)
     initialize_context()
-    @ccall libcutensornet.cutensornetCreateAccessor(handle::cutensornetHandle_t,
-                                                    tensorNetworkState::cutensornetState_t,
-                                                    numProjectedModes::Int32,
-                                                    projectedModes::Ptr{Int32},
-                                                    amplitudesTensorStrides::Ptr{Int64},
-                                                    tensorNetworkAccessor::Ptr{cutensornetStateAccessor_t})::cutensornetStatus_t
+    @gcsafe_ccall libcutensornet.cutensornetCreateAccessor(handle::cutensornetHandle_t,
+                                                           tensorNetworkState::cutensornetState_t,
+                                                           numProjectedModes::Int32,
+                                                           projectedModes::Ptr{Int32},
+                                                           amplitudesTensorStrides::Ptr{Int64},
+                                                           tensorNetworkAccessor::Ptr{cutensornetStateAccessor_t})::cutensornetStatus_t
 end
 
 @checked function cutensornetAccessorConfigure(handle, tensorNetworkAccessor, attribute,
                                                attributeValue, attributeSize)
     initialize_context()
-    @ccall libcutensornet.cutensornetAccessorConfigure(handle::cutensornetHandle_t,
-                                                       tensorNetworkAccessor::cutensornetStateAccessor_t,
-                                                       attribute::cutensornetAccessorAttributes_t,
-                                                       attributeValue::Ptr{Cvoid},
-                                                       attributeSize::Csize_t)::cutensornetStatus_t
+    @gcsafe_ccall libcutensornet.cutensornetAccessorConfigure(handle::cutensornetHandle_t,
+                                                              tensorNetworkAccessor::cutensornetStateAccessor_t,
+                                                              attribute::cutensornetAccessorAttributes_t,
+                                                              attributeValue::Ptr{Cvoid},
+                                                              attributeSize::Csize_t)::cutensornetStatus_t
 end
 
 @checked function cutensornetAccessorPrepare(handle, tensorNetworkAccessor,
                                              maxWorkspaceSizeDevice, workDesc, cudaStream)
     initialize_context()
-    @ccall libcutensornet.cutensornetAccessorPrepare(handle::cutensornetHandle_t,
-                                                     tensorNetworkAccessor::cutensornetStateAccessor_t,
-                                                     maxWorkspaceSizeDevice::Csize_t,
-                                                     workDesc::cutensornetWorkspaceDescriptor_t,
-                                                     cudaStream::cudaStream_t)::cutensornetStatus_t
+    @gcsafe_ccall libcutensornet.cutensornetAccessorPrepare(handle::cutensornetHandle_t,
+                                                            tensorNetworkAccessor::cutensornetStateAccessor_t,
+                                                            maxWorkspaceSizeDevice::Csize_t,
+                                                            workDesc::cutensornetWorkspaceDescriptor_t,
+                                                            cudaStream::cudaStream_t)::cutensornetStatus_t
 end
 
 @checked function cutensornetAccessorCompute(handle, tensorNetworkAccessor,
                                              projectedModeValues, workDesc,
                                              amplitudesTensor, stateNorm, cudaStream)
     initialize_context()
-    @ccall libcutensornet.cutensornetAccessorCompute(handle::cutensornetHandle_t,
-                                                     tensorNetworkAccessor::cutensornetStateAccessor_t,
-                                                     projectedModeValues::Ptr{Int64},
-                                                     workDesc::cutensornetWorkspaceDescriptor_t,
-                                                     amplitudesTensor::Ptr{Cvoid},
-                                                     stateNorm::Ptr{Cvoid},
-                                                     cudaStream::cudaStream_t)::cutensornetStatus_t
+    @gcsafe_ccall libcutensornet.cutensornetAccessorCompute(handle::cutensornetHandle_t,
+                                                            tensorNetworkAccessor::cutensornetStateAccessor_t,
+                                                            projectedModeValues::Ptr{Int64},
+                                                            workDesc::cutensornetWorkspaceDescriptor_t,
+                                                            amplitudesTensor::Ptr{Cvoid},
+                                                            stateNorm::Ptr{Cvoid},
+                                                            cudaStream::cudaStream_t)::cutensornetStatus_t
 end
 
 @checked function cutensornetDestroyAccessor(tensorNetworkAccessor)
     initialize_context()
-    @ccall libcutensornet.cutensornetDestroyAccessor(tensorNetworkAccessor::cutensornetStateAccessor_t)::cutensornetStatus_t
+    @gcsafe_ccall libcutensornet.cutensornetDestroyAccessor(tensorNetworkAccessor::cutensornetStateAccessor_t)::cutensornetStatus_t
 end
 
 @checked function cutensornetCreateExpectation(handle, tensorNetworkState,
                                                tensorNetworkOperator,
                                                tensorNetworkExpectation)
     initialize_context()
-    @ccall libcutensornet.cutensornetCreateExpectation(handle::cutensornetHandle_t,
-                                                       tensorNetworkState::cutensornetState_t,
-                                                       tensorNetworkOperator::cutensornetNetworkOperator_t,
-                                                       tensorNetworkExpectation::Ptr{cutensornetStateExpectation_t})::cutensornetStatus_t
+    @gcsafe_ccall libcutensornet.cutensornetCreateExpectation(handle::cutensornetHandle_t,
+                                                              tensorNetworkState::cutensornetState_t,
+                                                              tensorNetworkOperator::cutensornetNetworkOperator_t,
+                                                              tensorNetworkExpectation::Ptr{cutensornetStateExpectation_t})::cutensornetStatus_t
 end
 
 @checked function cutensornetExpectationConfigure(handle, tensorNetworkExpectation,
                                                   attribute, attributeValue, attributeSize)
     initialize_context()
-    @ccall libcutensornet.cutensornetExpectationConfigure(handle::cutensornetHandle_t,
-                                                          tensorNetworkExpectation::cutensornetStateExpectation_t,
-                                                          attribute::cutensornetExpectationAttributes_t,
-                                                          attributeValue::Ptr{Cvoid},
-                                                          attributeSize::Csize_t)::cutensornetStatus_t
+    @gcsafe_ccall libcutensornet.cutensornetExpectationConfigure(handle::cutensornetHandle_t,
+                                                                 tensorNetworkExpectation::cutensornetStateExpectation_t,
+                                                                 attribute::cutensornetExpectationAttributes_t,
+                                                                 attributeValue::Ptr{Cvoid},
+                                                                 attributeSize::Csize_t)::cutensornetStatus_t
 end
 
 @checked function cutensornetExpectationPrepare(handle, tensorNetworkExpectation,
                                                 maxWorkspaceSizeDevice, workDesc,
                                                 cudaStream)
     initialize_context()
-    @ccall libcutensornet.cutensornetExpectationPrepare(handle::cutensornetHandle_t,
-                                                        tensorNetworkExpectation::cutensornetStateExpectation_t,
-                                                        maxWorkspaceSizeDevice::Csize_t,
-                                                        workDesc::cutensornetWorkspaceDescriptor_t,
-                                                        cudaStream::cudaStream_t)::cutensornetStatus_t
+    @gcsafe_ccall libcutensornet.cutensornetExpectationPrepare(handle::cutensornetHandle_t,
+                                                               tensorNetworkExpectation::cutensornetStateExpectation_t,
+                                                               maxWorkspaceSizeDevice::Csize_t,
+                                                               workDesc::cutensornetWorkspaceDescriptor_t,
+                                                               cudaStream::cudaStream_t)::cutensornetStatus_t
 end
 
 @checked function cutensornetExpectationCompute(handle, tensorNetworkExpectation, workDesc,
                                                 expectationValue, stateNorm, cudaStream)
     initialize_context()
-    @ccall libcutensornet.cutensornetExpectationCompute(handle::cutensornetHandle_t,
-                                                        tensorNetworkExpectation::cutensornetStateExpectation_t,
-                                                        workDesc::cutensornetWorkspaceDescriptor_t,
-                                                        expectationValue::Ptr{Cvoid},
-                                                        stateNorm::Ptr{Cvoid},
-                                                        cudaStream::cudaStream_t)::cutensornetStatus_t
+    @gcsafe_ccall libcutensornet.cutensornetExpectationCompute(handle::cutensornetHandle_t,
+                                                               tensorNetworkExpectation::cutensornetStateExpectation_t,
+                                                               workDesc::cutensornetWorkspaceDescriptor_t,
+                                                               expectationValue::Ptr{Cvoid},
+                                                               stateNorm::Ptr{Cvoid},
+                                                               cudaStream::cudaStream_t)::cutensornetStatus_t
 end
 
 @checked function cutensornetDestroyExpectation(tensorNetworkExpectation)
     initialize_context()
-    @ccall libcutensornet.cutensornetDestroyExpectation(tensorNetworkExpectation::cutensornetStateExpectation_t)::cutensornetStatus_t
+    @gcsafe_ccall libcutensornet.cutensornetDestroyExpectation(tensorNetworkExpectation::cutensornetStateExpectation_t)::cutensornetStatus_t
 end
 
 @checked function cutensornetCreateMarginal(handle, tensorNetworkState, numMarginalModes,
@@ -1227,97 +1227,97 @@ end
                                             projectedModes, marginalTensorStrides,
                                             tensorNetworkMarginal)
     initialize_context()
-    @ccall libcutensornet.cutensornetCreateMarginal(handle::cutensornetHandle_t,
-                                                    tensorNetworkState::cutensornetState_t,
-                                                    numMarginalModes::Int32,
-                                                    marginalModes::Ptr{Int32},
-                                                    numProjectedModes::Int32,
-                                                    projectedModes::Ptr{Int32},
-                                                    marginalTensorStrides::Ptr{Int64},
-                                                    tensorNetworkMarginal::Ptr{cutensornetStateMarginal_t})::cutensornetStatus_t
+    @gcsafe_ccall libcutensornet.cutensornetCreateMarginal(handle::cutensornetHandle_t,
+                                                           tensorNetworkState::cutensornetState_t,
+                                                           numMarginalModes::Int32,
+                                                           marginalModes::Ptr{Int32},
+                                                           numProjectedModes::Int32,
+                                                           projectedModes::Ptr{Int32},
+                                                           marginalTensorStrides::Ptr{Int64},
+                                                           tensorNetworkMarginal::Ptr{cutensornetStateMarginal_t})::cutensornetStatus_t
 end
 
 @checked function cutensornetMarginalConfigure(handle, tensorNetworkMarginal, attribute,
                                                attributeValue, attributeSize)
     initialize_context()
-    @ccall libcutensornet.cutensornetMarginalConfigure(handle::cutensornetHandle_t,
-                                                       tensorNetworkMarginal::cutensornetStateMarginal_t,
-                                                       attribute::cutensornetMarginalAttributes_t,
-                                                       attributeValue::Ptr{Cvoid},
-                                                       attributeSize::Csize_t)::cutensornetStatus_t
+    @gcsafe_ccall libcutensornet.cutensornetMarginalConfigure(handle::cutensornetHandle_t,
+                                                              tensorNetworkMarginal::cutensornetStateMarginal_t,
+                                                              attribute::cutensornetMarginalAttributes_t,
+                                                              attributeValue::Ptr{Cvoid},
+                                                              attributeSize::Csize_t)::cutensornetStatus_t
 end
 
 @checked function cutensornetMarginalPrepare(handle, tensorNetworkMarginal,
                                              maxWorkspaceSizeDevice, workDesc, cudaStream)
     initialize_context()
-    @ccall libcutensornet.cutensornetMarginalPrepare(handle::cutensornetHandle_t,
-                                                     tensorNetworkMarginal::cutensornetStateMarginal_t,
-                                                     maxWorkspaceSizeDevice::Csize_t,
-                                                     workDesc::cutensornetWorkspaceDescriptor_t,
-                                                     cudaStream::cudaStream_t)::cutensornetStatus_t
+    @gcsafe_ccall libcutensornet.cutensornetMarginalPrepare(handle::cutensornetHandle_t,
+                                                            tensorNetworkMarginal::cutensornetStateMarginal_t,
+                                                            maxWorkspaceSizeDevice::Csize_t,
+                                                            workDesc::cutensornetWorkspaceDescriptor_t,
+                                                            cudaStream::cudaStream_t)::cutensornetStatus_t
 end
 
 @checked function cutensornetMarginalCompute(handle, tensorNetworkMarginal,
                                              projectedModeValues, workDesc, marginalTensor,
                                              cudaStream)
     initialize_context()
-    @ccall libcutensornet.cutensornetMarginalCompute(handle::cutensornetHandle_t,
-                                                     tensorNetworkMarginal::cutensornetStateMarginal_t,
-                                                     projectedModeValues::Ptr{Int64},
-                                                     workDesc::cutensornetWorkspaceDescriptor_t,
-                                                     marginalTensor::Ptr{Cvoid},
-                                                     cudaStream::cudaStream_t)::cutensornetStatus_t
+    @gcsafe_ccall libcutensornet.cutensornetMarginalCompute(handle::cutensornetHandle_t,
+                                                            tensorNetworkMarginal::cutensornetStateMarginal_t,
+                                                            projectedModeValues::Ptr{Int64},
+                                                            workDesc::cutensornetWorkspaceDescriptor_t,
+                                                            marginalTensor::Ptr{Cvoid},
+                                                            cudaStream::cudaStream_t)::cutensornetStatus_t
 end
 
 @checked function cutensornetDestroyMarginal(tensorNetworkMarginal)
     initialize_context()
-    @ccall libcutensornet.cutensornetDestroyMarginal(tensorNetworkMarginal::cutensornetStateMarginal_t)::cutensornetStatus_t
+    @gcsafe_ccall libcutensornet.cutensornetDestroyMarginal(tensorNetworkMarginal::cutensornetStateMarginal_t)::cutensornetStatus_t
 end
 
 @checked function cutensornetCreateSampler(handle, tensorNetworkState, numModesToSample,
                                            modesToSample, tensorNetworkSampler)
     initialize_context()
-    @ccall libcutensornet.cutensornetCreateSampler(handle::cutensornetHandle_t,
-                                                   tensorNetworkState::cutensornetState_t,
-                                                   numModesToSample::Int32,
-                                                   modesToSample::Ptr{Int32},
-                                                   tensorNetworkSampler::Ptr{cutensornetStateSampler_t})::cutensornetStatus_t
+    @gcsafe_ccall libcutensornet.cutensornetCreateSampler(handle::cutensornetHandle_t,
+                                                          tensorNetworkState::cutensornetState_t,
+                                                          numModesToSample::Int32,
+                                                          modesToSample::Ptr{Int32},
+                                                          tensorNetworkSampler::Ptr{cutensornetStateSampler_t})::cutensornetStatus_t
 end
 
 @checked function cutensornetSamplerConfigure(handle, tensorNetworkSampler, attribute,
                                               attributeValue, attributeSize)
     initialize_context()
-    @ccall libcutensornet.cutensornetSamplerConfigure(handle::cutensornetHandle_t,
-                                                      tensorNetworkSampler::cutensornetStateSampler_t,
-                                                      attribute::cutensornetSamplerAttributes_t,
-                                                      attributeValue::Ptr{Cvoid},
-                                                      attributeSize::Csize_t)::cutensornetStatus_t
+    @gcsafe_ccall libcutensornet.cutensornetSamplerConfigure(handle::cutensornetHandle_t,
+                                                             tensorNetworkSampler::cutensornetStateSampler_t,
+                                                             attribute::cutensornetSamplerAttributes_t,
+                                                             attributeValue::Ptr{Cvoid},
+                                                             attributeSize::Csize_t)::cutensornetStatus_t
 end
 
 @checked function cutensornetSamplerPrepare(handle, tensorNetworkSampler,
                                             maxWorkspaceSizeDevice, workDesc, cudaStream)
     initialize_context()
-    @ccall libcutensornet.cutensornetSamplerPrepare(handle::cutensornetHandle_t,
-                                                    tensorNetworkSampler::cutensornetStateSampler_t,
-                                                    maxWorkspaceSizeDevice::Csize_t,
-                                                    workDesc::cutensornetWorkspaceDescriptor_t,
-                                                    cudaStream::cudaStream_t)::cutensornetStatus_t
+    @gcsafe_ccall libcutensornet.cutensornetSamplerPrepare(handle::cutensornetHandle_t,
+                                                           tensorNetworkSampler::cutensornetStateSampler_t,
+                                                           maxWorkspaceSizeDevice::Csize_t,
+                                                           workDesc::cutensornetWorkspaceDescriptor_t,
+                                                           cudaStream::cudaStream_t)::cutensornetStatus_t
 end
 
 @checked function cutensornetSamplerSample(handle, tensorNetworkSampler, numShots, workDesc,
                                            samples, cudaStream)
     initialize_context()
-    @ccall libcutensornet.cutensornetSamplerSample(handle::cutensornetHandle_t,
-                                                   tensorNetworkSampler::cutensornetStateSampler_t,
-                                                   numShots::Int64,
-                                                   workDesc::cutensornetWorkspaceDescriptor_t,
-                                                   samples::Ptr{Int64},
-                                                   cudaStream::cudaStream_t)::cutensornetStatus_t
+    @gcsafe_ccall libcutensornet.cutensornetSamplerSample(handle::cutensornetHandle_t,
+                                                          tensorNetworkSampler::cutensornetStateSampler_t,
+                                                          numShots::Int64,
+                                                          workDesc::cutensornetWorkspaceDescriptor_t,
+                                                          samples::Ptr{Int64},
+                                                          cudaStream::cudaStream_t)::cutensornetStatus_t
 end
 
 @checked function cutensornetDestroySampler(tensorNetworkSampler)
     initialize_context()
-    @ccall libcutensornet.cutensornetDestroySampler(tensorNetworkSampler::cutensornetStateSampler_t)::cutensornetStatus_t
+    @gcsafe_ccall libcutensornet.cutensornetDestroySampler(tensorNetworkSampler::cutensornetStateSampler_t)::cutensornetStatus_t
 end
 
 const CUTENSORNET_ALLOCATOR_NAME_LEN = 64

--- a/lib/nvml/libnvml.jl
+++ b/lib/nvml/libnvml.jl
@@ -68,7 +68,7 @@ end
 const nvmlReturn_t = nvmlReturn_enum
 
 @checked function nvmlInit_v2()
-    @ccall (libnvml()).nvmlInit_v2()::nvmlReturn_t
+    @gcsafe_ccall (libnvml()).nvmlInit_v2()::nvmlReturn_t
 end
 
 mutable struct nvmlDevice_st end
@@ -89,32 +89,32 @@ const nvmlPciInfo_t = nvmlPciInfo_st
 
 @checked function nvmlDeviceGetPciInfo_v3(device, pci)
     initialize_context()
-    @ccall (libnvml()).nvmlDeviceGetPciInfo_v3(device::nvmlDevice_t,
-                                               pci::Ptr{nvmlPciInfo_t})::nvmlReturn_t
+    @gcsafe_ccall (libnvml()).nvmlDeviceGetPciInfo_v3(device::nvmlDevice_t,
+                                                      pci::Ptr{nvmlPciInfo_t})::nvmlReturn_t
 end
 
 @checked function nvmlDeviceGetCount_v2(deviceCount)
     initialize_context()
-    @ccall (libnvml()).nvmlDeviceGetCount_v2(deviceCount::Ptr{Cuint})::nvmlReturn_t
+    @gcsafe_ccall (libnvml()).nvmlDeviceGetCount_v2(deviceCount::Ptr{Cuint})::nvmlReturn_t
 end
 
 @checked function nvmlDeviceGetHandleByIndex_v2(index, device)
     initialize_context()
-    @ccall (libnvml()).nvmlDeviceGetHandleByIndex_v2(index::Cuint,
-                                                     device::Ptr{nvmlDevice_t})::nvmlReturn_t
+    @gcsafe_ccall (libnvml()).nvmlDeviceGetHandleByIndex_v2(index::Cuint,
+                                                            device::Ptr{nvmlDevice_t})::nvmlReturn_t
 end
 
 @checked function nvmlDeviceGetHandleByPciBusId_v2(pciBusId, device)
     initialize_context()
-    @ccall (libnvml()).nvmlDeviceGetHandleByPciBusId_v2(pciBusId::Cstring,
-                                                        device::Ptr{nvmlDevice_t})::nvmlReturn_t
+    @gcsafe_ccall (libnvml()).nvmlDeviceGetHandleByPciBusId_v2(pciBusId::Cstring,
+                                                               device::Ptr{nvmlDevice_t})::nvmlReturn_t
 end
 
 @checked function nvmlDeviceGetNvLinkRemotePciInfo_v2(device, link, pci)
     initialize_context()
-    @ccall (libnvml()).nvmlDeviceGetNvLinkRemotePciInfo_v2(device::nvmlDevice_t,
-                                                           link::Cuint,
-                                                           pci::Ptr{nvmlPciInfo_t})::nvmlReturn_t
+    @gcsafe_ccall (libnvml()).nvmlDeviceGetNvLinkRemotePciInfo_v2(device::nvmlDevice_t,
+                                                                  link::Cuint,
+                                                                  pci::Ptr{nvmlPciInfo_t})::nvmlReturn_t
 end
 
 @cenum nvmlDetachGpuState_enum::UInt32 begin
@@ -133,9 +133,9 @@ const nvmlPcieLinkState_t = nvmlPcieLinkState_enum
 
 @checked function nvmlDeviceRemoveGpu_v2(pciInfo, gpuState, linkState)
     initialize_context()
-    @ccall (libnvml()).nvmlDeviceRemoveGpu_v2(pciInfo::Ptr{nvmlPciInfo_t},
-                                              gpuState::nvmlDetachGpuState_t,
-                                              linkState::nvmlPcieLinkState_t)::nvmlReturn_t
+    @gcsafe_ccall (libnvml()).nvmlDeviceRemoveGpu_v2(pciInfo::Ptr{nvmlPciInfo_t},
+                                                     gpuState::nvmlDetachGpuState_t,
+                                                     linkState::nvmlPcieLinkState_t)::nvmlReturn_t
 end
 
 @cenum nvmlGridLicenseFeatureCode_t::UInt32 begin
@@ -180,8 +180,8 @@ const nvmlGridLicensableFeatures_t = nvmlGridLicensableFeatures_st
 
 @checked function nvmlDeviceGetGridLicensableFeatures_v4(device, pGridLicensableFeatures)
     initialize_context()
-    @ccall (libnvml()).nvmlDeviceGetGridLicensableFeatures_v4(device::nvmlDevice_t,
-                                                              pGridLicensableFeatures::Ptr{nvmlGridLicensableFeatures_t})::nvmlReturn_t
+    @gcsafe_ccall (libnvml()).nvmlDeviceGetGridLicensableFeatures_v4(device::nvmlDevice_t,
+                                                                     pGridLicensableFeatures::Ptr{nvmlGridLicensableFeatures_t})::nvmlReturn_t
 end
 
 mutable struct nvmlEventSet_st end
@@ -200,8 +200,9 @@ const nvmlEventData_t = nvmlEventData_st
 
 @checked function nvmlEventSetWait_v2(set, data, timeoutms)
     initialize_context()
-    @ccall (libnvml()).nvmlEventSetWait_v2(set::nvmlEventSet_t, data::Ptr{nvmlEventData_t},
-                                           timeoutms::Cuint)::nvmlReturn_t
+    @gcsafe_ccall (libnvml()).nvmlEventSetWait_v2(set::nvmlEventSet_t,
+                                                  data::Ptr{nvmlEventData_t},
+                                                  timeoutms::Cuint)::nvmlReturn_t
 end
 
 struct nvmlDeviceAttributes_st
@@ -220,8 +221,8 @@ const nvmlDeviceAttributes_t = nvmlDeviceAttributes_st
 
 @checked function nvmlDeviceGetAttributes_v2(device, attributes)
     initialize_context()
-    @ccall (libnvml()).nvmlDeviceGetAttributes_v2(device::nvmlDevice_t,
-                                                  attributes::Ptr{nvmlDeviceAttributes_t})::nvmlReturn_t
+    @gcsafe_ccall (libnvml()).nvmlDeviceGetAttributes_v2(device::nvmlDevice_t,
+                                                         attributes::Ptr{nvmlDeviceAttributes_t})::nvmlReturn_t
 end
 
 mutable struct nvmlComputeInstance_st end
@@ -251,8 +252,8 @@ const nvmlComputeInstanceInfo_t = nvmlComputeInstanceInfo_st
 
 @checked function nvmlComputeInstanceGetInfo_v2(computeInstance, info)
     initialize_context()
-    @ccall (libnvml()).nvmlComputeInstanceGetInfo_v2(computeInstance::nvmlComputeInstance_t,
-                                                     info::Ptr{nvmlComputeInstanceInfo_t})::nvmlReturn_t
+    @gcsafe_ccall (libnvml()).nvmlComputeInstanceGetInfo_v2(computeInstance::nvmlComputeInstance_t,
+                                                            info::Ptr{nvmlComputeInstanceInfo_t})::nvmlReturn_t
 end
 
 struct nvmlProcessInfo_v2_st
@@ -266,23 +267,23 @@ const nvmlProcessInfo_t = nvmlProcessInfo_v2_st
 
 @checked function nvmlDeviceGetComputeRunningProcesses_v3(device, infoCount, infos)
     initialize_context()
-    @ccall (libnvml()).nvmlDeviceGetComputeRunningProcesses_v3(device::nvmlDevice_t,
-                                                               infoCount::Ptr{Cuint},
-                                                               infos::Ptr{nvmlProcessInfo_t})::nvmlReturn_t
+    @gcsafe_ccall (libnvml()).nvmlDeviceGetComputeRunningProcesses_v3(device::nvmlDevice_t,
+                                                                      infoCount::Ptr{Cuint},
+                                                                      infos::Ptr{nvmlProcessInfo_t})::nvmlReturn_t
 end
 
 @checked function nvmlDeviceGetGraphicsRunningProcesses_v3(device, infoCount, infos)
     initialize_context()
-    @ccall (libnvml()).nvmlDeviceGetGraphicsRunningProcesses_v3(device::nvmlDevice_t,
-                                                                infoCount::Ptr{Cuint},
-                                                                infos::Ptr{nvmlProcessInfo_t})::nvmlReturn_t
+    @gcsafe_ccall (libnvml()).nvmlDeviceGetGraphicsRunningProcesses_v3(device::nvmlDevice_t,
+                                                                       infoCount::Ptr{Cuint},
+                                                                       infos::Ptr{nvmlProcessInfo_t})::nvmlReturn_t
 end
 
 @checked function nvmlDeviceGetMPSComputeRunningProcesses_v3(device, infoCount, infos)
     initialize_context()
-    @ccall (libnvml()).nvmlDeviceGetMPSComputeRunningProcesses_v3(device::nvmlDevice_t,
-                                                                  infoCount::Ptr{Cuint},
-                                                                  infos::Ptr{nvmlProcessInfo_t})::nvmlReturn_t
+    @gcsafe_ccall (libnvml()).nvmlDeviceGetMPSComputeRunningProcesses_v3(device::nvmlDevice_t,
+                                                                         infoCount::Ptr{Cuint},
+                                                                         infos::Ptr{nvmlProcessInfo_t})::nvmlReturn_t
 end
 
 struct nvmlExcludedDeviceInfo_st
@@ -294,13 +295,13 @@ const nvmlExcludedDeviceInfo_t = nvmlExcludedDeviceInfo_st
 
 @checked function nvmlGetExcludedDeviceCount(deviceCount)
     initialize_context()
-    @ccall (libnvml()).nvmlGetExcludedDeviceCount(deviceCount::Ptr{Cuint})::nvmlReturn_t
+    @gcsafe_ccall (libnvml()).nvmlGetExcludedDeviceCount(deviceCount::Ptr{Cuint})::nvmlReturn_t
 end
 
 @checked function nvmlGetExcludedDeviceInfoByIndex(index, info)
     initialize_context()
-    @ccall (libnvml()).nvmlGetExcludedDeviceInfoByIndex(index::Cuint,
-                                                        info::Ptr{nvmlExcludedDeviceInfo_t})::nvmlReturn_t
+    @gcsafe_ccall (libnvml()).nvmlGetExcludedDeviceInfoByIndex(index::Cuint,
+                                                               info::Ptr{nvmlExcludedDeviceInfo_t})::nvmlReturn_t
 end
 
 struct nvmlGpuInstancePlacement_st
@@ -313,10 +314,10 @@ const nvmlGpuInstancePlacement_t = nvmlGpuInstancePlacement_st
 @checked function nvmlDeviceGetGpuInstancePossiblePlacements_v2(device, profileId,
                                                                 placements, count)
     initialize_context()
-    @ccall (libnvml()).nvmlDeviceGetGpuInstancePossiblePlacements_v2(device::nvmlDevice_t,
-                                                                     profileId::Cuint,
-                                                                     placements::Ptr{nvmlGpuInstancePlacement_t},
-                                                                     count::Ptr{Cuint})::nvmlReturn_t
+    @gcsafe_ccall (libnvml()).nvmlDeviceGetGpuInstancePossiblePlacements_v2(device::nvmlDevice_t,
+                                                                            profileId::Cuint,
+                                                                            placements::Ptr{nvmlGpuInstancePlacement_t},
+                                                                            count::Ptr{Cuint})::nvmlReturn_t
 end
 
 const nvmlVgpuInstance_t = Cuint
@@ -343,8 +344,8 @@ const nvmlVgpuLicenseInfo_t = nvmlVgpuLicenseInfo_st
 
 @checked function nvmlVgpuInstanceGetLicenseInfo_v2(vgpuInstance, licenseInfo)
     initialize_context()
-    @ccall (libnvml()).nvmlVgpuInstanceGetLicenseInfo_v2(vgpuInstance::nvmlVgpuInstance_t,
-                                                         licenseInfo::Ptr{nvmlVgpuLicenseInfo_t})::nvmlReturn_t
+    @gcsafe_ccall (libnvml()).nvmlVgpuInstanceGetLicenseInfo_v2(vgpuInstance::nvmlVgpuInstance_t,
+                                                                licenseInfo::Ptr{nvmlVgpuLicenseInfo_t})::nvmlReturn_t
 end
 
 @cenum nvmlMemoryErrorType_enum::UInt32 begin
@@ -1366,1010 +1367,1023 @@ struct nvmlPowerValue_v2_t
 end
 
 @checked function nvmlInitWithFlags(flags)
-    @ccall (libnvml()).nvmlInitWithFlags(flags::Cuint)::nvmlReturn_t
+    @gcsafe_ccall (libnvml()).nvmlInitWithFlags(flags::Cuint)::nvmlReturn_t
 end
 
 @checked function nvmlShutdown()
-    @ccall (libnvml()).nvmlShutdown()::nvmlReturn_t
+    @gcsafe_ccall (libnvml()).nvmlShutdown()::nvmlReturn_t
 end
 
 function nvmlErrorString(result)
-    @ccall (libnvml()).nvmlErrorString(result::nvmlReturn_t)::Cstring
+    @gcsafe_ccall (libnvml()).nvmlErrorString(result::nvmlReturn_t)::Cstring
 end
 
 @checked function nvmlSystemGetDriverVersion(version, length)
     initialize_context()
-    @ccall (libnvml()).nvmlSystemGetDriverVersion(version::Cstring,
-                                                  length::Cuint)::nvmlReturn_t
+    @gcsafe_ccall (libnvml()).nvmlSystemGetDriverVersion(version::Cstring,
+                                                         length::Cuint)::nvmlReturn_t
 end
 
 @checked function nvmlSystemGetNVMLVersion(version, length)
     initialize_context()
-    @ccall (libnvml()).nvmlSystemGetNVMLVersion(version::Cstring,
-                                                length::Cuint)::nvmlReturn_t
+    @gcsafe_ccall (libnvml()).nvmlSystemGetNVMLVersion(version::Cstring,
+                                                       length::Cuint)::nvmlReturn_t
 end
 
 @checked function nvmlSystemGetCudaDriverVersion(cudaDriverVersion)
     initialize_context()
-    @ccall (libnvml()).nvmlSystemGetCudaDriverVersion(cudaDriverVersion::Ptr{Cint})::nvmlReturn_t
+    @gcsafe_ccall (libnvml()).nvmlSystemGetCudaDriverVersion(cudaDriverVersion::Ptr{Cint})::nvmlReturn_t
 end
 
 @checked function nvmlSystemGetCudaDriverVersion_v2(cudaDriverVersion)
     initialize_context()
-    @ccall (libnvml()).nvmlSystemGetCudaDriverVersion_v2(cudaDriverVersion::Ptr{Cint})::nvmlReturn_t
+    @gcsafe_ccall (libnvml()).nvmlSystemGetCudaDriverVersion_v2(cudaDriverVersion::Ptr{Cint})::nvmlReturn_t
 end
 
 @checked function nvmlSystemGetProcessName(pid, name, length)
     initialize_context()
-    @ccall (libnvml()).nvmlSystemGetProcessName(pid::Cuint, name::Cstring,
-                                                length::Cuint)::nvmlReturn_t
+    @gcsafe_ccall (libnvml()).nvmlSystemGetProcessName(pid::Cuint, name::Cstring,
+                                                       length::Cuint)::nvmlReturn_t
 end
 
 @checked function nvmlSystemGetHicVersion(hwbcCount, hwbcEntries)
     initialize_context()
-    @ccall (libnvml()).nvmlSystemGetHicVersion(hwbcCount::Ptr{Cuint},
-                                               hwbcEntries::Ptr{nvmlHwbcEntry_t})::nvmlReturn_t
+    @gcsafe_ccall (libnvml()).nvmlSystemGetHicVersion(hwbcCount::Ptr{Cuint},
+                                                      hwbcEntries::Ptr{nvmlHwbcEntry_t})::nvmlReturn_t
 end
 
 @checked function nvmlSystemGetTopologyGpuSet(cpuNumber, count, deviceArray)
     initialize_context()
-    @ccall (libnvml()).nvmlSystemGetTopologyGpuSet(cpuNumber::Cuint, count::Ptr{Cuint},
-                                                   deviceArray::Ptr{nvmlDevice_t})::nvmlReturn_t
+    @gcsafe_ccall (libnvml()).nvmlSystemGetTopologyGpuSet(cpuNumber::Cuint,
+                                                          count::Ptr{Cuint},
+                                                          deviceArray::Ptr{nvmlDevice_t})::nvmlReturn_t
 end
 
 @checked function nvmlUnitGetCount(unitCount)
     initialize_context()
-    @ccall (libnvml()).nvmlUnitGetCount(unitCount::Ptr{Cuint})::nvmlReturn_t
+    @gcsafe_ccall (libnvml()).nvmlUnitGetCount(unitCount::Ptr{Cuint})::nvmlReturn_t
 end
 
 @checked function nvmlUnitGetHandleByIndex(index, unit)
     initialize_context()
-    @ccall (libnvml()).nvmlUnitGetHandleByIndex(index::Cuint,
-                                                unit::Ptr{nvmlUnit_t})::nvmlReturn_t
+    @gcsafe_ccall (libnvml()).nvmlUnitGetHandleByIndex(index::Cuint,
+                                                       unit::Ptr{nvmlUnit_t})::nvmlReturn_t
 end
 
 @checked function nvmlUnitGetUnitInfo(unit, info)
     initialize_context()
-    @ccall (libnvml()).nvmlUnitGetUnitInfo(unit::nvmlUnit_t,
-                                           info::Ptr{nvmlUnitInfo_t})::nvmlReturn_t
+    @gcsafe_ccall (libnvml()).nvmlUnitGetUnitInfo(unit::nvmlUnit_t,
+                                                  info::Ptr{nvmlUnitInfo_t})::nvmlReturn_t
 end
 
 @checked function nvmlUnitGetLedState(unit, state)
     initialize_context()
-    @ccall (libnvml()).nvmlUnitGetLedState(unit::nvmlUnit_t,
-                                           state::Ptr{nvmlLedState_t})::nvmlReturn_t
+    @gcsafe_ccall (libnvml()).nvmlUnitGetLedState(unit::nvmlUnit_t,
+                                                  state::Ptr{nvmlLedState_t})::nvmlReturn_t
 end
 
 @checked function nvmlUnitGetPsuInfo(unit, psu)
     initialize_context()
-    @ccall (libnvml()).nvmlUnitGetPsuInfo(unit::nvmlUnit_t,
-                                          psu::Ptr{nvmlPSUInfo_t})::nvmlReturn_t
+    @gcsafe_ccall (libnvml()).nvmlUnitGetPsuInfo(unit::nvmlUnit_t,
+                                                 psu::Ptr{nvmlPSUInfo_t})::nvmlReturn_t
 end
 
 @checked function nvmlUnitGetTemperature(unit, type, temp)
     initialize_context()
-    @ccall (libnvml()).nvmlUnitGetTemperature(unit::nvmlUnit_t, type::Cuint,
-                                              temp::Ptr{Cuint})::nvmlReturn_t
+    @gcsafe_ccall (libnvml()).nvmlUnitGetTemperature(unit::nvmlUnit_t, type::Cuint,
+                                                     temp::Ptr{Cuint})::nvmlReturn_t
 end
 
 @checked function nvmlUnitGetFanSpeedInfo(unit, fanSpeeds)
     initialize_context()
-    @ccall (libnvml()).nvmlUnitGetFanSpeedInfo(unit::nvmlUnit_t,
-                                               fanSpeeds::Ptr{nvmlUnitFanSpeeds_t})::nvmlReturn_t
+    @gcsafe_ccall (libnvml()).nvmlUnitGetFanSpeedInfo(unit::nvmlUnit_t,
+                                                      fanSpeeds::Ptr{nvmlUnitFanSpeeds_t})::nvmlReturn_t
 end
 
 @checked function nvmlUnitGetDevices(unit, deviceCount, devices)
     initialize_context()
-    @ccall (libnvml()).nvmlUnitGetDevices(unit::nvmlUnit_t, deviceCount::Ptr{Cuint},
-                                          devices::Ptr{nvmlDevice_t})::nvmlReturn_t
+    @gcsafe_ccall (libnvml()).nvmlUnitGetDevices(unit::nvmlUnit_t, deviceCount::Ptr{Cuint},
+                                                 devices::Ptr{nvmlDevice_t})::nvmlReturn_t
 end
 
 @checked function nvmlDeviceGetHandleBySerial(serial, device)
     initialize_context()
-    @ccall (libnvml()).nvmlDeviceGetHandleBySerial(serial::Cstring,
-                                                   device::Ptr{nvmlDevice_t})::nvmlReturn_t
+    @gcsafe_ccall (libnvml()).nvmlDeviceGetHandleBySerial(serial::Cstring,
+                                                          device::Ptr{nvmlDevice_t})::nvmlReturn_t
 end
 
 @checked function nvmlDeviceGetHandleByUUID(uuid, device)
     initialize_context()
-    @ccall (libnvml()).nvmlDeviceGetHandleByUUID(uuid::Cstring,
-                                                 device::Ptr{nvmlDevice_t})::nvmlReturn_t
+    @gcsafe_ccall (libnvml()).nvmlDeviceGetHandleByUUID(uuid::Cstring,
+                                                        device::Ptr{nvmlDevice_t})::nvmlReturn_t
 end
 
 @checked function nvmlDeviceGetName(device, name, length)
     initialize_context()
-    @ccall (libnvml()).nvmlDeviceGetName(device::nvmlDevice_t, name::Cstring,
-                                         length::Cuint)::nvmlReturn_t
+    @gcsafe_ccall (libnvml()).nvmlDeviceGetName(device::nvmlDevice_t, name::Cstring,
+                                                length::Cuint)::nvmlReturn_t
 end
 
 @checked function nvmlDeviceGetBrand(device, type)
     initialize_context()
-    @ccall (libnvml()).nvmlDeviceGetBrand(device::nvmlDevice_t,
-                                          type::Ptr{nvmlBrandType_t})::nvmlReturn_t
+    @gcsafe_ccall (libnvml()).nvmlDeviceGetBrand(device::nvmlDevice_t,
+                                                 type::Ptr{nvmlBrandType_t})::nvmlReturn_t
 end
 
 @checked function nvmlDeviceGetIndex(device, index)
     initialize_context()
-    @ccall (libnvml()).nvmlDeviceGetIndex(device::nvmlDevice_t,
-                                          index::Ptr{Cuint})::nvmlReturn_t
+    @gcsafe_ccall (libnvml()).nvmlDeviceGetIndex(device::nvmlDevice_t,
+                                                 index::Ptr{Cuint})::nvmlReturn_t
 end
 
 @checked function nvmlDeviceGetSerial(device, serial, length)
     initialize_context()
-    @ccall (libnvml()).nvmlDeviceGetSerial(device::nvmlDevice_t, serial::Cstring,
-                                           length::Cuint)::nvmlReturn_t
+    @gcsafe_ccall (libnvml()).nvmlDeviceGetSerial(device::nvmlDevice_t, serial::Cstring,
+                                                  length::Cuint)::nvmlReturn_t
 end
 
 @checked function nvmlDeviceGetModuleId(device, moduleId)
     initialize_context()
-    @ccall (libnvml()).nvmlDeviceGetModuleId(device::nvmlDevice_t,
-                                             moduleId::Ptr{Cuint})::nvmlReturn_t
+    @gcsafe_ccall (libnvml()).nvmlDeviceGetModuleId(device::nvmlDevice_t,
+                                                    moduleId::Ptr{Cuint})::nvmlReturn_t
 end
 
 @checked function nvmlDeviceGetC2cModeInfoV(device, c2cModeInfo)
     initialize_context()
-    @ccall (libnvml()).nvmlDeviceGetC2cModeInfoV(device::nvmlDevice_t,
-                                                 c2cModeInfo::Ptr{nvmlC2cModeInfo_v1_t})::nvmlReturn_t
+    @gcsafe_ccall (libnvml()).nvmlDeviceGetC2cModeInfoV(device::nvmlDevice_t,
+                                                        c2cModeInfo::Ptr{nvmlC2cModeInfo_v1_t})::nvmlReturn_t
 end
 
 const nvmlAffinityScope_t = Cuint
 
 @checked function nvmlDeviceGetMemoryAffinity(device, nodeSetSize, nodeSet, scope)
     initialize_context()
-    @ccall (libnvml()).nvmlDeviceGetMemoryAffinity(device::nvmlDevice_t, nodeSetSize::Cuint,
-                                                   nodeSet::Ptr{Culong},
-                                                   scope::nvmlAffinityScope_t)::nvmlReturn_t
+    @gcsafe_ccall (libnvml()).nvmlDeviceGetMemoryAffinity(device::nvmlDevice_t,
+                                                          nodeSetSize::Cuint,
+                                                          nodeSet::Ptr{Culong},
+                                                          scope::nvmlAffinityScope_t)::nvmlReturn_t
 end
 
 @checked function nvmlDeviceGetCpuAffinityWithinScope(device, cpuSetSize, cpuSet, scope)
     initialize_context()
-    @ccall (libnvml()).nvmlDeviceGetCpuAffinityWithinScope(device::nvmlDevice_t,
-                                                           cpuSetSize::Cuint,
-                                                           cpuSet::Ptr{Culong},
-                                                           scope::nvmlAffinityScope_t)::nvmlReturn_t
+    @gcsafe_ccall (libnvml()).nvmlDeviceGetCpuAffinityWithinScope(device::nvmlDevice_t,
+                                                                  cpuSetSize::Cuint,
+                                                                  cpuSet::Ptr{Culong},
+                                                                  scope::nvmlAffinityScope_t)::nvmlReturn_t
 end
 
 @checked function nvmlDeviceGetCpuAffinity(device, cpuSetSize, cpuSet)
     initialize_context()
-    @ccall (libnvml()).nvmlDeviceGetCpuAffinity(device::nvmlDevice_t, cpuSetSize::Cuint,
-                                                cpuSet::Ptr{Culong})::nvmlReturn_t
+    @gcsafe_ccall (libnvml()).nvmlDeviceGetCpuAffinity(device::nvmlDevice_t,
+                                                       cpuSetSize::Cuint,
+                                                       cpuSet::Ptr{Culong})::nvmlReturn_t
 end
 
 @checked function nvmlDeviceSetCpuAffinity(device)
     initialize_context()
-    @ccall (libnvml()).nvmlDeviceSetCpuAffinity(device::nvmlDevice_t)::nvmlReturn_t
+    @gcsafe_ccall (libnvml()).nvmlDeviceSetCpuAffinity(device::nvmlDevice_t)::nvmlReturn_t
 end
 
 @checked function nvmlDeviceClearCpuAffinity(device)
     initialize_context()
-    @ccall (libnvml()).nvmlDeviceClearCpuAffinity(device::nvmlDevice_t)::nvmlReturn_t
+    @gcsafe_ccall (libnvml()).nvmlDeviceClearCpuAffinity(device::nvmlDevice_t)::nvmlReturn_t
 end
 
 @checked function nvmlDeviceGetTopologyCommonAncestor(device1, device2, pathInfo)
     initialize_context()
-    @ccall (libnvml()).nvmlDeviceGetTopologyCommonAncestor(device1::nvmlDevice_t,
-                                                           device2::nvmlDevice_t,
-                                                           pathInfo::Ptr{nvmlGpuTopologyLevel_t})::nvmlReturn_t
+    @gcsafe_ccall (libnvml()).nvmlDeviceGetTopologyCommonAncestor(device1::nvmlDevice_t,
+                                                                  device2::nvmlDevice_t,
+                                                                  pathInfo::Ptr{nvmlGpuTopologyLevel_t})::nvmlReturn_t
 end
 
 @checked function nvmlDeviceGetTopologyNearestGpus(device, level, count, deviceArray)
     initialize_context()
-    @ccall (libnvml()).nvmlDeviceGetTopologyNearestGpus(device::nvmlDevice_t,
-                                                        level::nvmlGpuTopologyLevel_t,
-                                                        count::Ptr{Cuint},
-                                                        deviceArray::Ptr{nvmlDevice_t})::nvmlReturn_t
+    @gcsafe_ccall (libnvml()).nvmlDeviceGetTopologyNearestGpus(device::nvmlDevice_t,
+                                                               level::nvmlGpuTopologyLevel_t,
+                                                               count::Ptr{Cuint},
+                                                               deviceArray::Ptr{nvmlDevice_t})::nvmlReturn_t
 end
 
 @checked function nvmlDeviceGetP2PStatus(device1, device2, p2pIndex, p2pStatus)
     initialize_context()
-    @ccall (libnvml()).nvmlDeviceGetP2PStatus(device1::nvmlDevice_t, device2::nvmlDevice_t,
-                                              p2pIndex::nvmlGpuP2PCapsIndex_t,
-                                              p2pStatus::Ptr{nvmlGpuP2PStatus_t})::nvmlReturn_t
+    @gcsafe_ccall (libnvml()).nvmlDeviceGetP2PStatus(device1::nvmlDevice_t,
+                                                     device2::nvmlDevice_t,
+                                                     p2pIndex::nvmlGpuP2PCapsIndex_t,
+                                                     p2pStatus::Ptr{nvmlGpuP2PStatus_t})::nvmlReturn_t
 end
 
 @checked function nvmlDeviceGetUUID(device, uuid, length)
     initialize_context()
-    @ccall (libnvml()).nvmlDeviceGetUUID(device::nvmlDevice_t, uuid::Cstring,
-                                         length::Cuint)::nvmlReturn_t
+    @gcsafe_ccall (libnvml()).nvmlDeviceGetUUID(device::nvmlDevice_t, uuid::Cstring,
+                                                length::Cuint)::nvmlReturn_t
 end
 
 @checked function nvmlDeviceGetMinorNumber(device, minorNumber)
     initialize_context()
-    @ccall (libnvml()).nvmlDeviceGetMinorNumber(device::nvmlDevice_t,
-                                                minorNumber::Ptr{Cuint})::nvmlReturn_t
+    @gcsafe_ccall (libnvml()).nvmlDeviceGetMinorNumber(device::nvmlDevice_t,
+                                                       minorNumber::Ptr{Cuint})::nvmlReturn_t
 end
 
 @checked function nvmlDeviceGetBoardPartNumber(device, partNumber, length)
     initialize_context()
-    @ccall (libnvml()).nvmlDeviceGetBoardPartNumber(device::nvmlDevice_t,
-                                                    partNumber::Cstring,
-                                                    length::Cuint)::nvmlReturn_t
+    @gcsafe_ccall (libnvml()).nvmlDeviceGetBoardPartNumber(device::nvmlDevice_t,
+                                                           partNumber::Cstring,
+                                                           length::Cuint)::nvmlReturn_t
 end
 
 @checked function nvmlDeviceGetInforomVersion(device, object, version, length)
     initialize_context()
-    @ccall (libnvml()).nvmlDeviceGetInforomVersion(device::nvmlDevice_t,
-                                                   object::nvmlInforomObject_t,
-                                                   version::Cstring,
-                                                   length::Cuint)::nvmlReturn_t
+    @gcsafe_ccall (libnvml()).nvmlDeviceGetInforomVersion(device::nvmlDevice_t,
+                                                          object::nvmlInforomObject_t,
+                                                          version::Cstring,
+                                                          length::Cuint)::nvmlReturn_t
 end
 
 @checked function nvmlDeviceGetInforomImageVersion(device, version, length)
     initialize_context()
-    @ccall (libnvml()).nvmlDeviceGetInforomImageVersion(device::nvmlDevice_t,
-                                                        version::Cstring,
-                                                        length::Cuint)::nvmlReturn_t
+    @gcsafe_ccall (libnvml()).nvmlDeviceGetInforomImageVersion(device::nvmlDevice_t,
+                                                               version::Cstring,
+                                                               length::Cuint)::nvmlReturn_t
 end
 
 @checked function nvmlDeviceGetInforomConfigurationChecksum(device, checksum)
     initialize_context()
-    @ccall (libnvml()).nvmlDeviceGetInforomConfigurationChecksum(device::nvmlDevice_t,
-                                                                 checksum::Ptr{Cuint})::nvmlReturn_t
+    @gcsafe_ccall (libnvml()).nvmlDeviceGetInforomConfigurationChecksum(device::nvmlDevice_t,
+                                                                        checksum::Ptr{Cuint})::nvmlReturn_t
 end
 
 @checked function nvmlDeviceValidateInforom(device)
     initialize_context()
-    @ccall (libnvml()).nvmlDeviceValidateInforom(device::nvmlDevice_t)::nvmlReturn_t
+    @gcsafe_ccall (libnvml()).nvmlDeviceValidateInforom(device::nvmlDevice_t)::nvmlReturn_t
 end
 
 @checked function nvmlDeviceGetLastBBXFlushTime(device, timestamp, durationUs)
     initialize_context()
-    @ccall (libnvml()).nvmlDeviceGetLastBBXFlushTime(device::nvmlDevice_t,
-                                                     timestamp::Ptr{Culonglong},
-                                                     durationUs::Ptr{Culong})::nvmlReturn_t
+    @gcsafe_ccall (libnvml()).nvmlDeviceGetLastBBXFlushTime(device::nvmlDevice_t,
+                                                            timestamp::Ptr{Culonglong},
+                                                            durationUs::Ptr{Culong})::nvmlReturn_t
 end
 
 @checked function nvmlDeviceGetDisplayMode(device, display)
     initialize_context()
-    @ccall (libnvml()).nvmlDeviceGetDisplayMode(device::nvmlDevice_t,
-                                                display::Ptr{nvmlEnableState_t})::nvmlReturn_t
+    @gcsafe_ccall (libnvml()).nvmlDeviceGetDisplayMode(device::nvmlDevice_t,
+                                                       display::Ptr{nvmlEnableState_t})::nvmlReturn_t
 end
 
 @checked function nvmlDeviceGetDisplayActive(device, isActive)
     initialize_context()
-    @ccall (libnvml()).nvmlDeviceGetDisplayActive(device::nvmlDevice_t,
-                                                  isActive::Ptr{nvmlEnableState_t})::nvmlReturn_t
+    @gcsafe_ccall (libnvml()).nvmlDeviceGetDisplayActive(device::nvmlDevice_t,
+                                                         isActive::Ptr{nvmlEnableState_t})::nvmlReturn_t
 end
 
 @checked function nvmlDeviceGetPersistenceMode(device, mode)
     initialize_context()
-    @ccall (libnvml()).nvmlDeviceGetPersistenceMode(device::nvmlDevice_t,
-                                                    mode::Ptr{nvmlEnableState_t})::nvmlReturn_t
+    @gcsafe_ccall (libnvml()).nvmlDeviceGetPersistenceMode(device::nvmlDevice_t,
+                                                           mode::Ptr{nvmlEnableState_t})::nvmlReturn_t
 end
 
 @checked function nvmlDeviceGetMaxPcieLinkGeneration(device, maxLinkGen)
     initialize_context()
-    @ccall (libnvml()).nvmlDeviceGetMaxPcieLinkGeneration(device::nvmlDevice_t,
-                                                          maxLinkGen::Ptr{Cuint})::nvmlReturn_t
+    @gcsafe_ccall (libnvml()).nvmlDeviceGetMaxPcieLinkGeneration(device::nvmlDevice_t,
+                                                                 maxLinkGen::Ptr{Cuint})::nvmlReturn_t
 end
 
 @checked function nvmlDeviceGetGpuMaxPcieLinkGeneration(device, maxLinkGenDevice)
     initialize_context()
-    @ccall (libnvml()).nvmlDeviceGetGpuMaxPcieLinkGeneration(device::nvmlDevice_t,
-                                                             maxLinkGenDevice::Ptr{Cuint})::nvmlReturn_t
+    @gcsafe_ccall (libnvml()).nvmlDeviceGetGpuMaxPcieLinkGeneration(device::nvmlDevice_t,
+                                                                    maxLinkGenDevice::Ptr{Cuint})::nvmlReturn_t
 end
 
 @checked function nvmlDeviceGetMaxPcieLinkWidth(device, maxLinkWidth)
     initialize_context()
-    @ccall (libnvml()).nvmlDeviceGetMaxPcieLinkWidth(device::nvmlDevice_t,
-                                                     maxLinkWidth::Ptr{Cuint})::nvmlReturn_t
+    @gcsafe_ccall (libnvml()).nvmlDeviceGetMaxPcieLinkWidth(device::nvmlDevice_t,
+                                                            maxLinkWidth::Ptr{Cuint})::nvmlReturn_t
 end
 
 @checked function nvmlDeviceGetCurrPcieLinkGeneration(device, currLinkGen)
     initialize_context()
-    @ccall (libnvml()).nvmlDeviceGetCurrPcieLinkGeneration(device::nvmlDevice_t,
-                                                           currLinkGen::Ptr{Cuint})::nvmlReturn_t
+    @gcsafe_ccall (libnvml()).nvmlDeviceGetCurrPcieLinkGeneration(device::nvmlDevice_t,
+                                                                  currLinkGen::Ptr{Cuint})::nvmlReturn_t
 end
 
 @checked function nvmlDeviceGetCurrPcieLinkWidth(device, currLinkWidth)
     initialize_context()
-    @ccall (libnvml()).nvmlDeviceGetCurrPcieLinkWidth(device::nvmlDevice_t,
-                                                      currLinkWidth::Ptr{Cuint})::nvmlReturn_t
+    @gcsafe_ccall (libnvml()).nvmlDeviceGetCurrPcieLinkWidth(device::nvmlDevice_t,
+                                                             currLinkWidth::Ptr{Cuint})::nvmlReturn_t
 end
 
 @checked function nvmlDeviceGetPcieThroughput(device, counter, value)
     initialize_context()
-    @ccall (libnvml()).nvmlDeviceGetPcieThroughput(device::nvmlDevice_t,
-                                                   counter::nvmlPcieUtilCounter_t,
-                                                   value::Ptr{Cuint})::nvmlReturn_t
+    @gcsafe_ccall (libnvml()).nvmlDeviceGetPcieThroughput(device::nvmlDevice_t,
+                                                          counter::nvmlPcieUtilCounter_t,
+                                                          value::Ptr{Cuint})::nvmlReturn_t
 end
 
 @checked function nvmlDeviceGetPcieReplayCounter(device, value)
     initialize_context()
-    @ccall (libnvml()).nvmlDeviceGetPcieReplayCounter(device::nvmlDevice_t,
-                                                      value::Ptr{Cuint})::nvmlReturn_t
+    @gcsafe_ccall (libnvml()).nvmlDeviceGetPcieReplayCounter(device::nvmlDevice_t,
+                                                             value::Ptr{Cuint})::nvmlReturn_t
 end
 
 @checked function nvmlDeviceGetClockInfo(device, type, clock)
     initialize_context()
-    @ccall (libnvml()).nvmlDeviceGetClockInfo(device::nvmlDevice_t, type::nvmlClockType_t,
-                                              clock::Ptr{Cuint})::nvmlReturn_t
+    @gcsafe_ccall (libnvml()).nvmlDeviceGetClockInfo(device::nvmlDevice_t,
+                                                     type::nvmlClockType_t,
+                                                     clock::Ptr{Cuint})::nvmlReturn_t
 end
 
 @checked function nvmlDeviceGetMaxClockInfo(device, type, clock)
     initialize_context()
-    @ccall (libnvml()).nvmlDeviceGetMaxClockInfo(device::nvmlDevice_t,
-                                                 type::nvmlClockType_t,
-                                                 clock::Ptr{Cuint})::nvmlReturn_t
+    @gcsafe_ccall (libnvml()).nvmlDeviceGetMaxClockInfo(device::nvmlDevice_t,
+                                                        type::nvmlClockType_t,
+                                                        clock::Ptr{Cuint})::nvmlReturn_t
 end
 
 @checked function nvmlDeviceGetGpcClkVfOffset(device, offset)
     initialize_context()
-    @ccall (libnvml()).nvmlDeviceGetGpcClkVfOffset(device::nvmlDevice_t,
-                                                   offset::Ptr{Cint})::nvmlReturn_t
+    @gcsafe_ccall (libnvml()).nvmlDeviceGetGpcClkVfOffset(device::nvmlDevice_t,
+                                                          offset::Ptr{Cint})::nvmlReturn_t
 end
 
 @checked function nvmlDeviceGetApplicationsClock(device, clockType, clockMHz)
     initialize_context()
-    @ccall (libnvml()).nvmlDeviceGetApplicationsClock(device::nvmlDevice_t,
-                                                      clockType::nvmlClockType_t,
-                                                      clockMHz::Ptr{Cuint})::nvmlReturn_t
-end
-
-@checked function nvmlDeviceGetDefaultApplicationsClock(device, clockType, clockMHz)
-    initialize_context()
-    @ccall (libnvml()).nvmlDeviceGetDefaultApplicationsClock(device::nvmlDevice_t,
+    @gcsafe_ccall (libnvml()).nvmlDeviceGetApplicationsClock(device::nvmlDevice_t,
                                                              clockType::nvmlClockType_t,
                                                              clockMHz::Ptr{Cuint})::nvmlReturn_t
 end
 
+@checked function nvmlDeviceGetDefaultApplicationsClock(device, clockType, clockMHz)
+    initialize_context()
+    @gcsafe_ccall (libnvml()).nvmlDeviceGetDefaultApplicationsClock(device::nvmlDevice_t,
+                                                                    clockType::nvmlClockType_t,
+                                                                    clockMHz::Ptr{Cuint})::nvmlReturn_t
+end
+
 @checked function nvmlDeviceGetClock(device, clockType, clockId, clockMHz)
     initialize_context()
-    @ccall (libnvml()).nvmlDeviceGetClock(device::nvmlDevice_t, clockType::nvmlClockType_t,
-                                          clockId::nvmlClockId_t,
-                                          clockMHz::Ptr{Cuint})::nvmlReturn_t
+    @gcsafe_ccall (libnvml()).nvmlDeviceGetClock(device::nvmlDevice_t,
+                                                 clockType::nvmlClockType_t,
+                                                 clockId::nvmlClockId_t,
+                                                 clockMHz::Ptr{Cuint})::nvmlReturn_t
 end
 
 @checked function nvmlDeviceGetMaxCustomerBoostClock(device, clockType, clockMHz)
     initialize_context()
-    @ccall (libnvml()).nvmlDeviceGetMaxCustomerBoostClock(device::nvmlDevice_t,
-                                                          clockType::nvmlClockType_t,
-                                                          clockMHz::Ptr{Cuint})::nvmlReturn_t
+    @gcsafe_ccall (libnvml()).nvmlDeviceGetMaxCustomerBoostClock(device::nvmlDevice_t,
+                                                                 clockType::nvmlClockType_t,
+                                                                 clockMHz::Ptr{Cuint})::nvmlReturn_t
 end
 
 @checked function nvmlDeviceGetSupportedMemoryClocks(device, count, clocksMHz)
     initialize_context()
-    @ccall (libnvml()).nvmlDeviceGetSupportedMemoryClocks(device::nvmlDevice_t,
-                                                          count::Ptr{Cuint},
-                                                          clocksMHz::Ptr{Cuint})::nvmlReturn_t
+    @gcsafe_ccall (libnvml()).nvmlDeviceGetSupportedMemoryClocks(device::nvmlDevice_t,
+                                                                 count::Ptr{Cuint},
+                                                                 clocksMHz::Ptr{Cuint})::nvmlReturn_t
 end
 
 @checked function nvmlDeviceGetSupportedGraphicsClocks(device, memoryClockMHz, count,
                                                        clocksMHz)
     initialize_context()
-    @ccall (libnvml()).nvmlDeviceGetSupportedGraphicsClocks(device::nvmlDevice_t,
-                                                            memoryClockMHz::Cuint,
-                                                            count::Ptr{Cuint},
-                                                            clocksMHz::Ptr{Cuint})::nvmlReturn_t
+    @gcsafe_ccall (libnvml()).nvmlDeviceGetSupportedGraphicsClocks(device::nvmlDevice_t,
+                                                                   memoryClockMHz::Cuint,
+                                                                   count::Ptr{Cuint},
+                                                                   clocksMHz::Ptr{Cuint})::nvmlReturn_t
 end
 
 @checked function nvmlDeviceGetAutoBoostedClocksEnabled(device, isEnabled, defaultIsEnabled)
     initialize_context()
-    @ccall (libnvml()).nvmlDeviceGetAutoBoostedClocksEnabled(device::nvmlDevice_t,
-                                                             isEnabled::Ptr{nvmlEnableState_t},
-                                                             defaultIsEnabled::Ptr{nvmlEnableState_t})::nvmlReturn_t
+    @gcsafe_ccall (libnvml()).nvmlDeviceGetAutoBoostedClocksEnabled(device::nvmlDevice_t,
+                                                                    isEnabled::Ptr{nvmlEnableState_t},
+                                                                    defaultIsEnabled::Ptr{nvmlEnableState_t})::nvmlReturn_t
 end
 
 @checked function nvmlDeviceGetFanSpeed(device, speed)
     initialize_context()
-    @ccall (libnvml()).nvmlDeviceGetFanSpeed(device::nvmlDevice_t,
-                                             speed::Ptr{Cuint})::nvmlReturn_t
+    @gcsafe_ccall (libnvml()).nvmlDeviceGetFanSpeed(device::nvmlDevice_t,
+                                                    speed::Ptr{Cuint})::nvmlReturn_t
 end
 
 @checked function nvmlDeviceGetFanSpeed_v2(device, fan, speed)
     initialize_context()
-    @ccall (libnvml()).nvmlDeviceGetFanSpeed_v2(device::nvmlDevice_t, fan::Cuint,
-                                                speed::Ptr{Cuint})::nvmlReturn_t
+    @gcsafe_ccall (libnvml()).nvmlDeviceGetFanSpeed_v2(device::nvmlDevice_t, fan::Cuint,
+                                                       speed::Ptr{Cuint})::nvmlReturn_t
 end
 
 @checked function nvmlDeviceGetTargetFanSpeed(device, fan, targetSpeed)
     initialize_context()
-    @ccall (libnvml()).nvmlDeviceGetTargetFanSpeed(device::nvmlDevice_t, fan::Cuint,
-                                                   targetSpeed::Ptr{Cuint})::nvmlReturn_t
+    @gcsafe_ccall (libnvml()).nvmlDeviceGetTargetFanSpeed(device::nvmlDevice_t, fan::Cuint,
+                                                          targetSpeed::Ptr{Cuint})::nvmlReturn_t
 end
 
 @checked function nvmlDeviceGetMinMaxFanSpeed(device, minSpeed, maxSpeed)
     initialize_context()
-    @ccall (libnvml()).nvmlDeviceGetMinMaxFanSpeed(device::nvmlDevice_t,
-                                                   minSpeed::Ptr{Cuint},
-                                                   maxSpeed::Ptr{Cuint})::nvmlReturn_t
+    @gcsafe_ccall (libnvml()).nvmlDeviceGetMinMaxFanSpeed(device::nvmlDevice_t,
+                                                          minSpeed::Ptr{Cuint},
+                                                          maxSpeed::Ptr{Cuint})::nvmlReturn_t
 end
 
 @checked function nvmlDeviceGetFanControlPolicy_v2(device, fan, policy)
     initialize_context()
-    @ccall (libnvml()).nvmlDeviceGetFanControlPolicy_v2(device::nvmlDevice_t, fan::Cuint,
-                                                        policy::Ptr{nvmlFanControlPolicy_t})::nvmlReturn_t
+    @gcsafe_ccall (libnvml()).nvmlDeviceGetFanControlPolicy_v2(device::nvmlDevice_t,
+                                                               fan::Cuint,
+                                                               policy::Ptr{nvmlFanControlPolicy_t})::nvmlReturn_t
 end
 
 @checked function nvmlDeviceGetNumFans(device, numFans)
     initialize_context()
-    @ccall (libnvml()).nvmlDeviceGetNumFans(device::nvmlDevice_t,
-                                            numFans::Ptr{Cuint})::nvmlReturn_t
+    @gcsafe_ccall (libnvml()).nvmlDeviceGetNumFans(device::nvmlDevice_t,
+                                                   numFans::Ptr{Cuint})::nvmlReturn_t
 end
 
 @checked function nvmlDeviceGetTemperature(device, sensorType, temp)
     initialize_context()
-    @ccall (libnvml()).nvmlDeviceGetTemperature(device::nvmlDevice_t,
-                                                sensorType::nvmlTemperatureSensors_t,
-                                                temp::Ptr{Cuint})::nvmlReturn_t
+    @gcsafe_ccall (libnvml()).nvmlDeviceGetTemperature(device::nvmlDevice_t,
+                                                       sensorType::nvmlTemperatureSensors_t,
+                                                       temp::Ptr{Cuint})::nvmlReturn_t
 end
 
 @checked function nvmlDeviceGetTemperatureThreshold(device, thresholdType, temp)
     initialize_context()
-    @ccall (libnvml()).nvmlDeviceGetTemperatureThreshold(device::nvmlDevice_t,
-                                                         thresholdType::nvmlTemperatureThresholds_t,
-                                                         temp::Ptr{Cuint})::nvmlReturn_t
+    @gcsafe_ccall (libnvml()).nvmlDeviceGetTemperatureThreshold(device::nvmlDevice_t,
+                                                                thresholdType::nvmlTemperatureThresholds_t,
+                                                                temp::Ptr{Cuint})::nvmlReturn_t
 end
 
 @checked function nvmlDeviceGetThermalSettings(device, sensorIndex, pThermalSettings)
     initialize_context()
-    @ccall (libnvml()).nvmlDeviceGetThermalSettings(device::nvmlDevice_t,
-                                                    sensorIndex::Cuint,
-                                                    pThermalSettings::Ptr{nvmlGpuThermalSettings_t})::nvmlReturn_t
+    @gcsafe_ccall (libnvml()).nvmlDeviceGetThermalSettings(device::nvmlDevice_t,
+                                                           sensorIndex::Cuint,
+                                                           pThermalSettings::Ptr{nvmlGpuThermalSettings_t})::nvmlReturn_t
 end
 
 @checked function nvmlDeviceGetPerformanceState(device, pState)
     initialize_context()
-    @ccall (libnvml()).nvmlDeviceGetPerformanceState(device::nvmlDevice_t,
-                                                     pState::Ptr{nvmlPstates_t})::nvmlReturn_t
+    @gcsafe_ccall (libnvml()).nvmlDeviceGetPerformanceState(device::nvmlDevice_t,
+                                                            pState::Ptr{nvmlPstates_t})::nvmlReturn_t
 end
 
 @checked function nvmlDeviceGetCurrentClocksEventReasons(device, clocksEventReasons)
     initialize_context()
-    @ccall (libnvml()).nvmlDeviceGetCurrentClocksEventReasons(device::nvmlDevice_t,
-                                                              clocksEventReasons::Ptr{Culonglong})::nvmlReturn_t
+    @gcsafe_ccall (libnvml()).nvmlDeviceGetCurrentClocksEventReasons(device::nvmlDevice_t,
+                                                                     clocksEventReasons::Ptr{Culonglong})::nvmlReturn_t
 end
 
 @checked function nvmlDeviceGetCurrentClocksThrottleReasons(device, clocksThrottleReasons)
     initialize_context()
-    @ccall (libnvml()).nvmlDeviceGetCurrentClocksThrottleReasons(device::nvmlDevice_t,
-                                                                 clocksThrottleReasons::Ptr{Culonglong})::nvmlReturn_t
+    @gcsafe_ccall (libnvml()).nvmlDeviceGetCurrentClocksThrottleReasons(device::nvmlDevice_t,
+                                                                        clocksThrottleReasons::Ptr{Culonglong})::nvmlReturn_t
 end
 
 @checked function nvmlDeviceGetSupportedClocksEventReasons(device,
                                                            supportedClocksEventReasons)
     initialize_context()
-    @ccall (libnvml()).nvmlDeviceGetSupportedClocksEventReasons(device::nvmlDevice_t,
-                                                                supportedClocksEventReasons::Ptr{Culonglong})::nvmlReturn_t
+    @gcsafe_ccall (libnvml()).nvmlDeviceGetSupportedClocksEventReasons(device::nvmlDevice_t,
+                                                                       supportedClocksEventReasons::Ptr{Culonglong})::nvmlReturn_t
 end
 
 @checked function nvmlDeviceGetSupportedClocksThrottleReasons(device,
                                                               supportedClocksThrottleReasons)
     initialize_context()
-    @ccall (libnvml()).nvmlDeviceGetSupportedClocksThrottleReasons(device::nvmlDevice_t,
-                                                                   supportedClocksThrottleReasons::Ptr{Culonglong})::nvmlReturn_t
+    @gcsafe_ccall (libnvml()).nvmlDeviceGetSupportedClocksThrottleReasons(device::nvmlDevice_t,
+                                                                          supportedClocksThrottleReasons::Ptr{Culonglong})::nvmlReturn_t
 end
 
 @checked function nvmlDeviceGetPowerState(device, pState)
     initialize_context()
-    @ccall (libnvml()).nvmlDeviceGetPowerState(device::nvmlDevice_t,
-                                               pState::Ptr{nvmlPstates_t})::nvmlReturn_t
+    @gcsafe_ccall (libnvml()).nvmlDeviceGetPowerState(device::nvmlDevice_t,
+                                                      pState::Ptr{nvmlPstates_t})::nvmlReturn_t
 end
 
 @checked function nvmlDeviceGetDynamicPstatesInfo(device, pDynamicPstatesInfo)
     initialize_context()
-    @ccall (libnvml()).nvmlDeviceGetDynamicPstatesInfo(device::nvmlDevice_t,
-                                                       pDynamicPstatesInfo::Ptr{nvmlGpuDynamicPstatesInfo_t})::nvmlReturn_t
+    @gcsafe_ccall (libnvml()).nvmlDeviceGetDynamicPstatesInfo(device::nvmlDevice_t,
+                                                              pDynamicPstatesInfo::Ptr{nvmlGpuDynamicPstatesInfo_t})::nvmlReturn_t
 end
 
 @checked function nvmlDeviceGetMemClkVfOffset(device, offset)
     initialize_context()
-    @ccall (libnvml()).nvmlDeviceGetMemClkVfOffset(device::nvmlDevice_t,
-                                                   offset::Ptr{Cint})::nvmlReturn_t
+    @gcsafe_ccall (libnvml()).nvmlDeviceGetMemClkVfOffset(device::nvmlDevice_t,
+                                                          offset::Ptr{Cint})::nvmlReturn_t
 end
 
 @checked function nvmlDeviceGetMinMaxClockOfPState(device, type, pstate, minClockMHz,
                                                    maxClockMHz)
     initialize_context()
-    @ccall (libnvml()).nvmlDeviceGetMinMaxClockOfPState(device::nvmlDevice_t,
-                                                        type::nvmlClockType_t,
-                                                        pstate::nvmlPstates_t,
-                                                        minClockMHz::Ptr{Cuint},
-                                                        maxClockMHz::Ptr{Cuint})::nvmlReturn_t
+    @gcsafe_ccall (libnvml()).nvmlDeviceGetMinMaxClockOfPState(device::nvmlDevice_t,
+                                                               type::nvmlClockType_t,
+                                                               pstate::nvmlPstates_t,
+                                                               minClockMHz::Ptr{Cuint},
+                                                               maxClockMHz::Ptr{Cuint})::nvmlReturn_t
 end
 
 @checked function nvmlDeviceGetSupportedPerformanceStates(device, pstates, size)
     initialize_context()
-    @ccall (libnvml()).nvmlDeviceGetSupportedPerformanceStates(device::nvmlDevice_t,
-                                                               pstates::Ptr{nvmlPstates_t},
-                                                               size::Cuint)::nvmlReturn_t
+    @gcsafe_ccall (libnvml()).nvmlDeviceGetSupportedPerformanceStates(device::nvmlDevice_t,
+                                                                      pstates::Ptr{nvmlPstates_t},
+                                                                      size::Cuint)::nvmlReturn_t
 end
 
 @checked function nvmlDeviceGetGpcClkMinMaxVfOffset(device, minOffset, maxOffset)
     initialize_context()
-    @ccall (libnvml()).nvmlDeviceGetGpcClkMinMaxVfOffset(device::nvmlDevice_t,
-                                                         minOffset::Ptr{Cint},
-                                                         maxOffset::Ptr{Cint})::nvmlReturn_t
+    @gcsafe_ccall (libnvml()).nvmlDeviceGetGpcClkMinMaxVfOffset(device::nvmlDevice_t,
+                                                                minOffset::Ptr{Cint},
+                                                                maxOffset::Ptr{Cint})::nvmlReturn_t
 end
 
 @checked function nvmlDeviceGetMemClkMinMaxVfOffset(device, minOffset, maxOffset)
     initialize_context()
-    @ccall (libnvml()).nvmlDeviceGetMemClkMinMaxVfOffset(device::nvmlDevice_t,
-                                                         minOffset::Ptr{Cint},
-                                                         maxOffset::Ptr{Cint})::nvmlReturn_t
+    @gcsafe_ccall (libnvml()).nvmlDeviceGetMemClkMinMaxVfOffset(device::nvmlDevice_t,
+                                                                minOffset::Ptr{Cint},
+                                                                maxOffset::Ptr{Cint})::nvmlReturn_t
 end
 
 @checked function nvmlDeviceGetPowerManagementMode(device, mode)
     initialize_context()
-    @ccall (libnvml()).nvmlDeviceGetPowerManagementMode(device::nvmlDevice_t,
-                                                        mode::Ptr{nvmlEnableState_t})::nvmlReturn_t
+    @gcsafe_ccall (libnvml()).nvmlDeviceGetPowerManagementMode(device::nvmlDevice_t,
+                                                               mode::Ptr{nvmlEnableState_t})::nvmlReturn_t
 end
 
 @checked function nvmlDeviceGetPowerManagementLimit(device, limit)
     initialize_context()
-    @ccall (libnvml()).nvmlDeviceGetPowerManagementLimit(device::nvmlDevice_t,
-                                                         limit::Ptr{Cuint})::nvmlReturn_t
+    @gcsafe_ccall (libnvml()).nvmlDeviceGetPowerManagementLimit(device::nvmlDevice_t,
+                                                                limit::Ptr{Cuint})::nvmlReturn_t
 end
 
 @checked function nvmlDeviceGetPowerManagementLimitConstraints(device, minLimit, maxLimit)
     initialize_context()
-    @ccall (libnvml()).nvmlDeviceGetPowerManagementLimitConstraints(device::nvmlDevice_t,
-                                                                    minLimit::Ptr{Cuint},
-                                                                    maxLimit::Ptr{Cuint})::nvmlReturn_t
+    @gcsafe_ccall (libnvml()).nvmlDeviceGetPowerManagementLimitConstraints(device::nvmlDevice_t,
+                                                                           minLimit::Ptr{Cuint},
+                                                                           maxLimit::Ptr{Cuint})::nvmlReturn_t
 end
 
 @checked function nvmlDeviceGetPowerManagementDefaultLimit(device, defaultLimit)
     initialize_context()
-    @ccall (libnvml()).nvmlDeviceGetPowerManagementDefaultLimit(device::nvmlDevice_t,
-                                                                defaultLimit::Ptr{Cuint})::nvmlReturn_t
+    @gcsafe_ccall (libnvml()).nvmlDeviceGetPowerManagementDefaultLimit(device::nvmlDevice_t,
+                                                                       defaultLimit::Ptr{Cuint})::nvmlReturn_t
 end
 
 @checked function nvmlDeviceGetPowerUsage(device, power)
     initialize_context()
-    @ccall (libnvml()).nvmlDeviceGetPowerUsage(device::nvmlDevice_t,
-                                               power::Ptr{Cuint})::nvmlReturn_t
+    @gcsafe_ccall (libnvml()).nvmlDeviceGetPowerUsage(device::nvmlDevice_t,
+                                                      power::Ptr{Cuint})::nvmlReturn_t
 end
 
 @checked function nvmlDeviceGetTotalEnergyConsumption(device, energy)
     initialize_context()
-    @ccall (libnvml()).nvmlDeviceGetTotalEnergyConsumption(device::nvmlDevice_t,
-                                                           energy::Ptr{Culonglong})::nvmlReturn_t
+    @gcsafe_ccall (libnvml()).nvmlDeviceGetTotalEnergyConsumption(device::nvmlDevice_t,
+                                                                  energy::Ptr{Culonglong})::nvmlReturn_t
 end
 
 @checked function nvmlDeviceGetEnforcedPowerLimit(device, limit)
     initialize_context()
-    @ccall (libnvml()).nvmlDeviceGetEnforcedPowerLimit(device::nvmlDevice_t,
-                                                       limit::Ptr{Cuint})::nvmlReturn_t
+    @gcsafe_ccall (libnvml()).nvmlDeviceGetEnforcedPowerLimit(device::nvmlDevice_t,
+                                                              limit::Ptr{Cuint})::nvmlReturn_t
 end
 
 @checked function nvmlDeviceGetGpuOperationMode(device, current, pending)
     initialize_context()
-    @ccall (libnvml()).nvmlDeviceGetGpuOperationMode(device::nvmlDevice_t,
-                                                     current::Ptr{nvmlGpuOperationMode_t},
-                                                     pending::Ptr{nvmlGpuOperationMode_t})::nvmlReturn_t
+    @gcsafe_ccall (libnvml()).nvmlDeviceGetGpuOperationMode(device::nvmlDevice_t,
+                                                            current::Ptr{nvmlGpuOperationMode_t},
+                                                            pending::Ptr{nvmlGpuOperationMode_t})::nvmlReturn_t
 end
 
 @checked function nvmlDeviceGetMemoryInfo(device, memory)
     initialize_context()
-    @ccall (libnvml()).nvmlDeviceGetMemoryInfo(device::nvmlDevice_t,
-                                               memory::Ptr{nvmlMemory_t})::nvmlReturn_t
+    @gcsafe_ccall (libnvml()).nvmlDeviceGetMemoryInfo(device::nvmlDevice_t,
+                                                      memory::Ptr{nvmlMemory_t})::nvmlReturn_t
 end
 
 @checked function nvmlDeviceGetMemoryInfo_v2(device, memory)
     initialize_context()
-    @ccall (libnvml()).nvmlDeviceGetMemoryInfo_v2(device::nvmlDevice_t,
-                                                  memory::Ptr{nvmlMemory_v2_t})::nvmlReturn_t
+    @gcsafe_ccall (libnvml()).nvmlDeviceGetMemoryInfo_v2(device::nvmlDevice_t,
+                                                         memory::Ptr{nvmlMemory_v2_t})::nvmlReturn_t
 end
 
 @checked function nvmlDeviceGetComputeMode(device, mode)
     initialize_context()
-    @ccall (libnvml()).nvmlDeviceGetComputeMode(device::nvmlDevice_t,
-                                                mode::Ptr{nvmlComputeMode_t})::nvmlReturn_t
+    @gcsafe_ccall (libnvml()).nvmlDeviceGetComputeMode(device::nvmlDevice_t,
+                                                       mode::Ptr{nvmlComputeMode_t})::nvmlReturn_t
 end
 
 @checked function nvmlDeviceGetCudaComputeCapability(device, major, minor)
     initialize_context()
-    @ccall (libnvml()).nvmlDeviceGetCudaComputeCapability(device::nvmlDevice_t,
-                                                          major::Ptr{Cint},
-                                                          minor::Ptr{Cint})::nvmlReturn_t
+    @gcsafe_ccall (libnvml()).nvmlDeviceGetCudaComputeCapability(device::nvmlDevice_t,
+                                                                 major::Ptr{Cint},
+                                                                 minor::Ptr{Cint})::nvmlReturn_t
 end
 
 @checked function nvmlDeviceGetEccMode(device, current, pending)
     initialize_context()
-    @ccall (libnvml()).nvmlDeviceGetEccMode(device::nvmlDevice_t,
-                                            current::Ptr{nvmlEnableState_t},
-                                            pending::Ptr{nvmlEnableState_t})::nvmlReturn_t
+    @gcsafe_ccall (libnvml()).nvmlDeviceGetEccMode(device::nvmlDevice_t,
+                                                   current::Ptr{nvmlEnableState_t},
+                                                   pending::Ptr{nvmlEnableState_t})::nvmlReturn_t
 end
 
 @checked function nvmlDeviceGetDefaultEccMode(device, defaultMode)
     initialize_context()
-    @ccall (libnvml()).nvmlDeviceGetDefaultEccMode(device::nvmlDevice_t,
-                                                   defaultMode::Ptr{nvmlEnableState_t})::nvmlReturn_t
+    @gcsafe_ccall (libnvml()).nvmlDeviceGetDefaultEccMode(device::nvmlDevice_t,
+                                                          defaultMode::Ptr{nvmlEnableState_t})::nvmlReturn_t
 end
 
 @checked function nvmlDeviceGetBoardId(device, boardId)
     initialize_context()
-    @ccall (libnvml()).nvmlDeviceGetBoardId(device::nvmlDevice_t,
-                                            boardId::Ptr{Cuint})::nvmlReturn_t
+    @gcsafe_ccall (libnvml()).nvmlDeviceGetBoardId(device::nvmlDevice_t,
+                                                   boardId::Ptr{Cuint})::nvmlReturn_t
 end
 
 @checked function nvmlDeviceGetMultiGpuBoard(device, multiGpuBool)
     initialize_context()
-    @ccall (libnvml()).nvmlDeviceGetMultiGpuBoard(device::nvmlDevice_t,
-                                                  multiGpuBool::Ptr{Cuint})::nvmlReturn_t
+    @gcsafe_ccall (libnvml()).nvmlDeviceGetMultiGpuBoard(device::nvmlDevice_t,
+                                                         multiGpuBool::Ptr{Cuint})::nvmlReturn_t
 end
 
 @checked function nvmlDeviceGetTotalEccErrors(device, errorType, counterType, eccCounts)
     initialize_context()
-    @ccall (libnvml()).nvmlDeviceGetTotalEccErrors(device::nvmlDevice_t,
-                                                   errorType::nvmlMemoryErrorType_t,
-                                                   counterType::nvmlEccCounterType_t,
-                                                   eccCounts::Ptr{Culonglong})::nvmlReturn_t
+    @gcsafe_ccall (libnvml()).nvmlDeviceGetTotalEccErrors(device::nvmlDevice_t,
+                                                          errorType::nvmlMemoryErrorType_t,
+                                                          counterType::nvmlEccCounterType_t,
+                                                          eccCounts::Ptr{Culonglong})::nvmlReturn_t
 end
 
 @checked function nvmlDeviceGetDetailedEccErrors(device, errorType, counterType, eccCounts)
     initialize_context()
-    @ccall (libnvml()).nvmlDeviceGetDetailedEccErrors(device::nvmlDevice_t,
-                                                      errorType::nvmlMemoryErrorType_t,
-                                                      counterType::nvmlEccCounterType_t,
-                                                      eccCounts::Ptr{nvmlEccErrorCounts_t})::nvmlReturn_t
+    @gcsafe_ccall (libnvml()).nvmlDeviceGetDetailedEccErrors(device::nvmlDevice_t,
+                                                             errorType::nvmlMemoryErrorType_t,
+                                                             counterType::nvmlEccCounterType_t,
+                                                             eccCounts::Ptr{nvmlEccErrorCounts_t})::nvmlReturn_t
 end
 
 @checked function nvmlDeviceGetMemoryErrorCounter(device, errorType, counterType,
                                                   locationType, count)
     initialize_context()
-    @ccall (libnvml()).nvmlDeviceGetMemoryErrorCounter(device::nvmlDevice_t,
-                                                       errorType::nvmlMemoryErrorType_t,
-                                                       counterType::nvmlEccCounterType_t,
-                                                       locationType::nvmlMemoryLocation_t,
-                                                       count::Ptr{Culonglong})::nvmlReturn_t
+    @gcsafe_ccall (libnvml()).nvmlDeviceGetMemoryErrorCounter(device::nvmlDevice_t,
+                                                              errorType::nvmlMemoryErrorType_t,
+                                                              counterType::nvmlEccCounterType_t,
+                                                              locationType::nvmlMemoryLocation_t,
+                                                              count::Ptr{Culonglong})::nvmlReturn_t
 end
 
 @checked function nvmlDeviceGetUtilizationRates(device, utilization)
     initialize_context()
-    @ccall (libnvml()).nvmlDeviceGetUtilizationRates(device::nvmlDevice_t,
-                                                     utilization::Ptr{nvmlUtilization_t})::nvmlReturn_t
+    @gcsafe_ccall (libnvml()).nvmlDeviceGetUtilizationRates(device::nvmlDevice_t,
+                                                            utilization::Ptr{nvmlUtilization_t})::nvmlReturn_t
 end
 
 @checked function nvmlDeviceGetEncoderUtilization(device, utilization, samplingPeriodUs)
     initialize_context()
-    @ccall (libnvml()).nvmlDeviceGetEncoderUtilization(device::nvmlDevice_t,
-                                                       utilization::Ptr{Cuint},
-                                                       samplingPeriodUs::Ptr{Cuint})::nvmlReturn_t
+    @gcsafe_ccall (libnvml()).nvmlDeviceGetEncoderUtilization(device::nvmlDevice_t,
+                                                              utilization::Ptr{Cuint},
+                                                              samplingPeriodUs::Ptr{Cuint})::nvmlReturn_t
 end
 
 @checked function nvmlDeviceGetEncoderCapacity(device, encoderQueryType, encoderCapacity)
     initialize_context()
-    @ccall (libnvml()).nvmlDeviceGetEncoderCapacity(device::nvmlDevice_t,
-                                                    encoderQueryType::nvmlEncoderType_t,
-                                                    encoderCapacity::Ptr{Cuint})::nvmlReturn_t
+    @gcsafe_ccall (libnvml()).nvmlDeviceGetEncoderCapacity(device::nvmlDevice_t,
+                                                           encoderQueryType::nvmlEncoderType_t,
+                                                           encoderCapacity::Ptr{Cuint})::nvmlReturn_t
 end
 
 @checked function nvmlDeviceGetEncoderStats(device, sessionCount, averageFps,
                                             averageLatency)
     initialize_context()
-    @ccall (libnvml()).nvmlDeviceGetEncoderStats(device::nvmlDevice_t,
-                                                 sessionCount::Ptr{Cuint},
-                                                 averageFps::Ptr{Cuint},
-                                                 averageLatency::Ptr{Cuint})::nvmlReturn_t
+    @gcsafe_ccall (libnvml()).nvmlDeviceGetEncoderStats(device::nvmlDevice_t,
+                                                        sessionCount::Ptr{Cuint},
+                                                        averageFps::Ptr{Cuint},
+                                                        averageLatency::Ptr{Cuint})::nvmlReturn_t
 end
 
 @checked function nvmlDeviceGetEncoderSessions(device, sessionCount, sessionInfos)
     initialize_context()
-    @ccall (libnvml()).nvmlDeviceGetEncoderSessions(device::nvmlDevice_t,
-                                                    sessionCount::Ptr{Cuint},
-                                                    sessionInfos::Ptr{nvmlEncoderSessionInfo_t})::nvmlReturn_t
+    @gcsafe_ccall (libnvml()).nvmlDeviceGetEncoderSessions(device::nvmlDevice_t,
+                                                           sessionCount::Ptr{Cuint},
+                                                           sessionInfos::Ptr{nvmlEncoderSessionInfo_t})::nvmlReturn_t
 end
 
 @checked function nvmlDeviceGetDecoderUtilization(device, utilization, samplingPeriodUs)
     initialize_context()
-    @ccall (libnvml()).nvmlDeviceGetDecoderUtilization(device::nvmlDevice_t,
-                                                       utilization::Ptr{Cuint},
-                                                       samplingPeriodUs::Ptr{Cuint})::nvmlReturn_t
+    @gcsafe_ccall (libnvml()).nvmlDeviceGetDecoderUtilization(device::nvmlDevice_t,
+                                                              utilization::Ptr{Cuint},
+                                                              samplingPeriodUs::Ptr{Cuint})::nvmlReturn_t
 end
 
 @checked function nvmlDeviceGetJpgUtilization(device, utilization, samplingPeriodUs)
     initialize_context()
-    @ccall (libnvml()).nvmlDeviceGetJpgUtilization(device::nvmlDevice_t,
-                                                   utilization::Ptr{Cuint},
-                                                   samplingPeriodUs::Ptr{Cuint})::nvmlReturn_t
+    @gcsafe_ccall (libnvml()).nvmlDeviceGetJpgUtilization(device::nvmlDevice_t,
+                                                          utilization::Ptr{Cuint},
+                                                          samplingPeriodUs::Ptr{Cuint})::nvmlReturn_t
 end
 
 @checked function nvmlDeviceGetOfaUtilization(device, utilization, samplingPeriodUs)
     initialize_context()
-    @ccall (libnvml()).nvmlDeviceGetOfaUtilization(device::nvmlDevice_t,
-                                                   utilization::Ptr{Cuint},
-                                                   samplingPeriodUs::Ptr{Cuint})::nvmlReturn_t
+    @gcsafe_ccall (libnvml()).nvmlDeviceGetOfaUtilization(device::nvmlDevice_t,
+                                                          utilization::Ptr{Cuint},
+                                                          samplingPeriodUs::Ptr{Cuint})::nvmlReturn_t
 end
 
 @checked function nvmlDeviceGetFBCStats(device, fbcStats)
     initialize_context()
-    @ccall (libnvml()).nvmlDeviceGetFBCStats(device::nvmlDevice_t,
-                                             fbcStats::Ptr{nvmlFBCStats_t})::nvmlReturn_t
+    @gcsafe_ccall (libnvml()).nvmlDeviceGetFBCStats(device::nvmlDevice_t,
+                                                    fbcStats::Ptr{nvmlFBCStats_t})::nvmlReturn_t
 end
 
 @checked function nvmlDeviceGetFBCSessions(device, sessionCount, sessionInfo)
     initialize_context()
-    @ccall (libnvml()).nvmlDeviceGetFBCSessions(device::nvmlDevice_t,
-                                                sessionCount::Ptr{Cuint},
-                                                sessionInfo::Ptr{nvmlFBCSessionInfo_t})::nvmlReturn_t
+    @gcsafe_ccall (libnvml()).nvmlDeviceGetFBCSessions(device::nvmlDevice_t,
+                                                       sessionCount::Ptr{Cuint},
+                                                       sessionInfo::Ptr{nvmlFBCSessionInfo_t})::nvmlReturn_t
 end
 
 @checked function nvmlDeviceGetDriverModel(device, current, pending)
     initialize_context()
-    @ccall (libnvml()).nvmlDeviceGetDriverModel(device::nvmlDevice_t,
-                                                current::Ptr{nvmlDriverModel_t},
-                                                pending::Ptr{nvmlDriverModel_t})::nvmlReturn_t
+    @gcsafe_ccall (libnvml()).nvmlDeviceGetDriverModel(device::nvmlDevice_t,
+                                                       current::Ptr{nvmlDriverModel_t},
+                                                       pending::Ptr{nvmlDriverModel_t})::nvmlReturn_t
 end
 
 @checked function nvmlDeviceGetVbiosVersion(device, version, length)
     initialize_context()
-    @ccall (libnvml()).nvmlDeviceGetVbiosVersion(device::nvmlDevice_t, version::Cstring,
-                                                 length::Cuint)::nvmlReturn_t
+    @gcsafe_ccall (libnvml()).nvmlDeviceGetVbiosVersion(device::nvmlDevice_t,
+                                                        version::Cstring,
+                                                        length::Cuint)::nvmlReturn_t
 end
 
 @checked function nvmlDeviceGetBridgeChipInfo(device, bridgeHierarchy)
     initialize_context()
-    @ccall (libnvml()).nvmlDeviceGetBridgeChipInfo(device::nvmlDevice_t,
-                                                   bridgeHierarchy::Ptr{nvmlBridgeChipHierarchy_t})::nvmlReturn_t
+    @gcsafe_ccall (libnvml()).nvmlDeviceGetBridgeChipInfo(device::nvmlDevice_t,
+                                                          bridgeHierarchy::Ptr{nvmlBridgeChipHierarchy_t})::nvmlReturn_t
 end
 
 @checked function nvmlDeviceGetRunningProcessDetailList(device, plist)
     initialize_context()
-    @ccall (libnvml()).nvmlDeviceGetRunningProcessDetailList(device::nvmlDevice_t,
-                                                             plist::Ptr{nvmlProcessDetailList_t})::nvmlReturn_t
+    @gcsafe_ccall (libnvml()).nvmlDeviceGetRunningProcessDetailList(device::nvmlDevice_t,
+                                                                    plist::Ptr{nvmlProcessDetailList_t})::nvmlReturn_t
 end
 
 @checked function nvmlDeviceOnSameBoard(device1, device2, onSameBoard)
     initialize_context()
-    @ccall (libnvml()).nvmlDeviceOnSameBoard(device1::nvmlDevice_t, device2::nvmlDevice_t,
-                                             onSameBoard::Ptr{Cint})::nvmlReturn_t
+    @gcsafe_ccall (libnvml()).nvmlDeviceOnSameBoard(device1::nvmlDevice_t,
+                                                    device2::nvmlDevice_t,
+                                                    onSameBoard::Ptr{Cint})::nvmlReturn_t
 end
 
 @checked function nvmlDeviceGetAPIRestriction(device, apiType, isRestricted)
     initialize_context()
-    @ccall (libnvml()).nvmlDeviceGetAPIRestriction(device::nvmlDevice_t,
-                                                   apiType::nvmlRestrictedAPI_t,
-                                                   isRestricted::Ptr{nvmlEnableState_t})::nvmlReturn_t
+    @gcsafe_ccall (libnvml()).nvmlDeviceGetAPIRestriction(device::nvmlDevice_t,
+                                                          apiType::nvmlRestrictedAPI_t,
+                                                          isRestricted::Ptr{nvmlEnableState_t})::nvmlReturn_t
 end
 
 @checked function nvmlDeviceGetSamples(device, type, lastSeenTimeStamp, sampleValType,
                                        sampleCount, samples)
     initialize_context()
-    @ccall (libnvml()).nvmlDeviceGetSamples(device::nvmlDevice_t, type::nvmlSamplingType_t,
-                                            lastSeenTimeStamp::Culonglong,
-                                            sampleValType::Ptr{nvmlValueType_t},
-                                            sampleCount::Ptr{Cuint},
-                                            samples::Ptr{nvmlSample_t})::nvmlReturn_t
+    @gcsafe_ccall (libnvml()).nvmlDeviceGetSamples(device::nvmlDevice_t,
+                                                   type::nvmlSamplingType_t,
+                                                   lastSeenTimeStamp::Culonglong,
+                                                   sampleValType::Ptr{nvmlValueType_t},
+                                                   sampleCount::Ptr{Cuint},
+                                                   samples::Ptr{nvmlSample_t})::nvmlReturn_t
 end
 
 @checked function nvmlDeviceGetBAR1MemoryInfo(device, bar1Memory)
     initialize_context()
-    @ccall (libnvml()).nvmlDeviceGetBAR1MemoryInfo(device::nvmlDevice_t,
-                                                   bar1Memory::Ptr{nvmlBAR1Memory_t})::nvmlReturn_t
+    @gcsafe_ccall (libnvml()).nvmlDeviceGetBAR1MemoryInfo(device::nvmlDevice_t,
+                                                          bar1Memory::Ptr{nvmlBAR1Memory_t})::nvmlReturn_t
 end
 
 @checked function nvmlDeviceGetViolationStatus(device, perfPolicyType, violTime)
     initialize_context()
-    @ccall (libnvml()).nvmlDeviceGetViolationStatus(device::nvmlDevice_t,
-                                                    perfPolicyType::nvmlPerfPolicyType_t,
-                                                    violTime::Ptr{nvmlViolationTime_t})::nvmlReturn_t
+    @gcsafe_ccall (libnvml()).nvmlDeviceGetViolationStatus(device::nvmlDevice_t,
+                                                           perfPolicyType::nvmlPerfPolicyType_t,
+                                                           violTime::Ptr{nvmlViolationTime_t})::nvmlReturn_t
 end
 
 @checked function nvmlDeviceGetIrqNum(device, irqNum)
     initialize_context()
-    @ccall (libnvml()).nvmlDeviceGetIrqNum(device::nvmlDevice_t,
-                                           irqNum::Ptr{Cuint})::nvmlReturn_t
+    @gcsafe_ccall (libnvml()).nvmlDeviceGetIrqNum(device::nvmlDevice_t,
+                                                  irqNum::Ptr{Cuint})::nvmlReturn_t
 end
 
 @checked function nvmlDeviceGetNumGpuCores(device, numCores)
     initialize_context()
-    @ccall (libnvml()).nvmlDeviceGetNumGpuCores(device::nvmlDevice_t,
-                                                numCores::Ptr{Cuint})::nvmlReturn_t
+    @gcsafe_ccall (libnvml()).nvmlDeviceGetNumGpuCores(device::nvmlDevice_t,
+                                                       numCores::Ptr{Cuint})::nvmlReturn_t
 end
 
 @checked function nvmlDeviceGetPowerSource(device, powerSource)
     initialize_context()
-    @ccall (libnvml()).nvmlDeviceGetPowerSource(device::nvmlDevice_t,
-                                                powerSource::Ptr{nvmlPowerSource_t})::nvmlReturn_t
+    @gcsafe_ccall (libnvml()).nvmlDeviceGetPowerSource(device::nvmlDevice_t,
+                                                       powerSource::Ptr{nvmlPowerSource_t})::nvmlReturn_t
 end
 
 @checked function nvmlDeviceGetMemoryBusWidth(device, busWidth)
     initialize_context()
-    @ccall (libnvml()).nvmlDeviceGetMemoryBusWidth(device::nvmlDevice_t,
-                                                   busWidth::Ptr{Cuint})::nvmlReturn_t
+    @gcsafe_ccall (libnvml()).nvmlDeviceGetMemoryBusWidth(device::nvmlDevice_t,
+                                                          busWidth::Ptr{Cuint})::nvmlReturn_t
 end
 
 @checked function nvmlDeviceGetPcieLinkMaxSpeed(device, maxSpeed)
     initialize_context()
-    @ccall (libnvml()).nvmlDeviceGetPcieLinkMaxSpeed(device::nvmlDevice_t,
-                                                     maxSpeed::Ptr{Cuint})::nvmlReturn_t
+    @gcsafe_ccall (libnvml()).nvmlDeviceGetPcieLinkMaxSpeed(device::nvmlDevice_t,
+                                                            maxSpeed::Ptr{Cuint})::nvmlReturn_t
 end
 
 @checked function nvmlDeviceGetPcieSpeed(device, pcieSpeed)
     initialize_context()
-    @ccall (libnvml()).nvmlDeviceGetPcieSpeed(device::nvmlDevice_t,
-                                              pcieSpeed::Ptr{Cuint})::nvmlReturn_t
+    @gcsafe_ccall (libnvml()).nvmlDeviceGetPcieSpeed(device::nvmlDevice_t,
+                                                     pcieSpeed::Ptr{Cuint})::nvmlReturn_t
 end
 
 @checked function nvmlDeviceGetAdaptiveClockInfoStatus(device, adaptiveClockStatus)
     initialize_context()
-    @ccall (libnvml()).nvmlDeviceGetAdaptiveClockInfoStatus(device::nvmlDevice_t,
-                                                            adaptiveClockStatus::Ptr{Cuint})::nvmlReturn_t
+    @gcsafe_ccall (libnvml()).nvmlDeviceGetAdaptiveClockInfoStatus(device::nvmlDevice_t,
+                                                                   adaptiveClockStatus::Ptr{Cuint})::nvmlReturn_t
 end
 
 @checked function nvmlDeviceGetBusType(device, type)
     initialize_context()
-    @ccall (libnvml()).nvmlDeviceGetBusType(device::nvmlDevice_t,
-                                            type::Ptr{nvmlBusType_t})::nvmlReturn_t
+    @gcsafe_ccall (libnvml()).nvmlDeviceGetBusType(device::nvmlDevice_t,
+                                                   type::Ptr{nvmlBusType_t})::nvmlReturn_t
 end
 
 @checked function nvmlDeviceGetGpuFabricInfo(device, gpuFabricInfo)
     initialize_context()
-    @ccall (libnvml()).nvmlDeviceGetGpuFabricInfo(device::nvmlDevice_t,
-                                                  gpuFabricInfo::Ptr{nvmlGpuFabricInfo_t})::nvmlReturn_t
+    @gcsafe_ccall (libnvml()).nvmlDeviceGetGpuFabricInfo(device::nvmlDevice_t,
+                                                         gpuFabricInfo::Ptr{nvmlGpuFabricInfo_t})::nvmlReturn_t
 end
 
 @checked function nvmlSystemGetConfComputeCapabilities(capabilities)
     initialize_context()
-    @ccall (libnvml()).nvmlSystemGetConfComputeCapabilities(capabilities::Ptr{nvmlConfComputeSystemCaps_t})::nvmlReturn_t
+    @gcsafe_ccall (libnvml()).nvmlSystemGetConfComputeCapabilities(capabilities::Ptr{nvmlConfComputeSystemCaps_t})::nvmlReturn_t
 end
 
 @checked function nvmlSystemGetConfComputeState(state)
     initialize_context()
-    @ccall (libnvml()).nvmlSystemGetConfComputeState(state::Ptr{nvmlConfComputeSystemState_t})::nvmlReturn_t
+    @gcsafe_ccall (libnvml()).nvmlSystemGetConfComputeState(state::Ptr{nvmlConfComputeSystemState_t})::nvmlReturn_t
 end
 
 @checked function nvmlDeviceGetConfComputeMemSizeInfo(device, memInfo)
     initialize_context()
-    @ccall (libnvml()).nvmlDeviceGetConfComputeMemSizeInfo(device::nvmlDevice_t,
-                                                           memInfo::Ptr{nvmlConfComputeMemSizeInfo_t})::nvmlReturn_t
+    @gcsafe_ccall (libnvml()).nvmlDeviceGetConfComputeMemSizeInfo(device::nvmlDevice_t,
+                                                                  memInfo::Ptr{nvmlConfComputeMemSizeInfo_t})::nvmlReturn_t
 end
 
 @checked function nvmlSystemGetConfComputeGpusReadyState(isAcceptingWork)
     initialize_context()
-    @ccall (libnvml()).nvmlSystemGetConfComputeGpusReadyState(isAcceptingWork::Ptr{Cuint})::nvmlReturn_t
+    @gcsafe_ccall (libnvml()).nvmlSystemGetConfComputeGpusReadyState(isAcceptingWork::Ptr{Cuint})::nvmlReturn_t
 end
 
 @checked function nvmlDeviceGetConfComputeProtectedMemoryUsage(device, memory)
     initialize_context()
-    @ccall (libnvml()).nvmlDeviceGetConfComputeProtectedMemoryUsage(device::nvmlDevice_t,
-                                                                    memory::Ptr{nvmlMemory_t})::nvmlReturn_t
+    @gcsafe_ccall (libnvml()).nvmlDeviceGetConfComputeProtectedMemoryUsage(device::nvmlDevice_t,
+                                                                           memory::Ptr{nvmlMemory_t})::nvmlReturn_t
 end
 
 @checked function nvmlDeviceGetConfComputeGpuCertificate(device, gpuCert)
     initialize_context()
-    @ccall (libnvml()).nvmlDeviceGetConfComputeGpuCertificate(device::nvmlDevice_t,
-                                                              gpuCert::Ptr{nvmlConfComputeGpuCertificate_t})::nvmlReturn_t
+    @gcsafe_ccall (libnvml()).nvmlDeviceGetConfComputeGpuCertificate(device::nvmlDevice_t,
+                                                                     gpuCert::Ptr{nvmlConfComputeGpuCertificate_t})::nvmlReturn_t
 end
 
 @checked function nvmlDeviceGetConfComputeGpuAttestationReport(device, gpuAtstReport)
     initialize_context()
-    @ccall (libnvml()).nvmlDeviceGetConfComputeGpuAttestationReport(device::nvmlDevice_t,
-                                                                    gpuAtstReport::Ptr{nvmlConfComputeGpuAttestationReport_t})::nvmlReturn_t
+    @gcsafe_ccall (libnvml()).nvmlDeviceGetConfComputeGpuAttestationReport(device::nvmlDevice_t,
+                                                                           gpuAtstReport::Ptr{nvmlConfComputeGpuAttestationReport_t})::nvmlReturn_t
 end
 
 @checked function nvmlDeviceGetGspFirmwareVersion(device, version)
     initialize_context()
-    @ccall (libnvml()).nvmlDeviceGetGspFirmwareVersion(device::nvmlDevice_t,
-                                                       version::Cstring)::nvmlReturn_t
+    @gcsafe_ccall (libnvml()).nvmlDeviceGetGspFirmwareVersion(device::nvmlDevice_t,
+                                                              version::Cstring)::nvmlReturn_t
 end
 
 @checked function nvmlDeviceGetGspFirmwareMode(device, isEnabled, defaultMode)
     initialize_context()
-    @ccall (libnvml()).nvmlDeviceGetGspFirmwareMode(device::nvmlDevice_t,
-                                                    isEnabled::Ptr{Cuint},
-                                                    defaultMode::Ptr{Cuint})::nvmlReturn_t
+    @gcsafe_ccall (libnvml()).nvmlDeviceGetGspFirmwareMode(device::nvmlDevice_t,
+                                                           isEnabled::Ptr{Cuint},
+                                                           defaultMode::Ptr{Cuint})::nvmlReturn_t
 end
 
 @checked function nvmlDeviceGetAccountingMode(device, mode)
     initialize_context()
-    @ccall (libnvml()).nvmlDeviceGetAccountingMode(device::nvmlDevice_t,
-                                                   mode::Ptr{nvmlEnableState_t})::nvmlReturn_t
+    @gcsafe_ccall (libnvml()).nvmlDeviceGetAccountingMode(device::nvmlDevice_t,
+                                                          mode::Ptr{nvmlEnableState_t})::nvmlReturn_t
 end
 
 @checked function nvmlDeviceGetAccountingStats(device, pid, stats)
     initialize_context()
-    @ccall (libnvml()).nvmlDeviceGetAccountingStats(device::nvmlDevice_t, pid::Cuint,
-                                                    stats::Ptr{nvmlAccountingStats_t})::nvmlReturn_t
+    @gcsafe_ccall (libnvml()).nvmlDeviceGetAccountingStats(device::nvmlDevice_t, pid::Cuint,
+                                                           stats::Ptr{nvmlAccountingStats_t})::nvmlReturn_t
 end
 
 @checked function nvmlDeviceGetAccountingPids(device, count, pids)
     initialize_context()
-    @ccall (libnvml()).nvmlDeviceGetAccountingPids(device::nvmlDevice_t, count::Ptr{Cuint},
-                                                   pids::Ptr{Cuint})::nvmlReturn_t
+    @gcsafe_ccall (libnvml()).nvmlDeviceGetAccountingPids(device::nvmlDevice_t,
+                                                          count::Ptr{Cuint},
+                                                          pids::Ptr{Cuint})::nvmlReturn_t
 end
 
 @checked function nvmlDeviceGetAccountingBufferSize(device, bufferSize)
     initialize_context()
-    @ccall (libnvml()).nvmlDeviceGetAccountingBufferSize(device::nvmlDevice_t,
-                                                         bufferSize::Ptr{Cuint})::nvmlReturn_t
+    @gcsafe_ccall (libnvml()).nvmlDeviceGetAccountingBufferSize(device::nvmlDevice_t,
+                                                                bufferSize::Ptr{Cuint})::nvmlReturn_t
 end
 
 @checked function nvmlDeviceGetRetiredPages(device, cause, pageCount, addresses)
     initialize_context()
-    @ccall (libnvml()).nvmlDeviceGetRetiredPages(device::nvmlDevice_t,
-                                                 cause::nvmlPageRetirementCause_t,
-                                                 pageCount::Ptr{Cuint},
-                                                 addresses::Ptr{Culonglong})::nvmlReturn_t
+    @gcsafe_ccall (libnvml()).nvmlDeviceGetRetiredPages(device::nvmlDevice_t,
+                                                        cause::nvmlPageRetirementCause_t,
+                                                        pageCount::Ptr{Cuint},
+                                                        addresses::Ptr{Culonglong})::nvmlReturn_t
 end
 
 @checked function nvmlDeviceGetRetiredPages_v2(device, cause, pageCount, addresses,
                                                timestamps)
     initialize_context()
-    @ccall (libnvml()).nvmlDeviceGetRetiredPages_v2(device::nvmlDevice_t,
-                                                    cause::nvmlPageRetirementCause_t,
-                                                    pageCount::Ptr{Cuint},
-                                                    addresses::Ptr{Culonglong},
-                                                    timestamps::Ptr{Culonglong})::nvmlReturn_t
+    @gcsafe_ccall (libnvml()).nvmlDeviceGetRetiredPages_v2(device::nvmlDevice_t,
+                                                           cause::nvmlPageRetirementCause_t,
+                                                           pageCount::Ptr{Cuint},
+                                                           addresses::Ptr{Culonglong},
+                                                           timestamps::Ptr{Culonglong})::nvmlReturn_t
 end
 
 @checked function nvmlDeviceGetRetiredPagesPendingStatus(device, isPending)
     initialize_context()
-    @ccall (libnvml()).nvmlDeviceGetRetiredPagesPendingStatus(device::nvmlDevice_t,
-                                                              isPending::Ptr{nvmlEnableState_t})::nvmlReturn_t
+    @gcsafe_ccall (libnvml()).nvmlDeviceGetRetiredPagesPendingStatus(device::nvmlDevice_t,
+                                                                     isPending::Ptr{nvmlEnableState_t})::nvmlReturn_t
 end
 
 @checked function nvmlDeviceGetRemappedRows(device, corrRows, uncRows, isPending,
                                             failureOccurred)
     initialize_context()
-    @ccall (libnvml()).nvmlDeviceGetRemappedRows(device::nvmlDevice_t, corrRows::Ptr{Cuint},
-                                                 uncRows::Ptr{Cuint}, isPending::Ptr{Cuint},
-                                                 failureOccurred::Ptr{Cuint})::nvmlReturn_t
+    @gcsafe_ccall (libnvml()).nvmlDeviceGetRemappedRows(device::nvmlDevice_t,
+                                                        corrRows::Ptr{Cuint},
+                                                        uncRows::Ptr{Cuint},
+                                                        isPending::Ptr{Cuint},
+                                                        failureOccurred::Ptr{Cuint})::nvmlReturn_t
 end
 
 @checked function nvmlDeviceGetRowRemapperHistogram(device, values)
     initialize_context()
-    @ccall (libnvml()).nvmlDeviceGetRowRemapperHistogram(device::nvmlDevice_t,
-                                                         values::Ptr{nvmlRowRemapperHistogramValues_t})::nvmlReturn_t
+    @gcsafe_ccall (libnvml()).nvmlDeviceGetRowRemapperHistogram(device::nvmlDevice_t,
+                                                                values::Ptr{nvmlRowRemapperHistogramValues_t})::nvmlReturn_t
 end
 
 @checked function nvmlDeviceGetArchitecture(device, arch)
     initialize_context()
-    @ccall (libnvml()).nvmlDeviceGetArchitecture(device::nvmlDevice_t,
-                                                 arch::Ptr{nvmlDeviceArchitecture_t})::nvmlReturn_t
+    @gcsafe_ccall (libnvml()).nvmlDeviceGetArchitecture(device::nvmlDevice_t,
+                                                        arch::Ptr{nvmlDeviceArchitecture_t})::nvmlReturn_t
 end
 
 @checked function nvmlDeviceGetClkMonStatus(device, status)
     initialize_context()
-    @ccall (libnvml()).nvmlDeviceGetClkMonStatus(device::nvmlDevice_t,
-                                                 status::Ptr{nvmlClkMonStatus_t})::nvmlReturn_t
+    @gcsafe_ccall (libnvml()).nvmlDeviceGetClkMonStatus(device::nvmlDevice_t,
+                                                        status::Ptr{nvmlClkMonStatus_t})::nvmlReturn_t
 end
 
 @checked function nvmlDeviceGetProcessUtilization(device, utilization, processSamplesCount,
                                                   lastSeenTimeStamp)
     initialize_context()
-    @ccall (libnvml()).nvmlDeviceGetProcessUtilization(device::nvmlDevice_t,
-                                                       utilization::Ptr{nvmlProcessUtilizationSample_t},
-                                                       processSamplesCount::Ptr{Cuint},
-                                                       lastSeenTimeStamp::Culonglong)::nvmlReturn_t
+    @gcsafe_ccall (libnvml()).nvmlDeviceGetProcessUtilization(device::nvmlDevice_t,
+                                                              utilization::Ptr{nvmlProcessUtilizationSample_t},
+                                                              processSamplesCount::Ptr{Cuint},
+                                                              lastSeenTimeStamp::Culonglong)::nvmlReturn_t
 end
 
 @checked function nvmlUnitSetLedState(unit, color)
     initialize_context()
-    @ccall (libnvml()).nvmlUnitSetLedState(unit::nvmlUnit_t,
-                                           color::nvmlLedColor_t)::nvmlReturn_t
+    @gcsafe_ccall (libnvml()).nvmlUnitSetLedState(unit::nvmlUnit_t,
+                                                  color::nvmlLedColor_t)::nvmlReturn_t
 end
 
 @checked function nvmlDeviceSetPersistenceMode(device, mode)
     initialize_context()
-    @ccall (libnvml()).nvmlDeviceSetPersistenceMode(device::nvmlDevice_t,
-                                                    mode::nvmlEnableState_t)::nvmlReturn_t
+    @gcsafe_ccall (libnvml()).nvmlDeviceSetPersistenceMode(device::nvmlDevice_t,
+                                                           mode::nvmlEnableState_t)::nvmlReturn_t
 end
 
 @checked function nvmlDeviceSetComputeMode(device, mode)
     initialize_context()
-    @ccall (libnvml()).nvmlDeviceSetComputeMode(device::nvmlDevice_t,
-                                                mode::nvmlComputeMode_t)::nvmlReturn_t
+    @gcsafe_ccall (libnvml()).nvmlDeviceSetComputeMode(device::nvmlDevice_t,
+                                                       mode::nvmlComputeMode_t)::nvmlReturn_t
 end
 
 @checked function nvmlDeviceSetEccMode(device, ecc)
     initialize_context()
-    @ccall (libnvml()).nvmlDeviceSetEccMode(device::nvmlDevice_t,
-                                            ecc::nvmlEnableState_t)::nvmlReturn_t
+    @gcsafe_ccall (libnvml()).nvmlDeviceSetEccMode(device::nvmlDevice_t,
+                                                   ecc::nvmlEnableState_t)::nvmlReturn_t
 end
 
 @checked function nvmlDeviceClearEccErrorCounts(device, counterType)
     initialize_context()
-    @ccall (libnvml()).nvmlDeviceClearEccErrorCounts(device::nvmlDevice_t,
-                                                     counterType::nvmlEccCounterType_t)::nvmlReturn_t
+    @gcsafe_ccall (libnvml()).nvmlDeviceClearEccErrorCounts(device::nvmlDevice_t,
+                                                            counterType::nvmlEccCounterType_t)::nvmlReturn_t
 end
 
 @checked function nvmlDeviceSetDriverModel(device, driverModel, flags)
     initialize_context()
-    @ccall (libnvml()).nvmlDeviceSetDriverModel(device::nvmlDevice_t,
-                                                driverModel::nvmlDriverModel_t,
-                                                flags::Cuint)::nvmlReturn_t
+    @gcsafe_ccall (libnvml()).nvmlDeviceSetDriverModel(device::nvmlDevice_t,
+                                                       driverModel::nvmlDriverModel_t,
+                                                       flags::Cuint)::nvmlReturn_t
 end
 
 @cenum nvmlClockLimitId_enum::UInt32 begin
@@ -2382,501 +2396,513 @@ const nvmlClockLimitId_t = nvmlClockLimitId_enum
 
 @checked function nvmlDeviceSetGpuLockedClocks(device, minGpuClockMHz, maxGpuClockMHz)
     initialize_context()
-    @ccall (libnvml()).nvmlDeviceSetGpuLockedClocks(device::nvmlDevice_t,
-                                                    minGpuClockMHz::Cuint,
-                                                    maxGpuClockMHz::Cuint)::nvmlReturn_t
+    @gcsafe_ccall (libnvml()).nvmlDeviceSetGpuLockedClocks(device::nvmlDevice_t,
+                                                           minGpuClockMHz::Cuint,
+                                                           maxGpuClockMHz::Cuint)::nvmlReturn_t
 end
 
 @checked function nvmlDeviceResetGpuLockedClocks(device)
     initialize_context()
-    @ccall (libnvml()).nvmlDeviceResetGpuLockedClocks(device::nvmlDevice_t)::nvmlReturn_t
+    @gcsafe_ccall (libnvml()).nvmlDeviceResetGpuLockedClocks(device::nvmlDevice_t)::nvmlReturn_t
 end
 
 @checked function nvmlDeviceSetMemoryLockedClocks(device, minMemClockMHz, maxMemClockMHz)
     initialize_context()
-    @ccall (libnvml()).nvmlDeviceSetMemoryLockedClocks(device::nvmlDevice_t,
-                                                       minMemClockMHz::Cuint,
-                                                       maxMemClockMHz::Cuint)::nvmlReturn_t
+    @gcsafe_ccall (libnvml()).nvmlDeviceSetMemoryLockedClocks(device::nvmlDevice_t,
+                                                              minMemClockMHz::Cuint,
+                                                              maxMemClockMHz::Cuint)::nvmlReturn_t
 end
 
 @checked function nvmlDeviceResetMemoryLockedClocks(device)
     initialize_context()
-    @ccall (libnvml()).nvmlDeviceResetMemoryLockedClocks(device::nvmlDevice_t)::nvmlReturn_t
+    @gcsafe_ccall (libnvml()).nvmlDeviceResetMemoryLockedClocks(device::nvmlDevice_t)::nvmlReturn_t
 end
 
 @checked function nvmlDeviceSetApplicationsClocks(device, memClockMHz, graphicsClockMHz)
     initialize_context()
-    @ccall (libnvml()).nvmlDeviceSetApplicationsClocks(device::nvmlDevice_t,
-                                                       memClockMHz::Cuint,
-                                                       graphicsClockMHz::Cuint)::nvmlReturn_t
+    @gcsafe_ccall (libnvml()).nvmlDeviceSetApplicationsClocks(device::nvmlDevice_t,
+                                                              memClockMHz::Cuint,
+                                                              graphicsClockMHz::Cuint)::nvmlReturn_t
 end
 
 @checked function nvmlDeviceResetApplicationsClocks(device)
     initialize_context()
-    @ccall (libnvml()).nvmlDeviceResetApplicationsClocks(device::nvmlDevice_t)::nvmlReturn_t
+    @gcsafe_ccall (libnvml()).nvmlDeviceResetApplicationsClocks(device::nvmlDevice_t)::nvmlReturn_t
 end
 
 @checked function nvmlDeviceSetAutoBoostedClocksEnabled(device, enabled)
     initialize_context()
-    @ccall (libnvml()).nvmlDeviceSetAutoBoostedClocksEnabled(device::nvmlDevice_t,
-                                                             enabled::nvmlEnableState_t)::nvmlReturn_t
+    @gcsafe_ccall (libnvml()).nvmlDeviceSetAutoBoostedClocksEnabled(device::nvmlDevice_t,
+                                                                    enabled::nvmlEnableState_t)::nvmlReturn_t
 end
 
 @checked function nvmlDeviceSetDefaultAutoBoostedClocksEnabled(device, enabled, flags)
     initialize_context()
-    @ccall (libnvml()).nvmlDeviceSetDefaultAutoBoostedClocksEnabled(device::nvmlDevice_t,
-                                                                    enabled::nvmlEnableState_t,
-                                                                    flags::Cuint)::nvmlReturn_t
+    @gcsafe_ccall (libnvml()).nvmlDeviceSetDefaultAutoBoostedClocksEnabled(device::nvmlDevice_t,
+                                                                           enabled::nvmlEnableState_t,
+                                                                           flags::Cuint)::nvmlReturn_t
 end
 
 @checked function nvmlDeviceSetDefaultFanSpeed_v2(device, fan)
     initialize_context()
-    @ccall (libnvml()).nvmlDeviceSetDefaultFanSpeed_v2(device::nvmlDevice_t,
-                                                       fan::Cuint)::nvmlReturn_t
+    @gcsafe_ccall (libnvml()).nvmlDeviceSetDefaultFanSpeed_v2(device::nvmlDevice_t,
+                                                              fan::Cuint)::nvmlReturn_t
 end
 
 @checked function nvmlDeviceSetFanControlPolicy(device, fan, policy)
     initialize_context()
-    @ccall (libnvml()).nvmlDeviceSetFanControlPolicy(device::nvmlDevice_t, fan::Cuint,
-                                                     policy::nvmlFanControlPolicy_t)::nvmlReturn_t
+    @gcsafe_ccall (libnvml()).nvmlDeviceSetFanControlPolicy(device::nvmlDevice_t,
+                                                            fan::Cuint,
+                                                            policy::nvmlFanControlPolicy_t)::nvmlReturn_t
 end
 
 @checked function nvmlDeviceSetTemperatureThreshold(device, thresholdType, temp)
     initialize_context()
-    @ccall (libnvml()).nvmlDeviceSetTemperatureThreshold(device::nvmlDevice_t,
-                                                         thresholdType::nvmlTemperatureThresholds_t,
-                                                         temp::Ptr{Cint})::nvmlReturn_t
+    @gcsafe_ccall (libnvml()).nvmlDeviceSetTemperatureThreshold(device::nvmlDevice_t,
+                                                                thresholdType::nvmlTemperatureThresholds_t,
+                                                                temp::Ptr{Cint})::nvmlReturn_t
 end
 
 @checked function nvmlDeviceSetPowerManagementLimit(device, limit)
     initialize_context()
-    @ccall (libnvml()).nvmlDeviceSetPowerManagementLimit(device::nvmlDevice_t,
-                                                         limit::Cuint)::nvmlReturn_t
+    @gcsafe_ccall (libnvml()).nvmlDeviceSetPowerManagementLimit(device::nvmlDevice_t,
+                                                                limit::Cuint)::nvmlReturn_t
 end
 
 @checked function nvmlDeviceSetGpuOperationMode(device, mode)
     initialize_context()
-    @ccall (libnvml()).nvmlDeviceSetGpuOperationMode(device::nvmlDevice_t,
-                                                     mode::nvmlGpuOperationMode_t)::nvmlReturn_t
+    @gcsafe_ccall (libnvml()).nvmlDeviceSetGpuOperationMode(device::nvmlDevice_t,
+                                                            mode::nvmlGpuOperationMode_t)::nvmlReturn_t
 end
 
 @checked function nvmlDeviceSetAPIRestriction(device, apiType, isRestricted)
     initialize_context()
-    @ccall (libnvml()).nvmlDeviceSetAPIRestriction(device::nvmlDevice_t,
-                                                   apiType::nvmlRestrictedAPI_t,
-                                                   isRestricted::nvmlEnableState_t)::nvmlReturn_t
+    @gcsafe_ccall (libnvml()).nvmlDeviceSetAPIRestriction(device::nvmlDevice_t,
+                                                          apiType::nvmlRestrictedAPI_t,
+                                                          isRestricted::nvmlEnableState_t)::nvmlReturn_t
 end
 
 @checked function nvmlDeviceSetFanSpeed_v2(device, fan, speed)
     initialize_context()
-    @ccall (libnvml()).nvmlDeviceSetFanSpeed_v2(device::nvmlDevice_t, fan::Cuint,
-                                                speed::Cuint)::nvmlReturn_t
+    @gcsafe_ccall (libnvml()).nvmlDeviceSetFanSpeed_v2(device::nvmlDevice_t, fan::Cuint,
+                                                       speed::Cuint)::nvmlReturn_t
 end
 
 @checked function nvmlDeviceSetGpcClkVfOffset(device, offset)
     initialize_context()
-    @ccall (libnvml()).nvmlDeviceSetGpcClkVfOffset(device::nvmlDevice_t,
-                                                   offset::Cint)::nvmlReturn_t
+    @gcsafe_ccall (libnvml()).nvmlDeviceSetGpcClkVfOffset(device::nvmlDevice_t,
+                                                          offset::Cint)::nvmlReturn_t
 end
 
 @checked function nvmlDeviceSetMemClkVfOffset(device, offset)
     initialize_context()
-    @ccall (libnvml()).nvmlDeviceSetMemClkVfOffset(device::nvmlDevice_t,
-                                                   offset::Cint)::nvmlReturn_t
+    @gcsafe_ccall (libnvml()).nvmlDeviceSetMemClkVfOffset(device::nvmlDevice_t,
+                                                          offset::Cint)::nvmlReturn_t
 end
 
 @checked function nvmlDeviceSetConfComputeUnprotectedMemSize(device, sizeKiB)
     initialize_context()
-    @ccall (libnvml()).nvmlDeviceSetConfComputeUnprotectedMemSize(device::nvmlDevice_t,
-                                                                  sizeKiB::Culonglong)::nvmlReturn_t
+    @gcsafe_ccall (libnvml()).nvmlDeviceSetConfComputeUnprotectedMemSize(device::nvmlDevice_t,
+                                                                         sizeKiB::Culonglong)::nvmlReturn_t
 end
 
 @checked function nvmlSystemSetConfComputeGpusReadyState(isAcceptingWork)
     initialize_context()
-    @ccall (libnvml()).nvmlSystemSetConfComputeGpusReadyState(isAcceptingWork::Cuint)::nvmlReturn_t
+    @gcsafe_ccall (libnvml()).nvmlSystemSetConfComputeGpusReadyState(isAcceptingWork::Cuint)::nvmlReturn_t
 end
 
 @checked function nvmlDeviceSetAccountingMode(device, mode)
     initialize_context()
-    @ccall (libnvml()).nvmlDeviceSetAccountingMode(device::nvmlDevice_t,
-                                                   mode::nvmlEnableState_t)::nvmlReturn_t
+    @gcsafe_ccall (libnvml()).nvmlDeviceSetAccountingMode(device::nvmlDevice_t,
+                                                          mode::nvmlEnableState_t)::nvmlReturn_t
 end
 
 @checked function nvmlDeviceClearAccountingPids(device)
     initialize_context()
-    @ccall (libnvml()).nvmlDeviceClearAccountingPids(device::nvmlDevice_t)::nvmlReturn_t
+    @gcsafe_ccall (libnvml()).nvmlDeviceClearAccountingPids(device::nvmlDevice_t)::nvmlReturn_t
 end
 
 @checked function nvmlDeviceGetNvLinkState(device, link, isActive)
     initialize_context()
-    @ccall (libnvml()).nvmlDeviceGetNvLinkState(device::nvmlDevice_t, link::Cuint,
-                                                isActive::Ptr{nvmlEnableState_t})::nvmlReturn_t
+    @gcsafe_ccall (libnvml()).nvmlDeviceGetNvLinkState(device::nvmlDevice_t, link::Cuint,
+                                                       isActive::Ptr{nvmlEnableState_t})::nvmlReturn_t
 end
 
 @checked function nvmlDeviceGetNvLinkVersion(device, link, version)
     initialize_context()
-    @ccall (libnvml()).nvmlDeviceGetNvLinkVersion(device::nvmlDevice_t, link::Cuint,
-                                                  version::Ptr{Cuint})::nvmlReturn_t
+    @gcsafe_ccall (libnvml()).nvmlDeviceGetNvLinkVersion(device::nvmlDevice_t, link::Cuint,
+                                                         version::Ptr{Cuint})::nvmlReturn_t
 end
 
 @checked function nvmlDeviceGetNvLinkCapability(device, link, capability, capResult)
     initialize_context()
-    @ccall (libnvml()).nvmlDeviceGetNvLinkCapability(device::nvmlDevice_t, link::Cuint,
-                                                     capability::nvmlNvLinkCapability_t,
-                                                     capResult::Ptr{Cuint})::nvmlReturn_t
+    @gcsafe_ccall (libnvml()).nvmlDeviceGetNvLinkCapability(device::nvmlDevice_t,
+                                                            link::Cuint,
+                                                            capability::nvmlNvLinkCapability_t,
+                                                            capResult::Ptr{Cuint})::nvmlReturn_t
 end
 
 @checked function nvmlDeviceGetNvLinkErrorCounter(device, link, counter, counterValue)
     initialize_context()
-    @ccall (libnvml()).nvmlDeviceGetNvLinkErrorCounter(device::nvmlDevice_t, link::Cuint,
-                                                       counter::nvmlNvLinkErrorCounter_t,
-                                                       counterValue::Ptr{Culonglong})::nvmlReturn_t
+    @gcsafe_ccall (libnvml()).nvmlDeviceGetNvLinkErrorCounter(device::nvmlDevice_t,
+                                                              link::Cuint,
+                                                              counter::nvmlNvLinkErrorCounter_t,
+                                                              counterValue::Ptr{Culonglong})::nvmlReturn_t
 end
 
 @checked function nvmlDeviceResetNvLinkErrorCounters(device, link)
     initialize_context()
-    @ccall (libnvml()).nvmlDeviceResetNvLinkErrorCounters(device::nvmlDevice_t,
-                                                          link::Cuint)::nvmlReturn_t
+    @gcsafe_ccall (libnvml()).nvmlDeviceResetNvLinkErrorCounters(device::nvmlDevice_t,
+                                                                 link::Cuint)::nvmlReturn_t
 end
 
 @checked function nvmlDeviceSetNvLinkUtilizationControl(device, link, counter, control,
                                                         reset)
     initialize_context()
-    @ccall (libnvml()).nvmlDeviceSetNvLinkUtilizationControl(device::nvmlDevice_t,
-                                                             link::Cuint, counter::Cuint,
-                                                             control::Ptr{nvmlNvLinkUtilizationControl_t},
-                                                             reset::Cuint)::nvmlReturn_t
+    @gcsafe_ccall (libnvml()).nvmlDeviceSetNvLinkUtilizationControl(device::nvmlDevice_t,
+                                                                    link::Cuint,
+                                                                    counter::Cuint,
+                                                                    control::Ptr{nvmlNvLinkUtilizationControl_t},
+                                                                    reset::Cuint)::nvmlReturn_t
 end
 
 @checked function nvmlDeviceGetNvLinkUtilizationControl(device, link, counter, control)
     initialize_context()
-    @ccall (libnvml()).nvmlDeviceGetNvLinkUtilizationControl(device::nvmlDevice_t,
-                                                             link::Cuint, counter::Cuint,
-                                                             control::Ptr{nvmlNvLinkUtilizationControl_t})::nvmlReturn_t
+    @gcsafe_ccall (libnvml()).nvmlDeviceGetNvLinkUtilizationControl(device::nvmlDevice_t,
+                                                                    link::Cuint,
+                                                                    counter::Cuint,
+                                                                    control::Ptr{nvmlNvLinkUtilizationControl_t})::nvmlReturn_t
 end
 
 @checked function nvmlDeviceGetNvLinkUtilizationCounter(device, link, counter, rxcounter,
                                                         txcounter)
     initialize_context()
-    @ccall (libnvml()).nvmlDeviceGetNvLinkUtilizationCounter(device::nvmlDevice_t,
-                                                             link::Cuint, counter::Cuint,
-                                                             rxcounter::Ptr{Culonglong},
-                                                             txcounter::Ptr{Culonglong})::nvmlReturn_t
+    @gcsafe_ccall (libnvml()).nvmlDeviceGetNvLinkUtilizationCounter(device::nvmlDevice_t,
+                                                                    link::Cuint,
+                                                                    counter::Cuint,
+                                                                    rxcounter::Ptr{Culonglong},
+                                                                    txcounter::Ptr{Culonglong})::nvmlReturn_t
 end
 
 @checked function nvmlDeviceFreezeNvLinkUtilizationCounter(device, link, counter, freeze)
     initialize_context()
-    @ccall (libnvml()).nvmlDeviceFreezeNvLinkUtilizationCounter(device::nvmlDevice_t,
-                                                                link::Cuint, counter::Cuint,
-                                                                freeze::nvmlEnableState_t)::nvmlReturn_t
+    @gcsafe_ccall (libnvml()).nvmlDeviceFreezeNvLinkUtilizationCounter(device::nvmlDevice_t,
+                                                                       link::Cuint,
+                                                                       counter::Cuint,
+                                                                       freeze::nvmlEnableState_t)::nvmlReturn_t
 end
 
 @checked function nvmlDeviceResetNvLinkUtilizationCounter(device, link, counter)
     initialize_context()
-    @ccall (libnvml()).nvmlDeviceResetNvLinkUtilizationCounter(device::nvmlDevice_t,
-                                                               link::Cuint,
-                                                               counter::Cuint)::nvmlReturn_t
+    @gcsafe_ccall (libnvml()).nvmlDeviceResetNvLinkUtilizationCounter(device::nvmlDevice_t,
+                                                                      link::Cuint,
+                                                                      counter::Cuint)::nvmlReturn_t
 end
 
 @checked function nvmlDeviceGetNvLinkRemoteDeviceType(device, link, pNvLinkDeviceType)
     initialize_context()
-    @ccall (libnvml()).nvmlDeviceGetNvLinkRemoteDeviceType(device::nvmlDevice_t,
-                                                           link::Cuint,
-                                                           pNvLinkDeviceType::Ptr{nvmlIntNvLinkDeviceType_t})::nvmlReturn_t
+    @gcsafe_ccall (libnvml()).nvmlDeviceGetNvLinkRemoteDeviceType(device::nvmlDevice_t,
+                                                                  link::Cuint,
+                                                                  pNvLinkDeviceType::Ptr{nvmlIntNvLinkDeviceType_t})::nvmlReturn_t
 end
 
 @checked function nvmlEventSetCreate(set)
     initialize_context()
-    @ccall (libnvml()).nvmlEventSetCreate(set::Ptr{nvmlEventSet_t})::nvmlReturn_t
+    @gcsafe_ccall (libnvml()).nvmlEventSetCreate(set::Ptr{nvmlEventSet_t})::nvmlReturn_t
 end
 
 @checked function nvmlDeviceRegisterEvents(device, eventTypes, set)
     initialize_context()
-    @ccall (libnvml()).nvmlDeviceRegisterEvents(device::nvmlDevice_t,
-                                                eventTypes::Culonglong,
-                                                set::nvmlEventSet_t)::nvmlReturn_t
+    @gcsafe_ccall (libnvml()).nvmlDeviceRegisterEvents(device::nvmlDevice_t,
+                                                       eventTypes::Culonglong,
+                                                       set::nvmlEventSet_t)::nvmlReturn_t
 end
 
 @checked function nvmlDeviceGetSupportedEventTypes(device, eventTypes)
     initialize_context()
-    @ccall (libnvml()).nvmlDeviceGetSupportedEventTypes(device::nvmlDevice_t,
-                                                        eventTypes::Ptr{Culonglong})::nvmlReturn_t
+    @gcsafe_ccall (libnvml()).nvmlDeviceGetSupportedEventTypes(device::nvmlDevice_t,
+                                                               eventTypes::Ptr{Culonglong})::nvmlReturn_t
 end
 
 @checked function nvmlEventSetFree(set)
     initialize_context()
-    @ccall (libnvml()).nvmlEventSetFree(set::nvmlEventSet_t)::nvmlReturn_t
+    @gcsafe_ccall (libnvml()).nvmlEventSetFree(set::nvmlEventSet_t)::nvmlReturn_t
 end
 
 @checked function nvmlDeviceModifyDrainState(pciInfo, newState)
     initialize_context()
-    @ccall (libnvml()).nvmlDeviceModifyDrainState(pciInfo::Ptr{nvmlPciInfo_t},
-                                                  newState::nvmlEnableState_t)::nvmlReturn_t
+    @gcsafe_ccall (libnvml()).nvmlDeviceModifyDrainState(pciInfo::Ptr{nvmlPciInfo_t},
+                                                         newState::nvmlEnableState_t)::nvmlReturn_t
 end
 
 @checked function nvmlDeviceQueryDrainState(pciInfo, currentState)
     initialize_context()
-    @ccall (libnvml()).nvmlDeviceQueryDrainState(pciInfo::Ptr{nvmlPciInfo_t},
-                                                 currentState::Ptr{nvmlEnableState_t})::nvmlReturn_t
+    @gcsafe_ccall (libnvml()).nvmlDeviceQueryDrainState(pciInfo::Ptr{nvmlPciInfo_t},
+                                                        currentState::Ptr{nvmlEnableState_t})::nvmlReturn_t
 end
 
 @checked function nvmlDeviceDiscoverGpus(pciInfo)
     initialize_context()
-    @ccall (libnvml()).nvmlDeviceDiscoverGpus(pciInfo::Ptr{nvmlPciInfo_t})::nvmlReturn_t
+    @gcsafe_ccall (libnvml()).nvmlDeviceDiscoverGpus(pciInfo::Ptr{nvmlPciInfo_t})::nvmlReturn_t
 end
 
 @checked function nvmlDeviceGetFieldValues(device, valuesCount, values)
     initialize_context()
-    @ccall (libnvml()).nvmlDeviceGetFieldValues(device::nvmlDevice_t, valuesCount::Cint,
-                                                values::Ptr{nvmlFieldValue_t})::nvmlReturn_t
+    @gcsafe_ccall (libnvml()).nvmlDeviceGetFieldValues(device::nvmlDevice_t,
+                                                       valuesCount::Cint,
+                                                       values::Ptr{nvmlFieldValue_t})::nvmlReturn_t
 end
 
 @checked function nvmlDeviceClearFieldValues(device, valuesCount, values)
     initialize_context()
-    @ccall (libnvml()).nvmlDeviceClearFieldValues(device::nvmlDevice_t, valuesCount::Cint,
-                                                  values::Ptr{nvmlFieldValue_t})::nvmlReturn_t
+    @gcsafe_ccall (libnvml()).nvmlDeviceClearFieldValues(device::nvmlDevice_t,
+                                                         valuesCount::Cint,
+                                                         values::Ptr{nvmlFieldValue_t})::nvmlReturn_t
 end
 
 @checked function nvmlDeviceGetVirtualizationMode(device, pVirtualMode)
     initialize_context()
-    @ccall (libnvml()).nvmlDeviceGetVirtualizationMode(device::nvmlDevice_t,
-                                                       pVirtualMode::Ptr{nvmlGpuVirtualizationMode_t})::nvmlReturn_t
+    @gcsafe_ccall (libnvml()).nvmlDeviceGetVirtualizationMode(device::nvmlDevice_t,
+                                                              pVirtualMode::Ptr{nvmlGpuVirtualizationMode_t})::nvmlReturn_t
 end
 
 @checked function nvmlDeviceGetHostVgpuMode(device, pHostVgpuMode)
     initialize_context()
-    @ccall (libnvml()).nvmlDeviceGetHostVgpuMode(device::nvmlDevice_t,
-                                                 pHostVgpuMode::Ptr{nvmlHostVgpuMode_t})::nvmlReturn_t
+    @gcsafe_ccall (libnvml()).nvmlDeviceGetHostVgpuMode(device::nvmlDevice_t,
+                                                        pHostVgpuMode::Ptr{nvmlHostVgpuMode_t})::nvmlReturn_t
 end
 
 @checked function nvmlDeviceSetVirtualizationMode(device, virtualMode)
     initialize_context()
-    @ccall (libnvml()).nvmlDeviceSetVirtualizationMode(device::nvmlDevice_t,
-                                                       virtualMode::nvmlGpuVirtualizationMode_t)::nvmlReturn_t
+    @gcsafe_ccall (libnvml()).nvmlDeviceSetVirtualizationMode(device::nvmlDevice_t,
+                                                              virtualMode::nvmlGpuVirtualizationMode_t)::nvmlReturn_t
 end
 
 @checked function nvmlGetVgpuDriverCapabilities(capability, capResult)
     initialize_context()
-    @ccall (libnvml()).nvmlGetVgpuDriverCapabilities(capability::nvmlVgpuDriverCapability_t,
-                                                     capResult::Ptr{Cuint})::nvmlReturn_t
+    @gcsafe_ccall (libnvml()).nvmlGetVgpuDriverCapabilities(capability::nvmlVgpuDriverCapability_t,
+                                                            capResult::Ptr{Cuint})::nvmlReturn_t
 end
 
 @checked function nvmlDeviceGetVgpuCapabilities(device, capability, capResult)
     initialize_context()
-    @ccall (libnvml()).nvmlDeviceGetVgpuCapabilities(device::nvmlDevice_t,
-                                                     capability::nvmlDeviceVgpuCapability_t,
-                                                     capResult::Ptr{Cuint})::nvmlReturn_t
+    @gcsafe_ccall (libnvml()).nvmlDeviceGetVgpuCapabilities(device::nvmlDevice_t,
+                                                            capability::nvmlDeviceVgpuCapability_t,
+                                                            capResult::Ptr{Cuint})::nvmlReturn_t
 end
 
 @checked function nvmlDeviceGetSupportedVgpus(device, vgpuCount, vgpuTypeIds)
     initialize_context()
-    @ccall (libnvml()).nvmlDeviceGetSupportedVgpus(device::nvmlDevice_t,
-                                                   vgpuCount::Ptr{Cuint},
-                                                   vgpuTypeIds::Ptr{nvmlVgpuTypeId_t})::nvmlReturn_t
+    @gcsafe_ccall (libnvml()).nvmlDeviceGetSupportedVgpus(device::nvmlDevice_t,
+                                                          vgpuCount::Ptr{Cuint},
+                                                          vgpuTypeIds::Ptr{nvmlVgpuTypeId_t})::nvmlReturn_t
 end
 
 @checked function nvmlDeviceGetCreatableVgpus(device, vgpuCount, vgpuTypeIds)
     initialize_context()
-    @ccall (libnvml()).nvmlDeviceGetCreatableVgpus(device::nvmlDevice_t,
-                                                   vgpuCount::Ptr{Cuint},
-                                                   vgpuTypeIds::Ptr{nvmlVgpuTypeId_t})::nvmlReturn_t
+    @gcsafe_ccall (libnvml()).nvmlDeviceGetCreatableVgpus(device::nvmlDevice_t,
+                                                          vgpuCount::Ptr{Cuint},
+                                                          vgpuTypeIds::Ptr{nvmlVgpuTypeId_t})::nvmlReturn_t
 end
 
 @checked function nvmlVgpuTypeGetClass(vgpuTypeId, vgpuTypeClass, size)
     initialize_context()
-    @ccall (libnvml()).nvmlVgpuTypeGetClass(vgpuTypeId::nvmlVgpuTypeId_t,
-                                            vgpuTypeClass::Cstring,
-                                            size::Ptr{Cuint})::nvmlReturn_t
+    @gcsafe_ccall (libnvml()).nvmlVgpuTypeGetClass(vgpuTypeId::nvmlVgpuTypeId_t,
+                                                   vgpuTypeClass::Cstring,
+                                                   size::Ptr{Cuint})::nvmlReturn_t
 end
 
 @checked function nvmlVgpuTypeGetName(vgpuTypeId, vgpuTypeName, size)
     initialize_context()
-    @ccall (libnvml()).nvmlVgpuTypeGetName(vgpuTypeId::nvmlVgpuTypeId_t,
-                                           vgpuTypeName::Cstring,
-                                           size::Ptr{Cuint})::nvmlReturn_t
+    @gcsafe_ccall (libnvml()).nvmlVgpuTypeGetName(vgpuTypeId::nvmlVgpuTypeId_t,
+                                                  vgpuTypeName::Cstring,
+                                                  size::Ptr{Cuint})::nvmlReturn_t
 end
 
 @checked function nvmlVgpuTypeGetGpuInstanceProfileId(vgpuTypeId, gpuInstanceProfileId)
     initialize_context()
-    @ccall (libnvml()).nvmlVgpuTypeGetGpuInstanceProfileId(vgpuTypeId::nvmlVgpuTypeId_t,
-                                                           gpuInstanceProfileId::Ptr{Cuint})::nvmlReturn_t
+    @gcsafe_ccall (libnvml()).nvmlVgpuTypeGetGpuInstanceProfileId(vgpuTypeId::nvmlVgpuTypeId_t,
+                                                                  gpuInstanceProfileId::Ptr{Cuint})::nvmlReturn_t
 end
 
 @checked function nvmlVgpuTypeGetDeviceID(vgpuTypeId, deviceID, subsystemID)
     initialize_context()
-    @ccall (libnvml()).nvmlVgpuTypeGetDeviceID(vgpuTypeId::nvmlVgpuTypeId_t,
-                                               deviceID::Ptr{Culonglong},
-                                               subsystemID::Ptr{Culonglong})::nvmlReturn_t
+    @gcsafe_ccall (libnvml()).nvmlVgpuTypeGetDeviceID(vgpuTypeId::nvmlVgpuTypeId_t,
+                                                      deviceID::Ptr{Culonglong},
+                                                      subsystemID::Ptr{Culonglong})::nvmlReturn_t
 end
 
 @checked function nvmlVgpuTypeGetFramebufferSize(vgpuTypeId, fbSize)
     initialize_context()
-    @ccall (libnvml()).nvmlVgpuTypeGetFramebufferSize(vgpuTypeId::nvmlVgpuTypeId_t,
-                                                      fbSize::Ptr{Culonglong})::nvmlReturn_t
+    @gcsafe_ccall (libnvml()).nvmlVgpuTypeGetFramebufferSize(vgpuTypeId::nvmlVgpuTypeId_t,
+                                                             fbSize::Ptr{Culonglong})::nvmlReturn_t
 end
 
 @checked function nvmlVgpuTypeGetNumDisplayHeads(vgpuTypeId, numDisplayHeads)
     initialize_context()
-    @ccall (libnvml()).nvmlVgpuTypeGetNumDisplayHeads(vgpuTypeId::nvmlVgpuTypeId_t,
-                                                      numDisplayHeads::Ptr{Cuint})::nvmlReturn_t
+    @gcsafe_ccall (libnvml()).nvmlVgpuTypeGetNumDisplayHeads(vgpuTypeId::nvmlVgpuTypeId_t,
+                                                             numDisplayHeads::Ptr{Cuint})::nvmlReturn_t
 end
 
 @checked function nvmlVgpuTypeGetResolution(vgpuTypeId, displayIndex, xdim, ydim)
     initialize_context()
-    @ccall (libnvml()).nvmlVgpuTypeGetResolution(vgpuTypeId::nvmlVgpuTypeId_t,
-                                                 displayIndex::Cuint, xdim::Ptr{Cuint},
-                                                 ydim::Ptr{Cuint})::nvmlReturn_t
+    @gcsafe_ccall (libnvml()).nvmlVgpuTypeGetResolution(vgpuTypeId::nvmlVgpuTypeId_t,
+                                                        displayIndex::Cuint,
+                                                        xdim::Ptr{Cuint},
+                                                        ydim::Ptr{Cuint})::nvmlReturn_t
 end
 
 @checked function nvmlVgpuTypeGetLicense(vgpuTypeId, vgpuTypeLicenseString, size)
     initialize_context()
-    @ccall (libnvml()).nvmlVgpuTypeGetLicense(vgpuTypeId::nvmlVgpuTypeId_t,
-                                              vgpuTypeLicenseString::Cstring,
-                                              size::Cuint)::nvmlReturn_t
+    @gcsafe_ccall (libnvml()).nvmlVgpuTypeGetLicense(vgpuTypeId::nvmlVgpuTypeId_t,
+                                                     vgpuTypeLicenseString::Cstring,
+                                                     size::Cuint)::nvmlReturn_t
 end
 
 @checked function nvmlVgpuTypeGetFrameRateLimit(vgpuTypeId, frameRateLimit)
     initialize_context()
-    @ccall (libnvml()).nvmlVgpuTypeGetFrameRateLimit(vgpuTypeId::nvmlVgpuTypeId_t,
-                                                     frameRateLimit::Ptr{Cuint})::nvmlReturn_t
+    @gcsafe_ccall (libnvml()).nvmlVgpuTypeGetFrameRateLimit(vgpuTypeId::nvmlVgpuTypeId_t,
+                                                            frameRateLimit::Ptr{Cuint})::nvmlReturn_t
 end
 
 @checked function nvmlVgpuTypeGetMaxInstances(device, vgpuTypeId, vgpuInstanceCount)
     initialize_context()
-    @ccall (libnvml()).nvmlVgpuTypeGetMaxInstances(device::nvmlDevice_t,
-                                                   vgpuTypeId::nvmlVgpuTypeId_t,
-                                                   vgpuInstanceCount::Ptr{Cuint})::nvmlReturn_t
+    @gcsafe_ccall (libnvml()).nvmlVgpuTypeGetMaxInstances(device::nvmlDevice_t,
+                                                          vgpuTypeId::nvmlVgpuTypeId_t,
+                                                          vgpuInstanceCount::Ptr{Cuint})::nvmlReturn_t
 end
 
 @checked function nvmlVgpuTypeGetMaxInstancesPerVm(vgpuTypeId, vgpuInstanceCountPerVm)
     initialize_context()
-    @ccall (libnvml()).nvmlVgpuTypeGetMaxInstancesPerVm(vgpuTypeId::nvmlVgpuTypeId_t,
-                                                        vgpuInstanceCountPerVm::Ptr{Cuint})::nvmlReturn_t
+    @gcsafe_ccall (libnvml()).nvmlVgpuTypeGetMaxInstancesPerVm(vgpuTypeId::nvmlVgpuTypeId_t,
+                                                               vgpuInstanceCountPerVm::Ptr{Cuint})::nvmlReturn_t
 end
 
 @checked function nvmlDeviceGetActiveVgpus(device, vgpuCount, vgpuInstances)
     initialize_context()
-    @ccall (libnvml()).nvmlDeviceGetActiveVgpus(device::nvmlDevice_t, vgpuCount::Ptr{Cuint},
-                                                vgpuInstances::Ptr{nvmlVgpuInstance_t})::nvmlReturn_t
+    @gcsafe_ccall (libnvml()).nvmlDeviceGetActiveVgpus(device::nvmlDevice_t,
+                                                       vgpuCount::Ptr{Cuint},
+                                                       vgpuInstances::Ptr{nvmlVgpuInstance_t})::nvmlReturn_t
 end
 
 @checked function nvmlVgpuInstanceGetVmID(vgpuInstance, vmId, size, vmIdType)
     initialize_context()
-    @ccall (libnvml()).nvmlVgpuInstanceGetVmID(vgpuInstance::nvmlVgpuInstance_t,
-                                               vmId::Cstring, size::Cuint,
-                                               vmIdType::Ptr{nvmlVgpuVmIdType_t})::nvmlReturn_t
+    @gcsafe_ccall (libnvml()).nvmlVgpuInstanceGetVmID(vgpuInstance::nvmlVgpuInstance_t,
+                                                      vmId::Cstring, size::Cuint,
+                                                      vmIdType::Ptr{nvmlVgpuVmIdType_t})::nvmlReturn_t
 end
 
 @checked function nvmlVgpuInstanceGetUUID(vgpuInstance, uuid, size)
     initialize_context()
-    @ccall (libnvml()).nvmlVgpuInstanceGetUUID(vgpuInstance::nvmlVgpuInstance_t,
-                                               uuid::Cstring, size::Cuint)::nvmlReturn_t
+    @gcsafe_ccall (libnvml()).nvmlVgpuInstanceGetUUID(vgpuInstance::nvmlVgpuInstance_t,
+                                                      uuid::Cstring,
+                                                      size::Cuint)::nvmlReturn_t
 end
 
 @checked function nvmlVgpuInstanceGetVmDriverVersion(vgpuInstance, version, length)
     initialize_context()
-    @ccall (libnvml()).nvmlVgpuInstanceGetVmDriverVersion(vgpuInstance::nvmlVgpuInstance_t,
-                                                          version::Cstring,
-                                                          length::Cuint)::nvmlReturn_t
+    @gcsafe_ccall (libnvml()).nvmlVgpuInstanceGetVmDriverVersion(vgpuInstance::nvmlVgpuInstance_t,
+                                                                 version::Cstring,
+                                                                 length::Cuint)::nvmlReturn_t
 end
 
 @checked function nvmlVgpuInstanceGetFbUsage(vgpuInstance, fbUsage)
     initialize_context()
-    @ccall (libnvml()).nvmlVgpuInstanceGetFbUsage(vgpuInstance::nvmlVgpuInstance_t,
-                                                  fbUsage::Ptr{Culonglong})::nvmlReturn_t
+    @gcsafe_ccall (libnvml()).nvmlVgpuInstanceGetFbUsage(vgpuInstance::nvmlVgpuInstance_t,
+                                                         fbUsage::Ptr{Culonglong})::nvmlReturn_t
 end
 
 @checked function nvmlVgpuInstanceGetLicenseStatus(vgpuInstance, licensed)
     initialize_context()
-    @ccall (libnvml()).nvmlVgpuInstanceGetLicenseStatus(vgpuInstance::nvmlVgpuInstance_t,
-                                                        licensed::Ptr{Cuint})::nvmlReturn_t
+    @gcsafe_ccall (libnvml()).nvmlVgpuInstanceGetLicenseStatus(vgpuInstance::nvmlVgpuInstance_t,
+                                                               licensed::Ptr{Cuint})::nvmlReturn_t
 end
 
 @checked function nvmlVgpuInstanceGetType(vgpuInstance, vgpuTypeId)
     initialize_context()
-    @ccall (libnvml()).nvmlVgpuInstanceGetType(vgpuInstance::nvmlVgpuInstance_t,
-                                               vgpuTypeId::Ptr{nvmlVgpuTypeId_t})::nvmlReturn_t
+    @gcsafe_ccall (libnvml()).nvmlVgpuInstanceGetType(vgpuInstance::nvmlVgpuInstance_t,
+                                                      vgpuTypeId::Ptr{nvmlVgpuTypeId_t})::nvmlReturn_t
 end
 
 @checked function nvmlVgpuInstanceGetFrameRateLimit(vgpuInstance, frameRateLimit)
     initialize_context()
-    @ccall (libnvml()).nvmlVgpuInstanceGetFrameRateLimit(vgpuInstance::nvmlVgpuInstance_t,
-                                                         frameRateLimit::Ptr{Cuint})::nvmlReturn_t
+    @gcsafe_ccall (libnvml()).nvmlVgpuInstanceGetFrameRateLimit(vgpuInstance::nvmlVgpuInstance_t,
+                                                                frameRateLimit::Ptr{Cuint})::nvmlReturn_t
 end
 
 @checked function nvmlVgpuInstanceGetEccMode(vgpuInstance, eccMode)
     initialize_context()
-    @ccall (libnvml()).nvmlVgpuInstanceGetEccMode(vgpuInstance::nvmlVgpuInstance_t,
-                                                  eccMode::Ptr{nvmlEnableState_t})::nvmlReturn_t
+    @gcsafe_ccall (libnvml()).nvmlVgpuInstanceGetEccMode(vgpuInstance::nvmlVgpuInstance_t,
+                                                         eccMode::Ptr{nvmlEnableState_t})::nvmlReturn_t
 end
 
 @checked function nvmlVgpuInstanceGetEncoderCapacity(vgpuInstance, encoderCapacity)
     initialize_context()
-    @ccall (libnvml()).nvmlVgpuInstanceGetEncoderCapacity(vgpuInstance::nvmlVgpuInstance_t,
-                                                          encoderCapacity::Ptr{Cuint})::nvmlReturn_t
+    @gcsafe_ccall (libnvml()).nvmlVgpuInstanceGetEncoderCapacity(vgpuInstance::nvmlVgpuInstance_t,
+                                                                 encoderCapacity::Ptr{Cuint})::nvmlReturn_t
 end
 
 @checked function nvmlVgpuInstanceSetEncoderCapacity(vgpuInstance, encoderCapacity)
     initialize_context()
-    @ccall (libnvml()).nvmlVgpuInstanceSetEncoderCapacity(vgpuInstance::nvmlVgpuInstance_t,
-                                                          encoderCapacity::Cuint)::nvmlReturn_t
+    @gcsafe_ccall (libnvml()).nvmlVgpuInstanceSetEncoderCapacity(vgpuInstance::nvmlVgpuInstance_t,
+                                                                 encoderCapacity::Cuint)::nvmlReturn_t
 end
 
 @checked function nvmlVgpuInstanceGetEncoderStats(vgpuInstance, sessionCount, averageFps,
                                                   averageLatency)
     initialize_context()
-    @ccall (libnvml()).nvmlVgpuInstanceGetEncoderStats(vgpuInstance::nvmlVgpuInstance_t,
-                                                       sessionCount::Ptr{Cuint},
-                                                       averageFps::Ptr{Cuint},
-                                                       averageLatency::Ptr{Cuint})::nvmlReturn_t
+    @gcsafe_ccall (libnvml()).nvmlVgpuInstanceGetEncoderStats(vgpuInstance::nvmlVgpuInstance_t,
+                                                              sessionCount::Ptr{Cuint},
+                                                              averageFps::Ptr{Cuint},
+                                                              averageLatency::Ptr{Cuint})::nvmlReturn_t
 end
 
 @checked function nvmlVgpuInstanceGetEncoderSessions(vgpuInstance, sessionCount,
                                                      sessionInfo)
     initialize_context()
-    @ccall (libnvml()).nvmlVgpuInstanceGetEncoderSessions(vgpuInstance::nvmlVgpuInstance_t,
-                                                          sessionCount::Ptr{Cuint},
-                                                          sessionInfo::Ptr{nvmlEncoderSessionInfo_t})::nvmlReturn_t
+    @gcsafe_ccall (libnvml()).nvmlVgpuInstanceGetEncoderSessions(vgpuInstance::nvmlVgpuInstance_t,
+                                                                 sessionCount::Ptr{Cuint},
+                                                                 sessionInfo::Ptr{nvmlEncoderSessionInfo_t})::nvmlReturn_t
 end
 
 @checked function nvmlVgpuInstanceGetFBCStats(vgpuInstance, fbcStats)
     initialize_context()
-    @ccall (libnvml()).nvmlVgpuInstanceGetFBCStats(vgpuInstance::nvmlVgpuInstance_t,
-                                                   fbcStats::Ptr{nvmlFBCStats_t})::nvmlReturn_t
+    @gcsafe_ccall (libnvml()).nvmlVgpuInstanceGetFBCStats(vgpuInstance::nvmlVgpuInstance_t,
+                                                          fbcStats::Ptr{nvmlFBCStats_t})::nvmlReturn_t
 end
 
 @checked function nvmlVgpuInstanceGetFBCSessions(vgpuInstance, sessionCount, sessionInfo)
     initialize_context()
-    @ccall (libnvml()).nvmlVgpuInstanceGetFBCSessions(vgpuInstance::nvmlVgpuInstance_t,
-                                                      sessionCount::Ptr{Cuint},
-                                                      sessionInfo::Ptr{nvmlFBCSessionInfo_t})::nvmlReturn_t
+    @gcsafe_ccall (libnvml()).nvmlVgpuInstanceGetFBCSessions(vgpuInstance::nvmlVgpuInstance_t,
+                                                             sessionCount::Ptr{Cuint},
+                                                             sessionInfo::Ptr{nvmlFBCSessionInfo_t})::nvmlReturn_t
 end
 
 @checked function nvmlVgpuInstanceGetGpuInstanceId(vgpuInstance, gpuInstanceId)
     initialize_context()
-    @ccall (libnvml()).nvmlVgpuInstanceGetGpuInstanceId(vgpuInstance::nvmlVgpuInstance_t,
-                                                        gpuInstanceId::Ptr{Cuint})::nvmlReturn_t
+    @gcsafe_ccall (libnvml()).nvmlVgpuInstanceGetGpuInstanceId(vgpuInstance::nvmlVgpuInstance_t,
+                                                               gpuInstanceId::Ptr{Cuint})::nvmlReturn_t
 end
 
 @checked function nvmlVgpuInstanceGetGpuPciId(vgpuInstance, vgpuPciId, length)
     initialize_context()
-    @ccall (libnvml()).nvmlVgpuInstanceGetGpuPciId(vgpuInstance::nvmlVgpuInstance_t,
-                                                   vgpuPciId::Cstring,
-                                                   length::Ptr{Cuint})::nvmlReturn_t
+    @gcsafe_ccall (libnvml()).nvmlVgpuInstanceGetGpuPciId(vgpuInstance::nvmlVgpuInstance_t,
+                                                          vgpuPciId::Cstring,
+                                                          length::Ptr{Cuint})::nvmlReturn_t
 end
 
 @checked function nvmlVgpuTypeGetCapabilities(vgpuTypeId, capability, capResult)
     initialize_context()
-    @ccall (libnvml()).nvmlVgpuTypeGetCapabilities(vgpuTypeId::nvmlVgpuTypeId_t,
-                                                   capability::nvmlVgpuCapability_t,
-                                                   capResult::Ptr{Cuint})::nvmlReturn_t
+    @gcsafe_ccall (libnvml()).nvmlVgpuTypeGetCapabilities(vgpuTypeId::nvmlVgpuTypeId_t,
+                                                          capability::nvmlVgpuCapability_t,
+                                                          capResult::Ptr{Cuint})::nvmlReturn_t
 end
 
 @checked function nvmlVgpuInstanceGetMdevUUID(vgpuInstance, mdevUuid, size)
     initialize_context()
-    @ccall (libnvml()).nvmlVgpuInstanceGetMdevUUID(vgpuInstance::nvmlVgpuInstance_t,
-                                                   mdevUuid::Cstring,
-                                                   size::Cuint)::nvmlReturn_t
+    @gcsafe_ccall (libnvml()).nvmlVgpuInstanceGetMdevUUID(vgpuInstance::nvmlVgpuInstance_t,
+                                                          mdevUuid::Cstring,
+                                                          size::Cuint)::nvmlReturn_t
 end
 
 struct nvmlVgpuVersion_st
@@ -2943,110 +2969,110 @@ const nvmlVgpuPgpuCompatibility_t = nvmlVgpuPgpuCompatibility_st
 
 @checked function nvmlVgpuInstanceGetMetadata(vgpuInstance, vgpuMetadata, bufferSize)
     initialize_context()
-    @ccall (libnvml()).nvmlVgpuInstanceGetMetadata(vgpuInstance::nvmlVgpuInstance_t,
-                                                   vgpuMetadata::Ptr{nvmlVgpuMetadata_t},
-                                                   bufferSize::Ptr{Cuint})::nvmlReturn_t
+    @gcsafe_ccall (libnvml()).nvmlVgpuInstanceGetMetadata(vgpuInstance::nvmlVgpuInstance_t,
+                                                          vgpuMetadata::Ptr{nvmlVgpuMetadata_t},
+                                                          bufferSize::Ptr{Cuint})::nvmlReturn_t
 end
 
 @checked function nvmlDeviceGetVgpuMetadata(device, pgpuMetadata, bufferSize)
     initialize_context()
-    @ccall (libnvml()).nvmlDeviceGetVgpuMetadata(device::nvmlDevice_t,
-                                                 pgpuMetadata::Ptr{nvmlVgpuPgpuMetadata_t},
-                                                 bufferSize::Ptr{Cuint})::nvmlReturn_t
+    @gcsafe_ccall (libnvml()).nvmlDeviceGetVgpuMetadata(device::nvmlDevice_t,
+                                                        pgpuMetadata::Ptr{nvmlVgpuPgpuMetadata_t},
+                                                        bufferSize::Ptr{Cuint})::nvmlReturn_t
 end
 
 @checked function nvmlGetVgpuCompatibility(vgpuMetadata, pgpuMetadata, compatibilityInfo)
     initialize_context()
-    @ccall (libnvml()).nvmlGetVgpuCompatibility(vgpuMetadata::Ptr{nvmlVgpuMetadata_t},
-                                                pgpuMetadata::Ptr{nvmlVgpuPgpuMetadata_t},
-                                                compatibilityInfo::Ptr{nvmlVgpuPgpuCompatibility_t})::nvmlReturn_t
+    @gcsafe_ccall (libnvml()).nvmlGetVgpuCompatibility(vgpuMetadata::Ptr{nvmlVgpuMetadata_t},
+                                                       pgpuMetadata::Ptr{nvmlVgpuPgpuMetadata_t},
+                                                       compatibilityInfo::Ptr{nvmlVgpuPgpuCompatibility_t})::nvmlReturn_t
 end
 
 @checked function nvmlDeviceGetPgpuMetadataString(device, pgpuMetadata, bufferSize)
     initialize_context()
-    @ccall (libnvml()).nvmlDeviceGetPgpuMetadataString(device::nvmlDevice_t,
-                                                       pgpuMetadata::Cstring,
-                                                       bufferSize::Ptr{Cuint})::nvmlReturn_t
+    @gcsafe_ccall (libnvml()).nvmlDeviceGetPgpuMetadataString(device::nvmlDevice_t,
+                                                              pgpuMetadata::Cstring,
+                                                              bufferSize::Ptr{Cuint})::nvmlReturn_t
 end
 
 @checked function nvmlDeviceGetVgpuSchedulerLog(device, pSchedulerLog)
     initialize_context()
-    @ccall (libnvml()).nvmlDeviceGetVgpuSchedulerLog(device::nvmlDevice_t,
-                                                     pSchedulerLog::Ptr{nvmlVgpuSchedulerLog_t})::nvmlReturn_t
+    @gcsafe_ccall (libnvml()).nvmlDeviceGetVgpuSchedulerLog(device::nvmlDevice_t,
+                                                            pSchedulerLog::Ptr{nvmlVgpuSchedulerLog_t})::nvmlReturn_t
 end
 
 @checked function nvmlDeviceGetVgpuSchedulerState(device, pSchedulerState)
     initialize_context()
-    @ccall (libnvml()).nvmlDeviceGetVgpuSchedulerState(device::nvmlDevice_t,
-                                                       pSchedulerState::Ptr{nvmlVgpuSchedulerGetState_t})::nvmlReturn_t
+    @gcsafe_ccall (libnvml()).nvmlDeviceGetVgpuSchedulerState(device::nvmlDevice_t,
+                                                              pSchedulerState::Ptr{nvmlVgpuSchedulerGetState_t})::nvmlReturn_t
 end
 
 @checked function nvmlDeviceGetVgpuSchedulerCapabilities(device, pCapabilities)
     initialize_context()
-    @ccall (libnvml()).nvmlDeviceGetVgpuSchedulerCapabilities(device::nvmlDevice_t,
-                                                              pCapabilities::Ptr{nvmlVgpuSchedulerCapabilities_t})::nvmlReturn_t
+    @gcsafe_ccall (libnvml()).nvmlDeviceGetVgpuSchedulerCapabilities(device::nvmlDevice_t,
+                                                                     pCapabilities::Ptr{nvmlVgpuSchedulerCapabilities_t})::nvmlReturn_t
 end
 
 @checked function nvmlDeviceSetVgpuSchedulerState(device, pSchedulerState)
     initialize_context()
-    @ccall (libnvml()).nvmlDeviceSetVgpuSchedulerState(device::nvmlDevice_t,
-                                                       pSchedulerState::Ptr{nvmlVgpuSchedulerSetState_t})::nvmlReturn_t
+    @gcsafe_ccall (libnvml()).nvmlDeviceSetVgpuSchedulerState(device::nvmlDevice_t,
+                                                              pSchedulerState::Ptr{nvmlVgpuSchedulerSetState_t})::nvmlReturn_t
 end
 
 @checked function nvmlGetVgpuVersion(supported, current)
     initialize_context()
-    @ccall (libnvml()).nvmlGetVgpuVersion(supported::Ptr{nvmlVgpuVersion_t},
-                                          current::Ptr{nvmlVgpuVersion_t})::nvmlReturn_t
+    @gcsafe_ccall (libnvml()).nvmlGetVgpuVersion(supported::Ptr{nvmlVgpuVersion_t},
+                                                 current::Ptr{nvmlVgpuVersion_t})::nvmlReturn_t
 end
 
 @checked function nvmlSetVgpuVersion(vgpuVersion)
     initialize_context()
-    @ccall (libnvml()).nvmlSetVgpuVersion(vgpuVersion::Ptr{nvmlVgpuVersion_t})::nvmlReturn_t
+    @gcsafe_ccall (libnvml()).nvmlSetVgpuVersion(vgpuVersion::Ptr{nvmlVgpuVersion_t})::nvmlReturn_t
 end
 
 @checked function nvmlDeviceGetVgpuUtilization(device, lastSeenTimeStamp, sampleValType,
                                                vgpuInstanceSamplesCount, utilizationSamples)
     initialize_context()
-    @ccall (libnvml()).nvmlDeviceGetVgpuUtilization(device::nvmlDevice_t,
-                                                    lastSeenTimeStamp::Culonglong,
-                                                    sampleValType::Ptr{nvmlValueType_t},
-                                                    vgpuInstanceSamplesCount::Ptr{Cuint},
-                                                    utilizationSamples::Ptr{nvmlVgpuInstanceUtilizationSample_t})::nvmlReturn_t
+    @gcsafe_ccall (libnvml()).nvmlDeviceGetVgpuUtilization(device::nvmlDevice_t,
+                                                           lastSeenTimeStamp::Culonglong,
+                                                           sampleValType::Ptr{nvmlValueType_t},
+                                                           vgpuInstanceSamplesCount::Ptr{Cuint},
+                                                           utilizationSamples::Ptr{nvmlVgpuInstanceUtilizationSample_t})::nvmlReturn_t
 end
 
 @checked function nvmlDeviceGetVgpuProcessUtilization(device, lastSeenTimeStamp,
                                                       vgpuProcessSamplesCount,
                                                       utilizationSamples)
     initialize_context()
-    @ccall (libnvml()).nvmlDeviceGetVgpuProcessUtilization(device::nvmlDevice_t,
-                                                           lastSeenTimeStamp::Culonglong,
-                                                           vgpuProcessSamplesCount::Ptr{Cuint},
-                                                           utilizationSamples::Ptr{nvmlVgpuProcessUtilizationSample_t})::nvmlReturn_t
+    @gcsafe_ccall (libnvml()).nvmlDeviceGetVgpuProcessUtilization(device::nvmlDevice_t,
+                                                                  lastSeenTimeStamp::Culonglong,
+                                                                  vgpuProcessSamplesCount::Ptr{Cuint},
+                                                                  utilizationSamples::Ptr{nvmlVgpuProcessUtilizationSample_t})::nvmlReturn_t
 end
 
 @checked function nvmlVgpuInstanceGetAccountingMode(vgpuInstance, mode)
     initialize_context()
-    @ccall (libnvml()).nvmlVgpuInstanceGetAccountingMode(vgpuInstance::nvmlVgpuInstance_t,
-                                                         mode::Ptr{nvmlEnableState_t})::nvmlReturn_t
+    @gcsafe_ccall (libnvml()).nvmlVgpuInstanceGetAccountingMode(vgpuInstance::nvmlVgpuInstance_t,
+                                                                mode::Ptr{nvmlEnableState_t})::nvmlReturn_t
 end
 
 @checked function nvmlVgpuInstanceGetAccountingPids(vgpuInstance, count, pids)
     initialize_context()
-    @ccall (libnvml()).nvmlVgpuInstanceGetAccountingPids(vgpuInstance::nvmlVgpuInstance_t,
-                                                         count::Ptr{Cuint},
-                                                         pids::Ptr{Cuint})::nvmlReturn_t
+    @gcsafe_ccall (libnvml()).nvmlVgpuInstanceGetAccountingPids(vgpuInstance::nvmlVgpuInstance_t,
+                                                                count::Ptr{Cuint},
+                                                                pids::Ptr{Cuint})::nvmlReturn_t
 end
 
 @checked function nvmlVgpuInstanceGetAccountingStats(vgpuInstance, pid, stats)
     initialize_context()
-    @ccall (libnvml()).nvmlVgpuInstanceGetAccountingStats(vgpuInstance::nvmlVgpuInstance_t,
-                                                          pid::Cuint,
-                                                          stats::Ptr{nvmlAccountingStats_t})::nvmlReturn_t
+    @gcsafe_ccall (libnvml()).nvmlVgpuInstanceGetAccountingStats(vgpuInstance::nvmlVgpuInstance_t,
+                                                                 pid::Cuint,
+                                                                 stats::Ptr{nvmlAccountingStats_t})::nvmlReturn_t
 end
 
 @checked function nvmlVgpuInstanceClearAccountingPids(vgpuInstance)
     initialize_context()
-    @ccall (libnvml()).nvmlVgpuInstanceClearAccountingPids(vgpuInstance::nvmlVgpuInstance_t)::nvmlReturn_t
+    @gcsafe_ccall (libnvml()).nvmlVgpuInstanceClearAccountingPids(vgpuInstance::nvmlVgpuInstance_t)::nvmlReturn_t
 end
 
 struct nvmlGpuInstanceProfileInfo_st
@@ -3159,186 +3185,189 @@ const nvmlComputeInstanceProfileInfo_v3_t = nvmlComputeInstanceProfileInfo_v3_st
 
 @checked function nvmlDeviceSetMigMode(device, mode, activationStatus)
     initialize_context()
-    @ccall (libnvml()).nvmlDeviceSetMigMode(device::nvmlDevice_t, mode::Cuint,
-                                            activationStatus::Ptr{nvmlReturn_t})::nvmlReturn_t
+    @gcsafe_ccall (libnvml()).nvmlDeviceSetMigMode(device::nvmlDevice_t, mode::Cuint,
+                                                   activationStatus::Ptr{nvmlReturn_t})::nvmlReturn_t
 end
 
 @checked function nvmlDeviceGetMigMode(device, currentMode, pendingMode)
     initialize_context()
-    @ccall (libnvml()).nvmlDeviceGetMigMode(device::nvmlDevice_t, currentMode::Ptr{Cuint},
-                                            pendingMode::Ptr{Cuint})::nvmlReturn_t
+    @gcsafe_ccall (libnvml()).nvmlDeviceGetMigMode(device::nvmlDevice_t,
+                                                   currentMode::Ptr{Cuint},
+                                                   pendingMode::Ptr{Cuint})::nvmlReturn_t
 end
 
 @checked function nvmlDeviceGetGpuInstanceProfileInfo(device, profile, info)
     initialize_context()
-    @ccall (libnvml()).nvmlDeviceGetGpuInstanceProfileInfo(device::nvmlDevice_t,
-                                                           profile::Cuint,
-                                                           info::Ptr{nvmlGpuInstanceProfileInfo_t})::nvmlReturn_t
+    @gcsafe_ccall (libnvml()).nvmlDeviceGetGpuInstanceProfileInfo(device::nvmlDevice_t,
+                                                                  profile::Cuint,
+                                                                  info::Ptr{nvmlGpuInstanceProfileInfo_t})::nvmlReturn_t
 end
 
 @checked function nvmlDeviceGetGpuInstanceProfileInfoV(device, profile, info)
     initialize_context()
-    @ccall (libnvml()).nvmlDeviceGetGpuInstanceProfileInfoV(device::nvmlDevice_t,
-                                                            profile::Cuint,
-                                                            info::Ptr{nvmlGpuInstanceProfileInfo_v2_t})::nvmlReturn_t
+    @gcsafe_ccall (libnvml()).nvmlDeviceGetGpuInstanceProfileInfoV(device::nvmlDevice_t,
+                                                                   profile::Cuint,
+                                                                   info::Ptr{nvmlGpuInstanceProfileInfo_v2_t})::nvmlReturn_t
 end
 
 @checked function nvmlDeviceGetGpuInstanceRemainingCapacity(device, profileId, count)
     initialize_context()
-    @ccall (libnvml()).nvmlDeviceGetGpuInstanceRemainingCapacity(device::nvmlDevice_t,
-                                                                 profileId::Cuint,
-                                                                 count::Ptr{Cuint})::nvmlReturn_t
+    @gcsafe_ccall (libnvml()).nvmlDeviceGetGpuInstanceRemainingCapacity(device::nvmlDevice_t,
+                                                                        profileId::Cuint,
+                                                                        count::Ptr{Cuint})::nvmlReturn_t
 end
 
 @checked function nvmlDeviceCreateGpuInstance(device, profileId, gpuInstance)
     initialize_context()
-    @ccall (libnvml()).nvmlDeviceCreateGpuInstance(device::nvmlDevice_t, profileId::Cuint,
-                                                   gpuInstance::Ptr{nvmlGpuInstance_t})::nvmlReturn_t
+    @gcsafe_ccall (libnvml()).nvmlDeviceCreateGpuInstance(device::nvmlDevice_t,
+                                                          profileId::Cuint,
+                                                          gpuInstance::Ptr{nvmlGpuInstance_t})::nvmlReturn_t
 end
 
 @checked function nvmlDeviceCreateGpuInstanceWithPlacement(device, profileId, placement,
                                                            gpuInstance)
     initialize_context()
-    @ccall (libnvml()).nvmlDeviceCreateGpuInstanceWithPlacement(device::nvmlDevice_t,
-                                                                profileId::Cuint,
-                                                                placement::Ptr{nvmlGpuInstancePlacement_t},
-                                                                gpuInstance::Ptr{nvmlGpuInstance_t})::nvmlReturn_t
+    @gcsafe_ccall (libnvml()).nvmlDeviceCreateGpuInstanceWithPlacement(device::nvmlDevice_t,
+                                                                       profileId::Cuint,
+                                                                       placement::Ptr{nvmlGpuInstancePlacement_t},
+                                                                       gpuInstance::Ptr{nvmlGpuInstance_t})::nvmlReturn_t
 end
 
 @checked function nvmlGpuInstanceDestroy(gpuInstance)
     initialize_context()
-    @ccall (libnvml()).nvmlGpuInstanceDestroy(gpuInstance::nvmlGpuInstance_t)::nvmlReturn_t
+    @gcsafe_ccall (libnvml()).nvmlGpuInstanceDestroy(gpuInstance::nvmlGpuInstance_t)::nvmlReturn_t
 end
 
 @checked function nvmlDeviceGetGpuInstances(device, profileId, gpuInstances, count)
     initialize_context()
-    @ccall (libnvml()).nvmlDeviceGetGpuInstances(device::nvmlDevice_t, profileId::Cuint,
-                                                 gpuInstances::Ptr{nvmlGpuInstance_t},
-                                                 count::Ptr{Cuint})::nvmlReturn_t
+    @gcsafe_ccall (libnvml()).nvmlDeviceGetGpuInstances(device::nvmlDevice_t,
+                                                        profileId::Cuint,
+                                                        gpuInstances::Ptr{nvmlGpuInstance_t},
+                                                        count::Ptr{Cuint})::nvmlReturn_t
 end
 
 @checked function nvmlDeviceGetGpuInstanceById(device, id, gpuInstance)
     initialize_context()
-    @ccall (libnvml()).nvmlDeviceGetGpuInstanceById(device::nvmlDevice_t, id::Cuint,
-                                                    gpuInstance::Ptr{nvmlGpuInstance_t})::nvmlReturn_t
+    @gcsafe_ccall (libnvml()).nvmlDeviceGetGpuInstanceById(device::nvmlDevice_t, id::Cuint,
+                                                           gpuInstance::Ptr{nvmlGpuInstance_t})::nvmlReturn_t
 end
 
 @checked function nvmlGpuInstanceGetInfo(gpuInstance, info)
     initialize_context()
-    @ccall (libnvml()).nvmlGpuInstanceGetInfo(gpuInstance::nvmlGpuInstance_t,
-                                              info::Ptr{nvmlGpuInstanceInfo_t})::nvmlReturn_t
+    @gcsafe_ccall (libnvml()).nvmlGpuInstanceGetInfo(gpuInstance::nvmlGpuInstance_t,
+                                                     info::Ptr{nvmlGpuInstanceInfo_t})::nvmlReturn_t
 end
 
 @checked function nvmlGpuInstanceGetComputeInstanceProfileInfo(gpuInstance, profile,
                                                                engProfile, info)
     initialize_context()
-    @ccall (libnvml()).nvmlGpuInstanceGetComputeInstanceProfileInfo(gpuInstance::nvmlGpuInstance_t,
-                                                                    profile::Cuint,
-                                                                    engProfile::Cuint,
-                                                                    info::Ptr{nvmlComputeInstanceProfileInfo_t})::nvmlReturn_t
+    @gcsafe_ccall (libnvml()).nvmlGpuInstanceGetComputeInstanceProfileInfo(gpuInstance::nvmlGpuInstance_t,
+                                                                           profile::Cuint,
+                                                                           engProfile::Cuint,
+                                                                           info::Ptr{nvmlComputeInstanceProfileInfo_t})::nvmlReturn_t
 end
 
 @checked function nvmlGpuInstanceGetComputeInstanceProfileInfoV(gpuInstance, profile,
                                                                 engProfile, info)
     initialize_context()
-    @ccall (libnvml()).nvmlGpuInstanceGetComputeInstanceProfileInfoV(gpuInstance::nvmlGpuInstance_t,
-                                                                     profile::Cuint,
-                                                                     engProfile::Cuint,
-                                                                     info::Ptr{nvmlComputeInstanceProfileInfo_v2_t})::nvmlReturn_t
+    @gcsafe_ccall (libnvml()).nvmlGpuInstanceGetComputeInstanceProfileInfoV(gpuInstance::nvmlGpuInstance_t,
+                                                                            profile::Cuint,
+                                                                            engProfile::Cuint,
+                                                                            info::Ptr{nvmlComputeInstanceProfileInfo_v2_t})::nvmlReturn_t
 end
 
 @checked function nvmlGpuInstanceGetComputeInstanceRemainingCapacity(gpuInstance, profileId,
                                                                      count)
     initialize_context()
-    @ccall (libnvml()).nvmlGpuInstanceGetComputeInstanceRemainingCapacity(gpuInstance::nvmlGpuInstance_t,
-                                                                          profileId::Cuint,
-                                                                          count::Ptr{Cuint})::nvmlReturn_t
+    @gcsafe_ccall (libnvml()).nvmlGpuInstanceGetComputeInstanceRemainingCapacity(gpuInstance::nvmlGpuInstance_t,
+                                                                                 profileId::Cuint,
+                                                                                 count::Ptr{Cuint})::nvmlReturn_t
 end
 
 @checked function nvmlGpuInstanceGetComputeInstancePossiblePlacements(gpuInstance,
                                                                       profileId, placements,
                                                                       count)
     initialize_context()
-    @ccall (libnvml()).nvmlGpuInstanceGetComputeInstancePossiblePlacements(gpuInstance::nvmlGpuInstance_t,
-                                                                           profileId::Cuint,
-                                                                           placements::Ptr{nvmlComputeInstancePlacement_t},
-                                                                           count::Ptr{Cuint})::nvmlReturn_t
+    @gcsafe_ccall (libnvml()).nvmlGpuInstanceGetComputeInstancePossiblePlacements(gpuInstance::nvmlGpuInstance_t,
+                                                                                  profileId::Cuint,
+                                                                                  placements::Ptr{nvmlComputeInstancePlacement_t},
+                                                                                  count::Ptr{Cuint})::nvmlReturn_t
 end
 
 @checked function nvmlGpuInstanceCreateComputeInstance(gpuInstance, profileId,
                                                        computeInstance)
     initialize_context()
-    @ccall (libnvml()).nvmlGpuInstanceCreateComputeInstance(gpuInstance::nvmlGpuInstance_t,
-                                                            profileId::Cuint,
-                                                            computeInstance::Ptr{nvmlComputeInstance_t})::nvmlReturn_t
+    @gcsafe_ccall (libnvml()).nvmlGpuInstanceCreateComputeInstance(gpuInstance::nvmlGpuInstance_t,
+                                                                   profileId::Cuint,
+                                                                   computeInstance::Ptr{nvmlComputeInstance_t})::nvmlReturn_t
 end
 
 @checked function nvmlGpuInstanceCreateComputeInstanceWithPlacement(gpuInstance, profileId,
                                                                     placement,
                                                                     computeInstance)
     initialize_context()
-    @ccall (libnvml()).nvmlGpuInstanceCreateComputeInstanceWithPlacement(gpuInstance::nvmlGpuInstance_t,
-                                                                         profileId::Cuint,
-                                                                         placement::Ptr{nvmlComputeInstancePlacement_t},
-                                                                         computeInstance::Ptr{nvmlComputeInstance_t})::nvmlReturn_t
+    @gcsafe_ccall (libnvml()).nvmlGpuInstanceCreateComputeInstanceWithPlacement(gpuInstance::nvmlGpuInstance_t,
+                                                                                profileId::Cuint,
+                                                                                placement::Ptr{nvmlComputeInstancePlacement_t},
+                                                                                computeInstance::Ptr{nvmlComputeInstance_t})::nvmlReturn_t
 end
 
 @checked function nvmlComputeInstanceDestroy(computeInstance)
     initialize_context()
-    @ccall (libnvml()).nvmlComputeInstanceDestroy(computeInstance::nvmlComputeInstance_t)::nvmlReturn_t
+    @gcsafe_ccall (libnvml()).nvmlComputeInstanceDestroy(computeInstance::nvmlComputeInstance_t)::nvmlReturn_t
 end
 
 @checked function nvmlGpuInstanceGetComputeInstances(gpuInstance, profileId,
                                                      computeInstances, count)
     initialize_context()
-    @ccall (libnvml()).nvmlGpuInstanceGetComputeInstances(gpuInstance::nvmlGpuInstance_t,
-                                                          profileId::Cuint,
-                                                          computeInstances::Ptr{nvmlComputeInstance_t},
-                                                          count::Ptr{Cuint})::nvmlReturn_t
+    @gcsafe_ccall (libnvml()).nvmlGpuInstanceGetComputeInstances(gpuInstance::nvmlGpuInstance_t,
+                                                                 profileId::Cuint,
+                                                                 computeInstances::Ptr{nvmlComputeInstance_t},
+                                                                 count::Ptr{Cuint})::nvmlReturn_t
 end
 
 @checked function nvmlGpuInstanceGetComputeInstanceById(gpuInstance, id, computeInstance)
     initialize_context()
-    @ccall (libnvml()).nvmlGpuInstanceGetComputeInstanceById(gpuInstance::nvmlGpuInstance_t,
-                                                             id::Cuint,
-                                                             computeInstance::Ptr{nvmlComputeInstance_t})::nvmlReturn_t
+    @gcsafe_ccall (libnvml()).nvmlGpuInstanceGetComputeInstanceById(gpuInstance::nvmlGpuInstance_t,
+                                                                    id::Cuint,
+                                                                    computeInstance::Ptr{nvmlComputeInstance_t})::nvmlReturn_t
 end
 
 @checked function nvmlDeviceIsMigDeviceHandle(device, isMigDevice)
     initialize_context()
-    @ccall (libnvml()).nvmlDeviceIsMigDeviceHandle(device::nvmlDevice_t,
-                                                   isMigDevice::Ptr{Cuint})::nvmlReturn_t
+    @gcsafe_ccall (libnvml()).nvmlDeviceIsMigDeviceHandle(device::nvmlDevice_t,
+                                                          isMigDevice::Ptr{Cuint})::nvmlReturn_t
 end
 
 @checked function nvmlDeviceGetGpuInstanceId(device, id)
     initialize_context()
-    @ccall (libnvml()).nvmlDeviceGetGpuInstanceId(device::nvmlDevice_t,
-                                                  id::Ptr{Cuint})::nvmlReturn_t
+    @gcsafe_ccall (libnvml()).nvmlDeviceGetGpuInstanceId(device::nvmlDevice_t,
+                                                         id::Ptr{Cuint})::nvmlReturn_t
 end
 
 @checked function nvmlDeviceGetComputeInstanceId(device, id)
     initialize_context()
-    @ccall (libnvml()).nvmlDeviceGetComputeInstanceId(device::nvmlDevice_t,
-                                                      id::Ptr{Cuint})::nvmlReturn_t
+    @gcsafe_ccall (libnvml()).nvmlDeviceGetComputeInstanceId(device::nvmlDevice_t,
+                                                             id::Ptr{Cuint})::nvmlReturn_t
 end
 
 @checked function nvmlDeviceGetMaxMigDeviceCount(device, count)
     initialize_context()
-    @ccall (libnvml()).nvmlDeviceGetMaxMigDeviceCount(device::nvmlDevice_t,
-                                                      count::Ptr{Cuint})::nvmlReturn_t
+    @gcsafe_ccall (libnvml()).nvmlDeviceGetMaxMigDeviceCount(device::nvmlDevice_t,
+                                                             count::Ptr{Cuint})::nvmlReturn_t
 end
 
 @checked function nvmlDeviceGetMigDeviceHandleByIndex(device, index, migDevice)
     initialize_context()
-    @ccall (libnvml()).nvmlDeviceGetMigDeviceHandleByIndex(device::nvmlDevice_t,
-                                                           index::Cuint,
-                                                           migDevice::Ptr{nvmlDevice_t})::nvmlReturn_t
+    @gcsafe_ccall (libnvml()).nvmlDeviceGetMigDeviceHandleByIndex(device::nvmlDevice_t,
+                                                                  index::Cuint,
+                                                                  migDevice::Ptr{nvmlDevice_t})::nvmlReturn_t
 end
 
 @checked function nvmlDeviceGetDeviceHandleFromMigDeviceHandle(migDevice, device)
     initialize_context()
-    @ccall (libnvml()).nvmlDeviceGetDeviceHandleFromMigDeviceHandle(migDevice::nvmlDevice_t,
-                                                                    device::Ptr{nvmlDevice_t})::nvmlReturn_t
+    @gcsafe_ccall (libnvml()).nvmlDeviceGetDeviceHandleFromMigDeviceHandle(migDevice::nvmlDevice_t,
+                                                                           device::Ptr{nvmlDevice_t})::nvmlReturn_t
 end
 
 @cenum nvmlGpmMetricId_t::UInt32 begin
@@ -3479,47 +3508,48 @@ end
 
 @checked function nvmlGpmMetricsGet(metricsGet)
     initialize_context()
-    @ccall (libnvml()).nvmlGpmMetricsGet(metricsGet::Ptr{nvmlGpmMetricsGet_t})::nvmlReturn_t
+    @gcsafe_ccall (libnvml()).nvmlGpmMetricsGet(metricsGet::Ptr{nvmlGpmMetricsGet_t})::nvmlReturn_t
 end
 
 @checked function nvmlGpmSampleFree(gpmSample)
     initialize_context()
-    @ccall (libnvml()).nvmlGpmSampleFree(gpmSample::nvmlGpmSample_t)::nvmlReturn_t
+    @gcsafe_ccall (libnvml()).nvmlGpmSampleFree(gpmSample::nvmlGpmSample_t)::nvmlReturn_t
 end
 
 @checked function nvmlGpmSampleAlloc(gpmSample)
     initialize_context()
-    @ccall (libnvml()).nvmlGpmSampleAlloc(gpmSample::Ptr{nvmlGpmSample_t})::nvmlReturn_t
+    @gcsafe_ccall (libnvml()).nvmlGpmSampleAlloc(gpmSample::Ptr{nvmlGpmSample_t})::nvmlReturn_t
 end
 
 @checked function nvmlGpmSampleGet(device, gpmSample)
     initialize_context()
-    @ccall (libnvml()).nvmlGpmSampleGet(device::nvmlDevice_t,
-                                        gpmSample::nvmlGpmSample_t)::nvmlReturn_t
+    @gcsafe_ccall (libnvml()).nvmlGpmSampleGet(device::nvmlDevice_t,
+                                               gpmSample::nvmlGpmSample_t)::nvmlReturn_t
 end
 
 @checked function nvmlGpmMigSampleGet(device, gpuInstanceId, gpmSample)
     initialize_context()
-    @ccall (libnvml()).nvmlGpmMigSampleGet(device::nvmlDevice_t, gpuInstanceId::Cuint,
-                                           gpmSample::nvmlGpmSample_t)::nvmlReturn_t
+    @gcsafe_ccall (libnvml()).nvmlGpmMigSampleGet(device::nvmlDevice_t,
+                                                  gpuInstanceId::Cuint,
+                                                  gpmSample::nvmlGpmSample_t)::nvmlReturn_t
 end
 
 @checked function nvmlGpmQueryDeviceSupport(device, gpmSupport)
     initialize_context()
-    @ccall (libnvml()).nvmlGpmQueryDeviceSupport(device::nvmlDevice_t,
-                                                 gpmSupport::Ptr{nvmlGpmSupport_t})::nvmlReturn_t
+    @gcsafe_ccall (libnvml()).nvmlGpmQueryDeviceSupport(device::nvmlDevice_t,
+                                                        gpmSupport::Ptr{nvmlGpmSupport_t})::nvmlReturn_t
 end
 
 @checked function nvmlGpmQueryIfStreamingEnabled(device, state)
     initialize_context()
-    @ccall (libnvml()).nvmlGpmQueryIfStreamingEnabled(device::nvmlDevice_t,
-                                                      state::Ptr{Cuint})::nvmlReturn_t
+    @gcsafe_ccall (libnvml()).nvmlGpmQueryIfStreamingEnabled(device::nvmlDevice_t,
+                                                             state::Ptr{Cuint})::nvmlReturn_t
 end
 
 @checked function nvmlGpmSetStreamingEnabled(device, state)
     initialize_context()
-    @ccall (libnvml()).nvmlGpmSetStreamingEnabled(device::nvmlDevice_t,
-                                                  state::Cuint)::nvmlReturn_t
+    @gcsafe_ccall (libnvml()).nvmlGpmSetStreamingEnabled(device::nvmlDevice_t,
+                                                         state::Cuint)::nvmlReturn_t
 end
 
 struct nvmlNvLinkPowerThres_st
@@ -3530,24 +3560,24 @@ const nvmlNvLinkPowerThres_t = nvmlNvLinkPowerThres_st
 
 @checked function nvmlDeviceSetNvLinkDeviceLowPowerThreshold(device, info)
     initialize_context()
-    @ccall (libnvml()).nvmlDeviceSetNvLinkDeviceLowPowerThreshold(device::nvmlDevice_t,
-                                                                  info::Ptr{nvmlNvLinkPowerThres_t})::nvmlReturn_t
+    @gcsafe_ccall (libnvml()).nvmlDeviceSetNvLinkDeviceLowPowerThreshold(device::nvmlDevice_t,
+                                                                         info::Ptr{nvmlNvLinkPowerThres_t})::nvmlReturn_t
 end
 
 @checked function nvmlSystemSetNvlinkBwMode(nvlinkBwMode)
     initialize_context()
-    @ccall (libnvml()).nvmlSystemSetNvlinkBwMode(nvlinkBwMode::Cuint)::nvmlReturn_t
+    @gcsafe_ccall (libnvml()).nvmlSystemSetNvlinkBwMode(nvlinkBwMode::Cuint)::nvmlReturn_t
 end
 
 @checked function nvmlSystemGetNvlinkBwMode(nvlinkBwMode)
     initialize_context()
-    @ccall (libnvml()).nvmlSystemGetNvlinkBwMode(nvlinkBwMode::Ptr{Cuint})::nvmlReturn_t
+    @gcsafe_ccall (libnvml()).nvmlSystemGetNvlinkBwMode(nvlinkBwMode::Ptr{Cuint})::nvmlReturn_t
 end
 
 @checked function nvmlDeviceSetPowerManagementLimit_v2(device, powerValue)
     initialize_context()
-    @ccall (libnvml()).nvmlDeviceSetPowerManagementLimit_v2(device::nvmlDevice_t,
-                                                            powerValue::Ptr{nvmlPowerValue_v2_t})::nvmlReturn_t
+    @gcsafe_ccall (libnvml()).nvmlDeviceSetPowerManagementLimit_v2(device::nvmlDevice_t,
+                                                                   powerValue::Ptr{nvmlPowerValue_v2_t})::nvmlReturn_t
 end
 
 struct var"##Ctag#318"

--- a/lib/utils/call.jl
+++ b/lib/utils/call.jl
@@ -251,7 +251,7 @@ macro gcunsafe_callback(ex)
     gcunsafe_body = quote
         gc_state = @ccall(jl_gc_unsafe_enter()::Int8)
         try
-            $(ex)
+            $body
         finally
             @ccall(jl_gc_unsafe_leave(gc_state::Int8)::Cvoid)
         end

--- a/lib/utils/call.jl
+++ b/lib/utils/call.jl
@@ -200,7 +200,8 @@ function ccall_macro_lower(func, rettype, types, args, nreq)
         $(unsafe_convert_exprs...)
 
         gc_state = @ccall(jl_gc_safe_enter()::Int8)
-        ret = ccall($(esc(func)), $(esc(rettype)), $(Expr(:tuple, map(esc, types)...)), $(unsafe_convert_args...))
+        ret = ccall($(esc(func)), $(esc(rettype)), $(Expr(:tuple, map(esc, types)...)),
+                    $(unsafe_convert_args...))
         @ccall(jl_gc_safe_leave(gc_state::Int8)::Cvoid)
         ret
     end

--- a/lib/utils/call.jl
+++ b/lib/utils/call.jl
@@ -165,6 +165,12 @@ render_arg(io, arg::Union{<:Base.RefValue, AbstractArray}) = summary(io, arg)
 
 # TODO: replace with JuliaLang/julia#49933 once merged
 
+# note that this is generally only safe with functions that do not call back into Julia.
+# when callbacks occur, the code should ensure the GC is not running:
+# - on 1.10 and later, everything is fine because of safepoint_on_entry
+# - on 1.9, @cfunction-based callbacks are fine because they transition to gc_unsafe
+# - on 1.8 and earlier, the code should explicitly call GC.safepoint()!
+
 function ccall_macro_lower(func, rettype, types, args, nreq)
     # instead of re-using ccall or Expr(:foreigncall) to perform argument conversion,
     # we need to do so ourselves in order to insert a jl_gc_safe_enter|leave

--- a/res/wrap/wrap.jl
+++ b/res/wrap/wrap.jl
@@ -162,6 +162,9 @@ function rewriter!(ctx, options)
             expr = node.exprs[1]
             call_expr = expr.args[2].args[1].args[3]    # assumes `use_ccall_macro` is true
 
+            # replace `@ccall` with `@gcsafe_ccall`
+            expr.args[2].args[1].args[1] = Symbol("@gcsafe_ccall")
+
             target_expr = call_expr.args[1].args[1]
             fn = String(target_expr.args[2].value)
 

--- a/src/pointer.jl
+++ b/src/pointer.jl
@@ -129,6 +129,10 @@ function Base.unsafe_convert(::Type{PtrOrCuPtr{T}}, val) where {T}
     return Base.bitcast(PtrOrCuPtr{T}, ptr)
 end
 
+# avoid ambiguities when passing PtrOrCuPtr instances
+# NOTE: this happens now with `@gcsafe_ccall` due to the double `ccall`
+Base.unsafe_convert(::Type{PtrOrCuPtr{T}}, x::PtrOrCuPtr{T}) where {T} = x
+
 
 #
 # CUDA array pointer
@@ -269,3 +273,7 @@ Base.convert(::Type{RefOrCuRef{T}}, x::Array{T}) where {T} = convert(Ref{T}, x)
 Base.convert(::Type{RefOrCuRef{T}}, x::AbstractArray{T}) where {T} = convert(CuRef{T}, x)
 Base.unsafe_convert(P::Type{RefOrCuRef{T}}, b::CuRefArray{T}) where T =
     Base.bitcast(RefOrCuRef{T}, Base.unsafe_convert(CuRef{T}, b))
+
+# avoid ambiguities when passing RefOrCuRef instances
+# NOTE: this happens now with `@gcsafe_ccall` due to the double `ccall`
+Base.unsafe_convert(::Type{RefOrCuRef{T}}, x::RefOrCuRef{T}) where {T} = x


### PR DESCRIPTION
Using https://docs.julialang.org/en/v1/stdlib/Profile/#Triggered-During-Execution I observed an issue in #2261 where
we acquire a lock in `cuOccupancyMaxPotentialBlockSize` and seemingly get live locked. Other threads
suspend in waiting for GC and no forward progress is being made.

Manually marking `cuOccupancyMaxPotentialBlockSize` as safe to execute GC next to seemingly fixes the issue,
we could add a convenience macro for doing this.

---

Update by @maleadt: I made all ccalls GC safe, made sure callbacks are GC unsafe again.

x-ref https://github.com/JuliaLang/julia/pull/49933