### PR TITLE
Elide bounds checks when kernels contains manual ones.

### DIFF
--- a/test/base/exceptions.jl
+++ b/test/base/exceptions.jl
@@ -52,7 +52,6 @@ let (proc, out, err) = julia_exec(`-g2 -e $script`)
     @test count(device_error_re, out) == 1
     @test count("BoundsError", out) == 1
     @test count("Out-of-bounds array access", out) == 1
-    @test occursin("] checkbounds at $(joinpath(".", "abstractarray.jl"))", out)
     @test occursin("] kernel at $(joinpath(".", "none"))", out)
 end
 


### PR DESCRIPTION
I noticed that the following dead-simple kernel contains a redundant bounds check:

```julia
function kernel(A)
    idx = threadIdx().x
    if idx <= length(A) # manual bounds check
        A[idx] = 1      # implicit, redundant bounds check
    end
    return
end

A = CuArray{Int}(undef, 2)
@cuda threads=2 kernel(A)
```

```llvm
define ptx_kernel void @_Z6kernel13CuDeviceArrayI5Int64Li1ELi1EE({ i64, i32 } %state, { i8 addrspace(1)*, i64, [1 x i64], i64 } %0) local_unnamed_addr {
conversion:
  %.fca.0.extract = extractvalue { i8 addrspace(1)*, i64, [1 x i64], i64 } %0, 0
  %.fca.3.extract = extractvalue { i8 addrspace(1)*, i64, [1 x i64], i64 } %0, 3
  %1 = call i32 @llvm.nvvm.read.ptx.sreg.tid.x()
  %2 = add nuw nsw i32 %1, 1
  %3 = zext i32 %2 to i64
  %.not = icmp slt i64 %.fca.3.extract, %3
  br i1 %.not, label %L34, label %L14

L14:                                              ; preds = %conversion
  %.fca.2.0.extract = extractvalue { i8 addrspace(1)*, i64, [1 x i64], i64 } %0, 2, 0
  %.not1 = icmp slt i64 %.fca.2.0.extract, %3
  br i1 %.not1, label %L24, label %L27

L24:                                              ; preds = %L14
  call fastcc void @julia_throw_boundserror_22792({ i64, i32 } %state)
  call void @llvm.trap()
  call void asm sideeffect "exit;", ""()
  unreachable

L27:                                              ; preds = %L14
  %4 = bitcast i8 addrspace(1)* %.fca.0.extract to i64 addrspace(1)*
  %5 = zext i32 %1 to i64
  %6 = getelementptr inbounds i64, i64 addrspace(1)* %4, i64 %5
  store i64 1, i64 addrspace(1)* %6, align 8
  br label %L34

L34:                                              ; preds = %L27, %conversion
  ret void
}
```

The reason here is that we store both `dims` and `len = prod(dims)`, to avoid having to compute `prod(dims)` at run time. However, because of that LLVM can't eliminate the second check. Let's avoid that by making sure `size(A::CuDeviceVector)` returns `len`.

```llvm
define ptx_kernel void @_Z6kernel13CuDeviceArrayI5Int64Li1ELi1EE({ i64, i32 } %state, { i8 addrspace(1)*, i64, [1 x i64], i64 } %0) local_unnamed_addr {
conversion:
  %.fca.3.extract = extractvalue { i8 addrspace(1)*, i64, [1 x i64], i64 } %0, 3
  %1 = call i32 @llvm.nvvm.read.ptx.sreg.tid.x()
  %2 = add nuw nsw i32 %1, 1
  %3 = zext i32 %2 to i64
  %.not = icmp slt i64 %.fca.3.extract, %3
  br i1 %.not, label %L32, label %L25

L25:                                              ; preds = %conversion
  %.fca.0.extract = extractvalue { i8 addrspace(1)*, i64, [1 x i64], i64 } %0, 0
  %4 = bitcast i8 addrspace(1)* %.fca.0.extract to i64 addrspace(1)*
  %5 = zext i32 %1 to i64
  %6 = getelementptr inbounds i64, i64 addrspace(1)* %4, i64 %5
  store i64 1, i64 addrspace(1)* %6, align 8
  br label %L32

L32:                                              ; preds = %L25, %conversion
  ret void
}
```

---

I then realized the same should also happen with ND inputs, at least if we index linearly:

```julia
A = CuArray{Int}(undef, 2, 1)
@cuda threads=2 kernel(A)
```

```llvm
define ptx_kernel void @_Z6kernel13CuDeviceArrayI5Int64Li2ELi1EE({ i64, i32 } %state, { i8 addrspace(1)*, i64, [2 x i64], i64 } %0) local_unnamed_addr {
conversion:
  %.fca.0.extract = extractvalue { i8 addrspace(1)*, i64, [2 x i64], i64 } %0, 0
  %.fca.3.extract = extractvalue { i8 addrspace(1)*, i64, [2 x i64], i64 } %0, 3
  %1 = call i32 @llvm.nvvm.read.ptx.sreg.tid.x()
  %2 = add nuw nsw i32 %1, 1
  %3 = zext i32 %2 to i64
  %.not = icmp slt i64 %.fca.3.extract, %3
  br i1 %.not, label %L34, label %L14

L14:                                              ; preds = %conversion
  %4 = call i64 @llvm.smax.i64(i64 %.fca.3.extract, i64 0)
  %.not3 = icmp ult i64 %4, %3
  br i1 %.not3, label %L24, label %L27

L24:                                              ; preds = %L14
  call fastcc void @julia_throw_boundserror_23439({ i64, i32 } %state)
  call void @llvm.trap()
  call void asm sideeffect "exit;", ""()
  unreachable

L27:                                              ; preds = %L14
  %5 = bitcast i8 addrspace(1)* %.fca.0.extract to i64 addrspace(1)*
  %6 = zext i32 %1 to i64
  %7 = getelementptr inbounds i64, i64 addrspace(1)* %5, i64 %6
  store i64 1, i64 addrspace(1)* %7, align 8
  br label %L34

L34:                                              ; preds = %L27, %conversion
  ret void
}
```

The problem here is that the generic definition of `checkbounds(A, idx)` first constructs a `OneTo` range before doing the bounds check. That constructor calls `max`, again breaking LLVM's ability to eliminate the second check. We can avoid that by using a simplified bounds check based on `length`:

```llvm
define ptx_kernel void @_Z6kernel13CuDeviceArrayI5Int64Li2ELi1EE({ i64, i32 } %state, { i8 addrspace(1)*, i64, [2 x i64], i64 } %0) local_unnamed_addr {
conversion:
  %.fca.3.extract = extractvalue { i8 addrspace(1)*, i64, [2 x i64], i64 } %0, 3
  %1 = call i32 @llvm.nvvm.read.ptx.sreg.tid.x()
  %2 = add nuw nsw i32 %1, 1
  %3 = zext i32 %2 to i64
  %.not = icmp slt i64 %.fca.3.extract, %3
  br i1 %.not, label %L29, label %L22

L22:                                              ; preds = %conversion
  %.fca.0.extract = extractvalue { i8 addrspace(1)*, i64, [2 x i64], i64 } %0, 0
  %4 = bitcast i8 addrspace(1)* %.fca.0.extract to i64 addrspace(1)*
  %5 = zext i32 %1 to i64
  %6 = getelementptr inbounds i64, i64 addrspace(1)* %4, i64 %5
  store i64 1, i64 addrspace(1)* %6, align 8
  br label %L29

L29:                                              ; preds = %L22, %conversion
  ret void
}
```

This change should be ported to other back-ends as well.