### PR TITLE
cuTENSOR: Preserve storage type when multiplying

### DIFF
--- a/lib/cutensor/src/interfaces.jl
+++ b/lib/cutensor/src/interfaces.jl
@@ -30,7 +30,7 @@ function Base.:(*)(A::CuTensor, B::CuTensor)
     B_sizes = map(x->size(B,x[1]), B_uniqs)
     A_inds = map(x->x[2], A_uniqs)
     B_inds = map(x->x[2], B_uniqs)
-    C = CuTensor(CUDA.zeros(tC, Dims(vcat(A_sizes, B_sizes))), vcat(A_inds, B_inds))
+    C = CuTensor(fill!(similar(B.data, tC, Dims(vcat(A_sizes, B_sizes))), zero(tC)), vcat(A_inds, B_inds))
     return mul!(C, A, B)
 end
 


### PR DESCRIPTION
This is the only instance I could find in cuTENSOR where the responsibility of the output storage type is on the library. 

I would appreciate a second look however.