### PR TITLE
Make Ahead-of-Time compilation feasible for packages using CUDA.jl

### DIFF
--- a/CUDACore/src/device/intrinsics/atomics.jl
+++ b/CUDACore/src/device/intrinsics/atomics.jl
@@ -151,7 +151,7 @@ for A in (AS.Generic, AS.Global, AS.Shared), T in (:Int16, :UInt16)
     end
 
     intr = "atom$scope.cas.b16 \$0, [\$1], \$2, \$3;"
-    @eval @inline atomic_cas!(ptr::LLVMPtr{$T,$A}, cmp::$T, val::$T) =
+    @eval @device_function @inline atomic_cas!(ptr::LLVMPtr{$T,$A}, cmp::$T, val::$T) =
         @asmcall($intr, "=h,l,h,h", true, $T, Tuple{Core.LLVMPtr{$T,$A},$T,$T}, ptr, cmp, val)
 end
 
@@ -172,7 +172,7 @@ for A in (AS.Generic, AS.Global, AS.Shared)
         nb = sizeof(T)*8
         fn = Symbol("atomic_$(op)!")
         intr = "llvm.nvvm.atomic.load.$op.$nb.p$(convert(Int, A))i$nb"
-        @eval @inline $fn(ptr::LLVMPtr{$T,$A}, val::$T) =
+        @eval @device_function @inline $fn(ptr::LLVMPtr{$T,$A}, val::$T) =
             @typed_ccall($intr, llvmcall, $T, (LLVMPtr{$T,$A}, $T), ptr, val)
     end
 end
@@ -192,7 +192,7 @@ for A in (AS.Generic, AS.Global, AS.Shared), T in (:Float16,)
     end
 
     intr = "atom$scope.add.noftz.f16 \$0, [\$1], \$2;"
-    @eval @inline atomic_add!(ptr::LLVMPtr{$T,$A}, val::$T) =
+    @eval @device_function @inline atomic_add!(ptr::LLVMPtr{$T,$A}, val::$T) =
         @asmcall($intr, "=h,l,h", true, $T, Tuple{Core.LLVMPtr{$T,$A},$T}, ptr, val)
 end
 

--- a/CUDACore/src/device/intrinsics/cooperative_groups.jl
+++ b/CUDACore/src/device/intrinsics/cooperative_groups.jl
@@ -561,7 +561,8 @@ end
 
 ## pipeline operations
 
-@device_function pipeline_commit() = ccall("llvm.nvvm.cp.async.commit.group", llvmcall, Cvoid, ())
+@device_function pipeline_commit() =
+    ccall("llvm.nvvm.cp.async.commit.group", llvmcall, Cvoid, ())
 
 @device_function pipeline_wait_prior(n) =
     ccall("llvm.nvvm.cp.async.wait.group", llvmcall, Cvoid, (Int32,), n)

--- a/CUDACore/src/device/intrinsics/cooperative_groups.jl
+++ b/CUDACore/src/device/intrinsics/cooperative_groups.jl
@@ -24,7 +24,7 @@ Noteworthy missing functionality:
 module CG
 
 using ..CUDACore
-using ..CUDACore: i32, Aligned, alignment
+using ..CUDACore: i32, Aligned, alignment, @device_function
 
 import ..LLVM
 using ..LLVM.Interop
@@ -73,7 +73,7 @@ const grid_workspace = Ptr{grid_workspace_st}
     end
 end
 
-function get_grid_workspace()
+@device_function function get_grid_workspace()
     # interpret the address from envreg 1 and 2 as the driver's grid workspace
     hi = ccall("llvm.nvvm.read.ptx.sreg.envreg1", llvmcall, UInt32, ())
     lo = ccall("llvm.nvvm.read.ptx.sreg.envreg2", llvmcall, UInt32, ())
@@ -561,12 +561,12 @@ end
 
 ## pipeline operations
 
-pipeline_commit() = ccall("llvm.nvvm.cp.async.commit.group", llvmcall, Cvoid, ())
+@device_function pipeline_commit() = ccall("llvm.nvvm.cp.async.commit.group", llvmcall, Cvoid, ())
 
-pipeline_wait_prior(n) =
+@device_function pipeline_wait_prior(n) =
     ccall("llvm.nvvm.cp.async.wait.group", llvmcall, Cvoid, (Int32,), n)
 
-@generated function pipeline_memcpy_async(dst::LLVMPtr{T}, src::LLVMPtr{T}) where T
+@device_function @generated function pipeline_memcpy_async(dst::LLVMPtr{T}, src::LLVMPtr{T}) where T
     size_and_align = sizeof(T)
     size_and_align in (4, 8, 16) || :(return error($"Unsupported size $size_and_align"))
     intr = "llvm.nvvm.cp.async.ca.shared.global.$(sizeof(T))"
@@ -754,5 +754,5 @@ export CG
 
 export this_grid, sync_grid
 
-this_grid() = CG.this_grid()
-sync_grid(grid) = CG.sync(grid)
+@device_function this_grid() = CG.this_grid()
+@device_function sync_grid(grid) = CG.sync(grid)

--- a/CUDACore/src/device/intrinsics/indexing.jl
+++ b/CUDACore/src/device/intrinsics/indexing.jl
@@ -5,7 +5,7 @@ export
     linearBlockIdxInCluster, linearClusterSize,
     laneid, lanemask, warpsize, active_mask, FULL_MASK
 
-@generated function _index(::Val{name}, ::Val{range}) where {name, range}
+@device_function @generated function _index(::Val{name}, ::Val{range}) where {name, range}
     @dispose ctx=Context() begin
         T_int32 = LLVM.Int32Type()
 

--- a/CUDACore/src/device/intrinsics/indexing.jl
+++ b/CUDACore/src/device/intrinsics/indexing.jl
@@ -49,42 +49,42 @@ for dim in (:x, :y, :z)
     # Thread index in block
     fn = Symbol("threadIdx_$dim")
     intr = Symbol("tid.$dim")
-    @eval @inline $fn() = _index($(Val(intr)), $(Val(0:max_block_size[dim]-1))) + 1i32
+    @eval @device_function @inline $fn() = _index($(Val(intr)), $(Val(0:max_block_size[dim]-1))) + 1i32
 
     # Block size (#threads per block)
     fn = Symbol("blockDim_$dim")
     intr = Symbol("ntid.$dim")
-    @eval @inline $fn() = _index($(Val(intr)), $(Val(1:max_block_size[dim])))
+    @eval @device_function @inline $fn() = _index($(Val(intr)), $(Val(1:max_block_size[dim])))
 
     # Block index in grid
     fn = Symbol("blockIdx_$dim")
     intr = Symbol("ctaid.$dim")
-    @eval @inline $fn() = _index($(Val(intr)), $(Val(0:max_grid_size[dim]-1))) + 1i32
+    @eval @device_function @inline $fn() = _index($(Val(intr)), $(Val(0:max_grid_size[dim]-1))) + 1i32
 
     # Grid size (#blocks per grid)
     fn = Symbol("gridDim_$dim")
     intr = Symbol("nctaid.$dim")
-    @eval @inline $fn() = _index($(Val(intr)), $(Val(1:max_grid_size[dim])))
+    @eval @device_function @inline $fn() = _index($(Val(intr)), $(Val(1:max_grid_size[dim])))
 
     # Block index in cluster
     fn = Symbol("blockIdxInCluster_$dim")
     intr = Symbol("cluster.ctaid.$dim")
-    @eval @inline $fn() = _index($(Val(intr)), $(Val(0:max_cluster_size[dim]-1))) + 1i32
+    @eval @device_function @inline $fn() = _index($(Val(intr)), $(Val(0:max_cluster_size[dim]-1))) + 1i32
 
     # Cluster size (#blocks per cluster)
     fn = Symbol("clusterDim_$dim")
     intr = Symbol("cluster.nctaid.$dim")
-    @eval @inline $fn() = _index($(Val(intr)), $(Val(1:max_cluster_size[dim])))
+    @eval @device_function @inline $fn() = _index($(Val(intr)), $(Val(1:max_cluster_size[dim])))
 
     # Cluster index in grid
     fn = Symbol("clusterIdx_$dim")
     intr = Symbol("clusterid.$dim")
-    @eval @inline $fn() = _index($(Val(intr)), $(Val(0:max_grid_size[dim]-1))) + 1i32
+    @eval @device_function @inline $fn() = _index($(Val(intr)), $(Val(0:max_grid_size[dim]-1))) + 1i32
 
     # Grid size in clusters (#clusters per grid)
     fn = Symbol("gridClusterDim_$dim")
     intr = Symbol("nclusterid.$dim")
-    @eval @inline $fn() = _index($(Val(intr)), $(Val(1:max_grid_size[dim])))
+    @eval @device_function @inline $fn() = _index($(Val(intr)), $(Val(1:max_grid_size[dim])))
 end
 
 @device_functions begin

--- a/CUDACore/src/device/intrinsics/libcudadevrt.jl
+++ b/CUDACore/src/device/intrinsics/libcudadevrt.jl
@@ -9,6 +9,7 @@
 
 import Base.Sys: WORD_SIZE
 
+@device_functions begin
 function cudaDeviceGetAttribute(value, attr, device)
     ccall("extern cudaDeviceGetAttribute", llvmcall, cudaError_t,
           (Ptr{Cint}, cudaDeviceAttr, Cint),
@@ -295,4 +296,5 @@ function cudaCGGetRank(threadRank, gridRank, handle)
     ccall("extern cudaCGGetRank", llvmcall, cudaError_t,
           (Ptr{UInt32}, Ptr{UInt32}, Culonglong),
           threadRank, gridRank, handle)
+end
 end

--- a/CUDACore/src/device/intrinsics/misc.jl
+++ b/CUDACore/src/device/intrinsics/misc.jl
@@ -7,6 +7,7 @@ Terminate a thread.
 """
 exit() = @asmcall("exit;")
 
+@device_functions begin
 """
     clock(UInt32)
 
@@ -21,6 +22,7 @@ Returns the value of a per-multiprocessor counter that is incremented every cloc
 """
 clock(::Type{UInt64}) = ccall("llvm.nvvm.read.ptx.sreg.clock64", llvmcall, UInt64, ())
 
+end
 
 """
     nanosleep(t)

--- a/CUDACore/src/device/intrinsics/misc.jl
+++ b/CUDACore/src/device/intrinsics/misc.jl
@@ -1,7 +1,5 @@
 export clock, nanosleep
 
-@device_functions begin
-
 """
     exit()
 
@@ -38,5 +36,3 @@ Puts a thread for a given amount `t`(in nanoseconds).
     @asmcall("nanosleep.u32 \$0;", "r", true,
              Cvoid, Tuple{UInt32}, convert(UInt32, t))
 end
-
-end # @device_functions

--- a/CUDACore/src/device/intrinsics/misc.jl
+++ b/CUDACore/src/device/intrinsics/misc.jl
@@ -1,5 +1,7 @@
 export clock, nanosleep
 
+@device_functions begin
+
 """
     exit()
 
@@ -36,3 +38,5 @@ Puts a thread for a given amount `t`(in nanoseconds).
     @asmcall("nanosleep.u32 \$0;", "r", true,
              Cvoid, Tuple{UInt32}, convert(UInt32, t))
 end
+
+end # @device_functions

--- a/CUDACore/src/device/intrinsics/shared_memory.jl
+++ b/CUDACore/src/device/intrinsics/shared_memory.jl
@@ -68,7 +68,7 @@ macro cuDynamicSharedMem(T, dims, offset=0)
     end
 end
 
-dynamic_smem_size() =
+@device_function dynamic_smem_size() =
     @asmcall("mov.u32 \$0, %dynamic_smem_size;", "=r", true, UInt32, Tuple{})
 
 @inline function CuDistributedSharedArray(shared_array::CuDeviceArray{T,N,AS.Shared}, blockidx::Integer) where {T,N}

--- a/CUDACore/src/device/intrinsics/synchronization.jl
+++ b/CUDACore/src/device/intrinsics/synchronization.jl
@@ -1,6 +1,5 @@
 # Synchronization (B.6)
 
-@device_functions begin
 ## simple synchronization (bar)
 
 export sync_threads, sync_warp

--- a/CUDACore/src/device/intrinsics/synchronization.jl
+++ b/CUDACore/src/device/intrinsics/synchronization.jl
@@ -6,6 +6,8 @@
 export sync_threads, sync_warp
 export sync_threads_count, sync_threads_and, sync_threads_or
 
+@device_functions begin
+
 """
     sync_threads()
 
@@ -59,12 +61,15 @@ the warp.
 @inline sync_warp(mask=FULL_MASK) =
     ccall("llvm.nvvm.bar.warp.sync", llvmcall, Cvoid, (UInt32,), mask)
 
+end # @device_functions
+
 
 ## generalized synchronization (barrier)
 
 export barrier_sync
 
-@inline barrier_sync(id=0) = ccall("llvm.nvvm.barrier.sync", llvmcall, Cvoid, (Int32,), id)
+@device_function barrier_sync(id=0) =
+    ccall("llvm.nvvm.barrier.sync", llvmcall, Cvoid, (Int32,), id)
 
 export cluster_arrive, cluster_arrive_relaxed, cluster_wait
 
@@ -76,6 +81,8 @@ cluster_wait() = ccall("llvm.nvvm.barrier.cluster.wait", llvmcall, Cvoid, ())
 ## memory barriers (membar)
 
 export threadfence, threadfence_block, threadfence_system
+
+@device_functions begin
 
 """
     threadfence_block()
@@ -114,4 +121,4 @@ memory made by the calling thread after the call to `threadfence_system()`.
 """
 @inline threadfence_system() = ccall("llvm.nvvm.membar.sys", llvmcall, Cvoid, ())
 
-end
+end # @device_functions

--- a/CUDACore/src/device/intrinsics/synchronization.jl
+++ b/CUDACore/src/device/intrinsics/synchronization.jl
@@ -1,6 +1,6 @@
 # Synchronization (B.6)
 
-
+@device_functions begin
 ## simple synchronization (bar)
 
 export sync_threads, sync_warp
@@ -64,7 +64,7 @@ the warp.
 
 export barrier_sync
 
-barrier_sync(id=0) = ccall("llvm.nvvm.barrier.sync", llvmcall, Cvoid, (Int32,), id)
+@inline barrier_sync(id=0) = ccall("llvm.nvvm.barrier.sync", llvmcall, Cvoid, (Int32,), id)
 
 export cluster_arrive, cluster_arrive_relaxed, cluster_wait
 
@@ -113,3 +113,5 @@ host threads, and all threads in peer devices as occurring before all writes to 
 memory made by the calling thread after the call to `threadfence_system()`.
 """
 @inline threadfence_system() = ccall("llvm.nvvm.membar.sys", llvmcall, Cvoid, ())
+
+end

--- a/CUDACore/src/device/intrinsics/version.jl
+++ b/CUDACore/src/device/intrinsics/version.jl
@@ -3,7 +3,7 @@
 export compute_capability, ptx_isa_version
 
 for var in ["sm_major", "sm_minor", "ptx_major", "ptx_minor"]
-    @eval @inline $(Symbol(var))() =
+    @eval @device_function @inline $(Symbol(var))() =
         Base.llvmcall(
             $("""@$var = external global i32
                  define i32 @entry() #0 {

--- a/CUDACore/src/device/intrinsics/warp.jl
+++ b/CUDACore/src/device/intrinsics/warp.jl
@@ -26,7 +26,7 @@ for (name, mode, mask, offset) in (("_up",   :up,   UInt32(0x00), src->src),
     for (T,typ) in ((Int32, "i32"), (UInt32, "i32"), (Float32, "f32"))
         intrinsic = "llvm.nvvm.shfl.sync.$mode.$typ"
         @eval begin
-            @inline $fname(mask, val::$T, src, width=$ws) =
+            @device_function @inline $fname(mask, val::$T, src, width=$ws) =
                 ccall($intrinsic, llvmcall, $T,
                       (UInt32, $T, UInt32, UInt32),
                       mask, val, $(offset(:src)), pack(width, $mask))
@@ -109,7 +109,7 @@ for mode in (:all, :any, :uni)
     @eval export $fname
 
     intrinsic = "llvm.nvvm.vote.$mode.sync"
-    @eval @inline $fname(mask, pred) =
+    @eval @device_function @inline $fname(mask, pred) =
         @typed_ccall($intrinsic, llvmcall, Bool, (UInt32, Bool), mask, pred)
 end
 
@@ -119,7 +119,7 @@ for mode in (:ballot, )
     @eval export $fname
 
     intrinsic = "llvm.nvvm.vote.$mode.sync"
-    @eval @inline $fname(mask, pred) =
+    @eval @device_function @inline $fname(mask, pred) =
         @typed_ccall($intrinsic, llvmcall, UInt32, (UInt32, Bool), mask, pred)
 end
 

--- a/CUDACore/src/device/intrinsics/wmma.jl
+++ b/CUDACore/src/device/intrinsics/wmma.jl
@@ -2,7 +2,7 @@ export WMMA
 module WMMA
 
 import ..LLVM
-using ..CUDACore: AS
+using ..CUDACore: AS, @device_function
 using Core: LLVMPtr
 using BFloat16s: BFloat16
 
@@ -214,10 +214,10 @@ for ops in all_ldst_ops,
     ptr_ty = :(LLVMPtr{$arr_ty, $addr_space_int})
 
     if sz == 1
-        @eval $func_name(src_addr, stride) = tuple(ccall($ccall_name, llvmcall, $frag_ty, ($ptr_ty, Int32), src_addr, stride))
+        @eval @device_function $func_name(src_addr, stride) = tuple(ccall($ccall_name, llvmcall, $frag_ty, ($ptr_ty, Int32), src_addr, stride))
     else
         struct_ty = Symbol("LLVMStruct$sz")
-        @eval $func_name(src_addr, stride) = convert(NTuple{$sz, $frag_ty}, ccall($ccall_name, llvmcall, $struct_ty{$frag_ty}, ($ptr_ty, Int32), src_addr, stride))
+        @eval @device_function $func_name(src_addr, stride) = convert(NTuple{$sz, $frag_ty}, ccall($ccall_name, llvmcall, $struct_ty{$frag_ty}, ($ptr_ty, Int32), src_addr, stride))
     end
     @eval export $func_name
     @eval @doc (@doc llvm_wmma_load) $func_name
@@ -284,7 +284,7 @@ export llvm_wmma_store
 
     ptr_ty = :(LLVMPtr{$arr_ty, $addr_space_int})
 
-    @eval $func_name(dst_addr, data, stride) = ccall($ccall_name, llvmcall, Nothing, ($ptr_ty, $(frag_types...), Int32), dst_addr, $(frag_vars...), stride)
+    @eval @device_function $func_name(dst_addr, data, stride) = ccall($ccall_name, llvmcall, Nothing, ($ptr_ty, $(frag_types...), Int32), dst_addr, $(frag_vars...), stride)
     @eval export $func_name
     @eval @doc (@doc llvm_wmma_store) $func_name
 end
@@ -361,10 +361,10 @@ for ops in all_wmma_ops,
     c_vars = ntuple(i -> :(c[$i]), c_sz)
 
     if d_sz == 1
-        @eval $func_name(a, b, c) = tuple(ccall($ccall_name, llvmcall, $d_frag_ty, ($(a_types...), $(b_types...), $(c_types...)), $(a_vars...), $(b_vars...), $(c_vars...)))
+        @eval @device_function $func_name(a, b, c) = tuple(ccall($ccall_name, llvmcall, $d_frag_ty, ($(a_types...), $(b_types...), $(c_types...)), $(a_vars...), $(b_vars...), $(c_vars...)))
     else
         struct_ty = Symbol("LLVMStruct$d_sz")
-        @eval $func_name(a, b, c) = convert(NTuple{$d_sz, $d_frag_ty}, ccall($ccall_name, llvmcall, $struct_ty{$d_frag_ty}, ($(a_types...), $(b_types...), $(c_types...)), $(a_vars...), $(b_vars...), $(c_vars...)))
+        @eval @device_function $func_name(a, b, c) = convert(NTuple{$d_sz, $d_frag_ty}, ccall($ccall_name, llvmcall, $struct_ty{$d_frag_ty}, ($(a_types...), $(b_types...), $(c_types...)), $(a_vars...), $(b_vars...), $(c_vars...)))
     end
     @eval export $func_name
     @eval @doc (@doc llvm_wmma_mma) $func_name

--- a/CUDACore/src/device/pointer.jl
+++ b/CUDACore/src/device/pointer.jl
@@ -34,7 +34,7 @@ for T in LDGTypes
     typ = Symbol(class, width)
 
     intr = "llvm.nvvm.ldg.global.$class.$typ.p1$typ"
-    @eval @inline function pointerref_ldg(base_ptr::LLVMPtr{$T,AS.Global}, i::Integer,
+    @eval @device_function @inline function pointerref_ldg(base_ptr::LLVMPtr{$T,AS.Global}, i::Integer,
                                           ::Val{align}) where align
         offset = i-one(i) # in elements
         ptr = base_ptr + offset*sizeof($T)
@@ -53,7 +53,7 @@ for (N, T) in ((4, Float32), (2, Float64), (4, Int8), (4, Int16), (4, Int32), (2
     typ = Symbol(class, width)
 
     intr = "llvm.nvvm.ldg.global.$class.v$N$typ.p1v$N$typ"
-    @eval @inline function pointerref_ldg(base_ptr::LLVMPtr{NTuple{$N, Base.VecElement{$T}},AS.Global}, i::Integer,
+    @eval @device_function @inline function pointerref_ldg(base_ptr::LLVMPtr{NTuple{$N, Base.VecElement{$T}},AS.Global}, i::Integer,
                                           ::Val{align}) where align
         offset = i-one(i) # in elements
         ptr = base_ptr + offset*$N*sizeof($T)

--- a/CUDACore/src/device/texture.jl
+++ b/CUDACore/src/device/texture.jl
@@ -68,7 +68,7 @@ for (dispatch_rettyp, julia_rettyp, llvm_rettyp) in
                     NTuple{4,$dispatch_rettyp}})
 
     # tex1D only supports array memory
-    @eval tex(texObject::CuDeviceTexture{<:$eltyp,1,ArrayMemorySource}, x::Number) =
+    @eval @device_function tex(texObject::CuDeviceTexture{<:$eltyp,1,ArrayMemorySource}, x::Number) =
         Tuple(ccall($("llvm.nvvm.tex.unified.1d.$llvm_rettyp.f32"), llvmcall,
                     $julia_rettyp, (CUtexObject, Float32), texObject, x))
 
@@ -79,7 +79,7 @@ for (dispatch_rettyp, julia_rettyp, llvm_rettyp) in
         julia_sig = ntuple(_->Float32, dims)
         julia_params = ntuple(i->:($(julia_args[i])::Number), dims)
 
-        @eval tex(texObject::CuDeviceTexture{<:$eltyp,$dims}, $(julia_params...)) =
+        @eval @device_function tex(texObject::CuDeviceTexture{<:$eltyp,$dims}, $(julia_params...)) =
             Tuple(ccall($("llvm.nvvm.tex.unified.$llvm_dim.$llvm_rettyp.f32"), llvmcall,
                         $julia_rettyp, (CUtexObject, $(julia_sig...)), texObject, $(julia_args...)))
     end

--- a/test/core/device/ldg.jl
+++ b/test/core/device/ldg.jl
@@ -1,5 +1,9 @@
 @testset "ldg" begin
-    ir = sprint(io->CUDA.code_llvm(io, CUDACore.pointerref_ldg, Tuple{Core.LLVMPtr{Int,AS.Global},Int,Val{1}}; raw=true))
+    # NOTE: This is necessary because it seems that code_llvm has a bug which causes it to ignore
+    #       the method table. Wrapping it in a function gets us what we want currently but the PR
+    #       here: https://github.com/JuliaLang/julia/pull/60718 will likely fix this according to
+    #       @vchuravy. It is currently not backported.
+    ir = sprint(io->CUDA.code_llvm(io, (args...)->CUDA.pointerref_ldg(args...), Tuple{Core.LLVMPtr{Int,AS.Global},Int,Val{1}}; raw=true))
     if Base.libllvm_version >= v"20"
         # `@llvm.nvvm.ldg` was removed in LLVM 20; the auto-upgrade
         # replaces it with a load bearing `!invariant.load` metadata

--- a/test/core/device/ldg.jl
+++ b/test/core/device/ldg.jl
@@ -3,7 +3,7 @@
     #       the method table. Wrapping it in a function gets us what we want currently but the PR
     #       here: https://github.com/JuliaLang/julia/pull/60718 will likely fix this according to
     #       @vchuravy. It is currently not backported.
-    ir = sprint(io->CUDA.code_llvm(io, (args...)->CUDA.pointerref_ldg(args...), Tuple{Core.LLVMPtr{Int,AS.Global},Int,Val{1}}; raw=true))
+    ir = sprint(io->CUDA.code_llvm(io, (args...)->CUDACore.pointerref_ldg(args...), Tuple{Core.LLVMPtr{Int,AS.Global},Int,Val{1}}; raw=true))
     if Base.libllvm_version >= v"20"
         # `@llvm.nvvm.ldg` was removed in LLVM 20; the auto-upgrade
         # replaces it with a load bearing `!invariant.load` metadata


### PR DESCRIPTION
Currently, Ahead-of-Time (AOT) compilation for any package `using CUDA.jl` is impossible (with or without `--trim`). This is due to several things as far as I can tell:
1. Many methods in `CUDA.jl` which are visible in the global method table, `llvmcall` LLVM ir with `llvm.nvvm` intrinsics which therefore leak through to the AOT step which generates assembly, leading to compilation failures.
2. It seems odd that these methods are being compiled in but it seems the common denominator is that even though no `MethodInstance`s exist for the methods, the methods are concrete (unsure if this is the correct Julia terminology). This is because they either are defined to take concrete types (for example the `clock` methods) or no arguments at all.
3. There is another issue caused specifically by the the wrapper in `libcudadevrt.jl`. The "concrete" methods in that file contain `ccall`s to external functions which do not exist until they are dynamically loaded.  
4. Unfortunately even fixing all of this in the current state of the PR, there seems to be calls to (at least) `gpu_malloc`, `gpu_signal_exception`, and `gpu_report_oom` in the produced llvm ir. These functions don't exist as they would come from the runtime compilation of the runtime. This is likely a problem more fixable in `GPUCompiler.jl`, but maybe @vchuravy or @maleadt you have a better understanding of that.


The relevant issues and other PRs:
- The conversation here: https://github.com/JuliaGPU/GPUCompiler.jl/issues/611 
- This draft PR which identifies some strangeness in what methods are precompiled: https://github.com/JuliaLang/julia/pull/54155
- This draft PR (which was the starting point for this PR, thanks @vchuravy) https://github.com/JuliaGPU/CUDA.jl/pull/2336 which uses `@device_function` to provide erroring copies of the methods for the global method table