### PR TITLE
Fix pointer types in `cublasHgemm`

### DIFF
--- a/lib/cublas/src/libcublas.jl
+++ b/lib/cublas/src/libcublas.jl
@@ -6199,9 +6199,9 @@ end
     initialize_context()
     @ccall libcublas.cublasHgemm(handle::cublasHandle_t, transa::cublasOperation_t,
                                  transb::cublasOperation_t, m::Cint, n::Cint, k::Cint,
-                                 alpha::Ptr{Float16}, A::Ptr{Float16}, lda::Cint,
-                                 B::Ptr{Float16}, ldb::Cint, beta::Ptr{Float16},
-                                 C::Ptr{Float16}, ldc::Cint)::cublasStatus_t
+                                 alpha::CuRef{Float16}, A::CuPtr{Float16}, lda::Cint,
+                                 B::CuPtr{Float16}, ldb::Cint, beta::CuRef{Float16},
+                                 C::CuPtr{Float16}, ldc::Cint)::cublasStatus_t
 end
 
 @checked function cublasHgemm_64(handle, transa, transb, m, n, k, alpha, A, lda, B, ldb,
@@ -6210,9 +6210,9 @@ end
     initialize_context()
     @ccall libcublas.cublasHgemm_64(handle::cublasHandle_t, transa::cublasOperation_t,
                                     transb::cublasOperation_t, m::Int64, n::Int64, k::Int64,
-                                    alpha::Ptr{Float16}, A::Ptr{Float16}, lda::Int64,
-                                    B::Ptr{Float16}, ldb::Int64, beta::Ptr{Float16},
-                                    C::Ptr{Float16}, ldc::Int64)::cublasStatus_t
+                                    alpha::CuRef{Float16}, A::CuPtr{Float16}, lda::Int64,
+                                    B::CuPtr{Float16}, ldb::Int64, beta::CuRef{Float16},
+                                    C::CuPtr{Float16}, ldc::Int64)::cublasStatus_t
 end
 
 @checked function cublasHgemmBatched(handle, transa, transb, m, n, k, alpha, Aarray, lda,

--- a/lib/cublas/test/level3/gemm.jl
+++ b/lib/cublas/test/level3/gemm.jl
@@ -16,7 +16,7 @@ n = 35
 k = 13
 
 @testset "level 3" begin
-    @testset for elty in [Float32, Float64, ComplexF32, ComplexF64]
+    @testset for elty in [Float16, Float32, Float64, ComplexF32, ComplexF64]
 
         @testset "mul! C = $f(A) * $g(B) * $Ts(a) + C * $Ts(b)" for f in (identity, transpose, adjoint), g in (identity, transpose, adjoint), Ts in (Int, elty)
             C, A, B = rand(elty, 5, 5), rand(elty, 5, 5), rand(elty, 5, 5)
@@ -42,12 +42,14 @@ k = 13
             @test Array(dC) ≈ C
         end
 
-        @testset "hermitian" begin
-            C, A, B = rand(elty, 5, 5), Hermitian(rand(elty, 5, 5)), rand(elty, 5, 5)
-            dC, dA, dB = CuArray(C), Hermitian(CuArray(A)), CuArray(B)
-            mul!(dC, dA, dB)
-            mul!(C, A, B)
-            @test Array(dC) ≈ C
+        if !(elty <: Float16)
+            @testset "hermitian" begin
+                C, A, B = rand(elty, 5, 5), Hermitian(rand(elty, 5, 5)), rand(elty, 5, 5)
+                dC, dA, dB = CuArray(C), Hermitian(CuArray(A)), CuArray(B)
+                mul!(dC, dA, dB)
+                mul!(C, A, B)
+                @test Array(dC) ≈ C
+            end
         end
 
         @testset "gemm!" begin
@@ -130,42 +132,44 @@ k = 13
             @test C1 ≈ h_C1
             @test C1 ≈ h_C2
         end
-        @testset "symm!" begin
-            alpha = rand(elty)
-            beta = rand(elty)
-            sA = rand(elty,m,m)
-            sA = sA + transpose(sA)
-            dsA = CuArray(sA)
-            B = rand(elty,m,n)
-            C = rand(elty,m,n)
-            Bbad = rand(elty,m+1,n+1)
-            d_B = CuArray(B)
-            d_C = CuArray(C)
-            d_Bbad = CuArray(Bbad)
-            cuBLAS.symm!('L','U',alpha,dsA,d_B,beta,d_C)
-            C = (alpha*sA)*B + beta*C
-            # compare
-            h_C = Array(d_C)
-            @test C ≈ h_C
-            @test_throws DimensionMismatch cuBLAS.symm!('L','U',alpha,dsA,d_Bbad,beta,d_C)
-        end
 
-        @testset "symm" begin
-            sA = rand(elty,m,m)
-            sA = sA + transpose(sA)
-            dsA = CuArray(sA)
-            B = rand(elty,m,n)
-            C = rand(elty,m,n)
-            Bbad = rand(elty,m+1,n+1)
-            d_B = CuArray(B)
-            d_C = CuArray(C)
-            d_Bbad = CuArray(Bbad)
-            d_C = cuBLAS.symm('L','U',dsA,d_B)
-            C = sA*B
-            # compare
-            h_C = Array(d_C)
-            @test C ≈ h_C
-            @test_throws DimensionMismatch cuBLAS.symm('L','U',dsA,d_Bbad)
+        if !(elty <: Float16)
+            @testset "symm!" begin
+                alpha = rand(elty)
+                beta = rand(elty)
+                sA = rand(elty,m,m)
+                sA = sA + transpose(sA)
+                dsA = CuArray(sA)
+                B = rand(elty,m,n)
+                C = rand(elty,m,n)
+                Bbad = rand(elty,m+1,n+1)
+                d_B = CuArray(B)
+                d_C = CuArray(C)
+                d_Bbad = CuArray(Bbad)
+                cuBLAS.symm!('L','U',alpha,dsA,d_B,beta,d_C)
+                C = (alpha*sA)*B + beta*C
+                # compare
+                h_C = Array(d_C)
+                @test C ≈ h_C
+                @test_throws DimensionMismatch cuBLAS.symm!('L','U',alpha,dsA,d_Bbad,beta,d_C)
+            end
+            @testset "symm" begin
+                sA = rand(elty,m,m)
+                sA = sA + transpose(sA)
+                dsA = CuArray(sA)
+                B = rand(elty,m,n)
+                C = rand(elty,m,n)
+                Bbad = rand(elty,m+1,n+1)
+                d_B = CuArray(B)
+                d_C = CuArray(C)
+                d_Bbad = CuArray(Bbad)
+                d_C = cuBLAS.symm('L','U',dsA,d_B)
+                C = sA*B
+                # compare
+                h_C = Array(d_C)
+                @test C ≈ h_C
+                @test_throws DimensionMismatch cuBLAS.symm('L','U',dsA,d_Bbad)
+            end
         end
 
         if elty <: Complex

--- a/res/wrap/libcublas_epilogue.jl
+++ b/res/wrap/libcublas_epilogue.jl
@@ -213,9 +213,9 @@ end
     initialize_context()
     @ccall libcublas.cublasHgemm(handle::cublasHandle_t, transa::cublasOperation_t,
                                  transb::cublasOperation_t, m::Cint, n::Cint, k::Cint,
-                                 alpha::Ptr{Float16}, A::Ptr{Float16}, lda::Cint,
-                                 B::Ptr{Float16}, ldb::Cint, beta::Ptr{Float16},
-                                 C::Ptr{Float16}, ldc::Cint)::cublasStatus_t
+                                 alpha::CuRef{Float16}, A::CuPtr{Float16}, lda::Cint,
+                                 B::CuPtr{Float16}, ldb::Cint, beta::CuRef{Float16},
+                                 C::CuPtr{Float16}, ldc::Cint)::cublasStatus_t
 end
 
 @checked function cublasHgemm_64(handle, transa, transb, m, n, k, alpha, A, lda, B, ldb, beta,
@@ -223,9 +223,9 @@ end
     initialize_context()
     @ccall libcublas.cublasHgemm_64(handle::cublasHandle_t, transa::cublasOperation_t,
                                     transb::cublasOperation_t, m::Int64, n::Int64, k::Int64,
-                                    alpha::Ptr{Float16}, A::Ptr{Float16}, lda::Int64,
-                                    B::Ptr{Float16}, ldb::Int64, beta::Ptr{Float16},
-                                    C::Ptr{Float16}, ldc::Int64)::cublasStatus_t
+                                    alpha::CuRef{Float16}, A::CuPtr{Float16}, lda::Int64,
+                                    B::CuPtr{Float16}, ldb::Int64, beta::CuRef{Float16},
+                                    C::CuPtr{Float16}, ldc::Int64)::cublasStatus_t
 end
 
 @checked function cublasHgemmBatched(handle, transa, transb, m, n, k, alpha, Aarray, lda,


### PR DESCRIPTION
In the current main branch this fails
```julia
N = 256
A = CUDA.rand(Float16, N, N)
B = CUDA.rand(Float16, N, N)
C = CUDA.zeros(Float16, N, N)
CUDA.CUBLAS.gemm!('N', 'N', one(Float16), A, B, zero(Float16), C)
```
with
```julia
ERROR: MethodError: no method matching unsafe_convert(::Type{Ptr{Float16}}, ::Float16)
The function `unsafe_convert` exists, but no method is defined for this combination of argument types.

Closest candidates are:
  unsafe_convert(::Type{Cwstring}, ::Any)
   @ Base strings/cstring.jl:101
  unsafe_convert(::Type{Ptr{T}}, ::Array{T}) where T
   @ Base pointer.jl:65
  unsafe_convert(::Type{Ptr{T}}, ::Ptr{NTuple{N, T}}) where {N, T}
   @ Base refpointer.jl:188

```
This PR fixes this issue.