### PR TITLE
CUSPARSE: fix sparse(::Symmetric/::Hermitian) stack overflow (#3042).

### DIFF
--- a/lib/cusparse/src/conversions.jl
+++ b/lib/cusparse/src/conversions.jl
@@ -138,6 +138,34 @@ for (wrapa, unwrapa) in adjtrans_wrappers
     end
 end
 
+# The SparseArrays fallback recurses forever on AbstractSparseArray parents
+# (issue #3042), so materialize the full matrix from the referenced triangle.
+function sparse_symmherm(A::Union{Symmetric{T},Hermitian{T}}, fmt::Symbol) where T
+    P = CuSparseMatrixCOO(parent(A))
+    diag_mask = P.rowInd .== P.colInd
+    strict_mask = A.uplo == 'U' ? P.rowInd .< P.colInd : P.rowInd .> P.colInd
+    op = A isa Hermitian ? conj : identity
+    diag_vals = A isa Hermitian ? T.(real.(P.nzVal[diag_mask])) : P.nzVal[diag_mask]
+    strict_rows = P.rowInd[strict_mask]
+    strict_cols = P.colInd[strict_mask]
+    strict_vals = P.nzVal[strict_mask]
+    diag_rows = P.rowInd[diag_mask]
+    m, n = size(A)
+    sparse(vcat(diag_rows, strict_rows, strict_cols),
+           vcat(diag_rows, strict_cols, strict_rows),
+           vcat(diag_vals, strict_vals, op.(strict_vals)),
+           m, n; fmt)
+end
+
+for (SparseMatrixType, fmt) in ((:CuSparseMatrixCSC, :csc),
+                                (:CuSparseMatrixCSR, :csr),
+                                (:CuSparseMatrixCOO, :coo))
+    @eval SparseArrays.sparse(A::Symmetric{T,<:$SparseMatrixType}) where {T} =
+        sparse_symmherm(A, $(QuoteNode(fmt)))
+    @eval SparseArrays.sparse(A::Hermitian{T,<:$SparseMatrixType}) where {T} =
+        sparse_symmherm(A, $(QuoteNode(fmt)))
+end
+
 function sort_csc(A::CuSparseMatrixCSC{Tv,Ti}, index::SparseChar='O') where {Tv,Ti}
 
     m,n = size(A)

--- a/lib/cusparse/src/interfaces.jl
+++ b/lib/cusparse/src/interfaces.jl
@@ -218,6 +218,15 @@ for op in (:(+), :(-))
                  B::Union{CuSparseMatrixCOO{T}, Transpose{T,<:CuSparseMatrixCOO}, Adjoint{T,<:CuSparseMatrixCOO}}) where {T <: BlasFloat} =
             CuSparseMatrixCOO($(op)(CuSparseMatrixCSR(A), CuSparseMatrixCSR(B)))
     end
+
+    # Symmetric/Hermitian wrappers: materialize, then defer. (issue #3043)
+    for (wrap, _) in adjtrans_wrappers,
+        SparseMatrixType in (:CuSparseMatrixCSC, :CuSparseMatrixCSR, :CuSparseMatrixCOO)
+
+        W = wrap(:($SparseMatrixType{T}))
+        @eval Base.$op(A::HermOrSym{T,<:$SparseMatrixType}, B::$W) where {T <: BlasFloat} = $op(sparse(A), B)
+        @eval Base.$op(A::$W, B::HermOrSym{T,<:$SparseMatrixType}) where {T <: BlasFloat} = $op(A, sparse(B))
+    end
 end
 
 # triangular

--- a/lib/cusparse/test/conversions.jl
+++ b/lib/cusparse/test/conversions.jl
@@ -74,6 +74,21 @@ end
     end
 end
 
+@testset "sparse(::Symmetric/::Hermitian) (CUDA.jl#3042)" begin
+    for typ in (Float32, ComplexF32, Float64, ComplexF64)
+        A = sprand(typ, 10, 10, 0.3)
+        for T in (CuSparseMatrixCSC, CuSparseMatrixCSR, CuSparseMatrixCOO),
+            wrap in (Symmetric, Hermitian),
+            uplo in (:U, :L)
+
+            dA = T(A)
+            dS = sparse(wrap(dA, uplo))
+            @test dS isa T
+            @test Array(dS) ≈ Array(sparse(wrap(A, uplo)))
+        end
+    end
+end
+
 @testset "CuSparseMatrix(::Diagonal)" begin
     X = Diagonal(rand(10))
     dX = cu(X)

--- a/lib/cusparse/test/interfaces.jl
+++ b/lib/cusparse/test/interfaces.jl
@@ -187,6 +187,20 @@ nB = 2
                 end
             end
         end
+        @testset "A ± HermOrSym(B) (CUDA.jl#3043)" begin
+            A = sprand(elty, n, n, 0.3)
+            B = sprand(elty, n, n, 0.3)
+            @testset "$SparseMatrixType" for SparseMatrixType in (CuSparseMatrixCSC, CuSparseMatrixCSR, CuSparseMatrixCOO)
+                dA = SparseMatrixType(A)
+                dB = SparseMatrixType(B)
+                for wrap in (Symmetric, Hermitian), uplo in (:U, :L),
+                    opa in (identity, transpose, adjoint), op in (+, -)
+
+                    @test collect(op(opa(dA), wrap(dB, uplo))) ≈ op(opa(A), wrap(B, uplo))
+                    @test collect(op(wrap(dB, uplo), opa(dA))) ≈ op(wrap(B, uplo), opa(A))
+                end
+            end
+        end
         @testset "ldiv $elty $triangle" for triangle in [LowerTriangular, UnitLowerTriangular, UpperTriangular, UnitUpperTriangular]
             A  = rand(elty, m, m)
             A  = triangle in (UnitLowerTriangular, LowerTriangular) ? tril(A) : triu(A)


### PR DESCRIPTION
The SparseArrays fallback's _sparsem recurses forever when the parent is an AbstractSparseArray, since _sparsewrap is a no-op in that case. Materialize the full matrix from the referenced triangle directly, matching the CPU SparseMatrixCSC behavior.

Fixes https://github.com/JuliaGPU/CUDA.jl/issues/3042
Fixes https://github.com/JuliaGPU/CUDA.jl/issues/3043