### PR TITLE
Revert "Fix Int32 overflow in !range metadata for large intrinsics"

### DIFF
--- a/CUDACore/src/device/intrinsics/indexing.jl
+++ b/CUDACore/src/device/intrinsics/indexing.jl
@@ -24,11 +24,9 @@ export
             idx = call!(builder, intr_typ, intr)
 
             # attach range metadata
-            if range.stop < typemax(Int32)
-                range_metadata = MDNode([ConstantInt(range.start % Int32),
-                                         ConstantInt((range.stop + 1) % Int32)])
-                metadata(idx)[LLVM.MD_range] = range_metadata
-            end
+            range_metadata = MDNode([ConstantInt(range.start % Int32),
+                                     ConstantInt((range.stop + 1) % Int32)])
+            metadata(idx)[LLVM.MD_range] = range_metadata
 
             ret!(builder, idx)
         end

--- a/test/core/device/intrinsics.jl
+++ b/test/core/device/intrinsics.jl
@@ -338,16 +338,3 @@ end
 
 ############################################################################################
 
-@testset "intrinsic range metadata" begin
-    # Create tiny kernels to isolate the x-dimension
-    kernel_block() = CUDA.blockDim().x
-    kernel_grid()  = CUDA.gridDim().x
-
-    ir_block = sprint(io -> CUDA.code_llvm(io, kernel_block, Tuple{}; dump_module=true, raw=true))
-    @test occursin("!range", ir_block)
-
-    ir_grid = sprint(io -> CUDA.code_llvm(io, kernel_grid, Tuple{}; dump_module=true, raw=true))
-    @test !occursin("!range", ir_grid)
-end
-
-############################################################################################


### PR DESCRIPTION
Reverts #3119, which removed `!range` metadata from `gridDim`-style intrinsics (`max = typemax(Int32)`) under the belief that the wrap-around encoding `!{i32 1, i32 -2147483648}` was an Int32 overflow bug.

It isn't. LLVM's LangRef explicitly defines `!range` with `Low > High` as the wrap-around set `[Low, INT_MAX] ∪ [INT_MIN, High)`, here equivalent to `[1, 2^31-1]`, exactly the valid range for `gridDim().x`. LLVM's value-range analysis uses this form, and without it, `gridDim().x ÷ length(Rother)` in `partial_mapreduce_grid` loses its lowering to unsigned 32-bit division, gaining a runtime upper-32-bits check and a `div.s64` fallback. Result: a ~1.5–2% regression on dims=2 reductions (visible across mapreduce/Int64, mapreduce/Float32, and reduce/Int64 on the benchmarks website).

The actual #3024 fix (the +1 for half-open `[Low, High)` encoding) was part of #3017 already.

cc @rainerrodrigues