### PR TITLE
Exclude device-side sorting code from coverage

### DIFF
--- a/src/CUDAKernels.jl
+++ b/src/CUDAKernels.jl
@@ -135,6 +135,7 @@ end
 
 ## indexing
 
+## COV_EXCL_START
 @device_override @inline function KA.__index_Local_Linear(ctx)
     return threadIdx().x
 end
@@ -190,6 +191,8 @@ end
 @device_override @inline function KA.__print(args...)
     CUDA._cuprint(args...)
 end
+
+## COV_EXCL_STOP
 
 ## other
 

--- a/src/indexing.jl
+++ b/src/indexing.jl
@@ -31,6 +31,7 @@ function Base.findall(bools::AnyCuArray{Bool})
     ys = CuArray{I}(undef, n)
 
     if n > 0
+        ## COV_EXCL_START
         function kernel(ys::CuDeviceArray, bools, indices)
             i = threadIdx().x + (blockIdx().x - 1i32) * blockDim().x
 
@@ -42,6 +43,7 @@ function Base.findall(bools::AnyCuArray{Bool})
 
             return
         end
+        ## COV_EXCL_STOP
 
         kernel = @cuda name="findall" launch=false kernel(ys, bools, indices)
         config = launch_configuration(kernel.fun)

--- a/src/random.jl
+++ b/src/random.jl
@@ -44,6 +44,7 @@ Random.seed!(rng::RNG) = Random.seed!(rng, make_seed())
 function Random.rand!(rng::RNG, A::AnyCuArray)
     isempty(A) && return A
 
+    ## COV_EXCL_START
     function kernel(A::AbstractArray{T}, seed::UInt32, counter::UInt32) where {T}
         device_rng = Random.default_rng()
 
@@ -65,6 +66,7 @@ function Random.rand!(rng::RNG, A::AnyCuArray)
 
         return
     end
+    ## COV_EXCL_STOP
 
     # XXX: because of how random numbers are generated, the launch configuration
     #      affects the results. as such, use a constant number of threads, set
@@ -88,6 +90,7 @@ end
 function Random.randn!(rng::RNG, A::AnyCuArray{<:Union{AbstractFloat,Complex{<:AbstractFloat}}})
     isempty(A) && return A
 
+    ## COV_EXCL_START
     function kernel(A::AbstractArray{T}, seed::UInt32, counter::UInt32) where {T<:Real}
         device_rng = Random.default_rng()
 
@@ -149,6 +152,7 @@ function Random.randn!(rng::RNG, A::AnyCuArray{<:Union{AbstractFloat,Complex{<:A
         end
         return
     end
+    ## COV_EXCL_STOP
 
     # see note in `rand!` about the launch configuration
     threads = 32

--- a/src/reverse.jl
+++ b/src/reverse.jl
@@ -15,6 +15,7 @@ function _reverse(input::AnyCuArray{T, N}, output::AnyCuArray{T, N};
     # converts a linear index in a reduced array to an ND-index, but using the reduced size
     nd_idx = CartesianIndices(input)
 
+    ## COV_EXCL_START
     function kernel(input::AbstractArray{T, N}, output::AbstractArray{T, N}) where {T, N}
         offset_in = blockDim().x * (blockIdx().x - 1i32)
         index_in = offset_in + threadIdx().x
@@ -28,6 +29,7 @@ function _reverse(input::AnyCuArray{T, N}, output::AnyCuArray{T, N};
 
         return
     end
+    ## COV_EXCL_STOP
 
     nthreads = 256
     nblocks = cld(length(input), nthreads)
@@ -51,6 +53,7 @@ function _reverse!(data::AnyCuArray{T, N}; dims=1:ndims(data)) where {T, N}
     # converts a linear index in a reduced array to an ND-index, but using the reduced size
     nd_idx = CartesianIndices(reduced_size)
 
+    ## COV_EXCL_START
     function kernel(data::AbstractArray{T, N}) where {T, N}
         offset_in = blockDim().x * (blockIdx().x - 1i32)
 
@@ -71,6 +74,7 @@ function _reverse!(data::AnyCuArray{T, N}; dims=1:ndims(data)) where {T, N}
 
         return
     end
+    ## COV_EXCL_STOP
 
     # NOTE: we launch slightly more than half the number of elements in the array as threads.
     # The last non-singleton dimension along which to reverse is used to define how the array is split.

--- a/src/sorting.jl
+++ b/src/sorting.jl
@@ -38,6 +38,7 @@ using ..CUDA: i32
 end
 
 
+## COV_EXCL_START
 # Batch partitioning
 """
 Performs in-place cumsum using shared memory. Intended for use with indexes
@@ -118,6 +119,8 @@ function partition_batches_kernel(values::AbstractArray{T}, pivot, lo, hi, parit
     return
 end
 
+## COV_EXCL_STOP
+
 
 # Batch consolidation
 
@@ -140,6 +143,7 @@ function find_partition(array, pivot, lo, hi, parity, lt::F1, by::F2) where {F1,
     return low - 1
 end
 
+## COV_EXCL_START
 """
 This assumes the region of `vals` of length `L` starting after `lo`
 has been batch partitioned with respect to `pivot`. Further, it assumes that
@@ -454,6 +458,7 @@ function qsort_kernel(vals::AbstractArray{T,N}, lo, hi, parity, sync::Val{S}, sy
 
     return
 end
+## COV_EXCL_STOP
 
 function sort_args(args, partial_k::Nothing)
     return args
@@ -524,6 +529,7 @@ using ..CUDA
 using ..CUDA: i32
 
 
+## COV_EXCL_START
 # General functions
 
 @inline two(::Type{Int}) = 2
@@ -882,7 +888,7 @@ function comparator_small_kernel(vals, length_vals::I, k::I, j_0::I, j_f::I,
     finalize_shmem!(slice, swap, index, in_range)
     return
 end
-
+## COV_EXCL_STOP
 
 # Host side code
 function bitonic_shmem(c::AbstractArray{T}, threads) where {T}


### PR DESCRIPTION
AFAICT this code is all device-side only and so we can/should exclude it from coverage for now.