### PR TITLE
Extend LLVM 18 workaround to other float types.

### DIFF
--- a/src/device/intrinsics/math.jl
+++ b/src/device/intrinsics/math.jl
@@ -365,9 +365,13 @@ end
 @static if Base.thismajor(LLVM.version()) <= v"18"
     # LLVM 18 and below generate non-existing instructions for Julia's default methods of
     # fast min/max on fp64: https://github.com/JuliaGPU/CUDA.jl/issues/2886
-    @device_override @inline Base.FastMath.max_fast(x::Float64, y::Float64) = ifelse(y > x, y, x)
-    @device_override @inline Base.FastMath.min_fast(x::Float64, y::Float64) = ifelse(y > x, x, y)
-    @device_override @inline Base.FastMath.minmax_fast(x::Float64, y::Float64) = ifelse(y > x, (x, y), (y, x))
+    for T in (Float16, Float32, Float64)
+        @eval begin
+            @device_override @inline Base.FastMath.max_fast(x::$T, y::$T) = ifelse(y > x, y, x)
+            @device_override @inline Base.FastMath.min_fast(x::$T, y::$T) = ifelse(y > x, x, y)
+            @device_override @inline Base.FastMath.minmax_fast(x::$T, y::$T) = ifelse(y > x, (x, y), (y, x))
+        end
+    end
 end
 
 @device_function saturate(x::Float32) = ccall("extern __nv_saturatef", llvmcall, Cfloat, (Cfloat,), x)


### PR DESCRIPTION
Extends #2937, fixes https://github.com/JuliaGPU/CUDA.jl/issues/2946