### PR TITLE
[CUSPARSE] Implement a sparse GEMV for CuSparseMatrixCSC * CuSparseVector

### DIFF
--- a/lib/cusparse/generic.jl
+++ b/lib/cusparse/generic.jl
@@ -575,7 +575,7 @@ function gemm(transa::SparseChar, transb::SparseChar, alpha::Number, A::CuSparse
 end
 
 """
-    y = gemv(transa, alpha, A, x, index, algo)
+    y = gemv(transa, alpha, A, x, index, [algo])
 
 Perform a product between a `CuSparseMatrix` and a `CuSparseVector`, returning a `CuSparseVector`.
 This function should only be used for highly sparse matrices and vectors, as the result is expected

--- a/lib/cusparse/generic.jl
+++ b/lib/cusparse/generic.jl
@@ -574,6 +574,19 @@ function gemm(transa::SparseChar, transb::SparseChar, alpha::Number, A::CuSparse
     return C
 end
 
+function gemv(transa::SparseChar, alpha::Number, A::CuSparseMatrixCSC{T},
+              x::CuSparseVector{T}, index::SparseChar, algo::cusparseSpGEMMAlg_t=CUSPARSE_SPGEMM_DEFAULT) where {T}
+    m, n = size(A)
+    p = length(x)
+    p == n || throw(DimensionMismatch("dimensions must match: x has length $p, A has length $m × $n"))
+    # we model x as a CuSparseMatrixCSC with one column.
+    rowPtrB = CuVector{Int32}([1; nnz(x)+1])
+    B = CuSparseMatrixCSC(rowPtrB, x.iPtr, nonzeros(x), (n,1)))
+    C = gemm(transa, 'N', alpha, A, B, index, algo)
+    y = CuSparseVector(C.colVal, C.nzVal, m)
+    return y
+end
+
 for SparseMatrixType in (:CuSparseMatrixCSC, :CuSparseMatrixCSR)
     @eval begin
         function gemm(transa::SparseChar, transb::SparseChar, alpha::Number, A::$SparseMatrixType{T}, B::$SparseMatrixType{T},

--- a/lib/cusparse/generic.jl
+++ b/lib/cusparse/generic.jl
@@ -574,6 +574,19 @@ function gemm(transa::SparseChar, transb::SparseChar, alpha::Number, A::CuSparse
     return C
 end
 
+# function gemv(transa::SparseChar, alpha::Number, A::CuSparseMatrixCSR{T},
+#               x::CuSparseVector{T}, index::SparseChar, algo::cusparseSpGEMMAlg_t=CUSPARSE_SPGEMM_DEFAULT) where {T}
+#     m, n = size(A)
+#     p = length(x)
+#     p == n || throw(DimensionMismatch("dimensions must match: x has length $p, A has length $m × $n"))
+#     # we model x as a CuSparseMatrixCSC with one column.
+#     rowPtrB = ...
+#     B = CuSparseMatrixCSR(..., x.iPtr, nonzeros(x), (n,1)))
+#     C = gemm(transa, 'N', alpha, A, B, index, algo)
+#     y = CuSparseVector(..., C.nzVal, m)
+#     return y
+# end
+
 function gemv(transa::SparseChar, alpha::Number, A::CuSparseMatrixCSC{T},
               x::CuSparseVector{T}, index::SparseChar, algo::cusparseSpGEMMAlg_t=CUSPARSE_SPGEMM_DEFAULT) where {T}
     m, n = size(A)
@@ -583,7 +596,7 @@ function gemv(transa::SparseChar, alpha::Number, A::CuSparseMatrixCSC{T},
     rowPtrB = CuVector{Int32}([1; nnz(x)+1])
     B = CuSparseMatrixCSC(rowPtrB, x.iPtr, nonzeros(x), (n,1)))
     C = gemm(transa, 'N', alpha, A, B, index, algo)
-    y = CuSparseVector(C.colVal, C.nzVal, m)
+    y = CuSparseVector(C.rowVal, C.nzVal, m)
     return y
 end
 

--- a/lib/cusparse/generic.jl
+++ b/lib/cusparse/generic.jl
@@ -1,7 +1,7 @@
 # generic APIs
 
 export gather!, scatter!, axpby!, rot!
-export vv!, sv!, sm!, gemm, gemm!, sddmm!
+export vv!, sv!, sm!, gemv, gemm, gemm!, sddmm!
 export bmm!
 
 ## API functions

--- a/lib/cusparse/generic.jl
+++ b/lib/cusparse/generic.jl
@@ -574,19 +574,6 @@ function gemm(transa::SparseChar, transb::SparseChar, alpha::Number, A::CuSparse
     return C
 end
 
-# function gemv(transa::SparseChar, alpha::Number, A::CuSparseMatrixCSR{T},
-#               x::CuSparseVector{T}, index::SparseChar, algo::cusparseSpGEMMAlg_t=CUSPARSE_SPGEMM_DEFAULT) where {T}
-#     m, n = size(A)
-#     p = length(x)
-#     p == n || throw(DimensionMismatch("dimensions must match: x has length $p, A has length $m × $n"))
-#     # we model x as a CuSparseMatrixCSC with one column.
-#     rowPtrB = ...
-#     B = CuSparseMatrixCSR(..., x.iPtr, nonzeros(x), (n,1)))
-#     C = gemm(transa, 'N', alpha, A, B, index, algo)
-#     y = CuSparseVector(..., C.nzVal, m)
-#     return y
-# end
-
 function gemv(transa::SparseChar, alpha::Number, A::CuSparseMatrixCSC{T},
               x::CuSparseVector{T}, index::SparseChar, algo::cusparseSpGEMMAlg_t=CUSPARSE_SPGEMM_DEFAULT) where {T}
     m, n = size(A)
@@ -594,7 +581,7 @@ function gemv(transa::SparseChar, alpha::Number, A::CuSparseMatrixCSC{T},
     p == n || throw(DimensionMismatch("dimensions must match: x has length $p, A has length $m × $n"))
     # we model x as a CuSparseMatrixCSC with one column.
     rowPtrB = CuVector{Int32}([1; nnz(x)+1])
-    B = CuSparseMatrixCSC(rowPtrB, x.iPtr, nonzeros(x), (n,1)))
+    B = CuSparseMatrixCSC(rowPtrB, x.iPtr, nonzeros(x), (n,1))
     C = gemm(transa, 'N', alpha, A, B, index, algo)
     y = CuSparseVector(C.rowVal, C.nzVal, m)
     return y

--- a/lib/cusparse/interfaces.jl
+++ b/lib/cusparse/interfaces.jl
@@ -187,12 +187,6 @@ for SparseMatrixType in (:CuSparseMatrixCSC, :CuSparseMatrixCSR)
     end
 end
 
-for SparseMatrixType in (:CuSparseMatrixCSC, :CuSparseMatrixCSR)
-    @eval function LinearAlgebra.:(*)(A::$SparseMatrixType{T}, b::CuSparseVector{T}) where {T <: BlasFloat}
-        gemv('N', one(T), A, b, 'O')
-    end
-end
-
 function LinearAlgebra.:(*)(A::CuSparseMatrixCOO{T}, B::CuSparseMatrixCOO{T}) where {T <: BlasFloat}
     A_csr = CuSparseMatrixCSR(A)
     B_csr = CuSparseMatrixCSR(B)

--- a/lib/cusparse/interfaces.jl
+++ b/lib/cusparse/interfaces.jl
@@ -187,7 +187,7 @@ for SparseMatrixType in (:CuSparseMatrixCSC, :CuSparseMatrixCSR)
     end
 end
 
-for SparseMatrixType in (:CuSparseMatrixCSC,)
+for SparseMatrixType in (:CuSparseMatrixCSC, :CuSparseMatrixCSR)
     @eval function LinearAlgebra.:(*)(A::$SparseMatrixType{T}, b::CuSparseVector{T}) where {T <: BlasFloat}
         gemv('N', one(T), A, b, 'O')
     end

--- a/lib/cusparse/interfaces.jl
+++ b/lib/cusparse/interfaces.jl
@@ -73,6 +73,7 @@ function LinearAlgebra.generic_matvecmul!(C::CuVector{T}, tA::AbstractChar, A::C
     tA = tA in ('S', 's', 'H', 'h') ? 'N' : tA
     mv_wrapper(tA, alpha, A, B, beta, C)
 end
+
 function LinearAlgebra.generic_matvecmul!(C::CuVector{T}, tA::AbstractChar, A::CuSparseMatrix{T}, B::CuSparseVector{T}, alpha::Number, beta::Number) where {T <: Union{Float16, ComplexF16, BlasFloat}}
     tA = tA in ('S', 's', 'H', 'h') ? 'N' : tA
     mv_wrapper(tA, alpha, A, CuVector{T}(B), beta, C)
@@ -183,6 +184,12 @@ end
 for SparseMatrixType in (:CuSparseMatrixCSC, :CuSparseMatrixCSR)
     @eval function LinearAlgebra.:(*)(A::$SparseMatrixType{T}, B::$SparseMatrixType{T}) where {T <: BlasFloat}
         gemm('N', 'N', one(T), A, B, 'O')
+    end
+end
+
+for SparseMatrixType in (:CuSparseMatrixCSC,)
+    @eval function LinearAlgebra.:(*)(A::$SparseMatrixType{T}, b::CuSparseVector{T}) where {T <: BlasFloat}
+        gemv('N', one(T), A, b, 'O')
     end
 end
 

--- a/test/libraries/cusparse/generic.jl
+++ b/test/libraries/cusparse/generic.jl
@@ -367,7 +367,7 @@ for SparseMatrixType in keys(SPGEMM_ALGOS)
             db = CuSparseVector(b)
             alpha = rand(T)
             y = alpha * opa(A) * b
-            dy = gemv(transa, alpha, dA, db, 'O', algo)
+            dy = gemv(transa, alpha, dA, db, 'O')
             @test collect(dy) ≈ y
         end
     end

--- a/test/libraries/cusparse/generic.jl
+++ b/test/libraries/cusparse/generic.jl
@@ -358,6 +358,19 @@ for SparseMatrixType in keys(SPGEMM_ALGOS)
             end
         end
     end
+
+    @testset "gemv $T" for T in [Float32, Float64, ComplexF32, ComplexF64]
+        for (transa, opa) in [('N', identity)]
+            A = sprand(T,25,10,0.2)
+            b = sprand(T,10,0.3)
+            dA = SparseMatrixType(A)
+            db = CuSparseVector(b)
+            alpha = rand(T)
+            y = alpha * opa(A) * b
+            dy = gemv(transa, alpha, dA, db, 'O', algo)
+            @test collect(dy) ≈ y
+        end
+    end
 end
 
 if CUSPARSE.version() >= v"11.4.1"


### PR DESCRIPTION
#2484 
I didn't added new tests because the current ones should check if the result is correct or not:
https://github.com/JuliaGPU/CUDA.jl/blob/master/test/libraries/cusparse/interfaces.jl#L267-L282

Note that a sparse GEMV `CuSparseMatrixCSR * CuSparseVector` is also implemented.