### PR TITLE
Fix performance of indexing unified memory.

### DIFF
--- a/src/memory.jl
+++ b/src/memory.jl
@@ -577,7 +577,7 @@ function Base.convert(::Type{Ptr{T}}, managed::Managed{M}) where {T,M}
   end
 
   # make sure any work on the memory has finished.
-  synchronize(managed)
+  maybe_synchronize(managed)
   convert(Ptr{T}, managed.mem)
 end
 


### PR DESCRIPTION
Part of the goal of https://github.com/JuliaGPU/CUDA.jl/pull/2335 was to improve the performance of deriving a CPU pointer from a unified memory object, i.e., to speed up indexing of `CuArray`s on the CPU. I did a typo resulting in actually regressing that performance, so this brings it back to the expected improvement.

Before https://github.com/JuliaGPU/CUDA.jl/pull/2335:

```julia
julia> a = [1]
1-element Vector{Int64}:
 1

julia> @benchmark $a[]
BenchmarkTools.Trial: 10000 samples with 1000 evaluations.
 Range (min … max):  1.879 ns … 6.970 ns  ┊ GC (min … max): 0.00% … 0.00%
 Time  (median):     1.910 ns             ┊ GC (median):    0.00%
 Time  (mean ± σ):   1.911 ns ± 0.100 ns  ┊ GC (mean ± σ):  0.00% ± 0.00%

   ▃             ▄             ▇           ▁ █            ▆ ▂
  ▅█▁▁▁▁▁▁▁▁▁▁▁▆▁█▁▁▁▁▁▁▁▁▁▁▁█▁█▁▁▁▁▁▁▁▁▁▁▁█▁█▁▁▁▁▁▁▁▁▁▁▁██ █
  1.88 ns     Histogram: log(frequency) by time     1.92 ns <

 Memory estimate: 0 bytes, allocs estimate: 0.

julia> b = cu(a; unified=true)
1-element CuArray{Int64, 1, CUDA.Mem.UnifiedBuffer}:
 1

julia> @benchmark $b[]
BenchmarkTools.Trial: 10000 samples with 999 evaluations.
 Range (min … max):  10.349 ns … 16.617 ns  ┊ GC (min … max): 0.00% … 0.00%
 Time  (median):     10.681 ns              ┊ GC (median):    0.00%
 Time  (mean ± σ):   10.685 ns ±  0.169 ns  ┊ GC (mean ± σ):  0.00% ± 0.00%

                                      ▃▇█ █▇▇▅ ▄▂▁
  ▂▂▂▂▁▂▂▂▂▁▂▂▂▂▁▂▂▂▂▁▂▂▃▂▁▂▂▃▄▁▅▅▄▅▁▇███▁████▁███▇▁▆▅▅▄▁▃▃▃▂ ▄
  10.3 ns         Histogram: frequency by time        10.8 ns <

 Memory estimate: 0 bytes, allocs estimate: 0.
```

After https://github.com/JuliaGPU/CUDA.jl/pull/2335 + this PR:

```julia
julia> @benchmark $b[]
BenchmarkTools.Trial: 10000 samples with 1000 evaluations.
 Range (min … max):  3.869 ns … 9.750 ns  ┊ GC (min … max): 0.00% … 0.00%
 Time  (median):     3.950 ns             ┊ GC (median):    0.00%
 Time  (mean ± σ):   3.954 ns ± 0.103 ns  ┊ GC (mean ± σ):  0.00% ± 0.00%

  ▃   ▁   ▂   ▁   ▃   ▂   ▆   ▆   ▇   █   ▂   ▂   ▁   ▄   ▃ ▂
  █▁▁▁█▁▁▁█▁▁▁█▁▁▁█▁▁▁█▁▁▁█▁▁▁█▁▁▁█▁▁▁█▁▁▁█▁▁▁█▁▁▁█▁▁▁█▁▁▁█ █
  3.87 ns     Histogram: log(frequency) by time     4.01 ns <

 Memory estimate: 0 bytes, allocs estimate: 0.
```

This starts to make it possible, I think, to actually use CPU functionality with unified `CuArray`s.