### PR TITLE
Remove second import of aligned_sizeof

### DIFF
--- a/lib/cudadrv/CUDAdrv.jl
+++ b/lib/cudadrv/CUDAdrv.jl
@@ -6,13 +6,6 @@ using Printf
 
 using LazyArtifacts
 
-# Julia has several notions of `sizeof`
-# - Base.sizeof is the size of an object in memory
-# - Base.aligned_sizeof is the size of an object in an array/inline alloced
-# Both of them are equivalent for immutable objects, but differ for mutable singtons and Symbol
-# We use `aligned_sizeof` since we care about the size of a type in an array
-import Base: aligned_sizeof
-
 # low-level wrappers
 include("libcuda.jl")
 include("libcuda_deprecated.jl")


### PR DESCRIPTION
Fixes #2766

In my head CUDAdrv was still a seperate module.
