### PR TITLE
@nospecialize testf/_compare forwarders in CUDA tests.

### DIFF
--- a/lib/cublas/test/setup.jl
+++ b/lib/cublas/test/setup.jl
@@ -6,23 +6,27 @@ using LinearAlgebra
 using Random
 using Adapt: adapt
 
-# compare CPU vs GPU results (simplified version of GPUArrays.TestSuite.compare)
-function testf(f, xs...; kwargs...)
+# compare CPU vs GPU results (simplified version of GPUArrays.TestSuite.compare).
+# @nospecialize on the closure and argument tuple: this forwarder has no per-type
+# computation, and each unique (f, xs...) call site would otherwise produce its own
+# specialization — the GPUArrays.TestSuite.compare equivalent was the #1 testsuite
+# compile hotspot before it was @nospecialize'd.
+function testf(@nospecialize(f), @nospecialize(xs...); kwargs...)
     cpu_in = map(x -> x isa Base.RefValue ? x[] : deepcopy(x), xs)
     gpu_in = map(x -> x isa Base.RefValue ? x[] : adapt(CuArray, x), xs)
     cpu_out = f(cpu_in...)
     gpu_out = f(gpu_in...)
     _compare(cpu_out, gpu_out; kwargs...)
 end
-function _compare(a::AbstractArray, b::AbstractArray; kwargs...)
+function _compare(@nospecialize(a::AbstractArray), @nospecialize(b::AbstractArray); kwargs...)
     return ≈(collect(a), collect(b); kwargs...)
 end
 function _compare(a::Number, b::Number; kwargs...)
     return ≈(a, b isa AbstractArray ? collect(b)[] : b; kwargs...)
 end
-function _compare(as::Tuple, bs::Tuple; kwargs...)
+function _compare(@nospecialize(as::Tuple), @nospecialize(bs::Tuple); kwargs...)
     all(zip(as, bs)) do (a, b)
         _compare(a, b; kwargs...)
     end
 end
-_compare(a, b; kwargs...) = a == b
+_compare(@nospecialize(a), @nospecialize(b); kwargs...) = a == b

--- a/lib/cufft/test/setup.jl
+++ b/lib/cufft/test/setup.jl
@@ -10,17 +10,17 @@ using AbstractFFTs
 using LinearAlgebra
 using Adapt: adapt
 
-# compare CPU vs GPU results
-function testf(f, xs...; kwargs...)
+# compare CPU vs GPU results. @nospecialize: see note in cublas/test/setup.jl.
+function testf(@nospecialize(f), @nospecialize(xs...); kwargs...)
     cpu_in = map(x -> x isa Base.RefValue ? x[] : deepcopy(x), xs)
     gpu_in = map(x -> x isa Base.RefValue ? x[] : adapt(CuArray, x), xs)
     cpu_out = f(cpu_in...)
     gpu_out = f(gpu_in...)
     _compare(cpu_out, gpu_out; kwargs...)
 end
-_compare(a::AbstractArray, b::AbstractArray; kwargs...) = ≈(collect(a), collect(b); kwargs...)
+_compare(@nospecialize(a::AbstractArray), @nospecialize(b::AbstractArray); kwargs...) = ≈(collect(a), collect(b); kwargs...)
 _compare(a::Number, b::Number; kwargs...) = ≈(a, b isa AbstractArray ? collect(b)[] : b; kwargs...)
-_compare(a, b; kwargs...) = a == b
+_compare(@nospecialize(a), @nospecialize(b); kwargs...) = a == b
 
 # FFTW does not support Float16, so we roll our own
 

--- a/lib/cusolver/test/setup.jl
+++ b/lib/cusolver/test/setup.jl
@@ -8,15 +8,15 @@ using cuSOLVER
 using LinearAlgebra
 using Adapt: adapt
 
-# compare CPU vs GPU results
-function testf(f, xs...; kwargs...)
+# compare CPU vs GPU results. @nospecialize: see note in cublas/test/setup.jl.
+function testf(@nospecialize(f), @nospecialize(xs...); kwargs...)
     cpu_in = map(x -> x isa Base.RefValue ? x[] : deepcopy(x), xs)
     gpu_in = map(x -> x isa Base.RefValue ? x[] : adapt(CuArray, x), xs)
     cpu_out = f(cpu_in...)
     gpu_out = f(gpu_in...)
     _compare(cpu_out, gpu_out; kwargs...)
 end
-_compare(a::AbstractArray, b::AbstractArray; kwargs...) = ≈(collect(a), collect(b); kwargs...)
+_compare(@nospecialize(a::AbstractArray), @nospecialize(b::AbstractArray); kwargs...) = ≈(collect(a), collect(b); kwargs...)
 _compare(a::Number, b::Number; kwargs...) = ≈(a, b isa AbstractArray ? collect(b)[] : b; kwargs...)
-_compare(as::Tuple, bs::Tuple; kwargs...) = all(zip(as, bs)) do (a, b); _compare(a, b; kwargs...); end
-_compare(a, b; kwargs...) = a == b
+_compare(@nospecialize(as::Tuple), @nospecialize(bs::Tuple); kwargs...) = all(zip(as, bs)) do (a, b); _compare(a, b; kwargs...); end
+_compare(@nospecialize(a), @nospecialize(b); kwargs...) = a == b

--- a/test/helpers.jl
+++ b/test/helpers.jl
@@ -8,7 +8,8 @@ using CUDA: i32
 using Adapt
 using ..Main: TestSuite, can_use_cupti, sanitize
 
-testf(f, xs...; kwargs...) = TestSuite.compare(f, CuArray, xs...; kwargs...)
+testf(@nospecialize(f), @nospecialize(xs...); kwargs...) =
+    TestSuite.compare(f, CuArray, xs...; kwargs...)
 
 # NOTE: based on test/pkg.jl::capture_stdout, but doesn't discard exceptions
 macro grab_output(ex)


### PR DESCRIPTION
The main test/helpers.jl \`testf\` and the private clones in lib/cublas, lib/cufft, lib/cusolver are all thin forwarders that call out to deepcopy / adapt / ≈. Each unique (f, xs...) call site was getting its own compiled method even though the body does no per-type compute.