### PR TITLE
Support disabling implicit synchronization

### DIFF
--- a/src/array.jl
+++ b/src/array.jl
@@ -471,6 +471,23 @@ function Base.unsafe_convert(::Type{CuDeviceArray{T,N,AS.Global}}, a::DenseCuArr
                                a.maxsize - a.offset*Base.elsize(a))
 end
 
+## synchronization behavior
+
+"""
+    unsafe_disable_task_sync!(arr::CuArray)
+
+By default `CuArray`s are implicitly synchronized when they are used on different CUDA streams.
+A `CuArray` that is used on multiple Julia tasks will be used by different streams
+and thus will cause a synchronization between multiple Julia tasks.
+
+This `unsafe_disable_task_sync` disables synchronization when stream are being switched.
+"""
+function unsafe_disable_task_sync!(arr::CuArray)
+    return arr.data[].task_sync = false
+end
+function unsafe_enable_task_sync!(arr::CuArray)
+    return arr.data[].task_sync = true
+end
 
 ## memory copying
 

--- a/src/array.jl
+++ b/src/array.jl
@@ -471,27 +471,35 @@ function Base.unsafe_convert(::Type{CuDeviceArray{T,N,AS.Global}}, a::DenseCuArr
                                a.maxsize - a.offset*Base.elsize(a))
 end
 
-## synchronization behavior
 
-"""
-    unsafe_disable_task_sync!(arr::CuArray)
-
-By default `CuArray`s are implicitly synchronized when they are used on different CUDA streams.
-A `CuArray` that is used on multiple Julia tasks will be used by different streams
-and thus will cause a synchronization between multiple Julia tasks.
-
-This `unsafe_disable_task_sync` disables synchronization when stream are being switched.
-"""
-function unsafe_disable_task_sync!(arr::CuArray)
-    return arr.data[].task_sync = false
-end
-function unsafe_enable_task_sync!(arr::CuArray)
-    return arr.data[].task_sync = true
-end
-
-## memory copying
+## synchronization
 
 synchronize(x::CuArray) = synchronize(x.data[])
+
+"""
+    enable_synchronization!(arr::CuArray, enable::Bool)
+
+By default `CuArray`s are implicitly synchronized when they are accessed on different CUDA
+devices or streams. This may be unwanted when e.g. using disjoint slices of memory across
+different tasks. This function allows to enable or disable this behavior.
+
+!!! warning
+
+    Disabling implicit synchronization affects _all_ `CuArray`s that are referring to the
+    same underlying memory. Unsafe use of this API _will_ result in data corruption.
+
+    This API is only provided as an escape hatch, and should not be used without careful
+    consideration. If automatic synchronization is generally problematic for your use case,
+    it is recommended to figure out a better model instead and file an issue or pull request.
+    For more details see [this discussion](https://github.com/JuliaGPU/CUDA.jl/issues/2617).
+"""
+function enable_synchronization!(arr::CuArray, enable::Bool=true)
+    arr.data[].synchronizing = enable
+    return arr
+end
+
+
+## memory copying
 
 if VERSION >= v"1.11.0-DEV.753"
 function typetagdata(a::Array, i=1)

--- a/test/base/array.jl
+++ b/test/base/array.jl
@@ -51,6 +51,13 @@ using ChainRulesCore: add!!, is_inplaceable_destination
   end
 end
 
+@testset "synchronization" begin
+  a = CUDA.zeros(2, 2)
+  synchronize(a)
+  enable_synchronization!(a, false)
+  enable_synchronization!(a)
+end
+
 @testset "unsafe_wrap" begin
     # managed memory -> CuArray
     for a in [cu([1]; device=true), cu([1]; unified=true)]

--- a/test/base/array.jl
+++ b/test/base/array.jl
@@ -54,8 +54,8 @@ end
 @testset "synchronization" begin
   a = CUDA.zeros(2, 2)
   synchronize(a)
-  enable_synchronization!(a, false)
-  enable_synchronization!(a)
+  CUDA.enable_synchronization!(a, false)
+  CUDA.enable_synchronization!(a)
 end
 
 @testset "unsafe_wrap" begin


### PR DESCRIPTION
@maleadt is that what you had in mind for #2617

One of the tricky things is if we should flip the stream, or not.
But we are about to set dirty so I think we must, but that of course means it is possible to "miss" logical sync events within a task.

```
@spawn begin
   # operation A
   # task switch -- synchronize on a different task
   # operation B
end
```

Closes https://github.com/JuliaGPU/CUDA.jl/issues/2617