### PR TITLE
Add narrow-precision floats to cudaDataType

### DIFF
--- a/CUDACore/src/library_types.jl
+++ b/CUDACore/src/library_types.jl
@@ -33,6 +33,12 @@ end
     C_64I  = 25 # complex as a pair of signed 64-bit int numbers
     R_64U  = 26 # real as a unsigned 64-bit int
     C_64U  = 27 # complex as a pair of unsigned 64-bit int numbers
+    R_8F_E4M3  = 28 # real as a nv_fp8_e4m3
+    R_8F_E5M2  = 29 # real as a nv_fp8_e5m2
+    R_8F_UE8M0 = 30 # real as an exponent-only unsigned nv_fp8_e8m0
+    R_6F_E2M3  = 31 # real as a nv_fp6_e2m3
+    R_6F_E3M2  = 32 # real as a nv_fp6_e3m2
+    R_4F_E2M1  = 33 # real as a nv_fp4_e2m1
 end
 
 function Base.convert(::Type{cudaDataType}, T::DataType)

--- a/CUDACore/src/library_types.jl
+++ b/CUDACore/src/library_types.jl
@@ -41,6 +41,8 @@ end
     R_4F_E2M1  = 33 # real as a nv_fp4_e2m1
 end
 
+const R_8F_UE4M3 = R_8F_E4M3 # real as an unsigned nv_fp8_e4m3
+
 function Base.convert(::Type{cudaDataType}, T::DataType)
     if T === Float16
         return R_16F

--- a/test/core/utils.jl
+++ b/test/core/utils.jl
@@ -30,4 +30,10 @@ end
     end
     @test_throws ArgumentError convert(CUDACore.cudaDataType, BigFloat)
     @test_throws ArgumentError Type(CUDACore.R_4I) # adjust once we support 4-bit Ints
+    # narrow-precision floats: enum members exist,
+    # but no Julia type maps to them in CUDACore.
+    for c_type in (CUDACore.R_8F_E4M3, CUDACore.R_8F_E5M2, CUDACore.R_8F_UE8M0,
+                   CUDACore.R_6F_E2M3, CUDACore.R_6F_E3M2, CUDACore.R_4F_E2M1)
+        @test_throws ArgumentError Type(c_type)
+    end
 end


### PR DESCRIPTION
Adds narrow-precision floats to the cudaDataType enum based on `library_types.h` in CUDA 13:

```c
    CUDA_R_8F_E4M3 = 28, /* real as a nv_fp8_e4m3 */
    CUDA_R_8F_UE4M3 = CUDA_R_8F_E4M3, /* real as an unsigned nv_fp8_e4m3 */
    CUDA_R_8F_E5M2 = 29, /* real as a nv_fp8_e5m2 */
    CUDA_R_8F_UE8M0 = 30,  /* real as an exponent-only unsigned nv_fp8_e8m0 */
    CUDA_R_6F_E2M3  = 31,  /* real as a nv_fp6_e2m3 */
    CUDA_R_6F_E3M2  = 32,  /* real as a nv_fp6_e3m2 */
    CUDA_R_4F_E2M1  = 33,  /* real as a nv_fp4_e2m1 */
```

`R_8F_UE4M3` is an alias of `R_8F_E4M3`, differing semantically in that the sign is meaningless in the NVFP4 block-scaling format where every element has a sign anyway.

Implementations like [DLFP8Types.jl](https://github.com/chengchingwen/DLFP8Types.jl) and [Microfloats.jl](https://github.com/MurrellGroup/Microfloats.jl) could define e.g. `Base.convert(::Type{CUDACore.cudaDataType}, ::Type{Float8_E5M2}) = CUDACore.R_8F_E5M2` in an extension, or there could be some `jltype_to_cudaDataType` function.

It doesn't work the other way though, since each cudaDataType can only map to one julia type, but not sure when this would be needed.