### PR TITLE
Even more sparse tests

### DIFF
--- a/lib/cusparse/array.jl
+++ b/lib/cusparse/array.jl
@@ -646,7 +646,7 @@ for (gpu, cpu) in [:CuSparseMatrixCSC => :SparseMatrixCSC,
                    :CuSparseMatrixCSR => :SparseMatrixCSC,
                    :CuSparseMatrixBSR => :SparseMatrixCSC,
                    :CuSparseMatrixCOO => :SparseMatrixCSC]
-    @eval Base.show(io::IOContext, x::$gpu) =
+    @eval Base.show(io::IO, x::$gpu) =
         show(io, $cpu(x))
 
     @eval function Base.show(io::IO, mime::MIME"text/plain", S::$gpu)

--- a/test/libraries/cusparse.jl
+++ b/test/libraries/cusparse.jl
@@ -23,6 +23,7 @@ blockdim = 5
     dense_d_x = CuVector(x)
     CUDA.@allowscalar begin
         @test sprint(show, d_x) == replace(sprint(show, x), "SparseVector{Float64, Int64}"=>"CUDA.CUSPARSE.CuSparseVector{Float64, Int32}", "sparsevec(["=>"sparsevec(Int32[")
+        @test sprint(show, MIME"text/plain"(), d_x) == replace(sprint(show, MIME"text/plain"(), x), "SparseVector{Float64, Int64}"=>"CuSparseVector{Float64, Int32}", "sparsevec(["=>"sparsevec(Int32[")
         @test Array(d_x[:])        == x[:]
         @test d_x[firstindex(d_x)] == x[firstindex(x)]
         @test d_x[div(end, 2)]     == x[div(end, 2)]
@@ -56,6 +57,7 @@ blockdim = 5
     @test size(d_x,3) == 1
     @test ndims(d_x)  == 2
     CUDA.@allowscalar begin
+        @test sprint(show, d_x) == sprint(show, SparseMatrixCSC(d_x))
         @test sprint(show, MIME"text/plain"(), d_x) == replace(sprint(show, MIME"text/plain"(), x), "SparseMatrixCSC{Float64, Int64}"=>"CuSparseMatrixCSC{Float64, Int32}")
         @test Array(d_x[:])        == x[:]
         @test d_x[:, :]            == x[:, :]

--- a/test/libraries/cusparse.jl
+++ b/test/libraries/cusparse.jl
@@ -44,6 +44,10 @@ blockdim = 5
     @test size(d_x) == (m, 1)
     x = sprand(m,n,0.2)
     d_x = CuSparseMatrixCSC(x)
+    d_tx = CuSparseMatrixCSC(transpose(x))
+    d_ax = CuSparseMatrixCSC(adjoint(x))
+    @test size(d_tx) == (n,m)
+    @test size(d_ax) == (n,m)
     @test CuSparseMatrixCSC(d_x) === d_x
     @test length(d_x) == m*n
     @test size(d_x)   == (m,n)
@@ -55,6 +59,8 @@ blockdim = 5
         @test sprint(show, MIME"text/plain"(), d_x) == replace(sprint(show, MIME"text/plain"(), x), "SparseMatrixCSC{Float64, Int64}"=>"CuSparseMatrixCSC{Float64, Int32}")
         @test Array(d_x[:])        == x[:]
         @test d_x[:, :]            == x[:, :]
+        @test d_tx[:, :]           == transpose(x)[:, :]
+        @test d_ax[:, :]           == adjoint(x)[:, :]
         @test d_x[(1, 1)]          == x[1, 1]
         @test d_x[firstindex(d_x)] == x[firstindex(x)]
         @test d_x[div(end, 2)]     == x[div(end, 2)]
@@ -91,6 +97,8 @@ blockdim = 5
     @test_throws ArgumentError copyto!(d_y,d_x)
     x = sprand(m,n,0.2)
     d_x = CuSparseMatrixCOO(x)
+    d_tx = CuSparseMatrixCOO(transpose(x))
+    d_ax = CuSparseMatrixCOO(adjoint(x))
     @test CuSparseMatrixCOO(d_x) === d_x
     @test length(d_x) == m*n
     @test size(d_x)   == (m,n)
@@ -107,6 +115,8 @@ blockdim = 5
         @test d_x[firstindex(d_x)] == x[firstindex(x)]
         @test d_x[div(end, 2)]     == x[div(end, 2)]
         @test d_x[end]             == x[end]
+        @test d_tx[:, 1]           == transpose(x)[:, 1]
+        @test d_ax[1, :]           == adjoint(x)[1, :]
         @test d_x[firstindex(d_x), firstindex(d_x)] == x[firstindex(x), firstindex(x)]
         @test d_x[div(end, 2), div(end, 2)]         == x[div(end, 2), div(end, 2)]
         @test d_x[end, end]        == x[end, end]

--- a/test/libraries/cusparse/reduce.jl
+++ b/test/libraries/cusparse/reduce.jl
@@ -1,8 +1,5 @@
 using CUDA.CUSPARSE, SparseArrays
 
-# XXX: these tests cause GC corruption (see JuliaGPU/CUDA.jl#2027)
-if false
-
 m,n = 5,6
 p = 0.5
 
@@ -25,7 +22,10 @@ for elty in [Int32, Int64, Float32, Float64]
         y = sum(x, dims=2)
         dy = sum(dx, dims=2)
         @test y ≈ Array(dy)
+        if elty in (Float32, Float64)
+            dy = mapreduce(abs, +, dx; init=zero(elty))
+            y  = mapreduce(abs, +, x; init=zero(elty))
+            @test y ≈ dy
+        end
     end
-end
-
 end


### PR DESCRIPTION
The reduce tests were causing GC corruption as seen in https://github.com/JuliaGPU/CUDA.jl/issues/2027. I didn't see this locally on 1.11 so maybe it's better? Let's see. If so, we can disable all the tests again for now but keep the additions for when that problem is fixed.

Closes #2027