### PR TITLE
fix and tests for zero-length arrays in level1 CUBLAS

### DIFF
--- a/lib/cublas/linalg.jl
+++ b/lib/cublas/linalg.jl
@@ -45,6 +45,7 @@ function LinearAlgebra.dot(x::AnyCuArray{T1}, y::AnyCuArray{T2}) where {T1,T2}
     n = length(x)
     n==length(y) || throw(DimensionMismatch("dot product arguments have lengths $(length(x)) and $(length(y))"))
 
+    n == 0 && return zero(promote_type(T1, T2))
     # custom kernel using simple linear indexing and atomic additions,
     # resulting in about 10% speed-up compared to a simple mapreduce.
     # COV_EXCL_START

--- a/test/libraries/cublas/level1.jl
+++ b/test/libraries/cublas/level1.jl
@@ -22,11 +22,14 @@ k = 13
 
         @test testf(rmul!, rand(T, 6, 9, 3), rand())
         @test testf(dot, rand(T, m), rand(T, m))
+        @test testf(dot, rand(T, 0), rand(T, 0))
         @test testf(*, transpose(rand(T, m)), rand(T, m))
         @test testf(*, rand(T, m)', rand(T, m))
         @test testf(norm, rand(T, m))
+        @test testf(norm, rand(T, 0))
         @test testf(LinearAlgebra.norm2, rand(T, m))
         @test testf(BLAS.asum, rand(T, m))
+        @test testf(BLAS.asum, rand(T, 0))
 
         @test testf(axpy!, rand(), rand(T, m), rand(T, m))
         @test testf(LinearAlgebra.axpby!, rand(), rand(T, m), rand(), rand(T, m))
@@ -175,9 +178,11 @@ k = 13
 
         @test testf(rmul!, rand(T, 6, 9, 3), rand())
         @test testf(dot, rand(T, m), rand(T, m))
+        @test testf(dot, rand(T, 0), rand(T, 0))
         @test testf(*, transpose(rand(T, m)), rand(T, m))
         @test testf(*, rand(T, m)', rand(T, m))
         @test testf(norm, rand(T, m))
+        @test testf(norm, rand(T, 0))
         @test testf(LinearAlgebra.norm2, rand(T, m))
         @test testf(axpy!, rand(), rand(T, m), rand(T, m))
         @test testf(LinearAlgebra.axpby!, rand(), rand(T, m), rand(), rand(T, m))
@@ -203,5 +208,11 @@ k = 13
             z = dot(x, y)
             @test dz ≈ z
         end
+    end
+    @testset "dot with mixed types" begin
+        T1 = Float32
+        T2 = Float64
+        @test testf(dot, rand(T1, m), rand(T2, m))
+        @test testf(dot, rand(T1, 0), rand(T2, 0))
     end
 end # level 1 testset


### PR DESCRIPTION
Passing length zero arrays to the mixed element type dot leads to a launch failure right now. Fixed that and added some more tests overall to see that length zero arrays are handled nicely.