### PR TITLE
Attempt to fix non inlined quirk for throw_boundserror

### DIFF
--- a/src/device/quirks.jl
+++ b/src/device/quirks.jl
@@ -48,7 +48,7 @@ end
     @gputhrow "InexactError" "Inexact conversion"
 
 # abstractarray.jl
-@noinline throw_boundserror() =
+@inline throw_boundserror() =
     @gputhrow "BoundsError" "Out-of-bounds array access"
 @device_override @inline Base.throw_boundserror(A, I) = throw_boundserror()
 


### PR DESCRIPTION
see https://github.com/EnzymeAD/Reactant.jl/issues/614