### PR TITLE
Fix log_message pileup

### DIFF
--- a/lib/cudnn/src/cuDNN.jl
+++ b/lib/cudnn/src/cuDNN.jl
@@ -183,8 +183,12 @@ function __init__()
     # register a log callback
     if !precompiling && (isdebug(:init, cuDNN) || Base.JLOptions().debug_level >= 2)
         log_cond[] = Base.AsyncCondition() do async_cond
-            message = Base.@lock log_lock popfirst!(log_messages)
-            _log_message(message...)
+            Base.@lock log_lock begin
+                while length(log_messages) > 0
+                    message = popfirst!(log_messages)
+                    _log_message(message...)
+                end
+            end 
         end
 
         callback = @cfunction(log_message, Nothing,

--- a/lib/cudnn/src/cuDNN.jl
+++ b/lib/cudnn/src/cuDNN.jl
@@ -188,7 +188,7 @@ function __init__()
                     message = popfirst!(log_messages)
                     _log_message(message...)
                 end
-            end 
+            end
         end
 
         callback = @cfunction(log_message, Nothing,


### PR DESCRIPTION
from libuv docs:

"libuv will coalesce calls to uv_async_send(), that is, not every call to it will yield an execution of the callback."