### PR TITLE
Fix complex CSC * dense vec

### DIFF
--- a/lib/cusparse/generic.jl
+++ b/lib/cusparse/generic.jl
@@ -158,16 +158,8 @@ function mv!(transa::SparseChar, alpha::Number, A::Union{CuSparseMatrixCSC{TA},C
     # Support transa = 'C' for real matrices
     transa = T <: Real && transa == 'C' ? 'T' : transa
 
-    if isa(A, CuSparseMatrixCSC)
-        # cusparseSpMV completely supports CSC matrices with CUSPARSE.version() ≥ v"12.0".
-        # We use Aᵀ to model them as CSR matrices for older versions of CUSPARSE.
-        descA = CuSparseMatrixDescriptor(A, index, transposed=true)
-        n,m = size(A)
-        transa = transa == 'N' ? 'T' : 'N'
-    else
-        descA = CuSparseMatrixDescriptor(A, index)
-        m,n = size(A)
-    end
+    descA = CuSparseMatrixDescriptor(A, index)
+    m,n = size(A)
 
     if transa == 'N'
         chkmvdims(X,n,Y,m)

--- a/test/libraries/cusparse/interfaces.jl
+++ b/test/libraries/cusparse/interfaces.jl
@@ -137,35 +137,33 @@ nB = 2
                                 @test collect(dC) ≈ C
                             end
                         end
-                        if !(SparseMatrixType == CuSparseMatrixCSC && elty <: Complex && opa == adjoint)
-                            @testset "A * CuVector" begin
-                                @testset "A * b" begin
-                                    c = opa(geam_A) * b_vec
-                                    dc = opa(d_geam_A) * db_vec
-                                    @test c ≈ collect(dc)
-                                end
-                                @testset "mul!(c, A, b)" begin
-                                    c = rand(elty, n)
-                                    dc = CuArray(c)
-
-                                    mul!(c, opa(geam_A), b_vec, alpha, beta)
-                                    mul!(dc, opa(d_geam_A), db_vec, alpha, beta)
-                                    @test c ≈ collect(dc)
-                                end
+                        @testset "A * CuVector" begin
+                            @testset "A * b" begin
+                                c = opa(geam_A) * b_vec
+                                dc = opa(d_geam_A) * db_vec
+                                @test c ≈ collect(dc)
                             end
-                            @testset "A * CuSparseVector" begin
-                                @testset "A * b" begin
-                                    c  = opa(geam_A) * b_spvec
-                                    dc = opa(d_geam_A) * db_spvec
-                                    @test c ≈ collect(dc)
-                                end
-                                @testset "mul!(c, A, b)" begin
-                                    c = rand(elty, n)
-                                    dc = CuArray(c)
-                                    mul!(c, opa(geam_A), b_spvec, alpha, beta)
-                                    mul!(dc, opa(d_geam_A), db_spvec, alpha, beta)
-                                    @test c ≈ collect(dc)
-                                end
+                            @testset "mul!(c, A, b)" begin
+                                c = rand(elty, n)
+                                dc = CuArray(c)
+
+                                mul!(c, opa(geam_A), b_vec, alpha, beta)
+                                mul!(dc, opa(d_geam_A), db_vec, alpha, beta)
+                                @test c ≈ collect(dc)
+                            end
+                        end
+                        @testset "A * CuSparseVector" begin
+                            @testset "A * b" begin
+                                c  = opa(geam_A) * b_spvec
+                                dc = opa(d_geam_A) * db_spvec
+                                @test c ≈ collect(dc)
+                            end
+                            @testset "mul!(c, A, b)" begin
+                                c = rand(elty, n)
+                                dc = CuArray(c)
+                                mul!(c, opa(geam_A), b_spvec, alpha, beta)
+                                mul!(dc, opa(d_geam_A), db_spvec, alpha, beta)
+                                @test c ≈ collect(dc)
                             end
                         end
                     end


### PR DESCRIPTION
Hopefully fixes https://github.com/JuliaGPU/CUDA.jl/issues/2945, worked for me locally. We no longer need the deleted code in `lib/cusparse/generic.jl` because we're firmly in the CUSPARSE 12.x era.