### PR TITLE
Change `device!` function parameter type from `Int32` to `Int`

### DIFF
--- a/src/CUDAKernels.jl
+++ b/src/CUDAKernels.jl
@@ -65,7 +65,7 @@ function KA.device(::CUDABackend)::Int
 end
 
 function KA.device!(backend::CUDABackend, id::Int)
-    if !(0 < id <= ndevices(backend))
+    if !(0 < id <= KA.ndevices(backend))
         throw(ArgumentError("Device id $id out of bounds."))
     end
     device!(id - 1)

--- a/src/CUDAKernels.jl
+++ b/src/CUDAKernels.jl
@@ -65,6 +65,9 @@ function KA.device(::CUDABackend)::Int
 end
 
 function KA.device!(::CUDABackend, id::Int)
+    if !(0 < id <= ndevices(backend))
+        throw(ArgumentError("Device id $id out of bounds."))
+    end
     device!(id - 1)
 end
 

--- a/src/CUDAKernels.jl
+++ b/src/CUDAKernels.jl
@@ -64,7 +64,7 @@ function KA.device(::CUDABackend)
     deviceid(CUDA.active_state().device) + 1
 end
 
-function KA.device!(::CUDABackend, id::Int32)
+function KA.device!(::CUDABackend, id::Int)
     device!(id - 1)
 end
 

--- a/src/CUDAKernels.jl
+++ b/src/CUDAKernels.jl
@@ -64,7 +64,7 @@ function KA.device(::CUDABackend)::Int
     deviceid(CUDA.active_state().device) + 1
 end
 
-function KA.device!(::CUDABackend, id::Int)
+function KA.device!(backend::CUDABackend, id::Int)
     if !(0 < id <= ndevices(backend))
         throw(ArgumentError("Device id $id out of bounds."))
     end

--- a/src/CUDAKernels.jl
+++ b/src/CUDAKernels.jl
@@ -57,7 +57,7 @@ end
 ## device operations
 
 function KA.ndevices(::CUDABackend)
-    return ndevices()
+    return Int(ndevices())
 end
 
 function KA.device(::CUDABackend)

--- a/src/CUDAKernels.jl
+++ b/src/CUDAKernels.jl
@@ -60,7 +60,7 @@ function KA.ndevices(::CUDABackend)
     return Int(ndevices())
 end
 
-function KA.device(::CUDABackend)
+function KA.device(::CUDABackend)::Int
     deviceid(CUDA.active_state().device) + 1
 end
 


### PR DESCRIPTION
Following the discussion in https://github.com/JuliaGPU/KernelAbstractions.jl/issues/636,
this PR aligns the type parameter of the `device!` function for `CUDABackend`s to the one required in 
https://github.com/JuliaGPU/KernelAbstractions.jl/blob/1ac546fc59cc611d749fa7a50e4a1efa3393851b/src/KernelAbstractions.jl#L622