### PR TITLE
Rework context handling

### DIFF
--- a/lib/cudadrv/context.jl
+++ b/lib/cudadrv/context.jl
@@ -23,7 +23,7 @@ deletion, or use do-block syntax with this constructor.
 """
 struct CuContext
     handle::CUcontext
-    id::Int
+    id::UInt64
 
     function CuContext(handle::CUcontext)
         handle == C_NULL && throw(UndefRefError())
@@ -99,6 +99,12 @@ end
 
 
 ## core context API
+
+function unique_id(ctx::CuContext)
+    id_ref = Ref{Culonglong}()
+    cuCtxGetId(ctx, id_ref)
+    return id_ref[]
+end
 
 """
     push!(CuContext, ctx::CuContext)

--- a/lib/cudadrv/context.jl
+++ b/lib/cudadrv/context.jl
@@ -2,8 +2,8 @@
 
 export
     CuPrimaryContext, CuContext, current_context, has_context, activate,
-    unsafe_reset!, isactive, flags, setflags!,
-    unique_id, device, device_synchronize
+    unsafe_reset!, isactive, flags, setflags!, unique_id, api_version,
+    device, device_synchronize
 
 
 ## construction and destruction
@@ -100,12 +100,6 @@ end
 
 ## core context API
 
-function unique_id(ctx::CuContext)
-    id_ref = Ref{Culonglong}()
-    cuCtxGetId(ctx, id_ref)
-    return id_ref[]
-end
-
 """
     push!(CuContext, ctx::CuContext)
 
@@ -140,6 +134,18 @@ function CuContext(f::Function, dev::CuDevice, args...)
         pop!(CuContext)
         unsafe_destroy!(ctx)
     end
+end
+
+function unique_id(ctx::CuContext)
+    id_ref = Ref{Culonglong}()
+    cuCtxGetId(ctx, id_ref)
+    return id_ref[]
+end
+
+function api_version(ctx::CuContext)
+    version = Ref{Cuint}()
+    cuCtxGetApiVersion(ctx, version)
+    return version[]
 end
 
 

--- a/lib/cudadrv/context.jl
+++ b/lib/cudadrv/context.jl
@@ -54,7 +54,7 @@ has no context bound to it, or if the bound context has been destroyed.
     This is a low-level API, returning the current context as known to the CUDA driver.
     For most users, it is recommended to use the [`context`](@ref) method instead.
 """
-global function current_context()
+function current_context()
     handle_ref = Ref{CUcontext}()
     cuCtxGetCurrent(handle_ref)
     handle_ref[] == C_NULL && throw(UndefRefError())

--- a/lib/cudadrv/context.jl
+++ b/lib/cudadrv/context.jl
@@ -56,7 +56,7 @@ has no context bound to it, or if the bound context has been destroyed.
 """
 global function current_context()
     handle_ref = Ref{CUcontext}()
-    @inline cuCtxGetCurrent(handle_ref) # JuliaGPU/CUDA.jl#2347
+    cuCtxGetCurrent(handle_ref)
     handle_ref[] == C_NULL && throw(UndefRefError())
     CuContext(handle_ref[])
 end

--- a/lib/cudadrv/context.jl
+++ b/lib/cudadrv/context.jl
@@ -56,7 +56,7 @@ has no context bound to it, or if the bound context has been destroyed.
 """
 global function current_context()
     handle_ref = Ref{CUcontext}()
-    cuCtxGetCurrent(handle_ref)
+    @inline cuCtxGetCurrent(handle_ref) # JuliaGPU/CUDA.jl#2347
     handle_ref[] == C_NULL && throw(UndefRefError())
     CuContext(handle_ref[])
 end

--- a/lib/cudadrv/devices.jl
+++ b/lib/cudadrv/devices.jl
@@ -42,23 +42,6 @@ Returns the current device.
 """
 current_device()
 
-"""
-    has_device()
-
-Returns whether there is an active device.
-"""
-function has_device()
-    device_ref = Ref{CUdevice}()
-    res = unchecked_cuCtxGetDevice(device_ref)
-    if res == SUCCESS
-        return true
-    elseif res == ERROR_INVALID_CONTEXT
-        return false
-    else
-        throw_api_error(res)
-    end
-end
-
 const DEVICE_CPU = _CuDevice(CUdevice(-1))
 const DEVICE_INVALID = _CuDevice(CUdevice(-2))
 

--- a/lib/cudadrv/libcuda.jl
+++ b/lib/cudadrv/libcuda.jl
@@ -3269,7 +3269,6 @@ end
 end
 
 @checked function cuCtxCreate_v3(pctx, paramsArray, numParams, flags, dev)
-    initialize_context()
     @gcsafe_ccall libcuda.cuCtxCreate_v3(pctx::Ptr{CUcontext},
                                          paramsArray::Ptr{CUexecAffinityParam},
                                          numParams::Cint, flags::Cuint,
@@ -3299,7 +3298,6 @@ end
 end
 
 @checked function cuCtxGetId(ctx, ctxId)
-    initialize_context()
     @gcsafe_ccall libcuda.cuCtxGetId(ctx::CUcontext, ctxId::Ptr{Culonglong})::CUresult
 end
 
@@ -3329,7 +3327,6 @@ end
 end
 
 @checked function cuCtxGetApiVersion(ctx, version)
-    initialize_context()
     @gcsafe_ccall libcuda.cuCtxGetApiVersion(ctx::CUcontext, version::Ptr{Cuint})::CUresult
 end
 

--- a/lib/cudadrv/libcuda.jl
+++ b/lib/cudadrv/libcuda.jl
@@ -31,7 +31,7 @@ end
     end
 end
 
-function check(f)
+@inline function check(f)
     res = f()
     if res != SUCCESS
         throw_api_error(res)

--- a/lib/cudadrv/memory.jl
+++ b/lib/cudadrv/memory.jl
@@ -31,6 +31,7 @@ Base.unsafe_convert(T::Type{<:Union{Ptr,CuPtr,CuArrayPtr}}, mem::AbstractMemory)
 Device memory residing on the GPU.
 """
 struct DeviceMemory <: AbstractMemory
+    dev::CuDevice
     ctx::CuContext
     ptr::CuPtr{Cvoid}
     bytesize::Int
@@ -38,7 +39,7 @@ struct DeviceMemory <: AbstractMemory
     async::Bool
 end
 
-DeviceMemory() = DeviceMemory(context(), CU_NULL, 0, false)
+DeviceMemory() = DeviceMemory(device(), context(), CU_NULL, 0, false)
 
 Base.pointer(mem::DeviceMemory) = mem.ptr
 Base.sizeof(mem::DeviceMemory) = mem.bytesize
@@ -75,7 +76,7 @@ function alloc(::Type{DeviceMemory}, bytesize::Integer;
         cuMemAlloc_v2(ptr_ref, bytesize)
     end
 
-    return DeviceMemory(context(), reinterpret(CuPtr{Cvoid}, ptr_ref[]), bytesize, async)
+    return DeviceMemory(device(), context(), reinterpret(CuPtr{Cvoid}, ptr_ref[]), bytesize, async)
 end
 
 function free(mem::DeviceMemory; stream::Union{Nothing,CuStream}=nothing)

--- a/lib/cudadrv/memory.jl
+++ b/lib/cudadrv/memory.jl
@@ -798,7 +798,7 @@ end
 Identify the context memory was allocated in.
 """
 context(ptr::Union{Ptr,CuPtr}) =
-    UniqueCuContext(attribute(CUcontext, ptr, POINTER_ATTRIBUTE_CONTEXT))
+    CuContext(attribute(CUcontext, ptr, POINTER_ATTRIBUTE_CONTEXT))
 
 """
     device(ptr)

--- a/lib/cudadrv/module/global.jl
+++ b/lib/cudadrv/module/global.jl
@@ -22,7 +22,7 @@ struct CuGlobal{T}
         if nbytes_ref[] != sizeof(T)
             throw(ArgumentError("size of global '$name' does not match type parameter type $T"))
         end
-        buf = DeviceMemory(context(), ptr_ref[], nbytes_ref[], false)
+        buf = DeviceMemory(device(), context(), ptr_ref[], nbytes_ref[], false)
 
         return new{T}(buf)
     end

--- a/lib/cudadrv/state.jl
+++ b/lib/cudadrv/state.jl
@@ -302,10 +302,6 @@ function device!(f::Function, dev::CuDevice)
     context!(f, ctx)
 end
 
-# NVIDIA bug #3240770
-can_reset_device() = !(Base.thisminor(driver_version()) == v"11.2" &&
-                       any(dev->stream_ordered(dev), devices()))
-
 """
     device_reset!(dev::CuDevice=device())
 
@@ -313,11 +309,6 @@ Reset the CUDA state associated with a device. This call with release the underl
 context, at which point any objects allocated in that context will be invalidated.
 """
 function device_reset!(dev::CuDevice=device())
-    if !can_reset_device()
-        @error "Due to a bug in CUDA, resetting the device is not possible on CUDA 11.2 when using the stream-ordered memory allocator."
-        return
-    end
-
     # unconditionally reset the primary context (don't just release it),
     # as there might be users outside of CUDA.jl
     pctx = CuPrimaryContext(dev)

--- a/lib/cudadrv/state.jl
+++ b/lib/cudadrv/state.jl
@@ -93,9 +93,7 @@ end
 @inline function prepare_cuda_state()
     state = task_local_state!()
 
-    # NOTE: current_context() is too slow to use here (taking a lock, accessing a dict)
-    #       so we use the raw handle. is that safe though, when we reset the device?
-    #ctx = current_context()
+    # current_context() is too slow to use here (as it also calls cuCtxGetId)
     ctx = Ref{CUcontext}()
     cuCtxGetCurrent(ctx)
     if ctx[] != state.context.handle

--- a/lib/cudadrv/state.jl
+++ b/lib/cudadrv/state.jl
@@ -305,8 +305,20 @@ end
 
 Reset the CUDA state associated with a device. This call with release the underlying
 context, at which point any objects allocated in that context will be invalidated.
+
+Note that this does not guarantee to free up all memory allocations, as many are not bound
+to a context, so it is generally not useful to call this function to free up memory.
+
+!!! warning
+
+    This function is only reliable on CUDA driver >= v12.0, and may lead to crashes if
+    used on older drivers.
 """
 function device_reset!(dev::CuDevice=device())
+    if driver_version() < v"12"
+        @error "CUDA.device_reset! is not reliable on CUDA driver < v12 (you are using v$(driver_version().major).$(driver_version().minor)), and may lead to crashes." maxlog=1
+    end
+
     # unconditionally reset the primary context (don't just release it),
     # as there might be users outside of CUDA.jl
     pctx = CuPrimaryContext(dev)

--- a/lib/cudadrv/stream.jl
+++ b/lib/cudadrv/stream.jl
@@ -101,9 +101,9 @@ function Base.show(io::IO, stream::CuStream)
 end
 
 function unique_id(s::CuStream)
-    id = Ref{Culonglong}()
-    cuStreamGetId(s, id)
-    return id[]
+    id_ref = Ref{Culonglong}()
+    cuStreamGetId(s, id_ref)
+    return id_ref[]
 end
 
 """

--- a/lib/cudadrv/version.jl
+++ b/lib/cudadrv/version.jl
@@ -1,12 +1,5 @@
 # Version management
 
-"""
-    driver_version()
-
-Returns the latest version of CUDA supported by the loaded driver.
-"""
-driver_version
-
 # because of this API call being used so frequently, we use a manual cache set in __init__
 # (@memoize's lazy/thread-safe initialization is too expensive for this purpose)
 const _driver_version = Ref{VersionNumber}()
@@ -17,6 +10,12 @@ function set_driver_version()
     minor, patch = divrem(ver, 10)
     _driver_version[] = VersionNumber(major, minor, patch)
 end
+
+"""
+    driver_version()
+
+Returns the latest version of CUDA supported by the loaded driver.
+"""
 function driver_version()
     assume(isassigned(_driver_version))
     _driver_version[]

--- a/lib/cudadrv/version.jl
+++ b/lib/cudadrv/version.jl
@@ -5,12 +5,21 @@
 
 Returns the latest version of CUDA supported by the loaded driver.
 """
-function driver_version()
+driver_version
+
+# because of this API call being used so frequently, we use a manual cache set in __init__
+# (@memoize's lazy/thread-safe initialization is too expensive for this purpose)
+const _driver_version = Ref{VersionNumber}()
+function set_driver_version()
     version_ref = Ref{Cint}()
     cuDriverGetVersion(version_ref)
     major, ver = divrem(version_ref[], 1000)
     minor, patch = divrem(ver, 10)
-    return VersionNumber(major, minor, patch)
+    _driver_version[] = VersionNumber(major, minor, patch)
+end
+function driver_version()
+    assume(isassigned(_driver_version))
+    _driver_version[]
 end
 
 """

--- a/lib/cupti/error.jl
+++ b/lib/cupti/error.jl
@@ -15,96 +15,96 @@ function name(err::CUPTIError)
     unsafe_string(str_ref[])
 end
 
+@enum_without_prefix CUptiResult CUPTI_
+
 ## COV_EXCL_START
 function description(err)
-    if err.code == CUPTI_SUCCESS
+    if err.code == SUCCESS
         "no error"
-    elseif err.code == CUPTI_ERROR_INVALID_PARAMETER
+    elseif err.code == ERROR_INVALID_PARAMETER
         "one or more of the parameters is invalid"
-    elseif err.code == CUPTI_ERROR_INVALID_DEVICE
+    elseif err.code == ERROR_INVALID_DEVICE
         "the device does not correspond to a valid CUDA device"
-    elseif err.code == CUPTI_ERROR_INVALID_CONTEXT
+    elseif err.code == ERROR_INVALID_CONTEXT
         "the context is NULL or not valid"
-    elseif err.code == CUPTI_ERROR_INVALID_EVENT_DOMAIN_ID
+    elseif err.code == ERROR_INVALID_EVENT_DOMAIN_ID
         "the event domain id is invalid"
-    elseif err.code == CUPTI_ERROR_INVALID_EVENT_ID
+    elseif err.code == ERROR_INVALID_EVENT_ID
         "the event id is invalid"
-    elseif err.code == CUPTI_ERROR_INVALID_EVENT_NAME
+    elseif err.code == ERROR_INVALID_EVENT_NAME
         "the event name is invalid"
-    elseif err.code == CUPTI_ERROR_INVALID_OPERATION
+    elseif err.code == ERROR_INVALID_OPERATION
         "the current operation cannot be performed due to dependency on other factors"
-    elseif err.code == CUPTI_ERROR_OUT_OF_MEMORY
+    elseif err.code == ERROR_OUT_OF_MEMORY
         "unable to allocate enough memory to perform the requested operation"
-    elseif err.code == CUPTI_ERROR_HARDWARE
+    elseif err.code == ERROR_HARDWARE
         "an error occurred on the performance monitoring hardware"
-    elseif err.code == CUPTI_ERROR_PARAMETER_SIZE_NOT_SUFFICIENT
+    elseif err.code == ERROR_PARAMETER_SIZE_NOT_SUFFICIENT
         "the output buffer size is not sufficient to return all requested data"
-    elseif err.code == CUPTI_ERROR_API_NOT_IMPLEMENTED
+    elseif err.code == ERROR_API_NOT_IMPLEMENTED
         "aPI is not implemented"
-    elseif err.code == CUPTI_ERROR_MAX_LIMIT_REACHED
+    elseif err.code == ERROR_MAX_LIMIT_REACHED
         "the maximum limit is reached"
-    elseif err.code == CUPTI_ERROR_NOT_READY
+    elseif err.code == ERROR_NOT_READY
         "the object is not yet ready to perform the requested operation"
-    elseif err.code == CUPTI_ERROR_NOT_COMPATIBLE
+    elseif err.code == ERROR_NOT_COMPATIBLE
         "the current operation is not compatible with the current state of the object"
-    elseif err.code == CUPTI_ERROR_NOT_INITIALIZED
+    elseif err.code == ERROR_NOT_INITIALIZED
         "CUPTI is unable to initialize its connection to the CUDA driver"
-    elseif err.code == CUPTI_ERROR_INVALID_METRIC_ID
+    elseif err.code == ERROR_INVALID_METRIC_ID
         "the metric id is invalid"
-    elseif err.code == CUPTI_ERROR_INVALID_METRIC_NAME
+    elseif err.code == ERROR_INVALID_METRIC_NAME
         "the metric name is invalid"
-    elseif err.code == CUPTI_ERROR_QUEUE_EMPTY
+    elseif err.code == ERROR_QUEUE_EMPTY
         "the queue is empty"
-    elseif err.code == CUPTI_ERROR_INVALID_HANDLE
+    elseif err.code == ERROR_INVALID_HANDLE
         "invalid handle (internal?)"
-    elseif err.code == CUPTI_ERROR_INVALID_STREAM
+    elseif err.code == ERROR_INVALID_STREAM
         "invalid stream"
-    elseif err.code == CUPTI_ERROR_INVALID_KIND
+    elseif err.code == ERROR_INVALID_KIND
         "invalid kind"
-    elseif err.code == CUPTI_ERROR_INVALID_EVENT_VALUE
+    elseif err.code == ERROR_INVALID_EVENT_VALUE
         "invalid event value"
-    elseif err.code == CUPTI_ERROR_DISABLED
+    elseif err.code == ERROR_DISABLED
         "CUPTI is disabled due to conflicts with other enabled profilers"
-    elseif err.code == CUPTI_ERROR_INVALID_MODULE
+    elseif err.code == ERROR_INVALID_MODULE
         "invalid module"
-    elseif err.code == CUPTI_ERROR_INVALID_METRIC_VALUE
+    elseif err.code == ERROR_INVALID_METRIC_VALUE
         "invalid metric value"
-    elseif err.code == CUPTI_ERROR_HARDWARE_BUSY
+    elseif err.code == ERROR_HARDWARE_BUSY
         "the performance monitoring hardware is in use by other client"
-    elseif err.code == CUPTI_ERROR_NOT_SUPPORTED
+    elseif err.code == ERROR_NOT_SUPPORTED
         "the attempted operation is not supported on the current system or device"
-    elseif err.code == CUPTI_ERROR_UM_PROFILING_NOT_SUPPORTED
+    elseif err.code == ERROR_UM_PROFILING_NOT_SUPPORTED
         "unified memory profiling is not supported on the system. Potential reason could be unsupported OS or architecture"
-    elseif err.code == CUPTI_ERROR_UM_PROFILING_NOT_SUPPORTED_ON_DEVICE
+    elseif err.code == ERROR_UM_PROFILING_NOT_SUPPORTED_ON_DEVICE
         "unified memory profiling is not supported on the device"
-    elseif err.code == CUPTI_ERROR_UM_PROFILING_NOT_SUPPORTED_ON_NON_P2P_DEVICES
+    elseif err.code == ERROR_UM_PROFILING_NOT_SUPPORTED_ON_NON_P2P_DEVICES
         "unified memory profiling is not supported on a multi-GPU configuration without P2P support between any pair of devices"
-    elseif err.code == CUPTI_ERROR_UM_PROFILING_NOT_SUPPORTED_WITH_MPS
+    elseif err.code == ERROR_UM_PROFILING_NOT_SUPPORTED_WITH_MPS
         "unified memory profiling is not supported under the Multi-Process Service (MPS) environment with CUDA 7.5"
-    elseif err.code == CUPTI_ERROR_CDP_TRACING_NOT_SUPPORTED
+    elseif err.code == ERROR_CDP_TRACING_NOT_SUPPORTED
         "Devices with compute capability 7.0 don't support CDP tracing"
-    elseif err.code == CUPTI_ERROR_VIRTUALIZED_DEVICE_NOT_SUPPORTED
+    elseif err.code == ERROR_VIRTUALIZED_DEVICE_NOT_SUPPORTED
         "profiling on virtualized GPU is not supported"
-    elseif err.code == CUPTI_ERROR_CUDA_COMPILER_NOT_COMPATIBLE
+    elseif err.code == ERROR_CUDA_COMPILER_NOT_COMPATIBLE
         "Profiling results might be incorrect for CUDA applications compiled with nvcc version older than 9.0 for devices with compute capability 6.0 and 6.1"
-    elseif err.code == CUPTI_ERROR_INSUFFICIENT_PRIVILEGES
+    elseif err.code == ERROR_INSUFFICIENT_PRIVILEGES
         """Insufficient privileges: You don't have permissions to profile GPU code.
            Please configure your system to allow all users to profile, or run Julia with
            elevated permissions: https://developer.nvidia.com/ERR_NVGPUCTRPERM#SolnAdminTag"""
-    elseif err.code == CUPTI_ERROR_OLD_PROFILER_API_INITIALIZED
+    elseif err.code == ERROR_OLD_PROFILER_API_INITIALIZED
         "old profiling api's are not supported with new profiling api's"
-    elseif err.code == CUPTI_ERROR_OPENACC_UNDEFINED_ROUTINE
+    elseif err.code == ERROR_OPENACC_UNDEFINED_ROUTINE
         "missing definition of the OpenACC API routine in the linked OpenACC library"
-    elseif err.code == CUPTI_ERROR_LEGACY_PROFILER_NOT_SUPPORTED
+    elseif err.code == ERROR_LEGACY_PROFILER_NOT_SUPPORTED
         "an unknown internal error has occurred. Legacy CUPTI Profiling is not supported on devices with Compute Capability 7.5 or higher (Turing+)"
-    elseif err.code == CUPTI_ERROR_MULTIPLE_SUBSCRIBERS_NOT_SUPPORTED
+    elseif err.code == ERROR_MULTIPLE_SUBSCRIBERS_NOT_SUPPORTED
         "CUPTI doesn't allow multiple callback subscribers. Only a single subscriber can be registered at a time."
-    elseif err.code == CUPTI_ERROR_UNKNOWN
+    elseif err.code == ERROR_UNKNOWN
         "an unknown error has occurred"
     else
         "unknown status"
     end
 end
 ## COV_EXCL_STOP
-
-@enum_without_prefix CUptiResult CUPTI_

--- a/lib/cupti/wrappers.jl
+++ b/lib/cupti/wrappers.jl
@@ -267,7 +267,7 @@ function process(f, cfg::ActivityConfig)
 
     # extract typed activity records
     for (ctx_handle, stream_id, buf_ptr, sz, valid_sz) in cfg.results
-        ctx = CUDA.UniqueCuContext(ctx_handle)
+        ctx = ctx_handle == C_NULL ? nothing : CUDA.UniqueCuContext(ctx_handle)
         # XXX: can we reconstruct the stream from the stream ID?
 
         record_ptr = Ref{Ptr{CUpti_Activity}}(C_NULL)

--- a/lib/cupti/wrappers.jl
+++ b/lib/cupti/wrappers.jl
@@ -267,7 +267,7 @@ function process(f, cfg::ActivityConfig)
 
     # extract typed activity records
     for (ctx_handle, stream_id, buf_ptr, sz, valid_sz) in cfg.results
-        ctx = ctx_handle == C_NULL ? nothing : CUDA.UniqueCuContext(ctx_handle)
+        ctx = ctx_handle == C_NULL ? nothing : CuContext(ctx_handle)
         # XXX: can we reconstruct the stream from the stream ID?
 
         record_ptr = Ref{Ptr{CUpti_Activity}}(C_NULL)

--- a/lib/nvml/libnvml.jl
+++ b/lib/nvml/libnvml.jl
@@ -23,7 +23,7 @@ function initialize_context()
     end
 end
 
-function check(f)
+@inline function check(f)
     res = f()
     if res != NVML_SUCCESS
         throw_api_error(res)

--- a/lib/utils/call.jl
+++ b/lib/utils/call.jl
@@ -25,8 +25,12 @@ macro checked(ex)
     body = ex.args[2]
     @assert Meta.isexpr(body, :block)
 
+    # make sure these functions are inlined
+    pushfirst!(body.args, Expr(:meta, :inline))
+
     # generate a "safe" version that performs a check
     safe_body = quote
+        @inline
         check() do
             $body
         end
@@ -218,11 +222,8 @@ function ccall_macro_lower(func, rettype, types, args, nreq)
     end
 
     quote
-        # the added operations push our simple ccall wrappers over the inlining limit
         @inline
-
         $(cconvert_exprs...)
-
         GC.@preserve $(cconvert_args...) $(call)
     end
 end

--- a/lib/utils/call.jl
+++ b/lib/utils/call.jl
@@ -174,7 +174,8 @@ macro debug_ccall(ex)
 end
 
 render_arg(io, arg) = print(io, arg)
-render_arg(io, arg::Union{<:Base.RefValue, AbstractArray}) = summary(io, arg)
+render_arg(io, arg::AbstractArray) = summary(io, arg)
+render_arg(io, arg::Base.RefValue{T}) where {T} = print(io, "Ref{", T, "}")
 
 
 ## version of ccall that calls jl_gc_safe_enter|leave around the inner ccall

--- a/res/wrap/cuda.toml
+++ b/res/wrap/cuda.toml
@@ -75,6 +75,9 @@ needs_context = false
 [api.cuCtxCreate_v2]
 needs_context = false
 
+[api.cuCtxCreate_v3]
+needs_context = false
+
 [api.cuCtxDestroy_v2]
 needs_context = false
 
@@ -91,6 +94,12 @@ needs_context = false
 needs_context = false
 
 [api.cuCtxGetDevice]
+needs_context = false
+
+[api.cuCtxGetId]
+needs_context = false
+
+[api.cuCtxGetApiVersion]
 needs_context = false
 
 [api.cuDeviceGetLuid]

--- a/res/wrap/libcuda_prologue.jl
+++ b/res/wrap/libcuda_prologue.jl
@@ -26,7 +26,7 @@ end
     end
 end
 
-function check(f)
+@inline function check(f)
     res = f()
     if res != SUCCESS
         throw_api_error(res)

--- a/res/wrap/libnvml_prologue.jl
+++ b/res/wrap/libnvml_prologue.jl
@@ -18,7 +18,7 @@ function initialize_context()
     end
 end
 
-function check(f)
+@inline function check(f)
     res = f()
     if res != NVML_SUCCESS
         throw_api_error(res)

--- a/src/array.jl
+++ b/src/array.jl
@@ -238,7 +238,7 @@ function _unsafe_wrap_managed(::Type{T}, ptr::CuPtr{T}, dims::NTuple{N,Int},
       UnifiedMemory(ctx, ptr, sz)
     elseif typ == CU_MEMORYTYPE_DEVICE
       # TODO: can we identify whether this pointer was allocated asynchronously?
-      DeviceMemory(ctx, ptr, sz, false)
+      DeviceMemory(device(ctx), ctx, ptr, sz, false)
     elseif typ == CU_MEMORYTYPE_HOST
       HostMemory(ctx, host_pointer(ptr), sz)
     else

--- a/src/initialization.jl
+++ b/src/initialization.jl
@@ -194,6 +194,9 @@ function __init__()
         end
     end
 
+    # global state that needs to be initialized
+    fill!(context_validity, true)
+
     _initialized[] = true
 end
 

--- a/src/initialization.jl
+++ b/src/initialization.jl
@@ -59,7 +59,7 @@ function __init__()
     end
 
     driver = try
-        driver_version()
+        set_driver_version()
     catch err
         @debug "CUDA driver failed to report a version" exception=(err, catch_backtrace())
         _initialization_error[] = "CUDA driver not functional"

--- a/src/initialization.jl
+++ b/src/initialization.jl
@@ -189,7 +189,7 @@ function __init__()
         # warn about Tegra being incompatible with our artifacts
         if is_tegra()
             @warn """You are using a Tegra device, which is currently not supported by the CUDA.jl artifacts.
-                     Please install the CUDA toolkit, and call `CUDA.set_runtime_version!("local")` to use it.
+                     Please install the CUDA toolkit, and call `CUDA.set_runtime_version!(local_toolkit=true)`.
                      For more information, see JuliaGPU/CUDA.jl#1978."""
         end
     end

--- a/src/initialization.jl
+++ b/src/initialization.jl
@@ -194,9 +194,6 @@ function __init__()
         end
     end
 
-    # global state that needs to be initialized
-    fill!(context_validity, true)
-
     _initialized[] = true
 end
 

--- a/src/memory.jl
+++ b/src/memory.jl
@@ -533,7 +533,7 @@ function Base.convert(::Type{CuPtr{T}}, managed::Managed{M}) where {T,M}
   # accessing memory on another device: ensure the data is ready and accessible
   if M == DeviceMemory && state.context != managed.mem.ctx
     maybe_synchronize(managed)
-    source_device = device(managed.mem.ctx)
+    source_device = managed.mem.dev
 
     # enable peer-to-peer access
     if maybe_enable_peer_access(state.device, source_device) != 1
@@ -701,7 +701,7 @@ end
         free(mem)
       end
     end
-    account!(memory_stats(device(mem.ctx)), -sizeof(mem))
+    account!(memory_stats(mem.dev), -sizeof(mem))
 end
 @inline _pool_free(mem::UnifiedMemory, stream::CuStream) = free(mem)
 @inline _pool_free(mem::HostMemory, stream::CuStream) = free(mem)

--- a/src/profile.jl
+++ b/src/profile.jl
@@ -687,7 +687,7 @@ function Base.show(io::IO, results::ProfileResults)
             # filter spammy API calls
             filter(results.host) do row
                 !in(row.name, [# context and stream queries we use for nonblocking sync
-                               "cuCtxGetCurrent", "cuStreamQuery",
+                               "cuCtxGetCurrent", "cuCtxGetId", "cuStreamQuery",
                                # occupancy API, done before every kernel launch
                                "cuOccupancyMaxPotentialBlockSize",
                                # driver pointer set-up

--- a/src/profile.jl
+++ b/src/profile.jl
@@ -687,7 +687,8 @@ function Base.show(io::IO, results::ProfileResults)
             # filter spammy API calls
             filter(results.host) do row
                 !in(row.name, [# context and stream queries we use for nonblocking sync
-                               "cuCtxGetCurrent", "cuCtxGetId", "cuStreamQuery",
+                               "cuCtxGetCurrent", "cuCtxGetId", "cuCtxGetApiVersion",
+                               "cuStreamQuery", "cuStreamGetId",
                                # occupancy API, done before every kernel launch
                                "cuOccupancyMaxPotentialBlockSize",
                                # driver pointer set-up

--- a/test/base/exceptions.jl
+++ b/test/base/exceptions.jl
@@ -1,5 +1,5 @@
 # these tests spawn subprocesses, so reset the current context to conserve memory
-CUDA.can_reset_device() && device_reset!()
+device_reset!()
 
 host_error_re = r"ERROR: (KernelException: exception thrown during kernel execution on device|CUDA error: an illegal instruction was encountered|CUDA error: unspecified launch failure)"
 device_error_re = r"ERROR: a \w+ was thrown during kernel execution"

--- a/test/core/cudadrv.jl
+++ b/test/core/cudadrv.jl
@@ -42,59 +42,64 @@ end
 
 # FIXME: these trample over our globally-managed context
 
-# @testset "primary context" begin
+@testset "primary context" begin
 
-# pctx = CuPrimaryContext(device())
+# we need to start from scratch for these tests
+dev = device()
+device_reset!()
+@test_throws UndefRefError current_context()
 
-# @test !isactive(pctx)
-# unsafe_reset!(pctx)
-# @test !isactive(pctx)
+pctx = CuPrimaryContext(dev)
 
-# @test flags(pctx) == 0
-# setflags!(pctx, CUDA.CTX_SCHED_BLOCKING_SYNC)
-# @test flags(pctx) == CUDA.CTX_SCHED_BLOCKING_SYNC
+@test !isactive(pctx)
+unsafe_reset!(pctx)
+@test !isactive(pctx)
 
-# let global_ctx = nothing
-#     CuContext(pctx) do ctx
-#         @test CUDA.isvalid(ctx)
-#         @test isactive(pctx)
-#         global_ctx = ctx
-#     end
-#     @test !isactive(pctx)
-#     @test !CUDA.isvalid(global_ctx)
-# end
+@test flags(pctx) == 0
+setflags!(pctx, CUDA.CTX_SCHED_BLOCKING_SYNC)
+@test flags(pctx) == CUDA.CTX_SCHED_BLOCKING_SYNC
 
-# CuContext(pctx) do ctx
-#     @test CUDA.isvalid(ctx)
-#     @test isactive(pctx)
+let global_ctx = nothing
+    CuContext(pctx) do ctx
+        @test CUDA.isvalid(ctx)
+        @test isactive(pctx)
+        global_ctx = ctx
+    end
+    @test !isactive(pctx) broken=true
+    @test !CUDA.isvalid(global_ctx) broken=true
+end
 
-#     unsafe_reset!(pctx)
+let
+    ctx = CuContext(pctx)
+    @test CUDA.isvalid(ctx)
+    @test isactive(pctx)
 
-#     @test !isactive(pctx)
-#     @test !CUDA.isvalid(ctx)
-# end
+    unsafe_reset!(pctx)
 
-# let
-#     @test !isactive(pctx)
+    @test !isactive(pctx)
+    @test !CUDA.isvalid(ctx)
+end
 
-#     ctx1 = CuContext(pctx)
-#     @test isactive(pctx)
-#     @test CUDA.isvalid(ctx1)
+let
+    @test !isactive(pctx)
 
-#     unsafe_reset!(pctx)
-#     @test !isactive(pctx)
-#     @test !CUDA.isvalid(ctx1)
-#     CUDA.valid_contexts
+    ctx1 = CuContext(pctx)
+    @test isactive(pctx)
+    @test CUDA.isvalid(ctx1)
 
-#     ctx2 = CuContext(pctx)
-#     @test isactive(pctx)
-#     @test !CUDA.isvalid(ctx1)
-#     @test CUDA.isvalid(ctx2)
+    unsafe_reset!(pctx)
+    @test !isactive(pctx)
+    @test !CUDA.isvalid(ctx1)
 
-#     unsafe_reset!(pctx)
-# end
+    ctx2 = CuContext(pctx)
+    @test isactive(pctx)
+    @test !CUDA.isvalid(ctx1)
+    @test CUDA.isvalid(ctx2)
 
-# end
+    unsafe_reset!(pctx)
+end
+
+end
 
 
 @testset "cache config" begin

--- a/test/core/cudadrv.jl
+++ b/test/core/cudadrv.jl
@@ -6,6 +6,7 @@ synchronize()
 
 ctx = current_context()
 @test CUDA.isvalid(ctx)
+@test unique_id(ctx) > 0
 
 dev = current_device()
 exclusive = attribute(dev, CUDA.DEVICE_ATTRIBUTE_COMPUTE_MODE) == CUDA.CU_COMPUTEMODE_EXCLUSIVE_PROCESS
@@ -843,6 +844,7 @@ end
 @testset "stream" begin
 
 s = CuStream()
+@test unique_id(s) > 0
 synchronize(s)
 @test CUDA.isdone(s)
 

--- a/test/core/cudadrv.jl
+++ b/test/core/cudadrv.jl
@@ -1,6 +1,12 @@
 @testset "context" begin
 
+# perform an API call to ensure everything is initialized
+# (or the low-level driver calls below can fail)
+synchronize()
+
 ctx = current_context()
+@test CUDA.isvalid(ctx)
+
 dev = current_device()
 exclusive = attribute(dev, CUDA.DEVICE_ATTRIBUTE_COMPUTE_MODE) == CUDA.CU_COMPUTEMODE_EXCLUSIVE_PROCESS
 

--- a/test/core/cudadrv.jl
+++ b/test/core/cudadrv.jl
@@ -41,8 +41,8 @@ end
 
 end
 
-# FIXME: these trample over our globally-managed context
 
+if CUDA.driver_version() >= v"12"
 @testset "primary context" begin
 
 # we need to start from scratch for these tests
@@ -100,6 +100,7 @@ let
     unsafe_reset!(pctx)
 end
 
+end
 end
 
 

--- a/test/core/initialization.jl
+++ b/test/core/initialization.jl
@@ -2,21 +2,19 @@
 @test has_cuda_gpu(true)
 
 # the API shouldn't have been initialized
-@test !has_context()
-@test !has_device()
+@test_throws UndefRefError current_context()
+@test_throws UndefRefError current_device()
 
 ctx = context()
 dev = device()
 
 # querying Julia's side of things shouldn't cause initialization
-@test !has_context()
-@test !has_device()
+@test_throws UndefRefError current_context()
+@test_throws UndefRefError current_device()
 
 # now cause initialization
 a = CuArray([42])
-@test has_context()
 @test current_context() == ctx
-@test has_device()
 @test current_device() == dev
 
 # ... on a different task

--- a/test/core/initialization.jl
+++ b/test/core/initialization.jl
@@ -177,3 +177,11 @@ end
     proc, out, err = julia_exec(`-e $script`, "CUDA_VISIBLE_DEVICES"=>"-1")
     @test success(proc)
 end
+
+
+## allocations
+
+@test @allocated(current_context()) == 0
+@test @allocated(context()) == 0
+@test @allocated(stream()) == 0
+@test @allocated(device()) == 0

--- a/test/core/initialization.jl
+++ b/test/core/initialization.jl
@@ -51,7 +51,9 @@ end
 if has_nvml()
     pid = getpid()
     try
-        nvml_dev = NVML.Device(uuid(device()))
+        cuda_dev = device()
+        mig = uuid(cuda_dev) != parent_uuid(cuda_dev)
+        nvml_dev = NVML.Device(uuid(cuda_dev); mig)
         @test haskey(NVML.compute_processes(nvml_dev), pid)
         device_reset!()
         @test !haskey(NVML.compute_processes(nvml_dev), pid)

--- a/test/core/initialization.jl
+++ b/test/core/initialization.jl
@@ -33,33 +33,35 @@ context!(ctx)
 
 # setting flags is only possible on a new context
 @test_throws ErrorException device!(0, CUDA.CU_CTX_SCHED_YIELD)
-device_reset!()
-device!(0, CUDA.CU_CTX_SCHED_YIELD)
+if CUDA.driver_version() >= v"12"
+    device_reset!()
+    device!(0, CUDA.CU_CTX_SCHED_YIELD)
 
-# reset on a different task
-let ctx = context()
-    @test CUDA.isvalid(ctx)
-    @test ctx == fetch(@async context())
+    # reset on a different task
+    let ctx = context()
+        @test CUDA.isvalid(ctx)
+        @test ctx == fetch(@async context())
 
-    @sync @async device_reset!()
+        @sync @async device_reset!()
 
-    @test CUDA.isvalid(context())
-    @test ctx != context()
-end
+        @test CUDA.isvalid(context())
+        @test ctx != context()
+    end
 
-# ensure that resetting the device really does get rid of the context
-if has_nvml()
-    pid = getpid()
-    try
-        cuda_dev = device()
-        mig = uuid(cuda_dev) != parent_uuid(cuda_dev)
-        nvml_dev = NVML.Device(uuid(cuda_dev); mig)
-        @test haskey(NVML.compute_processes(nvml_dev), pid)
-        device_reset!()
-        @test !haskey(NVML.compute_processes(nvml_dev), pid)
-    catch err
-        isa(err, NVML.NVMLError) || rethrow()
-        err.code in [NVML.ERROR_NOT_SUPPORTED, NVML.ERROR_NO_PERMISSION] || rethrow()
+    # ensure that resetting the device really does get rid of the context
+    if has_nvml()
+        pid = getpid()
+        try
+            cuda_dev = device()
+            mig = uuid(cuda_dev) != parent_uuid(cuda_dev)
+            nvml_dev = NVML.Device(uuid(cuda_dev); mig)
+            @test haskey(NVML.compute_processes(nvml_dev), pid)
+            device_reset!()
+            @test !haskey(NVML.compute_processes(nvml_dev), pid)
+        catch err
+            isa(err, NVML.NVMLError) || rethrow()
+            err.code in [NVML.ERROR_NOT_SUPPORTED, NVML.ERROR_NO_PERMISSION] || rethrow()
+        end
     end
 end
 
@@ -88,13 +90,15 @@ if length(devices()) > 1
 
     @test device() == CuDevice(0)
 
-    # reset on a task
-    task = @async begin
-        device!(1)
-        device_reset!()
+    if CUDA.driver_version() >= v"12"
+        # reset on a task
+        task = @async begin
+            device!(1)
+            device_reset!()
+        end
+        fetch(task)
+        @test device() == CuDevice(0)
     end
-    fetch(task)
-    @test device() == CuDevice(0)
 
     # math_mode
     old_mm = CUDA.math_mode()

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -135,7 +135,9 @@ function gpu_entry(dev)
     compute_mode = attribute(dev, CUDA.DEVICE_ATTRIBUTE_COMPUTE_MODE)
     free_memory = device!(dev) do
         mem = CUDA.free_memory()
-        device_reset!()
+        if CUDA.driver_version() >= v"12"
+            device_reset!()
+        end
         mem
     end
     (; id, name, cap, uuid="$(mig ? "MIG" : "GPU")-$uuid", compute_mode, free_memory)

--- a/test/setup.jl
+++ b/test/setup.jl
@@ -115,7 +115,6 @@ function runtests(f, name, time_source=:cuda)
         res = vcat(collect(data), cpu_rss, gpu_rss)
 
         GC.gc(true)
-        CUDA.can_reset_device() && device_reset!()
         res
     finally
         Test.TESTSET_PRINT_ENABLE[] = old_print_setting


### PR DESCRIPTION
## Problem

CUDA contexts are annoying:
- references to identical contexts can be constructed independently through different APIs (`cuCtxCreate`, `cuCtxGetCurrent`, etc)
- destroying a context means that all resources allocated in that context are now invalid, and cannot be used in any API call
- after destroying a context, creating a new one may result in the same handle being reused
- Julia can destroy objects out-of-order, e.g., first the CuContext, then a CuStream, even though the stream object had a reference to the context

All this significantly complicates our ability to determine whether objects are safe to use and/or need to be finalized. Currently, we solve this by using some kind of factory method that is guaranteed to return a unique context object for every session of a context handle (i.e., after handle destruction and recreation, this method returns a different object despite the handle being identical). In combination with targeted invalidation of that object from all known APIs that destroy a context, that makes it possible to automatically determine context validity in all derived objects storing a reference. All this relies on multiple global dictionaries, which are slow and fragile (and have resulted in several issues with use with threads, and in finalizers where we can't take locks to safely access that global dict). It also isn't guaranteed to be correct, especially when cooperating with other software that may call context APIs.

## Solution

CUDA 12.0 provides a new driver API, `cuCtxGetId`, which returns a monotonically incrementing identifier that _does_ change when a context is destroyed and re-allocated. This greatly simplifies the design:

- we no longer need a single unique CuContext object, as we can uniquely identify the object by its identifier
- we can simply check validity by ensuring we can fetch a context's ID, and that the ID matches what we stored at construction time

This makes it possible to demote CuContext to a simple immutable type, and get rid of all context-related global state, improving thread- and finalizer-safety, while making it much cheaper to store context objects in derived resources.

The flip side: CUDA.jl will require a CUDA 12.x-compatible driver. This seems acceptable to me, given the improvements in this PR and the fact that CUDA 12 has been out for quite a while. People relying on CUDA 11.x can always keep using CUDA.jl 5.x. If needed, we can even make additional releases of CUDA.jl 5.x if backport PRs are suggested.

cc @vchuravy 