### PR TITLE
Add compatibility entry for B200 and other GPUs

### DIFF
--- a/src/compatibility.jl
+++ b/src/compatibility.jl
@@ -56,6 +56,9 @@ const cuda_cap_db = Dict(
     v"8.7"   => between(v"11.4", highest),
     v"8.9"   => between(v"11.8", highest),
     v"9.0"   => between(v"11.8", highest),
+    v"10.0"  => between(v"12.8", highest),
+    v"10.3"  => between(v"12.8", highest),
+    v"11.0"  => between(v"12.8", highest),
     v"12.0"  => between(v"12.8", highest),
     v"12.1"  => between(v"12.9", highest),
 )


### PR DESCRIPTION
Without this PR I get
```julia-repl
julia> CUDA.capability(CUDA.device())
┌ Warning: Your NVIDIA B200 GPU (compute capability 10.0) is not fully supported by CUDA 12.8.0.
│ Some functionality may be broken. Ensure you are using the latest version of CUDA.jl in combination with an up-to-date NVIDIA driver.
│ If that does not help, please file an issue to add support for the latest CUDA toolkit.
└ @ CUDA ~/.julia/packages/CUDA/p6Klo/lib/cudadrv/state.jl:236
v"10.0.0"
```
With this PR:
```julia-repl
julia> using CUDA

julia> CUDA.capability(CUDA.device())
v"10.0.0"

julia> CUDA.device()
CuDevice(0): NVIDIA B200
```
The warning is gone.  Also, without this PR I was getting the same errors as in https://github.com/JuliaGPU/CUDA.jl/issues/2714#issue-2940881811, with this PR the test passes.