### PR TITLE
Add method for conversion of Diagonal matrices

### DIFF
--- a/lib/cublas/linalg.jl
+++ b/lib/cublas/linalg.jl
@@ -330,6 +330,7 @@ end
 # Diagonal
 Base.Array(D::Diagonal{T, <:CuArray{T}}) where {T} = Diagonal(Array(D.diag))
 CuArray(D::Diagonal{T, <:Vector{T}}) where {T} = Diagonal(CuArray(D.diag))
+CuArray{T1}(D::Diagonal{T2, <:Vector{T2}}) where {T1,T2} = Diagonal(CuArray{T1}(D.diag))
 
 function LinearAlgebra.inv(D::Diagonal{T, <:CuArray{T}}) where {T}
     Di = map(inv, D.diag)

--- a/lib/cublas/linalg.jl
+++ b/lib/cublas/linalg.jl
@@ -322,7 +322,7 @@ for (t, uploc, isunitc) in ((:LowerTriangular, 'L', 'N'),
     (:UpperTriangular, 'U', 'N'),
     (:UnitUpperTriangular, 'U', 'U'))
     @eval function LinearAlgebra.inv(x::$t{T, <:CuMatrix{T}}) where T<:CublasFloat
-        out = CuArray{T}(I(size(x,1)))
+        out = CuArray{T}(Array(I(size(x,1))))
         $t(LinearAlgebra.ldiv!(x, out))
     end
 end

--- a/test/libraries/cublas/extensions.jl
+++ b/test/libraries/cublas/extensions.jl
@@ -531,6 +531,24 @@ k = 13
             h_C = Array(d_C)
             @test C ≈ h_C
         end
+        @testset "diagonal conversion" begin
+            for T in (Int32, Int64, Float32, Float64, ComplexF32, ComplexF64)
+                X = Diagonal(rand(T, m))
+                d_X = CuArray(X)
+                @test d_X isa Diagonal{T, <:CuVector{T}}
+                @test Array(d_X.diag) == X.diag
+
+                types = (T in (ComplexF32, ComplexF64)) ? (ComplexF32, ComplexF64) : (Float32, Float64, ComplexF32, ComplexF64)
+                    
+                for T2 in types
+                    if T != T2
+                        d_X2 = CuArray{T2}(X)
+                        @test d_X2 isa Diagonal{T2, <:CuVector{T2}}
+                        @test Array(d_X2.diag) == convert(Vector{T2},X.diag)
+                    end
+                end
+            end
+        end
         @testset "diagonal -- mul!" begin
             XA = rand(elty,m,n)
             d_XA = CuArray(XA)


### PR DESCRIPTION
Before this PR, the conversion like `CuArray{T}(Diagonal(rand(10)))` was returning a dense array instead of a `Diagonal` with a `CuVector` in the diagonal.

Here I simply added a method to fix it.