### PR TITLE
Native RNG fixes for very large arrays

### DIFF
--- a/src/random.jl
+++ b/src/random.jl
@@ -52,8 +52,8 @@ function Random.rand!(rng::RNG, A::AnyCuArray)
 
         # grid-stride loop
         threadId = threadIdx().x
-        window = blockDim().x * gridDim().x
-        offset = (blockIdx().x - 1) * blockDim().x
+        window = widemul(blockDim().x, gridDim().x)
+        offset = widemul(blockIdx().x - 1i32, blockDim().x)
         while offset < length(A)
             i = threadId + offset
             if i <= length(A)
@@ -96,8 +96,8 @@ function Random.randn!(rng::RNG, A::AnyCuArray{<:Union{AbstractFloat,Complex{<:A
 
         # grid-stride loop
         threadId = threadIdx().x
-        window = (blockDim().x - 1) * gridDim().x
-        offset = (blockIdx().x - 1) * blockDim().x
+        window = widemul(blockDim().x - 1i32, gridDim().x)
+        offset = widemul(blockIdx().x - 1i32, blockDim().x)
         while offset < length(A)
             i = threadId + offset
             j = threadId + offset + window
@@ -129,8 +129,8 @@ function Random.randn!(rng::RNG, A::AnyCuArray{<:Union{AbstractFloat,Complex{<:A
 
         # grid-stride loop
         threadId = threadIdx().x
-        window = (blockDim().x - 1) * gridDim().x
-        offset = (blockIdx().x - 1) * blockDim().x
+        window = widemul(blockDim().x - 1i32, gridDim().x)
+        offset = widemul(blockIdx().x - 1i32, blockDim().x)
         while offset < length(A)
             i = threadId + offset
             if i <= length(A)

--- a/src/random.jl
+++ b/src/random.jl
@@ -150,11 +150,11 @@ function Random.randn!(rng::RNG, A::AnyCuArray{<:Union{AbstractFloat,Complex{<:A
         return
     end
 
-    kernel = @cuda launch=false name="rand!" kernel(A, rng.seed, rng.counter)
-    config = launch_configuration(kernel.fun; max_threads=64)
-    threads = max(32, min(config.threads, length(A)÷2))
-    blocks = min(config.blocks, cld(cld(length(A), 2), threads))
-    kernel(A, rng.seed, rng.counter; threads, blocks)
+    # see note in `rand!` about the launch configuration
+    threads = 32
+    blocks = cld(cld(length(A), 2), threads)
+
+    @cuda threads=threads blocks=blocks name="randn!" kernel(A, rng.seed, rng.counter)
 
     new_counter = Int64(rng.counter) + length(A)
     overflow, remainder = fldmod(new_counter, typemax(UInt32))

--- a/src/random.jl
+++ b/src/random.jl
@@ -96,7 +96,7 @@ function Random.randn!(rng::RNG, A::AnyCuArray{<:Union{AbstractFloat,Complex{<:A
 
         # grid-stride loop
         threadId = threadIdx().x
-        window = widemul(blockDim().x - 1i32, gridDim().x)
+        window = widemul(blockDim().x, gridDim().x)
         offset = widemul(blockIdx().x - 1i32, blockDim().x)
         while offset < length(A)
             i = threadId + offset
@@ -129,7 +129,7 @@ function Random.randn!(rng::RNG, A::AnyCuArray{<:Union{AbstractFloat,Complex{<:A
 
         # grid-stride loop
         threadId = threadIdx().x
-        window = widemul(blockDim().x - 1i32, gridDim().x)
+        window = widemul(blockDim().x, gridDim().x)
         offset = widemul(blockIdx().x - 1i32, blockDim().x)
         while offset < length(A)
             i = threadId + offset

--- a/test/base/random.jl
+++ b/test/base/random.jl
@@ -200,7 +200,12 @@ end
 
 @testset "counter overflow" begin
     rng = CUDA.RNG()
-    c = CUDA.zeros(Float16, (64, 32, 512, 32, 64))
-    rand!(rng, c)
-    randn!(rng, c)
+    # we may not be able to allocate over 4GB on the GPU, so use CPU memory
+    #c = CUDA.zeros(Float16, (64, 32, 512, 32, 64))
+    c = Array{Float16}(undef, 64, 32, 512, 32, 64)
+    GC.@preserve c begin
+        dc = unsafe_wrap(CuArray, c)
+        rand!(rng, dc)
+        randn!(rng, dc)
+    end
 end

--- a/test/base/random.jl
+++ b/test/base/random.jl
@@ -198,3 +198,9 @@ end
     end
 end
 
+@testset "counter overflow" begin
+    rng = CUDA.RNG()
+    c = CUDA.zeros(Float16, (64, 32, 512, 32, 64))
+    rand!(rng, c)
+    randn!(rng, c)
+end

--- a/test/base/random.jl
+++ b/test/base/random.jl
@@ -200,12 +200,8 @@ end
 
 @testset "counter overflow" begin
     rng = CUDA.RNG()
-    # we may not be able to allocate over 4GB on the GPU, so use CPU memory
-    #c = CUDA.zeros(Float16, (64, 32, 512, 32, 64))
-    c = Array{Float16}(undef, 64, 32, 512, 32, 64)
-    GC.@preserve c begin
-        dc = unsafe_wrap(CuArray, c)
-        rand!(rng, dc)
-        randn!(rng, dc)
-    end
+    # we may not be able to allocate over 4GB on the GPU, so use unified memory
+    c = CuArray{Float16, 5, CUDA.UnifiedMemory}(undef, 64, 32, 512, 32, 64)
+    rand!(rng, c)
+    randn!(rng, c)
 end


### PR DESCRIPTION
The overflow fix isn't great (sacrificing a couple of additional registers), and we probably have a bunch of similar bugs in other native kernels. I contemplated passing a typevar that determines the type of the counter, but that's additional complexity that's _probably_ not worth it (e.g. in `randn!` the window size depends on the element type, so that would further couple kernel implementation details to the call site).

As noted by @thomasfaingnaert 