### PR TITLE
Add intrinsics with directed rounding

### DIFF
--- a/CUDACore/src/device/intrinsics/math.jl
+++ b/CUDACore/src/device/intrinsics/math.jl
@@ -1,6 +1,11 @@
 # math functionality
 
 @public fma, rsqrt, saturate, byte_perm, assume
+@public add_rn, add_rz, add_rm, add_rp
+@public sub_rn, sub_rz, sub_rm, sub_rp
+@public mul_rn, mul_rz, mul_rm, mul_rp
+@public div_rn, div_rz, div_rm, div_rp
+@public fma_rn, fma_rz, fma_rm, fma_rp
 
 using Base: FastMath, @assume_effects
 
@@ -551,6 +556,40 @@ end
 @device_override Base.muladd(x::Float64, y::Float64, z::Float64) = ccall("llvm.fmuladd.f64", llvmcall, Cdouble, (Cdouble, Cdouble, Cdouble), x, y, z)
 @device_override Base.muladd(x::Float32, y::Float32, z::Float32) = ccall("llvm.fmuladd.f32", llvmcall, Cfloat, (Cfloat, Cfloat, Cfloat), x, y, z)
 @device_override Base.muladd(x::Float16, y::Float16, z::Float16) = ccall("llvm.fmuladd.f16", llvmcall, Float16, (Float16, Float16, Float16), x, y, z)
+
+# Directed rounding for binary arithmetic and fma. NVPTX exposes
+# `{add,mul,div,fma}.{rn,rz,rm,rp}.{f32,f64}` directly; there is no `sub`
+# intrinsic, so subtraction reuses add(x, -y) (negation is bit-exact for IEEE
+# floats). Names match the CUDA C intrinsics (`__fadd_rn`, `__dadd_rn`, ...) so
+# users porting from CUDA C can find the corresponding Julia method by dropping
+# the `__f`/`__d` prefix. We don't extend `Base.fma` / `Base.:+` etc. with a
+# `RoundingMode` argument because Base has no precedent for per-call rounding
+# on hardware floats (BigFloat reads a thread-local mode instead).
+for rnd in ("rn", "rz", "rm", "rp")
+    for op in (:add, :mul, :div)
+        fname = Symbol(op, :_, rnd)
+        intrinsic_f = "llvm.nvvm.$(op).$(rnd).f"
+        intrinsic_d = "llvm.nvvm.$(op).$(rnd).d"
+        @eval @device_function $fname(x::Float32, y::Float32) =
+            ccall($intrinsic_f, llvmcall, Cfloat, (Cfloat, Cfloat), x, y)
+        @eval @device_function $fname(x::Float64, y::Float64) =
+            ccall($intrinsic_d, llvmcall, Cdouble, (Cdouble, Cdouble), x, y)
+    end
+
+    # NVPTX has no sub.<rnd> intrinsic; reuse add with negated y.
+    sub_fname = Symbol(:sub_, rnd)
+    add_fname = Symbol(:add_, rnd)
+    @eval @device_function $sub_fname(x::T, y::T) where {T<:Union{Float32, Float64}} =
+        $add_fname(x, -y)
+
+    fma_fname = Symbol(:fma_, rnd)
+    intrinsic_f = "llvm.nvvm.fma.$(rnd).f"
+    intrinsic_d = "llvm.nvvm.fma.$(rnd).d"
+    @eval @device_function $fma_fname(x::Float32, y::Float32, z::Float32) =
+        ccall($intrinsic_f, llvmcall, Cfloat, (Cfloat, Cfloat, Cfloat), x, y, z)
+    @eval @device_function $fma_fname(x::Float64, y::Float64, z::Float64) =
+        ccall($intrinsic_d, llvmcall, Cdouble, (Cdouble, Cdouble, Cdouble), x, y, z)
+end
 
 @device_function sad(x::Int32, y::Int32, z::Int32) = ccall("extern __nv_sad", llvmcall, Int32, (Int32, Int32, Int32), x, y, z)
 @device_function sad(x::UInt32, y::UInt32, z::UInt32) = convert(UInt32, ccall("extern __nv_usad", llvmcall, Int32, (Int32, Int32, Int32), x, y, z))

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -23,6 +23,10 @@ function main()
             "src/tutorials/performance.jl", "src/tutorials";
             repo_root_url = "$src/blob/main/docs"
         )
+        Literate.markdown(
+            "src/hacking/exposing_new_intrinsics.jl", "src/hacking";
+            repo_root_url = "$src/blob/main/docs"
+        )
     end
     println()
 
@@ -83,6 +87,9 @@ function main()
                 "development/kernel.md",
                 "development/troubleshooting.md",
                 "development/debugging.md",
+            ],
+            "Hacking" => Any[
+                "hacking/exposing_new_intrinsics.md",
             ],
             "API reference" => Any[
                 "api/essentials.md",

--- a/docs/src/hacking/exposing_new_intrinsics.jl
+++ b/docs/src/hacking/exposing_new_intrinsics.jl
@@ -1,0 +1,77 @@
+# # Exposing new GPU intrinsics
+
+# This tutorial walks through how to expose a new NVPTX intrinsic in CUDA.jl,
+# using the directed-rounding floating-point operations as a worked example.
+
+# ## Identifying the intrinsic
+
+# The PTX ISA documents the available instructions at
+# [PTX – Floating Point Instructions](https://docs.nvidia.com/cuda/parallel-thread-execution/#floating-point-instructions).
+# Each floating-point arithmetic instruction comes in four directed-rounding
+# variants:
+#
+# ```
+# {add,sub,mul,div,fma}.rnd.{f32,f64}      rnd ∈ {.rn, .rz, .rm, .rp}
+# ```
+#
+# where `.rn` is round-to-nearest-even, `.rz` rounds toward zero, `.rm` rounds
+# toward minus infinity, and `.rp` rounds toward plus infinity.
+#
+# Most of these PTX instructions are exposed by LLVM as NVVM intrinsics. The
+# canonical list lives in
+# [`llvm/include/llvm/IR/IntrinsicsNVVM.td`](https://github.com/llvm/llvm-project/blob/main/llvm/include/llvm/IR/IntrinsicsNVVM.td).
+# The naming convention there maps `.f32` to `.f` and `.f64` to `.d`, so the
+# round-toward-plus-infinity FMA for Float64 is `llvm.nvvm.fma.rp.d`.
+#
+# If LLVM does not expose an intrinsic for the PTX instruction you need, the
+# fallback is to drop down to inline PTX assembly via `@asmcall`.
+
+# ## Calling the intrinsic from Julia
+
+# CUDA.jl invokes LLVM intrinsics through `ccall` with the `llvmcall` calling
+# convention. For example, the round-toward-plus-infinity FMA on Float64:
+
+fma_rp(x::Float64, y::Float64, z::Float64) =
+    ccall("llvm.nvvm.fma.rp.d", llvmcall, Cdouble, (Cdouble, Cdouble, Cdouble), x, y, z)
+
+# We can verify the generated PTX contains the expected instruction:
+
+using CUDA
+
+function fma_kernel(out, x, y, z)
+    out[] = fma_rp(x, y, z)
+    return
+end
+
+@device_code_ptx @cuda launch=false fma_kernel(CuArray{Float64}(undef, 1), 1.0, 1.0, 1.0)
+
+# Look for `fma.rp.f64` in the listing above.
+
+# ## Exposing the full family
+
+# Once the intrinsic for one rounding mode is wired up, the remaining three
+# follow the same pattern. CUDA.jl exposes the full
+# `{add,sub,mul,div,fma}_{rn,rz,rm,rp}` family for both `Float32` and
+# `Float64`. The names mirror CUDA C's `__fadd_rn`/`__dadd_rn`/etc.:
+
+function rounding_demo!(out, x, y, z)
+    out[1] = CUDA.fma_rn(x, y, z)
+    out[2] = CUDA.fma_rz(x, y, z)
+    out[3] = CUDA.fma_rp(x, y, z)
+    out[4] = CUDA.fma_rm(x, y, z)
+    return
+end
+
+out_d = CUDA.zeros(Float64, 4)
+@cuda threads=1 rounding_demo!(out_d, 1.0, 1.0, 2.0^-53)
+Array(out_d)
+
+# The exact value of `1·1 + 2⁻⁵³` lies on the boundary between `1.0` and
+# `nextfloat(1.0)`, so the four entries above are `1.0` (RN, ties to even),
+# `1.0` (RZ), `nextfloat(1.0)` (RP), and `1.0` (RM).
+
+# We deliberately don't extend `Base.fma` with a `RoundingMode` argument:
+# Julia's Base has no precedent for per-call rounding on hardware floats
+# (BigFloat reads a thread-local mode set via `setrounding`), so introducing
+# such an API in CUDA.jl would not be portable. Code that needs directed
+# rounding should call the `*_rn`/`*_rz`/`*_rm`/`*_rp` functions directly.

--- a/test/core/device/intrinsics/math.jl
+++ b/test/core/device/intrinsics/math.jl
@@ -92,6 +92,149 @@ using SpecialFunctions
         end
     end
 
+    @testset "directed rounding" begin
+        # Verify each NVPTX directed-rounding intrinsic lowers to the expected
+        # PTX instruction. The full PTX listing also catches accidental
+        # round-trips through fp32 or libdevice helpers.
+        #
+        # `.rn` is the default PTX rounding mode, so on older LLVM the suffix
+        # is elided (`add.f32` ≡ `add.rn.f32`). For the same reason LLVM may
+        # fold `sub_rn(x,y) = add_rn(x,-y)` back to `sub.f32`. The non-rn modes
+        # always emit the explicit suffix since the default doesn't apply.
+        for op in (:add, :mul, :div, :fma), rnd in (:rn, :rz, :rm, :rp)
+            fname = Symbol(op, :_, rnd)
+            f = getfield(CUDA, fname)
+            for (T, suffix) in ((Float32, "f32"), (Float64, "f64"))
+                args = ntuple(_ -> T(1), op === :fma ? 3 : 2)
+                kernel = if op === :fma
+                    (out, x, y, z) -> (out[] = f(x, y, z); nothing)
+                else
+                    (out, x, y) -> (out[] = f(x, y); nothing)
+                end
+                buf = CuArray{T}(undef, 1)
+                ptx = sprint(io->(@device_code_ptx io=io @cuda launch=false kernel(buf, args...)))
+                accepted = rnd === :rn ?
+                    ("$(op).rn.$(suffix)", "$(op).$(suffix)") :
+                    ("$(op).$(rnd).$(suffix)",)
+                @test any(s -> occursin(s, ptx), accepted)
+            end
+        end
+
+        # NVPTX has no sub.<rnd> intrinsic; sub_<rnd>(x,y) reuses add_<rnd>(x,-y).
+        # For non-rn modes LLVM keeps the rounded add; for rn (the default) it
+        # may fold back to a plain `sub`.
+        for rnd in (:rn, :rz, :rm, :rp)
+            f = getfield(CUDA, Symbol(:sub_, rnd))
+            for (T, suffix) in ((Float32, "f32"), (Float64, "f64"))
+                kernel = (out, x, y) -> (out[] = f(x, y); nothing)
+                buf = CuArray{T}(undef, 1)
+                ptx = sprint(io->(@device_code_ptx io=io @cuda launch=false kernel(buf, T(1), T(1))))
+                accepted = rnd === :rn ?
+                    ("add.rn.$(suffix)", "add.$(suffix)", "sub.$(suffix)") :
+                    ("add.$(rnd).$(suffix)",)
+                @test any(s -> occursin(s, ptx), accepted)
+            end
+        end
+
+        # Numerical checks: pick inputs whose true result is not exactly
+        # representable, so the four rounding modes give distinct outputs.
+
+        @testset "fma_($T)" for T in (Float32, Float64)
+            # The true value of fma(1, 1, 2^-prec) is 1.0 + half-ulp, an exact
+            # tie that distinguishes all four rounding modes for positive values.
+            prec = T === Float32 ? 24 : 53
+            eps_step = T(2)^-prec
+            function fma_kernel(out, x, y, z)
+                out[1] = CUDA.fma_rn(x, y, z)
+                out[2] = CUDA.fma_rz(x, y, z)
+                out[3] = CUDA.fma_rp(x, y, z)
+                out[4] = CUDA.fma_rm(x, y, z)
+                return
+            end
+            out_d = CUDA.zeros(T, 4)
+            @cuda threads=1 fma_kernel(out_d, one(T), one(T), eps_step)
+            out = Array(out_d)
+            @test out[1] == one(T)                # RN ties to even (mantissa LSB 0)
+            @test out[2] == one(T)                # RZ
+            @test out[3] == nextfloat(one(T))     # RP
+            @test out[4] == one(T)                # RM
+        end
+
+        @testset "add_/mul_/div_($T)" for T in (Float32, Float64)
+            # 0.1*3 ≠ 0.3 in any binary float, so mul_rn and mul_rp differ from
+            # mul_rz and mul_rm by one ulp.
+            x, y = T(1)/T(10), T(3)
+            function mul_kernel(out, x, y)
+                out[1] = CUDA.mul_rn(x, y)
+                out[2] = CUDA.mul_rz(x, y)
+                out[3] = CUDA.mul_rp(x, y)
+                out[4] = CUDA.mul_rm(x, y)
+                return
+            end
+            out_d = CUDA.zeros(T, 4)
+            @cuda threads=1 mul_kernel(out_d, x, y)
+            mul_out = Array(out_d)
+            @test mul_out[4] <= mul_out[1] <= mul_out[3]   # RM ≤ RN ≤ RP
+            @test mul_out[2] == mul_out[4]                 # RZ == RM for positive
+            @test mul_out[3] == nextfloat(mul_out[4])      # 1 ulp gap
+
+            # div 1/3 is inexact and positive.
+            function div_kernel(out, x, y)
+                out[1] = CUDA.div_rn(x, y)
+                out[2] = CUDA.div_rz(x, y)
+                out[3] = CUDA.div_rp(x, y)
+                out[4] = CUDA.div_rm(x, y)
+                return
+            end
+            out_d = CUDA.zeros(T, 4)
+            @cuda threads=1 div_kernel(out_d, T(1), T(3))
+            div_out = Array(out_d)
+            @test div_out[4] <= div_out[1] <= div_out[3]
+            @test div_out[2] == div_out[4]
+            @test div_out[3] == nextfloat(div_out[4])
+
+            # add 1 + 2^-(prec+1) lies strictly between 1.0 and nextfloat(1.0).
+            prec = T === Float32 ? 24 : 53
+            eps_half = T(2)^-(prec+1)
+            function add_kernel(out, x, y)
+                out[1] = CUDA.add_rn(x, y)
+                out[2] = CUDA.add_rz(x, y)
+                out[3] = CUDA.add_rp(x, y)
+                out[4] = CUDA.add_rm(x, y)
+                return
+            end
+            out_d = CUDA.zeros(T, 4)
+            @cuda threads=1 add_kernel(out_d, one(T), eps_half)
+            add_out = Array(out_d)
+            @test add_out[1] == one(T)              # RN ties to even
+            @test add_out[2] == one(T)              # RZ
+            @test add_out[3] == nextfloat(one(T))   # RP
+            @test add_out[4] == one(T)              # RM
+        end
+
+        @testset "sub_($T)" for T in (Float32, Float64)
+            # Pick a y whose addition to x is inexact so we can see directed
+            # rounding. 1.0 - 2^-(prec+1) is exactly halfway between
+            # prevfloat(1.0) and 1.0.
+            prec = T === Float32 ? 24 : 53
+            eps_half = T(2)^-(prec+1)
+            function sub_kernel(out, x, y)
+                out[1] = CUDA.sub_rn(x, y)
+                out[2] = CUDA.sub_rz(x, y)
+                out[3] = CUDA.sub_rp(x, y)
+                out[4] = CUDA.sub_rm(x, y)
+                return
+            end
+            out_d = CUDA.zeros(T, 4)
+            @cuda threads=1 sub_kernel(out_d, one(T), eps_half)
+            sub_out = Array(out_d)
+            @test sub_out[1] == one(T)              # RN ties to even
+            @test sub_out[2] == prevfloat(one(T))   # RZ
+            @test sub_out[3] == one(T)              # RP
+            @test sub_out[4] == prevfloat(one(T))   # RM
+        end
+    end
+
     @testset "muladd" begin
         for T in (Float16, Float32, Float64)
             @test testf((x,y,z)->muladd.(x,y,z), rand(T, 1), rand(T, 1), rand(T, 1))


### PR DESCRIPTION
In this pull request we add call to the intrinsics for directed add, sub, mul, div and fma and a small tutorial on how to expose intrinsics. The ptx code is as expected.