### PR TITLE
explicitly qualify Base constructors.

### DIFF
--- a/lib/cusolver/linalg.jl
+++ b/lib/cusolver/linalg.jl
@@ -143,10 +143,10 @@ using LinearAlgebra: Factorization, AbstractQ, QRCompactWY, QRCompactWYQ, QRPack
 LinearAlgebra.qr!(A::CuMatrix{T}) where T = QR(geqrf!(A::CuMatrix{T})...)
 
 # conversions
-CuMatrix(F::Union{QR,QRCompactWY}) = CuArray(AbstractArray(F))
-CuArray(F::Union{QR,QRCompactWY}) = CuMatrix(F)
-CuMatrix(F::QRPivoted) = CuArray(AbstractArray(F))
-CuArray(F::QRPivoted) = CuMatrix(F)
+CUDA.CuMatrix(F::Union{QR,QRCompactWY}) = CuArray(AbstractArray(F))
+CUDA.CuArray(F::Union{QR,QRCompactWY}) = CuMatrix(F)
+CUDA.CuMatrix(F::QRPivoted) = CuArray(AbstractArray(F))
+CUDA.CuArray(F::QRPivoted) = CuMatrix(F)
 
 function LinearAlgebra.ldiv!(_qr::QR, b::CuVector)
     m,n = size(_qr)
@@ -174,16 +174,16 @@ end
 # AbstractQ's `size` is the size of the full matrix,
 # while `Matrix(Q)` only gives the compact Q.
 # See JuliaLang/julia#26591 and JuliaGPU/CUDA.jl#969.
-CuArray(Q::AbstractQ) = CuMatrix(Q)
-CuArray{T}(Q::AbstractQ) where {T} = CuMatrix{T}(Q)
-CuMatrix(Q::AbstractQ{T}) where {T} = CuMatrix{T}(Q)
-CuMatrix{T}(Q::QRPackedQ{S}) where {T,S} =
+CUDA.CuArray(Q::AbstractQ) = CuMatrix(Q)
+CUDA.CuArray{T}(Q::AbstractQ) where {T} = CuMatrix{T}(Q)
+CUDA.CuMatrix(Q::AbstractQ{T}) where {T} = CuMatrix{T}(Q)
+CUDA.CuMatrix{T}(Q::QRPackedQ{S}) where {T,S} =
     CuMatrix{T}(lmul!(Q, CuMatrix{S}(I, size(Q, 1), min(size(Q.factors)...))))
-CuMatrix{T, B}(Q::QRPackedQ{S}) where {T, B, S} = CuMatrix{T}(Q)
-CuMatrix{T}(Q::QRCompactWYQ) where {T} = error("QRCompactWY format is not supported")
+CUDA.CuMatrix{T, B}(Q::QRPackedQ{S}) where {T, B, S} = CuMatrix{T}(Q)
+CUDA.CuMatrix{T}(Q::QRCompactWYQ) where {T} = error("QRCompactWY format is not supported")
 # avoid the CPU array in the above mul!
-Matrix{T}(Q::QRPackedQ{S,<:CuArray,<:CuArray}) where {T,S} = Array(CuMatrix{T}(Q))
-Matrix{T}(Q::QRCompactWYQ{S,<:CuArray,<:CuArray}) where {T,S} = Array(CuMatrix{T}(Q))
+Base.Matrix{T}(Q::QRPackedQ{S,<:CuArray,<:CuArray}) where {T,S} = Array(CuMatrix{T}(Q))
+Base.Matrix{T}(Q::QRCompactWYQ{S,<:CuArray,<:CuArray}) where {T,S} = Array(CuMatrix{T}(Q))
 
 function Base.getindex(Q::QRPackedQ{<:Any, <:CuArray}, ::Colon, j::Int)
     y = CUDA.zeros(eltype(Q), size(Q, 2))

--- a/lib/cusparse/array.jl
+++ b/lib/cusparse/array.jl
@@ -570,11 +570,11 @@ CuSparseMatrixCSC(x::Adjoint{T,<:Union{CuSparseMatrixCSC, CuSparseMatrixCSR, CuS
 CuSparseMatrixCOO(x::Adjoint{T,<:Union{CuSparseMatrixCSC, CuSparseMatrixCSR, CuSparseMatrixCOO}}) where {T} = CuSparseMatrixCOO(_spadjoint(parent(x)))
 
 # gpu to cpu
-SparseVector(x::CuSparseVector) = SparseVector(length(x), Array(nonzeroinds(x)), Array(nonzeros(x)))
-SparseMatrixCSC(x::CuSparseMatrixCSC) = SparseMatrixCSC(size(x)..., Array(x.colPtr), Array(rowvals(x)), Array(nonzeros(x)))
-SparseMatrixCSC(x::CuSparseMatrixCSR) = SparseMatrixCSC(CuSparseMatrixCSC(x))  # no direct conversion (gpu_CSR -> gpu_CSC -> cpu_CSC)
-SparseMatrixCSC(x::CuSparseMatrixBSR) = SparseMatrixCSC(CuSparseMatrixCSR(x))  # no direct conversion (gpu_BSR -> gpu_CSR -> gpu_CSC -> cpu_CSC)
-SparseMatrixCSC(x::CuSparseMatrixCOO) = SparseMatrixCSC(CuSparseMatrixCSC(x))  # no direct conversion (gpu_COO -> gpu_CSC -> cpu_CSC)
+SparseArrays.SparseVector(x::CuSparseVector) = SparseVector(length(x), Array(nonzeroinds(x)), Array(nonzeros(x)))
+SparseArrays.SparseMatrixCSC(x::CuSparseMatrixCSC) = SparseMatrixCSC(size(x)..., Array(x.colPtr), Array(rowvals(x)), Array(nonzeros(x)))
+SparseArrays.SparseMatrixCSC(x::CuSparseMatrixCSR) = SparseMatrixCSC(CuSparseMatrixCSC(x))  # no direct conversion (gpu_CSR -> gpu_CSC -> cpu_CSC)
+SparseArrays.SparseMatrixCSC(x::CuSparseMatrixBSR) = SparseMatrixCSC(CuSparseMatrixCSR(x))  # no direct conversion (gpu_BSR -> gpu_CSR -> gpu_CSC -> cpu_CSC)
+SparseArrays.SparseMatrixCSC(x::CuSparseMatrixCOO) = SparseMatrixCSC(CuSparseMatrixCSC(x))  # no direct conversion (gpu_COO -> gpu_CSC -> cpu_CSC)
 
 # collect to Array
 Base.collect(x::CuSparseVector) = collect(SparseVector(x))

--- a/lib/cusparse/conversions.jl
+++ b/lib/cusparse/conversions.jl
@@ -472,9 +472,9 @@ for (elty, felty) in ((:Int16, :Float16),
 end
 
 ## CuSparseVector to CuVector
-CuVector(x::CuSparseVector{T}) where {T} = CuVector{T}(x)
+CUDA.CuVector(x::CuSparseVector{T}) where {T} = CuVector{T}(x)
 
-function CuVector{T}(sv::CuSparseVector{T}) where {T}
+function CUDA.CuVector{T}(sv::CuSparseVector{T}) where {T}
     n = length(sv)
     dv = CUDA.zeros(T, n)
     scatter!(dv, sv, 'O')

--- a/src/broadcast.jl
+++ b/src/broadcast.jl
@@ -6,18 +6,18 @@ struct CuArrayStyle{N,B} <: AbstractGPUArrayStyle{N} end
 CuArrayStyle{M,B}(::Val{N}) where {N,M,B} = CuArrayStyle{N,B}()
 
 # identify the broadcast style of a (wrapped) CuArray
-BroadcastStyle(::Type{<:CuArray{T,N,B}}) where {T,N,B} = CuArrayStyle{N,B}()
-BroadcastStyle(W::Type{<:AnyCuArray{T,N}}) where {T,N} =
+Broadcast.BroadcastStyle(::Type{<:CuArray{T,N,B}}) where {T,N,B} = CuArrayStyle{N,B}()
+Broadcast.BroadcastStyle(W::Type{<:AnyCuArray{T,N}}) where {T,N} =
     CuArrayStyle{N, memory_type(Adapt.unwrap_type(W))}()
 
 # when we are dealing with different memory types, we cannot know
 # which one is better, so use unified memory
-BroadcastStyle(::CUDA.CuArrayStyle{N1, B1},
+Broadcast.BroadcastStyle(::CUDA.CuArrayStyle{N1, B1},
                ::CUDA.CuArrayStyle{N2, B2}) where {N1,N2,B1,B2} =
     CuArrayStyle{max(N1,N2), UnifiedMemory}()
 
 # resolve ambiguity: different N, same memory type
-BroadcastStyle(::CUDA.CuArrayStyle{N1, B},
+Broadcast.BroadcastStyle(::CUDA.CuArrayStyle{N1, B},
                ::CUDA.CuArrayStyle{N2, B}) where {N1,N2,B} =
     CuArrayStyle{max(N1,N2), B}()
 

--- a/src/pointer.jl
+++ b/src/pointer.jl
@@ -42,8 +42,8 @@ Base.eltype(::Type{<:CuPtr{T}}) where {T} = T
 Base.convert(::Type{T}, x::CuPtr) where {T<:Integer} = T(UInt(x))
 ## integer to pointer
 Base.convert(::Type{CuPtr{T}}, x::Union{Int,UInt}) where {T} = CuPtr{T}(x)
-Int(x::CuPtr)  = Base.bitcast(Int, x)
-UInt(x::CuPtr) = Base.bitcast(UInt, x)
+Base.Int(x::CuPtr)  = Base.bitcast(Int, x)
+Base.UInt(x::CuPtr) = Base.bitcast(UInt, x)
 
 # between regular and CUDA pointers
 Base.convert(::Type{<:Ptr}, p::CuPtr) =
@@ -167,8 +167,8 @@ Base.eltype(::Type{<:CuArrayPtr{T}}) where {T} = T
 Base.convert(::Type{T}, x::CuArrayPtr) where {T<:Integer} = T(UInt(x))
 ## integer to pointer
 Base.convert(::Type{CuArrayPtr{T}}, x::Union{Int,UInt}) where {T} = CuArrayPtr{T}(x)
-Int(x::CuArrayPtr)  = Base.bitcast(Int, x)
-UInt(x::CuArrayPtr) = Base.bitcast(UInt, x)
+Base.Int(x::CuArrayPtr)  = Base.bitcast(Int, x)
+Base.UInt(x::CuArrayPtr) = Base.bitcast(UInt, x)
 
 # between regular and CUDA pointers
 Base.convert(::Type{<:Ptr}, p::CuArrayPtr) =


### PR DESCRIPTION
1.12 now warns about these.