### PR TITLE
Avoid capturing `AbstractArray`s in `BoundsError`

### DIFF
--- a/src/device/quirks.jl
+++ b/src/device/quirks.jl
@@ -37,8 +37,9 @@ end
     @print_and_throw "Inexact conversion"
 
 # abstractarray.jl
-@device_override @noinline Base.throw_boundserror(A, I) =
+@noinline throw_boundserror() =
     @print_and_throw "Out-of-bounds array access"
+@device_override @inline Base.throw_boundserror(A, I) = throw_boundserror()
 
 # trig.jl
 @device_override @noinline Base.Math.sincos_domain_error(x) =


### PR DESCRIPTION
This quirk allows bounds checking of `MArray`s on device in more cases. This is a workaround to address <https://github.com/JuliaGPU/CUDA.jl/issues/2313>.