### PR TITLE
Add some installation tips to docs/README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,11 @@ kernels in Julia, and wrappers for various CUDA libraries.
 
 The latest development version of CUDA.jl requires **Julia 1.8** or higher. If you are using
 an older version of Julia, you need to use a previous version of CUDA.jl. This will happen
-automatically when you install the package using Julia's package manager.
+automatically when you install the package using Julia's package manager. 
+
+Note that CUDA.jl may not work with a custom build of Julia; it is recommended that you 
+install Julia using the [official binaries](https://julialang.org/downloads/) or 
+[juliaup](https://github.com/JuliaLang/juliaup). 
 
 CUDA.jl currently also requires a CUDA-capable GPU with **compute capability 3.5** (Kepler)
 or higher, and an accompanying NVIDIA driver with support for **CUDA 11.0** or newer. These
@@ -48,7 +52,6 @@ Depending on your system and GPU, you may need to install an older version of th
 
 Finally, you should be using a platform **supported by NVIDIA**. Currently, that means using
 64-bit Linux or Windows, with an X86, ARM, or PowerPC host processor.
-
 
 ## Quick start
 

--- a/docs/src/faq.md
+++ b/docs/src/faq.md
@@ -61,5 +61,5 @@ respective repositories.
 ## When installing CUDA.jl on a cluster, why does Julia stall during precompilation?
 
 If you're working on a cluster, precompilation may stall if you have not requested 
-sufficient memory. You may also wish to make sure you have enough disk space. 
-enough disk space. 
+sufficient memory. You may also wish to make sure you have enough disk space prior
+to installing CUDA.jl.

--- a/docs/src/faq.md
+++ b/docs/src/faq.md
@@ -56,3 +56,10 @@ their exported submodule handles, e.g., `CUBLAS.cublasGetVersion_v2`.
 Any help on designing or implementing high-level wrappers for this low-level functionality
 is greatly appreciated, so please consider contributing your uses of these APIs on the
 respective repositories.
+
+
+## When installing CUDA.jl on a cluster, why does Julia stall during precompilation?
+
+If you're working on a cluster, precompilation may stall if you have not requested 
+sufficient memory. You may also wish to make sure you have enough disk space. 
+enough disk space. 


### PR DESCRIPTION
This PR notes that the GPU stack is not expected to work with custom builds of Julia, and provides some tips on installing CUDA.jl on a cluster.