### PR TITLE
fixed typeerror of cuStateVec and add new api

### DIFF
--- a/lib/custatevec/src/libcustatevec.jl
+++ b/lib/custatevec/src/libcustatevec.jl
@@ -1000,7 +1000,7 @@ end
                                                                                     nIndexBits::UInt32,
                                                                                     nSVs::UInt32,
                                                                                     svStride::custatevecIndex_t,
-                                                                                    matrices::Ptr{Cvoid},
+                                                                                    matrices::PtrOrCuPtr{Cvoid},
                                                                                     matrixDataType::cudaDataType_t,
                                                                                     layout::custatevecMatrixLayout_t,
                                                                                     nMatrices::UInt32,
@@ -1018,20 +1018,20 @@ end
                                                       extraWorkspaceSizeInBytes)
     initialize_context()
     @gcsafe_ccall libcustatevec.custatevecComputeExpectationBatched(handle::custatevecHandle_t,
-                                                                    batchedSv::Ptr{Cvoid},
+                                                                    batchedSv::CuPtr{Cvoid},
                                                                     svDataType::cudaDataType_t,
                                                                     nIndexBits::UInt32,
                                                                     nSVs::UInt32,
                                                                     svStride::custatevecIndex_t,
-                                                                    expectationValues::Ptr{ComplexF64},
-                                                                    matrices::Ptr{Cvoid},
+                                                                    expectationValues::PtrOrCuPtr{ComplexF64},
+                                                                    matrices::PtrOrCuPtr{Cvoid},
                                                                     matrixDataType::cudaDataType_t,
                                                                     layout::custatevecMatrixLayout_t,
                                                                     nMatrices::UInt32,
                                                                     basisBits::Ptr{Int32},
                                                                     nBasisBits::UInt32,
                                                                     computeType::custatevecComputeType_t,
-                                                                    extraWorkspace::Ptr{Cvoid},
+                                                                    extraWorkspace::CuPtr{Cvoid},
                                                                     extraWorkspaceSizeInBytes::Csize_t)::custatevecStatus_t
 end
 


### PR DESCRIPTION
This update  fixes a type error in the function custatevecComputeExpectationBatched  and introduces two new APIs for custatevecComputeExpectationBatched and custatevecMeasureBatched .