### PR TITLE
Add override for muladd and use LLVM intrinsic for fma

### DIFF
--- a/CUDACore/src/device/intrinsics/math.jl
+++ b/CUDACore/src/device/intrinsics/math.jl
@@ -435,9 +435,13 @@ end
 @device_override Base.hypot(x::Float64, y::Float64) = ccall("extern __nv_hypot", llvmcall, Cdouble, (Cdouble, Cdouble), x, y)
 @device_override Base.hypot(x::Float32, y::Float32) = ccall("extern __nv_hypotf", llvmcall, Cfloat, (Cfloat, Cfloat), x, y)
 
-@device_override Base.fma(x::Float64, y::Float64, z::Float64) = ccall("extern __nv_fma", llvmcall, Cdouble, (Cdouble, Cdouble, Cdouble), x, y, z)
-@device_override Base.fma(x::Float32, y::Float32, z::Float32) = ccall("extern __nv_fmaf", llvmcall, Cfloat, (Cfloat, Cfloat, Cfloat), x, y, z)
+@device_override Base.fma(x::Float64, y::Float64, z::Float64) = ccall("llvm.fma.f64", llvmcall, Cdouble, (Cdouble, Cdouble, Cdouble), x, y, z)
+@device_override Base.fma(x::Float32, y::Float32, z::Float32) = ccall("llvm.fma.f32", llvmcall, Cfloat, (Cfloat, Cfloat, Cfloat), x, y, z)
 @device_override Base.fma(x::Float16, y::Float16, z::Float16) = ccall("llvm.fma.f16", llvmcall, Float16, (Float16, Float16, Float16), x, y, z)
+
+@device_override Base.muladd(x::Float64, y::Float64, z::Float64) = ccall("llvm.fmuladd.f64", llvmcall, Cdouble, (Cdouble, Cdouble, Cdouble), x, y, z)
+@device_override Base.muladd(x::Float32, y::Float32, z::Float32) = ccall("llvm.fmuladd.f32", llvmcall, Cfloat, (Cfloat, Cfloat, Cfloat), x, y, z)
+@device_override Base.muladd(x::Float16, y::Float16, z::Float16) = ccall("llvm.fmuladd.f16", llvmcall, Float16, (Float16, Float16, Float16), x, y, z)
 
 @device_function sad(x::Int32, y::Int32, z::Int32) = ccall("extern __nv_sad", llvmcall, Int32, (Int32, Int32, Int32), x, y, z)
 @device_function sad(x::UInt32, y::UInt32, z::UInt32) = convert(UInt32, ccall("extern __nv_usad", llvmcall, Int32, (Int32, Int32, Int32), x, y, z))

--- a/test/core/codegen.jl
+++ b/test/core/codegen.jl
@@ -22,6 +22,31 @@ end
     @test !occursin("@__nv_fmaf", ir)
 end
 
+@testset "fma uses LLVM intrinsic" begin
+    function fma_kernel(ptr)
+        unsafe_store!(ptr, fma(unsafe_load(ptr), unsafe_load(ptr,2), unsafe_load(ptr,3)))
+        return
+    end
+
+    for (T, suffix) in ((Float32, "f32"), (Float64, "f64"), (Float16, "f16"))
+        ir = sprint(io->CUDA.code_llvm(io, fma_kernel, Tuple{Ptr{T}}))
+        @test occursin("llvm.fma.$suffix", ir)
+        @test !occursin("__nv_fma", ir)
+    end
+end
+
+@testset "muladd uses LLVM intrinsic" begin
+    function muladd_kernel(ptr)
+        unsafe_store!(ptr, muladd(unsafe_load(ptr), unsafe_load(ptr,2), unsafe_load(ptr,3)))
+        return
+    end
+
+    for (T, suffix) in ((Float32, "f32"), (Float64, "f64"), (Float16, "f16"))
+        ir = sprint(io->CUDA.code_llvm(io, muladd_kernel, Tuple{Ptr{T}}))
+        @test occursin("llvm.fmuladd.$suffix", ir)
+    end
+end
+
 @testset "assume" begin
     foo(i) = cld(42, i)
     ir = sprint(io->CUDA.code_llvm(io, foo, Tuple{Int}))

--- a/test/core/codegen.jl
+++ b/test/core/codegen.jl
@@ -205,6 +205,29 @@ end
     @test occursin("sqrt.approx.ftz", asm)
 end
 
+@testset "fma/muladd emit fma.rn" begin
+    # fma and muladd should both lower to fma.rn in PTX
+    function fma_kernel(a, b, c)
+        @inbounds a[] = fma(b[], c[], a[])
+        return
+    end
+    function muladd_kernel(a, b, c)
+        @inbounds a[] = muladd(b[], c[], a[])
+        return
+    end
+
+    for T in (Float16, Float32, Float64)
+        asm = sprint(io->CUDA.code_ptx(io, fma_kernel,
+            NTuple{3,CuDeviceArray{T,1,AS.Global}}))
+        @test occursin("fma.rn", asm)
+        @test !occursin("__nv_fma", asm)
+
+        asm = sprint(io->CUDA.code_ptx(io, muladd_kernel,
+            NTuple{3,CuDeviceArray{T,1,AS.Global}}))
+        @test occursin("fma.rn", asm)
+    end
+end
+
 end
 
 ############################################################################################

--- a/test/core/device/intrinsics/math.jl
+++ b/test/core/device/intrinsics/math.jl
@@ -85,6 +85,35 @@ using SpecialFunctions
         end
     end
 
+    @testset "muladd" begin
+        for T in (Float16, Float32, Float64)
+            @test testf((x,y,z)->muladd.(x,y,z), rand(T, 1), rand(T, 1), rand(T, 1))
+            @test testf((x,y,z)->muladd.(x,y,z), rand(T, 1), -rand(T, 1), -rand(T, 1))
+        end
+    end
+
+    @testset "fma/muladd PTX codegen" begin
+        # fma and muladd should both lower to fma.rn in PTX
+        function fma_kernel(a, b, c)
+            @inbounds a[] = fma(b[], c[], a[])
+            return
+        end
+        function muladd_kernel(a, b, c)
+            @inbounds a[] = muladd(b[], c[], a[])
+            return
+        end
+
+        for T in (Float32, Float64)
+            asm = sprint(io->CUDA.code_ptx(io, fma_kernel,
+                NTuple{3,CuDeviceArray{T,1,AS.Global}}))
+            @test occursin("fma.rn", asm)
+
+            asm = sprint(io->CUDA.code_ptx(io, muladd_kernel,
+                NTuple{3,CuDeviceArray{T,1,AS.Global}}))
+            @test occursin("fma.rn", asm)
+        end
+    end
+
     # something from SpecialFunctions.jl
     @testset "erf" begin
         @test testf(a->SpecialFunctions.erf.(a), Float32[1.0])

--- a/test/core/device/intrinsics/math.jl
+++ b/test/core/device/intrinsics/math.jl
@@ -92,28 +92,6 @@ using SpecialFunctions
         end
     end
 
-    @testset "fma/muladd PTX codegen" begin
-        # fma and muladd should both lower to fma.rn in PTX
-        function fma_kernel(a, b, c)
-            @inbounds a[] = fma(b[], c[], a[])
-            return
-        end
-        function muladd_kernel(a, b, c)
-            @inbounds a[] = muladd(b[], c[], a[])
-            return
-        end
-
-        for T in (Float32, Float64)
-            asm = sprint(io->CUDA.code_ptx(io, fma_kernel,
-                NTuple{3,CuDeviceArray{T,1,AS.Global}}))
-            @test occursin("fma.rn", asm)
-
-            asm = sprint(io->CUDA.code_ptx(io, muladd_kernel,
-                NTuple{3,CuDeviceArray{T,1,AS.Global}}))
-            @test occursin("fma.rn", asm)
-        end
-    end
-
     # something from SpecialFunctions.jl
     @testset "erf" begin
         @test testf(a->SpecialFunctions.erf.(a), Float32[1.0])


### PR DESCRIPTION
Since Julia 0.7 (https://github.com/JuliaLang/julia/pull/22262) we are emitting

`muladd(a,b,c)` not as `llvm.fmuladd`, but rather as a sequence of:
```
%t = fmul contract %a %b
%r = fadd contract %t %c
```

The reason for that is vectorization of a potential reduction
(which is something we ought to investigate in Base if it is still worthwhile).

@efaulhaber had an example where

```
h = ...
for ...
  distance ...
  muladd(epsilon, h^2, distance^2)
```

and LLVM helpfully performed some code motion:

```
h = ...
t = mul(epsilon, h^2)
for ...
   add(t, distance^2)
```

Leading to a torn `contract` pair

```llvm
%69 = fmul contract float %"f::#parallel_foreach##10#parallel_foreach##11.fca.0.4.5.2.extract", %68
br label %L619, !dbg !197
;...
 %141 = fadd contract float %69, %140, !dbg !459
```

Manually using a fma leads to a performance improvement of `2.908` to `2.765` so ~5% faster.

I believe that the motivation in Base is not valid on GPUs since we benefit much more from the emission of fma,
in contrast to reduction vectorization.

@maleadt do you recall why we are using `__nv_fma`? LLVM should be able to perform better optimization over the `llvm.fma` intrinsic.

