### PR TITLE
Fix ambiguity of LinearAlgebra.dot

### DIFF
--- a/lib/cublas/linalg.jl
+++ b/lib/cublas/linalg.jl
@@ -28,7 +28,7 @@ function LinearAlgebra.dot(x::StridedCuVector{T},
 end
 
 # resolve ambiguities with generic wrapper below
-LinearAlgebra.dot(x::CuArray{T}, y::CuArray{T}) where T<:Union{Float32, Float64} =
+LinearAlgebra.dot(x::CuArray{T}, y::CuArray{T}) where T<:Union{Float32, Float64, ComplexF32, ComplexF64} =
     invoke(LinearAlgebra.dot, Tuple{StridedCuArray{T}, StridedCuArray{T}}, x, y)
 
 # generic fallback


### PR DESCRIPTION
close #2568 

Off-topic: We should try to dispatch to `CUBLAS.dot` for `CuArray{T,N}` if `N >= 2` and `T` is a `BlasFloat`.
We just need to call `vec` on the argument and rely on the version with CuVectors. We can also relax the types in `CUBLAS.dot`.