### PR TITLE
Work around LinearAlgebra.jl breakage in 1.11.2.

### DIFF
--- a/lib/cublas/linalg.jl
+++ b/lib/cublas/linalg.jl
@@ -202,6 +202,19 @@ LinearAlgebra.generic_trimatmul!(c::StridedCuVector{T}, uploc, isunitc, tfun::Fu
 LinearAlgebra.generic_trimatdiv!(C::StridedCuVector{T}, uploc, isunitc, tfun::Function, A::StridedCuMatrix{T}, B::StridedCuVector{T}) where {T<:CublasFloat} =
     trsv!(uploc, tfun === identity ? 'N' : tfun === transpose ? 'T' : 'C', isunitc, A, C === B ? C : copyto!(C, B))
 
+# work around upstream breakage from JuliaLang/julia#55547
+@static if VERSION == v"1.11.2"
+const CuUpperOrUnitUpperTriangular = LinearAlgebra.UpperOrUnitUpperTriangular{
+    <:Any,<:Union{<:CuArray, Adjoint{<:Any, <:CuArray}, Transpose{<:Any, <:CuArray}}}
+const CuLowerOrUnitLowerTriangular = LinearAlgebra.LowerOrUnitLowerTriangular{
+    <:Any,<:Union{<:CuArray, Adjoint{<:Any, <:CuArray}, Transpose{<:Any, <:CuArray}}}
+
+LinearAlgebra.istriu(::CuUpperOrUnitUpperTriangular) = true
+LinearAlgebra.istril(::CuUpperOrUnitUpperTriangular) = false
+LinearAlgebra.istriu(::CuLowerOrUnitLowerTriangular) = false
+LinearAlgebra.istril(::CuLowerOrUnitLowerTriangular) = true
+end
+
 
 #
 # BLAS 3

--- a/lib/cusparse/interfaces.jl
+++ b/lib/cusparse/interfaces.jl
@@ -243,6 +243,19 @@ for SparseMatrixType in (:CuSparseMatrixBSR,)
     end
 end # SparseMatrixType loop
 
+# work around upstream breakage from JuliaLang/julia#55547
+@static if VERSION == v"1.11.2"
+const CuSparseUpperOrUnitUpperTriangular = LinearAlgebra.UpperOrUnitUpperTriangular{
+    <:Any,<:Union{<:AbstractCuSparseArray, Adjoint{<:Any, <:AbstractCuSparseArray}, Transpose{<:Any, <:AbstractCuSparseArray}}}
+const CuSparseLowerOrUnitLowerTriangular = LinearAlgebra.LowerOrUnitLowerTriangular{
+    <:Any,<:Union{<:AbstractCuSparseArray, Adjoint{<:Any, <:AbstractCuSparseArray}, Transpose{<:Any, <:AbstractCuSparseArray}}}
+
+LinearAlgebra.istriu(::CuSparseUpperOrUnitUpperTriangular) = true
+LinearAlgebra.istril(::CuSparseUpperOrUnitUpperTriangular) = false
+LinearAlgebra.istriu(::CuSparseLowerOrUnitLowerTriangular) = false
+LinearAlgebra.istril(::CuSparseLowerOrUnitLowerTriangular) = true
+end
+
 for SparseMatrixType in (:CuSparseMatrixCOO, :CuSparseMatrixCSR, :CuSparseMatrixCSC)
     @eval begin
         function LinearAlgebra.generic_trimatdiv!(C::DenseCuVector{T}, uploc, isunitc, tfun::Function, A::$SparseMatrixType{T}, B::DenseCuVector{T}) where {T<:BlasFloat}

--- a/test/libraries/cublas.jl
+++ b/test/libraries/cublas.jl
@@ -478,7 +478,6 @@ end
             y = UpperTriangular(A) * x
             @test y ≈ Array(dy)
         end
-        if VERSION != v"1.11.2" # https://github.com/JuliaLang/julia/pull/55764
         @testset "lmul!(::UpperTriangular{Adjoint})" begin
             dy = copy(dx)
             lmul!(adjoint(UpperTriangular(dA)), dy)
@@ -496,7 +495,6 @@ end
             lmul!(LowerTriangular(dA), dy)
             y = LowerTriangular(A) * x
             @test y ≈ Array(dy)
-        end
         end
         @testset "lmul!(::LowerTriangular{Adjoint})" begin
             dy = copy(dx)
@@ -544,7 +542,6 @@ end
             @test y ≈ h_y
         end
 
-        if VERSION != v"1.11.2" # https://github.com/JuliaLang/julia/pull/55764
         @testset "ldiv!(::UpperTriangular)" begin
             A = copy(sA)
             dA = CuArray(A)
@@ -596,7 +593,6 @@ end
 
         @testset "inv($TR)" for TR in (UpperTriangular, LowerTriangular, UnitUpperTriangular, UnitLowerTriangular)
             @test testf(x -> inv(TR(x)), rand(elty, m, m))
-        end
         end
 
         A = rand(elty,m,m)
@@ -1036,7 +1032,6 @@ end
             end
         end
 
-        if VERSION != v"1.11.2" # https://github.com/JuliaLang/julia/pull/55764
         @testset "triangular ldiv!" begin
             A = triu(rand(elty, m, m))
             B = rand(elty, m,m)
@@ -1050,7 +1045,6 @@ end
                 C = t(TR(A)) \ B
                 @test C ≈ Array(dC)
             end
-        end
         end
 
         let A = rand(elty, m,m), B = triu(rand(elty, m, m)), alpha = rand(elty)
@@ -1081,7 +1075,6 @@ end
             end
         end
 
-        if VERSION != v"1.11.2" # https://github.com/JuliaLang/julia/pull/55764
         @testset "triangular rdiv!" begin
             A = rand(elty, m,m)
             B = triu(rand(elty, m, m))
@@ -1095,7 +1088,6 @@ end
                 C = A / t(TR(B))
                 @test C ≈ Array(dC)
             end
-        end
         end
 
         @testset "Diagonal rdiv!" begin


### PR DESCRIPTION
I tried temporarily disabling the tests, but apparently there's _a lot_ that now fail because of JuliaLang/julia#55547. So let's try the workaround from AMDGPU.jl instead.

cc @dkarrasch 