### PR TITLE
Switch to 1.12 for benchmarks

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -415,7 +415,7 @@ steps:
   - label: ":racehorse: Benchmarks"
     plugins:
       - JuliaCI/julia#v1:
-          version: "1.11"
+          version: "1.12"
     command: |
       julia --project=perf -e '
         using Pkg


### PR DESCRIPTION
Just changing this so it shows up on the benchmark graphs and makes it easier to figure out why a the sudden jump/drop in some benchmarks