### PR TITLE
Simplify specifying benchmark output file

### DIFF
--- a/perf/runbenchmarks.jl
+++ b/perf/runbenchmarks.jl
@@ -14,12 +14,16 @@ macro async_benchmarkable(ex...)
     end
 end
 
+if !@isdefined(BENCHOUT)
+    BENCHOUT = "benchmarkresults.json"
+end
+
 # before anything else, run latency benchmarks. these spawn subprocesses, so we don't want
 # to do so after regular benchmarks have caused the memory allocator to reserve memory.
 @info "Running latency benchmarks"
 latency_results = include("latency.jl")
 
-SUITE = BenchmarkGroup()
+SUITE = BenchmarkGroup([BENCHOUT])
 
 include("cuda.jl")
 include("kernel.jl")
@@ -50,4 +54,4 @@ results["latency"] = latency_results
 results["integration"] = integration_results
 
 # write out the results
-BenchmarkTools.save("benchmarkresults.json", median(results))
+BenchmarkTools.save(BENCHOUT, median(results))

--- a/perf/runbenchmarks.jl
+++ b/perf/runbenchmarks.jl
@@ -14,10 +14,6 @@ macro async_benchmarkable(ex...)
     end
 end
 
-if !@isdefined(BENCHOUT)
-    BENCHOUT = "benchmarkresults.json"
-end
-
 # before anything else, run latency benchmarks. these spawn subprocesses, so we don't want
 # to do so after regular benchmarks have caused the memory allocator to reserve memory.
 @info "Running latency benchmarks"
@@ -54,4 +50,5 @@ results["latency"] = latency_results
 results["integration"] = integration_results
 
 # write out the results
-BenchmarkTools.save(BENCHOUT, median(results))
+result_file = length(ARGS) >= 1 ? ARGS[1] : "benchmarkresults.json"
+BenchmarkTools.save(result_file, median(results))

--- a/perf/runbenchmarks.jl
+++ b/perf/runbenchmarks.jl
@@ -23,7 +23,7 @@ end
 @info "Running latency benchmarks"
 latency_results = include("latency.jl")
 
-SUITE = BenchmarkGroup([BENCHOUT])
+SUITE = BenchmarkGroup()
 
 include("cuda.jl")
 include("kernel.jl")


### PR DESCRIPTION
Makes no changes to CI but makes it easier to specify the benchmarks output filename without having to edit the file. Will open an equivalent PR for Metal if this is approved here.