### PR TITLE
Increase test timeout

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -33,7 +33,7 @@ steps:
           build.message !~ /\[only/ &&
             build.message !~ /\[skip tests\]/ &&
             build.message !~ /\[skip julia\]/
-        timeout_in_minutes: 60
+        timeout_in_minutes: 90
         matrix:
           setup:
             julia:


### PR DESCRIPTION
1.11 seems to either timeout or be [on the cusp](https://buildkite.com/julialang/cuda-dot-jl/builds/6487/steps/canvas?jid=01999f78-77a9-4316-a149-919e99fe13bd) of timing out.