### PR TITLE
Unbreak cusolver test on 1.12

### DIFF
--- a/test/libraries/cusolver/dense.jl
+++ b/test/libraries/cusolver/dense.jl
@@ -148,8 +148,8 @@ k = 1
             A = diag == 'N' ? A : A - Diagonal(A) + I
             dA = triangle(view(CuArray(A), 1:2:n, 1:2:n)) # without this view, we are hitting the CUBLAS method!
             dA⁻¹ = inv(dA)
-            dI = CuArray(dA) * CuArray(dA⁻¹)
-            @test Array(dI) ≈ I
+            hI = triangle(Array(parent(dA))) * Array(parent(dA⁻¹))
+            @test hI ≈ I
         end
     end
 


### PR DESCRIPTION
The root cause of this was that the copy of a `LowerTriangular{Float64, SubArray{Float64, 2, CuArray{Float64, 2, CUDA.DeviceMemory}, Tuple{StepRange{Int64, Int64}, StepRange{Int64, Int64}}, false}}` to a full `CuArray` goes through https://github.com/JuliaGPU/CUDA.jl/blob/master/src/array.jl#L436 which involves a copy to CPU. Rather than writing a whole specialized method right now, this is a workaround.