### PR TITLE
cuQuantum 24.3: Bump cuTensorNet.

### DIFF
--- a/lib/cutensornet/Project.toml
+++ b/lib/cutensornet/Project.toml
@@ -13,9 +13,9 @@ cuTENSOR = "011b41b2-24ef-40a8-b3eb-fa098493e9e1"
 
 [compat]
 CEnum = "0.2, 0.3, 0.4, 0.5"
-CUDA = "~5.1, ~5.2"
+CUDA = "~5.1, ~5.2, ~5.3, ~5.4"
 CUDA_Runtime_Discovery = "0.2"
-cuQuantum_jll = "~23.10"
-cuTENSOR = "~1.2"
+cuQuantum_jll = "~24.3"
+cuTENSOR = "~2.0"
 julia = "1.8"
 LinearAlgebra = "1"


### PR DESCRIPTION
Comes with cuTensor 2.0 support, so this finally unblocks compatibility with latest CUDA.jl.