### PR TITLE
fix broadcast defaulting to Mem.Unified()

### DIFF
--- a/src/broadcast.jl
+++ b/src/broadcast.jl
@@ -16,6 +16,11 @@ BroadcastStyle(::CUDA.CuArrayStyle{N1, B1},
                ::CUDA.CuArrayStyle{N2, B2}) where {N1,N2,B1,B2} =
     CuArrayStyle{max(N1,N2), Mem.Unified}()
 
+# resolve ambiguity: different N, same buffer
+BroadcastStyle(::CUDA.CuArrayStyle{N1, B},
+               ::CUDA.CuArrayStyle{N2, B}) where {N1,N2,B} =
+    CuArrayStyle{max(N1,N2), B}()
+
 # allocation of output arrays
 Base.similar(bc::Broadcasted{CuArrayStyle{N,B}}, ::Type{T}, dims) where {T,N,B} =
     similar(CuArray{T,length(dims),B}, dims)

--- a/test/base/broadcast.jl
+++ b/test/base/broadcast.jl
@@ -68,4 +68,10 @@ end
   g = cu([1 2]; host=true)
   h = f .+ g
   @test is_unified(h)
+
+  # however, differences in only shape shouldn't change the buffer type
+  i = cu([1]; device=true)
+  j = cu([1 2]; device=true)
+  k = i .+ j
+  @test !is_unified(k)
 end


### PR DESCRIPTION
On `5.3`, Broadcast defaults to `Mem.Unified()`.
```julia
julia> x = CUDA.ones(1, 4)
1×4 CuArray{Float32, 2, CUDA.Mem.DeviceBuffer}:
 1.0  1.0  1.0  1.0

julia> y = CUDA.ones(1)
1-element CuArray{Float32, 1, CUDA.Mem.DeviceBuffer}:
 1.0

julia> x .+ y
1×4 CuArray{Float32, 2, CUDA.Mem.UnifiedBuffer}:
 2.0  2.0  2.0  2.0
```
This PR defines an additional method so buffer of arguments is respected.
```julia
julia> x = CUDA.ones(1, 4)
1×4 CuArray{Float32, 2, CUDA.Mem.DeviceBuffer}:
 1.0  1.0  1.0  1.0

julia> y = CUDA.ones(1)
1-element CuArray{Float32, 1, CUDA.Mem.DeviceBuffer}:
 1.0

julia> x .+ y
1×4 CuArray{Float32, 2, CUDA.Mem.DeviceBuffer}:
 2.0  2.0  2.0  2.0
```