### PR TITLE
Split out copyto for texture arrays and add more tests

### DIFF
--- a/lib/cudadrv/memory.jl
+++ b/lib/cudadrv/memory.jl
@@ -485,7 +485,7 @@ function unsafe_copy2d!(dst::Union{Ptr{T},CuPtr{T},CuArrayPtr{T}}, dstTyp::Type{
 
     srcMemoryType, srcHost, srcDevice, srcArray = if srcTyp == HostMemory
         CU_MEMORYTYPE_HOST,
-        reinterpret(Ptr{T}, src),
+        src::Ptr,
         0,
         0
     elseif srcTyp == DeviceMemory
@@ -507,7 +507,7 @@ function unsafe_copy2d!(dst::Union{Ptr{T},CuPtr{T},CuArrayPtr{T}}, dstTyp::Type{
 
     dstMemoryType, dstHost, dstDevice, dstArray = if dstTyp == HostMemory
         CU_MEMORYTYPE_HOST,
-        reinterpret(Ptr{T}, dst),
+        dst::Ptr,
         0,
         0
     elseif dstTyp == DeviceMemory
@@ -578,7 +578,7 @@ function unsafe_copy3d!(dst::Union{Ptr{T},CuPtr{T},CuArrayPtr{T}}, dstTyp::Type{
 
     srcMemoryType, srcHost, srcDevice, srcArray = if srcTyp == HostMemory
         CU_MEMORYTYPE_HOST,
-        reinterpret(Ptr{T}, src) + srcOffset,
+        src::Ptr + srcOffset,
         0,
         0
     elseif srcTyp == DeviceMemory
@@ -600,7 +600,7 @@ function unsafe_copy3d!(dst::Union{Ptr{T},CuPtr{T},CuArrayPtr{T}}, dstTyp::Type{
 
     dstMemoryType, dstHost, dstDevice, dstArray = if dstTyp == HostMemory
         CU_MEMORYTYPE_HOST,
-        reinterpret(Ptr{T}, dst) + dstOffset,
+        dst::Ptr + dstOffset,
         0,
         0
     elseif dstTyp == DeviceMemory

--- a/lib/cudadrv/memory.jl
+++ b/lib/cudadrv/memory.jl
@@ -485,7 +485,7 @@ function unsafe_copy2d!(dst::Union{Ptr{T},CuPtr{T},CuArrayPtr{T}}, dstTyp::Type{
 
     srcMemoryType, srcHost, srcDevice, srcArray = if srcTyp == HostMemory
         CU_MEMORYTYPE_HOST,
-        src::Ptr,
+        reinterpret(Ptr{T}, src),
         0,
         0
     elseif srcTyp == DeviceMemory
@@ -507,7 +507,7 @@ function unsafe_copy2d!(dst::Union{Ptr{T},CuPtr{T},CuArrayPtr{T}}, dstTyp::Type{
 
     dstMemoryType, dstHost, dstDevice, dstArray = if dstTyp == HostMemory
         CU_MEMORYTYPE_HOST,
-        dst::Ptr,
+        dst::PtrOrCuPtr{T},
         0,
         0
     elseif dstTyp == DeviceMemory
@@ -578,7 +578,7 @@ function unsafe_copy3d!(dst::Union{Ptr{T},CuPtr{T},CuArrayPtr{T}}, dstTyp::Type{
 
     srcMemoryType, srcHost, srcDevice, srcArray = if srcTyp == HostMemory
         CU_MEMORYTYPE_HOST,
-        src::Ptr + srcOffset,
+        reinterpret(Ptr{T}, src) + srcOffset,
         0,
         0
     elseif srcTyp == DeviceMemory
@@ -600,7 +600,7 @@ function unsafe_copy3d!(dst::Union{Ptr{T},CuPtr{T},CuArrayPtr{T}}, dstTyp::Type{
 
     dstMemoryType, dstHost, dstDevice, dstArray = if dstTyp == HostMemory
         CU_MEMORYTYPE_HOST,
-        dst::Ptr + dstOffset,
+        dst::PtrOrCuPtr + dstOffset,
         0,
         0
     elseif dstTyp == DeviceMemory

--- a/lib/cudadrv/memory.jl
+++ b/lib/cudadrv/memory.jl
@@ -507,7 +507,7 @@ function unsafe_copy2d!(dst::Union{Ptr{T},CuPtr{T},CuArrayPtr{T}}, dstTyp::Type{
 
     dstMemoryType, dstHost, dstDevice, dstArray = if dstTyp == HostMemory
         CU_MEMORYTYPE_HOST,
-        dst::PtrOrCuPtr{T},
+        reinterpret(Ptr{T}, dst),
         0,
         0
     elseif dstTyp == DeviceMemory
@@ -600,7 +600,7 @@ function unsafe_copy3d!(dst::Union{Ptr{T},CuPtr{T},CuArrayPtr{T}}, dstTyp::Type{
 
     dstMemoryType, dstHost, dstDevice, dstArray = if dstTyp == HostMemory
         CU_MEMORYTYPE_HOST,
-        dst::PtrOrCuPtr + dstOffset,
+        reinterpret(Ptr{T}, dst) + dstOffset,
         0,
         0
     elseif dstTyp == DeviceMemory

--- a/src/texture.jl
+++ b/src/texture.jl
@@ -118,7 +118,7 @@ end
 
 function Base.copyto!(dst::CuTextureArray{T,2}, src::CuArray{T,2,M}) where {T, M}
     size(dst) == size(src) || throw(DimensionMismatch("source and destination sizes must match"))
-    unsafe_copy2d!(pointer(dst), ArrayMemory, pointer(src), M, size(dst)...)
+    unsafe_copy2d!(pointer(dst), ArrayMemory, pointer(src; type=M), M, size(dst)...)
     return dst
 end
 
@@ -136,7 +136,7 @@ end
 
 function Base.copyto!(dst::CuTextureArray{T,3}, src::CuArray{T,3,M}) where {T, M}
     size(dst) == size(src) || throw(DimensionMismatch("source and destination sizes must match"))
-    unsafe_copy3d!(pointer(dst), ArrayMemory, pointer(src), M, size(dst)...)
+    unsafe_copy3d!(pointer(dst), ArrayMemory, pointer(src; type=M), M, size(dst)...)
     return dst
 end
 

--- a/src/texture.jl
+++ b/src/texture.jl
@@ -104,7 +104,7 @@ CuTextureArray(A::AbstractArray{T,N}) where {T,N} = CuTextureArray{T,N}(A)
 
 ## memory operations
 
-function Base.copyto!(dst::CuTextureArray{T,1}, src::Union{Array{T,1}, CuArray{T,1}, CuTextureArray{T,3}}) where {T}
+function Base.copyto!(dst::CuTextureArray{T,1}, src::Union{Array{T,1}, CuArray{T,1}, CuTextureArray{T,1}}) where {T}
     size(dst) == size(src) || throw(DimensionMismatch("source and destination sizes must match"))
     Base.unsafe_copyto!(pointer(dst), pointer(src), length(dst))
     return dst

--- a/src/texture.jl
+++ b/src/texture.jl
@@ -104,29 +104,47 @@ CuTextureArray(A::AbstractArray{T,N}) where {T,N} = CuTextureArray{T,N}(A)
 
 ## memory operations
 
-function Base.copyto!(dst::CuTextureArray{T,1}, src::Union{Array{T,1}, CuArray{T,1}}) where {T}
+function Base.copyto!(dst::CuTextureArray{T,1}, src::Union{Array{T,1}, CuArray{T,1}, CuTextureArray{T,3}}) where {T}
     size(dst) == size(src) || throw(DimensionMismatch("source and destination sizes must match"))
     Base.unsafe_copyto!(pointer(dst), pointer(src), length(dst))
     return dst
 end
 
-function Base.copyto!(dst::CuTextureArray{T,2}, src::Union{Array{T,2}, CuArray{T,2}}) where {T}
+function Base.copyto!(dst::CuTextureArray{T,2}, src::Array{T,2}) where {T}
     size(dst) == size(src) || throw(DimensionMismatch("source and destination sizes must match"))
-    unsafe_copy2d!(pointer(dst), ArrayMemory,
-                   pointer(src), isa(src, Array) ? HostMemory : DeviceMemory,
-                   size(dst)...)
+    unsafe_copy2d!(pointer(dst), ArrayMemory, pointer(src), HostMemory, size(dst)...)
     return dst
 end
 
-function Base.copyto!(dst::CuTextureArray{T,3}, src::Union{Array{T,3}, CuArray{T,3}}) where {T}
+function Base.copyto!(dst::CuTextureArray{T,2}, src::CuArray{T,2,M}) where {T, M}
     size(dst) == size(src) || throw(DimensionMismatch("source and destination sizes must match"))
-    unsafe_copy3d!(pointer(dst), ArrayMemory,
-                   pointer(src), isa(src, Array) ? HostMemory : DeviceMemory,
-                   size(dst)...)
+    unsafe_copy2d!(pointer(dst), ArrayMemory, pointer(src), M, size(dst)...)
     return dst
 end
 
+function Base.copyto!(dst::CuTextureArray{T,2}, src::CuTextureArray{T,2}) where {T}
+    size(dst) == size(src) || throw(DimensionMismatch("source and destination sizes must match"))
+    unsafe_copy2d!(pointer(dst), ArrayMemory, pointer(src), ArrayMemory, size(dst)...)
+    return dst
+end
 
+function Base.copyto!(dst::CuTextureArray{T,3}, src::Array{T,3}) where {T}
+    size(dst) == size(src) || throw(DimensionMismatch("source and destination sizes must match"))
+    unsafe_copy3d!(pointer(dst), ArrayMemory, pointer(src), HostMemory, size(dst)...)
+    return dst
+end
+
+function Base.copyto!(dst::CuTextureArray{T,3}, src::CuArray{T,3,M}) where {T, M}
+    size(dst) == size(src) || throw(DimensionMismatch("source and destination sizes must match"))
+    unsafe_copy3d!(pointer(dst), ArrayMemory, pointer(src), M, size(dst)...)
+    return dst
+end
+
+function Base.copyto!(dst::CuTextureArray{T,3}, src::CuTextureArray{T,3}) where {T}
+    size(dst) == size(src) || throw(DimensionMismatch("source and destination sizes must match"))
+    unsafe_copy3d!(pointer(dst), ArrayMemory, pointer(src), ArrayMemory, size(dst)...)
+    return dst
+end
 
 #
 # Texture objects

--- a/src/texture.jl
+++ b/src/texture.jl
@@ -112,7 +112,11 @@ end
 
 function Base.copyto!(dst::CuTextureArray{T,1}, src::CuArray{T,1,M}) where {T, M}
     size(dst) == size(src) || throw(DimensionMismatch("source and destination sizes must match"))
-    Base.unsafe_copyto!(pointer(dst), pointer(src; type=M), length(dst))
+    if M <: Union{HostMemory, DeviceMemory}
+        Base.unsafe_copyto!(pointer(dst), pointer(src; type=M), length(dst))
+    else
+        Base.unsafe_copyto!(pointer(dst), pointer(src), length(dst))
+    end
     return dst
 end
 
@@ -124,7 +128,11 @@ end
 
 function Base.copyto!(dst::CuTextureArray{T,2}, src::CuArray{T,2,M}) where {T, M}
     size(dst) == size(src) || throw(DimensionMismatch("source and destination sizes must match"))
-    unsafe_copy2d!(pointer(dst), ArrayMemory, pointer(src; type=M), M, size(dst)...)
+    if M <: Union{HostMemory, DeviceMemory}
+        unsafe_copy2d!(pointer(dst), ArrayMemory, pointer(src; type=M), M, size(dst)...)
+    else
+        unsafe_copy2d!(pointer(dst), ArrayMemory, pointer(src), M, size(dst)...)
+    end
     return dst
 end
 
@@ -142,7 +150,11 @@ end
 
 function Base.copyto!(dst::CuTextureArray{T,3}, src::CuArray{T,3,M}) where {T, M}
     size(dst) == size(src) || throw(DimensionMismatch("source and destination sizes must match"))
-    unsafe_copy3d!(pointer(dst), ArrayMemory, pointer(src; type=M), M, size(dst)...)
+    if M <: Union{HostMemory, DeviceMemory}
+        unsafe_copy3d!(pointer(dst), ArrayMemory, pointer(src; type=M), M, size(dst)...)
+    else
+        unsafe_copy3d!(pointer(dst), ArrayMemory, pointer(src), M, size(dst)...)
+    end
     return dst
 end
 

--- a/src/texture.jl
+++ b/src/texture.jl
@@ -104,9 +104,15 @@ CuTextureArray(A::AbstractArray{T,N}) where {T,N} = CuTextureArray{T,N}(A)
 
 ## memory operations
 
-function Base.copyto!(dst::CuTextureArray{T,1}, src::Union{Array{T,1}, CuArray{T,1}, CuTextureArray{T,1}}) where {T}
+function Base.copyto!(dst::CuTextureArray{T,1}, src::Union{Array{T,1}, CuTextureArray{T,1}}) where {T}
     size(dst) == size(src) || throw(DimensionMismatch("source and destination sizes must match"))
     Base.unsafe_copyto!(pointer(dst), pointer(src), length(dst))
+    return dst
+end
+
+function Base.copyto!(dst::CuTextureArray{T,1}, src::CuArray{T,1,M}) where {T, M}
+    size(dst) == size(src) || throw(DimensionMismatch("source and destination sizes must match"))
+    Base.unsafe_copyto!(pointer(dst), pointer(src; type=M), length(dst))
     return dst
 end
 

--- a/test/base/texture.jl
+++ b/test/base/texture.jl
@@ -84,6 +84,12 @@ end
     @test Array(fetch_all(tex1D)) == a1D
     @test sizeof(texarr1D) == sizeof(a1D)
     @test eltype(texarr1D) == Float32
+    h_arr_1D = zeros(Float32, length(a1D))
+    Base.unsafe_copyto!(pointer(h_arr_1D), pointer(texarr1D), length(h_arr_1D))
+    @test h_arr_1D == a1D
+    cu_arr_1D = CUDA.zeros(Float32, length(a1D))
+    Base.unsafe_copyto!(pointer(cu_arr_1D), pointer(texarr1D), length(cu_arr_1D))
+    @test Array(cu_arr_1D) == a1D
 
     texarr2D = CuTextureArray(a2D)
     tex2D = CuTexture(texarr2D)
@@ -100,7 +106,6 @@ end
     @test sizeof(texarr2D) == sizeof(a2D)
     @test eltype(texarr2D) == Float32
 
-
     tex2D_dir = CuTexture(CuTextureArray(a2D))
     @test Array(fetch_all(tex2D_dir)) == a2D
 
@@ -111,6 +116,7 @@ end
     tex3D_2 = CuTexture(texarr3D_2)
     @test Array(fetch_all(tex3D_2)) == a3D
     texarr3D_3 = CuTextureArray{Float32, 3}(texarr3D)
+    copyto!(texarr2D_3, texarr2D_2)
     tex3D_3 = CuTexture(texarr3D_3)
     @test Array(fetch_all(tex3D_3)) == a3D
     @test sizeof(texarr3D) == sizeof(a3D)

--- a/test/base/texture.jl
+++ b/test/base/texture.jl
@@ -82,6 +82,8 @@ end
     copyto!(texarr1D, a1D)
     tex1D = CuTexture(texarr1D)
     @test Array(fetch_all(tex1D)) == a1D
+    @test sizeof(texarr1D) == sizeof(a1D)
+    @test eltype(texarr1D) == Float32
 
     texarr2D = CuTextureArray(a2D)
     tex2D = CuTexture(texarr2D)
@@ -89,6 +91,14 @@ end
     texarr2D_2 = CuTextureArray(texarr2D)
     tex2D_2 = CuTexture(texarr2D_2)
     @test Array(fetch_all(tex2D_2)) == a2D
+    texarr2D_3 = CuTextureArray{Float32, 2}(texarr2D)
+    tex2D_2 = CuTexture(texarr2D_3)
+    @test Array(fetch_all(tex2D_2)) == a2D
+    copyto!(texarr2D_3, texarr2D_2)
+    tex2D_2 = CuTexture(texarr2D_3)
+    @test Array(fetch_all(tex2D_2)) == a2D
+    @test sizeof(texarr2D) == sizeof(a2D)
+    @test eltype(texarr2D) == Float32
 
 
     tex2D_dir = CuTexture(CuTextureArray(a2D))
@@ -100,6 +110,8 @@ end
     texarr3D_2 = CuTextureArray(texarr3D)
     tex3D_2 = CuTexture(texarr3D_2)
     @test Array(fetch_all(tex3D_2)) == a3D
+    @test sizeof(texarr3D) == sizeof(a3D)
+    @test eltype(texarr3D) == Float32
 end
 
 @testset "CuTexture(::CuArray)" begin

--- a/test/base/texture.jl
+++ b/test/base/texture.jl
@@ -110,6 +110,9 @@ end
     texarr3D_2 = CuTextureArray(texarr3D)
     tex3D_2 = CuTexture(texarr3D_2)
     @test Array(fetch_all(tex3D_2)) == a3D
+    texarr3D_3 = CuTextureArray{Float32, 3}(texarr3D)
+    tex3D_3 = CuTexture(texarr3D_3)
+    @test Array(fetch_all(tex3D_3)) == a3D
     @test sizeof(texarr3D) == sizeof(a3D)
     @test eltype(texarr3D) == Float32
 end


### PR DESCRIPTION
Allows copying to `CuTextureArray` from `CuArray` to use the type parameter about the underlying memory type which should unlock using `UnifiedMemory`.