### PR TITLE
Store CuArray offset in bytes instead of elements

### DIFF
--- a/CUDACore/src/array.jl
+++ b/CUDACore/src/array.jl
@@ -75,7 +75,7 @@ mutable struct CuArray{T,N,M} <: AbstractGPUArray{T,N}
   data::DataRef{Managed{M}}
 
   maxsize::Int  # maximum data size; excluding any selector bytes
-  offset::Int   # offset of the data in memory, in number of elements
+  offset::Int   # offset of the data in memory, in bytes
 
   dims::Dims{N}
 
@@ -463,9 +463,9 @@ Base.convert(::Type{T}, x::T) where T <: CuArray = x
 # defer the conversion to Managed, where we handle memory consistency
 # XXX: conversion to Memory or Managed memory by cconvert?
 Base.unsafe_convert(typ::Type{Ptr{T}}, x::CuArray{T}) where {T} =
-  convert(typ, x.data[]) + x.offset * Base.elsize(x)
+  convert(typ, x.data[]) + x.offset
 Base.unsafe_convert(typ::Type{CuPtr{T}}, x::CuArray{T}) where {T} =
-  convert(typ, x.data[]) + x.offset * Base.elsize(x)
+  convert(typ, x.data[]) + x.offset
 
 
 ## indexing
@@ -485,7 +485,7 @@ end
 
 function Base.unsafe_convert(::Type{CuDeviceArray{T,N,AS.Global}}, a::DenseCuArray{T,N}) where {T,N}
   CuDeviceArray{T,N,AS.Global}(reinterpret(LLVMPtr{T,AS.Global}, pointer(a)), size(a),
-                               a.maxsize - a.offset*Base.elsize(a))
+                               a.maxsize - a.offset)
 end
 
 
@@ -534,7 +534,7 @@ function typetagdata(a::CuArray, i=1; type=DeviceMemory)
   else
     error("unknown memory type")
   end
-  convert(PT, a.data[]) + a.maxsize + a.offset + i - 1
+  convert(PT, a.data[]) + a.maxsize + a.offset ÷ Base.elsize(a) + i - 1
 end
 
 function Base.copyto!(dest::DenseCuArray{T}, doffs::Integer, src::Array{T}, soffs::Integer,
@@ -851,7 +851,7 @@ end
 ## derived arrays
 
 function GPUArrays.derive(::Type{T}, a::CuArray, dims::Dims{N}, offset::Int) where {T,N}
-  offset = (a.offset * Base.elsize(a)) ÷ aligned_sizeof(T) + offset
+  offset = a.offset + offset * aligned_sizeof(T)
   CuArray{T,N}(copy(a.data), dims; a.maxsize, offset)
 end
 

--- a/CUDACore/src/array.jl
+++ b/CUDACore/src/array.jl
@@ -534,7 +534,10 @@ function typetagdata(a::CuArray, i=1; type=DeviceMemory)
   else
     error("unknown memory type")
   end
-  convert(PT, a.data[]) + a.maxsize + a.offset ÷ Base.elsize(a) + i - 1
+  # for zero-size element types (e.g. singleton unions), the byte offset
+  # is always zero, so the corresponding element offset is also zero
+  elem_offset = iszero(Base.elsize(a)) ? 0 : a.offset ÷ Base.elsize(a)
+  convert(PT, a.data[]) + a.maxsize + elem_offset + i - 1
 end
 
 function Base.copyto!(dest::DenseCuArray{T}, doffs::Integer, src::Array{T}, soffs::Integer,

--- a/test/core/array.jl
+++ b/test/core/array.jl
@@ -290,6 +290,15 @@ end
 
   @test collect(reinterpret(Int32, CUDA.fill(1f0)))[] == reinterpret(Int32, 1f0)
 
+  @testset "reinterpret of view with non-aligned offset" begin
+    # reinterpreting a view to a larger element type where the byte offset
+    # is not a multiple of the new element size
+    a = CuArray(Float32[1,2,3,4,5,6,7,8,9])
+    v = view(a, 2:7)  # offset of 1 Float32 = 4 bytes
+    r = reinterpret(Float64, v)  # Float64 = 8 bytes; 4 is not a multiple of 8
+    @test Array(r) == reinterpret(Float64, @view Array(a)[2:7])
+  end
+
   @testset "unmanaged reinterpret" begin
     a = CuArray(Int32[-1,-2,-3])
     ptr = pointer(a, 2)


### PR DESCRIPTION
The element-based offset was lossy when materializing reinterpret on views with non-aligned offsets (e.g., reinterpreting a view of Float64 as SVector{3,Float64}). The byte offset would get truncated by integer division when converting to the new element count.

The original element-based design came from copying Julia, where wrappers like Reinterpret are never materialized.

Fixes https://github.com/JuliaGPU/CUDA.jl/issues/2980