### PR TITLE
Bump PTX `.target` to match `--gpu-name`

### DIFF
--- a/CUDACore/src/compiler/compilation.jl
+++ b/CUDACore/src/compiler/compilation.jl
@@ -122,7 +122,20 @@ function GPUCompiler.finish_module!(@nospecialize(job::CUDACompilerJob),
     return entry
 end
 
+# stamp `.version` with the ISA we want `ptxas` to validate against
+# and `.target` with the arch that `--gpu-name` will use
 function rewrite_ptx_header(asm, ptx, cap)
+    return replace(asm,
+        r"(\.version .+)"     => ".version $(ptx.major).$(ptx.minor)",
+        r"\.target sm_\d+\w*" => ".target sm_$(cap.major)$(cap.minor)")
+end
+
+function GPUCompiler.mcgen(@nospecialize(job::CUDACompilerJob), mod::LLVM.Module, format)
+    @assert format == LLVM.API.LLVMAssemblyFile
+    asm = invoke(GPUCompiler.mcgen,
+                 Tuple{CompilerJob{PTXCompilerTarget}, LLVM.Module, typeof(format)},
+                 job, mod, format)
+
     # remove extraneous debug info on lower debug levels
     if Base.JLOptions().debug_level < 2
         # LLVM sets `.target debug` as soon as the debug emission kind isn't NoDebug. this
@@ -137,20 +150,12 @@ function rewrite_ptx_header(asm, ptx, cap)
         asm = replace(asm, r"(\.target .+), debug" => s"\1")
     end
 
-    # stamp `.version` with the ISA we want `ptxas` to validate against
-    # and `.target` with the arch that `--gpu-name` will use
-    return replace(asm,
-        r"(\.version .+)"     => ".version $(ptx.major).$(ptx.minor)",
-        r"\.target sm_\d+\w*" => ".target sm_$(cap.major)$(cap.minor)")
-end
+    (; ptx, cap) = job.config.params
+    if job.config.target.ptx != ptx || job.config.target.cap != cap
+        asm = rewrite_ptx_header(asm, ptx, cap)
+    end
 
-function GPUCompiler.mcgen(@nospecialize(job::CUDACompilerJob), mod::LLVM.Module, format)
-    @assert format == LLVM.API.LLVMAssemblyFile
-    asm = invoke(GPUCompiler.mcgen,
-                 Tuple{CompilerJob{PTXCompilerTarget}, LLVM.Module, typeof(format)},
-                 job, mod, format)
-
-    return rewrite_ptx_header(asm, job.config.params.ptx, job.config.params.cap)
+    return asm
 end
 
 

--- a/CUDACore/src/compiler/compilation.jl
+++ b/CUDACore/src/compiler/compilation.jl
@@ -122,12 +122,7 @@ function GPUCompiler.finish_module!(@nospecialize(job::CUDACompilerJob),
     return entry
 end
 
-function GPUCompiler.mcgen(@nospecialize(job::CUDACompilerJob), mod::LLVM.Module, format)
-    @assert format == LLVM.API.LLVMAssemblyFile
-    asm = invoke(GPUCompiler.mcgen,
-                 Tuple{CompilerJob{PTXCompilerTarget}, LLVM.Module, typeof(format)},
-                 job, mod, format)
-
+function rewrite_ptx_header(asm, ptx, cap)
     # remove extraneous debug info on lower debug levels
     if Base.JLOptions().debug_level < 2
         # LLVM sets `.target debug` as soon as the debug emission kind isn't NoDebug. this
@@ -142,19 +137,20 @@ function GPUCompiler.mcgen(@nospecialize(job::CUDACompilerJob), mod::LLVM.Module
         asm = replace(asm, r"(\.target .+), debug" => s"\1")
     end
 
-    # if LLVM couldn't target the requested PTX ISA, bump it in the assembly.
-    if job.config.target.ptx != job.config.params.ptx
-        ptx = job.config.params.ptx
-        asm = replace(asm, r"(\.version .+)" => ".version $(ptx.major).$(ptx.minor)")
-    end
+    # stamp `.version` with the ISA we want `ptxas` to validate against
+    # and `.target` with the arch that `--gpu-name` will use
+    return replace(asm,
+        r"(\.version .+)"     => ".version $(ptx.major).$(ptx.minor)",
+        r"\.target sm_\d+\w*" => ".target sm_$(cap.major)$(cap.minor)")
+end
 
-    # align `.target` with the arch that gets passed to `ptxas`
-    if job.config.target.cap != job.config.params.cap
-        cap = job.config.params.cap
-        asm = replace(asm, r"\.target sm_\d+\w*" => ".target sm_$(cap.major)$(cap.minor)")
-    end
+function GPUCompiler.mcgen(@nospecialize(job::CUDACompilerJob), mod::LLVM.Module, format)
+    @assert format == LLVM.API.LLVMAssemblyFile
+    asm = invoke(GPUCompiler.mcgen,
+                 Tuple{CompilerJob{PTXCompilerTarget}, LLVM.Module, typeof(format)},
+                 job, mod, format)
 
-    asm
+    return rewrite_ptx_header(asm, job.config.params.ptx, job.config.params.cap)
 end
 
 

--- a/CUDACore/src/compiler/compilation.jl
+++ b/CUDACore/src/compiler/compilation.jl
@@ -148,7 +148,11 @@ function GPUCompiler.mcgen(@nospecialize(job::CUDACompilerJob), mod::LLVM.Module
         asm = replace(asm, r"(\.version .+)" => ".version $(ptx.major).$(ptx.minor)")
     end
 
-    # no need to bump the `.target` directive; we can do that by passing `-arch` to `ptxas`
+    # align `.target` with the arch that gets passed to `ptxas`
+    if job.config.target.cap != job.config.params.cap
+        cap = job.config.params.cap
+        asm = replace(asm, r"\.target sm_\d+\w*" => ".target sm_$(cap.major)$(cap.minor)")
+    end
 
     asm
 end

--- a/test/core/codegen.jl
+++ b/test/core/codegen.jl
@@ -228,6 +228,39 @@ end
     end
 end
 
+@testset "header rewrite (.target/.version bump)" begin
+    # When LLVM's NVPTX backend can't reach the device cap (e.g. Julia 1.12 +
+    # LLVM 18 on a Blackwell device), `_compiler_config` produces a split
+    # config and `mcgen` rewrites `.target`/`.version` in the emitted asm.
+    # `.attribute(.unified)` is target-gated on sm_90+ across CUDA 12.0+ —
+    # picked here as a stable cross-toolkit feature gate that exercises the
+    # rewrite without requiring Blackwell hardware in CI.
+    asm_pre = """
+    .version 8.0
+    .target sm_75
+    .address_size 64
+
+    .global .attribute(.unified(19, 95)) .f32 f;
+    """
+
+    function run_ptxas(src::String, gpu::String)
+        ptx = tempname() * ".ptx"; write(ptx, src)
+        out = tempname() * ".cubin"
+        opts = ["--compile-only", "--gpu-name", gpu, "--output-file", out, ptx]
+        proc = run(pipeline(ignorestatus(`$(CUDACore.CUDA_Compiler.ptxas()) $opts`);
+                            stdout=devnull, stderr=devnull); wait=true)
+        rm(ptx; force=true); rm(out; force=true)
+        proc
+    end
+
+    @test !success(run_ptxas(asm_pre, "sm_75"))
+
+    asm_post = CUDACore.rewrite_ptx_header(asm_pre, v"8.0", v"9.0")
+    @test occursin(".target sm_90", asm_post)
+
+    @test success(run_ptxas(asm_post, "sm_90"))
+end
+
 end
 
 ############################################################################################


### PR DESCRIPTION
I want to emit inline PTX through `@asmcall` on newer hardware. Suppose I want to use `add.f32x2`, gated on `sm_100`+, on a consumer Blackwell device (`sm_121`):

```julia
using CUDACore
using LLVM.Interop: @asmcall

function k()
    @asmcall("add.f32x2 \$0, \$1, \$2;", "=l,l,l", true,
               UInt64, Tuple{UInt64, UInt64}, UInt64(0), UInt64(0))
    return
end

@cuda k()
```

I get:

```
ERROR: Failed to compile PTX code (ptxas exited with code 255)
Invocation arguments: --generate-line-info --verbose --gpu-name sm_121 --output-file /tmp/jl_1WpIjMpMtY.cubin /tmp/jl_3AZwTS5w3o.ptx
ptxas /tmp/jl_3AZwTS5w3o.ptx, line 25; error   : Feature 'add.f32x2' requires .target sm_100 or higher
```

where the PTX generated by the outdated NVPTX from Julia 1.12's LLVM 18 emits `sm_90` as target:

```
shell> head /tmp/jl_3AZwTS5w3o.ptx
//
// Generated by LLVM NVPTX Back-End
//

.version 9.2
.target sm_90
```

meaning that the assumption in the code ("no need to bump the `.target` directive; we can do that by passing `-arch` to `ptxas`") doesn't hold up.

The fix mirrors the existing `.version` rewrite for `.target`, in a small `rewrite_ptx_header` helper extracted from `mcgen`.

With these changes, one can call e.g. `add.f32x2`, which is one of only a few operations that are not `a`-gated, meaning it doesn't need `.target sm_100a` and `--gpu-name sm_100a`. Architecture- and family-specific ops will require another PR.