### PR TITLE
Avoid Int128 in Float vs Rational comparisons on the device

### DIFF
--- a/CUDACore/src/device/quirks.jl
+++ b/CUDACore/src/device/quirks.jl
@@ -92,3 +92,14 @@ end
 @device_override @noinline Base.__throw_rational_argerror_typemin(::Type{T}) where {T} =
     @gputhrow "OverflowError" "rational numerator is typemin"
 end
+
+# Float vs Rational comparisons in Base use `widemul` of the decomposed components,
+# which produces Int128 and requires the `__divti3` / `__udivti3` compiler-rt routines
+# that NVPTX does not provide. Override with a float-conversion path; this loses some
+# precision when the rational cannot be represented exactly, but avoids Int128. (#2681)
+for op in (:(<), :(<=), :cmp)
+    @eval begin
+        @device_override Base.$op(x::AbstractFloat, q::Rational) = $op(x, float(q))
+        @device_override Base.$op(q::Rational, x::AbstractFloat) = $op(float(q), x)
+    end
+end

--- a/test/core/broadcast.jl
+++ b/test/core/broadcast.jl
@@ -81,3 +81,16 @@ end
   @test testf((x) -> (2 // 3 .* x),  rand(2, 3))
   @test testf((x) -> (f(x) = 2 // 3 * x; f.(x)),  rand(2, 3))
 end
+
+# https://github.com/JuliaGPU/CUDA.jl/issues/2681
+@testset "Broadcast Float vs Rational comparison" begin
+  for T in (Float32, Float64)
+    @test testf((x) -> x .<  3 // 2, rand(T, 4))
+    @test testf((x) -> x .<= 3 // 2, rand(T, 4))
+    @test testf((x) -> x .>  3 // 2, rand(T, 4))
+    @test testf((x) -> x .>= 3 // 2, rand(T, 4))
+    @test testf((x) -> 3 // 2 .<  x, rand(T, 4))
+    @test testf((x) -> 3 // 2 .<= x, rand(T, 4))
+    @test testf((x) -> cmp.(x, 3 // 2), rand(T, 4))
+  end
+end


### PR DESCRIPTION
Base's `<`, `<=`, and `cmp` between `AbstractFloat` and `Rational` decompose both sides and `widemul` the components, producing Int128 values that require the `__divti3` / `__udivti3` compiler-rt routines NVPTX does not provide. Override these with a float-conversion path, which avoids Int128 at the cost of some precision when the rational cannot be represented exactly. (#2681)

Fixes https://github.com/JuliaGPU/CUDA.jl/issues/2681