### PR TITLE
add cublas<t>getrsBatched

### DIFF
--- a/lib/cublas/README.md
+++ b/lib/cublas/README.md
@@ -44,8 +44,8 @@ CUBLAS functions:
 * [x] gemv (in julia/blas.jl)
 * [x] ger (in julia/blas.jl)
 * [x] sbmv (in julia/blas.jl)
-* [ ] spmv
-* [ ] spr
+* [x] spmv
+* [x] spr
 * [ ] spr2
 * [x] symv (in julia/blas.jl)
 * [x] syr (in julia/blas.jl)
@@ -87,6 +87,7 @@ CUBLAS functions:
 * [x] geam
 * [x] dgmm
 * [x] getrfBatched
+* [x] getrsBatched
 * [x] getriBatched
 * [x] geqrfBatched
 * [x] gelsBatched

--- a/lib/cublas/wrappers.jl
+++ b/lib/cublas/wrappers.jl
@@ -1868,7 +1868,7 @@ function getrf_batched!(A::Vector{<:StridedCuMatrix}, pivot::Bool)
     return getrf_batched!(n, Aptrs, lda, pivot)..., A
 end
 function getrf_batched(A::Vector{<:StridedCuMatrix}, pivot::Bool)
-    getrf_batched!(copy(A), pivot)
+    getrf_batched!(deepcopy(A), pivot)
 end
 
 # CUDA has no strided batched getrf, but we can at least avoid constructing costly views

--- a/lib/cublas/wrappers.jl
+++ b/lib/cublas/wrappers.jl
@@ -1887,6 +1887,90 @@ function getrf_strided_batched(A::DenseCuArray{<:Any, 3}, pivot::Bool)
 end
 
 
+## getrsBatched - solves system of linear equations
+
+for (fname, elty) in ((:cublasDgetrsBatched, :Float64),
+                      (:cublasSgetrsBatched, :Float32),
+                      (:cublasZgetrsBatched, :ComplexF64),
+                      (:cublasCgetrsBatched, :ComplexF32))
+    @eval begin
+        function getrs_batched!(trans::Char,
+                                n, nrhs,
+                                Aptrs::CuVector{CuPtr{$elty}}, lda,
+                                pivotArray::CuPtr,
+                                Bptrs::CuVector{CuPtr{$elty}}, ldb)
+            batchSize = length(Aptrs)
+            info = Ref{Cint}()
+            $fname(handle(), trans, n, nrhs, Aptrs, lda, pivotArray, Bptrs, ldb, info, batchSize)
+            unsafe_free!(Aptrs)
+            unsafe_free!(Bptrs)
+
+            return info
+        end
+    end
+end
+
+function getrs_batched!(trans::Char,
+                        A::Vector{<:StridedCuMatrix},
+                        B::Vector{<:StridedCuMatrix},
+                        pivotArray::T=nothing) where T<:Union{Nothing,CuMatrix{Cint}}
+    for (As,Bs) in zip(A,B)
+        m,n = size(As)
+        if m != n
+            throw(DimensionMismatch("All A matrices must be square!"))
+        end
+        o = size(Bs,1)
+        if m != o
+            throw(DimensionMismatch("Rows in A and B must be equal!"))
+        end
+    end
+    m,n = size(A[1])
+    lda = max(1,stride(A[1],2))
+    ldb = max(1,stride(B[1],2))
+    nrhs = size(B[1],2)
+
+    Aptrs = unsafe_batch(A)
+    Bptrs = unsafe_batch(B)
+    pivotptr = T==Nothing ? CU_NULL : pointer(pivotArray)
+    return getrs_batched!(trans, n, nrhs, Aptrs, lda, pivotptr, Bptrs, ldb), B
+end
+function getrs_batched(trans::Char,
+                       A::Vector{<:StridedCuMatrix},
+                       B::Vector{<:StridedCuMatrix},
+                       pivotArray::Union{Nothing,CuMatrix{Cint}}=nothing)
+    getrs_batched!(trans, A, deepcopy(B), pivotArray)
+end
+
+# CUDA has no strided batched getrs, but we can at least avoid constructing costly views
+function getrs_strided_batched!(trans::Char,
+                                A::DenseCuArray{<:Any, 3},
+                                B::DenseCuArray{<:Any, 3},
+                                pivotArray::T=nothing) where T<:Union{Nothing,CuMatrix{Cint}}
+    m,n = size(A,1), size(A,2)
+    if m != n
+        throw(DimensionMismatch("All matrices must be square!"))
+    end
+    o = size(B,1)
+    if m != o
+        throw(DimensionMismatch("Rows in A and B must be equal!"))
+    end
+    lda = max(1,stride(A,2))
+    ldb = max(1,stride(B,2))
+    nrhs = size(B,2)
+
+    Aptrs = unsafe_strided_batch(A)
+    Bptrs = unsafe_strided_batch(B)
+    pivotptr = T==Nothing ? CU_NULL : pointer(pivotArray)
+    return getrs_batched!(trans, n, nrhs, Aptrs, lda, pivotptr, Bptrs, ldb), B
+end
+function getrs_strided_batched(trans::Char,
+                               A::DenseCuArray{<:Any, 3},
+                               B::DenseCuArray{<:Any, 3},
+                               pivotArray::Union{Nothing,CuMatrix{Cint}}=nothing)
+    getrs_strided_batched!(trans, A, copy(B), pivotArray)
+end
+
+
 ## getriBatched - performs batched matrix inversion
 for (fname, elty) in ((:cublasDgetriBatched, :Float64),
                       (:cublasSgetriBatched, :Float32),


### PR DESCRIPTION
uses `getrf_batched` as a template.

also corrects README to indicate support for `spmv` and `spr`.

currently getting an error that i'm having trouble fixing:

```
julia> using CUDA

julia> A = CUDA.rand(5,5,3);

julia> B = CUDA.rand(5,2);

julia> pivot, _ = CUDA.CUBLAS.getrf_strided_batched!(A, true);

julia> CUDA.CUBLAS.getrs_strided_batched!('N', A, pivot, B)
ArgumentError: cannot take the CPU address of GPU memory.

You are probably falling back to or otherwise calling CPU functionality
with GPU array inputs. This is not supported by regular device memory;
ensure this operation is supported by CUDA.jl, and if it isn't, try to
avoid it or rephrase it in terms of supported operations. Alternatively,
you can consider using GPU arrays backed by unified memory by
allocating using `cu(...; unified=true)`.
Stacktrace:
  [1] convert(::Type{Ptr{Int32}}, managed::CUDA.Managed{CUDA.DeviceMemory})
    @ CUDA /groups/scicompsoft/home/arthurb/.julia/dev/CUDA/src/memory.jl:573
  [2] unsafe_convert(typ::Type{Ptr{Int32}}, x::CuArray{Int32, 1, CUDA.DeviceMemory})
    @ CUDA /groups/scicompsoft/home/arthurb/.julia/dev/CUDA/src/array.jl:432
  [3] macro expansion
    @ /groups/scicompsoft/home/arthurb/.julia/dev/CUDA/lib/utils/call.jl:215 [inlined]
  [4] macro expansion
    @ /groups/scicompsoft/home/arthurb/.julia/dev/CUDA/lib/cublas/libcublas.jl:5274 [inlined]
  [5] #990
    @ /groups/scicompsoft/home/arthurb/.julia/dev/CUDA/lib/utils/call.jl:35 [inlined]
  [6] retry_reclaim
    @ /groups/scicompsoft/home/arthurb/.julia/dev/CUDA/src/memory.jl:434 [inlined]
  [7] check
    @ /groups/scicompsoft/home/arthurb/.julia/dev/CUDA/lib/cublas/libcublas.jl:24 [inlined]
  [8] cublasSgetrsBatched
    @ /groups/scicompsoft/home/arthurb/.julia/dev/CUDA/lib/utils/call.jl:34 [inlined]
  [9] getrs_batched!(trans::Char, n::Int64, nrhs::Int64, Aptrs::CuArray{CuPtr{Float32}, 1, CUDA.DeviceMemory}, lda::Int64, pivotArray::CuPtr{Int32}, Bptrs::CuArray{CuPtr{Float32}, 1, CUDA.DeviceMemory}, ldb::Int64)
    @ CUDA.CUBLAS /groups/scicompsoft/home/arthurb/.julia/dev/CUDA/lib/cublas/wrappers.jl:1900
 [10] getrs_strided_batched!(trans::Char, A::CuArray{Float32, 3, CUDA.DeviceMemory}, pivotArray::CuArray{Int32, 2, CUDA.DeviceMemory}, B::CuArray{Float32, 2, CUDA.DeviceMemory})
    @ CUDA.CUBLAS /groups/scicompsoft/home/arthurb/.julia/dev/CUDA/lib/cublas/wrappers.jl:1951
 [11] top-level scope
    @ REPL[5]:1
```