### PR TITLE
Change input and output strides to use Int64

### DIFF
--- a/lib/cutensornet/src/types.jl
+++ b/lib/cutensornet/src/types.jl
@@ -110,12 +110,12 @@ mutable struct CuTensorNetwork{T}
     desc::CuTensorNetworkDescriptor
     input_modes::Vector{Vector{Int32}}
     input_extents::Vector{Vector{Int32}}
-    input_strides::Vector{<:Union{Ptr{Nothing}, Vector{Int32}}}
+    input_strides::Vector{<:Union{Ptr{Nothing}, Vector{Int64}}}
     input_qualifiers::Vector{cutensornetTensorQualifiers_t}
     input_arrs::Vector{CuArray{T}}
     output_modes::Vector{Int32}
     output_extents::Vector{Int32}
-    output_strides::Union{Ptr{Nothing}, Vector{Int32}}
+    output_strides::Union{Ptr{Nothing}, Vector{Int64}}
     output_arr::CuArray{T}
 end
 function CuTensorNetwork(T::DataType, input_modes, input_extents, input_strides, input_qualifiers, output_modes, output_extents, output_strides)


### PR DESCRIPTION
I think `cutensornetCreateNetworkDescriptor` expects `Int64` as strides.

Meaning, when constructing a `CuTensorNetwork` with non `C_NULL` input or output strides, the type of the strides needs to be `Int64`, however this cannot be stored in `CuTensorNetwork` at the moment.