### PR TITLE
Check whether debug logs would actually get logged.

### DIFF
--- a/src/debug.jl
+++ b/src/debug.jl
@@ -1,8 +1,8 @@
 # debug functionality
 
-function isdebug(group, mod=CUDA)
+function isdebug(group, mod = CUDA)
     level = Base.CoreLogging.Debug
     logger = Base.CoreLogging.current_logger_for_env(level, group, mod)
     # TODO: Which id to choose here instead of 0?
-    logger !== nothing && Base.CoreLogging.shouldlog(logger, level, mod, group, 0)
+    return logger !== nothing && Base.CoreLogging.shouldlog(logger, level, mod, group, 0)
 end

--- a/src/debug.jl
+++ b/src/debug.jl
@@ -1,4 +1,8 @@
 # debug functionality
 
-isdebug(group, mod=CUDA) =
-    Base.CoreLogging.current_logger_for_env(Base.CoreLogging.Debug, group, mod) !== nothing
+function isdebug(group, mod=CUDA)
+    level = Base.CoreLogging.Debug
+    logger = Base.CoreLogging.current_logger_for_env(level, group, mod)
+    # TODO: Which id to choose here instead of 0?
+    logger !== nothing && Base.CoreLogging.shouldlog(logger, level, mod, group, 0)
+end


### PR DESCRIPTION
Pluto installs a logger that has min_level == Debug but then continues to not log debug messages except for when they come from within a pluto cell.

This patch checks whether the logger actually would log debug messages by calling shouldlog().

This is still WIP since

1. I'm not sure this is the right approach
2. shouldlog() expects an id argument and I'm not sure what to pass there. Right now I just pass 0