### PR TITLE
Support Adjoint/Transpose -> COO

### DIFF
--- a/lib/cusparse/array.jl
+++ b/lib/cusparse/array.jl
@@ -464,6 +464,9 @@ CuSparseMatrixCSR{T}(Mat::SparseMatrixCSC) where {T} = CuSparseMatrixCSR(CuSpars
 CuSparseMatrixBSR{T}(Mat::SparseMatrixCSC, blockdim) where {T} = CuSparseMatrixBSR(CuSparseMatrixCSR{T}(Mat), blockdim)
 CuSparseMatrixCOO{T}(Mat::SparseMatrixCSC) where {T} = CuSparseMatrixCOO(CuSparseMatrixCSR{T}(Mat))
 
+CuSparseMatrixCOO{T}(Mat::Transpose{Tv, <:SparseMatrixCSC}) where {T, Tv} = CuSparseMatrixCOO{T}(CuSparseMatrixCSR{T}(Mat))
+CuSparseMatrixCOO{T}(Mat::Adjoint{Tv, <:SparseMatrixCSC}) where {T, Tv} = CuSparseMatrixCOO{T}(CuSparseMatrixCSR{T}(Mat))
+
 # untyped variants
 CuSparseVector(x::AbstractSparseArray{T}) where {T} = CuSparseVector{T}(x)
 CuSparseMatrixCSC(x::AbstractSparseArray{T}) where {T} = CuSparseMatrixCSC{T}(x)

--- a/test/libraries/cusparse/conversions.jl
+++ b/test/libraries/cusparse/conversions.jl
@@ -53,6 +53,14 @@ end
     end
 end
 
+@testset "CuSparseMatrix(::Adjoint/::Transpose)" begin
+    A = sprand(5, 5, 0.2)
+    for T in (CuSparseMatrixCSC, CuSparseMatrixCSR, CuSparseMatrixCOO), f in (transpose, adjoint)
+        dA = T(f(A))
+        @test Array(dA) == f(A)
+    end
+end
+
 @testset "CuSparseMatrix(::Diagonal)" begin
     X = Diagonal(rand(10))
     dX = cu(X)


### PR DESCRIPTION
Should help with https://github.com/JuliaGPU/CUDA.jl/issues/2647. For now I just pass the underlying CPU matrix to the CSR constructor then use the CUSPARSE converter itself, but if someone wants to write a nicer converter method, go for it.