### PR TITLE
Always use generated `aligned_sizeof`

### DIFF
--- a/src/CUDA.jl
+++ b/src/CUDA.jl
@@ -54,12 +54,8 @@ using Printf
 # - Base.aligned_sizeof is the size of an object in an array/inline alloced
 # Both of them are equivalent for immutable objects, but differ for mutable singtons and Symbol
 # We use `aligned_sizeof` since we care about the size of a type in an array
-@static if VERSION < v"1.11.0"
-   @generated function aligned_sizeof(::Type{T}) where T
-        return :($(Base.aligned_sizeof(T)))
-   end
-else
-    import Base: aligned_sizeof
+@generated function aligned_sizeof(::Type{T}) where T
+    return :($(Base.aligned_sizeof(T)))
 end
 
 ## source code includes


### PR DESCRIPTION
See https://github.com/JuliaGPU/CUDA.jl/issues/2790#issuecomment-3168859365

Close #2790