### PR TITLE
MORE tests for CUBLAS and a bugfix

### DIFF
--- a/test/libraries/cublas/level1.jl
+++ b/test/libraries/cublas/level1.jl
@@ -166,6 +166,17 @@ k = 13
         @test testf(axpy!, rand(), rand(T, m), rand(T, m))
         @test testf(LinearAlgebra.axpby!, rand(), rand(T, m), rand(), rand(T, m))
 
+        @testset "scal!" begin
+            x = rand(T, m)
+            d_x = CuArray(x)
+            α = rand(Float32)
+            d_α = CuArray([α])
+            y = α * x
+            d_x = CUBLAS.scal!(m, d_α, d_x)
+            h_y = Array(d_x)
+            @test h_y ≈ y
+        end
+
         if T <: Complex
             @test testf(dot, rand(T, m), rand(T, m))
             x = rand(T, m)

--- a/test/libraries/cublas/level2.jl
+++ b/test/libraries/cublas/level2.jl
@@ -355,6 +355,19 @@ k = 13
                 @test y ≈ hy
             end
 
+            @testset "spmv" begin
+                y = zeros(elty, m)
+                BLAS.spmv!('U',one(elty),sAPU,x,zero(elty),y)
+                dy = CUBLAS.spmv('U',dsAPU,dx)
+                hy = Array(dy)
+                @test y ≈ hy
+                y = zeros(elty, m)
+                BLAS.spmv!('L',one(elty),sAPL,x,zero(elty),y)
+                d_y = CUBLAS.spmv('L',dsAPL,dx)
+                hy = Array(dy)
+                @test y ≈ hy
+            end
+
             @testset "spr!" begin
                 alpha = rand(elty)
                 beta = rand(elty)

--- a/test/libraries/cublas/level3.jl
+++ b/test/libraries/cublas/level3.jl
@@ -16,6 +16,12 @@ n = 35
 k = 13
 
 @testset "level 3" begin
+    @testset "conversion argument errors" begin
+        @test_throws ArgumentError("Unknown operation D") convert(CUBLAS.cublasOperation_t, 'D')
+        @test_throws ArgumentError("Unknown fill mode D") convert(CUBLAS.cublasFillMode_t, 'D')
+        @test_throws ArgumentError("Unknown diag mode D") convert(CUBLAS.cublasDiagType_t, 'D')
+        @test_throws ArgumentError("Unknown side mode D") convert(CUBLAS.cublasSideMode_t, 'D')
+    end
     @testset for elty in [Float32, Float64, ComplexF32, ComplexF64]
         @testset "trmm!" begin
             alpha = rand(elty)

--- a/test/libraries/cublas/level3/gemm.jl
+++ b/test/libraries/cublas/level3/gemm.jl
@@ -364,10 +364,18 @@ k = 13
             bd_A = CuArray{elty, 2}[]
             bd_B = CuArray{elty, 2}[]
             bd_C = CuArray{elty, 2}[]
+            bd_A_bad1 = CuArray{elty, 2}[]
+            bd_A_bad2 = CuArray{elty, 2}[]
             for i in 1:length(bA)
                 push!(bd_A,CuArray(bA[i]))
                 push!(bd_B,CuArray(bB[i]))
                 push!(bd_C,CuArray(bC[i]))
+                if i < length(bA) - 1
+                    push!(bd_A_bad1,CuArray(bA[i]))
+                    push!(bd_A_bad2,CuArray(bA[i]))
+                else
+                    push!(bd_A_bad2,CUDA.rand(elty, 3*i+1, 2*i-1))
+                end
             end
 
             @testset "gemm_grouped_batched!" begin
@@ -378,6 +386,8 @@ k = 13
                     h_C = Array(bd_C[i])
                     @test bC[i] ≈ h_C
                 end
+                @test_throws DimensionMismatch CUBLAS.gemm_grouped_batched!(transA,transB,alpha,bd_A_bad1,bd_B,beta,bd_C)
+                @test_throws DimensionMismatch CUBLAS.gemm_grouped_batched!(transA,transB,alpha,bd_A_bad2,bd_B,beta,bd_C)
             end
 
             @testset "gemm_grouped_batched" begin

--- a/test/libraries/cublas/xt.jl
+++ b/test/libraries/cublas/xt.jl
@@ -108,6 +108,10 @@ k = 13
             C = (alpha*sA)*B + beta*C
             # compare
             @test C ≈ h_C
+
+            B = rand(elty,m,n)
+            C = rand(elty,m+1,n)
+            @test_throws DimensionMismatch CUBLAS.xt_symm!('L','U',alpha,copy(sA),copy(B),beta,C)
         end
 
         @testset "xt_symm gpu" begin
@@ -465,6 +469,11 @@ k = 13
                 C = triu(C)
                 h_C = triu(h_C)
                 @test C ≈ h_C
+
+                A = rand(elty,m,k)
+                B = rand(elty,m,k+1)
+                C = rand(elty,m,m)
+                @test_throws DimensionMismatch CUBLAS.xt_her2k!('U','N',α,A,B,β,h_C)
             end
             @testset "xt_her2k gpu" begin
                 # generate parameters


### PR DESCRIPTION
Went through codecov and identified uncovered lines. Removed checks for old CUDA versions (<11) we no longer support. This line for the `Complex{Int32}` is unreachable based on the NV documentation. Also fixed some VERY old code in extensions that still refers to "CuArrays.jl". 