### PR TITLE
Added Base.similar methods for CuSparseMatrixCOO and BSR

### DIFF
--- a/lib/cusparse/src/array.jl
+++ b/lib/cusparse/src/array.jl
@@ -295,20 +295,20 @@ Base.similar(Mat::CuSparseMatrixCOO, dims::Tuple{Int, Int}) = similar(Mat, dims.
 
 Base.similar(Mat::CuSparseArrayCSR) = CuSparseArrayCSR(copy(Mat.rowPtr), copy(Mat.colVal), similar(nonzeros(Mat)), size(Mat))
 
-
-function Base.similar(mat::CuSparseMatrixCOO, ::Type{T}, dims::Dims{2}) where {T}
+function Base.similar(mat::CuSparseMatrixCOO{Tv, Ti}, ::Type{T}, N::Int, M::Int) where {Tv, Ti, T}
     new_rowInd = similar(mat.rowInd)
     new_colInd = similar(mat.colInd)
     new_nzVal = similar(mat.nzVal, T)
-    return CuSparseMatrixCOO{T, Ti}(new_rowInd, new_colInd, new_nzVal, dims)
+    
+    return CuSparseMatrixCOO{T, Ti}(new_rowInd, new_colInd, new_nzVal, (N, M))
 end
 
-function Base.similar(mat::CuSparseMatrixBSR{Tv, Ti}, ::Type{T}, dims::Dims{2}) where {Tv, Ti, T}
+function Base.similar(mat::CuSparseMatrixBSR{Tv, Ti}, ::Type{T}, N::Int, M::Int) where {Tv, Ti, T}
     new_rowPtr = similar(mat.rowPtr)
     new_colVal = similar(mat.colVal)
     new_nzVal = similar(mat.nzVal, T) 
     
-    return CuSparseMatrixBSR{T, Ti}(new_rowPtr, new_colVal, new_nzVal, dims, mat.blockDim, mat.dir, mat.nnzb)
+    return CuSparseMatrixBSR{T, Ti}(new_rowPtr, new_colVal, new_nzVal, (N, M), mat.blockDim, mat.dir, mat.nnzb)
 end
 
 ## array interface

--- a/lib/cusparse/src/array.jl
+++ b/lib/cusparse/src/array.jl
@@ -300,7 +300,7 @@ function Base.similar(mat::CuSparseMatrixCOO, ::Type{T}, dims::Dims{2}) where {T
     new_rowInd = similar(mat.rowInd)
     new_colInd = similar(mat.colInd)
     new_nzVal = similar(mat.nzVal, T)
-    return CuSparseMatrixCOO(new_rowInd, new_colInd, new_nzVal, dims)
+    return CuSparseMatrixCOO{T, Ti}(new_rowInd, new_colInd, new_nzVal, dims)
 end
 
 function Base.similar(mat::CuSparseMatrixBSR{Tv, Ti}, ::Type{T}, dims::Dims{2}) where {Tv, Ti, T}
@@ -470,57 +470,39 @@ Base.getindex(A::CuSparseMatrixCSR, ::Colon, j::Integer) = CuSparseVector(sparse
 
 function Base.getindex(A::CuSparseVector{Tv, Ti}, i::Integer) where {Tv, Ti}
     @boundscheck checkbounds(A, i)
-    result = zero(Tv)
-    for k in 1:nnz(A)
-        A.iPtr[k] == i && (result = sum_duplicate(result, A.nzVal[k]))
-    end
-    return result
+    ii = searchsortedfirst(A.iPtr, convert(Ti, i))
+    (ii > nnz(A) || A.iPtr[ii] != i) && return zero(Tv)
+    A.nzVal[ii]
 end
-
-# Scalar getindex methods linear-scan the minor axis rather than binary-searching
-# and sum across matching entries. cuSPARSE formats don't guarantee sorted indices
-# within a major-axis slice (e.g. SpGEMM output may leave CSR columns unsorted
-# within a row, and COO is only guaranteed row-sorted), nor uniqueness — duplicate
-# (i, j) entries are permitted and their values sum, matching the convention of
-# Julia's `sparse()` constructor and SciPy/CuPy. For Bool we OR instead of sum,
-# also matching `sparse()`, since Bool + Bool doesn't stay Bool.
-sum_duplicate(a, b) = a + b
-sum_duplicate(a::Bool, b::Bool) = a | b
 
 function Base.getindex(A::CuSparseMatrixCSC{T}, i0::Integer, i1::Integer) where T
     @boundscheck checkbounds(A, i0, i1)
     r1 = Int(A.colPtr[i1])
     r2 = Int(A.colPtr[i1+1]-1)
-    result = zero(T)
-    for k in r1:r2
-        rowvals(A)[k] == i0 && (result = sum_duplicate(result, nonzeros(A)[k]))
-    end
-    return result
+    (r1 > r2) && return zero(T)
+    r1 = searchsortedfirst(rowvals(A), i0, r1, r2, Base.Order.Forward)
+    (r1 > r2 || rowvals(A)[r1] != i0) && return zero(T)
+    nonzeros(A)[r1]
 end
 
 function Base.getindex(A::CuSparseMatrixCSR{T}, i0::Integer, i1::Integer) where T
     @boundscheck checkbounds(A, i0, i1)
     c1 = Int(A.rowPtr[i0])
     c2 = Int(A.rowPtr[i0+1]-1)
-    result = zero(T)
-    for k in c1:c2
-        A.colVal[k] == i1 && (result = sum_duplicate(result, nonzeros(A)[k]))
-    end
-    return result
+    (c1 > c2) && return zero(T)
+    c1 = searchsortedfirst(A.colVal, i1, c1, c2, Base.Order.Forward)
+    (c1 > c2 || A.colVal[c1] != i1) && return zero(T)
+    nonzeros(A)[c1]
 end
 
 function Base.getindex(A::CuSparseMatrixCOO{T}, i0::Integer, i1::Integer) where T
     @boundscheck checkbounds(A, i0, i1)
-    # cuSPARSE only guarantees COO is sorted by row, so binary-search the row
-    # range but linear-scan for the column.
     r1 = searchsortedfirst(A.rowInd, i0, Base.Order.Forward)
     (r1 > length(A.rowInd) || A.rowInd[r1] > i0) && return zero(T)
-    r2 = searchsortedlast(A.rowInd, i0, Base.Order.Forward)
-    result = zero(T)
-    for k in r1:r2
-        A.colInd[k] == i1 && (result = sum_duplicate(result, nonzeros(A)[k]))
-    end
-    return result
+    r2 = min(searchsortedfirst(A.rowInd, i0+1, Base.Order.Forward), length(A.rowInd))
+    c1 = searchsortedfirst(A.colInd, i1, r1, r2, Base.Order.Forward)
+    (c1 > r2 || c1 == length(A.colInd) + 1 || A.colInd[c1] > i1) && return zero(T)
+    nonzeros(A)[c1]
 end
 
 function Base.getindex(A::CuSparseMatrixBSR{T}, i0::Integer, i1::Integer) where T
@@ -530,11 +512,10 @@ function Base.getindex(A::CuSparseMatrixBSR{T}, i0::Integer, i1::Integer) where 
     block_idx = (i0_idx - 1) * A.blockDim + i1_idx - 1
     c1 = Int(A.rowPtr[i0_block])
     c2 = Int(A.rowPtr[i0_block+1]-1)
-    result = zero(T)
-    for k in c1:c2
-        A.colVal[k] == i1_block && (result = sum_duplicate(result, nonzeros(A)[k+block_idx]))
-    end
-    return result
+    (c1 > c2) && return zero(T)
+    c1 = searchsortedfirst(A.colVal, i1_block, c1, c2, Base.Order.Forward)
+    (c1 > c2 || A.colVal[c1] != i1_block) && return zero(T)
+    nonzeros(A)[c1+block_idx]
 end
 
 # matrix slices

--- a/lib/cusparse/src/array.jl
+++ b/lib/cusparse/src/array.jl
@@ -295,6 +295,22 @@ Base.similar(Mat::CuSparseMatrixCOO, dims::Tuple{Int, Int}) = similar(Mat, dims.
 
 Base.similar(Mat::CuSparseArrayCSR) = CuSparseArrayCSR(copy(Mat.rowPtr), copy(Mat.colVal), similar(nonzeros(Mat)), size(Mat))
 
+
+function Base.similar(mat::CuSparseMatrixCOO, ::Type{T}, dims::Dims{2}) where {T}
+    new_rowInd = similar(mat.rowInd)
+    new_colInd = similar(mat.colInd)
+    new_nzVal = similar(mat.nzVal, T)
+    return CuSparseMatrixCOO(new_rowInd, new_colInd, new_nzVal, dims)
+end
+
+function Base.similar(mat::CuSparseMatrixBSR{Tv, Ti}, ::Type{T}, dims::Dims{2}) where {Tv, Ti, T}
+    new_rowPtr = similar(mat.rowPtr)
+    new_colVal = similar(mat.colVal)
+    new_nzVal = similar(mat.nzVal, T) 
+    
+    return CuSparseMatrixBSR{T, Ti}(new_rowPtr, new_colVal, new_nzVal, dims, mat.blockDim, mat.dir, mat.nnzb)
+end
+
 ## array interface
 
 Base.length(g::CuSparseVector) = g.len

--- a/lib/cusparse/src/array.jl
+++ b/lib/cusparse/src/array.jl
@@ -277,9 +277,10 @@ Base.similar(Mat::CuSparseMatrixCSR, T::Type) = CuSparseMatrixCSR(copy(Mat.rowPt
 Base.similar(Mat::CuSparseMatrixBSR, T::Type) = CuSparseMatrixBSR(copy(Mat.rowPtr), copy(Mat.colVal), similar(nonzeros(Mat), T), Mat.blockDim, Mat.dir, nnz(Mat), size(Mat))
 Base.similar(Mat::CuSparseMatrixCOO, T::Type) = CuSparseMatrixCOO(copy(Mat.rowInd), copy(Mat.colInd), similar(nonzeros(Mat), T), size(Mat), nnz(Mat))
 
-Base.similar(Mat::CuSparseMatrixCSC, T::Type, N::Int, M::Int) =  CuSparseMatrixCSC(CUDACore.zeros(Int32, 1), CUDACore.zeros(Int32, 0), CuVector{T}(undef, 0), (N, M))
-Base.similar(Mat::CuSparseMatrixCSR, T::Type, N::Int, M::Int) =  CuSparseMatrixCSR(CUDACore.zeros(Int32, 1), CUDACore.zeros(Int32, 0), CuVector{T}(undef, 0), (N,M))
-Base.similar(Mat::CuSparseMatrixCOO, T::Type, N::Int, M::Int) =  CuSparseMatrixCOO(CUDACore.zeros(Int32, 0), CUDACore.zeros(Int32, 0), CuVector{T}(undef, 0), (N,M))
+Base.similar(Mat::CuSparseMatrixCSC{Tv, Ti}, ::Type{T}, N::Int, M::Int) where {Tv, Ti, T} = CuSparseMatrixCSC(CUDACore.zeros(Ti, 1), CUDACore.zeros(Ti, 0), CuVector{T}(undef, 0), (N, M))
+Base.similar(Mat::CuSparseMatrixCSR{Tv, Ti}, ::Type{T}, N::Int, M::Int) where {Tv, Ti, T} = CuSparseMatrixCSR(CUDACore.zeros(Ti, 1), CUDACore.zeros(Ti, 0), CuVector{T}(undef, 0), (N, M))
+Base.similar(Mat::CuSparseMatrixCOO{Tv, Ti}, ::Type{T}, N::Int, M::Int) where {Tv, Ti, T} = CuSparseMatrixCOO(CUDACore.zeros(Ti, 0), CUDACore.zeros(Ti, 0), CuVector{T}(undef, 0), (N, M))
+Base.similar(Mat::CuSparseMatrixBSR{Tv, Ti}, ::Type{T}, N::Int, M::Int) where {Tv, Ti, T} = CuSparseMatrixBSR(CUDACore.zeros(Ti, 1), CUDACore.zeros(Ti, 0), CuVector{T}(undef, 0), Mat.blockDim, Mat.dir, 0, (N, M))
 
 Base.similar(Mat::CuSparseMatrixCSC{Tv, Ti}, N::Int, M::Int) where {Tv, Ti} = similar(Mat, Tv, N, M)
 Base.similar(Mat::CuSparseMatrixCSR{Tv, Ti}, N::Int, M::Int) where {Tv, Ti} = similar(Mat, Tv, N, M)
@@ -294,22 +295,6 @@ Base.similar(Mat::CuSparseMatrixCSR, dims::Tuple{Int, Int}) = similar(Mat, dims.
 Base.similar(Mat::CuSparseMatrixCOO, dims::Tuple{Int, Int}) = similar(Mat, dims...)
 
 Base.similar(Mat::CuSparseArrayCSR) = CuSparseArrayCSR(copy(Mat.rowPtr), copy(Mat.colVal), similar(nonzeros(Mat)), size(Mat))
-
-function Base.similar(mat::CuSparseMatrixCOO{Tv, Ti}, ::Type{T}, N::Int, M::Int) where {Tv, Ti, T}
-    new_rowInd = similar(mat.rowInd)
-    new_colInd = similar(mat.colInd)
-    new_nzVal = similar(mat.nzVal, T)
-    
-    return CuSparseMatrixCOO{T, Ti}(new_rowInd, new_colInd, new_nzVal, (N, M))
-end
-
-function Base.similar(mat::CuSparseMatrixBSR{Tv, Ti}, ::Type{T}, N::Int, M::Int) where {Tv, Ti, T}
-    new_rowPtr = similar(mat.rowPtr)
-    new_colVal = similar(mat.colVal)
-    new_nzVal = similar(mat.nzVal, T) 
-    
-    return CuSparseMatrixBSR{T, Ti}(new_rowPtr, new_colVal, new_nzVal, (N, M), mat.blockDim, mat.dir, mat.nnzb)
-end
 
 ## array interface
 

--- a/lib/cusparse/src/array.jl
+++ b/lib/cusparse/src/array.jl
@@ -329,6 +329,8 @@ Base.similar(Mat::CuSparseMatrixCSR{<:Any, Ti}, ::Type{T}, N::Int, M::Int) where
     CuSparseMatrixCSR{T, Ti}(CUDACore.zeros(Ti, 1), CUDACore.zeros(Ti, 0), CuVector{T}(undef, 0), (N, M))
 Base.similar(Mat::CuSparseMatrixCOO{<:Any, Ti}, ::Type{T}, N::Int, M::Int) where {T, Ti} =
     CuSparseMatrixCOO{T, Ti}(CUDACore.zeros(Ti, 0), CUDACore.zeros(Ti, 0), CuVector{T}(undef, 0), (N, M))
+Base.similar(Mat::CuSparseMatrixBSR{<:Any, Ti}, ::Type{T}, N::Int, M::Int) where {T, Ti} =
+    CuSparseMatrixBSR{T, Ti}(CUDACore.zeros(Ti, 1), CUDACore.zeros(Ti, 0), CuVector{T}(undef, 0), (N, M), Mat.blockDim, Mat.dir, 0)
 
 Base.similar(Mat::CuSparseMatrixCSC, ::Type{T}, ::Type{Ti}, N::Int, M::Int) where {T, Ti} =
     CuSparseMatrixCSC{T, Ti}(CUDACore.zeros(Ti, 1), CUDACore.zeros(Ti, 0), CuVector{T}(undef, 0), (N, M))
@@ -336,23 +338,29 @@ Base.similar(Mat::CuSparseMatrixCSR, ::Type{T}, ::Type{Ti}, N::Int, M::Int) wher
     CuSparseMatrixCSR{T, Ti}(CUDACore.zeros(Ti, 1), CUDACore.zeros(Ti, 0), CuVector{T}(undef, 0), (N, M))
 Base.similar(Mat::CuSparseMatrixCOO, ::Type{T}, ::Type{Ti}, N::Int, M::Int) where {T, Ti} =
     CuSparseMatrixCOO{T, Ti}(CUDACore.zeros(Ti, 0), CUDACore.zeros(Ti, 0), CuVector{T}(undef, 0), (N, M))
+Base.similar(Mat::CuSparseMatrixBSR, ::Type{T}, ::Type{Ti}, N::Int, M::Int) where {T, Ti} =
+    CuSparseMatrixBSR{T, Ti}(CUDACore.zeros(Ti, 1), CUDACore.zeros(Ti, 0), CuVector{T}(undef, 0), (N, M), Mat.blockDim, Mat.dir, 0)
 
 # Forwarders: no T (eltype inherited) → (Tv, n, m); tuple shape → varargs.
 Base.similar(Mat::CuSparseMatrixCSC{Tv}, N::Int, M::Int) where {Tv} = similar(Mat, Tv, N, M)
 Base.similar(Mat::CuSparseMatrixCSR{Tv}, N::Int, M::Int) where {Tv} = similar(Mat, Tv, N, M)
 Base.similar(Mat::CuSparseMatrixCOO{Tv}, N::Int, M::Int) where {Tv} = similar(Mat, Tv, N, M)
+Base.similar(Mat::CuSparseMatrixBSR{Tv}, N::Int, M::Int) where {Tv} = similar(Mat, Tv, N, M)
 
 Base.similar(Mat::CuSparseMatrixCSC, T::Type, dims::Tuple{Int, Int}) = similar(Mat, T, dims...)
 Base.similar(Mat::CuSparseMatrixCSR, T::Type, dims::Tuple{Int, Int}) = similar(Mat, T, dims...)
 Base.similar(Mat::CuSparseMatrixCOO, T::Type, dims::Tuple{Int, Int}) = similar(Mat, T, dims...)
+Base.similar(Mat::CuSparseMatrixBSR, T::Type, dims::Tuple{Int, Int}) = similar(Mat, T, dims...)
 
 Base.similar(Mat::CuSparseMatrixCSC, T::Type, Ti::Type, dims::Tuple{Int, Int}) = similar(Mat, T, Ti, dims...)
 Base.similar(Mat::CuSparseMatrixCSR, T::Type, Ti::Type, dims::Tuple{Int, Int}) = similar(Mat, T, Ti, dims...)
 Base.similar(Mat::CuSparseMatrixCOO, T::Type, Ti::Type, dims::Tuple{Int, Int}) = similar(Mat, T, Ti, dims...)
+Base.similar(Mat::CuSparseMatrixBSR, T::Type, Ti::Type, dims::Tuple{Int, Int}) = similar(Mat, T, Ti, dims...)
 
 Base.similar(Mat::CuSparseMatrixCSC, dims::Tuple{Int, Int}) = similar(Mat, dims...)
 Base.similar(Mat::CuSparseMatrixCSR, dims::Tuple{Int, Int}) = similar(Mat, dims...)
 Base.similar(Mat::CuSparseMatrixCOO, dims::Tuple{Int, Int}) = similar(Mat, dims...)
+Base.similar(Mat::CuSparseMatrixBSR, dims::Tuple{Int, Int}) = similar(Mat, dims...)
 
 # --- 1D with shape: empty CuSparseVector. `Ti` inherited or supplied. ---
 Base.similar(Mat::CuSparseMatrix{<:Any, Ti}, ::Type{T}, dims::Dims{1}) where {Ti, T} =

--- a/lib/cusparse/test/construction.jl
+++ b/lib/cusparse/test/construction.jl
@@ -88,4 +88,28 @@ if capability(device()) >= v"5.3"
         end
     end
 end
+
+@testset "similar for COO and BSR with custom types/dims" begin
+    row = CuVector{Cint}([1, 2, 3])
+    col = CuVector{Cint}([1, 2, 3])
+    val = CuVector{Float32}([1.0, 2.0, 3.0])
+    coo_mat = CuSparseMatrixCOO(row, col, val, (3, 3))
+
+    coo_sim = similar(coo_mat, Float64, (3, 3))
+    @test eltype(coo_sim) == Float64
+    @test size(coo_sim) == (3, 3)
+    @test typeof(coo_sim) <: CuSparseMatrixCOO
+
+    rowPtr = CuVector{Cint}([1, 2, 3])
+    colVal = CuVector{Cint}([1, 2])
+    valBSR = CuVector{Float32}([1.0, 2.0, 3.0, 4.0]) 
+    bsr_mat = CuSparseMatrixBSR(rowPtr, colVal, valBSR, 2, 'R', 1, (4, 4))
+
+    bsr_sim = similar(bsr_mat, Float64, (4, 4))
+    @test eltype(bsr_sim) == Float64
+    @test size(bsr_sim) == (4, 4)
+    @test typeof(bsr_sim) <: CuSparseMatrixBSR
+    @test bsr_sim.blockDim == bsr_mat.blockDim
+end
+
 end

--- a/lib/cusparse/test/construction.jl
+++ b/lib/cusparse/test/construction.jl
@@ -52,6 +52,12 @@
             @test collect(d_x) == collect(x)
             @test similar(d_x) isa CuSparseMatrixBSR{elty}
             @test similar(d_x, Float32) isa CuSparseMatrixBSR{Float32}
+            @test similar(d_x, (3, 4)) isa CuSparseMatrixBSR{elty}
+            @test size(similar(d_x, (3, 4))) == (3, 4)
+            @test similar(d_x, Float32, n, m) isa CuSparseMatrixBSR{Float32}
+            @test similar(d_x, Float32, (n, m)) isa CuSparseMatrixBSR{Float32}
+            @test similar(d_x, Float32, Int64, n, m) isa CuSparseMatrixBSR{Float32, Int64}
+            @test similar(d_x, n, m).blockDim == d_x.blockDim
         end
 
         @testset "COO" begin

--- a/test/core/device/intrinsics.jl
+++ b/test/core/device/intrinsics.jl
@@ -338,3 +338,16 @@ end
 
 ############################################################################################
 
+@testset "intrinsic range metadata" begin
+    # Create tiny kernels to isolate the x-dimension
+    kernel_block() = CUDA.blockDim().x
+    kernel_grid()  = CUDA.gridDim().x
+
+    ir_block = sprint(io -> CUDA.code_llvm(io, kernel_block, Tuple{}; dump_module=true, raw=true))
+    @test occursin("!range", ir_block)
+
+    ir_grid = sprint(io -> CUDA.code_llvm(io, kernel_grid, Tuple{}; dump_module=true, raw=true))
+    @test !occursin("!range", ir_grid)
+end
+
+############################################################################################

--- a/test/core/device/intrinsics.jl
+++ b/test/core/device/intrinsics.jl
@@ -338,16 +338,3 @@ end
 
 ############################################################################################
 
-@testset "intrinsic range metadata" begin
-    # Create tiny kernels to isolate the x-dimension
-    kernel_block() = CUDA.blockDim().x
-    kernel_grid()  = CUDA.gridDim().x
-
-    ir_block = sprint(io -> CUDA.code_llvm(io, kernel_block, Tuple{}; dump_module=true, raw=true))
-    @test occursin("!range", ir_block)
-
-    ir_grid = sprint(io -> CUDA.code_llvm(io, kernel_grid, Tuple{}; dump_module=true, raw=true))
-    @test !occursin("!range", ir_grid)
-end
-
-############################################################################################


### PR DESCRIPTION
This PR adds the missing Base.similar methods for CuSparseMatrixCOO and CuSparseMatrixBSR, allowing them to fallback gracefully without converting to dense CPU arrays.

Fixes #3061
Fixes #3055