### PR TITLE
Trial support for thread-block clusters

### DIFF
--- a/src/compiler/execution.jl
+++ b/src/compiler/execution.jl
@@ -7,7 +7,7 @@ export @cuda, cudaconvert, cufunction, dynamic_cufunction, nextwarp, prevwarp
 
 const MACRO_KWARGS = [:dynamic, :launch]
 const COMPILER_KWARGS = [:kernel, :name, :always_inline, :minthreads, :maxthreads, :blocks_per_sm, :maxregs, :fastmath, :cap, :ptx]
-const LAUNCH_KWARGS = [:cooperative, :blocks, :threads, :shmem, :stream]
+const LAUNCH_KWARGS = [:cooperative, :blocks, :threads, :clusters, :shmem, :stream]
 
 
 """
@@ -224,6 +224,10 @@ The following keyword arguments are supported:
 - `blocks` (default: `1`): Number of thread blocks to launch, or a 1-, 2- or 3-tuple of
   dimensions (e.g. `blocks=(2, 4, 2)` for a 3D grid of blocks).
   Use [`blockIdx()`](@ref) and [`gridDim()`](@ref) to query from within the kernel.
+- `clusters` (default: `0`): Number of thread blocks to launch as a cooperative cluster,
+  or a 1-, 2- or 3-tuple of dimensions (e.g. `clusters=(2, 2, 2)` for a 3D grid).
+  Use [`clusterIdx()`](@ref) and [`clusterDim()`](@ref) to query from within the kernel.
+  Only supported on compute capability 9.0 and above. If `clusters=0`, no clusters are launched.
 - `shmem`(default: `0`): Amount of dynamic shared memory in bytes to allocate per thread block;
   used by [`CuDynamicSharedArray`](@ref).
 - `stream` (default: [`stream()`](@ref)): [`CuStream`](@ref) to launch the kernel on.

--- a/test/core/execution.jl
+++ b/test/core/execution.jl
@@ -159,6 +159,13 @@ end
     @cuda stream=s dummy()
 end
 
+@testset "clusters" begin
+    if CUDA.capability(device()) >= v"9.0"
+        @cuda threads=64 clusters=2 dummy()
+    else
+        @test_throws ArgumentError @cuda threads=64 clusters=2 dummy()
+    end
+end
 
 @testset "external kernels" begin
     @eval module KernelModule


### PR DESCRIPTION
Trying to attack https://github.com/JuliaGPU/CUDA.jl/issues/1989

This should allow users to submit a `clusters=` kwarg at kernel launch, which will use `cuLaunchKernelEx` on supported hardware and throw an error if `clusters > 1` on any dimension on non-supported hardware. There are some tests but probably more can be done. I did wrap the necessary PTX instructions for detecting the cluster index and size within a kernel as well.