### PR TITLE
Fix cluster barriers silently trapping on Julia <= 1.11

### DIFF
--- a/CUDACore/src/device/intrinsics/synchronization.jl
+++ b/CUDACore/src/device/intrinsics/synchronization.jl
@@ -72,11 +72,26 @@ export barrier_sync
 
 export cluster_arrive, cluster_arrive_relaxed, cluster_wait
 
-@device_functions begin
-cluster_arrive() = ccall("llvm.nvvm.barrier.cluster.arrive", llvmcall, Cvoid, ())
-cluster_arrive_relaxed() = ccall("llvm.nvvm.barrier.cluster.arrive.relaxed", llvmcall, Cvoid, ())
-cluster_wait() = ccall("llvm.nvvm.barrier.cluster.wait", llvmcall, Cvoid, ())
-end # @device_functions
+# These intrinsics only exist in LLVM 17+, so `ccall(intr, llvmcall, ...)` cannot be
+# used here: on older LLVM (Julia <= 1.11) the unknown name demotes to a runtime trap.
+# A textual declaration passes through to the NVPTX back end on every version, but
+# must spell out the attributes the loaded LLVM can't infer: `convergent`, plus
+# `nomerge` to stop pre-17 SimplifyCFG from merging the calls across branches.
+for (fn, barrier) in ["cluster_arrive"         => "arrive",
+                      "cluster_arrive_relaxed" => "arrive.relaxed",
+                      "cluster_wait"           => "wait"]
+    intr = "llvm.nvvm.barrier.cluster.$barrier"
+    mod = """
+        declare void @$intr() #0
+        define void @entry() #1 {
+            call void @$intr()
+            ret void
+        }
+        attributes #0 = { convergent nomerge nounwind }
+        attributes #1 = { alwaysinline }"""
+    @eval @device_function @inline $(Symbol(fn))() =
+        Base.llvmcall(($mod, "entry"), Cvoid, Tuple{})
+end
 
 ## memory barriers (membar)
 

--- a/test/core/device/intrinsics/clusters.jl
+++ b/test/core/device/intrinsics/clusters.jl
@@ -1,4 +1,17 @@
 @testset "thread block clusters" begin
+
+# the barriers must survive to device IR on every Julia; on LLVM <= 16 they
+# used to demote to a silent trap stub (runs on any hardware)
+@testset "barrier codegen" begin
+    @test @filecheck CUDA.code_llvm(Tuple{}) do
+        @check "llvm.nvvm.barrier.cluster.arrive"
+        @check "llvm.nvvm.barrier.cluster.wait"
+        @check_not "gpu_report_exception"
+        cluster_arrive()
+        cluster_wait()
+    end
+end
+
 if capability(device()) >= v"9.0" && VERSION >= v"1.11-"
 
 ###########################################################################################


### PR DESCRIPTION
The cluster barriers use `ccall("llvm.nvvm.barrier.cluster.*", llvmcall, ...)`, which resolves the name against the loaded LLVM. These intrinsics only exist in LLVM 17+, so on Julia 1.10/1.11 the call lowers to a deferred runtime error: the kernel compiles cleanly and traps at launch, with no diagnostic. CI never sees it because the cluster tests require sm_90 hardware, which never runs with Julia 1.11.

Fix: emit them via the full-module `llvmcall` form (as `version.jl` does), so the name passes through to the NVPTX back end, with `convergent nomerge` spelled out since the loaded LLVM can't infer attributes for unknown names (`nomerge` because SimplifyCFG only learned to not merge convergent calls in LLVM 17).

Also adds a codegen test outside the capability gate — device IR must contain both calls and no `gpu_report_exception` — so it runs on all CI, including CPU-only. Verified on 1.10/1.11/1.12: IR and sm_90 PTX contain the barriers, and the new test fails on 1.11 without the fix.

Diagnosed by Fable 5