### PR TITLE
Fix cuTensor, cuTensorNet and cuStateVec when using local Toolkit

### DIFF
--- a/lib/custatevec/src/cuStateVec.jl
+++ b/lib/custatevec/src/cuStateVec.jl
@@ -119,8 +119,8 @@ function __init__()
     # find the library
     global libcustatevec
     if CUDA.local_toolkit
-        dirs = CUDA_Runtime.find_toolkit()
-        path = CUDA_Runtime.get_library(dirs, "custatevec"; optional=true)
+        dirs = CUDA_Runtime_Discovery.find_toolkit()
+        path = CUDA_Runtime_Discovery.get_library(dirs, "custatevec"; optional=true)
         if path === nothing
             precompiling || @error "cuQuantum is not available on your system (looked for custatevec in $(join(dirs, ", ")))"
             return

--- a/lib/cutensor/src/cuTENSOR.jl
+++ b/lib/cutensor/src/cuTENSOR.jl
@@ -95,8 +95,8 @@ function __init__()
     # find the library
     global libcutensor
     if CUDA.local_toolkit
-        dirs = CUDA_Runtime.find_toolkit()
-        path = CUDA_Runtime.get_library(dirs, "cutensor"; optional=true)
+        dirs = CUDA_Runtime_Discovery.find_toolkit()
+        path = CUDA_Runtime_Discovery.get_library(dirs, "cutensor"; optional=true)
         if path === nothing
             precompiling || @error "cuTENSOR is not available on your system (looked in $(join(dirs, ", ")))"
             return

--- a/lib/cutensornet/src/cuTensorNet.jl
+++ b/lib/cutensornet/src/cuTensorNet.jl
@@ -120,8 +120,8 @@ function __init__()
     # find the library
     global libcutensornet
     if CUDA.local_toolkit
-        dirs = CUDA_Runtime.find_toolkit()
-        path = CUDA_Runtime.get_library(dirs, "cutensornet"; optional=true)
+        dirs = CUDA_Runtime_Discovery.find_toolkit()
+        path = CUDA_Runtime_Discovery.get_library(dirs, "cutensornet"; optional=true)
         if path === nothing
             precompiling || @error "cuQuantum is not available on your system (looked for cutensornet in $(join(dirs, ", ")))"
             return


### PR DESCRIPTION
Currently when trying to use cuTENSOR with a local version of the CUDA toolkit, this fails with:

```
ERROR: LoadError: InitError: UndefVarError: `CUDA_Runtime` not defined
```
due to #2058 being incomplete.

Versions used:
- Julia 1.10.1
- Cuda Toolkit v12.3.2 loaded via Lmod on a HPC cluster

There are some more occurances of CUDA_Runtime in CUDA.jl, but I haven't had any errors due to these: https://github.com/search?q=repo%3AJuliaGPU%2FCUDA.jl%20CUDA_Runtime.&type=code

I have tested this PR by using cuTENSOR (also locally provided as Lmod module), and fixed cuTensorNet (currently not compatible with cuTensor v2?) and cuStateVec due to similarity without testing.