### PR TITLE
Add some packages to `versioninfo` output

### DIFF
--- a/src/CUDA.jl
+++ b/src/CUDA.jl
@@ -10,6 +10,8 @@ using LLVM
 using LLVM.Interop
 using Core: LLVMPtr
 
+import KernelAbstractions
+
 using Adapt: Adapt, adapt, WrappedArray
 
 using Requires: @require

--- a/src/utilities.jl
+++ b/src/utilities.jl
@@ -69,7 +69,8 @@ function versioninfo(io::IO=stdout)
 
     println(io, "Julia packages: ")
     println(io, "- CUDA: $(Base.pkgversion(CUDA))")
-    for name in [:CUDA_Driver_jll, :CUDA_Compiler_jll, :CUDA_Runtime_jll, :CUDA_Runtime_Discovery]
+    for name in [:CUDA_Driver_jll, :CUDA_Compiler_jll, :CUDA_Runtime_jll, :CUDA_Runtime_Discovery,
+                    :GPUArrays, :GPUCompiler, :KernelAbstractions]
         isdefined(CUDA, name) || continue
         mod = getfield(CUDA, name)
         println(io, "- $(name): $(Base.pkgversion(mod))")

--- a/src/utilities.jl
+++ b/src/utilities.jl
@@ -69,8 +69,8 @@ function versioninfo(io::IO=stdout)
 
     println(io, "Julia packages: ")
     println(io, "- CUDA: $(Base.pkgversion(CUDA))")
-    for name in [:CUDA_Driver_jll, :CUDA_Compiler_jll, :CUDA_Runtime_jll, :CUDA_Runtime_Discovery,
-                    :GPUArrays, :GPUCompiler, :KernelAbstractions]
+    for name in [:GPUArrays, :GPUCompiler, :KernelAbstractions, :CUDA_Driver_jll,
+                 :CUDA_Compiler_jll, :CUDA_Runtime_jll, :CUDA_Runtime_Discovery]
         isdefined(CUDA, name) || continue
         mod = getfield(CUDA, name)
         println(io, "- $(name): $(Base.pkgversion(mod))")


### PR DESCRIPTION
Metal.jl includes these in its `versioninfo` and it's good to have the version of these packages when helping people troubleshoot issues.

Metal.jl also includes the LLVM.jl version which isn't part of this PR. Maybe it should be?