### PR TITLE
Ensure diagm preserves eltype

### DIFF
--- a/lib/cublas/linalg.jl
+++ b/lib/cublas/linalg.jl
@@ -594,7 +594,7 @@ end
 function LinearAlgebra.diagm_container(size, kv::Pair{<:Integer,<:CuVector}...)
     T = promote_type(map(x -> eltype(x.second), kv)...)
     U = promote_type(T, typeof(zero(T)))
-    return cu(zeros(U, LinearAlgebra.diagm_size(size, kv...)...))
+    return CUDA.zeros(U, LinearAlgebra.diagm_size(size, kv...)...)
 end
 
 function LinearAlgebra.diagm_size(size::Nothing, kv::Pair{<:Integer,<:CuVector}...)

--- a/test/libraries/cublas/extensions.jl
+++ b/test/libraries/cublas/extensions.jl
@@ -531,6 +531,10 @@ k = 13
             h_C = Array(d_C)
             @test C ≈ h_C
         end
+        @testset "diagm" begin
+            d_fX = LinearAlgebra.diagm(d_x)
+            @test eltype(d_fX) == eltype(d_x)
+        end
         @testset "diagonal -- mul!, rmul!, lmul!" begin
             XA = rand(elty,m,n)
             d_XA = CuArray(XA)


### PR DESCRIPTION
Previously you could lose precision by using `diagm`. Very bad!