### PR TITLE
Add `_throw_dmrs` device override for reshape of views

### DIFF
--- a/CUDACore/src/device/quirks.jl
+++ b/CUDACore/src/device/quirks.jl
@@ -103,3 +103,7 @@ for op in (:(<), :(<=), :cmp)
         @device_override Base.$op(q::Rational, x::AbstractFloat) = $op(float(q), x)
     end
 end
+
+# reshape.jl
+@device_override Base._throw_dmrs(n, str, dims) =
+    @gputhrow "DimensionMismatch" "Dimensions mismatch when reshaping. New dimensions must be consistent with array size"

--- a/test/core/device/array.jl
+++ b/test/core/device/array.jl
@@ -146,6 +146,24 @@ end
     @test array == Array(array_dev)
 end
 
+@testset "reshape of view" begin
+    function kernel(out, data, n)
+        i = threadIdx().x
+        if i <= n * n
+            mat = reshape(@view(data[1:n*n]), (n, n))
+            out[i] = mat[i]
+        end
+        return
+    end
+
+    n = 4
+    data = CuArray(Float32.(1:n*n))
+    out = CUDA.zeros(Float32, n * n)
+
+    @cuda threads=n*n kernel(out, data, n)
+    @test Array(out) == Float32.(1:n*n)
+end
+
 @testset "non-Int index to unsafe_load" begin
     function kernel(a)
         a[UInt64(1)] = 1


### PR DESCRIPTION
## Problem

`reshape(@view(data[1:n*n]), (n, n))` fails to compile on the GPU. `@view` creates a `SubArray`, which has no specialized `reshape` method on the device, so it falls back to Base's generic `_reshape`. That path calls `_throw_dmrs`, which tries to construct a `DimensionMismatch` string — unsupported on the GPU.

```
Reason: unsupported call to an external C function
Stacktrace:
 [1] _string_n
   @ ./strings/string.jl:109
 [2] StringMemory
   @ ./iobuffer.jl:167
 [3] dec
   @ ./intfuncs.jl:918
 [4] #string#403
   @ ./intfuncs.jl:1000
 [5] multiple call sites
   @ unknown:0
   
  ```
  
  ```
  function _reshape(parent::AbstractArray, dims::Dims)
    n = length(parent)
    prod(dims) == n || _throw_dmrs(n, "size", dims)
    __reshape((parent, IndexStyle(parent)), dims)
end

@noinline function _throw_dmrs(n, str, dims)
    throw(DimensionMismatch("parent has $n elements, which is incompatible with $str $dims")) ## THIS IS THE CULPRIT
end
  ```