### PR TITLE
Fix copying between Symmetric and Hermitian matrices.

### DIFF
--- a/lib/cusolver/linalg.jl
+++ b/lib/cusolver/linalg.jl
@@ -110,6 +110,13 @@ function Base.:\(F::Union{LinearAlgebra.LAPACKFactorizations{<:Any,<:CuArray},
     return LinearAlgebra._cut_B(BB, 1:n)
 end
 
+# make copyto! for Hermitian and Symmetric dispatch to the Base implementation
+# instead of being overridden by GPUArrays' dense copy (because of AnyGPUArray)
+Base.copyto!(dst::Symmetric{<:Any,<:CuMatrix}, src::Symmetric{<:Any,<:CuMatrix}) =
+    @invoke copyto!(dst::Symmetric, src::Symmetric)
+Base.copyto!(dst::Hermitian{<:Any,<:CuMatrix}, src::Hermitian{<:Any,<:CuMatrix}) =
+    @invoke copyto!(dst::Hermitian, src::Hermitian)
+
 # eigenvalues
 
 function LinearAlgebra.eigen(A::Symmetric{T,<:CuMatrix}) where {T<:BlasReal}


### PR DESCRIPTION
We shouldn't perform a dense copy, which we started dispatching to after the Adapt.jl Union now lists Hermitian as well (Symmetric had been broken before).

Fixes #2912 
Ref https://github.com/JuliaGPU/Adapt.jl/pull/95 (cc @kshyatt)