### PR TITLE
Add device overrides for `FastMath.pow_fast` with integer exponents

### DIFF
--- a/CUDACore/src/device/intrinsics/math.jl
+++ b/CUDACore/src/device/intrinsics/math.jl
@@ -248,6 +248,31 @@ end
 @device_override Base.:(^)(x::Float64, y::Float64) = ccall("extern __nv_pow", llvmcall, Cdouble, (Cdouble, Cdouble), x, y)
 @device_override Base.:(^)(x::Float32, y::Float32) = ccall("extern __nv_powf", llvmcall, Cfloat, (Cfloat, Cfloat), x, y)
 @device_override FastMath.pow_fast(x::Float32, y::Float32) = ccall("extern __nv_fast_powf", llvmcall, Cfloat, (Cfloat, Cfloat), x, y)
+# pow_fast: Base methods call llvm.powi which NVPTX cannot lower (#3065)
+@device_override @inline function FastMath.pow_fast(x::Float64, y::Int32)
+    y == -1 && return inv(x)
+    y == 0 && return one(x)
+    y == 1 && return x
+    y == 2 && return x*x
+    y == 3 && return x*x*x
+    x ^ y  # no fast variant for Float64; uses __nv_powi
+end
+@device_override @inline function FastMath.pow_fast(x::Float32, y::Int32)
+    y == -1 && return inv(x)
+    y == 0 && return one(x)
+    y == 1 && return x
+    y == 2 && return x*x
+    y == 3 && return x*x*x
+    FastMath.pow_fast(x, Float32(y))  # uses __nv_fast_powf
+end
+@device_override @inline function FastMath.pow_fast(x::Float16, y::Int32)
+    y == -1 && return inv(x)
+    y == 0 && return one(x)
+    y == 1 && return x
+    y == 2 && return x*x
+    y == 3 && return x*x*x
+    Float16(FastMath.pow_fast(Float32(x), Float32(y)))
+end
 @device_override Base.:(^)(x::Float64, y::Int32) = ccall("extern __nv_powi", llvmcall, Cdouble, (Cdouble, Int32), x, y)
 @device_override Base.:(^)(x::Float32, y::Int32) = ccall("extern __nv_powif", llvmcall, Cfloat, (Cfloat, Int32), x, y)
 @device_override @inline function Base.:(^)(x::Float32, y::Int64)

--- a/CUDACore/src/device/intrinsics/math.jl
+++ b/CUDACore/src/device/intrinsics/math.jl
@@ -249,7 +249,7 @@ end
 @device_override Base.:(^)(x::Float32, y::Float32) = ccall("extern __nv_powf", llvmcall, Cfloat, (Cfloat, Cfloat), x, y)
 @device_override FastMath.pow_fast(x::Float32, y::Float32) = ccall("extern __nv_fast_powf", llvmcall, Cfloat, (Cfloat, Cfloat), x, y)
 # pow_fast: Base methods call llvm.powi which NVPTX cannot lower (#3065)
-@device_override @inline function FastMath.pow_fast(x::Float64, y::Int32)
+@device_override @inline function FastMath.pow_fast(x::Float64, y::Integer)
     y == -1 && return inv(x)
     y == 0 && return one(x)
     y == 1 && return x
@@ -257,7 +257,7 @@ end
     y == 3 && return x*x*x
     x ^ y  # no fast variant for Float64; uses __nv_powi
 end
-@device_override @inline function FastMath.pow_fast(x::Float32, y::Int32)
+@device_override @inline function FastMath.pow_fast(x::Float32, y::Integer)
     y == -1 && return inv(x)
     y == 0 && return one(x)
     y == 1 && return x
@@ -265,7 +265,7 @@ end
     y == 3 && return x*x*x
     FastMath.pow_fast(x, Float32(y))  # uses __nv_fast_powf
 end
-@device_override @inline function FastMath.pow_fast(x::Float16, y::Int32)
+@device_override @inline function FastMath.pow_fast(x::Float16, y::Integer)
     y == -1 && return inv(x)
     y == 0 && return one(x)
     y == 1 && return x

--- a/CUDACore/src/device/intrinsics/math.jl
+++ b/CUDACore/src/device/intrinsics/math.jl
@@ -275,7 +275,7 @@ end
 end
 @device_override Base.:(^)(x::Float64, y::Int32) = ccall("extern __nv_powi", llvmcall, Cdouble, (Cdouble, Int32), x, y)
 @device_override Base.:(^)(x::Float32, y::Int32) = ccall("extern __nv_powif", llvmcall, Cfloat, (Cfloat, Int32), x, y)
-@device_override @inline function Base.:(^)(x::Float32, y::Int64)
+@device_override @assume_effects :foldable @inline function Base.:(^)(x::Float32, y::Int64)
     y == -1 && return inv(x)
     y == 0 && return one(x)
     y == 1 && return x
@@ -283,7 +283,7 @@ end
     y == 3 && return x*x*x
     x ^ Float32(y)
 end
-@device_override @inline function Base.:(^)(x::Float64, y::Int64)
+@device_override @assume_effects :foldable @inline function Base.:(^)(x::Float64, y::Int64)
     y == -1 && return inv(x)
     y == 0 && return one(x)
     y == 1 && return x

--- a/CUDACore/src/device/intrinsics/math.jl
+++ b/CUDACore/src/device/intrinsics/math.jl
@@ -2,7 +2,7 @@
 
 @public fma, rsqrt, saturate, byte_perm, assume
 
-using Base: FastMath
+using Base: FastMath, @assume_effects
 
 
 ## helpers
@@ -249,7 +249,7 @@ end
 @device_override Base.:(^)(x::Float32, y::Float32) = ccall("extern __nv_powf", llvmcall, Cfloat, (Cfloat, Cfloat), x, y)
 @device_override FastMath.pow_fast(x::Float32, y::Float32) = ccall("extern __nv_fast_powf", llvmcall, Cfloat, (Cfloat, Cfloat), x, y)
 # pow_fast: Base methods call llvm.powi which NVPTX cannot lower (#3065)
-@device_override @inline function FastMath.pow_fast(x::Float64, y::Integer)
+@device_override @assume_effects :foldable @inline function FastMath.pow_fast(x::Float64, y::Integer)
     y == -1 && return inv(x)
     y == 0 && return one(x)
     y == 1 && return x
@@ -257,7 +257,7 @@ end
     y == 3 && return x*x*x
     x ^ y  # no fast variant for Float64; uses __nv_powi
 end
-@device_override @inline function FastMath.pow_fast(x::Float32, y::Integer)
+@device_override @assume_effects :foldable @inline function FastMath.pow_fast(x::Float32, y::Integer)
     y == -1 && return inv(x)
     y == 0 && return one(x)
     y == 1 && return x
@@ -265,7 +265,7 @@ end
     y == 3 && return x*x*x
     FastMath.pow_fast(x, Float32(y))  # uses __nv_fast_powf
 end
-@device_override @inline function FastMath.pow_fast(x::Float16, y::Integer)
+@device_override @assume_effects :foldable @inline function FastMath.pow_fast(x::Float16, y::Integer)
     y == -1 && return inv(x)
     y == 0 && return one(x)
     y == 1 && return x

--- a/test/core/device/intrinsics/math.jl
+++ b/test/core/device/intrinsics/math.jl
@@ -112,6 +112,20 @@ using SpecialFunctions
         # JuliaGPU/CUDA.jl#2886: LLVM below v18 emits non-existing min.NaN.f64/max.NaN.f64
         f(a, b) = @fastmath max(a, b)
         @test Array(map(f, CuArray([1.0, 2.0]), CuArray([4.0, 3.0]))) == [4.0, 3.0]
+
+        # JuliaGPU/CUDA.jl#3065: pow_fast with integer exponent used unsupported llvm.powi
+        function fastpow_kernel(A, y)
+            i = threadIdx().x
+            @inbounds @fastmath A[i] = A[i]^y
+            return nothing
+        end
+        for T in (Float32, Float64)
+            A = CUDA.ones(T, 4)
+            @cuda threads=4 fastpow_kernel(A, Int32(3))
+            @test Array(A) == ones(T, 4)
+            @cuda threads=4 fastpow_kernel(A, 3)
+            @test Array(A) == ones(T, 4)
+        end
     end
 
     @testset "byte_perm" begin


### PR DESCRIPTION
`Base.FastMath.pow_fast(::IEEEFloat, ::Int32)` emits the `llvm.powi` intrinsic, which the NVPTX backend cannot lower (it has no runtime libcalls). Override with inline small-exponent specializations and fast libdevice fallbacks (`__nv_fast_powf` for Float32, `__nv_powi` for Float64).

Also makes both the fast and regular versions use compiler flags that allow folding them.

Fixes https://github.com/JuliaGPU/CUDA.jl/issues/3065