### PR TITLE
Specialize transpose! for CuMatrix

### DIFF
--- a/src/array.jl
+++ b/src/array.jl
@@ -946,3 +946,11 @@ function Base.resize!(A::CuVector{T}, n::Integer) where T
   A.dims = (n,)
   return A
 end
+
+
+# CUBLAS.geam! is much faster than the generic implementation of transpose! in GPUArrays:
+function LinearAlgebra.transpose!(dest::CuMatrix{T}, src::CuMatrix{T}) where {T <: Union{Float32, Float64, ComplexF32, ComplexF64}}
+    axes(dest) == reverse(axes(src)) || throw(DimensionMismatch("axes of the destination are incompatible with that of the source"))
+    CUDA.CUBLAS.geam!('T', 'T', one(T), src, zero(T), src, dest)
+    return dest
+end

--- a/test/base/array.jl
+++ b/test/base/array.jl
@@ -979,6 +979,16 @@ end
   @test c === a
 end
 
+@testset "transpose!" begin
+    for T in [Float32, Float64, ComplexF32, ComplexF64]
+        a = CUDA.rand(T, 10, 20)
+        b = similar(a, reverse(size(a)))
+        c = similar(a)
+        @test Array(transpose!(b, a)) == transpose(Array(a))
+        @test_throws DimensionMismatch transpose!(c, a)
+    end
+end
+
 @testset "issue 2595" begin
   # mixed-type reductions resulted in a deadlock because of union splitting over shfl
   a = CUDA.zeros(Float32, 1)


### PR DESCRIPTION
`transpose!` performance can be very important when changing data layout to match the access pattern of kernels, etc.

With

```julia
using CUDA, LinearAlgebra, BenchmarkTools
A = cu(rand(Float32, 1000, 10000));
B = similar(A, reverse(size(A)));

@benchmark (transpose!($B, $A); CUDA.synchronize())
```

Before (current master branch on NVIDIA GH200):

```
BenchmarkTools.Trial: 10000 samples with 1 evaluation per sample.
 Range (min … max):  172.672 μs …  1.437 ms  ┊ GC (min … max): 0.00% … 0.00%
 Time  (median):     175.648 μs              ┊ GC (median):    0.00%
 Time  (mean ± σ):   176.020 μs ± 14.891 μs  ┊ GC (mean ± σ):  0.00% ± 0.00%
```

After (this PR on NVIDIA GH200):

```
BenchmarkTools.Trial: 10000 samples with 1 evaluation per sample.
 Range (min … max):  41.536 μs … 285.217 μs  ┊ GC (min … max): 0.00% … 0.00%
 Time  (median):     43.904 μs               ┊ GC (median):    0.00%
 Time  (mean ± σ):   44.114 μs ±   2.743 μs  ┊ GC (mean ± σ):  0.00% ± 0.00%
```

This implicitly speeds up `copy(transpose(A))` as well.

For `A = cu(rand(Float32, 5000, 50000))` I get 622 μs with this PR (3.9 ms with current master branch) on an GH200 96GB, so 1.6 TB/s throughput - which seems good for a transposing read/write, total HBM3 bandwidth on the device is about 4 TB/s (so we can reach about 80% of max. bandwidth for large arrays, including the CUBLAS call overhead).

Note: specialization (and speed-up) is limited to datatypes supported by `CUDA.CUBLAS.geam!` (`Float32`, `Float64`, `ComplexF32`, `ComplexF64`, same as in [CUBLAS itself](https://docs.nvidia.com/cuda/cublas/#cublas-t-geam)).