### PR TITLE
Ensure CUDACompilerJob works with subtypes of PTXCompilerTarget

### DIFF
--- a/CUDACore/src/compiler/compilation.jl
+++ b/CUDACore/src/compiler/compilation.jl
@@ -12,8 +12,8 @@ function Base.hash(params::CUDACompilerParams, h::UInt)
     return h
 end
 
-const CUDACompilerConfig = CompilerConfig{PTXCompilerTarget, CUDACompilerParams}
-const CUDACompilerJob = CompilerJob{PTXCompilerTarget,CUDACompilerParams}
+const CUDACompilerConfig = CompilerConfig{<:PTXCompilerTarget, CUDACompilerParams}
+const CUDACompilerJob = CompilerJob{<:PTXCompilerTarget,CUDACompilerParams}
 
 GPUCompiler.runtime_module(@nospecialize(job::CUDACompilerJob)) = CUDACore
 
@@ -262,7 +262,7 @@ end
     end
 
     # create GPUCompiler objects
-    target = PTXCompilerTarget(; cap=base_version(llvm_sm), ptx=llvm_ptx,
+    target = PTXCompilerTarget{Nothing}(; cap=base_version(llvm_sm), ptx=llvm_ptx,
                                  feature_set=llvm_sm.feature_set,
                                  debuginfo=true, kwargs...)
     params = CUDACompilerParams(; sm=ptxas_sm, ptx=ptxas_ptx)

--- a/CUDACore/src/device/runtime.jl
+++ b/CUDACore/src/device/runtime.jl
@@ -20,7 +20,7 @@ function precompile_runtime()
         for sm in sms, debuginfo in [false, true]
             # NOTE: this often runs when we don't have a functioning set-up,
             #       so we don't use `compiler_config` which requires NVML
-            target = PTXCompilerTarget(; cap=base_version(sm), ptx, debuginfo)
+            target = PTXCompilerTarget{Nothing}(; cap=base_version(sm), ptx, debuginfo)
             params = CUDACompilerParams(; sm, ptx)
             config = CompilerConfig(target, params)
             job = CompilerJob(mi, config)

--- a/CUDACore/src/precompile.jl
+++ b/CUDACore/src/precompile.jl
@@ -21,7 +21,7 @@ if :NVPTX in LLVM.backends()
                                     llvm_support.sm))
             llvm_ptx = maximum(filter(>=(v"6.2"), llvm_support.ptx))
 
-            target = PTXCompilerTarget(; cap=base_version(llvm_sm), ptx=llvm_ptx, debuginfo=true)
+            target = PTXCompilerTarget{Nothing}(; cap=base_version(llvm_sm), ptx=llvm_ptx, debuginfo=true)
             params = CUDACompilerParams(; sm=llvm_sm, ptx=llvm_ptx)
             config = CompilerConfig(target, params; kernel=true, name=nothing, always_inline=false)
 


### PR DESCRIPTION
companion to https://github.com/JuliaGPU/GPUCompiler.jl/pull/823

cc @gbaraldi @vchuravy @giordano @maleadt

since GPUCompiler defines several APIs, like optimization_options, on the job itself -- downstream compilers that use the PTX codegen cannot modify these methods without type piracy on all targets, or vendoring the entire api.

Adding a type parameter to PTXCompilerTarget enables this to work without piracy or vendoring large parts of the codebase