### PR TITLE
Make kernel launches allocation-free (on Julia 1.12+)

### DIFF
--- a/CUDACore/lib/cudadrv/execution.jl
+++ b/CUDACore/lib/cudadrv/execution.jl
@@ -36,37 +36,40 @@ function launch(f::CuFunction, args::Vararg{Any,N}; blocks::CuDim=1, threads::Cu
     threaddim = CuDim3(threads)
     clusterdim = CuDim3(clustersize)
 
-    attrs = CUDACore.CUlaunchAttribute[]
-    if cooperative
-        resize!(attrs, length(attrs)+1)
-        attr = pointer(attrs, length(attrs))
-        attr.id = CUDACore.CU_LAUNCH_ATTRIBUTE_COOPERATIVE
-        attr.value.cooperative = 1;
-    end
-    if clusterdim.x != 1 || clusterdim.y != 1 || clusterdim.z != 1
-        resize!(attrs, length(attrs)+1)
-        attr = pointer(attrs, length(attrs))
-        attr.id = CUDACore.CU_LAUNCH_ATTRIBUTE_CLUSTER_DIMENSION
-        attr.value.clusterDim.x = clusterdim.x
-        attr.value.clusterDim.y = clusterdim.y
-        attr.value.clusterDim.z = clusterdim.z
-    end
+    attributes = Ref{NTuple{2,CUlaunchAttribute}}()
+    GC.@preserve attributes stream begin
+        attributes_ptr = Base.unsafe_convert(Ptr{CUlaunchAttribute}, attributes)
+        num_attributes = 0
+        if cooperative
+            attribute = attributes_ptr + num_attributes * sizeof(CUlaunchAttribute)
+            attribute.id = CU_LAUNCH_ATTRIBUTE_COOPERATIVE
+            attribute.value.cooperative = 1
+            num_attributes += 1
+        end
+        if clusterdim.x != 1 || clusterdim.y != 1 || clusterdim.z != 1
+            attribute = attributes_ptr + num_attributes * sizeof(CUlaunchAttribute)
+            attribute.id = CU_LAUNCH_ATTRIBUTE_CLUSTER_DIMENSION
+            attribute.value.clusterDim.x = clusterdim.x
+            attribute.value.clusterDim.y = clusterdim.y
+            attribute.value.clusterDim.z = clusterdim.z
+            num_attributes += 1
+        end
 
-    GC.@preserve attrs stream begin
-        config = Ref(CUlaunchConfig(blockdim.x, blockdim.y, blockdim.z,
-                                    threaddim.x, threaddim.y, threaddim.z,
-                                    shmem, stream.handle, pointer(attrs), length(attrs)))
+        config_attrs = num_attributes == 0 ? Ptr{CUlaunchAttribute}(C_NULL) : attributes_ptr
+        config = CUlaunchConfig(blockdim.x, blockdim.y, blockdim.z,
+                                threaddim.x, threaddim.y, threaddim.z,
+                                shmem, stream.handle, config_attrs, num_attributes)
         try
             pack_arguments(args...) do kernelParams
                 cuLaunchKernelEx(config, f, kernelParams, C_NULL)
             end
         catch err
-            diagnose_launch_failure(f, config, err; blockdim, threaddim, clusterdim, shmem)
+            diagnose_launch_failure(f, err; blockdim, threaddim, clusterdim, shmem)
         end
     end
 end
 
-@noinline function diagnose_launch_failure(f::CuFunction, config::Ref{CUlaunchConfig}, err; blockdim, threaddim, clusterdim, shmem)
+@noinline function diagnose_launch_failure(f::CuFunction, err; blockdim, threaddim, clusterdim, shmem)
     if !isa(err, CuError) || !in(err.code, [ERROR_INVALID_VALUE,
                                             ERROR_LAUNCH_OUT_OF_RESOURCES])
         rethrow()

--- a/CUDACore/lib/cudadrv/execution.jl
+++ b/CUDACore/lib/cudadrv/execution.jl
@@ -1,46 +1,16 @@
 # Execution control
 
-# In contrast to `Base.RefValue` we just need a container for both pass-by-ref (Symbol),
-# and pass-by-value (immutable structs).
-mutable struct ArgBox{T}
-    const val::T
-end
-
-function Base.unsafe_convert(P::Union{Type{Ptr{T}}, Type{Ptr{Cvoid}}}, b::ArgBox{T})::P where {T}
-    # TODO: What to do if T is not a leaftype (compare case 3 for RefValue)
-    return pointer_from_objref(b)
-end
-
-
 ## device
 
 export cudacall
 
 # pack arguments in a buffer that CUDA expects
-@inline @generated function pack_arguments(f::Function, args...)
-    ex = quote end
-
-    # If f has N parameters, then kernelParams needs to be an array of N pointers.
-    # Each of kernelParams[0] through kernelParams[N-1] must point to a region of memory
-    # from which the actual kernel parameter will be copied.
-
-    # put arguments in Ref boxes so that we can get a pointers to them
-    arg_refs = Vector{Symbol}(undef, length(args))
-    for i in 1:length(args)
-        arg_refs[i] = gensym()
-        push!(ex.args, :($(arg_refs[i]) = $ArgBox(args[$i])))
+@inline function pack_arguments(f::F, args...) where {F}
+    refs = map(Ref, args)
+    GC.@preserve args refs begin
+        pointers = map(ref -> Ptr{Cvoid}(pointer_from_objref(ref)), refs)
+        f(Ref(pointers))
     end
-
-    # generate an array with pointers
-    arg_ptrs = [:(Base.unsafe_convert(Ptr{Cvoid}, $(arg_refs[i]))) for i in 1:length(args)]
-
-    append!(ex.args, (quote
-        GC.@preserve $(arg_refs...) begin
-            kernelParams = [$(arg_ptrs...)]
-            f(kernelParams)
-        end
-    end).args)
-    return ex
 end
 
 """

--- a/CUDACore/lib/cudadrv/execution.jl
+++ b/CUDACore/lib/cudadrv/execution.jl
@@ -1,14 +1,25 @@
 # Execution control
 
+# Kernel parameters need the address of the value slot, including for boxed values like Symbol.
+mutable struct ArgBox{T}
+    const val::T
+end
+
+@inline function Base.unsafe_convert(P::Union{Type{Ptr{T}},Type{Ptr{Cvoid}}},
+                                     box::ArgBox{T})::P where {T}
+    return pointer_from_objref(box)
+end
+
+
 ## device
 
 export cudacall
 
 # pack arguments in a buffer that CUDA expects
 @inline function pack_arguments(f::F, args...) where {F}
-    refs = map(Ref, args)
-    GC.@preserve args refs begin
-        pointers = map(ref -> Ptr{Cvoid}(pointer_from_objref(ref)), refs)
+    boxes = map(ArgBox, args)
+    GC.@preserve args boxes begin
+        pointers = map(box -> Base.unsafe_convert(Ptr{Cvoid}, box), boxes)
         f(Ref(pointers))
     end
 end

--- a/CUDACore/lib/cudadrv/graph.jl
+++ b/CUDACore/lib/cudadrv/graph.jl
@@ -157,8 +157,11 @@ function capture_status(stream::CuStream=stream())
             id=(status_ref[] == STREAM_CAPTURE_STATUS_ACTIVE ? id_ref[] : nothing))
 end
 
-is_capturing(stream::CuStream=stream()) =
-    capture_status(stream).status != STREAM_CAPTURE_STATUS_NONE
+@inline function is_capturing(stream::CuStream=stream())
+    status = Ref{CUstreamCaptureStatus}()
+    cuStreamIsCapturing(stream, status)
+    return status[] != STREAM_CAPTURE_STATUS_NONE
+end
 
 
 ## convenience macro

--- a/CUDACore/lib/cudadrv/libcuda.jl
+++ b/CUDACore/lib/cudadrv/libcuda.jl
@@ -4078,7 +4078,7 @@ end
 end
 
 @checked function cuCtxGetCurrent(pctx)
-    @gcsafe_ccall libcuda.cuCtxGetCurrent(pctx::Ptr{CUcontext})::CUresult
+    @gcsafe_ccall libcuda.cuCtxGetCurrent(pctx::Ref{CUcontext})::CUresult
 end
 
 @checked function cuCtxGetDevice(device)
@@ -5250,7 +5250,7 @@ end
 @checked function cuStreamIsCapturing(hStream, captureStatus)
     initialize_context()
     @gcsafe_ccall libcuda.cuStreamIsCapturing(hStream::CUstream,
-                                              captureStatus::Ptr{CUstreamCaptureStatus})::CUresult
+                                              captureStatus::Ref{CUstreamCaptureStatus})::CUresult
 end
 
 @checked function cuStreamAttachMemAsync(hStream, dptr, length, flags)

--- a/CUDACore/lib/cudadrv/libcuda.jl
+++ b/CUDACore/lib/cudadrv/libcuda.jl
@@ -5440,7 +5440,7 @@ end
 
 @checked function cuLaunchKernelEx(config, f, kernelParams, extra)
     initialize_context()
-    @gcsafe_ccall libcuda.cuLaunchKernelEx(config::Ptr{CUlaunchConfig}, f::CUfunction,
+    @gcsafe_ccall libcuda.cuLaunchKernelEx(config::Ref{CUlaunchConfig}, f::CUfunction,
                                            kernelParams::Ptr{Ptr{Cvoid}},
                                            extra::Ptr{Ptr{Cvoid}})::CUresult
 end

--- a/CUDACore/lib/cudadrv/state.jl
+++ b/CUDACore/lib/cudadrv/state.jl
@@ -86,7 +86,8 @@ end
 
     # current_context() is too slow to use here (as it also calls cuCtxGetId)
     ctx = Ref{CUcontext}()
-    cuCtxGetCurrent(ctx)
+    res = unchecked_cuCtxGetCurrent(ctx)
+    res == SUCCESS || throw_api_error(res)
     if ctx[] != state.context.handle
         activate(state.context)
     end

--- a/res/wrap/cuda.toml
+++ b/res/wrap/cuda.toml
@@ -93,6 +93,9 @@ needs_context = false
 [api.cuCtxGetCurrent]
 needs_context = false
 
+[api.cuCtxGetCurrent.argtypes]
+1 = "Ref{CUcontext}"
+
 [api.cuCtxGetDevice]
 needs_context = false
 
@@ -104,6 +107,9 @@ needs_context = false
 
 [api.cuLaunchKernelEx.argtypes]
 1 = "Ref{CUlaunchConfig}"
+
+[api.cuStreamIsCapturing.argtypes]
+2 = "Ref{CUstreamCaptureStatus}"
 
 [api.cuDeviceGetLuid]
 needs_context = false

--- a/res/wrap/cuda.toml
+++ b/res/wrap/cuda.toml
@@ -102,6 +102,9 @@ needs_context = false
 [api.cuCtxGetApiVersion]
 needs_context = false
 
+[api.cuLaunchKernelEx.argtypes]
+1 = "Ref{CUlaunchConfig}"
+
 [api.cuDeviceGetLuid]
 needs_context = false
 

--- a/test/core/cudadrv.jl
+++ b/test/core/cudadrv.jl
@@ -381,11 +381,13 @@ let A = CUDA.zeros(Int, 1)
     # ensure compilation
     A .+= 1
     @test Array(A) == [1]
+    @test !is_capturing()
 
     graph = capture() do
         @test is_capturing()
         A .+= 1
     end
+    @test !is_capturing()
     @test Array(A) == [1]
 
     exec = instantiate(graph)

--- a/test/core/execution.jl
+++ b/test/core/execution.jl
@@ -270,8 +270,16 @@ end
 end
 
 @testset "clusters" begin
+    cooperative = CUDA.attribute(device(), CUDA.DEVICE_ATTRIBUTE_COOPERATIVE_LAUNCH) == 1
+    if cooperative
+        @cuda cooperative=true dummy()
+    end
+
     if CUDA.capability(device()) >= v"9.0"
         @cuda threads=64 blocks=2 clustersize=2 dummy()
+        if cooperative
+            @cuda cooperative=true threads=64 blocks=2 clustersize=2 dummy()
+        end
     else
         @test_throws CuError @cuda threads=64 blocks=2 clustersize=2 dummy()
     end

--- a/test/core/execution.jl
+++ b/test/core/execution.jl
@@ -828,6 +828,16 @@ end
         @test Array(x) == [true, false]
         @cuda pass_symbol(x, :not_var)
         @test Array(x) == [true, true]
+
+        function pass_mixed(x, name, value)
+            i = name == :var ? 1 : 2
+            x[i] = value
+            return nothing
+        end
+        y = CUDA.zeros(Int, 2)
+        @cuda pass_mixed(y, :var, 42)
+        @cuda pass_mixed(y, :not_var, 7)
+        @test Array(y) == [42, 7]
     end
 
 end


### PR DESCRIPTION
Use stack-promotable `Ref` storage for kernel arguments, launch configuration, attributes, and driver query outputs. Also use `cuStreamIsCapturing` for the common capture check.

On Julia 1.12, a warmed `@cuda launch` with real `CuArray` arguments now allocates zero bytes.

Before:
```julia-repl
julia> using CUDA, BenchmarkTools

julia> include("examples/vadd.jl")
Test Passed

julia> function launch_vadd!(a, b, c, len, count)
           for _ in 1:count
               @cuda threads=len vadd(a, b, c)
           end
           return
       end
launch_vadd! (generic function with 1 method)

julia> launch_vadd!(d_a, d_b, d_c, len, 100)

julia> CUDA.synchronize()

julia> @benchmark launch_vadd!($d_a, $d_b, $d_c, $len, 100) teardown=(CUDA.synchronize()) evals=1 samples=1_000
BenchmarkTools.Trial: 1000 samples with 1 evaluation per sample.
 Range (min … max):  156.804 μs … 228.017 μs  ┊ GC (min … max): 0.00% … 0.00%
 Time  (median):     163.156 μs               ┊ GC (median):    0.00%
 Time  (mean ± σ):   171.002 μs ±  14.748 μs  ┊ GC (mean ± σ):  0.00% ± 0.00%

   ▄█▃▂                                                   ▆
  ▅████▇▆▆▄▆▅▄▄▃▄▅▃▃▂▃▂▂▂▂▃▃▂▃▃▃▄▃▃▂▂▃▃▃▂▂▃▂▂▂▂▂▂▂▁▁▂▁▂▂▃▇█▆▅▄▂ ▃
  157 μs           Histogram: frequency by time          197 μs <

 Memory estimate: 42.19 KiB, allocs estimate: 700.
```

After:

```julia-repl
julia> @benchmark launch_vadd!($d_a, $d_b, $d_c, $len, 100) teardown=(CUDA.synchronize()) evals=1 samples=1_000
BenchmarkTools.Trial: 1000 samples with 1 evaluation per sample.
 Range (min … max):  155.842 μs … 225.292 μs  ┊ GC (min … max): 0.00% … 0.00%
 Time  (median):     159.079 μs               ┊ GC (median):    0.00%
 Time  (mean ± σ):   169.735 μs ±  15.671 μs  ┊ GC (mean ± σ):  0.00% ± 0.00%

  ▄█▇▄▄▂          ▁▁                                     ▅▆▃▃
  ███████▇█▆▇▆██▇███▇▆▅▅▆▅▆▅▄▇▇▆▇██▇▇▇▄▆▅▇▇▆▆▆▅▁▄▆▄▅▄▅▅▄▁█████▄ █
  156 μs        Histogram: log(frequency) by time        197 μs <

 Memory estimate: 0 bytes, allocs estimate: 0.
```

cc @vchuravy 