### PR TITLE
Implementation of spdiagm for CUSPARSE

### DIFF
--- a/lib/cusparse/array.jl
+++ b/lib/cusparse/array.jl
@@ -324,7 +324,7 @@ end
 
 function SparseArrays.spdiagm(v::CuArray{Tv}) where {Tv}
     nzVal = v
-    N = Int32(length(v))
+    N = Int32(length(nzVal))
     
     colPtr = CuArray(one(Int32):(N + one(Int32)))
     rowVal = CuArray(one(Int32):N)

--- a/lib/cusparse/array.jl
+++ b/lib/cusparse/array.jl
@@ -322,7 +322,7 @@ function SparseArrays.sparsevec(I::CuArray{Ti}, V::CuArray{Tv}, n::Integer) wher
     CuSparseVector(I, V, n)
 end
 
-function SparseArrays.spdiagm(v::CuArray{Tv}) where {Tv}
+function SparseArrays.spdiagm(v::CuVector{Tv}) where {Tv}
     nzVal = v
     N = Int32(length(nzVal))
     

--- a/lib/cusparse/array.jl
+++ b/lib/cusparse/array.jl
@@ -322,6 +322,16 @@ function SparseArrays.sparsevec(I::CuArray{Ti}, V::CuArray{Tv}, n::Integer) wher
     CuSparseVector(I, V, n)
 end
 
+function SparseArrays.spdiagm(v::CuArray{Tv}) where {Tv}
+    nzVal = v
+    N = Int32(length(v))
+    
+    colPtr = CuArray(one(Int32):(N + one(Int32)))
+    rowVal = CuArray(one(Int32):N)
+    dims = (N, N)
+    CuSparseMatrixCSC(colPtr, rowVal, nzVal, dims)
+end
+
 LinearAlgebra.issymmetric(M::Union{CuSparseMatrixCSC,CuSparseMatrixCSR}) = size(M, 1) == size(M, 2) ? norm(M - transpose(M), Inf) == 0 : false
 LinearAlgebra.ishermitian(M::Union{CuSparseMatrixCSC,CuSparseMatrixCSR}) = size(M, 1) == size(M, 2) ? norm(M - adjoint(M), Inf) == 0 : false
 LinearAlgebra.issymmetric(M::Symmetric{CuSparseMatrixCSC}) = true

--- a/test/libraries/cusparse/interfaces.jl
+++ b/test/libraries/cusparse/interfaces.jl
@@ -541,7 +541,7 @@ end
 
 @testset "SparseArrays" begin
     @testset "spdiagm(CuVector{$elty})" for elty in [Float32, Float64, ComplexF32, ComplexF64]
-        ref_vec = collect(elty,100:121)
+        ref_vec = collect(elty, 100:121)
         cuda_vec = CuVector(ref_vec)
 
         ref_spdiagm = spdiagm(ref_vec) # SparseArrays
@@ -551,7 +551,7 @@ end
 
         @test ref_cuda_sparse.rowVal == cuda_spdiagm.rowVal
 
-        @test ref_cuda_sparse.nzVal== cuda_spdiagm.nzVal
+        @test ref_cuda_sparse.nzVal == cuda_spdiagm.nzVal
 
         @test ref_cuda_sparse.colPtr == cuda_spdiagm.colPtr
     end

--- a/test/libraries/cusparse/interfaces.jl
+++ b/test/libraries/cusparse/interfaces.jl
@@ -538,3 +538,21 @@ using LinearAlgebra, SparseArrays
         end
     end
 end
+
+@testset "SparseArrays" begin
+    @testset "spdiagm(CuVector{$elty})" for elty in [Float32, Float64, ComplexF32, ComplexF64]
+        ref_vec = collect(elty,100:121)
+        cuda_vec = CuVector(ref_vec)
+
+        ref_spdiagm = spdiagm(ref_vec) # SparseArrays
+        cuda_spdiagm = spdiagm(cuda_vec) # CuSparseMatrixCSC
+
+        ref_cuda_sparse = CuSparseMatrixCSC(ref_spdiagm)
+
+        @test ref_cuda_sparse.rowVal == cuda_spdiagm.rowVal
+
+        @test ref_cuda_sparse.nzVal== cuda_spdiagm.nzVal
+
+        @test ref_cuda_sparse.colPtr == cuda_spdiagm.colPtr
+    end
+end


### PR DESCRIPTION
Here is the implementation of SparseArrays.spdiagm(vec)

The one(Int32) and Int32 conversions are used to reduce allocations and enhance the performance of this simple function.

Closes #1857 