### PR TITLE
cuSPARSE: Align default behavior of higher-dimensional similar with SparseArrays

### DIFF
--- a/lib/cusparse/src/array.jl
+++ b/lib/cusparse/src/array.jl
@@ -420,16 +420,86 @@ Base.getindex(A::AbstractCuSparseMatrix, i, ::Colon)       = getindex(A, i, 1:si
 Base.getindex(A::AbstractCuSparseMatrix, ::Colon, i)       = getindex(A, 1:size(A, 1), i)
 Base.getindex(A::AbstractCuSparseMatrix, I::Tuple{Integer,Integer}) = getindex(A, I[1], I[2])
 
-# Indexing paths that produce a 1-D sparse result are implemented via a host-side
-# round-trip through `SparseMatrixCSC`. This keeps `Base._unsafe_getindex` out of
-# the picture: it would otherwise call `setindex!` on the `CuSparseVector` returned
-# by `similar`, which we don't define.
-# TODO: implement directly on the device. For CSC the linearization is mechanical
-# (no sort needed); CSR/COO/BSR need either a sort or a CSC conversion first.
-Base.getindex(A::CuSparseMatrix, ::Colon)                            = CuSparseVector(SparseMatrixCSC(A)[:])
-Base.getindex(A::CuSparseMatrix, I::AbstractUnitRange)               = CuSparseVector(SparseMatrixCSC(A)[I])
-Base.getindex(A::CuSparseMatrix, i::AbstractUnitRange, j::Integer)   = CuSparseVector(SparseMatrixCSC(A)[i, j])
-Base.getindex(A::CuSparseMatrix, i::Integer, j::AbstractUnitRange)   = CuSparseVector(SparseMatrixCSC(A)[i, j])
+# Indexing paths that produce a 1-D sparse result. These have to bypass
+# `Base._unsafe_getindex` — it would otherwise call `setindex!` on the
+# `CuSparseVector` returned by `similar`, which we don't define.
+
+# Linearization: write `(j-1)*nrows + rowVal[k]` per entry. CSC storage order is
+# already column-major with sorted rows within each column, so the output `iPtr` is
+# monotonically increasing without an explicit sort. Other formats convert to CSC.
+function _csc_linearize_kernel!(iPtr_out, colPtr, rowVal, nrows)
+    Ti = eltype(colPtr)
+    j = Ti(threadIdx().x + (blockIdx().x - Int32(1)) * blockDim().x)
+    j > Ti(length(colPtr) - 1) && return nothing
+    @inbounds for k in colPtr[j]:(colPtr[j + one(Ti)] - one(Ti))
+        iPtr_out[k] = (j - one(Ti)) * Ti(nrows) + rowVal[k]
+    end
+    return nothing
+end
+
+function Base.getindex(A::CuSparseMatrixCSC{Tv, Ti}, ::Colon) where {Tv, Ti}
+    nnz_A = nnz(A)
+    iPtr = CuVector{Ti}(undef, nnz_A)
+    if nnz_A > 0
+        ncols = size(A, 2)
+        threads = min(256, ncols)
+        blocks = cld(ncols, threads)
+        @cuda threads=threads blocks=blocks _csc_linearize_kernel!(
+            iPtr, A.colPtr, A.rowVal, size(A, 1)
+        )
+    end
+    return CuSparseVector(iPtr, copy(nonzeros(A)), prod(size(A)))
+end
+Base.getindex(A::CuSparseMatrixCSR, ::Colon) = CuSparseMatrixCSC(A)[:]
+Base.getindex(A::CuSparseMatrixCOO, ::Colon) = CuSparseMatrixCSC(A)[:]
+Base.getindex(A::CuSparseMatrixBSR, ::Colon) = CuSparseMatrixCSC(A)[:]
+
+# Range linearization: slice the full linearization. Wasteful for short ranges, but
+# avoids a second specialized kernel.
+function Base.getindex(A::CuSparseMatrix{Tv, Ti}, I::AbstractUnitRange) where {Tv, Ti}
+    @boundscheck checkbounds(LinearIndices(A), I)
+    v = A[:]
+    inds = nonzeroinds(v)
+    lo, hi = Ti(first(I)), Ti(last(I))
+    mask = (inds .>= lo) .& (inds .<= hi)
+    return CuSparseVector(inds[mask] .- (lo - one(Ti)), nonzeros(v)[mask], length(I))
+end
+
+# Row/column subset of a single column/row: walk one column (CSC) or row (CSR) of
+# storage and filter by the range. Two scalar `colPtr`/`rowPtr` reads at the
+# boundary, matching the existing `::Colon, j` / `i, ::Colon` methods below —
+# callers must enable scalar indexing if those rules are in effect.
+function Base.getindex(A::CuSparseMatrixCSC{Tv, Ti}, I::AbstractUnitRange, j::Integer) where {Tv, Ti}
+    @boundscheck checkbounds(A, I, j)
+    r1 = Int(A.colPtr[j])
+    r2 = Int(A.colPtr[j + 1]) - 1
+    r1 > r2 && return CuSparseVector(CuVector{Ti}(undef, 0), CuVector{Tv}(undef, 0), length(I))
+    rows = rowvals(A)[r1:r2]
+    vals = nonzeros(A)[r1:r2]
+    lo, hi = Ti(first(I)), Ti(last(I))
+    mask = (rows .>= lo) .& (rows .<= hi)
+    return CuSparseVector(rows[mask] .- (lo - one(Ti)), vals[mask], length(I))
+end
+
+function Base.getindex(A::CuSparseMatrixCSR{Tv, Ti}, i::Integer, J::AbstractUnitRange) where {Tv, Ti}
+    @boundscheck checkbounds(A, i, J)
+    c1 = Int(A.rowPtr[i])
+    c2 = Int(A.rowPtr[i + 1]) - 1
+    c1 > c2 && return CuSparseVector(CuVector{Ti}(undef, 0), CuVector{Tv}(undef, 0), length(J))
+    cols = A.colVal[c1:c2]
+    vals = nonzeros(A)[c1:c2]
+    lo, hi = Ti(first(J)), Ti(last(J))
+    mask = (cols .>= lo) .& (cols .<= hi)
+    return CuSparseVector(cols[mask] .- (lo - one(Ti)), vals[mask], length(J))
+end
+
+# Off-axis range slices for the other format: round-trip via CSC.
+Base.getindex(A::CuSparseMatrixCSR, I::AbstractUnitRange, j::Integer) = CuSparseMatrixCSC(A)[I, j]
+Base.getindex(A::CuSparseMatrixCSC, i::Integer, J::AbstractUnitRange) = CuSparseMatrixCSR(A)[i, J]
+Base.getindex(A::CuSparseMatrixCOO, I::AbstractUnitRange, j::Integer) = CuSparseMatrixCSC(A)[I, j]
+Base.getindex(A::CuSparseMatrixCOO, i::Integer, J::AbstractUnitRange) = CuSparseMatrixCSR(A)[i, J]
+Base.getindex(A::CuSparseMatrixBSR, I::AbstractUnitRange, j::Integer) = CuSparseMatrixCSC(A)[I, j]
+Base.getindex(A::CuSparseMatrixBSR, i::Integer, J::AbstractUnitRange) = CuSparseMatrixCSR(A)[i, J]
 
 # column slices
 function Base.getindex(x::CuSparseMatrixCSC, ::Colon, j::Integer)
@@ -474,10 +544,22 @@ function Base.getindex(x::CuSparseMatrixCOO{T}, ::Colon, j::Integer) where {T}
     end
 end
 
-# row slices (the off-axis ones; on-axis variants are above)
-# TODO: optimize (currently round-trips through the CPU)
-Base.getindex(A::CuSparseMatrixCSC, i::Integer, ::Colon) = CuSparseVector(SparseMatrixCSC(A)[i, :])
-Base.getindex(A::CuSparseMatrixCSR, ::Colon, j::Integer) = CuSparseVector(SparseMatrixCSC(A)[:, j])
+# Off-axis row/column slices: convert to COO (cheap on-device pointer expansion) and
+# mask. Output ordering of the result comes from COO's secondary-axis sort:
+#   - CSC→COO is sorted by row then col, so masking by row yields col-sorted output;
+#   - CSR→COO is sorted by row then col natively, so masking by col yields row-sorted output.
+function Base.getindex(A::CuSparseMatrixCSC{Tv, Ti}, i::Integer, ::Colon) where {Tv, Ti}
+    @boundscheck checkbounds(A, i, :)
+    coo = CuSparseMatrixCOO(A)
+    mask = coo.rowInd .== Cint(i)
+    return CuSparseVector(coo.colInd[mask], nonzeros(coo)[mask], size(A, 2))
+end
+function Base.getindex(A::CuSparseMatrixCSR{Tv, Ti}, ::Colon, j::Integer) where {Tv, Ti}
+    @boundscheck checkbounds(A, :, j)
+    coo = CuSparseMatrixCOO(A)
+    mask = coo.colInd .== Cint(j)
+    return CuSparseVector(coo.rowInd[mask], nonzeros(coo)[mask], size(A, 1))
+end
 
 function Base.getindex(A::CuSparseVector{Tv, Ti}, i::Integer) where {Tv, Ti}
     @boundscheck checkbounds(A, i)

--- a/lib/cusparse/src/array.jl
+++ b/lib/cusparse/src/array.jl
@@ -293,6 +293,21 @@ Base.similar(Mat::CuSparseMatrixCSC, dims::Tuple{Int, Int}) = similar(Mat, dims.
 Base.similar(Mat::CuSparseMatrixCSR, dims::Tuple{Int, Int}) = similar(Mat, dims...)
 Base.similar(Mat::CuSparseMatrixCOO, dims::Tuple{Int, Int}) = similar(Mat, dims...)
 
+# 1D `similar` returns an empty `CuSparseVector`, mirroring `SparseArrays.jl`. The
+# index type is hardcoded to `Int32` to match the 2D methods above (cuSPARSE's
+# canonical index type) rather than being inherited from the source matrix.
+Base.similar(Mat::CuSparseMatrix, ::Type{T}, dims::Dims{1}) where {T} =
+    CuSparseVector(CuVector{Int32}(undef, 0), CuVector{T}(undef, 0), dims[1])
+Base.similar(Mat::CuSparseMatrix, dims::Dims{1}) = similar(Mat, eltype(Mat), dims)
+
+# For shapes that can't be represented as a sparse matrix (N≥3), fall back to a
+# dense `CuArray`, mirroring `SparseArrays.jl`'s fallback to a regular `Array`.
+# The 1D method above and the existing concrete 2D methods are more specific and
+# take precedence; this catches everything else.
+# TODO: lift to `AbstractGPUSparseArray` in GPUArrays.jl using `dense_array_type`.
+Base.similar(::CuSparseMatrix, ::Type{T}, dims::Dims) where {T} = CuArray{T}(undef, dims)
+Base.similar(Mat::CuSparseMatrix, dims::Dims) = similar(Mat, eltype(Mat), dims)
+
 Base.similar(Mat::CuSparseArrayCSR) = CuSparseArrayCSR(copy(Mat.rowPtr), copy(Mat.colVal), similar(nonzeros(Mat)), size(Mat))
 
 ## array interface
@@ -405,6 +420,17 @@ Base.getindex(A::AbstractCuSparseMatrix, i, ::Colon)       = getindex(A, i, 1:si
 Base.getindex(A::AbstractCuSparseMatrix, ::Colon, i)       = getindex(A, 1:size(A, 1), i)
 Base.getindex(A::AbstractCuSparseMatrix, I::Tuple{Integer,Integer}) = getindex(A, I[1], I[2])
 
+# Indexing paths that produce a 1-D sparse result are implemented via a host-side
+# round-trip through `SparseMatrixCSC`. This keeps `Base._unsafe_getindex` out of
+# the picture: it would otherwise call `setindex!` on the `CuSparseVector` returned
+# by `similar`, which we don't define.
+# TODO: implement directly on the device. For CSC the linearization is mechanical
+# (no sort needed); CSR/COO/BSR need either a sort or a CSC conversion first.
+Base.getindex(A::CuSparseMatrix, ::Colon)                            = CuSparseVector(SparseMatrixCSC(A)[:])
+Base.getindex(A::CuSparseMatrix, I::AbstractUnitRange)               = CuSparseVector(SparseMatrixCSC(A)[I])
+Base.getindex(A::CuSparseMatrix, i::AbstractUnitRange, j::Integer)   = CuSparseVector(SparseMatrixCSC(A)[i, j])
+Base.getindex(A::CuSparseMatrix, i::Integer, j::AbstractUnitRange)   = CuSparseVector(SparseMatrixCSC(A)[i, j])
+
 # column slices
 function Base.getindex(x::CuSparseMatrixCSC, ::Colon, j::Integer)
     checkbounds(x, :, j)
@@ -448,9 +474,10 @@ function Base.getindex(x::CuSparseMatrixCOO{T}, ::Colon, j::Integer) where {T}
     end
 end
 
-# row slices
-Base.getindex(A::CuSparseMatrixCSC, i::Integer, ::Colon) = CuSparseVector(sparse(A[i, 1:end]))  # TODO: optimize
-Base.getindex(A::CuSparseMatrixCSR, ::Colon, j::Integer) = CuSparseVector(sparse(A[1:end, j]))  # TODO: optimize
+# row slices (the off-axis ones; on-axis variants are above)
+# TODO: optimize (currently round-trips through the CPU)
+Base.getindex(A::CuSparseMatrixCSC, i::Integer, ::Colon) = CuSparseVector(SparseMatrixCSC(A)[i, :])
+Base.getindex(A::CuSparseMatrixCSR, ::Colon, j::Integer) = CuSparseVector(SparseMatrixCSC(A)[:, j])
 
 function Base.getindex(A::CuSparseVector{Tv, Ti}, i::Integer) where {Tv, Ti}
     @boundscheck checkbounds(A, i)

--- a/lib/cusparse/src/array.jl
+++ b/lib/cusparse/src/array.jl
@@ -294,10 +294,9 @@ Base.similar(Mat::CuSparseMatrixCSR, dims::Tuple{Int, Int}) = similar(Mat, dims.
 Base.similar(Mat::CuSparseMatrixCOO, dims::Tuple{Int, Int}) = similar(Mat, dims...)
 
 # 1D `similar` returns an empty `CuSparseVector`, mirroring `SparseArrays.jl`. The
-# index type is hardcoded to `Int32` to match the 2D methods above (cuSPARSE's
-# canonical index type) rather than being inherited from the source matrix.
-Base.similar(Mat::CuSparseMatrix, ::Type{T}, dims::Dims{1}) where {T} =
-    CuSparseVector(CuVector{Int32}(undef, 0), CuVector{T}(undef, 0), dims[1])
+# index type is inherited from the source matrix.
+Base.similar(Mat::CuSparseMatrix{Tv, Ti}, ::Type{T}, dims::Dims{1}) where {Tv, Ti, T} =
+    CuSparseVector(CuVector{Ti}(undef, 0), CuVector{T}(undef, 0), dims[1])
 Base.similar(Mat::CuSparseMatrix, dims::Dims{1}) = similar(Mat, eltype(Mat), dims)
 
 # For shapes that can't be represented as a sparse matrix (N≥3), fall back to a

--- a/lib/cusparse/src/array.jl
+++ b/lib/cusparse/src/array.jl
@@ -265,45 +265,106 @@ CuSparseMatrixCOO(rowInd::DenseCuArray, colInd::DenseCuArray, nzVal::DenseCuArra
 CuSparseArrayCSR(rowPtr::DenseCuArray, colVal::DenseCuArray, nzVal::DenseCuArray{T}, dims::NTuple{N,<:Integer}) where {T,N} =
     CuSparseArrayCSR{T}(rowPtr, colVal, nzVal, dims)
 
-Base.similar(Vec::CuSparseVector) = CuSparseVector(copy(nonzeroinds(Vec)), similar(nonzeros(Vec)), length(Vec))
-Base.similar(Mat::CuSparseMatrixCSC) = CuSparseMatrixCSC(copy(Mat.colPtr), copy(rowvals(Mat)), similar(nonzeros(Mat)), size(Mat))
-Base.similar(Mat::CuSparseMatrixCSR) = CuSparseMatrixCSR(copy(Mat.rowPtr), copy(Mat.colVal), similar(nonzeros(Mat)), size(Mat))
-Base.similar(Mat::CuSparseMatrixBSR) = CuSparseMatrixBSR(copy(Mat.rowPtr), copy(Mat.colVal), similar(nonzeros(Mat)), Mat.blockDim, Mat.dir, nnz(Mat), size(Mat))
-Base.similar(Mat::CuSparseMatrixCOO) = CuSparseMatrixCOO(copy(Mat.rowInd), copy(Mat.colInd), similar(nonzeros(Mat)), size(Mat), nnz(Mat))
+# Base.similar — mirrors SparseArrays.jl's contract.
+#
+# Two families of methods exist:
+#   - Implicit `Ti` (inherited from the source):
+#       similar(M)
+#       similar(M, TvNew)
+#       similar(M, TvNew, dims::Union{Dims{1}, Dims{2}})  (and Integer-vararg forms)
+#   - Explicit `Ti` (caller-supplied, overrides the source):
+#       similar(M, TvNew, TiNew)
+#       similar(M, TvNew, TiNew, dims::Union{Dims{1}, Dims{2}})  (and Integer-vararg forms)
+#
+# For shapes that can't be represented as a sparse matrix (N≥3) we fall back to a
+# dense `CuArray`, mirroring SparseArrays.jl's fallback to `Array`. The explicit-Ti
+# family is restricted to Dims{1}/Dims{2}, matching SparseArrays.jl — for N≥3 the
+# index type is irrelevant since the result is dense.
+#
+# Every method below routes through the fully-parameterized struct constructor
+# (e.g. `CuSparseMatrixCSC{Tv, Ti}(...)`). The single-Tv-parameter convenience
+# constructors (line ~220) canonicalize `Ti` to `Cint`, which would silently
+# discard whatever index type was requested or inherited here.
 
-Base.similar(Vec::CuSparseVector, T::Type) = CuSparseVector(copy(nonzeroinds(Vec)), similar(nonzeros(Vec), T), length(Vec))
-Base.similar(Mat::CuSparseMatrixCSC, T::Type) = CuSparseMatrixCSC(copy(Mat.colPtr), copy(rowvals(Mat)), similar(nonzeros(Mat), T), size(Mat))
-Base.similar(Mat::CuSparseMatrixCSR, T::Type) = CuSparseMatrixCSR(copy(Mat.rowPtr), copy(Mat.colVal), similar(nonzeros(Mat), T), size(Mat))
-Base.similar(Mat::CuSparseMatrixBSR, T::Type) = CuSparseMatrixBSR(copy(Mat.rowPtr), copy(Mat.colVal), similar(nonzeros(Mat), T), Mat.blockDim, Mat.dir, nnz(Mat), size(Mat))
-Base.similar(Mat::CuSparseMatrixCOO, T::Type) = CuSparseMatrixCOO(copy(Mat.rowInd), copy(Mat.colInd), similar(nonzeros(Mat), T), size(Mat), nnz(Mat))
+# --- 0-dim: preserve everything (Tv, Ti, sparsity pattern) ---
+Base.similar(Vec::CuSparseVector{Tv, Ti}) where {Tv, Ti} =
+    CuSparseVector{Tv, Ti}(copy(nonzeroinds(Vec)), similar(nonzeros(Vec)), length(Vec))
+Base.similar(Mat::CuSparseMatrixCSC{Tv, Ti}) where {Tv, Ti} =
+    CuSparseMatrixCSC{Tv, Ti}(copy(Mat.colPtr), copy(rowvals(Mat)), similar(nonzeros(Mat)), size(Mat))
+Base.similar(Mat::CuSparseMatrixCSR{Tv, Ti}) where {Tv, Ti} =
+    CuSparseMatrixCSR{Tv, Ti}(copy(Mat.rowPtr), copy(Mat.colVal), similar(nonzeros(Mat)), size(Mat))
+Base.similar(Mat::CuSparseMatrixBSR{Tv, Ti}) where {Tv, Ti} =
+    CuSparseMatrixBSR{Tv, Ti}(copy(Mat.rowPtr), copy(Mat.colVal), similar(nonzeros(Mat)), size(Mat), Mat.blockDim, Mat.dir, nnz(Mat))
+Base.similar(Mat::CuSparseMatrixCOO{Tv, Ti}) where {Tv, Ti} =
+    CuSparseMatrixCOO{Tv, Ti}(copy(Mat.rowInd), copy(Mat.colInd), similar(nonzeros(Mat)), size(Mat), nnz(Mat))
 
-Base.similar(Mat::CuSparseMatrixCSC, T::Type, N::Int, M::Int) =  CuSparseMatrixCSC(CUDACore.zeros(Int32, 1), CUDACore.zeros(Int32, 0), CuVector{T}(undef, 0), (N, M))
-Base.similar(Mat::CuSparseMatrixCSR, T::Type, N::Int, M::Int) =  CuSparseMatrixCSR(CUDACore.zeros(Int32, 1), CUDACore.zeros(Int32, 0), CuVector{T}(undef, 0), (N,M))
-Base.similar(Mat::CuSparseMatrixCOO, T::Type, N::Int, M::Int) =  CuSparseMatrixCOO(CUDACore.zeros(Int32, 0), CUDACore.zeros(Int32, 0), CuVector{T}(undef, 0), (N,M))
+# --- 1 type arg (TvNew): change eltype, preserve Ti and sparsity pattern ---
+Base.similar(Vec::CuSparseVector{<:Any, Ti}, ::Type{T}) where {T, Ti} =
+    CuSparseVector{T, Ti}(copy(nonzeroinds(Vec)), similar(nonzeros(Vec), T), length(Vec))
+Base.similar(Mat::CuSparseMatrixCSC{<:Any, Ti}, ::Type{T}) where {T, Ti} =
+    CuSparseMatrixCSC{T, Ti}(copy(Mat.colPtr), copy(rowvals(Mat)), similar(nonzeros(Mat), T), size(Mat))
+Base.similar(Mat::CuSparseMatrixCSR{<:Any, Ti}, ::Type{T}) where {T, Ti} =
+    CuSparseMatrixCSR{T, Ti}(copy(Mat.rowPtr), copy(Mat.colVal), similar(nonzeros(Mat), T), size(Mat))
+Base.similar(Mat::CuSparseMatrixBSR{<:Any, Ti}, ::Type{T}) where {T, Ti} =
+    CuSparseMatrixBSR{T, Ti}(copy(Mat.rowPtr), copy(Mat.colVal), similar(nonzeros(Mat), T), size(Mat), Mat.blockDim, Mat.dir, nnz(Mat))
+Base.similar(Mat::CuSparseMatrixCOO{<:Any, Ti}, ::Type{T}) where {T, Ti} =
+    CuSparseMatrixCOO{T, Ti}(copy(Mat.rowInd), copy(Mat.colInd), similar(nonzeros(Mat), T), size(Mat), nnz(Mat))
 
-Base.similar(Mat::CuSparseMatrixCSC{Tv, Ti}, N::Int, M::Int) where {Tv, Ti} = similar(Mat, Tv, N, M)
-Base.similar(Mat::CuSparseMatrixCSR{Tv, Ti}, N::Int, M::Int) where {Tv, Ti} = similar(Mat, Tv, N, M)
-Base.similar(Mat::CuSparseMatrixCOO{Tv, Ti}, N::Int, M::Int) where {Tv, Ti} = similar(Mat, Tv, N, M)
+# --- 2 type args (TvNew, TiNew): structure-preserving, with explicit index type ---
+Base.similar(Vec::CuSparseVector, ::Type{T}, ::Type{Ti}) where {T, Ti} =
+    CuSparseVector{T, Ti}(copyto!(similar(nonzeroinds(Vec), Ti), nonzeroinds(Vec)), similar(nonzeros(Vec), T), length(Vec))
+Base.similar(Mat::CuSparseMatrixCSC, ::Type{T}, ::Type{Ti}) where {T, Ti} =
+    CuSparseMatrixCSC{T, Ti}(copyto!(similar(Mat.colPtr, Ti), Mat.colPtr), copyto!(similar(rowvals(Mat), Ti), rowvals(Mat)), similar(nonzeros(Mat), T), size(Mat))
+Base.similar(Mat::CuSparseMatrixCSR, ::Type{T}, ::Type{Ti}) where {T, Ti} =
+    CuSparseMatrixCSR{T, Ti}(copyto!(similar(Mat.rowPtr, Ti), Mat.rowPtr), copyto!(similar(Mat.colVal, Ti), Mat.colVal), similar(nonzeros(Mat), T), size(Mat))
+Base.similar(Mat::CuSparseMatrixBSR, ::Type{T}, ::Type{Ti}) where {T, Ti} =
+    CuSparseMatrixBSR{T, Ti}(copyto!(similar(Mat.rowPtr, Ti), Mat.rowPtr), copyto!(similar(Mat.colVal, Ti), Mat.colVal), similar(nonzeros(Mat), T), size(Mat), Mat.blockDim, Mat.dir, nnz(Mat))
+Base.similar(Mat::CuSparseMatrixCOO, ::Type{T}, ::Type{Ti}) where {T, Ti} =
+    CuSparseMatrixCOO{T, Ti}(copyto!(similar(Mat.rowInd, Ti), Mat.rowInd), copyto!(similar(Mat.colInd, Ti), Mat.colInd), similar(nonzeros(Mat), T), size(Mat), nnz(Mat))
+
+# --- 2D with shape: empty sparse matrix. `Ti` is inherited from source, or supplied. ---
+Base.similar(Mat::CuSparseMatrixCSC{<:Any, Ti}, ::Type{T}, N::Int, M::Int) where {T, Ti} =
+    CuSparseMatrixCSC{T, Ti}(CUDACore.zeros(Ti, 1), CUDACore.zeros(Ti, 0), CuVector{T}(undef, 0), (N, M))
+Base.similar(Mat::CuSparseMatrixCSR{<:Any, Ti}, ::Type{T}, N::Int, M::Int) where {T, Ti} =
+    CuSparseMatrixCSR{T, Ti}(CUDACore.zeros(Ti, 1), CUDACore.zeros(Ti, 0), CuVector{T}(undef, 0), (N, M))
+Base.similar(Mat::CuSparseMatrixCOO{<:Any, Ti}, ::Type{T}, N::Int, M::Int) where {T, Ti} =
+    CuSparseMatrixCOO{T, Ti}(CUDACore.zeros(Ti, 0), CUDACore.zeros(Ti, 0), CuVector{T}(undef, 0), (N, M))
+
+Base.similar(Mat::CuSparseMatrixCSC, ::Type{T}, ::Type{Ti}, N::Int, M::Int) where {T, Ti} =
+    CuSparseMatrixCSC{T, Ti}(CUDACore.zeros(Ti, 1), CUDACore.zeros(Ti, 0), CuVector{T}(undef, 0), (N, M))
+Base.similar(Mat::CuSparseMatrixCSR, ::Type{T}, ::Type{Ti}, N::Int, M::Int) where {T, Ti} =
+    CuSparseMatrixCSR{T, Ti}(CUDACore.zeros(Ti, 1), CUDACore.zeros(Ti, 0), CuVector{T}(undef, 0), (N, M))
+Base.similar(Mat::CuSparseMatrixCOO, ::Type{T}, ::Type{Ti}, N::Int, M::Int) where {T, Ti} =
+    CuSparseMatrixCOO{T, Ti}(CUDACore.zeros(Ti, 0), CUDACore.zeros(Ti, 0), CuVector{T}(undef, 0), (N, M))
+
+# Forwarders: no T (eltype inherited) → (Tv, n, m); tuple shape → varargs.
+Base.similar(Mat::CuSparseMatrixCSC{Tv}, N::Int, M::Int) where {Tv} = similar(Mat, Tv, N, M)
+Base.similar(Mat::CuSparseMatrixCSR{Tv}, N::Int, M::Int) where {Tv} = similar(Mat, Tv, N, M)
+Base.similar(Mat::CuSparseMatrixCOO{Tv}, N::Int, M::Int) where {Tv} = similar(Mat, Tv, N, M)
 
 Base.similar(Mat::CuSparseMatrixCSC, T::Type, dims::Tuple{Int, Int}) = similar(Mat, T, dims...)
 Base.similar(Mat::CuSparseMatrixCSR, T::Type, dims::Tuple{Int, Int}) = similar(Mat, T, dims...)
 Base.similar(Mat::CuSparseMatrixCOO, T::Type, dims::Tuple{Int, Int}) = similar(Mat, T, dims...)
 
+Base.similar(Mat::CuSparseMatrixCSC, T::Type, Ti::Type, dims::Tuple{Int, Int}) = similar(Mat, T, Ti, dims...)
+Base.similar(Mat::CuSparseMatrixCSR, T::Type, Ti::Type, dims::Tuple{Int, Int}) = similar(Mat, T, Ti, dims...)
+Base.similar(Mat::CuSparseMatrixCOO, T::Type, Ti::Type, dims::Tuple{Int, Int}) = similar(Mat, T, Ti, dims...)
+
 Base.similar(Mat::CuSparseMatrixCSC, dims::Tuple{Int, Int}) = similar(Mat, dims...)
 Base.similar(Mat::CuSparseMatrixCSR, dims::Tuple{Int, Int}) = similar(Mat, dims...)
 Base.similar(Mat::CuSparseMatrixCOO, dims::Tuple{Int, Int}) = similar(Mat, dims...)
 
-# 1D `similar` returns an empty `CuSparseVector`, mirroring `SparseArrays.jl`. The
-# index type is inherited from the source matrix.
-Base.similar(Mat::CuSparseMatrix{Tv, Ti}, ::Type{T}, dims::Dims{1}) where {Tv, Ti, T} =
-    CuSparseVector(CuVector{Ti}(undef, 0), CuVector{T}(undef, 0), dims[1])
+# --- 1D with shape: empty CuSparseVector. `Ti` inherited or supplied. ---
+Base.similar(Mat::CuSparseMatrix{<:Any, Ti}, ::Type{T}, dims::Dims{1}) where {Ti, T} =
+    CuSparseVector{T, Ti}(CuVector{Ti}(undef, 0), CuVector{T}(undef, 0), dims[1])
+Base.similar(Mat::CuSparseMatrix, ::Type{T}, ::Type{Ti}, dims::Dims{1}) where {T, Ti} =
+    CuSparseVector{T, Ti}(CuVector{Ti}(undef, 0), CuVector{T}(undef, 0), dims[1])
 Base.similar(Mat::CuSparseMatrix, dims::Dims{1}) = similar(Mat, eltype(Mat), dims)
 
-# For shapes that can't be represented as a sparse matrix (N≥3), fall back to a
-# dense `CuArray`, mirroring `SparseArrays.jl`'s fallback to a regular `Array`.
-# The 1D method above and the existing concrete 2D methods are more specific and
-# take precedence; this catches everything else.
-# TODO: lift to `AbstractGPUSparseArray` in GPUArrays.jl using `dense_array_type`.
+# Integer-vararg forwarders for the explicit-Ti family (SparseArrays.jl has these).
+Base.similar(Mat::CuSparseMatrix, T::Type, Ti::Type, m::Integer) = similar(Mat, T, Ti, (Int(m),))
+
+# --- N≥3: dense CuArray (Ti is irrelevant; no explicit-Ti variant per SparseArrays). ---
 Base.similar(::CuSparseMatrix, ::Type{T}, dims::Dims) where {T} = CuArray{T}(undef, dims)
 Base.similar(Mat::CuSparseMatrix, dims::Dims) = similar(Mat, eltype(Mat), dims)
 

--- a/lib/cusparse/test/array.jl
+++ b/lib/cusparse/test/array.jl
@@ -398,11 +398,11 @@ using Adapt
     @testset "similar (out-of-shape) — $SparseT" for SparseT in
             (CuSparseMatrixCSC, CuSparseMatrixCSR, CuSparseMatrixCOO)
         A = SparseT(sprand(Float32, m, n, 0.2))
-        # 2D — sparse representation preserved
-        @test similar(A, 4, 4)            isa SparseT{Float32}
-        @test similar(A, Float64, (4, 4)) isa SparseT{Float64}
-        # 1D — sparse vector, matching SparseArrays.jl (and inheriting the index type)
         Ti = typeof(A).parameters[2]
+        # 2D — sparse, with Ti inherited from source
+        @test similar(A, 4, 4)            isa SparseT{Float32, Ti}
+        @test similar(A, Float64, (4, 4)) isa SparseT{Float64, Ti}
+        # 1D — sparse vector, with Ti inherited from source
         @test similar(A, 7)               isa CuSparseVector{Float32, Ti}
         @test similar(A, Float64, (7,))   isa CuSparseVector{Float64, Ti}
         @test length(similar(A, 7))       == 7
@@ -414,5 +414,24 @@ using Adapt
             @test similar(A, Float64, shape)    isa CuArray{Float64, length(shape)}
             @test size(similar(A, shape...))    == shape
         end
+    end
+
+    @testset "similar (explicit Ti override) — $SparseT" for SparseT in
+            (CuSparseMatrixCSC, CuSparseMatrixCSR, CuSparseMatrixCOO)
+        A = SparseT(sprand(Float32, m, n, 0.2))
+        # Structure-preserving (no dims): types swap, sparsity pattern copied
+        let B = similar(A, Float64, Int64)
+            @test B isa SparseT{Float64, Int64}
+            @test size(B) == size(A)
+            @test nnz(B) == nnz(A)
+        end
+        # 2D with explicit Ti
+        @test similar(A, Float64, Int64, 4, 4)      isa SparseT{Float64, Int64}
+        @test similar(A, Float64, Int64, (4, 4))    isa SparseT{Float64, Int64}
+        # 1D with explicit Ti
+        @test similar(A, Float64, Int64, 7)         isa CuSparseVector{Float64, Int64}
+        @test similar(A, Float64, Int64, (7,))      isa CuSparseVector{Float64, Int64}
+        # N≥3 with explicit Ti is not supported (matches SparseArrays.jl)
+        @test_throws MethodError similar(A, Float64, Int64, (4, 4, 4))
     end
 end

--- a/lib/cusparse/test/array.jl
+++ b/lib/cusparse/test/array.jl
@@ -394,4 +394,24 @@ using Adapt
             @test Adapt.adapt(CuArray{Float32}, v) isa CuSparseVector{Float32}
         end
     end
+
+    @testset "similar (out-of-shape) — $SparseT" for SparseT in
+            (CuSparseMatrixCSC, CuSparseMatrixCSR, CuSparseMatrixCOO)
+        A = SparseT(sprand(Float32, m, n, 0.2))
+        # 2D — sparse representation preserved
+        @test similar(A, 4, 4)            isa SparseT{Float32}
+        @test similar(A, Float64, (4, 4)) isa SparseT{Float64}
+        # 1D — sparse vector, matching SparseArrays.jl
+        @test similar(A, 7)               isa CuSparseVector{Float32}
+        @test similar(A, Float64, (7,))   isa CuSparseVector{Float64}
+        @test length(similar(A, 7))       == 7
+        # N≥3 — dense CuArray, matching SparseArrays.jl's fallback to Array (issue #3061)
+        for shape in ((4, 4, 4), (3, 4, 5, 2))
+            @test similar(A, shape...)          isa CuArray{Float32, length(shape)}
+            @test similar(A, shape)             isa CuArray{Float32, length(shape)}
+            @test similar(A, Float64, shape...) isa CuArray{Float64, length(shape)}
+            @test similar(A, Float64, shape)    isa CuArray{Float64, length(shape)}
+            @test size(similar(A, shape...))    == shape
+        end
+    end
 end

--- a/lib/cusparse/test/array.jl
+++ b/lib/cusparse/test/array.jl
@@ -401,9 +401,10 @@ using Adapt
         # 2D — sparse representation preserved
         @test similar(A, 4, 4)            isa SparseT{Float32}
         @test similar(A, Float64, (4, 4)) isa SparseT{Float64}
-        # 1D — sparse vector, matching SparseArrays.jl
-        @test similar(A, 7)               isa CuSparseVector{Float32}
-        @test similar(A, Float64, (7,))   isa CuSparseVector{Float64}
+        # 1D — sparse vector, matching SparseArrays.jl (and inheriting the index type)
+        Ti = typeof(A).parameters[2]
+        @test similar(A, 7)               isa CuSparseVector{Float32, Ti}
+        @test similar(A, Float64, (7,))   isa CuSparseVector{Float64, Ti}
         @test length(similar(A, 7))       == 7
         # N≥3 — dense CuArray, matching SparseArrays.jl's fallback to Array (issue #3061)
         for shape in ((4, 4, 4), (3, 4, 5, 2))


### PR DESCRIPTION
As mentioned in #3061 , when calling `similar` with CUSPARSE arguments and dimensions higher than 2, the fallback CPU method is called. As a result, calls to `similar` with GPU (sparse) matrices sometimes return host arrays, causing scalar indexing issues down the line

This PR introduces a fallback to `similar` that creates un-initialized `CuArray`s when there are 3 or more dimensions given as arguments, which is similar to what Base and SparseArrays do

Important note: I wasn't able to fully test this locally due to some issues instantiating the repo environment with Pkg