### PR TITLE
Let cuQuantum soft fail on CI

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -99,9 +99,12 @@ steps:
               - "cuTensorNet"
           adjustments:
             - with:
-              package:
-                - "cuStateVec"
-                - "cuTensorNet"
+                package: "cuStateVec"
+                cuda: "12.0"
+              soft_fail: true
+            - with:
+                package: "cuTensorNet"
+                cuda: "12.0"
               soft_fail: true
         plugins:
           - JuliaCI/julia#v1:

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -97,6 +97,12 @@ steps:
               - "cuTENSOR"
               - "cuStateVec"
               - "cuTensorNet"
+        adjustments:
+            - with:
+                package:
+                  - "cuStateVec"
+                  - "cuTensorNet"
+              soft_fail: true
         plugins:
           - JuliaCI/julia#v1:
               version: "1.10"

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -97,11 +97,11 @@ steps:
               - "cuTENSOR"
               - "cuStateVec"
               - "cuTensorNet"
-        adjustments:
+          adjustments:
             - with:
-                package:
-                  - "cuStateVec"
-                  - "cuTensorNet"
+              package:
+                - "cuStateVec"
+                - "cuTensorNet"
               soft_fail: true
         plugins:
           - JuliaCI/julia#v1:


### PR DESCRIPTION
There isn't yet a cuQuantum release that works with the CUDA 13 driver yet, so these tests will always fail for now.

[only subpackages]