### PR TITLE
[CUSPARSE] create slices of sparse matrices using boolean masks

### DIFF
--- a/lib/cusparse/src/array.jl
+++ b/lib/cusparse/src/array.jl
@@ -522,52 +522,89 @@ function Base.getindex(A::CuSparseArrayCSR{Tv, Ti, N}, i0::Integer, i1::Integer,
 end
 
 # slice matrix by masking rows and columns
-function _getindex_boolmask(A::Union{CuSparseMatrixCSR, CuSparseMatrixCSC},
-                            Imask::CuVector{Bool}, Jmask::CuVector{Bool})
+
+function Base.getindex(A::CuSparseMatrixCSR{Tv,Ti}, Imask::CuVector{Bool}, Jmask::CuVector{Bool}) where {Tv,Ti}
     m, n = size(A)
     length(Imask) == m || throw(DimensionMismatch("boolean row mask length $(length(Imask)) must match row count $m"))
     length(Jmask) == n || throw(DimensionMismatch("boolean column mask length $(length(Jmask)) must match column count $n"))
 
-    # convert to COO for uniform element-wise access
-    A_coo = CuSparseMatrixCOO(A)
-    rowInd = A_coo.rowInd
-    colInd = A_coo.colInd
-    nzVal  = A_coo.nzVal
+    rowmap = cumsum(Ti.(Imask))
+    colmap = cumsum(Ti.(Jmask))
+    new_m = Int(CUDA.@allowscalar rowmap[end])
+    new_n = Int(CUDA.@allowscalar colmap[end])
 
-    # build selection mask: keep entry if both row and col are selected
-    row_sel = Imask[rowInd]
-    col_sel = Jmask[colInd]
-    keep = row_sel .& col_sel
+    # pass 1: count kept entries per new row
+    counts = CUDA.zeros(Ti, new_m)
+    if new_m > 0 && new_n > 0
+        threads = min(256, m)
+        blocks = cld(m, threads)
+        @cuda threads=threads blocks=blocks _csr_count_kernel!(counts, A.rowPtr, A.colVal, Imask, Jmask, rowmap)
+    end
 
-    # filter entries
-    new_rowInd = rowInd[keep]
-    new_colInd = colInd[keep]
-    new_nzVal  = nzVal[keep]
+    # build new rowPtr from counts: [1, 1+cumsum(counts)...]
+    new_rowPtr = vcat(CuVector{Ti}([one(Ti)]), cumsum(counts) .+ one(Ti))
+    new_nnz = Int(CUDA.@allowscalar new_rowPtr[end]) - 1
 
-    # build index remapping via cumulative sum of masks
-    rowmap = cumsum(Int32.(Imask))
-    colmap = cumsum(Int32.(Jmask))
+    # pass 2: fill entries
+    new_colVal = CuVector{Ti}(undef, new_nnz)
+    new_nzVal = CuVector{Tv}(undef, new_nnz)
+    if new_nnz > 0
+        threads = min(256, m)
+        blocks = cld(m, threads)
+        @cuda threads=threads blocks=blocks _csr_fill_kernel!(
+            new_colVal, new_nzVal, new_rowPtr, A.rowPtr, A.colVal, A.nzVal,
+            Imask, Jmask, rowmap, colmap)
+    end
 
-    # remap to compacted indices
-    new_rowInd = rowmap[new_rowInd]
-    new_colInd = colmap[new_colInd]
-
-    new_m = Int(sum(Imask))
-    new_n = Int(sum(Jmask))
-    new_nnz = length(new_nzVal)
-
-    return CuSparseMatrixCOO(new_rowInd, new_colInd, new_nzVal, (new_m, new_n), new_nnz)
+    return CuSparseMatrixCSR{Tv,Ti}(new_rowPtr, new_colVal, new_nzVal, (new_m, new_n))
 end
 
-function Base.getindex(A::CuSparseMatrixCSR, Imask::CuVector{Bool}, Jmask::CuVector{Bool})
-    coo = _getindex_boolmask(A, Imask, Jmask)
-    return CuSparseMatrixCSR(coo)
+# CSR: one thread per original row — count entries where column is selected
+function _csr_count_kernel!(counts, rowPtr, colVal, Imask, Jmask, rowmap)
+    i = threadIdx().x + (blockIdx().x - Int32(1)) * blockDim().x
+    i > length(Imask) && return nothing
+    @inbounds begin
+        Imask[i] || return nothing
+        new_i = rowmap[i]
+        c = zero(eltype(counts))
+        for j in rowPtr[i]:(rowPtr[i+1] - one(eltype(rowPtr)))
+            if Jmask[colVal[j]]
+                c += one(eltype(counts))
+            end
+        end
+        counts[new_i] = c
+    end
+    return nothing
 end
 
-function Base.getindex(A::CuSparseMatrixCSC, Imask::CuVector{Bool}, Jmask::CuVector{Bool})
-    coo = _getindex_boolmask(A, Imask, Jmask)
-    return CuSparseMatrixCSC(coo)
+# CSR: one thread per original row — fill entries with remapped column indices
+function _csr_fill_kernel!(new_colVal, new_nzVal, new_rowPtr, rowPtr, colVal, nzVal,
+                           Imask, Jmask, rowmap, colmap)
+    i = threadIdx().x + (blockIdx().x - Int32(1)) * blockDim().x
+    i > length(Imask) && return nothing
+    @inbounds begin
+        Imask[i] || return nothing
+        offset = new_rowPtr[rowmap[i]]
+        for j in rowPtr[i]:(rowPtr[i+1] - one(eltype(rowPtr)))
+            col = colVal[j]
+            if Jmask[col]
+                new_colVal[offset] = colmap[col]
+                new_nzVal[offset] = nzVal[j]
+                offset += one(eltype(new_rowPtr))
+            end
+        end
+    end
+    return nothing
 end
+
+# CSC: reinterpret as transposed CSR, index with swapped masks, reinterpret back.
+# A CSC (colPtr, rowVal, nzVal, (m,n)) is the same layout as CSR (rowPtr, colVal, nzVal, (n,m)).
+function Base.getindex(A::CuSparseMatrixCSC{Tv,Ti}, Imask::CuVector{Bool}, Jmask::CuVector{Bool}) where {Tv,Ti}
+    A_as_csr = CuSparseMatrixCSR{Tv,Ti}(A.colPtr, A.rowVal, A.nzVal, reverse(size(A)))
+    result_csr = A_as_csr[Jmask, Imask]
+    return CuSparseMatrixCSC{Tv,Ti}(result_csr.rowPtr, result_csr.colVal, result_csr.nzVal, reverse(size(result_csr)))
+end
+
 
 ## interop with sparse CPU arrays
 

--- a/lib/cusparse/src/array.jl
+++ b/lib/cusparse/src/array.jl
@@ -530,11 +530,11 @@ function Base.getindex(A::CuSparseMatrixCSR{Tv, Ti}, Imask::CuVector{Bool}, Jmas
 
     rowmap = cumsum(Ti.(Imask))
     colmap = cumsum(Ti.(Jmask))
-    new_m = Int(CUDA.@allowscalar rowmap[end])
-    new_n = Int(CUDA.@allowscalar colmap[end])
+    new_m = Int(CUDACore.@allowscalar rowmap[end])
+    new_n = Int(CUDACore.@allowscalar colmap[end])
 
     # pass 1: count kept entries per new row
-    counts = CUDA.zeros(Ti, new_m)
+    counts = CUDACore.zeros(Ti, new_m)
     if new_m > 0 && new_n > 0
         threads = min(256, m)
         blocks = cld(m, threads)
@@ -543,7 +543,7 @@ function Base.getindex(A::CuSparseMatrixCSR{Tv, Ti}, Imask::CuVector{Bool}, Jmas
 
     # build new rowPtr from counts: [1, 1+cumsum(counts)...]
     new_rowPtr = vcat(CuVector{Ti}([one(Ti)]), cumsum(counts) .+ one(Ti))
-    new_nnz = Int(CUDA.@allowscalar new_rowPtr[end]) - 1
+    new_nnz = Int(CUDACore.@allowscalar new_rowPtr[end]) - 1
 
     # pass 2: fill entries
     new_colVal = CuVector{Ti}(undef, new_nnz)

--- a/lib/cusparse/src/array.jl
+++ b/lib/cusparse/src/array.jl
@@ -524,14 +524,13 @@ end
 # slice matrix by masking rows and columns
 
 function Base.getindex(A::CuSparseMatrixCSR{Tv, Ti}, Imask::CuVector{Bool}, Jmask::CuVector{Bool}) where {Tv, Ti}
-    m, n = size(A)
-    length(Imask) == m || throw(DimensionMismatch("boolean row mask length $(length(Imask)) must match row count $m"))
-    length(Jmask) == n || throw(DimensionMismatch("boolean column mask length $(length(Jmask)) must match column count $n"))
+    @boundscheck checkbounds(A, Imask, Jmask)
 
+    m, n = size(A)
     rowmap = cumsum(Ti.(Imask))
     colmap = cumsum(Ti.(Jmask))
-    new_m = Int(CUDACore.@allowscalar rowmap[end])
-    new_n = Int(CUDACore.@allowscalar colmap[end])
+    new_m = m > 0 ? Int(CUDACore.@allowscalar rowmap[end]) : 0
+    new_n = n > 0 ? Int(CUDACore.@allowscalar colmap[end]) : 0
 
     # pass 1: count kept entries per new row
     counts = CUDACore.zeros(Ti, new_m)
@@ -603,6 +602,7 @@ end
 # CSC: reinterpret as transposed CSR, index with swapped masks, reinterpret back.
 # A CSC (colPtr, rowVal, nzVal, (m,n)) is the same layout as CSR (rowPtr, colVal, nzVal, (n,m)).
 function Base.getindex(A::CuSparseMatrixCSC{Tv, Ti}, Imask::CuVector{Bool}, Jmask::CuVector{Bool}) where {Tv, Ti}
+    @boundscheck checkbounds(A, Imask, Jmask)
     A_as_csr = CuSparseMatrixCSR{Tv, Ti}(A.colPtr, A.rowVal, A.nzVal, reverse(size(A)))
     result_csr = A_as_csr[Jmask, Imask]
     return CuSparseMatrixCSC{Tv, Ti}(result_csr.rowPtr, result_csr.colVal, result_csr.nzVal, reverse(size(result_csr)))

--- a/lib/cusparse/src/array.jl
+++ b/lib/cusparse/src/array.jl
@@ -523,7 +523,7 @@ end
 
 # slice matrix by masking rows and columns
 
-function Base.getindex(A::CuSparseMatrixCSR{Tv,Ti}, Imask::CuVector{Bool}, Jmask::CuVector{Bool}) where {Tv,Ti}
+function Base.getindex(A::CuSparseMatrixCSR{Tv, Ti}, Imask::CuVector{Bool}, Jmask::CuVector{Bool}) where {Tv, Ti}
     m, n = size(A)
     length(Imask) == m || throw(DimensionMismatch("boolean row mask length $(length(Imask)) must match row count $m"))
     length(Jmask) == n || throw(DimensionMismatch("boolean column mask length $(length(Jmask)) must match column count $n"))
@@ -538,7 +538,7 @@ function Base.getindex(A::CuSparseMatrixCSR{Tv,Ti}, Imask::CuVector{Bool}, Jmask
     if new_m > 0 && new_n > 0
         threads = min(256, m)
         blocks = cld(m, threads)
-        @cuda threads=threads blocks=blocks _csr_count_kernel!(counts, A.rowPtr, A.colVal, Imask, Jmask, rowmap)
+        @cuda threads = threads blocks = blocks _csr_count_kernel!(counts, A.rowPtr, A.colVal, Imask, Jmask, rowmap)
     end
 
     # build new rowPtr from counts: [1, 1+cumsum(counts)...]
@@ -551,12 +551,13 @@ function Base.getindex(A::CuSparseMatrixCSR{Tv,Ti}, Imask::CuVector{Bool}, Jmask
     if new_nnz > 0
         threads = min(256, m)
         blocks = cld(m, threads)
-        @cuda threads=threads blocks=blocks _csr_fill_kernel!(
+        @cuda threads = threads blocks = blocks _csr_fill_kernel!(
             new_colVal, new_nzVal, new_rowPtr, A.rowPtr, A.colVal, A.nzVal,
-            Imask, Jmask, rowmap, colmap)
+            Imask, Jmask, rowmap, colmap
+        )
     end
 
-    return CuSparseMatrixCSR{Tv,Ti}(new_rowPtr, new_colVal, new_nzVal, (new_m, new_n))
+    return CuSparseMatrixCSR{Tv, Ti}(new_rowPtr, new_colVal, new_nzVal, (new_m, new_n))
 end
 
 # CSR: one thread per original row — count entries where column is selected
@@ -567,7 +568,7 @@ function _csr_count_kernel!(counts, rowPtr, colVal, Imask, Jmask, rowmap)
         Imask[i] || return nothing
         new_i = rowmap[i]
         c = zero(eltype(counts))
-        for j in rowPtr[i]:(rowPtr[i+1] - one(eltype(rowPtr)))
+        for j in rowPtr[i]:(rowPtr[i + 1] - one(eltype(rowPtr)))
             if Jmask[colVal[j]]
                 c += one(eltype(counts))
             end
@@ -578,14 +579,16 @@ function _csr_count_kernel!(counts, rowPtr, colVal, Imask, Jmask, rowmap)
 end
 
 # CSR: one thread per original row — fill entries with remapped column indices
-function _csr_fill_kernel!(new_colVal, new_nzVal, new_rowPtr, rowPtr, colVal, nzVal,
-                           Imask, Jmask, rowmap, colmap)
+function _csr_fill_kernel!(
+        new_colVal, new_nzVal, new_rowPtr, rowPtr, colVal, nzVal,
+        Imask, Jmask, rowmap, colmap
+    )
     i = threadIdx().x + (blockIdx().x - Int32(1)) * blockDim().x
     i > length(Imask) && return nothing
     @inbounds begin
         Imask[i] || return nothing
         offset = new_rowPtr[rowmap[i]]
-        for j in rowPtr[i]:(rowPtr[i+1] - one(eltype(rowPtr)))
+        for j in rowPtr[i]:(rowPtr[i + 1] - one(eltype(rowPtr)))
             col = colVal[j]
             if Jmask[col]
                 new_colVal[offset] = colmap[col]
@@ -599,10 +602,10 @@ end
 
 # CSC: reinterpret as transposed CSR, index with swapped masks, reinterpret back.
 # A CSC (colPtr, rowVal, nzVal, (m,n)) is the same layout as CSR (rowPtr, colVal, nzVal, (n,m)).
-function Base.getindex(A::CuSparseMatrixCSC{Tv,Ti}, Imask::CuVector{Bool}, Jmask::CuVector{Bool}) where {Tv,Ti}
-    A_as_csr = CuSparseMatrixCSR{Tv,Ti}(A.colPtr, A.rowVal, A.nzVal, reverse(size(A)))
+function Base.getindex(A::CuSparseMatrixCSC{Tv, Ti}, Imask::CuVector{Bool}, Jmask::CuVector{Bool}) where {Tv, Ti}
+    A_as_csr = CuSparseMatrixCSR{Tv, Ti}(A.colPtr, A.rowVal, A.nzVal, reverse(size(A)))
     result_csr = A_as_csr[Jmask, Imask]
-    return CuSparseMatrixCSC{Tv,Ti}(result_csr.rowPtr, result_csr.colVal, result_csr.nzVal, reverse(size(result_csr)))
+    return CuSparseMatrixCSC{Tv, Ti}(result_csr.rowPtr, result_csr.colVal, result_csr.nzVal, reverse(size(result_csr)))
 end
 
 

--- a/lib/cusparse/src/array.jl
+++ b/lib/cusparse/src/array.jl
@@ -521,6 +521,54 @@ function Base.getindex(A::CuSparseArrayCSR{Tv, Ti, N}, i0::Integer, i1::Integer,
     CuSparseMatrixCSR(A.rowPtr[:,idxs...], A.colVal[:,idxs...], nonzeros(A)[:,idxs...], size(A)[1:2])[i0, i1]
 end
 
+# slice matrix by masking rows and columns
+function _getindex_boolmask(A::Union{CuSparseMatrixCSR, CuSparseMatrixCSC},
+                            Imask::CuVector{Bool}, Jmask::CuVector{Bool})
+    m, n = size(A)
+    length(Imask) == m || throw(DimensionMismatch("boolean row mask length $(length(Imask)) must match row count $m"))
+    length(Jmask) == n || throw(DimensionMismatch("boolean column mask length $(length(Jmask)) must match column count $n"))
+
+    # convert to COO for uniform element-wise access
+    A_coo = CuSparseMatrixCOO(A)
+    rowInd = A_coo.rowInd
+    colInd = A_coo.colInd
+    nzVal  = A_coo.nzVal
+
+    # build selection mask: keep entry if both row and col are selected
+    row_sel = Imask[rowInd]
+    col_sel = Jmask[colInd]
+    keep = row_sel .& col_sel
+
+    # filter entries
+    new_rowInd = rowInd[keep]
+    new_colInd = colInd[keep]
+    new_nzVal  = nzVal[keep]
+
+    # build index remapping via cumulative sum of masks
+    rowmap = cumsum(Int32.(Imask))
+    colmap = cumsum(Int32.(Jmask))
+
+    # remap to compacted indices
+    new_rowInd = rowmap[new_rowInd]
+    new_colInd = colmap[new_colInd]
+
+    new_m = Int(sum(Imask))
+    new_n = Int(sum(Jmask))
+    new_nnz = length(new_nzVal)
+
+    return CuSparseMatrixCOO(new_rowInd, new_colInd, new_nzVal, (new_m, new_n), new_nnz)
+end
+
+function Base.getindex(A::CuSparseMatrixCSR, Imask::CuVector{Bool}, Jmask::CuVector{Bool})
+    coo = _getindex_boolmask(A, Imask, Jmask)
+    return CuSparseMatrixCSR(coo)
+end
+
+function Base.getindex(A::CuSparseMatrixCSC, Imask::CuVector{Bool}, Jmask::CuVector{Bool})
+    coo = _getindex_boolmask(A, Imask, Jmask)
+    return CuSparseMatrixCSC(coo)
+end
+
 ## interop with sparse CPU arrays
 
 # cpu to gpu

--- a/lib/cusparse/test/interfaces.jl
+++ b/lib/cusparse/test/interfaces.jl
@@ -416,7 +416,7 @@ nB = 2
 
         S_all_csr = A_csr[CuVector(trues(m)), CuVector(trues(n))]
         @test S_all_csr isa CuSparseMatrixCSR
-        @allowscalar for i in eachindex(A, S_all_csr)
+        CUDA.@allowscalar for i in eachindex(A, S_all_csr)
             @test A[i] ≈ S_all_csr[i]
         end
 

--- a/lib/cusparse/test/interfaces.jl
+++ b/lib/cusparse/test/interfaces.jl
@@ -339,7 +339,9 @@ nB = 2
         rowmask_d = CuVector(rowmask)
         colmask_d = CuVector(colmask)
         @testset "type = $SparseMatrixType" for SparseMatrixType in (CuSparseMatrixCSC, CuSparseMatrixCSR)
-            dA = SparseMatrixType(A)
+            # CUDA 12.0 has a bug in CSC -> CSR conversion, so we go though COO
+            dA_coo = CuSparseMatrixCOO(A)
+            dA = SparseMatrixType(dA_coo)
             dS = dA[rowmask_d, colmask_d]
             @test dS isa SparseMatrixType
             @test S_cpu ≈ collect(dS)

--- a/lib/cusparse/test/interfaces.jl
+++ b/lib/cusparse/test/interfaces.jl
@@ -338,13 +338,31 @@ nB = 2
 
         rowmask_d = CuVector(rowmask)
         colmask_d = CuVector(colmask)
-        @testset "type = $SparseMatrixType" for SparseMatrixType in (CuSparseMatrixCSC, CuSparseMatrixCSR)
-            # CUDA 12.0 has a bug in CSC -> CSR conversion, so we go though COO
-            dA_coo = CuSparseMatrixCOO(A)
-            dA = SparseMatrixType(dA_coo)
-            dS = dA[rowmask_d, colmask_d]
-            @test dS isa SparseMatrixType
-            @test S_cpu ≈ collect(dS)
+
+        # test slicing of CSC format
+        A_csc = CuSparseMatrixCSC(A)
+        S_csc = A_csc[rowmask_d, colmask_d]
+        @test S_csc isa CuSparseMatrixCSC
+        @test S_cpu ≈ collect(S_csc)
+
+        # test slicing of CSR format
+        # Conversion between CSC and CSR is broken in many ways on CUDA 12.0,
+        # therefore we construct the CSR matrix manually from the transposed CSC.
+        Aᵀ_csc = CuSparseMatrixCSC(Transpose(A))
+        A_csr = CuSparseMatrixCSR{eltype(A), Int32}(
+            copy(Aᵀ_csc.colPtr), # rowPtr is the same as colPtr of the transposed CSC
+            copy(Aᵀ_csc.rowVal), # colVal is the same as rowVal of the transposed CSC
+            copy(Aᵀ_csc.nzVal),  # nzVal is unchanged by transposition
+            size(A)
+        )
+        # collect calls CSR→CSC conversion again which is broken, so we test on scalar level
+        CUDA.@allowscalar for i in eachindex(A, A_csr)
+            @test A[i] ≈ A_csr[i]
+        end
+        S_csr = A_csr[rowmask_d, colmask_d]
+        @test S_csr isa CuSparseMatrixCSR
+        CUDA.@allowscalar for i in eachindex(S_cpu, S_csr)
+            @test S_cpu[i] ≈ S_csr[i]
         end
     end
 end

--- a/lib/cusparse/test/interfaces.jl
+++ b/lib/cusparse/test/interfaces.jl
@@ -329,4 +329,20 @@ nB = 2
             @test ref_cuda_sparse.colPtr == cuda_spdiagm.colPtr
         end
     end
+
+    @testset "getindex with boolean masks" begin
+        A = sprand(elty, m, n, 0.4)
+        rowmask = rand(Bool, m)
+        colmask = rand(Bool, n)
+        S_cpu = A[rowmask, colmask]
+
+        rowmask_d = CuVector(rowmask)
+        colmask_d = CuVector(colmask)
+        @testset "type = $SparseMatrixType" for SparseMatrixType in (CuSparseMatrixCSC, CuSparseMatrixCSR)
+            dA = SparseMatrixType(A)
+            dS = dA[rowmask_d, colmask_d]
+            @test dS isa SparseMatrixType
+            @test S_cpu ≈ SparseMatrixCSC(dS)
+        end
+    end
 end

--- a/lib/cusparse/test/interfaces.jl
+++ b/lib/cusparse/test/interfaces.jl
@@ -342,7 +342,7 @@ nB = 2
             dA = SparseMatrixType(A)
             dS = dA[rowmask_d, colmask_d]
             @test dS isa SparseMatrixType
-            @test S_cpu ≈ SparseMatrixCSC(dS)
+            @test S_cpu ≈ collect(dS)
         end
     end
 end

--- a/lib/cusparse/test/interfaces.jl
+++ b/lib/cusparse/test/interfaces.jl
@@ -364,5 +364,98 @@ nB = 2
         CUDA.@allowscalar for i in eachindex(S_cpu, S_csr)
             @test S_cpu[i] ≈ S_csr[i]
         end
+
+        # wrong mask size: throws BoundsError for both too-long and too-short, matching the behaviour of dense Array.
+        @test_throws BoundsError A_csc[CuVector(trues(m + 1)), colmask_d]
+        @test_throws BoundsError A_csc[rowmask_d, CuVector(trues(n + 1))]
+        @test_throws BoundsError A_csc[CuVector(trues(m - 1)), colmask_d]
+        @test_throws BoundsError A_csc[rowmask_d, CuVector(trues(n - 1))]
+        @test_throws BoundsError A_csr[CuVector(trues(m + 1)), colmask_d]
+        @test_throws BoundsError A_csr[rowmask_d, CuVector(trues(n + 1))]
+        @test_throws BoundsError A_csr[CuVector(trues(m - 1)), colmask_d]
+        @test_throws BoundsError A_csr[rowmask_d, CuVector(trues(n - 1))]
+
+        # empty mask (all zeros): cumsum gives all-zero rowmap/colmap, new_m or new_n = 0,
+        # both kernels are guarded by `new_m > 0 && new_n > 0`, so nothing executes.
+        # new_rowPtr collapses to [1] (or all-ones), nnz = 0. Same as CPU SparseArrays.
+        S_empty_rows_csc = A_csc[CuVector(falses(m)), CuVector(trues(n))]
+        @test S_empty_rows_csc isa CuSparseMatrixCSC
+        @test size(S_empty_rows_csc) == (0, n)
+        @test nnz(S_empty_rows_csc) == 0
+
+        S_empty_cols_csc = A_csc[CuVector(trues(m)), CuVector(falses(n))]
+        @test S_empty_cols_csc isa CuSparseMatrixCSC
+        @test size(S_empty_cols_csc) == (m, 0)
+        @test nnz(S_empty_cols_csc) == 0
+
+        S_empty_rows_csr = A_csr[CuVector(falses(m)), CuVector(trues(n))]
+        @test S_empty_rows_csr isa CuSparseMatrixCSR
+        @test size(S_empty_rows_csr) == (0, n)
+        @test nnz(S_empty_rows_csr) == 0
+
+        S_empty_cols_csr = A_csr[CuVector(trues(m)), CuVector(falses(n))]
+        @test S_empty_cols_csr isa CuSparseMatrixCSR
+        @test size(S_empty_cols_csr) == (m, 0)
+        @test nnz(S_empty_cols_csr) == 0
+
+        S_empty_both_csc = A_csc[CuVector(falses(m)), CuVector(falses(n))]
+        @test S_empty_both_csc isa CuSparseMatrixCSC
+        @test size(S_empty_both_csc) == (0, 0)
+        @test nnz(S_empty_both_csc) == 0
+
+        S_empty_both_csr = A_csr[CuVector(falses(m)), CuVector(falses(n))]
+        @test S_empty_both_csr isa CuSparseMatrixCSR
+        @test size(S_empty_both_csr) == (0, 0)
+        @test nnz(S_empty_both_csr) == 0
+
+        # all-ones mask: rowmap = 1:m, colmap = 1:n, both kernels run unfiltered.
+        # Result should equal the full matrix. Same as CPU SparseArrays.
+        S_all_csc = A_csc[CuVector(trues(m)), CuVector(trues(n))]
+        @test S_all_csc isa CuSparseMatrixCSC
+        @test collect(S_all_csc) ≈ Matrix(A)
+
+        S_all_csr = A_csr[CuVector(trues(m)), CuVector(trues(n))]
+        @test S_all_csr isa CuSparseMatrixCSR
+        @allowscalar for i in eachindex(A, S_all_csr)
+            @test A[i] ≈ S_all_csr[i]
+        end
+
+        # zero-dimension matrix: accessing rowmap[end] / colmap[end] on an empty CuVector
+        # would crash without the `m > 0` / `n > 0` guard in the implementation.
+        A_zero_rows_csr = CuSparseMatrixCSR(spzeros(elty, 0, n))
+        S_zr = A_zero_rows_csr[CuVector{Bool}([]), CuVector(trues(n))]
+        @test S_zr isa CuSparseMatrixCSR
+        @test size(S_zr) == (0, n)
+        @test nnz(S_zr) == 0
+
+        A_zero_cols_csr = CuSparseMatrixCSR(spzeros(elty, m, 0))
+        S_zc = A_zero_cols_csr[CuVector(trues(m)), CuVector{Bool}([])]
+        @test S_zc isa CuSparseMatrixCSR
+        @test size(S_zc) == (m, 0)
+        @test nnz(S_zc) == 0
+
+        A_zero_both_csr = CuSparseMatrixCSR(spzeros(elty, 0, 0))
+        S_zb = A_zero_both_csr[CuVector{Bool}([]), CuVector{Bool}([])]
+        @test S_zb isa CuSparseMatrixCSR
+        @test size(S_zb) == (0, 0)
+        @test nnz(S_zb) == 0
+
+        A_zero_rows_csc = CuSparseMatrixCSC(spzeros(elty, 0, n))
+        S_zr_csc = A_zero_rows_csc[CuVector{Bool}([]), CuVector(trues(n))]
+        @test S_zr_csc isa CuSparseMatrixCSC
+        @test size(S_zr_csc) == (0, n)
+        @test nnz(S_zr_csc) == 0
+
+        A_zero_cols_csc = CuSparseMatrixCSC(spzeros(elty, m, 0))
+        S_zc_csc = A_zero_cols_csc[CuVector(trues(m)), CuVector{Bool}([])]
+        @test S_zc_csc isa CuSparseMatrixCSC
+        @test size(S_zc_csc) == (m, 0)
+        @test nnz(S_zc_csc) == 0
+
+        A_zero_both_csc = CuSparseMatrixCSC(spzeros(elty, 0, 0))
+        S_zb_csc = A_zero_both_csc[CuVector{Bool}([]), CuVector{Bool}([])]
+        @test S_zb_csc isa CuSparseMatrixCSC
+        @test size(S_zb_csc) == (0, 0)
+        @test nnz(S_zb_csc) == 0
     end
 end


### PR DESCRIPTION
Slicing into a sparse matrix by providing `Vector{Bool}` per axis to select a subset of rows and cols is quite usefull. It is implemented for several types, for example "normal" matrices and sparse matrices.

```juila
N = 10
A = sprand(N, N, 0.5)
rowmask = [rand([true, false]) for _ in 1:size(A, 1)]
colmask = [rand([true, false]) for _ in 1:size(A, 2)]
S = A[rowmask, colmask]
```
This PR implements this functionality for `CuSparseMatrixCSR` and `CuSparseMatrixCSC`.

AI Disclaimer: Claude code and Chat GPT helped me to implement the kernels. But I think they are straight forward and it is tested against the slicing results of CPU code.
