### PR TITLE
Add Base.min override for Float16 and extend LLVM version guard to v20.

### DIFF
--- a/src/device/intrinsics/math.jl
+++ b/src/device/intrinsics/math.jl
@@ -362,8 +362,8 @@ end
     ifelse(anynan, NaN, minval), ifelse(anynan, NaN, maxval)
 end
 
-@static if Base.thismajor(LLVM.version()) <= v"18"
-    # LLVM 18 and below generate non-existing instructions for Julia's default methods of
+@static if Base.thismajor(LLVM.version()) <= v"20"
+    # LLVM 20 and below generate non-existing instructions for Julia's default methods of
     # fast min/max on fp64: https://github.com/JuliaGPU/CUDA.jl/issues/2886
     for T in (Float16, Float32, Float64)
         @eval begin
@@ -373,8 +373,9 @@ end
         end
     end
 
-    # For Float16, this even happens with a non-fastmath @llvm.maximum.f16
+    # For Float16, this even happens with a non-fastmath @llvm.minimum/maximum.f16
     @device_override @inline Base.max(x::Float16, y::Float16) = ifelse(y > x, y, x)
+    @device_override @inline Base.min(x::Float16, y::Float16) = ifelse(y > x, x, y)
 
 end
 


### PR DESCRIPTION
LLVM 20 lowers Base.min(::Float16, ::Float16) to min.NaN.f16, a PTX instruction requiring sm_80+, causing failures on Turing (sm_75) GPUs. Add a Julia-level override matching the existing Base.max workaround, and extend the version guard from LLVM 18 to 20 since the upstream fix (llvm/llvm-project@6f318d47) only landed in LLVM 21.

As observed in https://github.com/JuliaGPU/CUDA.jl/pull/3020