### PR TITLE
Use invariant.load for ldg

### DIFF
--- a/src/device/pointer.jl
+++ b/src/device/pointer.jl
@@ -78,9 +78,5 @@ end
 
 export unsafe_cached_load
 
-unsafe_cached_load(p::LLVMPtr{<:Union{LDGTypes...},AS.Global}, i::Integer=1, align::Val=Val(1)) =
-    pointerref_ldg(p, i, align)
-# NOTE: fall back to normal unsafe_load for unsupported types. we could be smarter here,
-#       e.g. destruct/load/reconstruct, but that's too complicated for what it's worth.
 unsafe_cached_load(p::LLVMPtr, i::Integer=1, align::Val=Val(1)) =
-    unsafe_load(p, i, align)
+    pointerref_ldg(p, i, align)


### PR DESCRIPTION
Fixes #2531

Trying out the suggestion in https://github.com/JuliaGPU/CUDA.jl/issues/41#issuecomment-2655642904

Currently, the metadata is correctly generated, but at somepoint it is stripped.


