### PR TITLE
Prefer aligned_sizeof

### DIFF
--- a/lib/cudadrv/CUDAdrv.jl
+++ b/lib/cudadrv/CUDAdrv.jl
@@ -6,6 +6,12 @@ using Printf
 
 using LazyArtifacts
 
+# Julia has several notions of `sizeof`
+# - Base.sizeof is the size of an object in memory
+# - Base.aligned_sizeof is the size of an object in an array/inline alloced
+# Both of them are equivalent for immutable objects, but differ for mutable singtons and Symbol
+# We use `aligned_sizeof` since we care about the size of a type in an array
+import Base: aligned_sizeof
 
 # low-level wrappers
 include("libcuda.jl")

--- a/lib/cudadrv/module/global.jl
+++ b/lib/cudadrv/module/global.jl
@@ -19,7 +19,7 @@ struct CuGlobal{T}
         ptr_ref = Ref{CuPtr{Cvoid}}()
         nbytes_ref = Ref{Csize_t}()
         cuModuleGetGlobal_v2(ptr_ref, nbytes_ref, mod, name)
-        if nbytes_ref[] != sizeof(T)
+        if nbytes_ref[] != aligned_sizeof(T)
             throw(ArgumentError("size of global '$name' does not match type parameter type $T"))
         end
         buf = DeviceMemory(device(), context(), ptr_ref[], nbytes_ref[], false)

--- a/src/CUDA.jl
+++ b/src/CUDA.jl
@@ -47,6 +47,18 @@ import NVTX
 
 using Printf
 
+# Julia has several notions of `sizeof`
+# - Base.sizeof is the size of an object in memory
+# - Base.aligned_sizeof is the size of an object in an array/inline alloced
+# Both of them are equivalent for immutable objects, but differ for mutable singtons and Symbol
+# We use `aligned_sizeof` since we care about the size of a type in an array
+@static if VERSION < v"1.11.0"
+   @generated function aligned_sizeof(::Type{T}) where T
+        return :($(Base.aligned_sizeof(T)))
+   end
+else
+    import Base: aligned_sizeof
+end
 
 ## source code includes
 

--- a/src/device/texture.jl
+++ b/src/device/texture.jl
@@ -35,7 +35,7 @@ Base.convert(::Type{CUtexObject}, t::CuDeviceTexture) = t.handle
 
 ## array interface
 
-Base.elsize(::Type{<:CuDeviceTexture{T}}) where {T} = sizeof(T)
+Base.elsize(::Type{<:CuDeviceTexture{T}}) where {T} = aligned_sizeof(T)
 
 Base.size(tm::CuDeviceTexture) = tm.dims
 Base.sizeof(tm::CuDeviceTexture) = Base.elsize(x) * length(x)

--- a/src/refpointer.jl
+++ b/src/refpointer.jl
@@ -42,7 +42,7 @@ mutable struct CuRefValue{T} <: AbstractCuRef{T}
 
     function CuRefValue{T}() where {T}
         check_eltype("CuRef", T)
-        buf = pool_alloc(DeviceMemory, sizeof(T))
+        buf = pool_alloc(DeviceMemory, aligned_sizeof(T))
         obj = new(buf)
         finalizer(obj) do _
             pool_free(buf)

--- a/src/texture.jl
+++ b/src/texture.jl
@@ -59,8 +59,9 @@ Base.size(tm::CuTextureArray) = tm.dims
 Base.length(tm::CuTextureArray) = prod(size(tm))
 
 Base.eltype(tm::CuTextureArray{T,N}) where {T,N} = T
+Base.elsize(tm::CuTextureArray) = aligned_sizeof(eltype(tm))
 
-Base.sizeof(tm::CuTextureArray) = sizeof(eltype(tm)) * length(tm)
+Base.sizeof(tm::CuTextureArray) = Base.elsize(tm) * length(tm)
 
 Base.pointer(t::CuTextureArray) = t.mem.ptr
 


### PR DESCRIPTION
Base itself uses `aligned_sizeof ` for things like `elsize(::Array)`. `aligned_sizeof` calculates the inline sizof, in contrast to the memory sizeof.

Matters for Symbols and `mutable` singleton objects x-ref  #2753 