### PR TITLE
Fix type of AbstractFFTs.Plan for real-complex FFTs

### DIFF
--- a/lib/cufft/fft.jl
+++ b/lib/cufft/fft.jl
@@ -25,7 +25,7 @@ Base.:(*)(p::ScaledPlan, x::DenseCuArray) = rmul!(p.p * x, p.scale)
 
 # N is the number of dimensions
 
-mutable struct CuFFTPlan{T<:cufftNumber,S<:cufftNumber,K,inplace,N} <: Plan{T}
+mutable struct CuFFTPlan{T<:cufftNumber,S<:cufftNumber,K,inplace,N} <: Plan{S}
     # handle to Cuda low level plan. Note that this plan sometimes has lower dimensions
     # to handle more transform cases such as individual directions
     handle::cufftHandle
@@ -34,7 +34,7 @@ mutable struct CuFFTPlan{T<:cufftNumber,S<:cufftNumber,K,inplace,N} <: Plan{T}
     input_size::NTuple{N,Int}   # Julia size of input array
     output_size::NTuple{N,Int}  # Julia size of output array
     region::Any
-    pinv::ScaledPlan{S}         # required by AbstractFFTs API, will be defined by AbstractFFTs if needed
+    pinv::ScaledPlan{T}         # required by AbstractFFTs API, will be defined by AbstractFFTs if needed
 
     function CuFFTPlan{T,S,K,inplace,N}(handle::cufftHandle,
                                         input_size::NTuple{N,Int}, output_size::NTuple{N,Int}, region

--- a/test/libraries/cufft.jl
+++ b/test/libraries/cufft.jl
@@ -445,3 +445,13 @@ end
     # Make sure the value was modified
     @test sz[] != typemax(Csize_t)
 end
+
+@testset "CUDA.jl#2504" begin
+    x = CUDA.zeros(Float32, 4)
+    p = plan_rfft(x)
+    pinv = inv(p)
+    @test p isa AbstractFFTs.Plan{Float32}
+    @test eltype(p) === Float32
+    @test pinv isa AbstractFFTs.Plan{ComplexF32}
+    @test eltype(pinv) === ComplexF32
+end


### PR DESCRIPTION
In AbstractFFTs.jl, the [`Plan{T}`](https://github.com/JuliaMath/AbstractFFTs.jl/blob/70524d2e79cbeb3d21665c64b0e612e6eff72b17/src/definitions.jl#L9) abstract type is defined such that `T` is the *input* type of the FFT. For example, a real-to-complex plan returned by `plan_rfft` should be a subtype of `Plan{T}` for `T` real, while the inverse plan (complex-to-real) should be a `Plan{Complex{T}}`. This is satisfied in particular by plans created by FFTW.jl.

Currently, the opposite is true for `CuFFTPlan`s:

```julia
using CUDA
using FFTW
using AbstractFFTs

T = Float64

# CPU

u = rand(T, 256)
p_cpu = plan_rfft(u)
v = p_cpu * u
w = p_cpu \ v

p_cpu isa AbstractFFTs.Plan{T}  # true
p_cpu.pinv isa AbstractFFTs.Plan{Complex{T}}  # true

eltype(p_cpu)       # Float64
eltype(p_cpu.pinv)  # ComplexF64

# GPU

u_gpu = CuArray(u)
p_gpu = plan_rfft(u_gpu)
v_gpu = p_gpu * u_gpu
w_gpu = p_gpu \ v_gpu

p_gpu isa AbstractFFTs.Plan{T}  # false
p_gpu.pinv isa AbstractFFTs.Plan{Complex{T}}  # false

eltype(p_gpu)       # ComplexF64
eltype(p_gpu.pinv)  # Float64
```

This PR attempts to fix this issue.