### PR TITLE
unsafe_wrap: unconditionally use the memory type provided by the user.

### DIFF
--- a/test/base/array.jl
+++ b/test/base/array.jl
@@ -109,7 +109,6 @@ end
     # errors
     let a = cu([1]; device=true)
         @test_throws ArgumentError unsafe_wrap(Array, a)
-        @test_throws ArgumentError unsafe_wrap(CuArray{Int,1,CUDA.UnifiedMemory}, pointer(a), 1)
     end
     let a = [1]
         @test_throws ArgumentError unsafe_wrap(CuArray{Int,1,CUDA.DeviceMemory}, a)


### PR DESCRIPTION
This makes it possible to create 'fake' CuArrays:

```julia
julia> a = unsafe_wrap(CuArray{Int,2,CUDA.DeviceMemory}, convert(CuPtr{Int}, CU_NULL), (1,2));

julia> typeof(a)
CuArray{Int64, 2, CUDA.DeviceMemory}
```

This can be useful to compile without having to allocate memory.