### PR TITLE
Improve toolkit version detection.

### DIFF
--- a/CUDACore/lib/cudadrv/version.jl
+++ b/CUDACore/lib/cudadrv/version.jl
@@ -27,15 +27,53 @@ end
     runtime_version()
 
 Returns the CUDA Runtime version.
+
+On Linux, this calls `cudaRuntimeGetVersion`, which returns a compile-time constant baked
+into the loaded `libcudart`. On Windows we instead read the cudart DLL's PE file version
+directly, because NVIDIA's `cudaRuntimeGetVersion` there delegates to a driver-bundled
+"hybrid" runtime and reports the driver's version rather than the loaded toolkit's.
 """
 function runtime_version()
-    version_ref = Ref{Cint}()
-    check() do
-        @ccall libcudart.cudaRuntimeGetVersion(version_ref::Ptr{Cint})::CUresult
-    end
-    major, ver = divrem(version_ref[], 1000)
-    minor, patch = divrem(ver, 10)
-    return VersionNumber(major, minor, patch)
+    @memoize begin
+        @static if Sys.iswindows()
+            # Read the cudart DLL's PE VS_FIXEDFILEINFO via Win32. NVIDIA encodes the
+            # toolkit major.minor in the low 16 bits of dwFileVersionLS as a decimal MMm0
+            # (e.g. 13010 → 13.1.0).
+            path = Libdl.dlpath(libcudart)
+            hver = Libdl.dlopen("version.dll")
+            GetFileVersionInfoSizeA = Libdl.dlsym(hver, :GetFileVersionInfoSizeA)
+            GetFileVersionInfoA     = Libdl.dlsym(hver, :GetFileVersionInfoA)
+            VerQueryValueA          = Libdl.dlsym(hver, :VerQueryValueA)
+
+            handle_ref = Ref{Culong}(0)
+            sz = ccall(GetFileVersionInfoSizeA, Culong, (Cstring, Ptr{Culong}), path, handle_ref)
+            sz == 0 && error("GetFileVersionInfoSizeA returned 0 for $path")
+            buf = Vector{UInt8}(undef, sz)
+            ok = ccall(GetFileVersionInfoA, Cint, (Cstring, Culong, Culong, Ptr{UInt8}), path, 0, sz, buf)
+            ok == 0 && error("GetFileVersionInfoA failed for $path")
+
+            info_ptr = Ref{Ptr{UInt8}}(C_NULL)
+            len_ref  = Ref{Cuint}(0)
+            ok = ccall(VerQueryValueA, Cint, (Ptr{UInt8}, Cstring, Ptr{Ptr{UInt8}}, Ptr{Cuint}),
+                       buf, "\\", info_ptr, len_ref)
+            ok == 0 && error("VerQueryValueA failed for $path")
+
+            # VS_FIXEDFILEINFO: dwSignature, dwStrucVersion, dwFileVersionMS, dwFileVersionLS, ...
+            dwFileVersionLS = unsafe_load(reinterpret(Ptr{UInt32}, info_ptr[]), 4)
+            encoded = Int(dwFileVersionLS & 0xffff)
+            major, ver = divrem(encoded, 1000)
+            minor, patch = divrem(ver, 10)
+            VersionNumber(major, minor, patch)
+        else
+            v = Ref{Cint}()
+            check() do
+                @ccall libcudart.cudaRuntimeGetVersion(v::Ptr{Cint})::CUresult
+            end
+            major, ver = divrem(v[], 1000)
+            minor, patch = divrem(ver, 10)
+            VersionNumber(major, minor, patch)
+        end
+    end::VersionNumber
 end
 
 """
@@ -96,11 +134,22 @@ end
     compiler_version()
 
 Returns the CUDA toolkit version that is used to provide the CUDA compiler (`ptxas`) and
-other tools. This is version separately from the CUDA Runtime, in order to ensure
+other tools. This is versioned separately from the CUDA Runtime, in order to ensure
 compatibility with the driver, and make sure we use the latest compatible version regardless
 of the selected runtime.
+
+Derived by parsing `ptxas --version`.
 """
-compiler_version() = CUDA_Compiler.cuda_version
+function compiler_version()
+    @memoize begin
+        output = readchomp(`$(CUDA_Compiler.ptxas()) --version`)
+        m = match(r"release (\d+)\.(\d+),\s*V(\d+)\.(\d+)\.(\d+)", output)
+        m === nothing && error("Could not parse `ptxas --version` output: $output")
+        VersionNumber(parse(Int, m.captures[3]),
+                      parse(Int, m.captures[4]),
+                      parse(Int, m.captures[5]))
+    end::VersionNumber
+end
 
 
 ## helpers

--- a/CUDACore/src/compatibility.jl
+++ b/CUDACore/src/compatibility.jl
@@ -301,19 +301,22 @@ function llvm_compat(version=LLVM.version())
     return (cap=cap_support, ptx=ptx_support)
 end
 
-function cuda_compat(version=runtime_version())
+function cuda_compat(runtime=runtime_version(), compiler=compiler_version())
     # we don't have to check the driver version, because it offers backwards compatbility
     # beyond the CUDA toolkit version (e.g. R580 for CUDA 13 still supports Volta as
     # deprecated in CUDA 13), and we don't have a reliable way to query the actual version
     # as NVML isn't available on all platforms. let's instead simply assume that unsupported
     # devices will not be exposed to the CUDA runtime and thus won't be visible to us.
 
-    # we also don't have to check the compiler version, because CUDA_Compiler_jll is
-    # guaranteed to have the same major version as CUDA_Runtime_jll, meaning that the
-    # compiler will always support at least the same devices as the runtime.
-
-    cap_support = sort(collect(cuda_cap_support(version)))
-    ptx_support = sort(collect(cuda_ptx_support(version)))
+    # the compiler and runtime are versioned independently (and either can come from a
+    # local install), so we need to consider both:
+    # - device caps are dropped when either ptxas can't emit for them or the runtime
+    #   libraries drop them. take the intersection of both supported sets.
+    # - PTX ISA availability is a property of ptxas; the runtime doesn't care which ISA
+    #   compiled cubin came from.
+    cap_support = sort(collect(intersect(cuda_cap_support(runtime),
+                                         cuda_cap_support(compiler))))
+    ptx_support = sort(collect(cuda_ptx_support(compiler)))
 
     return (cap=cap_support, ptx=ptx_support)
 end

--- a/CUDACore/src/compiler/compilation.jl
+++ b/CUDACore/src/compiler/compilation.jl
@@ -204,7 +204,7 @@ end
             error("CUDA.jl requires PTX $requested_ptx, which is not supported by LLVM $(LLVM.version())")
         llvm_ptx = maximum(llvm_ptxs)
         isempty(cuda_ptxs) &&
-            error("CUDA.jl requires PTX $requested_ptx, which is not supported by CUDA $(runtime_version())")
+            error("CUDA.jl requires PTX $requested_ptx, which is not supported by CUDA $(compiler_version())")
         cuda_ptx = maximum(cuda_ptxs)
     end
 
@@ -234,7 +234,7 @@ end
     end
 
     # NVIDIA bug #3600554: ptxas segfaults with our debug info, fixed in 11.7
-    debuginfo = runtime_version() >= v"11.7"
+    debuginfo = compiler_version() >= v"11.7"
 
     # create GPUCompiler objects
     target = PTXCompilerTarget(; cap=llvm_cap, ptx=llvm_ptx, debuginfo, kwargs...)

--- a/CUDACore/src/initialization.jl
+++ b/CUDACore/src/initialization.jl
@@ -142,44 +142,20 @@ function __init__()
         _initialization_error[] = "CUDA runtime not found"
         return
     end
-    runtime = try
-        runtime_version()
-    catch err
-        if err isa CuError && err.code == ERROR_NO_DEVICE
-            _initialization_error[] = "No CUDA-capable device found"
-            return
-        end
-        rethrow()
-    end
-
-    # ensure the loaded runtime is supported
-    if runtime < v"12"
-        @error "This version of CUDA.jl only supports CUDA 12 or higher (your toolkit provides CUDA $runtime)"
-    end
-
-    # ensure the loaded runtime matches the artifact we were compiled against
-    if !local_toolkit
-        if CUDA_Runtime_jll.host_platform["cuda"] == "none"
-            @error """CUDA.jl was precompiled without knowing the CUDA toolkit version. This is unsupported.
-                      You should either precompile CUDA.jl in an environment where the CUDA driver is available,
-                      or call `CUDA.set_runtime_version!` to specify which CUDA version to use at run time."""
-            _initialization_error[] = "Precompiled without CUDA toolkit version"
-            return
-        end
-
-        artifact = parse(VersionNumber, CUDA_Runtime_jll.host_platform["cuda"])
-        if Base.thisminor(runtime) != Base.thisminor(artifact)
-            @error """You are using CUDA $runtime, but CUDA.jl was precompiled for CUDA $artifact.
-                      This is unexpected; please file an issue."""
-            _initialization_error[] = "CUDA version mismatch"
-        end
-    end
-
     # finally, initialize CUDA
     try
         cuInit(0)
     catch err
         _initialization_error[] = "CUDA initialization failed: " * sprint(showerror, err)
+        return
+    end
+
+    # ensure the loaded runtime is supported. done after cuInit so that runtime_version()
+    # (on Linux, a ccall into libcudart) doesn't have to deal with ERROR_NO_DEVICE.
+    runtime = runtime_version()
+    if runtime < v"12"
+        @error "This version of CUDA.jl only supports CUDA 12 or higher (your toolkit provides CUDA $runtime)"
+        _initialization_error[] = "CUDA runtime too old"
         return
     end
 

--- a/CUDATools/src/profile.jl
+++ b/CUDATools/src/profile.jl
@@ -381,11 +381,8 @@ function profile_internally(@nospecialize(f); concurrent=true, kwargs...)
         CUPTI.CUPTI_ACTIVITY_KIND_MEMORY2,
         # NVTX markers
         CUPTI.CUPTI_ACTIVITY_KIND_MARKER,
+        CUPTI.CUPTI_ACTIVITY_KIND_MARKER_DATA,
     ]
-    if CUDACore.runtime_version() >= v"12.0"
-        # additional data on NVTX markers
-        push!(activity_kinds, CUPTI.CUPTI_ACTIVITY_KIND_MARKER_DATA)
-    end
     cfg = CUPTI.ActivityConfig(activity_kinds)
 
     # wait for the device to become idle
@@ -452,7 +449,6 @@ function capture(cfg)
     # memory_kind fields are sometimes typed CUpti_ActivityMemoryKind, sometimes UInt
     as_memory_kind(x) = isa(x, CUPTI.CUpti_ActivityMemoryKind) ? x : CUPTI.CUpti_ActivityMemoryKind(x)
 
-    cuda_version = CUDACore.runtime_version()
     CUPTI.process(cfg) do ctx, stream_id, record
         # driver API calls
         if record.kind in [CUPTI.CUPTI_ACTIVITY_KIND_DRIVER,

--- a/CUDATools/src/utilities.jl
+++ b/CUDATools/src/utilities.jl
@@ -9,7 +9,8 @@ function versioninfo(io::IO=stdout)
 
     println(io, "CUDA toolchain: ")
 
-    print(io, "- runtime $(runtime_version().major).$(runtime_version().minor), ")
+    rv = runtime_version()
+    print(io, "- runtime $(rv.major).$(rv.minor).$(rv.patch), ")
     if CUDACore.local_toolkit
         println(io, "local installation")
     else
@@ -21,7 +22,8 @@ function versioninfo(io::IO=stdout)
         print(io, "- unknown driver")
     end
     println(io, " for $(driver_version().major).$(driver_version().minor)")
-    print(io, "- compiler $(compiler_version().major).$(compiler_version().minor), ")
+    cv = compiler_version()
+    print(io, "- compiler $(cv.major).$(cv.minor).$(cv.patch), ")
     if CUDACore.local_compiler
         println(io, "local installation")
     else

--- a/docs/src/lib/cudadrv.md
+++ b/docs/src/lib/cudadrv.md
@@ -26,6 +26,7 @@ description(::CuError)
 ```@docs
 driver_version()
 runtime_version()
+compiler_version()
 set_runtime_version!
 reset_runtime_version!
 ```

--- a/lib/cupti/src/wrappers.jl
+++ b/lib/cupti/src/wrappers.jl
@@ -32,7 +32,10 @@ const cupti_versions = [
 function version()
     version_ref = Ref{Cuint}()
     cuptiGetVersion(version_ref)
-    if CUDACore.runtime_version() < v"13"
+    # CUPTI changed the encoding of cuptiGetVersion in CUDA 13: pre-13 it returns a small
+    # index into a hand-maintained table, from 13 onwards it encodes major.minor.patch
+    # directly (so >= 130000).
+    if version_ref[] < 1000
         cupti_versions[version_ref[]]
     else
         major, ver = divrem(version_ref[], 10000)
@@ -295,9 +298,6 @@ function process(f, cfg::ActivityConfig)
         CUPTI_ACTIVITY_KIND_MARKER              => CUpti_ActivityMarker2,
         CUPTI_ACTIVITY_KIND_MARKER_DATA         => CUpti_ActivityMarkerData,
     )
-    # NOTE: the CUPTI version is unreliable, e.g., both CUDA 11.5 and 11.6 have CUPTI 16,
-    #       yet CUpti_ActivityMemset4 is only available in CUDA 11.6.
-    cuda_version = CUDACore.runtime_version()
     ## kernel activities
     activity_types[CUPTI_ACTIVITY_KIND_KERNEL] =
         CUpti_ActivityKernel9

--- a/lib/cutensor/test/kernel_cache.jl
+++ b/lib/cutensor/test/kernel_cache.jl
@@ -1,7 +1,7 @@
 using cuTENSOR
 using CUDACore
 
-if CUDACore.runtime_version() >= v"11.8" && capability(device()) >= v"8.0"
+if capability(device()) >= v"8.0"
     @testset "kernel cache" begin
         mktempdir() do dir
             cd(dir) do

--- a/test/core/cudadrv.jl
+++ b/test/core/cudadrv.jl
@@ -912,4 +912,6 @@ end
 
 @test isa(CUDA.runtime_version(), VersionNumber)
 
+@test isa(CUDA.compiler_version(), VersionNumber)
+
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -17,9 +17,9 @@ include(joinpath(@__DIR__, "setup.jl"))
 args = parse_args(ARGS; custom = ["sanitize", "all"])
 
 # check that CI is using the requested toolkit
-toolkit_release = Base.thisminor(CUDA.runtime_version())
 label_match = match(r"^CUDA ([\d.]+)$", get(ENV, "BUILDKITE_LABEL", ""))
 if label_match !== nothing
+    toolkit_release = Base.thisminor(CUDA.runtime_version())
     @test toolkit_release == VersionNumber(label_match.captures[1])
 end
 

--- a/test/setup.jl
+++ b/test/setup.jl
@@ -30,11 +30,6 @@ const sanitize = any(contains("NV_SANITIZER"), keys(ENV))
 function can_use_cupti()
     sanitize && return false
 
-    # NVIDIA bug #3964667: CUPTI in CUDA 11.7+ broken for sm_35 devices
-    if CUDA.runtime_version() >= v"11.7" && capability(device()) <= v"3.7"
-        return false
-    end
-
     # Tegra requires running as root and modifying the device tree
     if CUDA.is_tegra()
         return false


### PR DESCRIPTION
- detects the runtime version on Windows by inspecting the runtime library, not calling it (which unconditionally resolves to a copy from the driver store)
- removes some pre 12.0 version checks
- switches `runtime_version`-gated code to something specific to the functionality
- determines the compiler version by parsing `ptxas` output
- gates functionality on the compiler version too (now that local compilers are supported)

Fixes https://github.com/JuliaGPU/CUDA.jl/issues/3000