### PR TITLE
More tests and bugfixes for CUSOLVER

### DIFF
--- a/lib/cusolver/dense_generic.jl
+++ b/lib/cusolver/dense_generic.jl
@@ -122,7 +122,7 @@ function Xgeqrf!(A::StridedCuMatrix{T}) where {T <: BlasFloat}
 end
 
 # Xsytrs
-function sytrs!(uplo::Char, A::StridedCuMatrix{T}, p::CuVector{Int64}, B::StridedCuMatrix{T}) where {T <: BlasFloat}
+function sytrs!(uplo::Char, A::StridedCuMatrix{T}, p::CuVector{Int64}, B::StridedCuVecOrMat{T}) where {T <: BlasFloat}
     chkuplo(uplo)
     n = checksquare(A)
     nrhs = size(B, 2)
@@ -149,7 +149,7 @@ function sytrs!(uplo::Char, A::StridedCuMatrix{T}, p::CuVector{Int64}, B::Stride
     B
 end
 
-function sytrs!(uplo::Char, A::StridedCuMatrix{T}, B::StridedCuMatrix{T}) where {T <: BlasFloat}
+function sytrs!(uplo::Char, A::StridedCuMatrix{T}, B::StridedCuVecOrMat{T}) where {T <: BlasFloat}
     chkuplo(uplo)
     n = checksquare(A)
     nrhs = size(B, 2)

--- a/lib/cusolver/linalg.jl
+++ b/lib/cusolver/linalg.jl
@@ -66,7 +66,7 @@ function Base.:\(_A::CuMatOrAdj, _B::CuOrAdj)
 end
 
 function Base.:\(_A::Symmetric{<:Any,<:CuMatOrAdj}, _B::CuOrAdj)
-    uplo = A.uplo
+    uplo = _A.uplo
     A, B = copy_cublasfloat(_A.data, _B)
 
     # LDLᴴ decomposition with partial pivoting
@@ -371,9 +371,9 @@ for (triangle, uplo, diag) in ((:LowerTriangular, 'L', 'N'),
     @eval begin
         function LinearAlgebra.inv(A::$triangle{T,<:StridedCuMatrix{T}}) where T <: BlasFloat
             n = checksquare(A)
-            B = copy(A.data)
-            trtri!(uplo, diag, B)
-            return B
+            B = copy(parent(A))
+            trtri!($uplo, $diag, B)
+            return $triangle(B)
         end
     end
 end


### PR DESCRIPTION
So it appears we have a duplication of `inv` for triangulars - if the matrix is strided, CUSOLVER is used, but if it's dense, CUBLAS is used. Not sure we want to keep that but for now this finally tests and fixes the CUSOLVER one and addresses another bug in `Symmetrix \ CuMat`.