### PR TITLE
fix compute-sanitizer typo

### DIFF
--- a/docs/src/development/debugging.md
+++ b/docs/src/development/debugging.md
@@ -111,7 +111,7 @@ julia> options = ["--launch-timeout=0", "--target-processes=all", "--report-api-
  "--report-api-errors=no"
 
 # Run the executable with Julia
-julia> run(`$compute_sanitizer $options$(Base.julia_cmd())`)
+julia> run(`$compute_sanitizer $options $(Base.julia_cmd())`)
 ========= COMPUTE-SANITIZER
 julia> using CUDA
 


### PR DESCRIPTION
Forgot to add a space in line 114 from PR #[2440](https://github.com/JuliaGPU/CUDA.jl/pull/2440), command fails without it.