### PR TITLE
[CUBLAS] Update wrapppers to use the ILP64 API

### DIFF
--- a/lib/cublas/libcublas.jl
+++ b/lib/cublas/libcublas.jl
@@ -5914,6 +5914,17 @@ end
                                           incy::Cint, batchCount::Cint)::cublasStatus_t
 end
 
+@checked function cublasHSHgemvBatched_64(handle, trans, m, n, alpha, Aarray, lda, xarray,
+                                          incx, beta, yarray, incy, batchCount)
+    initialize_context()
+    @ccall libcublas.cublasHSHgemvBatched_64(handle::cublasHandle_t, trans::cublasOperation_t,
+                                             m::Int64, n::Int64, alpha::CuRef{Cfloat},
+                                             Aarray::CuPtr{Ptr{Float16}}, lda::Int64,
+                                             xarray::CuPtr{Ptr{Float16}}, incx::Int64,
+                                             beta::CuRef{Cfloat}, yarray::CuPtr{Ptr{Float16}},
+                                             incy::Int64, batchCount::Int64)::cublasStatus_t
+end
+
 @checked function cublasHSSgemvBatched(handle, trans, m, n, alpha, Aarray, lda, xarray,
                                        incx, beta, yarray, incy, batchCount)
     initialize_context()
@@ -5923,6 +5934,17 @@ end
                                           xarray::CuPtr{Ptr{Float16}}, incx::Cint,
                                           beta::CuRef{Cfloat}, yarray::CuPtr{Ptr{Cfloat}},
                                           incy::Cint, batchCount::Cint)::cublasStatus_t
+end
+
+@checked function cublasHSSgemvBatched_64(handle, trans, m, n, alpha, Aarray, lda, xarray,
+                                          incx, beta, yarray, incy, batchCount)
+    initialize_context()
+    @ccall libcublas.cublasHSSgemvBatched_64(handle::cublasHandle_t, trans::cublasOperation_t,
+                                             m::Int64, n::Int64, alpha::CuRef{Cfloat},
+                                             Aarray::CuPtr{Ptr{Float16}}, lda::Int64,
+                                             xarray::CuPtr{Ptr{Float16}}, incx::Int64,
+                                             beta::CuRef{Cfloat}, yarray::CuPtr{Ptr{Cfloat}},
+                                             incy::Int64, batchCount::Int64)::cublasStatus_t
 end
 
 @checked function cublasTSTgemvBatched(handle, trans, m, n, alpha, Aarray, lda, xarray,
@@ -5936,6 +5958,17 @@ end
                                           incy::Cint, batchCount::Cint)::cublasStatus_t
 end
 
+@checked function cublasTSTgemvBatched_64(handle, trans, m, n, alpha, Aarray, lda, xarray,
+                                          incx, beta, yarray, incy, batchCount)
+    initialize_context()
+    @ccall libcublas.cublasTSTgemvBatched_64(handle::cublasHandle_t, trans::cublasOperation_t,
+                                             m::Int64, n::Int64, alpha::Ptr{Cfloat},
+                                             Aarray::Ptr{Ptr{BFloat16}}, lda::Int64,
+                                             xarray::Ptr{Ptr{BFloat16}}, incx::Int64,
+                                             beta::Ptr{Cfloat}, yarray::Ptr{Ptr{BFloat16}},
+                                             incy::Int64, batchCount::Int64)::cublasStatus_t
+end
+
 @checked function cublasTSSgemvBatched(handle, trans, m, n, alpha, Aarray, lda, xarray,
                                        incx, beta, yarray, incy, batchCount)
     initialize_context()
@@ -5945,6 +5978,17 @@ end
                                           xarray::Ptr{Ptr{BFloat16}}, incx::Cint,
                                           beta::Ptr{Cfloat}, yarray::Ptr{Ptr{Cfloat}},
                                           incy::Cint, batchCount::Cint)::cublasStatus_t
+end
+
+@checked function cublasTSSgemvBatched_64(handle, trans, m, n, alpha, Aarray, lda, xarray,
+                                          incx, beta, yarray, incy, batchCount)
+    initialize_context()
+    @ccall libcublas.cublasTSSgemvBatched_64(handle::cublasHandle_t, trans::cublasOperation_t,
+                                             m::Int64, n::Int64, alpha::Ptr{Cfloat},
+                                             Aarray::Ptr{Ptr{BFloat16}}, lda::Int64,
+                                             xarray::Ptr{Ptr{BFloat16}}, incx::Int64,
+                                             beta::Ptr{Cfloat}, yarray::Ptr{Ptr{Cfloat}},
+                                             incy::Int64, batchCount::Int64)::cublasStatus_t
 end
 
 @checked function cublasHSHgemvStridedBatched(handle, trans, m, n, alpha, A, lda, strideA,
@@ -5962,6 +6006,21 @@ end
                                                  batchCount::Cint)::cublasStatus_t
 end
 
+@checked function cublasHSHgemvStridedBatched_64(handle, trans, m, n, alpha, A, lda, strideA,
+                                                 x, incx, stridex, beta, y, incy, stridey,
+                                                 batchCount)
+    initialize_context()
+    @ccall libcublas.cublasHSHgemvStridedBatched_64(handle::cublasHandle_t,
+                                                    trans::cublasOperation_t, m::Int64, n::Int64,
+                                                    alpha::CuRef{Cfloat}, A::CuPtr{Float16},
+                                                    lda::Int64, strideA::Clonglong,
+                                                    x::CuPtr{Float16}, incx::Int64,
+                                                    stridex::Clonglong, beta::CuRef{Cfloat},
+                                                    y::CuPtr{Float16}, incy::Int64,
+                                                    stridey::Clonglong,
+                                                    batchCount::Int64)::cublasStatus_t
+end
+
 @checked function cublasHSSgemvStridedBatched(handle, trans, m, n, alpha, A, lda, strideA,
                                               x, incx, stridex, beta, y, incy, stridey,
                                               batchCount)
@@ -5975,6 +6034,21 @@ end
                                                  y::CuPtr{Cfloat}, incy::Cint,
                                                  stridey::Clonglong,
                                                  batchCount::Cint)::cublasStatus_t
+end
+
+@checked function cublasHSSgemvStridedBatched_64(handle, trans, m, n, alpha, A, lda, strideA,
+                                                 x, incx, stridex, beta, y, incy, stridey,
+                                                 batchCount)
+    initialize_context()
+    @ccall libcublas.cublasHSSgemvStridedBatched_64(handle::cublasHandle_t,
+                                                    trans::cublasOperation_t, m::Int64, n::Int64,
+                                                    alpha::CuRef{Cfloat}, A::CuPtr{Float16},
+                                                    lda::Int64, strideA::Clonglong,
+                                                    x::CuPtr{Float16}, incx::Int64,
+                                                    stridex::Clonglong, beta::CuRef{Cfloat},
+                                                    y::CuPtr{Cfloat}, incy::Int64,
+                                                    stridey::Clonglong,
+                                                    batchCount::Int64)::cublasStatus_t
 end
 
 @checked function cublasTSTgemvStridedBatched(handle, trans, m, n, alpha, A, lda, strideA,
@@ -5992,6 +6066,21 @@ end
                                                  batchCount::Cint)::cublasStatus_t
 end
 
+@checked function cublasTSTgemvStridedBatched_64(handle, trans, m, n, alpha, A, lda, strideA,
+                                                 x, incx, stridex, beta, y, incy, stridey,
+                                                 batchCount)
+    initialize_context()
+    @ccall libcublas.cublasTSTgemvStridedBatched_64(handle::cublasHandle_t,
+                                                    trans::cublasOperation_t, m::Int64, n::Int64,
+                                                    alpha::CuRef{Cfloat}, A::CuPtr{BFloat16},
+                                                    lda::Int64, strideA::Clonglong,
+                                                    x::CuPtr{BFloat16}, incx::Int64,
+                                                    stridex::Clonglong, beta::CuRef{Cfloat},
+                                                    y::CuPtr{BFloat16}, incy::Int64,
+                                                    stridey::Clonglong,
+                                                    batchCount::Int64)::cublasStatus_t
+end
+
 @checked function cublasTSSgemvStridedBatched(handle, trans, m, n, alpha, A, lda, strideA,
                                               x, incx, stridex, beta, y, incy, stridey,
                                               batchCount)
@@ -6007,6 +6096,21 @@ end
                                                  batchCount::Cint)::cublasStatus_t
 end
 
+@checked function cublasTSSgemvStridedBatched_64(handle, trans, m, n, alpha, A, lda, strideA,
+                                                 x, incx, stridex, beta, y, incy, stridey,
+                                                 batchCount)
+    initialize_context()
+    @ccall libcublas.cublasTSSgemvStridedBatched_64(handle::cublasHandle_t,
+                                                    trans::cublasOperation_t, m::Int64, n::Int64,
+                                                    alpha::CuRef{Cfloat}, A::CuPtr{BFloat16},
+                                                    lda::Int64, strideA::Clonglong,
+                                                    x::CuPtr{BFloat16}, incx::Int64,
+                                                    stridex::Clonglong, beta::CuRef{Cfloat},
+                                                    y::CuPtr{Cfloat}, incy::Int64,
+                                                    stridey::Clonglong,
+                                                    batchCount::Int64)::cublasStatus_t
+end
+
 @checked function cublasHgemm(handle, transa, transb, m, n, k, alpha, A, lda, B, ldb, beta,
                               C, ldc)
     initialize_context()
@@ -6015,6 +6119,16 @@ end
                                  alpha::Ptr{Float16}, A::Ptr{Float16}, lda::Cint,
                                  B::Ptr{Float16}, ldb::Cint, beta::Ptr{Float16},
                                  C::Ptr{Float16}, ldc::Cint)::cublasStatus_t
+end
+
+@checked function cublasHgemm_64(handle, transa, transb, m, n, k, alpha, A, lda, B, ldb, beta,
+                                 C, ldc)
+    initialize_context()
+    @ccall libcublas.cublasHgemm_64(handle::cublasHandle_t, transa::cublasOperation_t,
+                                    transb::cublasOperation_t, m::Int64, n::Int64, k::Int64,
+                                    alpha::Ptr{Float16}, A::Ptr{Float16}, lda::Int64,
+                                    B::Ptr{Float16}, ldb::Int64, beta::Ptr{Float16},
+                                    C::Ptr{Float16}, ldc::Int64)::cublasStatus_t
 end
 
 @checked function cublasHgemmBatched(handle, transa, transb, m, n, k, alpha, Aarray, lda,
@@ -6028,6 +6142,19 @@ end
                                         beta::CuRef{Float16},
                                         Carray::CuPtr{Ptr{Float16}}, ldc::Cint,
                                         batchCount::Cint)::cublasStatus_t
+end
+
+@checked function cublasHgemmBatched_64(handle, transa, transb, m, n, k, alpha, Aarray, lda,
+                                        Barray, ldb, beta, Carray, ldc, batchCount)
+    initialize_context()
+    @ccall libcublas.cublasHgemmBatched_64(handle::cublasHandle_t, transa::cublasOperation_t,
+                                           transb::cublasOperation_t, m::Int64, n::Int64,
+                                           k::Int64, alpha::CuRef{Float16},
+                                           Aarray::CuPtr{Ptr{Float16}}, lda::Int64,
+                                           Barray::CuPtr{Ptr{Float16}}, ldb::Int64,
+                                           beta::CuRef{Float16},
+                                           Carray::CuPtr{Ptr{Float16}}, ldc::Int64,
+                                           batchCount::Int64)::cublasStatus_t
 end
 
 @checked function cublasHgemmStridedBatched(handle, transa, transb, m, n, k, alpha, A, lda,
@@ -6044,4 +6171,20 @@ end
                                                beta::CuRef{Float16}, C::CuPtr{Float16},
                                                ldc::Cint, strideC::Clonglong,
                                                batchCount::Cint)::cublasStatus_t
+end
+
+@checked function cublasHgemmStridedBatched_64(handle, transa, transb, m, n, k, alpha, A, lda,
+                                               strideA, B, ldb, strideB, beta, C, ldc, strideC,
+                                               batchCount)
+    initialize_context()
+    @ccall libcublas.cublasHgemmStridedBatched_64(handle::cublasHandle_t,
+                                                  transa::cublasOperation_t,
+                                                  transb::cublasOperation_t, m::Int64, n::Int64,
+                                                  k::Int64, alpha::CuRef{Float16},
+                                                  A::CuPtr{Float16}, lda::Int64,
+                                                  strideA::Clonglong, B::CuPtr{Float16},
+                                                  ldb::Int64, strideB::Clonglong,
+                                                  beta::CuRef{Float16}, C::CuPtr{Float16},
+                                                  ldc::Int64, strideC::Clonglong,
+                                                  batchCount::Int64)::cublasStatus_t
 end

--- a/lib/cublas/wrappers.jl
+++ b/lib/cublas/wrappers.jl
@@ -400,8 +400,8 @@ for (fname, fname_64, elty) in ((:cublasSrotm_v2, :cublasSrotm_v2_64, :Float32),
 end
 
 ## rotmg
-for (fname, elty) in ((:cublasSrotmg_v2, :Float32),
-                      (:cublasDrotmg_v2, :Float64))
+for (fname, fname_64, elty) in ((:cublasSrotmg_v2, :cublasSrotmg_v2_64, :Float32),
+                                (:cublasDrotmg_v2, :cublasSrotmg_v2_64, :Float64))
     @eval begin
         function rotmg!(d1::$elty,
                         d2::$elty,
@@ -412,7 +412,11 @@ for (fname, elty) in ((:cublasSrotmg_v2, :Float32),
             ref_d2 = CuRef(d2)
             ref_x  = CuRef(x)
             ref_y  = CuRef(y)
-            $fname(handle(), ref_d1, ref_d2, ref_x, ref_y, param)
+            if CUBLAS.version() >= v"12.0"
+                $fname_64(handle(), ref_d1, ref_d2, ref_x, ref_y, param)
+            else
+                $fname(handle(), ref_d1, ref_d2, ref_x, ref_y, param)
+            end
             ref_d1[], ref_d2[], ref_x[], ref_y[], param
         end
     end
@@ -545,8 +549,8 @@ end
 for (fname, fname_64, eltyin, eltyout) in (
         (:cublasDgemvBatched, :cublasDgemvBatched_64, :Float64, :Float64),
         (:cublasSgemvBatched, :cublasSgemvBatched_64, :Float32, :Float32),
-        (:cublasHSHgemvBatched, :cublasHSHgemvBatched, :Float16, :Float16),
-        (:cublasHSSgemvBatched, :cublasHSSgemvBatched, :Float16, :Float32),
+        (:cublasHSHgemvBatched, :cublasHSHgemvBatched_64, :Float16, :Float16),
+        (:cublasHSSgemvBatched, :cublasHSSgemvBatched_64, :Float16, :Float32),
         (:cublasZgemvBatched, :cublasZgemvBatched_64, :ComplexF64, :ComplexF64),
         (:cublasCgemvBatched, :cublasCgemvBatched_64, :ComplexF32, :ComplexF32),
     )
@@ -594,8 +598,8 @@ end
 for (fname, fname_64, eltyin, eltyout) in (
         (:cublasDgemvStridedBatched, :cublasDgemvStridedBatched_64, :Float64, :Float64),
         (:cublasSgemvStridedBatched, :cublasSgemvStridedBatched_64, :Float32, :Float32),
-        (:cublasHSHgemvStridedBatched, :cublasHSHgemvStridedBatched, :Float16, :Float16),
-        (:cublasHSSgemvStridedBatched, :cublasHSSgemvStridedBatched, :Float16, :Float32),
+        (:cublasHSHgemvStridedBatched, :cublasHSHgemvStridedBatched_64, :Float16, :Float16),
+        (:cublasHSSgemvStridedBatched, :cublasHSSgemvStridedBatched_64, :Float16, :Float32),
         (:cublasZgemvStridedBatched, :cublasZgemvStridedBatched_64, :ComplexF64, :ComplexF64),
         (:cublasCgemvStridedBatched, :cublasCgemvStridedBatched_64, :ComplexF32, :ComplexF32),
     )
@@ -1116,7 +1120,7 @@ end
 ## (GE) general matrix-matrix multiplication
 for (fname, fname_64, elty) in ((:cublasDgemm_v2, :cublasDgemm_v2_64, :Float64),
                                 (:cublasSgemm_v2, :cublasSgemm_v2_64, :Float32),
-                                (:cublasHgemm, :cublasHgemm, :Float16),
+                                (:cublasHgemm, :cublasHgemm_64, :Float16),
                                 (:cublasZgemm_v2, :cublasZgemm_v2_64, :ComplexF64),
                                 (:cublasCgemm_v2, :cublasCgemm_v2_64, :ComplexF32))
     @eval begin
@@ -1527,7 +1531,7 @@ end
 ## (GE) general matrix-matrix multiplication batched
 for (fname, fname_64, elty) in ((:cublasDgemmBatched, :cublasDgemmBatched_64, :Float64),
                                 (:cublasSgemmBatched, :cublasSgemmBatched_64, :Float32),
-                                (:cublasHgemmBatched, :cublasHgemmBatched, :Float16),
+                                (:cublasHgemmBatched, :cublasHgemmBatched_64, :Float16),
                                 (:cublasZgemmBatched, :cublasZgemmBatched_64, :ComplexF64),
                                 (:cublasCgemmBatched, :cublasCgemmBatched_64, :ComplexF32))
     @eval begin
@@ -1594,7 +1598,7 @@ end
 ## (GE) general matrix-matrix multiplication strided batched
 for (fname, fname_64, elty) in ((:cublasDgemmStridedBatched, :cublasDgemmStridedBatched_64, :Float64),
                                 (:cublasSgemmStridedBatched, :cublasSgemmStridedBatched_64, :Float32),
-                                (:cublasHgemmStridedBatched, :cublasHgemmStridedBatched, :Float16),
+                                (:cublasHgemmStridedBatched, :cublasHgemmStridedBatched_64, :Float16),
                                 (:cublasZgemmStridedBatched, :cublasZgemmStridedBatched_64, :ComplexF64),
                                 (:cublasCgemmStridedBatched, :cublasCgemmStridedBatched_64, :ComplexF32))
     @eval begin
@@ -1945,11 +1949,11 @@ function her2k(uplo::Char, trans::Char,
 end
 
 ## (TR) Triangular matrix and vector multiplication and solution
-for (mmname, smname, elty) in
-        ((:cublasDtrmm_v2,:cublasDtrsm_v2,:Float64),
-         (:cublasStrmm_v2,:cublasStrsm_v2,:Float32),
-         (:cublasZtrmm_v2,:cublasZtrsm_v2,:ComplexF64),
-         (:cublasCtrmm_v2,:cublasCtrsm_v2,:ComplexF32))
+for (mmname, mmname_64, elty) in
+        ((:cublasDtrmm_v2, :cublasDtrmm_v2_64, :Float64),
+         (:cublasStrmm_v2, :cublasStrmm_v2_64, :Float32),
+         (:cublasZtrmm_v2, :cublasZtrmm_v2_64, :ComplexF64),
+         (:cublasCtrmm_v2, :cublasCtrmm_v2_64, :ComplexF32))
     @eval begin
         # Note: CUBLAS differs from BLAS API for trmm
         #   BLAS: inplace modification of B
@@ -1972,10 +1976,21 @@ for (mmname, smname, elty) in
             lda = max(1,stride(A,2))
             ldb = max(1,stride(B,2))
             ldc = max(1,stride(C,2))
-            $mmname(handle(), side, uplo, transa, diag, m, n, alpha, A, lda, B, ldb, C, ldc)
+            if CUBLAS.version() >= v"12.0"
+                $mmname_64(handle(), side, uplo, transa, diag, m, n, alpha, A, lda, B, ldb, C, ldc)
+            else
+                $mmname(handle(), side, uplo, transa, diag, m, n, alpha, A, lda, B, ldb, C, ldc)
+            end
             C
         end
+    end
+end
 
+for (smname, smname_64, elty) in
+        ((:cublasDtrsm_v2, :cublasDtrsm_v2_64, :Float64),
+         (:cublasStrsm_v2, :cublasStrsm_v2_64, :Float32),
+         (:cublasZtrsm_v2, :cublasZtrsm_v2_64, :ComplexF64),
+         (:cublasCtrsm_v2, :cublasCtrsm_v2_64, :ComplexF32))
         function trsm!(side::Char,
                        uplo::Char,
                        transa::Char,
@@ -1990,7 +2005,11 @@ for (mmname, smname, elty) in
             if nA != (side == 'L' ? m : n) throw(DimensionMismatch("trsm!")) end
             lda = max(1,stride(A,2))
             ldb = max(1,stride(B,2))
-            $smname(handle(), side, uplo, transa, diag, m, n, alpha, A, lda, B, ldb)
+            if CUBLAS.version() >= v"12.0"
+                $smname_64(handle(), side, uplo, transa, diag, m, n, alpha, A, lda, B, ldb)
+            else
+                $smname(handle(), side, uplo, transa, diag, m, n, alpha, A, lda, B, ldb)
+            end
             B
         end
     end

--- a/lib/cublas/wrappers.jl
+++ b/lib/cublas/wrappers.jl
@@ -1991,6 +1991,7 @@ for (smname, smname_64, elty) in
          (:cublasStrsm_v2, :cublasStrsm_v2_64, :Float32),
          (:cublasZtrsm_v2, :cublasZtrsm_v2_64, :ComplexF64),
          (:cublasCtrsm_v2, :cublasCtrsm_v2_64, :ComplexF32))
+    @eval begin
         function trsm!(side::Char,
                        uplo::Char,
                        transa::Char,

--- a/lib/cublas/wrappers.jl
+++ b/lib/cublas/wrappers.jl
@@ -400,8 +400,8 @@ for (fname, fname_64, elty) in ((:cublasSrotm_v2, :cublasSrotm_v2_64, :Float32),
 end
 
 ## rotmg
-for (fname, fname_64, elty) in ((:cublasSrotmg_v2, :cublasSrotmg_v2_64, :Float32),
-                                (:cublasDrotmg_v2, :cublasSrotmg_v2_64, :Float64))
+for (fname, elty) in ((:cublasSrotmg_v2, :Float32),
+                      (:cublasDrotmg_v2, :Float64))
     @eval begin
         function rotmg!(d1::$elty,
                         d2::$elty,
@@ -412,11 +412,7 @@ for (fname, fname_64, elty) in ((:cublasSrotmg_v2, :cublasSrotmg_v2_64, :Float32
             ref_d2 = CuRef(d2)
             ref_x  = CuRef(x)
             ref_y  = CuRef(y)
-            if CUBLAS.version() >= v"12.0"
-                $fname_64(handle(), ref_d1, ref_d2, ref_x, ref_y, param)
-            else
-                $fname(handle(), ref_d1, ref_d2, ref_x, ref_y, param)
-            end
+            $fname(handle(), ref_d1, ref_d2, ref_x, ref_y, param)
             ref_d1[], ref_d2[], ref_x[], ref_y[], param
         end
     end

--- a/res/wrap/libcublas_epilogue.jl
+++ b/res/wrap/libcublas_epilogue.jl
@@ -11,6 +11,17 @@
                                           incy::Cint, batchCount::Cint)::cublasStatus_t
 end
 
+@checked function cublasHSHgemvBatched_64(handle, trans, m, n, alpha, Aarray, lda, xarray,
+                                          incx, beta, yarray, incy, batchCount)
+    initialize_context()
+    @ccall libcublas.cublasHSHgemvBatched_64(handle::cublasHandle_t, trans::cublasOperation_t,
+                                             m::Int64, n::Int64, alpha::CuRef{Cfloat},
+                                             Aarray::CuPtr{Ptr{Float16}}, lda::Int64,
+                                             xarray::CuPtr{Ptr{Float16}}, incx::Int64,
+                                             beta::CuRef{Cfloat}, yarray::CuPtr{Ptr{Float16}},
+                                             incy::Int64, batchCount::Int64)::cublasStatus_t
+end
+
 @checked function cublasHSSgemvBatched(handle, trans, m, n, alpha, Aarray, lda, xarray,
                                        incx, beta, yarray, incy, batchCount)
     initialize_context()
@@ -20,6 +31,17 @@ end
                                           xarray::CuPtr{Ptr{Float16}}, incx::Cint,
                                           beta::CuRef{Cfloat}, yarray::CuPtr{Ptr{Cfloat}},
                                           incy::Cint, batchCount::Cint)::cublasStatus_t
+end
+
+@checked function cublasHSSgemvBatched_64(handle, trans, m, n, alpha, Aarray, lda, xarray,
+                                          incx, beta, yarray, incy, batchCount)
+    initialize_context()
+    @ccall libcublas.cublasHSSgemvBatched_64(handle::cublasHandle_t, trans::cublasOperation_t,
+                                             m::Int64, n::Int64, alpha::CuRef{Cfloat},
+                                             Aarray::CuPtr{Ptr{Float16}}, lda::Int64,
+                                             xarray::CuPtr{Ptr{Float16}}, incx::Int64,
+                                             beta::CuRef{Cfloat}, yarray::CuPtr{Ptr{Cfloat}},
+                                             incy::Int64, batchCount::Int64)::cublasStatus_t
 end
 
 @checked function cublasTSTgemvBatched(handle, trans, m, n, alpha, Aarray, lda, xarray,
@@ -33,6 +55,17 @@ end
                                           incy::Cint, batchCount::Cint)::cublasStatus_t
 end
 
+@checked function cublasTSTgemvBatched_64(handle, trans, m, n, alpha, Aarray, lda, xarray,
+                                          incx, beta, yarray, incy, batchCount)
+    initialize_context()
+    @ccall libcublas.cublasTSTgemvBatched_64(handle::cublasHandle_t, trans::cublasOperation_t,
+                                             m::Int64, n::Int64, alpha::Ptr{Cfloat},
+                                             Aarray::Ptr{Ptr{BFloat16}}, lda::Int64,
+                                             xarray::Ptr{Ptr{BFloat16}}, incx::Int64,
+                                             beta::Ptr{Cfloat}, yarray::Ptr{Ptr{BFloat16}},
+                                             incy::Int64, batchCount::Int64)::cublasStatus_t
+end
+
 @checked function cublasTSSgemvBatched(handle, trans, m, n, alpha, Aarray, lda, xarray,
                                        incx, beta, yarray, incy, batchCount)
     initialize_context()
@@ -42,6 +75,17 @@ end
                                           xarray::Ptr{Ptr{BFloat16}}, incx::Cint,
                                           beta::Ptr{Cfloat}, yarray::Ptr{Ptr{Cfloat}},
                                           incy::Cint, batchCount::Cint)::cublasStatus_t
+end
+
+@checked function cublasTSSgemvBatched_64(handle, trans, m, n, alpha, Aarray, lda, xarray,
+                                          incx, beta, yarray, incy, batchCount)
+    initialize_context()
+    @ccall libcublas.cublasTSSgemvBatched_64(handle::cublasHandle_t, trans::cublasOperation_t,
+                                             m::Int64, n::Int64, alpha::Ptr{Cfloat},
+                                             Aarray::Ptr{Ptr{BFloat16}}, lda::Int64,
+                                             xarray::Ptr{Ptr{BFloat16}}, incx::Int64,
+                                             beta::Ptr{Cfloat}, yarray::Ptr{Ptr{Cfloat}},
+                                             incy::Int64, batchCount::Int64)::cublasStatus_t
 end
 
 @checked function cublasHSHgemvStridedBatched(handle, trans, m, n, alpha, A, lda, strideA,
@@ -59,6 +103,21 @@ end
                                                  batchCount::Cint)::cublasStatus_t
 end
 
+@checked function cublasHSHgemvStridedBatched_64(handle, trans, m, n, alpha, A, lda, strideA,
+                                                 x, incx, stridex, beta, y, incy, stridey,
+                                                 batchCount)
+    initialize_context()
+    @ccall libcublas.cublasHSHgemvStridedBatched_64(handle::cublasHandle_t,
+                                                    trans::cublasOperation_t, m::Int64, n::Int64,
+                                                    alpha::CuRef{Cfloat}, A::CuPtr{Float16},
+                                                    lda::Int64, strideA::Clonglong,
+                                                    x::CuPtr{Float16}, incx::Int64,
+                                                    stridex::Clonglong, beta::CuRef{Cfloat},
+                                                    y::CuPtr{Float16}, incy::Int64,
+                                                    stridey::Clonglong,
+                                                    batchCount::Int64)::cublasStatus_t
+end
+
 @checked function cublasHSSgemvStridedBatched(handle, trans, m, n, alpha, A, lda, strideA,
                                               x, incx, stridex, beta, y, incy, stridey,
                                               batchCount)
@@ -72,6 +131,21 @@ end
                                                  y::CuPtr{Cfloat}, incy::Cint,
                                                  stridey::Clonglong,
                                                  batchCount::Cint)::cublasStatus_t
+end
+
+@checked function cublasHSSgemvStridedBatched_64(handle, trans, m, n, alpha, A, lda, strideA,
+                                                 x, incx, stridex, beta, y, incy, stridey,
+                                                 batchCount)
+    initialize_context()
+    @ccall libcublas.cublasHSSgemvStridedBatched_64(handle::cublasHandle_t,
+                                                    trans::cublasOperation_t, m::Int64, n::Int64,
+                                                    alpha::CuRef{Cfloat}, A::CuPtr{Float16},
+                                                    lda::Int64, strideA::Clonglong,
+                                                    x::CuPtr{Float16}, incx::Int64,
+                                                    stridex::Clonglong, beta::CuRef{Cfloat},
+                                                    y::CuPtr{Cfloat}, incy::Int64,
+                                                    stridey::Clonglong,
+                                                    batchCount::Int64)::cublasStatus_t
 end
 
 @checked function cublasTSTgemvStridedBatched(handle, trans, m, n, alpha, A, lda, strideA,
@@ -89,6 +163,21 @@ end
                                                  batchCount::Cint)::cublasStatus_t
 end
 
+@checked function cublasTSTgemvStridedBatched_64(handle, trans, m, n, alpha, A, lda, strideA,
+                                                 x, incx, stridex, beta, y, incy, stridey,
+                                                 batchCount)
+    initialize_context()
+    @ccall libcublas.cublasTSTgemvStridedBatched_64(handle::cublasHandle_t,
+                                                    trans::cublasOperation_t, m::Int64, n::Int64,
+                                                    alpha::CuRef{Cfloat}, A::CuPtr{BFloat16},
+                                                    lda::Int64, strideA::Clonglong,
+                                                    x::CuPtr{BFloat16}, incx::Int64,
+                                                    stridex::Clonglong, beta::CuRef{Cfloat},
+                                                    y::CuPtr{BFloat16}, incy::Int64,
+                                                    stridey::Clonglong,
+                                                    batchCount::Int64)::cublasStatus_t
+end
+
 @checked function cublasTSSgemvStridedBatched(handle, trans, m, n, alpha, A, lda, strideA,
                                               x, incx, stridex, beta, y, incy, stridey,
                                               batchCount)
@@ -104,6 +193,21 @@ end
                                                  batchCount::Cint)::cublasStatus_t
 end
 
+@checked function cublasTSSgemvStridedBatched_64(handle, trans, m, n, alpha, A, lda, strideA,
+                                                 x, incx, stridex, beta, y, incy, stridey,
+                                                 batchCount)
+    initialize_context()
+    @ccall libcublas.cublasTSSgemvStridedBatched_64(handle::cublasHandle_t,
+                                                    trans::cublasOperation_t, m::Int64, n::Int64,
+                                                    alpha::CuRef{Cfloat}, A::CuPtr{BFloat16},
+                                                    lda::Int64, strideA::Clonglong,
+                                                    x::CuPtr{BFloat16}, incx::Int64,
+                                                    stridex::Clonglong, beta::CuRef{Cfloat},
+                                                    y::CuPtr{Cfloat}, incy::Int64,
+                                                    stridey::Clonglong,
+                                                    batchCount::Int64)::cublasStatus_t
+end
+
 @checked function cublasHgemm(handle, transa, transb, m, n, k, alpha, A, lda, B, ldb, beta,
                               C, ldc)
     initialize_context()
@@ -112,6 +216,16 @@ end
                                  alpha::Ptr{Float16}, A::Ptr{Float16}, lda::Cint,
                                  B::Ptr{Float16}, ldb::Cint, beta::Ptr{Float16},
                                  C::Ptr{Float16}, ldc::Cint)::cublasStatus_t
+end
+
+@checked function cublasHgemm_64(handle, transa, transb, m, n, k, alpha, A, lda, B, ldb, beta,
+                                 C, ldc)
+    initialize_context()
+    @ccall libcublas.cublasHgemm_64(handle::cublasHandle_t, transa::cublasOperation_t,
+                                    transb::cublasOperation_t, m::Int64, n::Int64, k::Int64,
+                                    alpha::Ptr{Float16}, A::Ptr{Float16}, lda::Int64,
+                                    B::Ptr{Float16}, ldb::Int64, beta::Ptr{Float16},
+                                    C::Ptr{Float16}, ldc::Int64)::cublasStatus_t
 end
 
 @checked function cublasHgemmBatched(handle, transa, transb, m, n, k, alpha, Aarray, lda,
@@ -125,6 +239,19 @@ end
                                         beta::CuRef{Float16},
                                         Carray::CuPtr{Ptr{Float16}}, ldc::Cint,
                                         batchCount::Cint)::cublasStatus_t
+end
+
+@checked function cublasHgemmBatched_64(handle, transa, transb, m, n, k, alpha, Aarray, lda,
+                                        Barray, ldb, beta, Carray, ldc, batchCount)
+    initialize_context()
+    @ccall libcublas.cublasHgemmBatched_64(handle::cublasHandle_t, transa::cublasOperation_t,
+                                           transb::cublasOperation_t, m::Int64, n::Int64,
+                                           k::Int64, alpha::CuRef{Float16},
+                                           Aarray::CuPtr{Ptr{Float16}}, lda::Int64,
+                                           Barray::CuPtr{Ptr{Float16}}, ldb::Int64,
+                                           beta::CuRef{Float16},
+                                           Carray::CuPtr{Ptr{Float16}}, ldc::Int64,
+                                           batchCount::Int64)::cublasStatus_t
 end
 
 @checked function cublasHgemmStridedBatched(handle, transa, transb, m, n, k, alpha, A, lda,
@@ -141,4 +268,20 @@ end
                                                beta::CuRef{Float16}, C::CuPtr{Float16},
                                                ldc::Cint, strideC::Clonglong,
                                                batchCount::Cint)::cublasStatus_t
+end
+
+@checked function cublasHgemmStridedBatched_64(handle, transa, transb, m, n, k, alpha, A, lda,
+                                               strideA, B, ldb, strideB, beta, C, ldc, strideC,
+                                               batchCount)
+    initialize_context()
+    @ccall libcublas.cublasHgemmStridedBatched_64(handle::cublasHandle_t,
+                                                  transa::cublasOperation_t,
+                                                  transb::cublasOperation_t, m::Int64, n::Int64,
+                                                  k::Int64, alpha::CuRef{Float16},
+                                                  A::CuPtr{Float16}, lda::Int64,
+                                                  strideA::Clonglong, B::CuPtr{Float16},
+                                                  ldb::Int64, strideB::Clonglong,
+                                                  beta::CuRef{Float16}, C::CuPtr{Float16},
+                                                  ldc::Int64, strideC::Clonglong,
+                                                  batchCount::Int64)::cublasStatus_t
 end


### PR DESCRIPTION
I checked the symbols with `nm -D .../libcusolver.so` and it seems that they are in the library.