### PR TITLE
cuTENSOR: Fix reference to undefined variable

### DIFF
--- a/lib/cutensor/src/operations.jl
+++ b/lib/cutensor/src/operations.jl
@@ -430,7 +430,7 @@ function plan_reduction(
     modeC = collect(Cint, Cinds)
 
     actual_compute_type = if compute_type === nothing
-        reduction_compute_types[(eltype(A), eltype(B), eltype(C))]
+        reduction_compute_types[(eltype(A), eltype(C))]
     else
         compute_type
     end


### PR DESCRIPTION
This is a small fix about a typo in figuring out the `compute_type` in the `plan_reduction` function, having three arguments, while only two tensors are involved.

On a different note, this is never caught in the tests, as `reduce!` actually determines the `compute_type` before it creates the plan, and there it is correctly implemented. (This is also true for `contract!`, `permute!`, `elementwise_binary_exectute!` and `elementwise_trinary_execute!`, but as far as I can tell, these are all correct). I think it could make sense to remove this duplicate code, and just let the `plan_**operation**` functions be the only place where the `compute_type` is determined.
I can file a PR for that as well, or update this one, but this is a bit larger of a change so I'd rather get some feedback first.