### PR TITLE
EnzymeCoreExt: overlay autodiff/deferred_codegen for kernel codegen

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -190,19 +190,26 @@ steps:
 
             println("--- :julia: Instantiating project")
             withenv("JULIA_PKG_PRECOMPILE_AUTO" => 0) do
+              # TODO(#3150): revert to registered Enzyme before merge. Points at
+              # EnzymeAD/Enzyme.jl#3112 for the matching `GLOBAL_METHOD_TABLE`
+              # overlay + `EnzymeCore._deferred_marker` shell.
+              enzyme_spec = PackageSpec(; name="Enzyme",
+                                          url="https://github.com/EnzymeAD/Enzyme.jl",
+                                          rev="deferred-codegen-overlay")
+
               # add Enzyme to the test deps
               Pkg.activate("test")
-              Pkg.add(["Enzyme", "EnzymeCore"])
+              Pkg.add([enzyme_spec, PackageSpec("EnzymeCore")])
 
               # to check compatibility, also add Enzyme to the main environment
               # (or Pkg.test, which merges both environments, could fail)
               Pkg.activate(".")
               # Try to co-develop Enzyme and KA, if that fails, try just to dev Enzyme
               try
-                Pkg.develop([PackageSpec("Enzyme"), PackageSpec("KernelAbstractions")])
+                Pkg.develop([enzyme_spec, PackageSpec("KernelAbstractions")])
               catch err
                 try
-                  Pkg.develop([PackageSpec("Enzyme")])
+                  Pkg.develop([enzyme_spec])
                 catch err
                   @error "Could not install Enzyme" exception=(err,catch_backtrace())
                   exit(3)

--- a/CUDACore/ext/EnzymeCoreExt.jl
+++ b/CUDACore/ext/EnzymeCoreExt.jl
@@ -13,6 +13,45 @@ else
 end
 using GPUArrays
 
+# Two overlays in `CUDACore.method_table` that route deferred-codegen through
+# CUDA's `GPUInterpreter` during kernel compilation:
+#
+# 1. `EnzymeCore._deferred_marker(id::UInt)` — its body holds the
+#    `extern deferred_codegen` ccall marker that GPUCompiler's scanner picks
+#    up to link the inner Enzyme adjoint into the kernel module. The
+#    default body in EnzymeCore is just `reinterpret(Ptr{Cvoid}, id)`, so
+#    host-side Julia codegen never has to resolve an extern symbol — this
+#    keeps the sysimage build clean (EnzymeAD/Enzyme.jl#3091). Enzyme.jl
+#    provides a matching overlay in `GPUCompiler.GLOBAL_METHOD_TABLE` for
+#    higher-order CPU AD via its own interpreter.
+#
+# 2. `EnzymeCore.autodiff(::ReverseMode|::ForwardMode, …)` — redirect to
+#    `autodiff_deferred` so user kernels can call plain
+#    `Enzyme.autodiff(...)` and get the deferred-codegen path inside CUDA
+#    compilation. Eliminates the manual `autodiff` vs `autodiff_deferred`
+#    choice that KernelAbstractions's `gpu_fwd` makes today.
+Base.Experimental.@overlay CUDACore.method_table @inline function EnzymeCore._deferred_marker(id::UInt)
+    return ccall("extern deferred_codegen", llvmcall, Ptr{Cvoid}, (UInt,), id)
+end
+
+Base.Experimental.@overlay CUDACore.method_table @inline function EnzymeCore.autodiff(
+        mode::EnzymeCore.ReverseMode,
+        f::EnzymeCore.Annotation,
+        ::Type{A},
+        args::Vararg{EnzymeCore.Annotation, Nargs},
+    ) where {A <: EnzymeCore.Annotation, Nargs}
+    return EnzymeCore.autodiff_deferred(mode, f, A, args...)
+end
+
+Base.Experimental.@overlay CUDACore.method_table @inline function EnzymeCore.autodiff(
+        mode::EnzymeCore.ForwardMode,
+        f::EnzymeCore.Annotation,
+        ::Type{A},
+        args::Vararg{EnzymeCore.Annotation, Nargs},
+    ) where {A <: EnzymeCore.Annotation, Nargs}
+    return EnzymeCore.autodiff_deferred(mode, f, A, args...)
+end
+
 function EnzymeCore.EnzymeRules.inactive_noinl(::typeof(CUDACore.context!), args...)
     return nothing
 end


### PR DESCRIPTION
Companion to [EnzymeAD/Enzyme.jl#3112](https://github.com/EnzymeAD/Enzyme.jl/pull/3112) — addresses [EnzymeAD/Enzyme.jl#3091](https://github.com/EnzymeAD/Enzyme.jl/issues/3091).

## Summary

Two new overlays in \`CUDA.method_table\` inside \`ext/EnzymeCoreExt.jl\`:

1. **\`EnzymeCore.deferred_codegen(id::UInt) -> Ptr{Cvoid}\`** — the body holds the \`ccall(\"extern deferred_codegen\", llvmcall, …)\` marker that GPUCompiler's scanner picks up to link the inner Enzyme adjoint into the kernel module. EnzymeCore declares \`deferred_codegen\` as a method-less generic function so that \`jl_compile_all_defs\` can't despecialize the llvmcall into a host sysimage. CUDA's overlay supplies the body during kernel compilation; Enzyme.jl provides a matching overlay in \`GPUCompiler.GLOBAL_METHOD_TABLE\` for its own interpreter.

2. **\`EnzymeCore.autodiff(::ReverseMode|::ForwardMode, …)\` redirect** — inside CUDA's \`GPUInterpreter\` this forwards to \`autodiff_deferred\`, so user kernels can write plain \`Enzyme.autodiff(...)\` and get the deferred-codegen path automatically. Removes the manual \`autodiff\` vs \`autodiff_deferred\` choice that KernelAbstractions's \`gpu_fwd\` makes today.

The overlays only use EnzymeCore types, so no new weakdep is needed.

## Test plan

- [ ] CI green
- [ ] Verified locally with a CUDA kernel calling plain \`Enzyme.autodiff(Reverse, kernel, ...)\` — gradient comes out correct
- [ ] Existing \`test/extensions/enzyme.jl\` keeps passing