### PR TITLE
Possible fix for #2745, change args in call to `cusparseCreateBsr`

### DIFF
--- a/lib/cusparse/helpers.jl
+++ b/lib/cusparse/helpers.jl
@@ -239,13 +239,14 @@ mutable struct CuSparseMatrixDescriptor
 
     function CuSparseMatrixDescriptor(A::CuSparseMatrixBSR, IndexBase::Char)
         desc_ref = Ref{cusparseSpMatDescr_t}()
+        brows, bcols = cld.(size(A), A.blockDim)
         cusparseCreateBsr(
             desc_ref,
-            size(A)..., nnz(A),
+            brows, bcols, A.nnzb,
             A.blockDim, A.blockDim,
-            A.rowPtr, A.colVal, nonzeros(A),
+            A.rowPtr, A.colVal, A.nzVal,
             eltype(A.rowPtr), eltype(A.colVal), IndexBase,
-            eltype(nonzeros(A)), A.dir
+            eltype(A.nzVal), A.dir
         )
         obj = new(desc_ref[])
         finalizer(cusparseDestroySpMat, obj)


### PR DESCRIPTION
Looking at the [interface description](https://docs.nvidia.com/cuda/cusparse/index.html#cusparsecreatebsr) I think wrong dimensions are passed to `cusparseCreateBsr` in `CuSparseMatrixDescriptor` for BSR format, which would explain my problems in #2745.
With these fixes, this MWE works for me:
```julia
using SparseArrays
import CUDA: cu
import CUDA.CUSPARSE: CuSparseMatrixBSR
# 4 x 4 matrix with 2D blocks
csc = sparse(
    [1, 2, 1, 2, 3, 4, 3, 4] |> cu, 
    [1, 1, 2, 2, 3, 3, 4, 4] |> cu, 
    [fill(1f0, 4); fill(2f0, 4)] |> cu
)
bsr = CuSparseMatrixBSR(csc, 2)

x = ones(Float32, 4) |> cu
X = ones(Float32, 4, 2) |> cu

y_csc = csc * x # mat-vec works
Y_csc = csc * X # mat-mat works

y_bsr = bsr * x # mat-vec works
Y_bsr = bsr * X # mat-mat fails!
```