### PR TITLE
Add convert method for ScaledPlan

### DIFF
--- a/lib/cufft/fft.jl
+++ b/lib/cufft/fft.jl
@@ -22,6 +22,8 @@ abstract type CuFFTPlan{T<:cufftNumber, K, inplace} <: Plan{T} end
 
 # for some reason, cufftHandle is an integer and not a pointer...
 Base.convert(::Type{cufftHandle}, p::CuFFTPlan) = p.handle
+# we also need to be able to convert CuFFTPlans that have been wrapped in a ScaledPlan
+Base.convert(::Type{cufftHandle}, p::ScaledPlan{T,P,N}) where {T,N,P<:CuFFTPlan} = convert(cufftHandle, p.p)
 
 function CUDA.unsafe_free!(plan::CuFFTPlan)
     if plan.handle != C_NULL

--- a/test/libraries/cufft.jl
+++ b/test/libraries/cufft.jl
@@ -347,5 +347,10 @@ end
     x = CUDA.zeros(ComplexF32, 4)
     p = plan_ifft(x)
     @test p isa AbstractFFTs.ScaledPlan
-    @test convert(CUFFT.cufftHandle, p) === convert(CUFFT.cufftHandle, p.p)
+    # Initialize sz ref to invalid value
+    sz = Ref{Csize_t}(typemax(Csize_t))
+    # This will call the new convert method for ScaledPlan
+    CUFFT.cufftGetSize(p, sz)
+    # Make sure the value was modified
+    @test sz[] != typemax(Csize_t)
 end

--- a/test/libraries/cufft.jl
+++ b/test/libraries/cufft.jl
@@ -342,3 +342,10 @@ end
 
     @test Array(dy) ≈ y
 end
+
+@testset "CUDA.jl#2409" begin
+    x = CUDA.zeros(ComplexF32, 4)
+    p = plan_ifft(x)
+    @test p isa AbstractFFTs.ScaledPlan
+    @test convert(CUFFT.cufftHandle, p) === convert(CUFFT.cufftHandle, p.p)
+end


### PR DESCRIPTION
This allows inverse CUFFT plans to be passed to CUFFT functions that take a cufftHandle.  These CUFFT plans are wrapped in an AbstractFFTs.ScaledPlan so we need the conversion of the ScaledPlan to call convert on the contained CUFFT plan.