### PR TITLE
Update `gemmStridedBatchedEx!` size checks

### DIFF
--- a/lib/cublas/wrappers.jl
+++ b/lib/cublas/wrappers.jl
@@ -1306,7 +1306,7 @@ function gemmStridedBatchedEx!(
                  @nospecialize(beta),
                  @nospecialize(C::AbstractArray{Tc, 3});
                  algo::cublasGemmAlgo_t=CUBLAS_GEMM_DEFAULT) where {Ta, Tb, Tc}
-    if size(A, 3) != size(B, 3) || size(A, 3) != size(C, 3)
+    if size(A, 3) != size(C, 3)
         throw(DimensionMismatch("Batch sizes must be equal for all inputs"))
     end
     m = size(A, transA == 'N' ? 1 : 2)

--- a/lib/cublas/wrappers.jl
+++ b/lib/cublas/wrappers.jl
@@ -1306,9 +1306,8 @@ function gemmStridedBatchedEx!(
                  @nospecialize(beta),
                  @nospecialize(C::AbstractArray{Tc, 3});
                  algo::cublasGemmAlgo_t=CUBLAS_GEMM_DEFAULT) where {Ta, Tb, Tc}
-    if size(A, 3) != size(C, 3)
-        throw(DimensionMismatch("Batch sizes must be equal for all inputs"))
-    end
+    @assert size(A, 3) == size(C, 3) || size(A, 3) == 1 "batch size mismatch: A != C"
+    @assert size(B, 3) == size(C, 3) || size(B, 3) == 1 "batch size mismatch: B != C"
     m = size(A, transA == 'N' ? 1 : 2)
     k = size(A, transA == 'N' ? 2 : 1)
     n = size(B, transB == 'N' ? 2 : 1)


### PR DESCRIPTION
This changes the size checks in `gemmStridedBatchedEx!` to match the ones in `gemm_strided_batched!`. Now this works
```julia
using CUDA

N = 3
nbatch = 4

A = CUDA.rand(N, N, nbatch)
B = CUDA.rand(N, N)
C = CUDA.zeros(N, N, nbatch)
CUDA.CUBLAS.gemmStridedBatchedEx!('N', 'N', 1, A, reshape(B, size(B)..., 1), 0, C)
all(A[:, :, i] * B ≈ C[:, :, i] for i=1:nbatch)
```