### PR TITLE
Fix workspace size on 5.11 and CUDA 13.2, backport #3062

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "CUDA"
 uuid = "052768ef-5323-5732-b1bb-66c8b64840ba"
-version = "5.11.0"
+version = "5.11.1"
 
 [workspace]
 projects = ["test", "docs", "perf", "examples",

--- a/lib/utils/call.jl
+++ b/lib/utils/call.jl
@@ -62,6 +62,13 @@ function with_workspaces(f::Base.Callable,
         if workspace_gpu === nothing
             workspace_gpu = CuVector{UInt8}(undef, sz_gpu)
         else
+            if workspace_gpu.maxsize < sz_gpu
+                # workspace data is scratch space that doesn't need to be preserved across
+                # calls, so shrink to 0 first to free the old buffer before growing. this
+                # avoids holding both old and new buffers simultaneously during resize,
+                # which can cause OOM on memory-constrained GPUs.
+                resize!(workspace_gpu, 0)
+            end
             resize!(workspace_gpu, sz_gpu)
         end
         sz_gpu = get_size_gpu()


### PR DESCRIPTION
https://github.com/JuliaGPU/CUDA.jl/pull/3062 fixed this for CUDA 6, but some packages can't update to that yet