### PR TITLE
Revert "Run full GC when under very high memory pressure."

### DIFF
--- a/src/memory.jl
+++ b/src/memory.jl
@@ -130,7 +130,7 @@ function maybe_collect(will_block::Bool=false)
 
   # finally, call the GC
   pre_gc_live = stats.live
-  gc_time = Base.@elapsed GC.gc(pressure > 0.9 ? true : false)
+  gc_time = Base.@elapsed GC.gc(false)
   post_gc_live = stats.live
   memory_freed = pre_gc_live - post_gc_live
   Base.@atomic stats.last_freed = memory_freed


### PR DESCRIPTION
Reverts JuliaGPU/CUDA.jl#2421, fixing https://github.com/JuliaGPU/CUDA.jl/issues/2467