### PR TITLE
add two quirks for rationals

### DIFF
--- a/src/device/quirks.jl
+++ b/src/device/quirks.jl
@@ -84,3 +84,9 @@ end
     end
     return v
 end
+
+# rational.jl
+@device_override @noinline Base.__throw_rational_argerror_zero(::Type{T}) where {T} =
+    @gputhrow "ArgumentError" "invalid rational: 0//0"
+@device_override @noinline Base.__throw_rational_argerror_typemin(::Type{T}) where {T} =
+    @gputhrow "OverflowError" "rational numerator is typemin"

--- a/test/base/broadcast.jl
+++ b/test/base/broadcast.jl
@@ -75,3 +75,9 @@ end
   k = i .+ j
   @test !is_unified(k)
 end
+
+# https://github.com/JuliaGPU/CUDA.jl/issues/1926
+@testset "Broadcast rational" begin
+  @test testf((x) -> (2 // 3 .* x),  rand(2, 3))
+  @test testf((x) -> (f(x) = 2 // 3 * x; f.(x)),  rand(2, 3))
+end


### PR DESCRIPTION
Add quirks for `__throw_rational_argerror_zero` and `__throw_r…ational_argerror_typemin`. This addition should fix #1926. Could you let me know which file I should add a test to? 😄 