### PR TITLE
Avoid LLVM 18- generate non-existing min/max instructions

### DIFF
--- a/src/device/intrinsics/math.jl
+++ b/src/device/intrinsics/math.jl
@@ -362,8 +362,8 @@ end
     ifelse(anynan, NaN, minval), ifelse(anynan, NaN, maxval)
 end
 
-@static if Base.thismajor(LLVM.version()) == v"18"
-    # LLVM 18 generates non-existing instructions for Julia's default methods of
+@static if Base.thismajor(LLVM.version()) <= v"18"
+    # LLVM 18 and below generate non-existing instructions for Julia's default methods of
     # fast min/max on fp64: https://github.com/JuliaGPU/CUDA.jl/issues/2886
     @device_override @inline Base.FastMath.max_fast(x::Float64, y::Float64) = ifelse(y > x, y, x)
     @device_override @inline Base.FastMath.min_fast(x::Float64, y::Float64) = ifelse(y > x, x, y)

--- a/src/device/intrinsics/math.jl
+++ b/src/device/intrinsics/math.jl
@@ -362,6 +362,14 @@ end
     ifelse(anynan, NaN, minval), ifelse(anynan, NaN, maxval)
 end
 
+@static if LLVM.version() <= v"18"
+    # LLVM 18- generate non-existing instructions for Julia's default methods of
+    # fast min/max on fp64: https://github.com/JuliaGPU/CUDA.jl/issues/2886
+    @device_override @inline Base.FastMath.max_fast(x::Float64, y::Float64) = ifelse(y > x, y, x)
+    @device_override @inline Base.FastMath.min_fast(x::Float64, y::Float64) = ifelse(y > x, x, y)
+    @device_override @inline Base.FastMath.minmax_fast(x::Float64, y::Float64) = ifelse(y > x, (x, y), (y, x))
+end
+
 @device_function saturate(x::Float32) = ccall("extern __nv_saturatef", llvmcall, Cfloat, (Cfloat,), x)
 
 

--- a/src/device/intrinsics/math.jl
+++ b/src/device/intrinsics/math.jl
@@ -362,8 +362,8 @@ end
     ifelse(anynan, NaN, minval), ifelse(anynan, NaN, maxval)
 end
 
-@static if LLVM.version() <= v"18"
-    # LLVM 18- generate non-existing instructions for Julia's default methods of
+@static if Base.thismajor(LLVM.version()) == v"18"
+    # LLVM 18 generates non-existing instructions for Julia's default methods of
     # fast min/max on fp64: https://github.com/JuliaGPU/CUDA.jl/issues/2886
     @device_override @inline Base.FastMath.max_fast(x::Float64, y::Float64) = ifelse(y > x, y, x)
     @device_override @inline Base.FastMath.min_fast(x::Float64, y::Float64) = ifelse(y > x, x, y)

--- a/test/core/device/intrinsics/math.jl
+++ b/test/core/device/intrinsics/math.jl
@@ -108,6 +108,10 @@ using SpecialFunctions
         f(x) = log1p(x)
         g(x) = @fastmath log1p(x)
         @test Array(map(f, cu([0.1,0.2]))) ≈ Array(map(g, cu([0.1,0.2])))
+
+        # JuliaGPU/CUDA.jl#2886: LLVM 18-20 emit non-existing min.NaN.f64/max.NaN.f64 instructions
+        f(a, b) = @fastmath max(a, b)
+        @test Array(map(f, CuArray([1.0, 2.0]), CuArray([4.0, 3.0]))) == [4.0, 3.0]
     end
 
     @testset "byte_perm" begin

--- a/test/core/device/intrinsics/math.jl
+++ b/test/core/device/intrinsics/math.jl
@@ -109,7 +109,7 @@ using SpecialFunctions
         g(x) = @fastmath log1p(x)
         @test Array(map(f, cu([0.1,0.2]))) ≈ Array(map(g, cu([0.1,0.2])))
 
-        # JuliaGPU/CUDA.jl#2886: LLVM 18-20 emit non-existing min.NaN.f64/max.NaN.f64 instructions
+        # JuliaGPU/CUDA.jl#2886: LLVM 18 emit non-existing min.NaN.f64/max.NaN.f64 instructions
         f(a, b) = @fastmath max(a, b)
         @test Array(map(f, CuArray([1.0, 2.0]), CuArray([4.0, 3.0]))) == [4.0, 3.0]
     end

--- a/test/core/device/intrinsics/math.jl
+++ b/test/core/device/intrinsics/math.jl
@@ -109,7 +109,7 @@ using SpecialFunctions
         g(x) = @fastmath log1p(x)
         @test Array(map(f, cu([0.1,0.2]))) ≈ Array(map(g, cu([0.1,0.2])))
 
-        # JuliaGPU/CUDA.jl#2886: LLVM 18 emit non-existing min.NaN.f64/max.NaN.f64 instructions
+        # JuliaGPU/CUDA.jl#2886: LLVM below v18 emits non-existing min.NaN.f64/max.NaN.f64
         f(a, b) = @fastmath max(a, b)
         @test Array(map(f, CuArray([1.0, 2.0]), CuArray([4.0, 3.0]))) == [4.0, 3.0]
     end


### PR DESCRIPTION
Should fix #2886, but I don't have to write a test now, will do in a few hours.
Closes https://github.com/WaterLily-jl/WaterLily.jl/issues/258.