### PR TITLE
Fix undefined variable in memory_source error message

### DIFF
--- a/src/texture.jl
+++ b/src/texture.jl
@@ -353,7 +353,7 @@ Currently, that is not being enforced.
 CuTexture(x::CuArray{T,N}; kwargs...) where {T,N} =
     CuTexture{T,N}(x; kwargs...)
 
-memory_source(::Any) = error("Unknown texture source $(typeof(t))")
+memory_source(t::Any) = error("Unknown texture source $(typeof(t))")
 memory_source(::CuArray) = LinearMemorySource()
 memory_source(::CuTextureArray) = ArrayMemorySource()
 


### PR DESCRIPTION
The fallback `memory_source(::Any)` method references an undefined variable `t` in its error message. This causes an `UndefVarError` instead of the intended helpful message when passing an unsupported type to `CuTexture`.

**Before:** `memory_source(::Any) = error("Unknown texture source $(typeof(t))")`
**After:** `memory_source(t::Any) = error("Unknown texture source $(typeof(t))")`