### PR TITLE
cuSPARSE: Interface generic mv! for SparseMatrixBSR

### DIFF
--- a/lib/cusparse/src/generic.jl
+++ b/lib/cusparse/src/generic.jl
@@ -230,8 +230,10 @@ function vv!(transx::SparseChar, X::CuSparseVector{T}, Y::DenseCuVector{T}, inde
     return result[]
 end
 
-function mv!(transa::SparseChar, alpha::Number, A::Union{CuSparseMatrixCSC{TA},CuSparseMatrixCSR{TA},CuSparseMatrixCOO{TA}}, X::DenseCuVector{T},
+function mv!(transa::SparseChar, alpha::Number, A::CuSparseMatrix{TA}, X::DenseCuVector{T},
              beta::Number, Y::DenseCuVector{T}, index::SparseChar, algo::cusparseSpMVAlg_t=CUSPARSE_SPMV_ALG_DEFAULT) where {TA, T}
+
+    (A isa CuSparseMatrixBSR) && (cuSPARSE.version() < v"12.6.3") && throw(ErrorException("This operation is not supported by the current CUDA version."))
 
     # Support transa = 'C' for real matrices
     transa = T <: Real && transa == 'C' ? 'T' : transa
@@ -309,11 +311,8 @@ function mm!(transa::SparseChar, transb::SparseChar, alpha::Number, A::CuSparseM
         return out[]
     end
     with_workspace(bufferSize) do buffer
-        # Uncomment if we find a way to reuse the buffer (issue #1362)
-        # cusparseSpMM_preprocess(
-        #     handle(), transa, transb, Ref{T}(alpha), descA, descB, Ref{T}(beta),
-        #     descC, T, algo, buffer)
-        # end
+        # `cusparseSpMM_preprocess` is skipped: we recreate descriptors and
+        # buffers each call, so there is no buffer to reuse (see issue #1362).
         cusparseSpMM(
             handle(), transa, transb, Ref{T}(alpha), descA, descB, Ref{T}(beta),
             descC, T, algo, buffer)
@@ -404,12 +403,8 @@ function bmm!(transa::SparseChar, transb::SparseChar, alpha::Number, A::CuSparse
         return out[]
     end
     with_workspace(bufferSize) do buffer
-        # We should find a way to reuse the buffer (issue #1362)
-        if !(A isa CuSparseMatrixCOO)
-            cusparseSpMM_preprocess(
-                handle(), transa, transb, Ref{T}(alpha), descA, descB, Ref{T}(beta),
-                descC, T, algo, buffer)
-        end
+        # `cusparseSpMM_preprocess` is skipped: we recreate descriptors and
+        # buffers each call, so there is no buffer to reuse (see issue #1362).
         cusparseSpMM(
             handle(), transa, transb, Ref{T}(alpha), descA, descB, Ref{T}(beta),
             descC, T, algo, buffer)

--- a/lib/cusparse/src/level2.jl
+++ b/lib/cusparse/src/level2.jl
@@ -1,20 +1,20 @@
 # sparse linear algebra functions that perform operations between sparse matrices and dense
 # vectors
 
-export sv2!, sv2, gemvi!
+export sv2!, sv2, mv2!, gemvi!
 
 for (fname,elty) in ((:cusparseSbsrmv, :Float32),
                      (:cusparseDbsrmv, :Float64),
                      (:cusparseCbsrmv, :ComplexF32),
                      (:cusparseZbsrmv, :ComplexF64))
     @eval begin
-        function mv!(transa::SparseChar,
-                     alpha::Number,
-                     A::CuSparseMatrixBSR{$elty},
-                     X::CuVector{$elty},
-                     beta::Number,
-                     Y::CuVector{$elty},
-                     index::SparseChar)
+        function mv2!(transa::SparseChar,
+                      alpha::Number,
+                      A::CuSparseMatrixBSR{$elty},
+                      X::CuVector{$elty},
+                      beta::Number,
+                      Y::CuVector{$elty},
+                      index::SparseChar)
 
             # Support transa = 'C' for real matrices
             transa = $elty <: Real && transa == 'C' ? 'T' : transa

--- a/lib/cusparse/test/generic.jl
+++ b/lib/cusparse/test/generic.jl
@@ -58,15 +58,22 @@ if cuSPARSE.version() >= v"12.5.1"
                                      cuSPARSE.CUSPARSE_SPMM_BSR_ALG1]
 end
 
+if cuSPARSE.version() >= v"12.6.3"
+    SPMV_ALGOS[CuSparseMatrixBSR] = [cuSPARSE.CUSPARSE_SPMV_ALG_DEFAULT,
+                                     cuSPARSE.CUSPARSE_SPMV_BSR_ALG1]
+end
+
 for SparseMatrixType in keys(SPMV_ALGOS)
     @testset "$SparseMatrixType -- mv! algo=$algo" for algo in SPMV_ALGOS[SparseMatrixType]
         @testset "mv! $T" for T in [Float32, Float64, ComplexF32, ComplexF64]
             @testset "transa = $transa" for (transa, opa) in [('N', identity), ('T', transpose), ('C', adjoint)]
                 SparseMatrixType == CuSparseMatrixCSC && T <: Complex && transa == 'C' && continue
+                (SparseMatrixType == CuSparseMatrixBSR) && (transa != 'N') && continue
                 A = sprand(T, 20, 10, 0.1)
                 B = transa == 'N' ? rand(T, 10) : rand(T, 20)
                 C = transa == 'N' ? rand(T, 20) : rand(T, 10)
-                dA = SparseMatrixType(A)
+                # BSR generic SpMV does not support block dim 1
+                dA = SparseMatrixType == CuSparseMatrixBSR ? SparseMatrixType(A, 2) : SparseMatrixType(A)
                 dB = CuArray(B)
                 dC = CuArray(C)
 

--- a/lib/cusparse/test/operations.jl
+++ b/lib/cusparse/test/operations.jl
@@ -6,8 +6,7 @@
         alpha = rand(elty)
         beta = rand(elty)
         @testset "$(typeof(d_A))" for d_A in [CuSparseMatrixCSR(A),
-                                              CuSparseMatrixCSC(A),
-                                              CuSparseMatrixBSR(A, blockdim)]
+                                              CuSparseMatrixCSC(A)]
             d_x = CuArray(x)
             d_y = CuArray(y)
             @test_throws DimensionMismatch cuSPARSE.mv!('T',alpha,d_A,d_x,beta,d_y,'O')
@@ -16,9 +15,16 @@
             h_z = collect(d_y)
             z = alpha * A * x + beta * y
             @test z ≈ h_z
-            #if d_A isa CuSparseMatrixCSR
-            #    @test d_y' * (d_A * d_x) ≈ (d_y' * d_A) * d_x
-            #end
+        end
+        @testset "$(typeof(d_A))" for d_A in [CuSparseMatrixBSR(A, blockdim)]
+            d_x = CuArray(x)
+            d_y = CuArray(y)
+            @test_throws DimensionMismatch cuSPARSE.mv2!('T',alpha,d_A,d_x,beta,d_y,'O')
+            @test_throws DimensionMismatch cuSPARSE.mv2!('N',alpha,d_A,d_y,beta,d_x,'O')
+            cuSPARSE.mv2!('N',alpha,d_A,d_x,beta,d_y,'O')
+            h_z = collect(d_y)
+            z = alpha * A * x + beta * y
+            @test z ≈ h_z
         end
     end
 


### PR DESCRIPTION
- Support `CuSparseMatrixBSR` for generic sparse `mv!` added with CUDA `13.0.1`.
- I also removed also some dead code for CUDA < 12.0
- We should not call the "preprocess" routines for `mv!` and `mm!` because we don't have any high-level way to reuse the buffer / descriptor. We just do more work for nothing.