### PR TITLE
XsyevBatched! interface accepting 3D StridedCuArray

### DIFF
--- a/lib/cusolver/dense_generic.jl
+++ b/lib/cusolver/dense_generic.jl
@@ -505,6 +505,43 @@ function Xgeev!(jobvl::Char, jobvr::Char, A::StridedCuMatrix{T}) where {T <: Bla
 end
 
 # XsyevBatched
+function XsyevBatched!(jobz::Char, uplo::Char, A::StridedCuArray{T,3}) where {T <: BlasFloat}
+    CUSOLVER.version() < v"11.7.1" && throw(ErrorException("This operation is not supported by the current CUDA version."))
+    chkuplo(uplo)
+    n = checksquare(A)
+    batch_size = size(A,3)
+    R = real(T)
+    lda = max(1, stride(A,2))
+    W = CuMatrix{R}(undef, n, batch_size)
+    params = CuSolverParameters()
+    dh = dense_handle()
+    resize!(dh.info, batch_size)
+
+    function bufferSize()
+        out_cpu = Ref{Csize_t}(0)
+        out_gpu = Ref{Csize_t}(0)
+        cusolverDnXsyevBatched_bufferSize(dh, params, jobz, uplo, n,
+                                          T, A, lda, R, W, T, out_gpu, out_cpu, batch_size)
+        out_gpu[], out_cpu[]
+    end
+    with_workspaces(dh.workspace_gpu, dh.workspace_cpu, bufferSize()...) do buffer_gpu, buffer_cpu
+        cusolverDnXsyevBatched(dh, params, jobz, uplo, n, T, A,
+                               lda, R, W, T, buffer_gpu, sizeof(buffer_gpu),
+                               buffer_cpu, sizeof(buffer_cpu), dh.info, batch_size)
+    end
+
+    info = @allowscalar collect(dh.info)
+    for i = 1:batch_size
+        chkargsok(info[i] |> BlasInt)
+    end
+
+    if jobz == 'N'
+        return W
+    elseif jobz == 'V'
+        return W, A
+    end
+end
+
 function XsyevBatched!(jobz::Char, uplo::Char, A::StridedCuMatrix{T}) where {T <: BlasFloat}
     CUSOLVER.version() < v"11.7.1" && throw(ErrorException("This operation is not supported by the current CUDA version."))
     chkuplo(uplo)

--- a/lib/cusolver/dense_generic.jl
+++ b/lib/cusolver/dense_generic.jl
@@ -506,7 +506,9 @@ end
 
 # XsyevBatched
 function XsyevBatched!(jobz::Char, uplo::Char, A::StridedCuArray{T, 3}) where {T <: BlasFloat}
-    CUSOLVER.version() < v"11.7.1" && throw(ErrorException("This operation is not supported by the current CUDA version."))
+    minimum_version = v"11.7.1"
+    CUSOLVER.version() < minimum_version && throw(ErrorException("This operation requires cuSOLVER
+        $(minimum_version) or later. Current cuSOLVER version: $(CUSOLVER.version())."))
     chkuplo(uplo)
     n = checksquare(A)
     batch_size = size(A, 3)
@@ -547,7 +549,9 @@ function XsyevBatched!(jobz::Char, uplo::Char, A::StridedCuArray{T, 3}) where {T
 end
 
 function XsyevBatched!(jobz::Char, uplo::Char, A::StridedCuMatrix{T}) where {T <: BlasFloat}
-    CUSOLVER.version() < v"11.7.1" && throw(ErrorException("This operation is not supported by the current CUDA version."))
+    minimum_version = v"11.7.1"
+    CUSOLVER.version() < minimum_version && throw(ErrorException("This operation requires cuSOLVER
+        $(minimum_version) or later. Current cuSOLVER version: $(CUSOLVER.version())."))
     chkuplo(uplo)
     n, num_matrices = size(A)
     batch_size = num_matrices ÷ n

--- a/test/libraries/cusolver/dense_generic.jl
+++ b/test/libraries/cusolver/dense_generic.jl
@@ -39,21 +39,21 @@ p = 5
 
                 A = rand(elty, n, n, batch_size)
                 B = rand(elty, n, n, batch_size)
-                for i = 1:batch_size
-                    S = rand(elty,n,n)
+                for i in 1:batch_size
+                    S = rand(elty, n, n)
                     S = S * S' + I
-                    B[:,:,i] .= S
+                    B[:, :, i] .= S
                     S = uplo == 'L' ? tril(S) : triu(S)
-                    A[:,:,i] .= S
+                    A[:, :, i] .= S
                 end
                 d_A = CuArray(A)
                 d_W, d_V = CUSOLVER.XsyevBatched!('V', uplo, d_A)
                 W = collect(d_W)
                 V = collect(d_V)
-                for i = 1:batch_size
-                    Bᵢ = B[:,:,i]
-                    Wᵢ = Diagonal(W[:,i])
-                    Vᵢ = V[:,:,i]
+                for i in 1:batch_size
+                    Bᵢ = B[:, :, i]
+                    Wᵢ = Diagonal(W[:, i])
+                    Vᵢ = V[:, :, i]
                     @test Bᵢ * Vᵢ ≈ Vᵢ * Diagonal(Wᵢ)
                 end
 

--- a/test/libraries/cusolver/dense_generic.jl
+++ b/test/libraries/cusolver/dense_generic.jl
@@ -37,6 +37,36 @@ p = 5
             for uplo in ('L', 'U')
                 (CUSOLVER.version() < v"11.7.2") && (uplo == 'L') && (elty == ComplexF32) && continue
 
+                A = rand(elty, n, n, batch_size)
+                B = rand(elty, n, n, batch_size)
+                for i = 1:batch_size
+                    S = rand(elty,n,n)
+                    S = S * S' + I
+                    B[:,:,i] .= S
+                    S = uplo == 'L' ? tril(S) : triu(S)
+                    A[:,:,i] .= S
+                end
+                d_A = CuArray(A)
+                d_W, d_V = CUSOLVER.XsyevBatched!('V', uplo, d_A)
+                W = collect(d_W)
+                V = collect(d_V)
+                for i = 1:batch_size
+                    Bᵢ = B[:,:,i]
+                    Wᵢ = Diagonal(W[:,i])
+                    Vᵢ = V[:,:,i]
+                    @test Bᵢ * Vᵢ ≈ Vᵢ * Diagonal(Wᵢ)
+                end
+
+                d_A = CuArray(A)
+                d_W = CUSOLVER.XsyevBatched!('N', uplo, d_A)
+            end
+        end
+
+        @testset "syevBatched! updated" begin
+            batch_size = 5
+            for uplo in ('L', 'U')
+                (CUSOLVER.version() < v"11.7.2") && (uplo == 'L') && (elty == ComplexF32) && continue
+
                 A = rand(elty, n, n * batch_size)
                 B = rand(elty, n, n * batch_size)
                 for i = 1:batch_size
@@ -61,6 +91,7 @@ p = 5
                 d_W = CUSOLVER.XsyevBatched!('N', uplo, d_A)
             end
         end
+
     end
 
     if CUSOLVER.version() >= v"11.6.0"

--- a/test/libraries/cusolver/dense_generic.jl
+++ b/test/libraries/cusolver/dense_generic.jl
@@ -91,7 +91,6 @@ p = 5
                 d_W = CUSOLVER.XsyevBatched!('N', uplo, d_A)
             end
         end
-
     end
 
     if CUSOLVER.version() >= v"11.6.0"


### PR DESCRIPTION
I noticed that the batched eigensolver function [CUSOLVER.heevjBatched!](https://github.com/JuliaGPU/CUDA.jl/blob/b0b484c5bf7e7a8342e0285e42c5e235aa252c32/lib/cusolver/dense.jl#L771) accepts a 3-dimensional StridedCuArray while the similar function CUSOLVER.XsyevBatched! accepts a 2-dimensional StridedCuMatrix.  I think having the same interface for both would be desirable.