### PR TITLE
Profiler: relax parsing of color flags in marker data.

### DIFF
--- a/CUDATools/src/profile.jl
+++ b/CUDATools/src/profile.jl
@@ -590,12 +590,9 @@ function capture(cfg)
                 nothing
             end
 
-            color = if record.flags & CUPTI.CUPTI_ACTIVITY_FLAG_MARKER_COLOR_NONE == CUPTI.CUPTI_ACTIVITY_FLAG_MARKER_COLOR_NONE
-                nothing
-            elseif record.flags & CUPTI.CUPTI_ACTIVITY_FLAG_MARKER_COLOR_ARGB == CUPTI.CUPTI_ACTIVITY_FLAG_MARKER_COLOR_ARGB
+            color = if record.flags & CUPTI.CUPTI_ACTIVITY_FLAG_MARKER_COLOR_ARGB == CUPTI.CUPTI_ACTIVITY_FLAG_MARKER_COLOR_ARGB
                 record.color
             else
-                @error "Unexpected CUPTI marker color flag $(Int(record.flags)). Please file an issue."
                 nothing
             end
 


### PR DESCRIPTION
Even though the flag enum supports explicitly indicating the color is not set, I guess it's also valid to provide _no_ indication of the color; although it seems weird to me that both should be supported.

In any case, relaxed the parsing because @vchuravy actually reported encountering this:
```
┌ Error: Unexpected CUPTI marker color flag 0. Please file an issue.
└ @ CUDA.Profile ~/.julia/packages/CUDA/Il00B/src/profile.jl:596
```