### PR TITLE
Update EnzymeCoreExt.jl

### DIFF
--- a/ext/EnzymeCoreExt.jl
+++ b/ext/EnzymeCoreExt.jl
@@ -25,7 +25,7 @@ end
 function EnzymeCore.EnzymeRules.inactive_noinl(::typeof(CUDA.is_pinned), args...)
     return nothing
 end
-function EnzymeCore.EnzymeRules.inactive_noinl(::typeof(CUDA.launch_configuration), args...; kwargs...)
+function EnzymeCore.EnzymeRules.inactive(::typeof(CUDA.launch_configuration), args...; kwargs...)
     return nothing
 end
 

--- a/test/extensions/enzyme.jl
+++ b/test/extensions/enzyme.jl
@@ -151,8 +151,7 @@ sumabs2(x) = sum(abs2.(x))
 @testset "Reverse sum abs2" begin
     x = CuArray([1.0, 2.0, 3.0, 4.0])
     dx = CuArray([0., 0.0, 0.0, 0.0])
-    f(x) = sum(abs2.(x))
-    Enzyme.autodiff(Reverse, f, Active, Duplicated(x, dx))
+    Enzyme.autodiff(Reverse, sumabs2, Active, Duplicated(x, dx))
     @test all(dx .≈ 2 .* x)
 end
 

--- a/test/extensions/enzyme.jl
+++ b/test/extensions/enzyme.jl
@@ -151,8 +151,9 @@ sumabs2(x) = sum(abs2.(x))
 @testset "Reverse sum abs2" begin
     x = CuArray([1.0, 2.0, 3.0, 4.0])
     dx = CuArray([0., 0.0, 0.0, 0.0])
+    f(x) = sum(abs2.(x))
     Enzyme.autodiff(Reverse, f, Active, Duplicated(x, dx))
-    @test all(dx .≈ 2.*x)
+    @test all(dx .≈ 2 .* x)
 end
 
 # TODO once reverse kernels are in

--- a/test/extensions/enzyme.jl
+++ b/test/extensions/enzyme.jl
@@ -145,6 +145,16 @@ end
     @test all(dx .≈ 1)
     @test all(dy .≈ 1)
 end
+
+sumabs2(x) = sum(abs2.(x))
+
+@testset "Reverse sum abs2" begin
+    x = CuArray([1.0, 2.0, 3.0, 4.0])
+    dx = CuArray([0., 0.0, 0.0, 0.0])
+    Enzyme.autodiff(Reverse, f, Active, Duplicated(x, dx))
+    @test all(dx .≈ 2.*x)
+end
+
 # TODO once reverse kernels are in
 # function togpu(x)
 #     x = CuArray(x)


### PR DESCRIPTION
The inactive_noinl failed in broadcast assignment when using Enzyme=0.13.16 and CUDA=5.5.2. Switching to the version that prevents inlining seem to have fixed it. Are there any negative consequences of this?

The issue where the error can be reproduced can be found here: EnzymeAD/Enzyme.jl#2116