### PR TITLE
Fill in missing KA functionality (KA.functional + sparse matrices adaption from CUDAbackend)

### DIFF
--- a/src/CUDAKernels.jl
+++ b/src/CUDAKernels.jl
@@ -28,6 +28,8 @@ KA.get_backend(::CuArray) = CUDABackend()
 KA.get_backend(::CUSPARSE.AbstractCuSparseArray) = CUDABackend()
 KA.synchronize(::CUDABackend) = synchronize()
 
+KA.functional(::CUDABackend) = CUDA.functional()
+
 Adapt.adapt_storage(::CUDABackend, a::Array) = Adapt.adapt(CuArray, a)
 Adapt.adapt_storage(::CUDABackend, a::CuArray) = a
 Adapt.adapt_storage(::KA.CPU, a::CuArray) = convert(Array, a)

--- a/src/CUDAKernels.jl
+++ b/src/CUDAKernels.jl
@@ -1,11 +1,12 @@
 module CUDAKernels
 
 using ..CUDA
-using ..CUDA: @device_override
+using ..CUDA: @device_override, CUSPARSE
 
 import KernelAbstractions as KA
 
 import StaticArrays
+import SparseArrays: AbstractSparseArray
 
 import Adapt
 
@@ -30,9 +31,9 @@ KA.synchronize(::CUDABackend) = synchronize()
 
 KA.functional(::CUDABackend) = CUDA.functional()
 
-Adapt.adapt_storage(::CUDABackend, a::Array) = Adapt.adapt(CuArray, a)
-Adapt.adapt_storage(::CUDABackend, a::CuArray) = a
-Adapt.adapt_storage(::KA.CPU, a::CuArray) = convert(Array, a)
+Adapt.adapt_storage(::CUDABackend, a::AbstractArray) = Adapt.adapt(CuArray, a)
+Adapt.adapt_storage(::CUDABackend, a::Union{CuArray,CUSPARSE.AbstractCuSparseArray}) = a
+Adapt.adapt_storage(::KA.CPU, a::Union{CuArray,CUSPARSE.AbstractCuSparseArray}) = Adapt.adapt(Array, a)
 
 ## memory operations
 

--- a/test/base/kernelabstractions.jl
+++ b/test/base/kernelabstractions.jl
@@ -1,8 +1,9 @@
+import KernelAbstractions
 import KernelAbstractions as KA
 using SparseArrays
 using Adapt
 
-include(joinpath(dirname(pathof(KA)), "..", "test", "testsuite.jl"))
+include(joinpath(dirname(pathof(KernelAbstractions)), "..", "test", "testsuite.jl"))
 
 Testsuite.testsuite(()->CUDABackend(false, false), "CUDA", CUDA, CuArray, CuDeviceArray)
 for (PreferBlocks, AlwaysInline) in Iterators.product((true, false), (true, false))

--- a/test/base/kernelabstractions.jl
+++ b/test/base/kernelabstractions.jl
@@ -1,7 +1,28 @@
-import KernelAbstractions
-include(joinpath(dirname(pathof(KernelAbstractions)), "..", "test", "testsuite.jl"))
+import KernelAbstractions as KA
+using SparseArrays
+using Adapt
+
+include(joinpath(dirname(pathof(KA)), "..", "test", "testsuite.jl"))
 
 Testsuite.testsuite(()->CUDABackend(false, false), "CUDA", CUDA, CuArray, CuDeviceArray)
 for (PreferBlocks, AlwaysInline) in Iterators.product((true, false), (true, false))
     Testsuite.unittest_testsuite(()->CUDABackend(PreferBlocks, AlwaysInline), "CUDA", CUDA, CuDeviceArray)
+end
+
+@testset "KA.functional" begin
+    @test KA.functional(CUDABackend()) == CUDA.functional()
+end
+
+@testset "CUDA Backend Adapt Tests" begin
+    # CPU → GPU
+    A = sprand(Float32, 10, 10, 0.5) #CSC
+    A_d = adapt(CUDABackend(), A) 
+    @test A_d isa CUSPARSE.CuSparseMatrixCSC
+    @test adapt(CUDABackend(), A_d) |> typeof == typeof(A_d)
+
+    # GPU → CPU
+    B_d = A |> cu # CuCSC
+    B = adapt(KA.CPU(), A_d)
+    @test B isa SparseMatrixCSC
+    @test adapt(KA.CPU(), B) |> typeof == typeof(B) 
 end


### PR DESCRIPTION
This PR should be able to solve two missing pieces:
```julia
julia> KA.functional(CUDABackend())
missing
```
```julia
julia> adapt(CUDABackend(),sprand(10,10,0.2))
10×10 SparseMatrixCSC{Float64, Int64} with 14 stored entries:
```

I might need help on where I should write the tests, because `KA.jl` only tests for `Array` type (https://github.com/JuliaGPU/KernelAbstractions.jl/blob/365bf2cd461b297cf723ee3f819220ecb73c1e1e/test/test.jl#L94), so tests for sparse matrices should be put in `test/kernelabstractions.jl` , right? 