### PR TITLE
Use a private task-local RNG for kernel launch seeds

### DIFF
--- a/CUDACore/src/compiler/execution.jl
+++ b/CUDACore/src/compiler/execution.jl
@@ -473,7 +473,12 @@ end
 # cache of kernel instances
 const _kernel_instances = Dict{Any, Any}()
 
-make_seed(::HostKernel) = Random.rand(UInt32)
+# task-local RNG for kernel launch seeds, so that launching a kernel does not
+# perturb the user-visible `rand()` stream
+launch_rng() = get!(Random.Xoshiro, task_local_storage(),
+                    :CUDACore_launch_rng)::Random.Xoshiro
+
+make_seed(::HostKernel) = rand(launch_rng(), UInt32)
 
 
 ## device-side kernels

--- a/test/core/execution.jl
+++ b/test/core/execution.jl
@@ -1222,3 +1222,28 @@ end
 end
 
 ############################################################################################
+
+@testset "launch seed does not perturb host RNG" begin
+
+    dummy_kernel() = return
+
+    Random.seed!(0xdeadbeef)
+    a_before = rand(UInt64)
+    @cuda threads=1 dummy_kernel()
+    a_after  = rand(UInt64)
+
+    Random.seed!(0xdeadbeef)
+    b_before = rand(UInt64)
+    b_after  = rand(UInt64)
+
+    @test a_before == b_before
+    @test a_after  == b_after
+
+    k = @cuda launch=false dummy_kernel()
+    seed1 = CUDACore.make_seed(k)
+    seed2 = CUDACore.make_seed(k)
+    @test seed1 != seed2
+
+end
+
+############################################################################################


### PR DESCRIPTION
Fixes #2417.

## Problem

`make_seed(::HostKernel)` draws from Julia's default RNG on every kernel launch, so launching a kernel advances the user-visible `rand()` stream:

```julia
Random.seed!(42); a = rand()
Random.seed!(42); @cuda kernel(); b = rand()
a != b  # surprising
```

## Fix

Following the direction suggested in the issue ("probably better to maintain a local RNG in CUDA.jl for launching kernels"), `make_seed` now draws from a private task-local `Xoshiro` that is lazily created in `task_local_storage()`:

```julia
launch_rng() = get!(Random.Xoshiro, task_local_storage(),
                    :CUDACore_launch_rng)::Random.Xoshiro

make_seed(::HostKernel) = rand(launch_rng(), UInt32)
```

`Xoshiro()` seeds itself from system entropy *without* touching the default RNG, so the launch RNG is fully decoupled from the default RNG in both directions:

- launches no longer perturb the user's `rand()` stream, and
- `Random.seed!(...)` no longer influences which seeds reach kernels (device-side reproducibility remains available via in-kernel `Random.seed!`, which is unchanged).

Task-local storage was chosen over a module-global RNG to stay thread-safe without locking on the launch path, mirroring how Julia's own default RNG is per-task. The `get!(factory, dict, key)` form matches the existing `devices()` helpers in `lib/cublas` / `lib/cusolver`, and the `::Random.Xoshiro` assertion keeps the launch path type-stable (0 allocations on the fast path). Device-side seeding (`make_seed(::DeviceKernel)` and `device/random.jl`'s Philox2x32) is untouched.

An alternative considered: a global atomic counter (Philox keys only need to be distinct, not random, so sequential keys would give independent streams). That would make seeds deterministic across runs, which is a bigger semantic change — happy to switch if that behavior is preferred.

## Testing

Added a regression test in `test/core/execution.jl` asserting the host RNG stream is identical with and without an interleaved launch, and that consecutive launches still receive distinct seeds. Verified on a Quadro RTX 6000 (sm_75, Julia 1.11.9): new testset passes (6/6) and the existing device-side RNG tests are unaffected (11/11).

## Possible follow-up (out of scope here)

If deterministic launch seeds are ever wanted (e.g. for debugging), a `CUDA.seed_launch!(seed)` that reseeds the task-local launch RNG would slot in cleanly on top of this — happy to do that as a separate PR if there's interest.
