### PR TITLE
Optimize array allocation.

### DIFF
--- a/lib/cudadrv/pool.jl
+++ b/lib/cudadrv/pool.jl
@@ -78,8 +78,8 @@ trim(pool::CuMemoryPool, bytes_to_keep::Integer=0) = cuMemPoolTrimTo(pool, bytes
 Returns attribute `attr` about `pool`. The type of the returned value depends on the
 attribute, and as such must be passed as the `X` parameter.
 """
-function attribute(X::Type, pool::CuMemoryPool, attr::CUmemPool_attribute)
-    value = Ref{X}()
+function attribute(::Type{T}, pool::CuMemoryPool, attr::CUmemPool_attribute) where T
+    value = Ref{T}()
     cuMemPoolGetAttribute(pool, attr, value)
     return value[]
 end


### PR DESCRIPTION
Before:

```
julia> @benchmark CuArray{Float32}(undef, 1)
BenchmarkTools.Trial: 10000 samples with 10 evaluations.
 Range (min … max):  1.226 μs …  8.022 ms  ┊ GC (min … max): 0.00% … 11.43%
 Time  (median):     1.316 μs              ┊ GC (median):    0.00%
 Time  (mean ± σ):   2.129 μs ± 80.204 μs  ┊ GC (mean ± σ):  4.31% ±  0.11%

           ▂▄▅▅▇██▇▇▆▃▅▃▄▃▃▁▁▁▁
  ▂▁▂▂▂▃▄▅▇█████████████████████▇▆▅▅▄▄▃▃▃▃▃▃▃▃▂▂▂▂▂▂▂▂▂▂▂▂▂▂ ▅
  1.23 μs        Histogram: frequency by time        1.51 μs <

 Memory estimate: 464 bytes, allocs estimate: 10.
```
 
After:

```
julia> @benchmark CuArray{Float32}(undef, 1)
BenchmarkTools.Trial: 10000 samples with 119 evaluations.
 Range (min … max):  758.815 ns …  2.191 ms  ┊ GC (min … max): 0.00% … 15.43%
 Time  (median):     824.029 ns              ┊ GC (median):    0.00%
 Time  (mean ± σ):     1.545 μs ± 35.931 μs  ┊ GC (mean ± σ):  5.17% ±  0.22%

            ▂▅▆▆▆▆▆▇▆█▆▇▅▄▁▁
  ▁▁▁▁▂▃▄▅▇█████████████████▇▆▆▅▃▃▃▃▃▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▁ ▄
  759 ns          Histogram: frequency by time          965 ns <

 Memory estimate: 208 bytes, allocs estimate: 5.
```

This had regressed in recent PRs compared to 5.3:

```
julia> @benchmark CuArray{Float32}(undef, 1)
BenchmarkTools.Trial: 10000 samples with 102 evaluations.
 Range (min … max):  774.598 ns …  1.552 ms  ┊ GC (min … max): 0.00% … 8.63%
 Time  (median):     881.559 ns              ┊ GC (median):    0.00%
 Time  (mean ± σ):     1.911 μs ± 37.185 μs  ┊ GC (mean ± σ):  4.72% ± 0.25%

           ▁▁▁▁▃▃▃▁▁ ▁▁▂▃▄▆▇████▅▅▂
  ▁▂▃▂▂▂▃▅██████████████████████████▆▅▄▃▃▂▃▂▂▂▂▂▂▃▃▃▃▃▃▃▃▃▂▂▂▂ ▄
  775 ns          Histogram: frequency by time         1.03 μs <

 Memory estimate: 320 bytes, allocs estimate: 11.
```

So we're back to the original performance now, while allocating significantly less.