### PR TITLE
Fix inference of FFT plan creation

### DIFF
--- a/lib/cufft/fft.jl
+++ b/lib/cufft/fft.jl
@@ -152,12 +152,21 @@ end
 # region is an iterable subset of dimensions
 # spec. an integer, range, tuple, or array
 
+# convert `region` to a tuple within an inlined function to help constant propagation
+for f in (:plan_fft!, :plan_bfft!, :plan_fft, :plan_bfft)
+    @eval begin
+        @inline function $f(X::DenseCuArray{T,N}, region) where {T<:cufftComplexes,N}
+            R = length(region)
+            region = NTuple{R,Int}(region)
+            $f(X, region)
+        end
+    end
+end
+
 # inplace complex
-function plan_fft!(X::DenseCuArray{T,N}, region) where {T<:cufftComplexes,N}
+function plan_fft!(X::DenseCuArray{T,N}, region::NTuple{R,Int}) where {T<:cufftComplexes,N,R}
     K = CUFFT_FORWARD
     inplace = true
-    R = length(region)
-    region = NTuple{R,Int}(region)
 
     md = plan_max_dims(region, size(X))
     sizex = size(X)[1:md]
@@ -166,11 +175,9 @@ function plan_fft!(X::DenseCuArray{T,N}, region) where {T<:cufftComplexes,N}
     CuFFTPlan{T,T,K,inplace,N,R,Nothing}(handle, X, size(X), region, nothing)
 end
 
-function plan_bfft!(X::DenseCuArray{T,N}, region) where {T<:cufftComplexes,N}
+function plan_bfft!(X::DenseCuArray{T,N}, region::NTuple{R,Int}) where {T<:cufftComplexes,N,R}
     K = CUFFT_INVERSE
     inplace = true
-    R = length(region)
-    region = NTuple{R,Int}(region)
 
     md = plan_max_dims(region, size(X))
     sizex = size(X)[1:md]
@@ -180,11 +187,9 @@ function plan_bfft!(X::DenseCuArray{T,N}, region) where {T<:cufftComplexes,N}
 end
 
 # out-of-place complex
-function plan_fft(X::DenseCuArray{T,N}, region) where {T<:cufftComplexes,N}
+function plan_fft(X::DenseCuArray{T,N}, region::NTuple{R,Int}) where {T<:cufftComplexes,N,R}
     K = CUFFT_FORWARD
     inplace = false
-    R = length(region)
-    region = NTuple{R,Int}(region)
 
     md = plan_max_dims(region,size(X))
     sizex = size(X)[1:md]
@@ -193,11 +198,9 @@ function plan_fft(X::DenseCuArray{T,N}, region) where {T<:cufftComplexes,N}
     CuFFTPlan{T,T,K,inplace,N,R,Nothing}(handle, X, size(X), region, nothing)
 end
 
-function plan_bfft(X::DenseCuArray{T,N}, region) where {T<:cufftComplexes,N}
+function plan_bfft(X::DenseCuArray{T,N}, region::NTuple{R,Int}) where {T<:cufftComplexes,N,R}
     K = CUFFT_INVERSE
     inplace = false
-    R = length(region)
-    region = NTuple{R,Int}(region)
 
     md = plan_max_dims(region,size(X))
     sizex = size(X)[1:md]
@@ -207,19 +210,23 @@ function plan_bfft(X::DenseCuArray{T,N}, region) where {T<:cufftComplexes,N}
 end
 
 # out-of-place real-to-complex
-function plan_rfft(X::DenseCuArray{T,N}, region) where {T<:cufftReals,N}
-    K = CUFFT_FORWARD
-    inplace = false
+@inline function plan_rfft(X::DenseCuArray{T,N}, region) where {T<:cufftReals,N}
     R = length(region)
     region = NTuple{R,Int}(region)
+    plan_rfft(X, region)
+end
+
+function plan_rfft(X::DenseCuArray{T,N}, region::NTuple{R,Int}) where {T<:cufftReals,N,R}
+    K = CUFFT_FORWARD
+    inplace = false
 
     md = plan_max_dims(region,size(X))
     sizex = size(X)[1:md]
 
     handle = cufftGetPlan(complex(T), T, sizex, region)
 
-    ydims = collect(size(X))
-    ydims[region[1]] = div(ydims[region[1]], 2) + 1
+    xdims = size(X)
+    ydims = Base.setindex(xdims, div(xdims[region[1]], 2) + 1, region[1])
 
     # The buffer is not needed for real-to-complex (`mul!`),
     # but it’s required for complex-to-real (`ldiv!`).
@@ -230,21 +237,24 @@ function plan_rfft(X::DenseCuArray{T,N}, region) where {T<:cufftReals,N}
 end
 
 # out-of-place complex-to-real
-function plan_brfft(X::DenseCuArray{T,N}, d::Integer, region) where {T<:cufftComplexes,N}
-    K = CUFFT_INVERSE
-    inplace = false
+@inline function plan_brfft(X::DenseCuArray{T,N}, d::Integer, region) where {T<:cufftComplexes,N}
     R = length(region)
     region = NTuple{R,Int}(region)
+    plan_brfft(X, d, region)
+end
 
-    ydims = collect(size(X))
-    ydims[region[1]] = d
+function plan_brfft(X::DenseCuArray{T,N}, d::Integer, region::NTuple{R,Int}) where {T<:cufftComplexes,N,R}
+    K = CUFFT_INVERSE
+    inplace = false
 
-    handle = cufftGetPlan(real(T), T, (ydims...,), region)
+    xdims = size(X)
+    ydims = Base.setindex(xdims, d, region[1])
+    handle = cufftGetPlan(real(T), T, ydims, region)
 
     buffer = CuArray{T}(undef, size(X))
     B = typeof(buffer)
 
-    CuFFTPlan{real(T),T,K,inplace,N,R,B}(handle, size(X), (ydims...,), region, buffer)
+    CuFFTPlan{real(T),T,K,inplace,N,R,B}(handle, size(X), ydims, region, buffer)
 end
 
 


### PR DESCRIPTION
This PR fixes a couple of type inference issues when creating FFT plans (on Julia 1.11.3 at least):

1. Since #2578, the return type of `plan_rfft(u, region)` is not fully inferred since the number of dimensions of the created buffer is itself not inferred. This is even the case when `region` is a `NTuple`, which should in principle allow for inference since the number of dimensions to be transformed is statically known.

2. Plan creation _without_ the `region` argument may or may not be inferred, as this relies on constant propagation by the Julia compiler. This is because AbstractFFTs.jl currently sets `region = 1:ndims(u)`, and inference relies on this argument being constant-propagated. A solution would be to set `region = ntuple(identity, ndims(u))` in AbstractFFTs.jl, but unfortunately an [existent PR](https://github.com/JuliaMath/AbstractFFTs.jl/pull/98) doing precisely that is still open.

Issue 1 is fixed by avoiding things like `collect(size(X))` and array splatting, and directly working with tuples instead.

A workaround for issue 2 is to inline calls to `plan_*`, at least when the `region` argument is not a tuple. An alternative would be to use `Base.@constprop :aggressive`, but this needs Julia 1.10.