### PR TITLE
Enzyme: mark device_sync as non-differentiable [only downstream]

### DIFF
--- a/ext/EnzymeCoreExt.jl
+++ b/ext/EnzymeCoreExt.jl
@@ -25,6 +25,9 @@ end
 function EnzymeCore.EnzymeRules.inactive_noinl(::typeof(CUDA.is_pinned), args...)
     return nothing
 end
+function EnzymeCore.EnzymeRules.inactive_noinl(::typeof(CUDA.device_synchronize), args...)
+    return nothing
+end
 function EnzymeCore.EnzymeRules.inactive(::typeof(CUDA.launch_configuration), args...; kwargs...)
     return nothing
 end


### PR DESCRIPTION
leads to a compile-time performance boost