### PR TITLE
Add back-end flag to `@cuda`

### DIFF
--- a/CUDACore/src/compiler/execution.jl
+++ b/CUDACore/src/compiler/execution.jl
@@ -2,7 +2,7 @@
 
 export @cuda, cudaconvert, cufunction, dynamic_cufunction, nextwarp, prevwarp
 @public maxthreads, registers, memory, version, KernelAdaptor
-@public AbstractBackend, NativeBackend, kernel_convert, kernel_compile
+@public AbstractBackend, LLVMBackend, kernel_convert, kernel_compile
 
 
 ## backend dispatch
@@ -11,38 +11,42 @@ export @cuda, cudaconvert, cufunction, dynamic_cufunction, nextwarp, prevwarp
     AbstractBackend
 
 Abstract supertype for `@cuda` backend dispatch. The default backend is
-[`NativeBackend`](@ref), which compiles SIMT/PTX kernels via
+[`LLVMBackend`](@ref), which compiles SIMT/PTX kernels via
 [`cufunction`](@ref). Other backends (e.g. Tile IR via cuTile.jl) register
 a subtype and define methods for [`kernel_convert`](@ref) and
 [`kernel_compile`](@ref); `@cuda backend=...` then routes through them.
+
+`@cuda backend=...` accepts either an `AbstractBackend` instance or a
+module that defines `DefaultBackend()` returning one (e.g.
+`@cuda backend=cuTile ...` resolves to `cuTile.DefaultBackend()`).
 """
 abstract type AbstractBackend end
 
 """
-    NativeBackend()
+    LLVMBackend()
 
 Default `@cuda` backend. Compiles SIMT/PTX kernels via [`cufunction`](@ref)
 and converts arguments via [`cudaconvert`](@ref).
 """
-struct NativeBackend <: AbstractBackend end
+struct LLVMBackend <: AbstractBackend end
 
 """
     kernel_convert(backend, x)
 
 Convert a host-side launch argument to its kernel-side form. The default
-implementation for [`NativeBackend`](@ref) forwards to [`cudaconvert`](@ref);
+implementation for [`LLVMBackend`](@ref) forwards to [`cudaconvert`](@ref);
 other backends override to produce backend-specific argument types.
 """
-kernel_convert(::NativeBackend, x) = cudaconvert(x)
+kernel_convert(::LLVMBackend, x) = cudaconvert(x)
 
 """
     kernel_compile(backend, f, tt::Type{<:Tuple}; kwargs...) -> AbstractKernel
 
 Compile a function for the given backend. Returns an [`AbstractKernel`](@ref)
 callable as `kernel(args...; launch_kwargs...)` to launch on the GPU. The
-default implementation for [`NativeBackend`](@ref) is [`cufunction`](@ref).
+default implementation for [`LLVMBackend`](@ref) is [`cufunction`](@ref).
 """
-kernel_compile(::NativeBackend, f::F, tt::TT=Tuple{}; kwargs...) where {F,TT} =
+kernel_compile(::LLVMBackend, f::F, tt::TT=Tuple{}; kwargs...) where {F,TT} =
     cufunction(f, tt; kwargs...)
 
 
@@ -101,7 +105,7 @@ macro cuda(ex...)
     # handle keyword arguments that influence the macro's behavior
     dynamic = false
     launch = true
-    backend_expr = :($NativeBackend())
+    backend_expr = :($LLVMBackend())
     for kwarg in macro_kwargs
         key::Symbol, val = kwarg.args
         if key === :dynamic
@@ -150,7 +154,12 @@ macro cuda(ex...)
         # while keeping the original arguments alive
         push!(code.args,
             quote
-                $backend = $backend_expr
+                # Accept either an `AbstractBackend` instance or a module
+                # providing `DefaultBackend()` (e.g. `backend=cuTile`).
+                # Inference folds the branch away on concretely-typed inputs.
+                $backend = let _b = $backend_expr
+                    _b isa $AbstractBackend ? _b : _b.DefaultBackend()
+                end
                 $f_var = $f
                 GC.@preserve $(vars...) $f_var begin
                     $kernel_f = $kernel_convert($backend, $f_var)
@@ -286,10 +295,12 @@ The following keyword arguments are supported:
 AbstractKernel
 
 function Base.show(io::IO, k::AbstractKernel{F,TT}) where {F,TT}
-    print(io, "CUDACore.$(nameof(typeof(k)))($(k.f))")
+    T = typeof(k)
+    print(io, "$(parentmodule(T)).$(nameof(T))($(k.f))")
 end
 function Base.show(io::IO, ::MIME"text/plain", k::AbstractKernel{F,TT}) where {F,TT}
-    print(io, "CUDACore.$(nameof(typeof(k))) for $(k.f)($(join(TT.parameters, ", ")))")
+    T = typeof(k)
+    print(io, "$(parentmodule(T)).$(nameof(T)) for $(k.f)($(join(TT.parameters, ", ")))")
 end
 
 @inline @generated function (kernel::AbstractKernel{F,TT})(args::Vararg{Any,N};

--- a/CUDACore/src/compiler/execution.jl
+++ b/CUDACore/src/compiler/execution.jl
@@ -2,7 +2,7 @@
 
 export @cuda, cudaconvert, cufunction, dynamic_cufunction, nextwarp, prevwarp
 @public maxthreads, registers, memory, version, KernelAdaptor
-@public AbstractBackend, LLVMBackend, kernel_convert, kernel_compile
+@public AbstractBackend, LLVMBackend, DefaultBackend, kernel_convert, kernel_compile
 
 
 ## backend dispatch
@@ -29,6 +29,16 @@ Default `@cuda` backend. Compiles SIMT/PTX kernels via [`cufunction`](@ref)
 and converts arguments via [`cudaconvert`](@ref).
 """
 struct LLVMBackend <: AbstractBackend end
+
+"""
+    DefaultBackend()
+
+Returns the default `@cuda` backend for this module ([`LLVMBackend`](@ref)).
+This makes `@cuda backend=CUDA ...` (or `backend=CUDACore`) resolve to
+[`LLVMBackend`](@ref), mirroring the convention used by other backend
+packages (e.g. `@cuda backend=cuTile ...` resolves to `cuTile.DefaultBackend()`).
+"""
+DefaultBackend() = LLVMBackend()
 
 """
     kernel_convert(backend, x)
@@ -70,6 +80,10 @@ Several keyword arguments are supported that influence the behavior of `@cuda`.
 - `launch`: whether to launch this kernel, defaults to `true`. If `false` the returned
   kernel object should be launched by calling it and passing arguments again.
 - `dynamic`: use dynamic parallelism to launch device-side kernels, defaults to `false`.
+- `backend`: which compiler backend to use, defaults to [`LLVMBackend`](@ref). Either an
+  [`AbstractBackend`](@ref) instance or a module that defines `DefaultBackend()` (e.g.
+  `backend=CUDA` resolves to `CUDA.DefaultBackend()`). Backend-specific compiler kwargs
+  not recognized by `@cuda` itself are forwarded to [`kernel_compile`](@ref).
 - arguments that influence kernel compilation: see [`cufunction`](@ref) and
   [`dynamic_cufunction`](@ref)
 - arguments that influence kernel launch: see [`CUDACore.HostKernel`](@ref) and
@@ -126,7 +140,7 @@ macro cuda(ex...)
 
     # FIXME: macro hygiene wrt. escaping kwarg values (this broke with 1.5)
     #        we esc() the whole thing now, necessitating gensyms...
-    @gensym f_var kernel_f kernel_args kernel_tt kernel backend
+    @gensym f_var kernel_f kernel_args kernel_tt kernel backend backend_raw
     if dynamic
         # FIXME: we could probably somehow support kwargs with constant values by either
         #        saving them in a global Dict here, or trying to pick them up from the Julia
@@ -157,8 +171,8 @@ macro cuda(ex...)
                 # Accept either an `AbstractBackend` instance or a module
                 # providing `DefaultBackend()` (e.g. `backend=cuTile`).
                 # Inference folds the branch away on concretely-typed inputs.
-                $backend = let _b = $backend_expr
-                    _b isa $AbstractBackend ? _b : _b.DefaultBackend()
+                $backend = let $backend_raw = $backend_expr
+                    $backend_raw isa $AbstractBackend ? $backend_raw : $backend_raw.DefaultBackend()
                 end
                 $f_var = $f
                 GC.@preserve $(vars...) $f_var begin

--- a/CUDACore/src/compiler/execution.jl
+++ b/CUDACore/src/compiler/execution.jl
@@ -2,11 +2,53 @@
 
 export @cuda, cudaconvert, cufunction, dynamic_cufunction, nextwarp, prevwarp
 @public maxthreads, registers, memory, version, KernelAdaptor
+@public AbstractBackend, NativeBackend, kernel_convert, kernel_compile
+
+
+## backend dispatch
+
+"""
+    AbstractBackend
+
+Abstract supertype for `@cuda` backend dispatch. The default backend is
+[`NativeBackend`](@ref), which compiles SIMT/PTX kernels via
+[`cufunction`](@ref). Other backends (e.g. Tile IR via cuTile.jl) register
+a subtype and define methods for [`kernel_convert`](@ref) and
+[`kernel_compile`](@ref); `@cuda backend=...` then routes through them.
+"""
+abstract type AbstractBackend end
+
+"""
+    NativeBackend()
+
+Default `@cuda` backend. Compiles SIMT/PTX kernels via [`cufunction`](@ref)
+and converts arguments via [`cudaconvert`](@ref).
+"""
+struct NativeBackend <: AbstractBackend end
+
+"""
+    kernel_convert(backend, x)
+
+Convert a host-side launch argument to its kernel-side form. The default
+implementation for [`NativeBackend`](@ref) forwards to [`cudaconvert`](@ref);
+other backends override to produce backend-specific argument types.
+"""
+kernel_convert(::NativeBackend, x) = cudaconvert(x)
+
+"""
+    kernel_compile(backend, f, tt::Type{<:Tuple}; kwargs...) -> AbstractKernel
+
+Compile a function for the given backend. Returns an [`AbstractKernel`](@ref)
+callable as `kernel(args...; launch_kwargs...)` to launch on the GPU. The
+default implementation for [`NativeBackend`](@ref) is [`cufunction`](@ref).
+"""
+kernel_compile(::NativeBackend, f::F, tt::TT=Tuple{}; kwargs...) where {F,TT} =
+    cufunction(f, tt; kwargs...)
 
 
 ## high-level @cuda interface
 
-const MACRO_KWARGS = [:dynamic, :launch]
+const MACRO_KWARGS = [:dynamic, :launch, :backend]
 const COMPILER_KWARGS = [:kernel, :name, :always_inline, :minthreads, :maxthreads, :blocks_per_sm, :maxregs, :fastmath, :cap, :ptx]
 const LAUNCH_KWARGS = [:cooperative, :blocks, :threads, :clustersize, :shmem, :stream]
 
@@ -50,17 +92,16 @@ macro cuda(ex...)
     code = quote end
     vars, var_exprs = assign_args!(code, args)
 
-    # group keyword argument
+    # group keyword argument. Backend-specific compiler kwargs land in
+    # `other_kwargs` and are forwarded to `kernel_compile`; the backend
+    # validates them.
     macro_kwargs, compiler_kwargs, call_kwargs, other_kwargs =
         split_kwargs(kwargs, MACRO_KWARGS, COMPILER_KWARGS, LAUNCH_KWARGS)
-    if !isempty(other_kwargs)
-        key,val = first(other_kwargs).args
-        throw(ArgumentError("Unsupported keyword argument '$key'"))
-    end
 
     # handle keyword arguments that influence the macro's behavior
     dynamic = false
     launch = true
+    backend_expr = :($NativeBackend())
     for kwarg in macro_kwargs
         key::Symbol, val = kwarg.args
         if key === :dynamic
@@ -69,6 +110,8 @@ macro cuda(ex...)
         elseif key === :launch
             isa(val, Bool) || throw(ArgumentError("`launch` keyword argument to @cuda should be a constant value"))
             launch = val::Bool
+        elseif key === :backend
+            backend_expr = val
         else
             throw(ArgumentError("Unsupported keyword argument '$key'"))
         end
@@ -79,12 +122,14 @@ macro cuda(ex...)
 
     # FIXME: macro hygiene wrt. escaping kwarg values (this broke with 1.5)
     #        we esc() the whole thing now, necessitating gensyms...
-    @gensym f_var kernel_f kernel_args kernel_tt kernel
+    @gensym f_var kernel_f kernel_args kernel_tt kernel backend
     if dynamic
         # FIXME: we could probably somehow support kwargs with constant values by either
         #        saving them in a global Dict here, or trying to pick them up from the Julia
         #        IR when processing the dynamic parallelism marker
         isempty(compiler_kwargs) || error("@cuda dynamic parallelism does not support compiler keyword arguments")
+        isempty(other_kwargs) ||
+            error("@cuda dynamic parallelism does not support backend-specific compiler keyword arguments")
 
         # dynamic, device-side kernel launch
         push!(code.args,
@@ -105,12 +150,14 @@ macro cuda(ex...)
         # while keeping the original arguments alive
         push!(code.args,
             quote
+                $backend = $backend_expr
                 $f_var = $f
                 GC.@preserve $(vars...) $f_var begin
-                    $kernel_f = $cudaconvert($f_var)
-                    $kernel_args = map($cudaconvert, ($(var_exprs...),))
+                    $kernel_f = $kernel_convert($backend, $f_var)
+                    $kernel_args = map(x -> $kernel_convert($backend, x), ($(var_exprs...),))
                     $kernel_tt = Tuple{map(Core.Typeof, $kernel_args)...}
-                    $kernel = $cufunction($kernel_f, $kernel_tt; $(compiler_kwargs...))
+                    $kernel = $kernel_compile($backend, $kernel_f, $kernel_tt;
+                                              $(compiler_kwargs...), $(other_kwargs...))
                     if $launch
                         $kernel($kernel_args...; $(call_kwargs...), convert=Val(false))
                     end

--- a/docs/src/api/compiler.md
+++ b/docs/src/api/compiler.md
@@ -17,11 +17,23 @@ If needed, you can use a lower-level API that lets you inspect the compiler kern
 ```@docs
 cudaconvert
 cufunction
+AbstractKernel
 HostKernel
 version
 maxthreads
 registers
 memory
+```
+
+To plug in alternative compiler back-ends (e.g. cuTile.jl), `@cuda` dispatches
+through a small protocol:
+
+```@docs
+AbstractBackend
+LLVMBackend
+DefaultBackend
+kernel_convert
+kernel_compile
 ```
 
 

--- a/test/core/execution.jl
+++ b/test/core/execution.jl
@@ -80,6 +80,69 @@ end
 end
 
 
+@testset "backend dispatch" begin
+    # instance form: explicit LLVMBackend
+    @cuda backend=CUDACore.LLVMBackend() dummy()
+    k = @cuda launch=false backend=CUDACore.LLVMBackend() dummy()
+    @test k isa CUDACore.HostKernel
+    k()
+
+    # instance form via the re-exported CUDA name
+    @cuda backend=CUDA.LLVMBackend() dummy()
+
+    # module form: CUDA / CUDACore both define DefaultBackend()
+    @cuda backend=CUDA dummy()
+    @cuda backend=CUDACore dummy()
+
+    # custom backend stub: assert kernel_convert/kernel_compile are called
+    # and that unknown kwargs are forwarded
+    @eval module BackendStub
+        using CUDA
+        const compile_calls = Ref(0)
+        const convert_calls = Ref(0)
+        const last_kwargs = Ref{Any}(nothing)
+
+        struct Backend <: CUDACore.AbstractBackend end
+        DefaultBackend() = Backend()
+
+        struct Kernel{F}
+            f::F
+        end
+        (::Kernel)(args...; kwargs...) = nothing
+
+        CUDACore.kernel_convert(::Backend, x) = (convert_calls[] += 1; x)
+        function CUDACore.kernel_compile(::Backend, f::F, tt::Type{<:Tuple};
+                                         kwargs...) where {F}
+            compile_calls[] += 1
+            last_kwargs[] = (; kwargs...)
+            Kernel{F}(f)
+        end
+    end
+
+    BackendStub.compile_calls[] = 0
+    BackendStub.convert_calls[] = 0
+    BackendStub.last_kwargs[] = nothing
+    @cuda backend=BackendStub.Backend() dummy()
+    @test BackendStub.compile_calls[] == 1
+    # f + 0 args, all routed through kernel_convert
+    @test BackendStub.convert_calls[] == 1
+
+    # module-as-backend resolution for the custom backend
+    @cuda backend=BackendStub dummy()
+    @test BackendStub.compile_calls[] == 2
+
+    # other_kwargs forwarding to kernel_compile
+    @cuda backend=BackendStub.Backend() opt_level=2 dummy()
+    @test haskey(BackendStub.last_kwargs[], :opt_level)
+    @test BackendStub.last_kwargs[][:opt_level] == 2
+
+    # dynamic + backend kwargs are rejected
+    @test_throws "does not support backend-specific" begin
+        @cuda dynamic=true opt_level=2 dummy()
+    end
+end
+
+
 @testset "streams" begin
     s = CuStream()
     @cuda stream=s dummy()

--- a/test/core/execution.jl
+++ b/test/core/execution.jl
@@ -136,9 +136,10 @@ end
     @test haskey(BackendStub.last_kwargs[], :opt_level)
     @test BackendStub.last_kwargs[][:opt_level] == 2
 
-    # dynamic + backend kwargs are rejected
+    # dynamic + backend kwargs are rejected (errors at macro-expansion time,
+    # so wrap in @macroexpand to defer)
     @test_throws "does not support backend-specific" begin
-        @cuda dynamic=true opt_level=2 dummy()
+        @macroexpand @cuda dynamic=true opt_level=2 dummy()
     end
 end
 


### PR DESCRIPTION
This makes `@cuda` reusable by external packages like cuTile.jl.