### PR TITLE
Add GPU-compatible iszero methods for CuSparse arrays

### DIFF
--- a/lib/cusparse/linalg.jl
+++ b/lib/cusparse/linalg.jl
@@ -218,9 +218,6 @@ function LinearAlgebra.dot(y::CuVector{T}, A::CuSparseMatrixCSR{T}, x::CuVector{
     return sum(result)
 end
 
-# iszero for sparse arrays - GPU compatible implementation
-# This avoids scalar indexing that would occur with the default Base.iszero fallback
-# See: https://github.com/SciML/SciMLOperators.jl/issues/338
 Base.iszero(A::CuSparseVector) = nnz(A) == 0 || all(iszero, nonzeros(A))
 Base.iszero(A::CuSparseMatrixCSC) = nnz(A) == 0 || all(iszero, nonzeros(A))
 Base.iszero(A::CuSparseMatrixCSR) = nnz(A) == 0 || all(iszero, nonzeros(A))

--- a/lib/cusparse/linalg.jl
+++ b/lib/cusparse/linalg.jl
@@ -218,3 +218,12 @@ function LinearAlgebra.dot(y::CuVector{T}, A::CuSparseMatrixCSR{T}, x::CuVector{
     return sum(result)
 end
 
+# iszero for sparse arrays - GPU compatible implementation
+# This avoids scalar indexing that would occur with the default Base.iszero fallback
+# See: https://github.com/SciML/SciMLOperators.jl/issues/338
+Base.iszero(A::CuSparseVector) = nnz(A) == 0 || all(iszero, nonzeros(A))
+Base.iszero(A::CuSparseMatrixCSC) = nnz(A) == 0 || all(iszero, nonzeros(A))
+Base.iszero(A::CuSparseMatrixCSR) = nnz(A) == 0 || all(iszero, nonzeros(A))
+Base.iszero(A::CuSparseMatrixBSR) = nnz(A) == 0 || all(iszero, nonzeros(A))
+Base.iszero(A::CuSparseMatrixCOO) = nnz(A) == 0 || all(iszero, nonzeros(A))
+

--- a/test/libraries/cusparse/linalg.jl
+++ b/test/libraries/cusparse/linalg.jl
@@ -73,8 +73,6 @@ end
 end
 
 @testset "iszero for sparse arrays" begin
-    # Test iszero without scalar indexing (GPU-compatible)
-    # See: https://github.com/SciML/SciMLOperators.jl/issues/338
     @testset "CuSparseVector" begin
         v = sprand(Float32, 10, 0.5)
         dv = CuSparseVector(v)

--- a/test/libraries/cusparse/linalg.jl
+++ b/test/libraries/cusparse/linalg.jl
@@ -72,11 +72,18 @@ end
     @test_throws DimensionMismatch("dimensions must match") dot(CUDA.rand(elty, N1+1), A2, y2)
 end
 
-CuSparseVectorvec(A) = CuSparseVector(vec(A))
-CuSparseMatrixBSR3(A) = CuSparseMatrixBSR(A, 3)
+@testset "izzero for CuSparseVector" begin
+    v = sprand(Float32, 10, 0.5)
+    dv = CuSparseVector(v)
+    @test iszero(dv) == iszero(v)
+    v_zero = spzeros(Float32, 10)
+    dv_zero = CuSparseVector(v_zero)
+    @test iszero(dv_zero) == true
+end
 
+CuSparseMatrixBSR3(A) = CuSparseMatrixBSR(A, 3)
 @testset "iszero for sparse arrays, type = $typ" for 
-    typ in [CuSparseVectorvec, CuSparseMatrixCSC, CuSparseMatrixCSR, CuSparseMatrixCOO, CuSparseMatrixBSR3]
+    typ in [CuSparseMatrixCSC, CuSparseMatrixCSR, CuSparseMatrixCOO, CuSparseMatrixBSR3]
     
     A = sprand(Float32, 10, 10, 0.5)
     dA = typ(A)

--- a/test/libraries/cusparse/linalg.jl
+++ b/test/libraries/cusparse/linalg.jl
@@ -72,41 +72,15 @@ end
     @test_throws DimensionMismatch("dimensions must match") dot(CUDA.rand(elty, N1+1), A2, y2)
 end
 
-@testset "iszero for sparse arrays" begin
-    @testset "CuSparseVector" begin
-        v = sprand(Float32, 10, 0.5)
-        dv = CuSparseVector(v)
-        @test iszero(dv) == iszero(v)
+CuSparseVectorvec(A) = CuSparseVector(vec(A))
+CuSparseMatrixBSR3(A) = CuSparseMatrixBSR(A, 3)
 
-        v_zero = spzeros(Float32, 10)
-        dv_zero = CuSparseVector(v_zero)
-        @test iszero(dv_zero) == true
-    end
+@testset "iszero for sparse arrays, type = $typ" for typ in [CuSparseVectorvec, CuSparseMatrixCSC, CuSparseMatrixCSR, CuSparseMatrixCOO, CuSparseMatrixBSR3]
+    A = sprand(Float32, 10, 10, 0.5)
+    dA = typ(A)
+    @test iszero(dA) == iszero(A)
 
-    @testset "type = $typ" for typ in [CuSparseMatrixCSC, CuSparseMatrixCSR]
-        A = sprand(Float32, 10, 10, 0.5)
-        dA = typ(A)
-        @test iszero(dA) == iszero(A)
-
-        A_zero = spzeros(Float32, 10, 10)
-        dA_zero = typ(A_zero)
-        @test iszero(dA_zero) == true
-    end
-
-    @testset "CuSparseMatrixCOO" begin
-        A = sprand(Float32, 10, 10, 0.5)
-        dA = CuSparseMatrixCOO(A)
-        @test iszero(dA) == iszero(A)
-
-        A_zero = spzeros(Float32, 10, 10)
-        dA_zero = CuSparseMatrixCOO(A_zero)
-        @test iszero(dA_zero) == true
-    end
-
-    @testset "CuSparseMatrixBSR" begin
-        A = sprand(Float32, 12, 12, 0.5)
-        dA_csr = CuSparseMatrixCSR(A)
-        dA = CuSparseMatrixBSR(dA_csr, 3)
-        @test iszero(dA) == iszero(A)
-    end
+    A_zero = spzeros(Float32, 10, 10)
+    dA_zero = typ(A_zero)
+    @test iszero(dA_zero) == true
 end

--- a/test/libraries/cusparse/linalg.jl
+++ b/test/libraries/cusparse/linalg.jl
@@ -77,6 +77,7 @@ CuSparseMatrixBSR3(A) = CuSparseMatrixBSR(A, 3)
 
 @testset "iszero for sparse arrays, type = $typ" for 
     typ in [CuSparseVectorvec, CuSparseMatrixCSC, CuSparseMatrixCSR, CuSparseMatrixCOO, CuSparseMatrixBSR3]
+    
     A = sprand(Float32, 10, 10, 0.5)
     dA = typ(A)
     @test iszero(dA) == iszero(A)

--- a/test/libraries/cusparse/linalg.jl
+++ b/test/libraries/cusparse/linalg.jl
@@ -109,15 +109,4 @@ end
         dA = CuSparseMatrixBSR(dA_csr, 3)
         @test iszero(dA) == iszero(A)
     end
-
-    # Test with scalar indexing disabled to ensure GPU compatibility
-    @testset "no scalar indexing" begin
-        A = sprand(Float32, 10, 10, 0.5)
-        CUDA.@allowscalar false begin
-            for typ in [CuSparseMatrixCSC, CuSparseMatrixCSR, CuSparseMatrixCOO]
-                dA = typ(A)
-                @test iszero(dA) == false
-            end
-        end
-    end
 end

--- a/test/libraries/cusparse/linalg.jl
+++ b/test/libraries/cusparse/linalg.jl
@@ -71,3 +71,55 @@ end
     @test dot(x, A, y) ≈ dot(x2, A2, y2)
     @test_throws DimensionMismatch("dimensions must match") dot(CUDA.rand(elty, N1+1), A2, y2)
 end
+
+@testset "iszero for sparse arrays" begin
+    # Test iszero without scalar indexing (GPU-compatible)
+    # See: https://github.com/SciML/SciMLOperators.jl/issues/338
+    @testset "CuSparseVector" begin
+        v = sprand(Float32, 10, 0.5)
+        dv = CuSparseVector(v)
+        @test iszero(dv) == iszero(v)
+
+        v_zero = spzeros(Float32, 10)
+        dv_zero = CuSparseVector(v_zero)
+        @test iszero(dv_zero) == true
+    end
+
+    @testset "type = $typ" for typ in [CuSparseMatrixCSC, CuSparseMatrixCSR]
+        A = sprand(Float32, 10, 10, 0.5)
+        dA = typ(A)
+        @test iszero(dA) == iszero(A)
+
+        A_zero = spzeros(Float32, 10, 10)
+        dA_zero = typ(A_zero)
+        @test iszero(dA_zero) == true
+    end
+
+    @testset "CuSparseMatrixCOO" begin
+        A = sprand(Float32, 10, 10, 0.5)
+        dA = CuSparseMatrixCOO(A)
+        @test iszero(dA) == iszero(A)
+
+        A_zero = spzeros(Float32, 10, 10)
+        dA_zero = CuSparseMatrixCOO(A_zero)
+        @test iszero(dA_zero) == true
+    end
+
+    @testset "CuSparseMatrixBSR" begin
+        A = sprand(Float32, 12, 12, 0.5)
+        dA_csr = CuSparseMatrixCSR(A)
+        dA = CuSparseMatrixBSR(dA_csr, 3)
+        @test iszero(dA) == iszero(A)
+    end
+
+    # Test with scalar indexing disabled to ensure GPU compatibility
+    @testset "no scalar indexing" begin
+        A = sprand(Float32, 10, 10, 0.5)
+        CUDA.@allowscalar false begin
+            for typ in [CuSparseMatrixCSC, CuSparseMatrixCSR, CuSparseMatrixCOO]
+                dA = typ(A)
+                @test iszero(dA) == false
+            end
+        end
+    end
+end

--- a/test/libraries/cusparse/linalg.jl
+++ b/test/libraries/cusparse/linalg.jl
@@ -75,7 +75,8 @@ end
 CuSparseVectorvec(A) = CuSparseVector(vec(A))
 CuSparseMatrixBSR3(A) = CuSparseMatrixBSR(A, 3)
 
-@testset "iszero for sparse arrays, type = $typ" for typ in [CuSparseVectorvec, CuSparseMatrixCSC, CuSparseMatrixCSR, CuSparseMatrixCOO, CuSparseMatrixBSR3]
+@testset "iszero for sparse arrays, type = $typ" for 
+    typ in [CuSparseVectorvec, CuSparseMatrixCSC, CuSparseMatrixCSR, CuSparseMatrixCOO, CuSparseMatrixBSR3]
     A = sprand(Float32, 10, 10, 0.5)
     dA = typ(A)
     @test iszero(dA) == iszero(A)


### PR DESCRIPTION
## Summary

Add `Base.iszero` methods for CUSPARSE arrays that avoid scalar indexing, fixing compatibility issues with packages like SciMLOperators.jl.

## Problem

The default `Base.iszero(A::AbstractArray) = all(iszero, A)` iterates element-by-element, which triggers scalar indexing errors on GPU arrays when scalar indexing is disabled:

```julia
using CUDA, SciMLOperators, FillArrays, SparseArrays
CUDA.allowscalar(false)

A = cu(sprand(4, 4, 0.5))
II = Eye{Float32}(4)
v = CUDA.rand(4)

M = MatrixOperator(A) - II
M * v  # ERROR: Scalar indexing is disallowed
```

This happens because `SciMLOperators.AddedOperator` calls `iszero` on each operator during multiplication to potentially skip zero operators.

## Solution

Add specialized `iszero` methods for all CuSparse types:

```julia
Base.iszero(A::CuSparseVector) = nnz(A) == 0 || all(iszero, nonzeros(A))
Base.iszero(A::CuSparseMatrixCSC) = nnz(A) == 0 || all(iszero, nonzeros(A))
Base.iszero(A::CuSparseMatrixCSR) = nnz(A) == 0 || all(iszero, nonzeros(A))
Base.iszero(A::CuSparseMatrixBSR) = nnz(A) == 0 || all(iszero, nonzeros(A))
Base.iszero(A::CuSparseMatrixCOO) = nnz(A) == 0 || all(iszero, nonzeros(A))
```

This works because:
1. `nnz(A) == 0` is a simple integer comparison (no GPU access)
2. `nonzeros(A)` returns a `CuArray` of stored values
3. `all(iszero, CuArray)` uses GPU-compatible reduction from GPUArrays

## Test Plan

- [x] Added tests in `test/libraries/cusparse/linalg.jl`
- [ ] Tests cover all sparse types: `CuSparseVector`, `CuSparseMatrixCSC`, `CuSparseMatrixCSR`, `CuSparseMatrixBSR`, `CuSparseMatrixCOO`
- [ ] Tests verify behavior matches CPU sparse arrays
- [ ] Tests verify no scalar indexing occurs when `allowscalar(false)`

Fixes https://github.com/SciML/SciMLOperators.jl/issues/338

🤖 Generated with [Claude Code](https://claude.com/claude-code)