### PR TITLE
Temporarily disable cross-device memory access from kernels

### DIFF
--- a/CUDACore/lib/cudadrv/state.jl
+++ b/CUDACore/lib/cudadrv/state.jl
@@ -459,7 +459,12 @@ function Base.get!(constructor::F, x::PerDevice{T}, dev::CuDevice) where {F <: B
         if y[id] === nothing || (y[id]::Tuple)[1] !== ctx
             Base.@lock x.lock begin
                 if y[id] === nothing || (y[id]::Tuple)[1] !== ctx
-                    y[id] = (context(), constructor())
+                    # store the device's own context (it may be created during `constructor()`),
+                    # so subsequent lookups — which compare against `device_context(id)`, not
+                    # the currently-active context — hit the cache regardless of which context
+                    # was active when the value was constructed.
+                    value = constructor()
+                    y[id] = (context(dev), value)
                 end
             end
         end

--- a/CUDACore/src/memory.jl
+++ b/CUDACore/src/memory.jl
@@ -604,10 +604,11 @@ function Base.convert(::Type{CuPtr{T}}, managed::Managed{M}) where {T,M}
     end
 
     # set pool visibility
-    if stream_ordered(source_device)
-      pool = pool_create(source_device)
-      access!(pool, state.device, ACCESS_FLAGS_PROT_READWRITE)
-    end
+    # XXX: disabled because of NVIDIA bug #6098762
+    #if stream_ordered(source_device)
+    #  pool = pool_create(source_device)
+    #  access!(pool, state.device, ACCESS_FLAGS_PROT_READWRITE)
+    #end
   end
 
   # accessing memory on another stream: ensure the data is ready and take ownership


### PR DESCRIPTION
Calling `cuMemPoolSetAccess` somehow seems to break `cuMemcpyPeerAsync`. MWE:

```c
// Reproducer for a suspected CUDA driver bug on multi-GPU peer copies from
// stream-ordered memory pools. See comments in the main loop for the expected
// behavior.
//
// Build:
//   gcc -O0 -g -o repro repro.c -I/usr/local/cuda-13.2/targets/x86_64-linux/include -lcuda
// Run (with two P2P-capable GPUs):
//   CUDA_VISIBLE_DEVICES=0,1 ./repro
//
// On Turing sm_75 + driver 590.48.01 + CUDA 13.2 we observe that after
// `cuMemPoolSetAccess` has been called on a custom device memory pool,
// `cuMemcpyPeerAsync` into allocations from that pool silently fails to
// write the data.

#include <stdio.h>
#include <stdlib.h>
#include <string.h>
#include <cuda.h>

#define CHECK(call) do { \
    CUresult _r = (call); \
    if (_r != CUDA_SUCCESS) { \
        const char *err_name = NULL, *err_str = NULL; \
        cuGetErrorName(_r, &err_name); \
        cuGetErrorString(_r, &err_str); \
        fprintf(stderr, "%s:%d: %s failed: %s (%s)\n", \
                __FILE__, __LINE__, #call, \
                err_name ? err_name : "?", err_str ? err_str : "?"); \
        exit(1); \
    } \
} while (0)

// Create a custom memory pool for `dev` and set it as the default pool.
static CUmemoryPool make_pool(CUdevice dev) {
    CUmemPoolProps props;
    memset(&props, 0, sizeof(props));
    props.allocType = CU_MEM_ALLOCATION_TYPE_PINNED;
    props.handleTypes = CU_MEM_HANDLE_TYPE_NONE;
    props.location.type = CU_MEM_LOCATION_TYPE_DEVICE;
    props.location.id = dev;

    CUmemoryPool pool;
    CHECK(cuMemPoolCreate(&pool, &props));

    CHECK(cuDeviceSetMemPool(dev, pool));

    cuuint64_t threshold = (cuuint64_t)-1;
    CHECK(cuMemPoolSetAttribute(pool, CU_MEMPOOL_ATTR_RELEASE_THRESHOLD,
                                &threshold));
    return pool;
}

// Grant `peer` read/write access to allocations from `pool`.
static void grant_pool_access(CUmemoryPool pool, CUdevice peer) {
    CUmemAccessDesc desc;
    memset(&desc, 0, sizeof(desc));
    desc.location.type = CU_MEM_LOCATION_TYPE_DEVICE;
    desc.location.id = peer;
    desc.flags = CU_MEM_ACCESS_FLAGS_PROT_READWRITE;
    CHECK(cuMemPoolSetAccess(pool, &desc, 1));
}

int main(int argc, char **argv) {
    CHECK(cuInit(0));

    int ndev;
    CHECK(cuDeviceGetCount(&ndev));
    if (ndev < 2) {
        fprintf(stderr, "need at least 2 devices, have %d\n", ndev);
        return 1;
    }

    CUdevice dev0, dev1;
    CHECK(cuDeviceGet(&dev0, 0));
    CHECK(cuDeviceGet(&dev1, 1));

    int p2p_01 = 0, p2p_10 = 0;
    CHECK(cuDeviceCanAccessPeer(&p2p_01, dev0, dev1));
    CHECK(cuDeviceCanAccessPeer(&p2p_10, dev1, dev0));
    if (!p2p_01 || !p2p_10) {
        fprintf(stderr, "need bidirectional P2P; 0->1=%d 1->0=%d\n",
                p2p_01, p2p_10);
        return 1;
    }

    // Retain primary contexts for each device.
    CUcontext ctx0, ctx1;
    CHECK(cuDevicePrimaryCtxRetain(&ctx0, dev0));
    CHECK(cuDevicePrimaryCtxRetain(&ctx1, dev1));

    // Enable context-level peer access in both directions.
    CHECK(cuCtxSetCurrent(ctx0));
    CHECK(cuCtxEnablePeerAccess(ctx1, 0));
    CHECK(cuCtxSetCurrent(ctx1));
    CHECK(cuCtxEnablePeerAccess(ctx0, 0));

    // Create custom pools for both devices.
    CHECK(cuCtxSetCurrent(ctx0));
    CUmemoryPool pool0 = make_pool(dev0);
    CHECK(cuCtxSetCurrent(ctx1));
    CUmemoryPool pool1 = make_pool(dev1);

    // NVIDIA's documented pattern: grant pool-level peer access ONCE, before
    // any allocations come out of the pool. Per the programming guide,
    // "once a pool is made accessible from a given GPU, it should remain
    // accessible from that GPU for the lifetime of the pool."
    int grant_pool_access_flag = 1;
    if (argc >= 2 && strcmp(argv[1], "--no-pool-access") == 0) {
        grant_pool_access_flag = 0;
    }
    if (grant_pool_access_flag) {
        grant_pool_access(pool0, dev1);
        grant_pool_access(pool1, dev0);
    }

    // Create a stream on each device.
    CHECK(cuCtxSetCurrent(ctx0));
    CUstream s0;
    CHECK(cuStreamCreate(&s0, CU_STREAM_NON_BLOCKING));
    CHECK(cuCtxSetCurrent(ctx1));
    CUstream s1;
    CHECK(cuStreamCreate(&s1, CU_STREAM_NON_BLOCKING));

    // Main loop: per iteration, allocate a on dev0 and b on dev1, initialize
    // a with host data, peer-copy a -> b on dev0's stream, and verify b
    // contains the same data by copying back to the host via dev1's stream.
    const size_t N = 25;
    const size_t bytes = N * sizeof(double);
    double host_a[N], host_b[N];
    for (size_t i = 0; i < N; i++) host_a[i] = (double)(i + 1) * 1.5;

    int fails = 0;
    const int iters = 500;
    for (int it = 0; it < iters; it++) {
        // alloc a on dev0 (stream-ordered, from pool0)
        CHECK(cuCtxSetCurrent(ctx0));
        CUdeviceptr a;
        CHECK(cuMemAllocFromPoolAsync(&a, bytes, pool0, s0));

        // alloc b on dev1 (stream-ordered, from pool1)
        CHECK(cuCtxSetCurrent(ctx1));
        CUdeviceptr b;
        CHECK(cuMemAllocFromPoolAsync(&b, bytes, pool1, s1));

        // make sure b's allocation is physically done before the peer write
        // touches it from dev0's stream
        CHECK(cuStreamSynchronize(s1));

        // HtoD fill of a on dev0's stream
        CHECK(cuCtxSetCurrent(ctx0));
        CHECK(cuMemcpyHtoDAsync(a, host_a, bytes, s0));

        // peer copy a -> b on dev0's stream
        CHECK(cuMemcpyPeerAsync(b, ctx1, a, ctx0, bytes, s0));

        // wait for peer copy to complete
        CHECK(cuStreamSynchronize(s0));

        // DtoH read of b on dev1's stream
        CHECK(cuCtxSetCurrent(ctx1));
        memset(host_b, 0, bytes);
        CHECK(cuMemcpyDtoHAsync(host_b, b, bytes, s1));
        CHECK(cuStreamSynchronize(s1));

        // verify
        int ok = (memcmp(host_a, host_b, bytes) == 0);
        if (!ok) {
            fails++;
            if (fails <= 3) {
                fprintf(stderr, "iter %d: mismatch; first 3 values: "
                        "host_a=[%g,%g,%g] host_b=[%g,%g,%g]\n",
                        it, host_a[0], host_a[1], host_a[2],
                        host_b[0], host_b[1], host_b[2]);
            }
        }

        // free (stream-ordered)
        CHECK(cuCtxSetCurrent(ctx0));
        CHECK(cuMemFreeAsync(a, s0));
        CHECK(cuCtxSetCurrent(ctx1));
        CHECK(cuMemFreeAsync(b, s1));
    }

    printf("grant_pool_access=%d: %d/%d peer copies returned wrong data\n",
           grant_pool_access_flag, fails, iters);

    CHECK(cuStreamDestroy(s0));
    CHECK(cuStreamDestroy(s1));
    CHECK(cuMemPoolDestroy(pool0));
    CHECK(cuMemPoolDestroy(pool1));
    CHECK(cuDevicePrimaryCtxRelease(dev0));
    CHECK(cuDevicePrimaryCtxRelease(dev1));
    return fails == 0 ? 0 : 2;
}
```

Replacing the memcpy by a kernel-based one doesn't help. So temporarily disabling this until I hear back from NVIDIA.

Works around https://github.com/JuliaGPU/CUDA.jl/issues/2930