### PR TITLE
Fixes zero-dim matmatmul & matvecmul

### DIFF
--- a/lib/cublas/linalg.jl
+++ b/lib/cublas/linalg.jl
@@ -362,7 +362,7 @@ function LinearAlgebra.generic_matmatmul!(C::StridedCuVecOrMat, tA, tB, A::Strid
         if size(C) != (mA, nB)
             throw(DimensionMismatch("C has dimensions $(size(C)), should have ($mA,$nB)"))
         end
-        return LinearAlgebra.rmul!(C, 0)
+        return LinearAlgebra.rmul!(C, beta)
     end
 
     if all(in(('N', 'T', 'C')), (tA, tB))

--- a/lib/cublas/linalg.jl
+++ b/lib/cublas/linalg.jl
@@ -273,7 +273,7 @@ function LinearAlgebra.generic_matvecmul!(Y::StridedCuVector, tA::AbstractChar, 
     end
 
     if nA == 0
-        return rmul!(Y, 0)
+        return rmul!(Y, beta)
     end
 
     T = eltype(Y)

--- a/lib/cublas/linalg.jl
+++ b/lib/cublas/linalg.jl
@@ -9,6 +9,12 @@ end
 # BLAS 1
 #
 
+function LinearAlgebra.rmul!(x::CuArray{<:CublasFloat}, k::Bool)
+    # explicitly fill x with zero to comply with julias "false = strong zero"
+    !k && fill!(x, zero(eltype(x)))
+    return x
+end
+
 LinearAlgebra.rmul!(x::StridedCuArray{<:CublasFloat}, k::Number) =
   scal!(length(x), k, x)
 

--- a/test/libraries/cublas/level1.jl
+++ b/test/libraries/cublas/level1.jl
@@ -41,6 +41,12 @@ k = 13
             @test dz ≈ z
         end
 
+        @testset "rmul! strong zero" begin
+            @test testf(rmul!, fill(NaN, 3), false)
+            @test testf(rmul!, rand(3), false)
+            @test testf(rmul!, rand(3), true)
+        end
+
         @testset "rotate!" begin
             @test testf(rotate!, rand(T, m), rand(T, m), rand(real(T)), rand(real(T)))
             @test testf(rotate!, rand(T, m), rand(T, m), rand(real(T)), rand(T))

--- a/test/libraries/cublas/level1.jl
+++ b/test/libraries/cublas/level1.jl
@@ -42,9 +42,9 @@ k = 13
         end
 
         @testset "rmul! strong zero" begin
-            @test testf(rmul!, fill(NaN, 3), false)
-            @test testf(rmul!, rand(3), false)
-            @test testf(rmul!, rand(3), true)
+            @test testf(rmul!, fill(T(NaN), 3), false)
+            @test testf(rmul!, rand(T, 3), false)
+            @test testf(rmul!, rand(T, 3), true)
         end
 
         @testset "rotate!" begin


### PR DESCRIPTION
Closes #2952 and #2607. 
The (m x 0) * (0 x n) matmatmul and the (m x 0) * (0) matvecmul edgecase should probably be tested in the GPUArrays.jl testsuite (for all GPU backends). I'll add a PR there (https://github.com/JuliaGPU/GPUArrays.jl/pull/646).