### PR TITLE
Support mixed-eltype sparse/dense matmul (#3128)

### DIFF
--- a/lib/cusparse/src/interfaces.jl
+++ b/lib/cusparse/src/interfaces.jl
@@ -63,17 +63,20 @@ sparse_with_eltype(A::CuSparseMatrixCOO, ::Type{T}) where {T} =
 sparse_with_eltype(A::CuSparseVector, ::Type{T}) where {T} =
     CuSparseVector(nonzeroinds(A), convert(CuVector{T}, nonzeros(A)), length(A))
 
-# Mixed-eltype products: Julia's generic `*(::AbstractMatrix, ::AbstractMatrix)` allocates
-# its output as `similar(B, TS)` (on 1.10; via `matprod_dest` on 1.11+) — both return a
-# `CuSparseMatrix` when B is sparse, which then forces a scalar fallback. Override `*` to
-# allocate a dense result and dispatch to `mul!` (our relaxed `generic_matmatmul!` handles
-# the mixed-eltype case). The loop-generated single-T `*` methods below remain more
-# specific and take precedence when `eltype(A) == eltype(B)`.
+# Mixed-eltype `dense × sparse`: Julia's generic `*(::AbstractMatrix, ::AbstractMatrix)`
+# allocates its output as `similar(B, TS)` (on 1.10; via `matprod_dest` on 1.11+); when
+# B is sparse, that returns a `CuSparseMatrix`, which then forces a scalar fallback.
+# Allocate a dense result and dispatch to `mul!` instead (our relaxed `generic_matmatmul!`
+# handles the mixed-eltype case). The loop-generated single-T `*` methods below remain
+# more specific and continue to win when `eltype(A) == eltype(B)`.
+#
+# No override needed for `sparse × dense`: `similar(B_dense, TS)` already returns dense,
+# so Julia's default `*` allocates the right container and dispatches via `mul!`.
 const DenseCuMatOrAdj = Union{DenseCuMatrix, AdjOrTrans{<:Any, <:DenseCuMatrix},
                               HermOrSym{<:Any, <:DenseCuMatrix}}
 const CuSparseMatOrAdj = Union{CuSparseMatrix, AdjOrTrans{<:Any, <:CuSparseMatrix},
                                HermOrSym{<:Any, <:CuSparseMatrix}}
-function Base.:(*)(A::DenseCuMatOrAdj, B::CuSparseMatOrAdj)
+function Base.:(*)(@nospecialize(A::DenseCuMatOrAdj), @nospecialize(B::CuSparseMatOrAdj))
     T = promote_type(eltype(A), eltype(B))
     C = CuMatrix{T}(undef, size(A, 1), size(B, 2))
     return mul!(C, A, B, true, false)

--- a/lib/cusparse/src/interfaces.jl
+++ b/lib/cusparse/src/interfaces.jl
@@ -1,7 +1,7 @@
 # interfacing with other packages
 
 using LinearAlgebra
-using LinearAlgebra: BlasComplex, BlasFloat, BlasReal, MulAddMul, AdjOrTrans
+using LinearAlgebra: BlasComplex, BlasFloat, BlasReal, MulAddMul, AdjOrTrans, HermOrSym
 using GPUArrays: _spadjoint, _sptranspose
 
 function GPUArrays._spadjoint(A::CuSparseMatrixCSR)
@@ -46,6 +46,39 @@ function mm_wrapper(transa::SparseChar, transb::SparseChar, alpha::Number,
     mm!(transa, transb, alpha, A, B, beta, C, 'O')
 end
 
+# element types accepted by cuSPARSE's generic SpMV/SpMM API (`mv!`, `mm!`, `bmm!`).
+# half-precision types are not in `BlasFloat` because CPU BLAS doesn't support them;
+# cuSPARSE handles them by accumulating in Float32/ComplexF32 (see `mv!` in generic.jl).
+# Routines based on the classical BLAS bindings (`gemvi!`, `gemm!`, `geam`, ...) stay
+# restricted to plain `BlasFloat`.
+const SpMatMulFloat = Union{Float16, ComplexF16, BlasFloat}
+
+# convert the element type of a CuSparseMatrix/Vector (issue #3128: mixed-eltype matmul)
+sparse_with_eltype(A::CuSparseMatrixCSC, ::Type{T}) where {T} =
+    CuSparseMatrixCSC(A.colPtr, A.rowVal, convert(CuVector{T}, nonzeros(A)), size(A))
+sparse_with_eltype(A::CuSparseMatrixCSR, ::Type{T}) where {T} =
+    CuSparseMatrixCSR(A.rowPtr, A.colVal, convert(CuVector{T}, nonzeros(A)), size(A))
+sparse_with_eltype(A::CuSparseMatrixCOO, ::Type{T}) where {T} =
+    CuSparseMatrixCOO(A.rowInd, A.colInd, convert(CuVector{T}, nonzeros(A)), size(A), nnz(A))
+sparse_with_eltype(A::CuSparseVector, ::Type{T}) where {T} =
+    CuSparseVector(nonzeroinds(A), convert(CuVector{T}, nonzeros(A)), length(A))
+
+# Mixed-eltype products: Julia's generic `*(::AbstractMatrix, ::AbstractMatrix)` allocates
+# its output as `similar(B, TS)` (on 1.10; via `matprod_dest` on 1.11+) — both return a
+# `CuSparseMatrix` when B is sparse, which then forces a scalar fallback. Override `*` to
+# allocate a dense result and dispatch to `mul!` (our relaxed `generic_matmatmul!` handles
+# the mixed-eltype case). The loop-generated single-T `*` methods below remain more
+# specific and take precedence when `eltype(A) == eltype(B)`.
+const DenseCuMatOrAdj = Union{DenseCuMatrix, AdjOrTrans{<:Any, <:DenseCuMatrix},
+                              HermOrSym{<:Any, <:DenseCuMatrix}}
+const CuSparseMatOrAdj = Union{CuSparseMatrix, AdjOrTrans{<:Any, <:CuSparseMatrix},
+                               HermOrSym{<:Any, <:CuSparseMatrix}}
+function Base.:(*)(A::DenseCuMatOrAdj, B::CuSparseMatOrAdj)
+    T = promote_type(eltype(A), eltype(B))
+    C = CuMatrix{T}(undef, size(A, 1), size(B, 2))
+    return mul!(C, A, B, true, false)
+end
+
 LinearAlgebra.dot(x::CuSparseVector{T}, y::DenseCuVector{T}) where {T <: BlasReal} = vv!('N', x, y, 'O')
 LinearAlgebra.dot(x::DenseCuVector{T}, y::CuSparseVector{T}) where {T <: BlasReal} = dot(y, x)
 
@@ -62,33 +95,38 @@ op_wrappers = ((identity, T -> 'N', identity),
                (T -> :(HermOrSym{T, <:$T}), T -> 'N', A -> :(parent($A))))
 
 # legacy methods with final MulAddMul argument
-LinearAlgebra.generic_matvecmul!(C::CuVector{T}, tA::AbstractChar, A::CuSparseMatrix{S}, B::DenseCuVector{T}, _add::MulAddMul) where {T <: Union{Float16, ComplexF16, BlasFloat}, S <: Union{Float16, ComplexF16, BlasFloat}} =
+LinearAlgebra.generic_matvecmul!(C::CuVector{Tc}, tA::AbstractChar, A::CuSparseMatrix{Ta}, B::DenseCuVector{Tb}, _add::MulAddMul) where {Tc <: SpMatMulFloat, Ta <: SpMatMulFloat, Tb <: SpMatMulFloat} =
     LinearAlgebra.generic_matvecmul!(C, tA, A, B, _add.alpha, _add.beta)
-LinearAlgebra.generic_matvecmul!(C::CuVector{T}, tA::AbstractChar, A::CuSparseMatrix{S}, B::CuSparseVector{T}, _add::MulAddMul) where {T <: Union{Float16, ComplexF16, BlasFloat}, S <: Union{Float16, ComplexF16, BlasFloat}} =
+LinearAlgebra.generic_matvecmul!(C::CuVector{Tc}, tA::AbstractChar, A::CuSparseMatrix{Ta}, B::CuSparseVector{Tb}, _add::MulAddMul) where {Tc <: SpMatMulFloat, Ta <: SpMatMulFloat, Tb <: SpMatMulFloat} =
     LinearAlgebra.generic_matvecmul!(C, tA, A, B, _add.alpha, _add.beta)
-LinearAlgebra.generic_matmatmul!(C::CuMatrix{T}, tA, tB, A::CuSparseMatrix{T}, B::DenseCuMatrix{T}, _add::MulAddMul) where {T <: Union{Float16, ComplexF16, BlasFloat}} =
+LinearAlgebra.generic_matmatmul!(C::CuMatrix{Tc}, tA, tB, A::CuSparseMatrix{Ta}, B::DenseCuMatrix{Tb}, _add::MulAddMul) where {Tc <: SpMatMulFloat, Ta <: SpMatMulFloat, Tb <: SpMatMulFloat} =
     LinearAlgebra.generic_matmatmul!(C, tA, tB, A, B, _add.alpha, _add.beta)
 
-function LinearAlgebra.generic_matvecmul!(C::CuVector{T}, tA::AbstractChar, A::CuSparseMatrix{S}, B::DenseCuVector{T}, alpha::Number, beta::Number) where {T <: Union{Float16, ComplexF16, BlasFloat}, S <: Union{Float16, ComplexF16, BlasFloat}}
+# mv! tolerates A.eltype ≠ X.eltype, but requires X.eltype == Y.eltype, so only B may need promotion.
+function LinearAlgebra.generic_matvecmul!(C::CuVector{Tc}, tA::AbstractChar, A::CuSparseMatrix{Ta}, B::DenseCuVector{Tb}, alpha::Number, beta::Number) where {Tc <: SpMatMulFloat, Ta <: SpMatMulFloat, Tb <: SpMatMulFloat}
+    B′ = Tb === Tc ? B : convert(CuVector{Tc}, B)
     tA = tA in ('S', 's', 'H', 'h') ? 'N' : tA
-    mv_wrapper(tA, alpha, A, B, beta, C)
+    mv_wrapper(tA, alpha, A, B′, beta, C)
 end
 
-function LinearAlgebra.generic_matvecmul!(C::CuVector{T}, tA::AbstractChar, A::CuSparseMatrix{S}, B::CuSparseVector{T}, alpha::Number, beta::Number) where {T <: Union{Float16, ComplexF16, BlasFloat}, S <: Union{Float16, ComplexF16, BlasFloat}}
+function LinearAlgebra.generic_matvecmul!(C::CuVector{Tc}, tA::AbstractChar, A::CuSparseMatrix{Ta}, B::CuSparseVector{Tb}, alpha::Number, beta::Number) where {Tc <: SpMatMulFloat, Ta <: SpMatMulFloat, Tb <: SpMatMulFloat}
     tA = tA in ('S', 's', 'H', 'h') ? 'N' : tA
-    mv_wrapper(tA, alpha, A, CuVector{T}(B), beta, C)
+    mv_wrapper(tA, alpha, A, CuVector{Tc}(B), beta, C)
 end
 
-function LinearAlgebra.generic_matmatmul!(C::CuMatrix{T}, tA, tB, A::CuSparseMatrix{T}, B::DenseCuMatrix{T}, alpha::Number, beta::Number) where {T <: Union{Float16, ComplexF16, BlasFloat}}
+# mm! requires all three operands to share an eltype, so promote A and B to match C.
+function LinearAlgebra.generic_matmatmul!(C::CuMatrix{Tc}, tA, tB, A::CuSparseMatrix{Ta}, B::DenseCuMatrix{Tb}, alpha::Number, beta::Number) where {Tc <: SpMatMulFloat, Ta <: SpMatMulFloat, Tb <: SpMatMulFloat}
+    A′ = Ta === Tc ? A : sparse_with_eltype(A, Tc)
+    B′ = Tb === Tc ? B : convert(CuMatrix{Tc}, B)
     tA = tA in ('S', 's', 'H', 'h') ? 'N' : tA
     tB = tB in ('S', 's', 'H', 'h') ? 'N' : tB
-    mm_wrapper(tA, tB, alpha, A, B, beta, C)
+    mm_wrapper(tA, tB, alpha, A′, B′, beta, C)
 end
 
 for (wrapa, transa, unwrapa) in op_wrappers
     TypeA = wrapa(:(CuSparseMatrix{T}))
 
-    @eval function LinearAlgebra.:(*)(A::$TypeA, x::CuSparseVector{T}) where {T <: Union{Float16, ComplexF16, BlasFloat}}
+    @eval function LinearAlgebra.:(*)(A::$TypeA, x::CuSparseVector{T}) where {T <: SpMatMulFloat}
         m, n = size(A)
         length(x) == n || throw(DimensionMismatch())
         y = CuVector{T}(undef, m)
@@ -97,35 +135,45 @@ for (wrapa, transa, unwrapa) in op_wrappers
 end
 
 # legacy methods with final MulAddMul argument
-LinearAlgebra.generic_matvecmul!(C::CuVector{T}, tA::AbstractChar, A::DenseCuMatrix{T}, B::CuSparseVector{T}, _add::MulAddMul) where {T <: BlasFloat} =
+LinearAlgebra.generic_matvecmul!(C::CuVector{Tc}, tA::AbstractChar, A::DenseCuMatrix{Ta}, B::CuSparseVector{Tb}, _add::MulAddMul) where {Tc <: BlasFloat, Ta <: BlasFloat, Tb <: BlasFloat} =
     LinearAlgebra.generic_matvecmul!(C, tA, A, B, _add.alpha, _add.beta)
 
-LinearAlgebra.generic_matmatmul!(C::CuMatrix{T}, tA, tB, A::DenseCuMatrix{T}, B::CuSparseMatrixCSC{T}, _add::MulAddMul) where {T <: Union{Float16, ComplexF16, BlasFloat}} =
+LinearAlgebra.generic_matmatmul!(C::CuMatrix{Tc}, tA, tB, A::DenseCuMatrix{Ta}, B::CuSparseMatrixCSC{Tb}, _add::MulAddMul) where {Tc <: SpMatMulFloat, Ta <: SpMatMulFloat, Tb <: SpMatMulFloat} =
     LinearAlgebra.generic_matmatmul!(C, tA, tB, A, B, _add.alpha, _add.beta)
-LinearAlgebra.generic_matmatmul!(C::CuMatrix{T}, tA, tB, A::DenseCuMatrix{T}, B::CuSparseMatrixCSR{T}, _add::MulAddMul) where {T <: Union{Float16, ComplexF16, BlasFloat}} =
+LinearAlgebra.generic_matmatmul!(C::CuMatrix{Tc}, tA, tB, A::DenseCuMatrix{Ta}, B::CuSparseMatrixCSR{Tb}, _add::MulAddMul) where {Tc <: SpMatMulFloat, Ta <: SpMatMulFloat, Tb <: SpMatMulFloat} =
     LinearAlgebra.generic_matmatmul!(C, tA, tB, A, B, _add.alpha, _add.beta)
-LinearAlgebra.generic_matmatmul!(C::CuMatrix{T}, tA, tB, A::DenseCuMatrix{T}, B::CuSparseMatrixCOO{T}, _add::MulAddMul) where {T <: Union{Float16, ComplexF16, BlasFloat}} =
+LinearAlgebra.generic_matmatmul!(C::CuMatrix{Tc}, tA, tB, A::DenseCuMatrix{Ta}, B::CuSparseMatrixCOO{Tb}, _add::MulAddMul) where {Tc <: SpMatMulFloat, Ta <: SpMatMulFloat, Tb <: SpMatMulFloat} =
     LinearAlgebra.generic_matmatmul!(C, tA, tB, A, B, _add.alpha, _add.beta)
 
-function LinearAlgebra.generic_matvecmul!(C::CuVector{T}, tA::AbstractChar, A::DenseCuMatrix{T}, B::CuSparseVector{T}, alpha::Number, beta::Number) where {T <: BlasFloat}
+# gemvi! requires matching eltypes, so promote A and B to match C.
+function LinearAlgebra.generic_matvecmul!(C::CuVector{Tc}, tA::AbstractChar, A::DenseCuMatrix{Ta}, B::CuSparseVector{Tb}, alpha::Number, beta::Number) where {Tc <: BlasFloat, Ta <: BlasFloat, Tb <: BlasFloat}
+    A′ = Ta === Tc ? A : convert(CuMatrix{Tc}, A)
+    B′ = Tb === Tc ? B : sparse_with_eltype(B, Tc)
     tA = tA in ('S', 's', 'H', 'h') ? 'N' : tA
-    gemvi!(tA, alpha, A, B, beta, C, 'O')
+    gemvi!(tA, alpha, A′, B′, beta, C, 'O')
 end
 
-function LinearAlgebra.generic_matmatmul!(C::CuMatrix{T}, tA, tB, A::DenseCuMatrix{T}, B::CuSparseMatrixCSC{T}, alpha::Number, beta::Number) where {T <: Union{Float16, ComplexF16, BlasFloat}}
+# mm! requires matching eltypes, so promote A and B to match C.
+function LinearAlgebra.generic_matmatmul!(C::CuMatrix{Tc}, tA, tB, A::DenseCuMatrix{Ta}, B::CuSparseMatrixCSC{Tb}, alpha::Number, beta::Number) where {Tc <: SpMatMulFloat, Ta <: SpMatMulFloat, Tb <: SpMatMulFloat}
+    A′ = Ta === Tc ? A : convert(CuMatrix{Tc}, A)
+    B′ = Tb === Tc ? B : sparse_with_eltype(B, Tc)
     tA = tA in ('S', 's', 'H', 'h') ? 'N' : tA
     tB = tB in ('S', 's', 'H', 'h') ? 'N' : tB
-    mm!(tA, tB, alpha, A, B, beta, C, 'O')
+    mm!(tA, tB, alpha, A′, B′, beta, C, 'O')
 end
-function LinearAlgebra.generic_matmatmul!(C::CuMatrix{T}, tA, tB, A::DenseCuMatrix{T}, B::CuSparseMatrixCSR{T}, alpha::Number, beta::Number) where {T <: Union{Float16, ComplexF16, BlasFloat}}
+function LinearAlgebra.generic_matmatmul!(C::CuMatrix{Tc}, tA, tB, A::DenseCuMatrix{Ta}, B::CuSparseMatrixCSR{Tb}, alpha::Number, beta::Number) where {Tc <: SpMatMulFloat, Ta <: SpMatMulFloat, Tb <: SpMatMulFloat}
+    A′ = Ta === Tc ? A : convert(CuMatrix{Tc}, A)
+    B′ = Tb === Tc ? B : sparse_with_eltype(B, Tc)
     tA = tA in ('S', 's', 'H', 'h') ? 'N' : tA
     tB = tB in ('S', 's', 'H', 'h') ? 'N' : tB
-    mm!(tA, tB, alpha, A, B, beta, C, 'O')
+    mm!(tA, tB, alpha, A′, B′, beta, C, 'O')
 end
-function LinearAlgebra.generic_matmatmul!(C::CuMatrix{T}, tA, tB, A::DenseCuMatrix{T}, B::CuSparseMatrixCOO{T}, alpha::Number, beta::Number) where {T <: Union{Float16, ComplexF16, BlasFloat}}
+function LinearAlgebra.generic_matmatmul!(C::CuMatrix{Tc}, tA, tB, A::DenseCuMatrix{Ta}, B::CuSparseMatrixCOO{Tb}, alpha::Number, beta::Number) where {Tc <: SpMatMulFloat, Ta <: SpMatMulFloat, Tb <: SpMatMulFloat}
+    A′ = Ta === Tc ? A : convert(CuMatrix{Tc}, A)
+    B′ = Tb === Tc ? B : sparse_with_eltype(B, Tc)
     tA = tA in ('S', 's', 'H', 'h') ? 'N' : tA
     tB = tB in ('S', 's', 'H', 'h') ? 'N' : tB
-    mm!(tA, tB, alpha, A, B, beta, C, 'O')
+    mm!(tA, tB, alpha, A′, B′, beta, C, 'O')
 end
 
 for (wrapa, transa, unwrapa) in op_wrappers
@@ -142,7 +190,7 @@ for (wrapa, transa, unwrapa) in op_wrappers
         for SparseMatrixType in (:(CuSparseMatrixCSC{T}), :(CuSparseMatrixCSR{T}), :(CuSparseMatrixCOO{T}))
             TypeB = wrapb(SparseMatrixType)
 
-            @eval function Base.:(*)(A::$TypeA, B::$TypeB) where {T <: Union{Float16, ComplexF16, BlasFloat}}
+            @eval function Base.:(*)(A::$TypeA, B::$TypeB) where {T <: SpMatMulFloat}
                 m, n = size(A)
                 k, p = size(B)
                 n == k || throw(DimensionMismatch())

--- a/lib/cusparse/test/interfaces/mul.jl
+++ b/lib/cusparse/test/interfaces/mul.jl
@@ -27,6 +27,45 @@ using LinearAlgebra, SparseArrays
         end
     end
 
+    # issue CUDA.jl#3128: mixed-eltype products where the sparse side is complex
+    if elty <: Real
+        eltya = complex(elty)
+        eltyb = elty
+        @testset "mixed-eltype sparse*dense ($eltya, $eltyb) $SparseMatrixType opa = $opa" for
+            SparseMatrixType in (CuSparseMatrixCSC, CuSparseMatrixCSR, CuSparseMatrixCOO),
+            opa in (identity, transpose, adjoint)
+
+            A = opa == identity ? sprand(eltya, n, m, 0.5) : sprand(eltya, m, n, 0.5)
+            B = rand(eltyb, m, k)
+            b = rand(eltyb, m)
+            dA = SparseMatrixType(A)
+            dB = CuArray(B)
+            db = CuArray(b)
+
+            # sparse * dense matrix
+            C  = opa(A) * B
+            dC = opa(dA) * dB
+            @test C ≈ collect(dC)
+            @test dC isa CuMatrix
+
+            # sparse * dense vector
+            c  = opa(A) * b
+            dc = opa(dA) * db
+            @test c ≈ collect(dc)
+            @test dc isa CuVector
+
+            # dense * sparse matrix (reverse direction)
+            # cusparseSpMM requires a column-sorted COO when the sparse arg is on the right
+            dA_r = SparseMatrixType == CuSparseMatrixCOO ? sort_coo(dA, 'C') : dA
+            Br = rand(eltyb, k, n)
+            dBr = CuArray(Br)
+            Cr  = Br * opa(A)
+            dCr = dBr * opa(dA_r)
+            @test Cr ≈ collect(dCr)
+            @test dCr isa CuMatrix
+        end
+    end
+
     @testset "CuMatrix ops opa = $opa" for opa in (identity, transpose, adjoint)
         A_mv  = opa == identity ? rand(elty, n, m) : rand(elty, m, n)
         dA_mv = CuArray(A_mv)

--- a/lib/cusparse/test/interfaces/mul.jl
+++ b/lib/cusparse/test/interfaces/mul.jl
@@ -9,60 +9,27 @@ using LinearAlgebra, SparseArrays
     alpha = rand(elty)
     beta  = rand(elty)
 
-    if elty <: Real
-        eltya = elty
-        eltyb = complex(elty)
-        @testset "CuSparseMatrix * CuVector -- mul!(c, A, b) mixed ($eltya, $eltyb) opa = $opa" for opa in (identity, transpose, adjoint)
-            A = opa == identity ? sprand(eltya, n, m, 0.5) : sprand(eltya, m, n, 0.5)
-            b = rand(eltyb, m)
-            c = rand(eltyb, n)
-
-            dA = CuSparseMatrixCSR(A)
-            db = CuArray(b)
-            dc = CuArray(c)
-
-            mul!(c, opa(A), b)
-            mul!(dc, opa(dA), db)
-            @test c ≈ collect(dc)
-        end
-    end
-
-    # issue CUDA.jl#3128: mixed-eltype products where the sparse side is complex
+    # mixed-eltype sparse/dense products (CUDA.jl#3128)
     if elty <: Real
         eltya = complex(elty)
         eltyb = elty
-        @testset "mixed-eltype sparse*dense ($eltya, $eltyb) $SparseMatrixType opa = $opa" for
-            SparseMatrixType in (CuSparseMatrixCSC, CuSparseMatrixCSR, CuSparseMatrixCOO),
-            opa in (identity, transpose, adjoint)
+        @testset "mixed-eltype sparse↔dense $SparseMatrixType" for
+            SparseMatrixType in (CuSparseMatrixCSC, CuSparseMatrixCSR, CuSparseMatrixCOO)
 
-            A = opa == identity ? sprand(eltya, n, m, 0.5) : sprand(eltya, m, n, 0.5)
+            A = sprand(eltya, n, m, 0.5)
             B = rand(eltyb, m, k)
             b = rand(eltyb, m)
             dA = SparseMatrixType(A)
             dB = CuArray(B)
             db = CuArray(b)
+            @test collect(dA * dB) ≈ A * B
+            @test collect(dA * db) ≈ A * b
 
-            # sparse * dense matrix
-            C  = opa(A) * B
-            dC = opa(dA) * dB
-            @test C ≈ collect(dC)
-            @test dC isa CuMatrix
-
-            # sparse * dense vector
-            c  = opa(A) * b
-            dc = opa(dA) * db
-            @test c ≈ collect(dc)
-            @test dc isa CuVector
-
-            # dense * sparse matrix (reverse direction)
-            # cusparseSpMM requires a column-sorted COO when the sparse arg is on the right
+            # dense × sparse (reverse direction); COO must be column-sorted on the right
             dA_r = SparseMatrixType == CuSparseMatrixCOO ? sort_coo(dA, 'C') : dA
             Br = rand(eltyb, k, n)
             dBr = CuArray(Br)
-            Cr  = Br * opa(A)
-            dCr = dBr * opa(dA_r)
-            @test Cr ≈ collect(dCr)
-            @test dCr isa CuMatrix
+            @test collect(dBr * dA_r) ≈ Br * A
         end
     end
 


### PR DESCRIPTION
Promote operands to a common eltype in generic_matvecmul!/generic_matmatmul!, and override matprod_dest so dense × sparse allocates a dense result.

Fixes https://github.com/JuliaGPU/CUDA.jl/issues/3128