### PR TITLE
Skip device-to-device copies of zero-byte arrays.

### DIFF
--- a/CUDACore/lib/cudadrv/memory.jl
+++ b/CUDACore/lib/cudadrv/memory.jl
@@ -421,7 +421,9 @@ for (fn, srcPtrTy, dstPtrTy) in (("cuMemcpyDtoHAsync_v2", :CuPtr, :Ptr),
     @eval function Base.unsafe_copyto!(dst::$dstPtrTy{T}, src::$srcPtrTy{T}, N::Integer;
                                        stream::CuStream=stream(),
                                        async::Bool=false) where T
-        $(getproperty(CUDACore, Symbol(fn)))(dst, src, N*aligned_sizeof(T), stream)
+        nbytes = N*aligned_sizeof(T)
+        nbytes == 0 && return dst
+        $(getproperty(CUDACore, Symbol(fn)))(dst, src, nbytes, stream)
         async || synchronize(stream)
         return dst
     end
@@ -430,14 +432,16 @@ end
 function Base.unsafe_copyto!(dst::CuPtr{T}, src::CuPtr{T}, N::Integer;
                              stream::CuStream=stream(),
                              async::Bool=false) where T
+    nbytes = N*aligned_sizeof(T)
+    nbytes == 0 && return dst
     dst_dev = device(dst)
     src_dev = device(src)
     if dst_dev == src_dev
-        cuMemcpyDtoDAsync_v2(dst, src, N*aligned_sizeof(T), stream)
+        cuMemcpyDtoDAsync_v2(dst, src, nbytes, stream)
     else
         cuMemcpyPeerAsync(dst, context(dst_dev),
                           src, context(src_dev),
-                          N*aligned_sizeof(T), stream)
+                          nbytes, stream)
     end
     async || synchronize(stream)
     return dst
@@ -446,7 +450,9 @@ end
 function Base.unsafe_copyto!(dst::CuArrayPtr{T}, doffs::Integer, src::Ptr{T}, N::Integer;
                              stream::CuStream=stream(),
                              async::Bool=false) where T
-    cuMemcpyHtoAAsync_v2(dst, doffs, src, N*aligned_sizeof(T), stream)
+    nbytes = N*aligned_sizeof(T)
+    nbytes == 0 && return dst
+    cuMemcpyHtoAAsync_v2(dst, doffs, src, nbytes, stream)
     async || synchronize(stream)
     return dst
 end
@@ -454,7 +460,9 @@ end
 function Base.unsafe_copyto!(dst::Ptr{T}, src::CuArrayPtr{T}, soffs::Integer, N::Integer;
                              stream::CuStream=stream(),
                              async::Bool=false) where T
-    cuMemcpyAtoHAsync_v2(dst, src, soffs, N*aligned_sizeof(T), stream)
+    nbytes = N*aligned_sizeof(T)
+    nbytes == 0 && return dst
+    cuMemcpyAtoHAsync_v2(dst, src, soffs, nbytes, stream)
     async || synchronize(stream)
     return dst
 end

--- a/test/core/array.jl
+++ b/test/core/array.jl
@@ -629,6 +629,18 @@ end
   @test b.x != a.x
 end
 
+struct Issue3181 end
+@testset "issue 3181: copy with zero-size element type" begin
+  # copying a non-empty array of a zero-size element type should not touch the
+  # (NULL) backing pointer, as there are no bytes to copy
+  a = CuArray(fill(Issue3181(), 10))
+  @test sizeof(a) == 0
+  @test length(copy(a)) == 10
+  @test length(deepcopy(a)) == 10
+  @test Array(a) == fill(Issue3181(), 10)
+  @test length(copyto!(similar(a), a)) == 10
+end
+
 @testset "isbits unions" begin
   # test that the selector bytes are preserved when up and downloading
   let a = [1, nothing, 3]


### PR DESCRIPTION
Fixes #3181.