### PR TITLE
Fix dynamic function invocation in `unsafe_strided_batch` on Julia 1.12.

### DIFF
--- a/lib/cublas/src/wrappers.jl
+++ b/lib/cublas/src/wrappers.jl
@@ -1341,7 +1341,7 @@ end
 end
 
 # create a batch of pointers in device memory from a strided device array
-@inline function unsafe_strided_batch(strided::DenseCuArray{T}) where {T}
+@inline function unsafe_strided_batch(strided::DenseCuArray{T, N}) where {T, N}
     batch_size = last(size(strided))
     batch_stride = prod(size(strided)[1:end-1])
     #ptrs = [pointer(strided, (i-1)*batch_stride + 1) for i in 1:batch_size]

--- a/lib/cublas/test/extensions.jl
+++ b/lib/cublas/test/extensions.jl
@@ -102,6 +102,13 @@ k = 13
             end
         end
 
+        @testset "unsafe_strided_batch" begin
+            A = CuArray(rand(elty, m, m, 10))
+            ptrs = cuBLAS.unsafe_strided_batch(A)
+            @test ptrs isa CuVector{CuPtr{elty}}
+            @test length(ptrs) == 10
+        end
+
         @testset "getrf_strided_batched!" begin
             Random.seed!(1)
             local k


### PR DESCRIPTION
Add `N` to the type parameters so the closure captures a fully-typed array, avoiding dynamic dispatch when the GPU compiler converts captured variables to device arrays.

Fixes https://github.com/JuliaGPU/CUDA.jl/issues/3082