### PR TITLE
Ignore Enzyme.jl CI failures

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -230,8 +230,7 @@ steps:
             build.message !~ /\[skip tests\]/ &&
             build.message !~ /\[skip downstream\]/
         timeout_in_minutes: 30
-        soft_fail:
-          - exit_status: 3
+        soft_fail: true
 
   - group: ":eyes: Special"
     depends_on: "cuda"


### PR DESCRIPTION
It looks like Enzyme.jl is not correctly using GPUCompiler.jl's deferred compilation mode, leading to ICEs: https://github.com/JuliaGPU/GPUCompiler.jl/pull/619#pullrequestreview-2259868418

Let's disable Enzyme.jl CI for now.

cc @wsmoses 