### PR TITLE
Fix misreport of non-SMEM launch failures as SMEM overflow

### DIFF
--- a/CUDACore/lib/cudadrv/execution.jl
+++ b/CUDACore/lib/cudadrv/execution.jl
@@ -152,11 +152,6 @@ end
              error("Thread block cluster dimensions exceed device limit ($(clusterdim.x) * $(clusterdim.y) * $(clusterdim.z) > 1). (The device does not support thread block clusters.)")
          end
     end
-    ## shared memory limit
-    shmem_lim = attribute(dev, DEVICE_ATTRIBUTE_MAX_SHARED_MEMORY_PER_BLOCK)
-    if shmem > shmem_lim
-        error("Amount of dynamic shared memory exceeds device limit ($(Base.format_bytes(shmem)) > $(Base.format_bytes(shmem_lim))).")
-    end
 
     # check kernel limits
     fattr = attributes(f)

--- a/test/core/execution.jl
+++ b/test/core/execution.jl
@@ -64,6 +64,19 @@ end
 end
 
 
+@testset "launch failure: opt-in shmem + thread overrun" begin
+    # A non-SMEM launch failure on a kernel that opted into >48 KiB dynamic SMEM
+    # must report the real cause, not a spurious "exceeds device limit" SMEM message.
+    # Only meaningful on Volta+ (Maxwell/Pascal have no >48 KiB opt-in).
+    optin = CUDA.attribute(device(), CUDA.DEVICE_ATTRIBUTE_MAX_SHARED_MEMORY_PER_BLOCK_OPTIN)
+    if optin > 48*1024
+        k = @cuda launch=false maxthreads=1 dummy()
+        attributes(k.fun)[CUDA.FUNC_ATTRIBUTE_MAX_DYNAMIC_SHARED_SIZE_BYTES] = optin
+        @test_throws "exceeds kernel limit" k(; threads=2, shmem=optin)
+    end
+end
+
+
 @testset "inference" begin
     foo() = @cuda dummy()
     @inferred foo()

--- a/test/core/execution.jl
+++ b/test/core/execution.jl
@@ -65,11 +65,13 @@ end
 
 
 @testset "launch failure: opt-in shmem + thread overrun" begin
-    # A non-SMEM launch failure on a kernel that opted into >48 KiB dynamic SMEM
-    # must report the real cause, not a spurious "exceeds device limit" SMEM message.
-    # Only meaningful on Volta+ (Maxwell/Pascal have no >48 KiB opt-in).
-    optin = CUDA.attribute(device(), CUDA.DEVICE_ATTRIBUTE_MAX_SHARED_MEMORY_PER_BLOCK_OPTIN)
-    if optin > 48*1024
+    # A non-SMEM launch failure on a kernel that opted into dynamic SMEM beyond
+    # the non-opt-in ceiling must report the real cause, not a spurious "exceeds
+    # device limit" SMEM message. Only meaningful when the device exposes an
+    # opt-in cap above the non-opt-in ceiling (Volta+).
+    nonoptin = CUDA.attribute(device(), CUDA.DEVICE_ATTRIBUTE_MAX_SHARED_MEMORY_PER_BLOCK)
+    optin    = CUDA.attribute(device(), CUDA.DEVICE_ATTRIBUTE_MAX_SHARED_MEMORY_PER_BLOCK_OPTIN)
+    if optin > nonoptin
         k = @cuda launch=false maxthreads=1 dummy()
         attributes(k.fun)[CUDA.FUNC_ATTRIBUTE_MAX_DYNAMIC_SHARED_SIZE_BYTES] = optin
         @test_throws "exceeds kernel limit" k(; threads=2, shmem=optin)


### PR DESCRIPTION
## Problem

`diagnose_launch_failure` (in `CUDACore/lib/cudadrv/execution.jl`) misreports launch failures unrelated to shared memory as SMEM overflows whenever the kernel has opted into >48 KiB of dynamic shared memory.

Concretely, the device-level SMEM check compares `shmem` against `DEVICE_ATTRIBUTE_MAX_SHARED_MEMORY_PER_BLOCK`, which returns the *non-opt-in* 48 KiB ceiling on every architecture from Volta onward. The architectural hard cap is exposed by a separate attribute, `DEVICE_ATTRIBUTE_MAX_SHARED_MEMORY_PER_BLOCK_OPTIN`, which returns e.g. 96 / 163 / 228 / 99 KiB on V100 / A100 / H100 / GB10. The current check uses the wrong attribute, so any kernel that legitimately raised `FUNC_ATTRIBUTE_MAX_DYNAMIC_SHARED_SIZE_BYTES` above 48 KiB and then fails launch in `{ERROR_INVALID_VALUE, ERROR_LAUNCH_OUT_OF_RESOURCES}` for an unrelated reason gets reported as a SMEM overflow that does not exist.

## Fix

Delete the device-level SMEM check. The kernel-level SMEM check that follows it already provides a strict tightening:

- For kernels that never opt in, `fattr[FUNC_ATTRIBUTE_MAX_DYNAMIC_SHARED_SIZE_BYTES]` defaults to 49 152 (= the non-opt-in ceiling), so the two checks were equivalent in this regime.
- For kernels that opt in, `cuFuncSetAttribute(f, MAX_DYNAMIC_SHARED_SIZE_BYTES, N)` returns `CUDA_ERROR_INVALID_VALUE` when `N` exceeds the device opt-in cap — verified empirically on GB10 (sm_121) with optin + 1024 and optin + 100_000; both rejected, no silent clamping. So the per-function attribute is bounded above by the architectural cap and shmem > fattr[…] catches every device-level overflow.

The check was therefore either equivalent to or strictly subsumed by the kernel-level check.

### Before / after

The new regression test:

```julia
optin = CUDA.attribute(device(), CUDA.DEVICE_ATTRIBUTE_MAX_SHARED_MEMORY_PER_BLOCK_OPTIN)
if optin > 48*1024
    k = @cuda launch=false maxthreads=1 dummy()
    attributes(k.fun)[CUDA.FUNC_ATTRIBUTE_MAX_DYNAMIC_SHARED_SIZE_BYTES] = optin
    @test_throws "exceeds kernel limit" k(; threads=2, shmem=optin)
end
```

Pre-fix:
```
Test Failed
  Expected: "exceeds kernel limit"
   Message: "Amount of dynamic shared memory exceeds device limit (99.000 KiB > 48.000 KiB)."
```

Post-fix:
```
Test Passed
   Message: "Number of threads per block exceeds kernel limit (2 > 1)."
```

## Question for maintainers (out of scope)

There's no high-level counterpart to the launch kwarg `shmem=N` for raising the per-function `FUNC_ATTRIBUTE_MAX_DYNAMIC_SHARED_SIZE_BYTES` cap. Users who need >48 KiB of dynamic SMEM have to drop to `attributes(k.fun)[…] = N`, with no symmetric kwarg next to the existing `maxregs` / `maxthreads` / `minthreads` family on `@cuda` / `cufunction`. Is that intentional (per-function attribute mutation has different semantics from compile params — it persists on the `CuFunction` handle across launches), or would you accept a follow-up PR adding e.g. a `max_dynamic_shmem` kwarg?