### PR TITLE
Improve exception output

### DIFF
--- a/ext/StaticArraysExt.jl
+++ b/ext/StaticArraysExt.jl
@@ -3,12 +3,12 @@
 module StaticArraysExt
 
 using ..CUDA
-using ..CUDA: @device_override, @print_and_throw
+using ..CUDA: @device_override, @gputhrow
 
 import StaticArrays
 
 # same quirk as for some Base methods in src/device/quirks.jl
 @device_override @noinline StaticArrays.dimension_mismatch_fail(::Type{SA}, a::AbstractArray) where {SA<:StaticArrays.StaticArray} =
-    @print_and_throw("DimensionMismatch while trying to convert to StaticArray: Expected and actual length of input array differ.")
+    @gputhrow("DimensionMismatch", "DimensionMismatch while trying to convert to StaticArray: Expected and actual length of input array differ.")
 
 end  # extension module

--- a/src/compiler/exceptions.jl
+++ b/src/compiler/exceptions.jl
@@ -13,26 +13,28 @@ end
 
 ## exception handling
 
-const exception_flags = Dict{CuContext, HostMemory}()
+const exception_infos = Dict{CuContext, HostMemory}()
 
 # create a CPU/GPU exception flag for error signalling, and put it in the module
 function create_exceptions!(mod::CuModule)
-    mem = get!(exception_flags, mod.ctx) do
-        alloc(HostMemory, sizeof(UInt8), MEMHOSTALLOC_DEVICEMAP)
+    mem = get!(exception_infos, mod.ctx) do
+        alloc(HostMemory, sizeof(ExceptionInfo_st), MEMHOSTALLOC_DEVICEMAP)
     end
-    ptr = convert(Ptr{UInt8}, mem)
-    unsafe_store!(ptr, 0)
-    return ptr
+    exception_info = convert(ExceptionInfo, mem)
+    unsafe_store!(exception_info, ExceptionInfo_st())
+    return exception_info
 end
 
 # check the exception flags on every API call, similarly to how CUDA handles errors
 function check_exceptions()
-    for (ctx,mem) in exception_flags
+    for (ctx,mem) in exception_infos
         if isvalid(ctx)
-            ptr = convert(Ptr{UInt8}, mem)
-            flag = unsafe_load(ptr)
-            if flag != 0
-                unsafe_store!(ptr, 0)
+            exception_info = convert(ExceptionInfo, mem)
+            if exception_info.status != 0
+                # restore the structure
+                unsafe_store!(exception_info, ExceptionInfo_st())
+
+                # throw host-side
                 dev = device(ctx)
                 throw(KernelException(dev))
             end

--- a/src/compiler/execution.jl
+++ b/src/compiler/execution.jl
@@ -259,7 +259,7 @@ end
 
     # add the kernel state, passing an instance with a unique seed
     pushfirst!(call_t, KernelState)
-    pushfirst!(call_args, :(KernelState(kernel.state.exception_flag, make_seed(kernel))))
+    pushfirst!(call_args, :(KernelState(kernel.state.exception_info, make_seed(kernel))))
 
     # finalize types
     call_tt = Base.to_tuple_type(call_t)
@@ -374,8 +374,7 @@ function cufunction(f::F, tt::TT=Tuple{}; kwargs...) where {F,TT}
         kernel = get(_kernel_instances, key, nothing)
         if kernel === nothing
             # create the kernel state object
-            exception_ptr = create_exceptions!(fun.mod)
-            state = KernelState(exception_ptr, UInt32(0))
+            state = KernelState(create_exceptions!(fun.mod), UInt32(0))
 
             kernel = HostKernel{F,tt}(f, fun, state)
             _kernel_instances[key] = kernel

--- a/src/device/quirks.jl
+++ b/src/device/quirks.jl
@@ -1,62 +1,73 @@
-macro print_and_throw(args...)
+# Overlay quirks replacing GPU-incompatible methods
+
+# most of the quirks below deal with exceptions, avoiding calls to often purposefully
+# underspecialized constructors that would result in allocations and/or dynamic dispatches.
+# GPUCompiler.jl cannot detect the type of these exceptions (only those thrown by C code,
+# as identified by calls to specific functions like `throw_boundserror`), so store extra
+# information about the exception type and reason in the `ExceptionInfo` struct, where it
+# will be read by the GPU runtime and printed to the console.
+
+macro gputhrow(subtype, reason)
     quote
-        @cuprintln "ERROR: " $(args...) "."
+        info = kernel_state().exception_info
+        info.subtype = @strptr $subtype
+        info.reason = @strptr $reason
         throw(nothing)
     end
 end
 
 # math.jl
 @device_override @noinline Base.Math.throw_complex_domainerror(f::Symbol, x) =
-    @print_and_throw "This operation requires a complex input to return a complex result"
+    @gputhrow "DomainError" "This operation requires a complex input to return a complex result"
 @device_override @noinline Base.Math.throw_exp_domainerror(x) =
-    @print_and_throw "Exponentiation yielding a complex result requires a complex argument"
+    @gputhrow "DomainError" "Exponentiation yielding a complex result requires a complex argument"
 
 # intfuncs.jl
 @device_override @noinline Base.throw_domerr_powbysq(::Any, p) =
-    @print_and_throw "Cannot raise an integer to a negative power"
+    @gputhrow "DomainError" "Cannot raise an integer to a negative power"
 @device_override @noinline Base.throw_domerr_powbysq(::Integer, p) =
-    @print_and_throw "Cannot raise an integer to a negative power"
+    @gputhrow "DomainError" "Cannot raise an integer to a negative power"
 @device_override @noinline Base.throw_domerr_powbysq(::AbstractMatrix, p) =
-    @print_and_throw "Cannot raise an integer to a negative power"
+    @gputhrow "DomainError" "Cannot raise an integer to a negative power"
 @device_override @noinline Base.__throw_gcd_overflow(a, b) =
-    @print_and_throw "gcd overflow"
+    @gputhrow "OverflowError" "gcd overflow"
 
 # checked.jl
 @device_override @noinline Base.Checked.throw_overflowerr_binaryop(op, x, y) =
-    @print_and_throw "Binary operation overflowed"
+    @gputhrow "OverflowError" "Binary operation overflowed"
 @device_override @noinline Base.Checked.throw_overflowerr_negation(op, x, y) =
-    @print_and_throw "Negation overflowed"
+    @gputhrow "OverflowError" "Negation overflowed"
 @device_override function Base.Checked.checked_abs(x::Base.Checked.SignedInt)
     r = ifelse(x<0, -x, x)
-    r<0 && @print_and_throw("checked arithmetic: cannot compute |x|")
+    r<0 && @gputhrow("OverflowError", "checked arithmetic: cannot compute |x|")
     r
 end
 
 # boot.jl
 @device_override @noinline Core.throw_inexacterror(f::Symbol, ::Type{T}, val) where {T} =
-    @print_and_throw "Inexact conversion"
+    @gputhrow "InexactError" "Inexact conversion"
 
 # abstractarray.jl
 @noinline throw_boundserror() =
-    @print_and_throw "Out-of-bounds array access"
+    @gputhrow "BoundsError" "Out-of-bounds array access"
 @device_override @inline Base.throw_boundserror(A, I) = throw_boundserror()
 
 # trig.jl
 @device_override @noinline Base.Math.sincos_domain_error(x) =
-    @print_and_throw "sincos(x) is only defined for finite x."
+    @gputhrow "DomainError" "sincos(x) is only defined for finite x."
 
 # range.jl
 @eval begin
     @device_override function Base.StepRangeLen{T,R,S,L}(ref::R, step::S, len::Integer,
                                                          offset::Integer=1) where {T,R,S,L}
         if T <: Integer && !isinteger(ref + step)
-            @print_and_throw("StepRangeLen{<:Integer} cannot have non-integer step")
+            @gputhrow("ArgumentError", "StepRangeLen{<:Integer} cannot have non-integer step")
         end
         len = convert(L, len)
-        len >= zero(len) || @print_and_throw("StepRangeLen length cannot be negative")
+        len >= zero(len) || @gputhrow("ArgumentError", "StepRangeLen length cannot be negative")
         offset = convert(L, offset)
         L1 = oneunit(typeof(len))
-        L1 <= offset <= max(L1, len) || @print_and_throw("StepRangeLen: offset must be in [1,...]")
+        L1 <= offset <= max(L1, len) || @gputhrow("ArgumentError", "StepRangeLen: offset must be in [1,...]")
         $(
             Expr(:new, :(StepRangeLen{T,R,S,L}), :ref, :step, :len, :offset)
         )
@@ -69,7 +80,7 @@ end
     if i == j
         @inbounds D.diag[i] = v
     elseif !iszero(v)
-        @print_and_throw("cannot set off-diagonal entry to a nonzero value")
+        @gputhrow("ArgumentError", "cannot set off-diagonal entry to a nonzero value")
     end
     return v
 end

--- a/src/device/runtime.jl
+++ b/src/device/runtime.jl
@@ -1,9 +1,6 @@
-# CUDA-specific runtime libraries
+# GPU runtime library
 
 import Base.Sys: WORD_SIZE
-
-
-## GPU runtime library
 
 # reset the runtime cache from global scope, so that any change triggers recompilation
 GPUCompiler.reset_runtime()
@@ -29,50 +26,140 @@ function precompile_runtime()
     return
 end
 
+
+## exception handling
+
+# TODO: overloads in quirks.jl still do their own printing. maybe have them set an exception
+#       reason in the info structure/
+
+struct ExceptionInfo_st
+    # whether an exception has been encountered (0 -> 1)
+    status::Int32
+
+    # whether an exception is in the process of being reported (0 -> 1 -> 2)
+    output_lock::Int32
+
+    # who is reporting the exception
+    thread::@NamedTuple{x::Int32,y::Int32,z::Int32}
+    blockIdx::@NamedTuple{x::Int32,y::Int32,z::Int32}
+
+    ExceptionInfo_st() = new(0, 0)
+end
+
+# to simplify use of this struct, which is passed by-reference, use property overloading
+const ExceptionInfo = Ptr{ExceptionInfo_st}
+@inline function Base.getproperty(info::ExceptionInfo, sym::Symbol)
+    if sym === :status
+        unsafe_load(convert(Ptr{Int32}, info))
+    elseif sym === :output_lock
+        unsafe_load(convert(Ptr{Int32}, info + 4))
+    elseif sym === :output_lock_ptr
+        reinterpret(LLVMPtr{Int32,AS.Generic}, info + 4)
+    elseif sym === :threadIdx
+        unsafe_load(convert(Ptr{@NamedTuple{x::Int32,y::Int32,z::Int32}}, info + 8))
+    elseif sym === :blockIdx
+        unsafe_load(convert(Ptr{@NamedTuple{x::Int32,y::Int32,z::Int32}}, info + 20))
+    else
+        getfield(info, sym)
+    end
+end
+@inline function Base.setproperty!(info::ExceptionInfo, sym::Symbol, value)
+    if sym === :status
+        unsafe_store!(convert(Ptr{Int32}, info), value)
+    elseif sym === :output_lock
+        unsafe_store!(convert(Ptr{Int32}, info + 4), value)
+    elseif sym === :threadIdx
+        unsafe_store!(convert(Ptr{@NamedTuple{x::Int32,y::Int32,z::Int32}}, info + 8), value)
+    elseif sym === :blockIdx
+        unsafe_store!(convert(Ptr{@NamedTuple{x::Int32,y::Int32,z::Int32}}, info + 20), value)
+    else
+        setfield!(info, sym, value)
+    end
+end
+
+# it's not useful to have several threads report exceptions (interleaved output, can crash
+# CUDA), so use an output lock to only have a single thread write the exception message
+@inline function take_output_lock(info::ExceptionInfo)
+    # atomic operations on host-pinned memory are iffy, but are fine from the POV of one GPU
+    if atomic_cas!(info.output_lock_ptr, Int32(0), Int32(1)) == Int32(0)
+        info.threadIdx, info.blockIdx = threadIdx(), blockIdx()
+        threadfence()
+        return true
+    else
+        return false
+    end
+end
+@inline function has_output_lock(info::ExceptionInfo)
+    info.output_lock == 1 || return false
+
+    info.threadIdx == threadIdx() || return false
+    info.blockIdx == blockIdx() || return false
+
+    return true
+end
+
+function report_exception(ex)
+    # this is the first reporting function being called, so claim the exception
+    if take_output_lock(kernel_state().exception_info)
+        @cuprintf("""
+            ERROR: a %s was thrown during kernel execution on thread (%d, %d, %d) in block (%d, %d, %d).
+            For stacktrace reporting, run Julia on debug level 2 (by passing -g2 to the executable).
+            """, ex, threadIdx().x, threadIdx().y, threadIdx().z, blockIdx().x, blockIdx().y, blockIdx().z)
+    end
+    return
+end
+
+function report_exception_name(ex)
+    # this is the first reporting function being called, so claim the exception
+    if take_output_lock(kernel_state().exception_info)
+        @cuprintf("""
+            ERROR: a %s was thrown during kernel execution on thread (%d, %d, %d) in block (%d, %d, %d).
+            Stacktrace:
+            """, ex, threadIdx().x, threadIdx().y, threadIdx().z, blockIdx().x, blockIdx().y, blockIdx().z)
+    end
+    return
+end
+
+function report_exception_frame(idx, func, file, line)
+    if has_output_lock(kernel_state().exception_info)
+        @cuprintf(" [%d] %s at %s:%d\n", idx, func, file, line)
+    end
+    return
+end
+
+function signal_exception()
+    info = kernel_state().exception_info
+
+    # finalize output
+    if has_output_lock(info)
+        @cuprintf("\n")
+        info.output_lock = 2
+    end
+
+    # inform the host
+    info.status = 1
+    threadfence_system()
+
+    # stop executing
+    exit()
+
+    return
+end
+
+
+## kernel state
+
 struct KernelState
-    exception_flag::Ptr{UInt8}
+    exception_info::ExceptionInfo
     random_seed::UInt32
 end
 
 @inline @generated kernel_state() = GPUCompiler.kernel_state_value(KernelState)
 
-function signal_exception()
-    ptr = kernel_state().exception_flag
-    if ptr !== C_NULL
-        unsafe_store!(ptr, 1)
-        threadfence_system()
-    else
-        @cuprintf("""
-            WARNING: could not signal exception status to the host, execution will continue.
-                     Please file a bug.
-            """)
-    end
-    exit()
-    return
-end
 
-function report_exception(ex)
-    @cuprintf("""
-        ERROR: a %s was thrown during kernel execution.
-        For stacktrace reporting, run Julia on debug level 2 (by passing -g2 to the executable).
-        """, ex)
-    return
-end
+## other
 
 function report_oom(sz)
-    @cuprintf("ERROR: Out of dynamic GPU memory (trying to allocate %i bytes)\n", sz)
-    return
-end
-
-function report_exception_name(ex)
-    @cuprintf("""
-        ERROR: a %s was thrown during kernel execution.
-        Stacktrace:
-        """, ex)
-    return
-end
-
-function report_exception_frame(idx, func, file, line)
-    @cuprintf(" [%i] %s at %s:%i\n", idx, func, file, line)
+    @cuprintf("ERROR: Out of dynamic GPU memory (trying to allocate %d bytes)\n", sz)
     return
 end

--- a/test/base/exceptions.jl
+++ b/test/base/exceptions.jl
@@ -16,7 +16,7 @@ script = """
 
     cpu = zeros(Int)
     gpu = CuArray(cpu)
-    @cuda kernel(gpu, 1.2)
+    @cuda threads=2 kernel(gpu, 1.3)
     synchronize()
 
     # FIXME: on some platforms (Windows...), for some users, the exception flag change
@@ -29,7 +29,6 @@ script = """
 
 # NOTE: kernel exceptions aren't always caught on the CPU as a KernelException.
 #       on older devices, we emit a `trap` which causes a CUDA error...
-#
 
 let (proc, out, err) = julia_exec(`-g0 -e $script`)
     @test !success(proc)
@@ -41,14 +40,14 @@ end
 let (proc, out, err) = julia_exec(`-g1 -e $script`)
     @test !success(proc)
     @test occursin(host_error_re, err)
-    @test occursin(device_error_re, out)
+    @test count(device_error_re, out) == 1
     @test occursin("run Julia on debug level 2", out)
 end
 
 let (proc, out, err) = julia_exec(`-g2 -e $script`)
     @test !success(proc)
     @test occursin(host_error_re, err)
-    @test occursin(device_error_re, out)
+    @test count(device_error_re, out) == 1
     @test occursin("[1] Int64 at $(joinpath(".", "float.jl"))", out)
     @test occursin("[4] kernel at $(joinpath(".", "none"))", out)
 end


### PR DESCRIPTION
This PR expands the simple exception flag to an info struct that can contain much more information.
I then use it to:
- add an output lock to ensure only one exception is reported by only a single thread
- store the exception type and reason forwarded from overlay quirks

Fixes https://github.com/JuliaGPU/CUDA.jl/issues/1780, https://github.com/JuliaGPU/CUDA.jl/issues/2341, significantly improving the output.

Before:

```julia
julia> using CUDA

julia> a = cu([1])
1-element CuArray{Int64, 1, CUDA.DeviceMemory}:
 1

julia> kernel(a) = (a[threadIdx().x]; nothing)
kernel (generic function with 1 method)

julia> @cuda threads=3 kernel(a)
CUDA.HostKernel for kernel(CuDeviceVector{Int64, 1})

julia> ERROR: Out-of-bounds array access.
ERROR: Out-of-bounds array access.
ERROR: a exception was thrown during kernel execution.
Stacktrace:
ERROR: a exception was thrown during kernel execution.
Stacktrace:
 [1] throw_boundserror at /home/tim/Julia/pkg/CUDA/src/device/quirks.jl:4
 [1] throw_boundserror at /home/tim/Julia/pkg/CUDA/src/device/quirks.jl:4
 [2] #throw_boundserror at /home/tim/Julia/pkg/CUDA/src/device/quirks.jl:42
 [2] #throw_boundserror at /home/tim/Julia/pkg/CUDA/src/device/quirks.jl:42
 [3] checkbounds at ./abstractarray.jl:702
 [3] checkbounds at ./abstractarray.jl:702
 [4] #arrayref at /home/tim/Julia/pkg/CUDA/src/device/array.jl:81
 [4] #arrayref at /home/tim/Julia/pkg/CUDA/src/device/array.jl:81
 [5] getindex at /home/tim/Julia/pkg/CUDA/src/device/array.jl:164
 [5] getindex at /home/tim/Julia/pkg/CUDA/src/device/array.jl:164
 [6] kernel at ./REPL[3]:1
 [6] kernel at ./REPL[3]:1
```

After:

```julia
julia> @cuda threads=3 kernel(a)
CUDA.HostKernel for kernel(CuDeviceVector{Int64, 1})

julia> ERROR: a BoundsError was thrown during kernel execution on thread (2, 1, 1) in block (1, 1, 1).
Out-of-bounds array access
Stacktrace:
 [1] throw_boundserror at /home/tim/Julia/pkg/CUDA/src/device/quirks.jl:15
 [2] #throw_boundserror at /home/tim/Julia/pkg/CUDA/src/device/quirks.jl:53
 [3] checkbounds at ./abstractarray.jl:702
 [4] #arrayref at /home/tim/Julia/pkg/CUDA/src/device/array.jl:81
 [5] getindex at /home/tim/Julia/pkg/CUDA/src/device/array.jl:164
 [6] kernel at ./REPL[4]:1
```

Note that this still doesn't cover all exception generating sites though, e.g., if code does `throw(BoundsError())` and we don't have a quirk that provides additional exception information, we still report a simple `Exception`. An IR-level transformation to recover that info would be great, but we currently don't have the tooling for that in GPUCompiler.
