### PR TITLE
cuSPARSE: Implement dense * coo matmul without prior sorting

### DIFF
--- a/lib/cusparse/src/generic.jl
+++ b/lib/cusparse/src/generic.jl
@@ -8,7 +8,7 @@ export bmm!
     mv!(transa::SparseChar, alpha::Number, A::CuSparseMatrix, X::CuVector, beta::Number, Y::CuVector, index::SparseChar)
 
 Performs `Y = alpha * op(A) * X + beta * Y`, where `op` can be nothing (`transa = N`),
-tranpose (`transa = T`) or conjugate transpose (`transa = C`).
+transpose (`transa = T`) or conjugate transpose (`transa = C`).
 `X` and `Y` are dense vectors.
 """
 function mv! end
@@ -18,7 +18,7 @@ function mv! end
     mm!(transa::SparseChar, transb::SparseChar, alpha::Number, A::CuMatrix, B::Union{CuSparseMatrixCSC,CuSparseMatrixCSR,CuSparseMatrixCOO}, beta::Number, C::CuMatrix, index::SparseChar)
 
 Performs `C = alpha * op(A) * op(B) + beta * C`, where `op` can be nothing (`transa = N`),
-tranpose (`transa = T`) or conjugate transpose (`transa = C`).
+transpose (`transa = T`) or conjugate transpose (`transa = C`).
 """
 function mm! end
 
@@ -273,7 +273,7 @@ function mv!(transa::SparseChar, alpha::Number, A::Union{CuSparseMatrixCSC{TA},C
 end
 
 function mm!(transa::SparseChar, transb::SparseChar, alpha::Number, A::CuSparseMatrix{T},
-             B::DenseCuMatrix{T}, beta::Number, C::DenseCuMatrix{T}, index::SparseChar, algo::cusparseSpMMAlg_t=CUSPARSE_SPMM_ALG_DEFAULT) where {T}
+             B::Union{DenseCuMatrix{T}, Transpose{T, <:DenseCuMatrix{T}}}, beta::Number, C::Union{DenseCuMatrix{T}, Transpose{T, <:DenseCuMatrix{T}}}, index::SparseChar, algo::cusparseSpMMAlg_t=CUSPARSE_SPMM_ALG_DEFAULT) where {T}
 
     (A isa CuSparseMatrixBSR) && (cuSPARSE.version() < v"12.5.1") && throw(ErrorException("This operation is not supported by the current CUDA version."))
 
@@ -298,12 +298,6 @@ function mm!(transa::SparseChar, transb::SparseChar, alpha::Number, A::CuSparseM
     descB = CuDenseMatrixDescriptor(B)
     descC = CuDenseMatrixDescriptor(C)
 
-    # cusparseDnMatSetStridedBatch(descB, size(B,3), size(B,1)*size(B,2))
-    # cusparseDnMatSetStridedBatch(descB, size(B,3), size(B,1)*size(B,2))
-    # batchsize = length(nonzeros(A)) ÷ nnz(A)
-    # if batchsize > 1
-    #     cusparseCsrSetStridedBatch(obj, batchsize, 0, nnz(A))
-    # end
 
     # Set default buffer for small matrices (1000 chosen arbitrarly)
     # Otherwise tries to allocate 120TB of memory (see #2296)
@@ -323,6 +317,28 @@ function mm!(transa::SparseChar, transb::SparseChar, alpha::Number, A::CuSparseM
         cusparseSpMM(
             handle(), transa, transb, Ref{T}(alpha), descA, descB, Ref{T}(beta),
             descC, T, algo, buffer)
+    end
+    return C
+end
+
+function mm!(transa::SparseChar, transb::SparseChar, alpha::Number, A::DenseCuMatrix{T}, B::CuSparseMatrixCSC{T}, beta::Number, C::DenseCuMatrix{T}, index::SparseChar, algo::cusparseSpMMAlg_t=CUSPARSE_SPMM_ALG_DEFAULT) where T
+    _B = CuSparseMatrixCSR{T}(B.colPtr, B.rowVal, B.nzVal, reverse(B.dims))
+    mm!(transb, transa, alpha, _B, transpose(A), beta, transpose(C), index, algo)
+    return C
+end
+
+function mm!(transa::SparseChar, transb::SparseChar, alpha::Number, A::DenseCuMatrix{T}, B::CuSparseMatrixCSR{T}, beta::Number, C::DenseCuMatrix{T}, index::SparseChar, algo::cusparseSpMMAlg_t=CUSPARSE_SPMM_ALG_DEFAULT) where T
+    _B = CuSparseMatrixCSC{T}(B.rowPtr, B.colVal, B.nzVal, reverse(B.dims))
+    mm!(transb, transa, alpha, _B, transpose(A), beta, transpose(C), index, algo)
+    return C
+end
+
+function mm!(transa::SparseChar, transb::SparseChar, alpha::Number, A::DenseCuMatrix{T}, B::CuSparseMatrixCOO{T}, beta::Number, C::DenseCuMatrix{T}, index::SparseChar, algo::cusparseSpMMAlg_t=CUSPARSE_SPMM_ALG_DEFAULT) where T
+    if T <: Real || transb == 'N' || transb == 'T'
+        mm!((transb == 'N') ? 'T' : 'N', transa, alpha, B, transpose(A), beta, transpose(C), index, algo)
+    else # transb == 'C'
+        _B = CuSparseMatrixCOO{T}(B.rowInd, B.colInd, conj.(B.nzVal), B.dims)
+        mm!('N', transa, alpha, _B, transpose(A), beta, transpose(C), index, algo)
     end
     return C
 end
@@ -396,60 +412,6 @@ function bmm!(transa::SparseChar, transb::SparseChar, alpha::Number, A::CuSparse
         end
         cusparseSpMM(
             handle(), transa, transb, Ref{T}(alpha), descA, descB, Ref{T}(beta),
-            descC, T, algo, buffer)
-    end
-    return C
-end
-
-function mm!(transa::SparseChar, transb::SparseChar, alpha::Number, A::DenseCuMatrix{T},
-             B::Union{CuSparseMatrixCSC{T},CuSparseMatrixCSR{T},CuSparseMatrixCOO{T}}, beta::Number,
-             C::DenseCuMatrix{T}, index::SparseChar, algo::cusparseSpMMAlg_t=CUSPARSE_SPMM_ALG_DEFAULT) where {T}
-
-    # Support transa = 'C' and `transb = 'C' for real matrices
-    transa = T <: Real && transa == 'C' ? 'T' : transa
-    transb = T <: Real && transb == 'C' ? 'T' : transb
-
-    # cusparseSpMM can be also used to perform the multiplication of a dense matrix and a sparse matrix by switching the dense matrices layout:
-    # Cc = α * Ac * B  + β * Cc → α * Bᵀ * Ar + β * Cr
-    # Cc = α * Ac * Bᵀ + β * Cc → α * B  * Ar + β * Cr
-    # Cc = α * Ac * Bᴴ + β * Cc → α * B̅  * Ar + β * Cr
-    # where B is a sparse matrix, Ac and Cc indicate column-major layout, while Ar and Cr refer to row-major layout.
-
-    m,k = size(A)
-    n = size(C)[2]
-
-    if transa == 'N' && transb == 'N'
-        chkmmdims(B,C,k,n,m,n)
-    elseif transa == 'N' && transb != 'N'
-        chkmmdims(B,C,n,k,m,n)
-    elseif transa != 'N' && transb == 'N'
-        chkmmdims(B,C,m,n,k,n)
-    elseif transa != 'N' && transb != 'N'
-        chkmmdims(B,C,n,m,k,n)
-    end
-
-    descA = CuDenseMatrixDescriptor(A, transposed=true)
-    descB = CuSparseMatrixDescriptor(B, index, transposed=true)
-    descC = CuDenseMatrixDescriptor(C, transposed=true)
-
-    # Set default buffer for small matrices (1000 chosen arbitrarly)
-    # Otherwise tries to allocate 120TB of memory (see #2296)
-    function bufferSize()
-        out = Ref{Csize_t}(1000)
-        cusparseSpMM_bufferSize(
-            handle(), transb, transa, Ref{T}(alpha), descB, descA, Ref{T}(beta),
-            descC, T, algo, out)
-        return out[]
-    end
-    with_workspace(bufferSize) do buffer
-        # We should find a way to reuse the buffer (issue #1362)
-        if !(B isa CuSparseMatrixCOO)
-            cusparseSpMM_preprocess(
-                handle(), transb, transa, Ref{T}(alpha), descB, descA, Ref{T}(beta),
-                descC, T, algo, buffer)
-        end
-        cusparseSpMM(
-            handle(), transb, transa, Ref{T}(alpha), descB, descA, Ref{T}(beta),
             descC, T, algo, buffer)
     end
     return C

--- a/lib/cusparse/src/helpers.jl
+++ b/lib/cusparse/src/helpers.jl
@@ -103,6 +103,8 @@ mutable struct CuDenseMatrixDescriptor
         obj
     end
 
+    CuDenseMatrixDescriptor(At::Transpose{<:Any, <:DenseCuMatrix}) = CuDenseMatrixDescriptor(parent(At), transposed=true)
+
     function CuDenseMatrixDescriptor(A::DenseCuArray{T, 3}; transposed::Bool=false) where T
         desc_ref = Ref{cusparseDnMatDescr_t}()
         if transposed

--- a/lib/cusparse/src/interfaces.jl
+++ b/lib/cusparse/src/interfaces.jl
@@ -34,18 +34,6 @@ function mv_wrapper(transa::SparseChar, alpha::Number, A::CuSparseMatrix, X::Den
     mv!(transa, alpha, A, X, beta, Y, 'O')
 end
 
-function mm_wrapper(transa::SparseChar, transb::SparseChar, alpha::Number,
-                    A::CuSparseMatrix{T}, B::CuMatrix{T}, beta::Number, C::CuMatrix{T}) where {T}
-    n_A, m_A = (transa != 'N') ? reverse(size(A)) : size(A)
-    n_B, m_B = (transb != 'N') ? reverse(size(B)) : size(B)
-    n_C, m_C = size(C)
-    m_A == n_B || throw(DimensionMismatch())
-    n_A == n_C || throw(DimensionMismatch())
-    m_B == m_C || throw(DimensionMismatch())
-    isempty(B) && return CUDACore.zeros(eltype(B), size(A, 1), 0)
-    mm!(transa, transb, alpha, A, B, beta, C, 'O')
-end
-
 # element types accepted by cuSPARSE's generic SpMV/SpMM API (`mv!`, `mm!`, `bmm!`).
 # half-precision types are not in `BlasFloat` because CPU BLAS doesn't support them;
 # cuSPARSE handles them by accumulating in Float32/ComplexF32 (see `mv!` in generic.jl).
@@ -123,7 +111,7 @@ function LinearAlgebra.generic_matmatmul!(C::CuMatrix{Tc}, tA, tB, A::CuSparseMa
     B′ = Tb === Tc ? B : convert(CuMatrix{Tc}, B)
     tA = tA in ('S', 's', 'H', 'h') ? 'N' : tA
     tB = tB in ('S', 's', 'H', 'h') ? 'N' : tB
-    mm_wrapper(tA, tB, alpha, A′, B′, beta, C)
+    mm!(tA, tB, alpha, A′, B′, beta, C, 'O')
 end
 
 for (wrapa, transa, unwrapa) in op_wrappers

--- a/lib/cusparse/test/generic.jl
+++ b/lib/cusparse/test/generic.jl
@@ -84,20 +84,38 @@ for SparseMatrixType in keys(SPMM_ALGOS)
         @testset "mm! $T" for T in [Float32, Float64, ComplexF32, ComplexF64]
             @testset "transa = $transa" for (transa, opa) in [('N', identity), ('T', transpose), ('C', adjoint)]
                 @testset "transb = $transb" for (transb, opb) in [('N', identity), ('T', transpose), ('C', adjoint)]
-                    cuSPARSE.version() < v"12.0" && SparseMatrixType == CuSparseMatrixCSC && T <: Complex && transa == 'C' && continue
-                    algo == cuSPARSE.CUSPARSE_SPMM_CSR_ALG3 && (transa != 'N' || transb != 'N') && continue
+                    cuSPARSE.version() < v"12.5.8" && algo == cuSPARSE.CUSPARSE_SPMM_CSR_ALG3 && (transa != 'N' || transb != 'N') && continue
+                    algo == cuSPARSE.CUSPARSE_SPMM_CSR_ALG3 && transa != 'N' && continue # https://docs.nvidia.com/cuda/cusparse/index.html#cusparsespmm: CSR_ALG3 supports only 'NON_TRANSPOSE'
+                    algo == cuSPARSE.CUSPARSE_SPMM_CSR_ALG3 && transb == 'C' && continue # https://docs.nvidia.com/cuda/cusparse/index.html#cusparsespmm: CSR_ALG3 does not support 'CONJUGATE_TRANSPOSE'
                     (SparseMatrixType == CuSparseMatrixBSR) && (transa != 'N') && continue
                     A = sprand(T, 10, 10, 0.1)
                     B = transb == 'N' ? rand(T, 10, 2) : rand(T, 2, 10)
+                    Bt = collect(transpose(B))
                     C = rand(T, 10, 2)
+                    Ct = collect(transpose(C))
                     dA = SparseMatrixType == CuSparseMatrixBSR ? SparseMatrixType(A,1) : SparseMatrixType(A)
                     dB = CuArray(B)
-                    dC = CuArray(C)
+                    dBt = CuArray(Bt)
 
                     alpha = rand(T)
                     beta = rand(T)
+
+                    dC = CuArray(C)
                     mm!(transa, transb, alpha, dA, dB, beta, dC, 'O', algo)
                     @test alpha * opa(A) * opb(B) + beta * C ≈ collect(dC)
+
+                    dCt = CuArray(Ct)
+                    mm!(transa, transb, alpha, dA, transpose(dBt), beta, transpose(dCt), 'O', algo)
+                    @test alpha * opa(A) * opb(B) + beta * C ≈ transpose(collect(dCt))
+
+                    cuSPARSE.version() < v"12.5.8" && continue
+                    dC = CuArray(C)
+                    mm!(transa, transb, alpha, dA, transpose(dBt), beta, dC, 'O', algo)
+                    @test alpha * opa(A) * opb(B) + beta * C ≈ collect(dC)
+
+                    dCt = CuArray(Ct)
+                    mm!(transa, transb, alpha, dA, dB, beta, transpose(dCt), 'O', algo)
+                    @test alpha * opa(A) * opb(B) + beta * C ≈ transpose(collect(dCt))
                 end
             end
         end
@@ -123,16 +141,14 @@ for SparseMatrixType in keys(SPMM_ALGOS)
         @testset "$T" for T in [Float32, Float64, ComplexF32, ComplexF64]
             @testset "transa = $transa" for (transa, opa) in [('N', identity), ('T', transpose), ('C', adjoint)]
                 @testset "transb = $transb" for (transb, opb) in [('N', identity), ('T', transpose), ('C', adjoint)]
-                    cuSPARSE.version() < v"12.0" && SparseMatrixType == CuSparseMatrixCSR && T <: Complex && transb == 'C' && continue
-                    algo == cuSPARSE.CUSPARSE_SPMM_CSR_ALG3 && (transa != 'N' || transb != 'N') && continue
+                    cuSPARSE.version() < v"12.5.8" && algo == cuSPARSE.CUSPARSE_SPMM_CSR_ALG3 && continue
+                    algo == cuSPARSE.CUSPARSE_SPMM_CSR_ALG3 && transb != 'N' && continue # https://docs.nvidia.com/cuda/cusparse/index.html#cusparsespmm: CSR_ALG3 supports only 'NON_TRANSPOSE'
+                    algo == cuSPARSE.CUSPARSE_SPMM_CSR_ALG3 && transa == 'C' && continue # https://docs.nvidia.com/cuda/cusparse/index.html#cusparsespmm: CSR_ALG3 does not support 'CONJUGATE_TRANSPOSE'
                     A = rand(T, 10, 10)
                     B = transb == 'N' ? sprand(T, 10, 5, 0.5) : sprand(T, 5, 10, 0.5)
                     C = rand(T, 10, 5)
                     dA = CuArray(A)
                     dB = SparseMatrixType(B)
-                    if SparseMatrixType == CuSparseMatrixCOO
-                        dB = sort_coo(dB, 'C')
-                    end
                     dC = CuArray(C)
 
                     alpha = rand(T)
@@ -142,8 +158,8 @@ for SparseMatrixType in keys(SPMM_ALGOS)
 
                     # add tests for very small matrices (see #2296)
                     # skip conjugate transpose - causes errors with 1x1 matrices
-                    # CUSPARSE_SPMM_CSR_ALG3 also fails
-                    (algo == cuSPARSE.CUSPARSE_SPMM_CSR_ALG3 || transa == 'C') && continue
+                    cuSPARSE.version() < v"12.6.3" && algo == cuSPARSE.CUSPARSE_SPMM_CSR_ALG3 && continue
+                    transa == 'C' && continue
                     A = rand(T, 1, 1)
                     B = sprand(T, 1, 1, 1.)
                     C = rand(T, 1, 1)

--- a/lib/cusparse/test/interfaces/mul.jl
+++ b/lib/cusparse/test/interfaces/mul.jl
@@ -25,11 +25,10 @@ using LinearAlgebra, SparseArrays
             @test collect(dA * dB) ≈ A * B
             @test collect(dA * db) ≈ A * b
 
-            # dense × sparse (reverse direction); COO must be column-sorted on the right
-            dA_r = SparseMatrixType == CuSparseMatrixCOO ? sort_coo(dA, 'C') : dA
+            # dense × sparse (reverse direction)
             Br = rand(eltyb, k, n)
             dBr = CuArray(Br)
-            @test collect(dBr * dA_r) ≈ Br * A
+            @test collect(dBr * dA) ≈ Br * A
         end
     end
 
@@ -59,9 +58,6 @@ using LinearAlgebra, SparseArrays
             B  = opb == identity ? sprand(elty, k, n, 0.2) : sprand(elty, n, k, 0.2)
             for SparseMatrixType in (CuSparseMatrixCSC, CuSparseMatrixCSR, CuSparseMatrixCOO)
                 dB = SparseMatrixType(B)
-                if SparseMatrixType == CuSparseMatrixCOO
-                    dB = sort_coo(dB, 'C')
-                end
                 @testset "CuMatrix * $SparseMatrixType" begin
                     @testset "A * B" begin
                         C  = opa(A) * opb(B)


### PR DESCRIPTION
The current implementation of matrix-matrix multiplication [`mm!`](https://github.com/JuliaGPU/CUDA.jl/blob/77191afe121aaa415d273de86233f9d8b071007e/lib/cusparse/generic.jl#L404) of a dense and a sparse matrix (with a coo-matrix as the second argument) required a user to sort the sparse matrix before multiplication. This was tested behavior, see [generic.jl](https://github.com/JuliaGPU/CUDA.jl/blob/77191afe121aaa415d273de86233f9d8b071007e/test/libraries/cusparse/generic.jl#L132-L134)  or [interfaces.jl](https://github.com/JuliaGPU/CUDA.jl/blob/77191afe121aaa415d273de86233f9d8b071007e/test/libraries/cusparse/interfaces.jl#L77-L79).
This is because CUSPARSE only provides an API for `C = a*A*B + b*C` (where A is sparse), the case where B is sparse is implemented by transposing the identity to `Ct = a*Bt*At + b*Ct`. For csc/csr we can exchange the type to realize the transpose, but for coo we would have to resort the col- and row-indices. Sorting currently copies the whole matrix.

The requirement to sort before multiplication is somewhat unexpected, especially in the higher level interfaces `mul!` and `*` which should produce the correct result without prior sorting (or should check for correct ordering and warn/error). Currently the matrix multiplication returns normally but with a wrong result (see https://github.com/JuliaGPU/CUDA.jl/issues/2820).

However, in almost all cases we can realize the multiplication of dense * coo without sorting by flipping the 'N'/'T'/'C' argument of the sparse matrix correspondingly. See this PR.
The only case that cannot be easily realized is if the `eltype(B)` of the matrix is `<:Complex` and the transb argument `== 'C'`. The lazy transpose would need a "only conjugate" (no transpose) flag. This PR implements this case by materializing the conjugate of the coo-matrix entries. (Compared to sorting this already reduces memory consumption, because only a copy of the entries is required instead of a full copy).

An alternative implementation (fully inplace) could: 1. conjugate the values of `C` (if `!iszero(b)`), 2. compute the matrix product and 3. conjugate the values of `C` again. Without a only conjugate flag provided by CUSPARSE, I don't see a way to realize this case without additional work or implementing our own matmul (which would probably be slow).

Both of these options are suboptimal for a matmul implementation, we could also error for this specific case asking the user to supply the matrix in csc/csr format. Any opinions on that?

Closes https://github.com/JuliaGPU/CUDA.jl/issues/2820.

Also this removes `mm_wrapper` that would only duplicate the size checks in `mm!` and shortcut if `isempty(B)` but return a zero matrix of wrong shape.