### PR TITLE
Fix GC race in CuRef getindex causing intermittent CUDA errors

### DIFF
--- a/CUDACore/src/refpointer.jl
+++ b/CUDACore/src/refpointer.jl
@@ -78,7 +78,7 @@ function Base.getindex(gpu::CuRefValue{T}) where {T}
     synchronize(gpu.buf)
 
     cpu = Ref{T}()
-    GC.@preserve cpu begin
+    GC.@preserve cpu gpu begin
         cpu_ptr = Base.unsafe_convert(Ptr{T}, cpu)
         gpu_ptr = Base.unsafe_convert(CuPtr{T}, gpu)
         unsafe_copyto!(cpu_ptr, gpu_ptr, 1; async=false)
@@ -126,7 +126,7 @@ function Base.getindex(gpu::CuRefArray{T}) where {T}
     synchronize(gpu.x)
 
     cpu = Ref{T}()
-    GC.@preserve cpu begin
+    GC.@preserve cpu gpu begin
         cpu_ptr = Base.unsafe_convert(Ptr{T}, cpu)
         gpu_ptr = pointer(gpu.x, gpu.i)
         unsafe_copyto!(cpu_ptr, gpu_ptr, 1; async=false)


### PR DESCRIPTION
The `getindex` methods for `CuRefValue` and `CuRefArray` only preserved the CPU `Ref` with `GC.@preserve`, but not the GPU reference. After extracting the raw device pointer via `unsafe_convert`, the GC could collect the `CuRefValue` (running its `pool_free` finalizer) before the `unsafe_copyto!` memcpy completed, resulting in use-after-free.

Fixes https://github.com/JuliaGPU/CUDA.jl/issues/3012