### PR TITLE
Name register pressure in launch-failure diagnostics

### DIFF
--- a/CUDACore/lib/cudadrv/execution.jl
+++ b/CUDACore/lib/cudadrv/execution.jl
@@ -161,7 +161,8 @@ end
     nregs = fattr[FUNC_ATTRIBUTE_NUM_REGS]
     reg_lim = attribute(dev, DEVICE_ATTRIBUTE_MAX_REGISTERS_PER_BLOCK)
     if nregs * nthreads > reg_lim
-        error("Register pressure exceeds device limit ($nregs regs/thread * $nthreads threads/block = $(nregs * nthreads) regs/block > $reg_lim regs/block).")
+        error("Block register count exceeds device limit ($nregs regs/thread * $nthreads threads/block = $(nregs * nthreads) > $reg_lim regs/block). " *
+              "Reduce per-thread register use (e.g. via the `maxregs` compiler kwarg) or launch with fewer threads per block.")
     end
     ## thread limit
     threadlim = fattr[FUNC_ATTRIBUTE_MAX_THREADS_PER_BLOCK]

--- a/CUDACore/lib/cudadrv/execution.jl
+++ b/CUDACore/lib/cudadrv/execution.jl
@@ -155,10 +155,18 @@ end
 
     # check kernel limits
     fattr = attributes(f)
+    nthreads = threaddim.x * threaddim.y * threaddim.z
+    ## register pressure (names the resource on the register-binding subset of
+    ## thread-limit failures; falls through to the thread-limit check otherwise)
+    nregs = fattr[FUNC_ATTRIBUTE_NUM_REGS]
+    reg_lim = attribute(dev, DEVICE_ATTRIBUTE_MAX_REGISTERS_PER_BLOCK)
+    if nregs * nthreads > reg_lim
+        error("Register pressure exceeds device limit ($nregs regs/thread * $nthreads threads/block = $(nregs * nthreads) regs/block > $reg_lim regs/block).")
+    end
     ## thread limit
     threadlim = fattr[FUNC_ATTRIBUTE_MAX_THREADS_PER_BLOCK]
-    if threaddim.x * threaddim.y * threaddim.z > threadlim
-        error("Number of threads per block exceeds kernel limit ($(threaddim.x * threaddim.y * threaddim.z) > $threadlim).")
+    if nthreads > threadlim
+        error("Number of threads per block exceeds kernel limit ($nthreads > $threadlim).")
     end
     ## shared memory limit
     shmem_lim = fattr[FUNC_ATTRIBUTE_MAX_DYNAMIC_SHARED_SIZE_BYTES]

--- a/test/core/execution.jl
+++ b/test/core/execution.jl
@@ -79,6 +79,31 @@ end
 end
 
 
+@testset "launch failure: register pressure" begin
+    # Force ptxas to keep N live values across a barrier. The stores into
+    # `out` are the observable side effect that prevents the optimizer from
+    # eliminating the loads as dead code.
+    function reg_kernel(out, inp, ::Val{N}) where N
+        i = threadIdx().x
+        v = ntuple(j -> inp[i + (j-1)*N], Val(N))
+        sync_threads()
+        ntuple(j -> (out[i + (j-1)*N] = v[j]; nothing), Val(N))
+        return
+    end
+    N = 256
+    hw_cap = CUDA.attribute(device(), CUDA.DEVICE_ATTRIBUTE_MAX_THREADS_PER_BLOCK)
+    workspace = CuArray{Float32}(undef, hw_cap + N^2)
+    k       = @cuda launch=false reg_kernel(workspace, workspace, Val(N))
+    nregs   = CUDA.registers(k)
+    reglim  = CUDA.attribute(device(), CUDA.DEVICE_ATTRIBUTE_MAX_REGISTERS_PER_BLOCK)
+    threads = fld(reglim, nregs) + 1
+    @test_throws "Register pressure exceeds device limit" begin
+        @assert threads > CUDA.maxthreads(k)
+        k(workspace, workspace; threads=threads)
+    end
+end
+
+
 @testset "inference" begin
     foo() = @cuda dummy()
     @inferred foo()

--- a/test/core/execution.jl
+++ b/test/core/execution.jl
@@ -97,7 +97,7 @@ end
     nregs   = CUDA.registers(k)
     reglim  = CUDA.attribute(device(), CUDA.DEVICE_ATTRIBUTE_MAX_REGISTERS_PER_BLOCK)
     threads = fld(reglim, nregs) + 1
-    @test_throws "Register pressure exceeds device limit" begin
+    @test_throws "Block register count exceeds device limit" begin
         @assert threads > CUDA.maxthreads(k)
         k(workspace, workspace; threads=threads)
     end


### PR DESCRIPTION
## Problem

Register-pressure launch failures produce the generic kernel-thread-limit message, e.g.:

```
Number of threads per block exceeds kernel limit (258 > 256).
```

`256` here is the smallest of at least two numbers the driver minimizes over: the register-budget thread count (`floor(reglim / NUM_REGS)`, warp-aligned) and the hardware per-block cap (1024). The message doesn't say which is binding, so users have to query `FUNC_ATTRIBUTE_NUM_REGS` and back-solve to confirm registers were the cause.

## Fix

Insert a register-specific check before the kernel-thread-limit check, firing when `NUM_REGS * nthreads > MAX_REGISTERS_PER_BLOCK`:

```
Register pressure exceeds device limit (255 regs/thread * 258 threads/block = 65790 regs/block > 65536 regs/block).
```

This is strictly a refinement rather than a new catch: the new check's condition (`NUM_REGS * nthreads > reglim`) implies the existing threadlim condition (since `MAX_THREADS_PER_BLOCK ≤ floor(reglim / NUM_REGS)`), so detection is unchanged.