### PR TITLE
Use 64-bit API for eigenvalue functions

### DIFF
--- a/lib/cusolver/src/linalg.jl
+++ b/lib/cusolver/src/linalg.jl
@@ -121,11 +121,11 @@ Base.copyto!(dst::Hermitian{<:Any,<:CuMatrix}, src::Hermitian{<:Any,<:CuMatrix})
 
 function LinearAlgebra.eigen(A::Symmetric{T,<:CuMatrix}) where {T<:BlasReal}
     A2 = copy(A.data)
-    return Eigen(syevd!('V', 'U', A2)...)
+    return Eigen(Xsyevd!('V', 'U', A2)...)
 end
 function LinearAlgebra.eigen(A::Hermitian{T,<:CuMatrix}) where {T<:BlasComplex}
     A2 = copy(A.data)
-    return Eigen(heevd!('V', 'U', A2)...)
+    return Eigen(Xsyevd!('V', 'U', A2)...)
 end
 function LinearAlgebra.eigen(A::Hermitian{T,<:CuMatrix}) where {T<:BlasReal}
     return eigen(Symmetric(A))
@@ -134,7 +134,7 @@ end
 function LinearAlgebra.eigen(A::CuMatrix{T}) where {T<:BlasReal}
     A2 = copy(A)
     if issymmetric(A)
-        return Eigen(syevd!('V', 'U', A2)...)
+        return Eigen(Xsyevd!('V', 'U', A2)...)
     else
         W, _, VR = Xgeev!('N', 'V', A2)
         C = Complex{T}
@@ -157,7 +157,7 @@ end
 function LinearAlgebra.eigen(A::CuMatrix{T}) where {T<:BlasComplex}
     A2 = copy(A)
     if ishermitian(A)
-        return Eigen(heevd!('V', 'U', A2)...)
+        return Eigen(Xsyevd!('V', 'U', A2)...)
     else
         r = Xgeev!('N', 'V', A2)
         return Eigen(r[1], r[3])
@@ -168,11 +168,11 @@ end
 
 function LinearAlgebra.eigvals(A::Symmetric{T, <:CuMatrix}) where {T <: BlasReal}
     A2 = copy(A.data)
-    return syevd!('N', 'U', A2)
+    return Xsyevd!('N', 'U', A2)
 end
 function LinearAlgebra.eigvals(A::Hermitian{T, <:CuMatrix}) where {T <: BlasComplex}
     A2 = copy(A.data)
-    return heevd!('N', 'U', A2)
+    return Xsyevd!('N', 'U', A2)
 end
 function LinearAlgebra.eigvals(A::Hermitian{T, <:CuMatrix}) where {T <: BlasReal}
     return eigvals(Symmetric(A))
@@ -181,7 +181,7 @@ end
 function LinearAlgebra.eigvals(A::CuMatrix{T}) where {T <: BlasReal}
     A2 = copy(A)
     if issymmetric(A)
-        return syevd!('N', 'U', A2)
+        return Xsyevd!('N', 'U', A2)
     else
         return Xgeev!('N', 'N', A2)[1]
     end
@@ -189,7 +189,7 @@ end
 function LinearAlgebra.eigvals(A::CuMatrix{T}) where {T <: BlasComplex}
     A2 = copy(A)
     if ishermitian(A)
-        return heevd!('N', 'U', A2)
+        return Xsyevd!('N', 'U', A2)
     else
         return Xgeev!('N', 'N', A2)[1]
     end


### PR DESCRIPTION
`cusolverDn<t>syevd` and `cusolverDn<t>heevd` are part of the legacy CUDA API, which only supports 32-bit matrix indexing. The newer generic API, `cusolverDnXsyevd`, fully supports 64-bit matrix indexing since CUDA 13.0 (see [release notes](https://docs.nvidia.com/cuda/archive/13.0.0/cuda-toolkit-release-notes/index.html#cusolver-release-13-0)).

I don't know if it still makes sense to keep testing these in `dense.jl` instead of `dense_generic.jl`, btw...