### PR TITLE
Cleanup and less memory use for cusparse linalg tests

### DIFF
--- a/test/libraries/cusparse/linalg.jl
+++ b/test/libraries/cusparse/linalg.jl
@@ -1,91 +1,55 @@
 using CUDA.CUSPARSE
 using LinearAlgebra, SparseArrays
 
-@testset "opnorm and norm $T" for T in [Float32, Float64, ComplexF32, ComplexF64]
-    S = sprand(T, 10, 10, 0.1)
-    dS_csc = CuSparseMatrixCSC(S)
-    dS_csr = CuSparseMatrixCSR(S)
-    @test opnorm(S, Inf) ≈ opnorm(dS_csc, Inf)
-    @test opnorm(S, Inf) ≈ opnorm(dS_csr, Inf)
-    @test opnorm(S, 1) ≈ opnorm(dS_csc, 1)
-    @test opnorm(S, 1) ≈ opnorm(dS_csr, 1)
-    @test_throws ArgumentError("p=2 is not supported") opnorm(dS_csr, 2)
-    @test norm(S, 0) ≈ norm(dS_csc, 0)
-    @test norm(S, 0) ≈ norm(dS_csr, 0)
-    @test norm(S, 1) ≈ norm(dS_csc, 1)
-    @test norm(S, 1) ≈ norm(dS_csr, 1)
-    @test norm(S, 2) ≈ norm(dS_csc, 2)
-    @test norm(S, 2) ≈ norm(dS_csr, 2)
-    @test norm(S, Inf) ≈ norm(dS_csc, Inf)
-    @test norm(S, Inf) ≈ norm(dS_csr, Inf)
-    @test norm(S, -Inf) ≈ norm(dS_csc, -Inf)
-    @test norm(S, -Inf) ≈ norm(dS_csr, -Inf)
-end
-
-@testset "triu tril exp $typ" for
-    typ in [CuSparseMatrixCSR, CuSparseMatrixCSC]
-
-    a = sprand(ComplexF32, 100, 100, 0.02)
-    A = typ(a)
-    @test Array(triu(A)) ≈ triu(a)
-    @test Array(triu(A, 1)) ≈ triu(a, 1)
-    @test Array(tril(A)) ≈ tril(a)
-    @test Array(tril(A, 1)) ≈ tril(a, 1)
-    if CUSPARSE.version() > v"11.4.1"
-        @test Array(exp(A)) ≈ exp(collect(a))
+m = 10
+@testset "T = $T" for T in [Float32, Float64, ComplexF32, ComplexF64]
+    A  = sprand(T, m, m, 0.2)
+    B  = sprand(T, m, m, 0.3)
+    ZA = spzeros(T, m, m)
+    C  = I(div(m, 2))
+    @testset "type = $typ" for typ in [CuSparseMatrixCSR, CuSparseMatrixCSC]
+        dA = typ(A)
+        dB = typ(B)
+        dZA = typ(ZA)
+        @testset "opnorm and norm" begin
+            @test opnorm(A, Inf) ≈ opnorm(dA, Inf)
+            @test opnorm(A, 1)   ≈ opnorm(dA, 1)
+            @test_throws ArgumentError("p=2 is not supported") opnorm(dA, 2)
+            @test norm(A, 0) ≈ norm(dA, 0)
+            @test norm(A, 1) ≈ norm(dA, 1)
+            @test norm(A, 2) ≈ norm(dA, 2)
+            @test norm(A, Inf) ≈ norm(dA, Inf)
+            @test norm(A, -Inf) ≈ norm(dA, -Inf)
+        end
+        @testset "triu tril exp" begin
+            @test Array(triu(dA)) ≈ triu(A)
+            @test Array(triu(dA, 1)) ≈ triu(A, 1)
+            @test Array(tril(dA)) ≈ tril(A)
+            @test Array(tril(dA, 1)) ≈ tril(A, 1)
+            if CUSPARSE.version() > v"11.4.1"
+                @test Array(exp(dA)) ≈ exp(collect(A))
+            end
+        end
+        @testset "kronecker product opa = $opa, opb = $opb" for opa in (identity, transpose, adjoint), opb in (identity, transpose, adjoint)
+            if !(opa == transpose && opb == adjoint) && !(opa == adjoint && opb == transpose)
+                @test collect(kron(opa(dA), opb(dB)))  ≈ kron(opa(A), opb(B))
+                @test collect(kron(opa(dZA), opb(dB))) ≈ kron(opa(ZA), opb(B))
+            end
+        end
+        @testset "kronecker product with I opa = $opa" for opa in (identity, transpose, adjoint)
+            @test collect(kron(opa(dA), C)) ≈ kron(opa(A), C) 
+            @test collect(kron(C, opa(dA))) ≈ kron(C, opa(A)) 
+            @test collect(kron(opa(dZA), C)) ≈ kron(opa(ZA), C)
+            @test collect(kron(C, opa(dZA))) ≈ kron(C, opa(ZA))
+        end
     end
-end
-
-@testset "$typ kronecker product" for
-    typ in [CuSparseMatrixCSR, CuSparseMatrixCSC]
-
-    a = sprand(ComplexF32, 100, 100, 0.1)
-    b = sprand(ComplexF32, 100, 100, 0.1)
-    A = typ(a)
-    B = typ(b)
-    za = spzeros(ComplexF32, 100, 100)
-    ZA = typ(za)
-    @test collect(kron(A, B)) ≈ kron(a, b)
-    @test collect(kron(transpose(A), B)) ≈ kron(transpose(a), b)
-    @test collect(kron(A, transpose(B))) ≈ kron(a, transpose(b))
-    @test collect(kron(transpose(A), transpose(B))) ≈ kron(transpose(a), transpose(b))
-    @test collect(kron(A', B)) ≈ kron(a', b)
-    @test collect(kron(A, B')) ≈ kron(a, b')
-    @test collect(kron(A', B')) ≈ kron(a', b')
-    
-    @test collect(kron(ZA, B)) ≈ kron(za, b)
-    @test collect(kron(transpose(ZA), B)) ≈ kron(transpose(za), b)
-    @test collect(kron(ZA, transpose(B))) ≈ kron(za, transpose(b))
-    @test collect(kron(transpose(ZA), transpose(B))) ≈ kron(transpose(za), transpose(b))
-    @test collect(kron(ZA', B)) ≈ kron(za', b)
-    @test collect(kron(ZA, B')) ≈ kron(za, b')
-    @test collect(kron(ZA', B')) ≈ kron(za', b')
-
-    C = I(50)
-    @test collect(kron(A, C)) ≈ kron(a, C)
-    @test collect(kron(C, A)) ≈ kron(C, a)
-    @test collect(kron(transpose(A), C)) ≈ kron(transpose(a), C)
-    @test collect(kron(C, transpose(A))) ≈ kron(C, transpose(a))
-    @test collect(kron(adjoint(A), C)) ≈ kron(adjoint(a), C)
-    @test collect(kron(C, adjoint(A))) ≈ kron(C, adjoint(a))
-    @test collect(kron(A', C)) ≈ kron(a', C)
-    @test collect(kron(C, A')) ≈ kron(C, a')
-    
-    @test collect(kron(ZA, C)) ≈ kron(za, C)
-    @test collect(kron(C, ZA)) ≈ kron(C, za)
-    @test collect(kron(transpose(ZA), C)) ≈ kron(transpose(za), C)
-    @test collect(kron(C, transpose(ZA))) ≈ kron(C, transpose(za))
-    @test collect(kron(adjoint(ZA), C)) ≈ kron(adjoint(za), C)
-    @test collect(kron(C, adjoint(ZA))) ≈ kron(C, adjoint(za))
-    @test collect(kron(ZA', C)) ≈ kron(za', C)
-    @test collect(kron(C, ZA')) ≈ kron(C, za')
 end
 
 @testset "Reshape $typ (100,100) -> (20, 500) and droptol" for
     typ in [CuSparseMatrixCSR, CuSparseMatrixCSC]
 
-    a = sprand(ComplexF32, 100, 100, 0.1)
-    dims = (20, 500)
+    a = sprand(ComplexF32, 10, 10, 0.1)
+    dims = (20, 5)
     A = typ(a)
     @test Array(reshape(A, dims)) ≈ reshape(a, dims)
     droptol!(a, 0.4)
@@ -96,8 +60,8 @@ end
 @testset "Generalized dot product for $typ and $elty" for
     typ in [CuSparseMatrixCSR, CuSparseMatrixCSC], elty in [Int64, Float32, Float64, ComplexF64]
 
-    N1 = 1000*2
-    N2 = 1000*3
+    N1 = 100*2
+    N2 = 100*3
     x = rand(elty, N1)
     y = rand(elty, N2)
     A = sprand(elty, N1, N2, 1/N1)


### PR DESCRIPTION
Not sure we need to generate a bunch of 10,000 by 10,000 matrices. Seems to have cut memory use by a factor of two locally for me, might help with memory pressure for the test suite.