### PR TITLE
Improve/add low-level API for conversion-free launches

### DIFF
--- a/CUDACore/src/CUDAKernels.jl
+++ b/CUDACore/src/CUDAKernels.jl
@@ -122,8 +122,8 @@ function (obj::KA.Kernel{CUDABackend})(args...; ndrange=nothing, workgroupsize=n
         maxthreads = nothing
     end
 
-    invocation = CUDACore.KernelInvocation(obj.f, ctx, args...)
-    kernel = CUDACore.kernel_compile(invocation; always_inline=backend.always_inline,
+    call = CUDACore.KernelCall(obj.f, ctx, args...)
+    kernel = CUDACore.kernel_compile(call; always_inline=backend.always_inline,
                              maxthreads)
 
     # figure out the optimal workgroupsize automatically
@@ -142,7 +142,7 @@ function (obj::KA.Kernel{CUDABackend})(args...; ndrange=nothing, workgroupsize=n
         workgroupsize = threads_to_workgroupsize(threads, ndrange)
         iterspace, dynamic = KA.partition(obj, ndrange, workgroupsize)
         ctx = KA.mkcontext(obj, ndrange, iterspace)
-        invocation = CUDACore.rebind(invocation, 1 => ctx)
+        call = CUDACore.rebind(call, 1 => ctx)
     end
 
     blocks = length(KA.blocks(iterspace))
@@ -153,7 +153,7 @@ function (obj::KA.Kernel{CUDABackend})(args...; ndrange=nothing, workgroupsize=n
     end
 
     # Launch kernel
-    CUDACore.kernel_launch(kernel, invocation; threads, blocks)
+    CUDACore.kernel_launch(kernel, call; threads, blocks)
     return nothing
 end
 

--- a/CUDACore/src/CUDAKernels.jl
+++ b/CUDACore/src/CUDAKernels.jl
@@ -142,7 +142,7 @@ function (obj::KA.Kernel{CUDABackend})(args...; ndrange=nothing, workgroupsize=n
         workgroupsize = threads_to_workgroupsize(threads, ndrange)
         iterspace, dynamic = KA.partition(obj, ndrange, workgroupsize)
         ctx = KA.mkcontext(obj, ndrange, iterspace)
-        invocation = Base.setindex(invocation, ctx, 1)
+        invocation = CUDACore.rebind(invocation, 1 => ctx)
     end
 
     blocks = length(KA.blocks(iterspace))

--- a/CUDACore/src/CUDAKernels.jl
+++ b/CUDACore/src/CUDAKernels.jl
@@ -122,8 +122,8 @@ function (obj::KA.Kernel{CUDABackend})(args...; ndrange=nothing, workgroupsize=n
         maxthreads = nothing
     end
 
-    invocation = CUDACore.prepare(obj.f, ctx, args...)
-    kernel = CUDACore.compile(invocation; always_inline=backend.always_inline,
+    invocation = CUDACore.KernelInvocation(obj.f, ctx, args...)
+    kernel = CUDACore.kernel_compile(invocation; always_inline=backend.always_inline,
                              maxthreads)
 
     # figure out the optimal workgroupsize automatically
@@ -153,7 +153,7 @@ function (obj::KA.Kernel{CUDABackend})(args...; ndrange=nothing, workgroupsize=n
     end
 
     # Launch kernel
-    CUDACore.launch(kernel, invocation; threads, blocks)
+    CUDACore.kernel_launch(kernel, invocation; threads, blocks)
     return nothing
 end
 

--- a/CUDACore/src/CUDAKernels.jl
+++ b/CUDACore/src/CUDAKernels.jl
@@ -123,20 +123,19 @@ function (obj::KA.Kernel{CUDABackend})(args...; ndrange=nothing, workgroupsize=n
     end
 
     call = CUDACore.KernelCall(obj.f, ctx, args...)
-    kernel = CUDACore.kernel_compile(call; always_inline=backend.always_inline,
-                             maxthreads)
+    kernel = CUDACore.kernel_compile(call; always_inline=backend.always_inline, maxthreads)
 
     # figure out the optimal workgroupsize automatically
     if KA.workgroupsize(obj) <: KA.DynamicSize && workgroupsize === nothing
         config = CUDACore.launch_configuration(kernel.fun; max_threads=prod(ndrange))
-        threads = if backend.prefer_blocks
+        if backend.prefer_blocks
             # Prefer blocks over threads
             threads = min(prod(ndrange), config.threads)
             # XXX: Some kernels performs much better with all blocks active
             cu_blocks = max(cld(prod(ndrange), threads), config.blocks)
-            cld(prod(ndrange), cu_blocks)
+            threads = cld(prod(ndrange), cu_blocks)
         else
-            config.threads
+            threads = config.threads
         end
 
         workgroupsize = threads_to_workgroupsize(threads, ndrange)
@@ -154,6 +153,7 @@ function (obj::KA.Kernel{CUDABackend})(args...; ndrange=nothing, workgroupsize=n
 
     # Launch kernel
     CUDACore.kernel_launch(kernel, call; threads, blocks)
+
     return nothing
 end
 

--- a/CUDACore/src/CUDAKernels.jl
+++ b/CUDACore/src/CUDAKernels.jl
@@ -141,7 +141,7 @@ function (obj::KA.Kernel{CUDABackend})(args...; ndrange=nothing, workgroupsize=n
         workgroupsize = threads_to_workgroupsize(threads, ndrange)
         iterspace, dynamic = KA.partition(obj, ndrange, workgroupsize)
         ctx = KA.mkcontext(obj, ndrange, iterspace)
-        call = CUDACore.rebind(call, 1, ctx)
+        call = CUDACore.rebind(call, ctx, 1)
     end
 
     blocks = length(KA.blocks(iterspace))

--- a/CUDACore/src/CUDAKernels.jl
+++ b/CUDACore/src/CUDAKernels.jl
@@ -122,54 +122,37 @@ function (obj::KA.Kernel{CUDABackend})(args...; ndrange=nothing, workgroupsize=n
         maxthreads = nothing
     end
 
-    if KA.workgroupsize(obj) <: KA.DynamicSize
-        launch_kernel(obj, args, ndrange, workgroupsize, iterspace, ctx, maxthreads, backend)
-    else
-        launch_configured_kernel(obj, args, iterspace, ctx, maxthreads, backend)
-    end
-    return nothing
-end
-
-@inline function launch_kernel(obj, args, ndrange, ::Nothing, iterspace, ctx,
-                               maxthreads, backend)
     invocation = CUDACore.prepare(obj.f, ctx, args...)
     kernel = CUDACore.compile(invocation; always_inline=backend.always_inline,
                              maxthreads)
-    config = CUDACore.launch_configuration(kernel.fun;
-                                           max_threads=prod(ndrange))
-    threads = if backend.prefer_blocks
-        threads = min(prod(ndrange), config.threads)
-        cu_blocks = max(cld(prod(ndrange), threads), config.blocks)
-        cld(prod(ndrange), cu_blocks)
-    else
-        config.threads
+
+    # figure out the optimal workgroupsize automatically
+    if KA.workgroupsize(obj) <: KA.DynamicSize && workgroupsize === nothing
+        config = CUDACore.launch_configuration(kernel.fun; max_threads=prod(ndrange))
+        threads = if backend.prefer_blocks
+            # Prefer blocks over threads
+            threads = min(prod(ndrange), config.threads)
+            # XXX: Some kernels performs much better with all blocks active
+            cu_blocks = max(cld(prod(ndrange), threads), config.blocks)
+            cld(prod(ndrange), cu_blocks)
+        else
+            config.threads
+        end
+
+        workgroupsize = threads_to_workgroupsize(threads, ndrange)
+        iterspace, dynamic = KA.partition(obj, ndrange, workgroupsize)
+        ctx = KA.mkcontext(obj, ndrange, iterspace)
+        invocation = Base.setindex(invocation, ctx, 1)
     end
 
-    workgroupsize = threads_to_workgroupsize(threads, ndrange)
-    iterspace = first(KA.partition(obj, ndrange, workgroupsize))
     blocks = length(KA.blocks(iterspace))
-    blocks == 0 && return nothing
-
     threads = length(KA.workitems(iterspace))
-    ctx = KA.mkcontext(obj, ndrange, iterspace)
-    invocation = Base.setindex(invocation, ctx, 1)
-    CUDACore.launch(kernel, invocation; threads, blocks)
-    return nothing
-end
 
-@inline function launch_kernel(obj, args, ndrange, workgroupsize, iterspace, ctx,
-                               maxthreads, backend)
-    launch_configured_kernel(obj, args, iterspace, ctx, maxthreads, backend)
-end
+    if blocks == 0
+        return nothing
+    end
 
-@inline function launch_configured_kernel(obj, args, iterspace, ctx, maxthreads, backend)
-    blocks = length(KA.blocks(iterspace))
-    blocks == 0 && return nothing
-
-    invocation = CUDACore.prepare(obj.f, ctx, args...)
-    kernel = CUDACore.compile(invocation; always_inline=backend.always_inline,
-                             maxthreads)
-    threads = length(KA.workitems(iterspace))
+    # Launch kernel
     CUDACore.launch(kernel, invocation; threads, blocks)
     return nothing
 end

--- a/CUDACore/src/CUDAKernels.jl
+++ b/CUDACore/src/CUDAKernels.jl
@@ -132,10 +132,10 @@ end
 
 @inline function launch_kernel(obj, args, ndrange, ::Nothing, iterspace, ctx,
                                maxthreads, backend)
-    launch = CUDACore.prepared_launch(obj.f, ctx, args...;
-                                      always_inline=backend.always_inline,
-                                      maxthreads=maxthreads)
-    config = CUDACore.launch_configuration(launch.kernel.fun;
+    invocation = CUDACore.prepare(obj.f, ctx, args...)
+    kernel = CUDACore.compile(invocation; always_inline=backend.always_inline,
+                             maxthreads)
+    config = CUDACore.launch_configuration(kernel.fun;
                                            max_threads=prod(ndrange))
     threads = if backend.prefer_blocks
         threads = min(prod(ndrange), config.threads)
@@ -152,7 +152,8 @@ end
 
     threads = length(KA.workitems(iterspace))
     ctx = KA.mkcontext(obj, ndrange, iterspace)
-    CUDACore.launch_replacing(launch, Val(1), ctx; threads, blocks)
+    invocation = Base.setindex(invocation, ctx, 1)
+    CUDACore.launch(kernel, invocation; threads, blocks)
     return nothing
 end
 
@@ -162,16 +163,15 @@ end
 end
 
 @inline function launch_configured_kernel(obj, args, iterspace, ctx, maxthreads, backend)
-    CUDACore.prepare_launch(obj.f, ctx, args...;
-                            always_inline=backend.always_inline,
-                            maxthreads=maxthreads) do launch
-        blocks = length(KA.blocks(iterspace))
-        blocks == 0 && return nothing
+    blocks = length(KA.blocks(iterspace))
+    blocks == 0 && return nothing
 
-        threads = length(KA.workitems(iterspace))
-        launch(; threads, blocks)
-        return nothing
-    end
+    invocation = CUDACore.prepare(obj.f, ctx, args...)
+    kernel = CUDACore.compile(invocation; always_inline=backend.always_inline,
+                             maxthreads)
+    threads = length(KA.workitems(iterspace))
+    CUDACore.launch(kernel, invocation; threads, blocks)
+    return nothing
 end
 
 ## indexing

--- a/CUDACore/src/CUDAKernels.jl
+++ b/CUDACore/src/CUDAKernels.jl
@@ -122,34 +122,53 @@ function (obj::KA.Kernel{CUDABackend})(args...; ndrange=nothing, workgroupsize=n
         maxthreads = nothing
     end
 
+    if KA.workgroupsize(obj) <: KA.DynamicSize
+        launch_kernel(obj, args, ndrange, workgroupsize, iterspace, ctx, maxthreads, backend)
+    else
+        launch_configured_kernel(obj, args, iterspace, ctx, maxthreads, backend)
+    end
+    return nothing
+end
+
+@inline function launch_kernel(obj, args, ndrange, ::Nothing, iterspace, ctx,
+                               maxthreads, backend)
+    launch = CUDACore.prepared_launch(obj.f, ctx, args...;
+                                      always_inline=backend.always_inline,
+                                      maxthreads=maxthreads)
+    config = CUDACore.launch_configuration(launch.kernel.fun;
+                                           max_threads=prod(ndrange))
+    threads = if backend.prefer_blocks
+        threads = min(prod(ndrange), config.threads)
+        cu_blocks = max(cld(prod(ndrange), threads), config.blocks)
+        cld(prod(ndrange), cu_blocks)
+    else
+        config.threads
+    end
+
+    workgroupsize = threads_to_workgroupsize(threads, ndrange)
+    iterspace = first(KA.partition(obj, ndrange, workgroupsize))
+    blocks = length(KA.blocks(iterspace))
+    blocks == 0 && return nothing
+
+    threads = length(KA.workitems(iterspace))
+    ctx = KA.mkcontext(obj, ndrange, iterspace)
+    CUDACore.launch_replacing(launch, Val(1), ctx; threads, blocks)
+    return nothing
+end
+
+@inline function launch_kernel(obj, args, ndrange, workgroupsize, iterspace, ctx,
+                               maxthreads, backend)
+    launch_configured_kernel(obj, args, iterspace, ctx, maxthreads, backend)
+end
+
+@inline function launch_configured_kernel(obj, args, iterspace, ctx, maxthreads, backend)
     CUDACore.prepare_launch(obj.f, ctx, args...;
                             always_inline=backend.always_inline,
                             maxthreads=maxthreads) do launch
-        final_iterspace = if KA.workgroupsize(obj) <: KA.DynamicSize &&
-                             workgroupsize === nothing
-            config = CUDACore.launch_configuration(launch.kernel.fun;
-                                                   max_threads=prod(ndrange))
-            threads = if backend.prefer_blocks
-                threads = min(prod(ndrange), config.threads)
-                cu_blocks = max(cld(prod(ndrange), threads), config.blocks)
-                cld(prod(ndrange), cu_blocks)
-            else
-                config.threads
-            end
-
-            tuned_workgroupsize = threads_to_workgroupsize(threads, ndrange)
-            tuned_iterspace = first(KA.partition(obj, ndrange, tuned_workgroupsize))
-            tuned_ctx = KA.mkcontext(obj, ndrange, tuned_iterspace)
-            launch = CUDACore.replace_arguments(launch, 1 => tuned_ctx)
-            tuned_iterspace
-        else
-            iterspace
-        end
-
-        blocks = length(KA.blocks(final_iterspace))
+        blocks = length(KA.blocks(iterspace))
         blocks == 0 && return nothing
 
-        threads = length(KA.workitems(final_iterspace))
+        threads = length(KA.workitems(iterspace))
         launch(; threads, blocks)
         return nothing
     end

--- a/CUDACore/src/CUDAKernels.jl
+++ b/CUDACore/src/CUDAKernels.jl
@@ -122,37 +122,37 @@ function (obj::KA.Kernel{CUDABackend})(args...; ndrange=nothing, workgroupsize=n
         maxthreads = nothing
     end
 
-    kernel = @cuda launch=false always_inline=backend.always_inline maxthreads=maxthreads obj.f(ctx, args...)
+    CUDACore.prepare_launch(obj.f, ctx, args...;
+                            always_inline=backend.always_inline,
+                            maxthreads=maxthreads) do launch
+        final_iterspace = if KA.workgroupsize(obj) <: KA.DynamicSize &&
+                             workgroupsize === nothing
+            config = CUDACore.launch_configuration(launch.kernel.fun;
+                                                   max_threads=prod(ndrange))
+            threads = if backend.prefer_blocks
+                threads = min(prod(ndrange), config.threads)
+                cu_blocks = max(cld(prod(ndrange), threads), config.blocks)
+                cld(prod(ndrange), cu_blocks)
+            else
+                config.threads
+            end
 
-    # figure out the optimal workgroupsize automatically
-    if KA.workgroupsize(obj) <: KA.DynamicSize && workgroupsize === nothing
-        config = CUDACore.launch_configuration(kernel.fun; max_threads=prod(ndrange))
-        if backend.prefer_blocks
-            # Prefer blocks over threads
-            threads = min(prod(ndrange), config.threads)
-            # XXX: Some kernels performs much better with all blocks active
-            cu_blocks = max(cld(prod(ndrange), threads), config.blocks)
-            threads = cld(prod(ndrange), cu_blocks)
+            tuned_workgroupsize = threads_to_workgroupsize(threads, ndrange)
+            tuned_iterspace = first(KA.partition(obj, ndrange, tuned_workgroupsize))
+            tuned_ctx = KA.mkcontext(obj, ndrange, tuned_iterspace)
+            launch = CUDACore.replace_arguments(launch, 1 => tuned_ctx)
+            tuned_iterspace
         else
-            threads = config.threads
+            iterspace
         end
 
-        workgroupsize = threads_to_workgroupsize(threads, ndrange)
-        iterspace, dynamic = KA.partition(obj, ndrange, workgroupsize)
-        ctx = KA.mkcontext(obj, ndrange, iterspace)
-    end
+        blocks = length(KA.blocks(final_iterspace))
+        blocks == 0 && return nothing
 
-    blocks = length(KA.blocks(iterspace))
-    threads = length(KA.workitems(iterspace))
-
-    if blocks == 0
+        threads = length(KA.workitems(final_iterspace))
+        launch(; threads, blocks)
         return nothing
     end
-
-    # Launch kernel
-    kernel(ctx, args...; threads, blocks)
-
-    return nothing
 end
 
 ## indexing

--- a/CUDACore/src/CUDAKernels.jl
+++ b/CUDACore/src/CUDAKernels.jl
@@ -122,7 +122,7 @@ function (obj::KA.Kernel{CUDABackend})(args...; ndrange=nothing, workgroupsize=n
         maxthreads = nothing
     end
 
-    call = CUDACore.KernelCall(obj.f, ctx, args...)
+    call = CUDACore.kernel_call(obj.f, (ctx, args...))
     kernel = CUDACore.kernel_compile(call; always_inline=backend.always_inline, maxthreads)
 
     # figure out the optimal workgroupsize automatically
@@ -141,7 +141,7 @@ function (obj::KA.Kernel{CUDABackend})(args...; ndrange=nothing, workgroupsize=n
         workgroupsize = threads_to_workgroupsize(threads, ndrange)
         iterspace, dynamic = KA.partition(obj, ndrange, workgroupsize)
         ctx = KA.mkcontext(obj, ndrange, iterspace)
-        call = CUDACore.rebind(call, 1 => ctx)
+        call = CUDACore.rebind(call, 1, ctx)
     end
 
     blocks = length(KA.blocks(iterspace))

--- a/CUDACore/src/accumulate.jl
+++ b/CUDACore/src/accumulate.jl
@@ -149,53 +149,54 @@ function scan!(f::Function, output::AnyCuArray{T}, input::AnyCuArray;
     Rother = CartesianIndices((length(Rpre), length(Rpost)))
 
     # determine how many threads we can launch for the scan kernel
-    prepare_launch(partial_scan, f, output, input, Rdim, Rpre, Rpost, Rother,
-                   neutral, init, Val(true); name="scan") do launch
-        kernel_config = launch_configuration(launch.kernel.fun;
-                                             shmem=threads -> 2*threads*sizeof(T))
+    invocation = prepare(partial_scan, f, output, input, Rdim, Rpre, Rpost, Rother,
+                         neutral, init, Val(true))
+    kernel = compile(invocation; name="scan")
+    kernel_config = launch_configuration(kernel.fun;
+                                         shmem=threads -> 2*threads*sizeof(T))
 
-        # determine the grid layout to cover the other dimensions
-        blocks_other = if length(Rother) > 1
-            dev = device()
-            max_other_blocks = attribute(dev, DEVICE_ATTRIBUTE_MAX_GRID_DIM_Y)
-            (min(length(Rother), max_other_blocks),
-             cld(length(Rother), max_other_blocks))
-        else
-            (1, 1)
-        end
-
-        # does that suffice to scan the array in one go?
-        full = nextpow(2, length(Rdim))
-        if full <= kernel_config.threads
-            launch(; threads=full, blocks=(1, blocks_other...), shmem=2*full*sizeof(T))
-            return
-        end
-
-        # perform partial scans across the scanning dimension
-        # NOTE: don't set init here to avoid applying the value multiple times
-        partial = prevpow(2, kernel_config.threads)
-        blocks_dim = cld(length(Rdim), partial)
-        @cuda(threads=partial, blocks=(blocks_dim, blocks_other...), shmem=2*partial*sizeof(T),
-              partial_scan(f, output, input, Rdim, Rpre, Rpost, Rother, neutral, nothing, Val(true)))
-
-        # get the total of each thread block (except the first) of the partial scans
-        aggregates = fill(neutral, Base.setindex(size(input), blocks_dim, dims))
-        partials = selectdim(output, dims, partial:partial:length(Rdim))
-        indices = CartesianIndices(partials)
-        copyto!(aggregates, indices, partials, indices)
-
-        # scan these totals to get totals for the entire partial scan
-        accumulate!(f, aggregates, aggregates; dims=dims)
-
-        # add those totals to the partial scan result
-        # NOTE: we assume that this kernel requires fewer resources than the scan kernel.
-        #       if that does not hold, launch with fewer threads and calculate
-        #       the aggregate block index within the kernel itself.
-        @cuda(threads=partial, blocks=(blocks_dim, blocks_other...),
-              aggregate_partial_scan(f, output, aggregates, Rdim, Rpre, Rpost, Rother, init))
-
-        unsafe_free!(aggregates)
+    # determine the grid layout to cover the other dimensions
+    blocks_other = if length(Rother) > 1
+        dev = device()
+        max_other_blocks = attribute(dev, DEVICE_ATTRIBUTE_MAX_GRID_DIM_Y)
+        (min(length(Rother), max_other_blocks),
+         cld(length(Rother), max_other_blocks))
+    else
+        (1, 1)
     end
+
+    # does that suffice to scan the array in one go?
+    full = nextpow(2, length(Rdim))
+    if full <= kernel_config.threads
+        launch(kernel, invocation;
+               threads=full, blocks=(1, blocks_other...), shmem=2*full*sizeof(T))
+        return output
+    end
+
+    # perform partial scans across the scanning dimension
+    # NOTE: don't set init here to avoid applying the value multiple times
+    partial = prevpow(2, kernel_config.threads)
+    blocks_dim = cld(length(Rdim), partial)
+    @cuda(threads=partial, blocks=(blocks_dim, blocks_other...), shmem=2*partial*sizeof(T),
+          partial_scan(f, output, input, Rdim, Rpre, Rpost, Rother, neutral, nothing, Val(true)))
+
+    # get the total of each thread block (except the first) of the partial scans
+    aggregates = fill(neutral, Base.setindex(size(input), blocks_dim, dims))
+    partials = selectdim(output, dims, partial:partial:length(Rdim))
+    indices = CartesianIndices(partials)
+    copyto!(aggregates, indices, partials, indices)
+
+    # scan these totals to get totals for the entire partial scan
+    accumulate!(f, aggregates, aggregates; dims=dims)
+
+    # add those totals to the partial scan result
+    # NOTE: we assume that this kernel requires fewer resources than the scan kernel.
+    #       if that does not hold, launch with fewer threads and calculate
+    #       the aggregate block index within the kernel itself.
+    @cuda(threads=partial, blocks=(blocks_dim, blocks_other...),
+          aggregate_partial_scan(f, output, aggregates, Rdim, Rpre, Rpost, Rother, init))
+
+    unsafe_free!(aggregates)
 
     return output
 end

--- a/CUDACore/src/accumulate.jl
+++ b/CUDACore/src/accumulate.jl
@@ -149,25 +149,28 @@ function scan!(f::Function, output::AnyCuArray{T}, input::AnyCuArray;
     Rother = CartesianIndices((length(Rpre), length(Rpost)))
 
     # determine how many threads we can launch for the scan kernel
-    kernel = @cuda launch=false partial_scan(f, output, input, Rdim, Rpre, Rpost, Rother, neutral, init, Val(true))
-    kernel_config = launch_configuration(kernel.fun; shmem=(threads)->2*threads*sizeof(T))
+    prepare_launch(partial_scan, f, output, input, Rdim, Rpre, Rpost, Rother,
+                   neutral, init, Val(true); name="scan") do launch
+        kernel_config = launch_configuration(launch.kernel.fun;
+                                             shmem=threads -> 2*threads*sizeof(T))
 
-    # determine the grid layout to cover the other dimensions
-    if length(Rother) > 1
-        dev = device()
-        max_other_blocks = attribute(dev, DEVICE_ATTRIBUTE_MAX_GRID_DIM_Y)
-        blocks_other = (min(length(Rother), max_other_blocks),
-                        cld(length(Rother), max_other_blocks))
-    else
-        blocks_other = (1, 1)
-    end
+        # determine the grid layout to cover the other dimensions
+        blocks_other = if length(Rother) > 1
+            dev = device()
+            max_other_blocks = attribute(dev, DEVICE_ATTRIBUTE_MAX_GRID_DIM_Y)
+            (min(length(Rother), max_other_blocks),
+             cld(length(Rother), max_other_blocks))
+        else
+            (1, 1)
+        end
 
-    # does that suffice to scan the array in one go?
-    full = nextpow(2, length(Rdim))
-    if full <= kernel_config.threads
-        @cuda(threads=full, blocks=(1, blocks_other...), shmem=2*full*sizeof(T), name="scan",
-              partial_scan(f, output, input, Rdim, Rpre, Rpost, Rother, neutral, init, Val(true)))
-    else
+        # does that suffice to scan the array in one go?
+        full = nextpow(2, length(Rdim))
+        if full <= kernel_config.threads
+            launch(; threads=full, blocks=(1, blocks_other...), shmem=2*full*sizeof(T))
+            return
+        end
+
         # perform partial scans across the scanning dimension
         # NOTE: don't set init here to avoid applying the value multiple times
         partial = prevpow(2, kernel_config.threads)
@@ -231,4 +234,3 @@ function Base.accumulate(op, A::AnyCuArray;
     end
     accumulate!(op, out, A; dims=dims, kw...)
 end
-

--- a/CUDACore/src/accumulate.jl
+++ b/CUDACore/src/accumulate.jl
@@ -149,8 +149,8 @@ function scan!(f::Function, output::AnyCuArray{T}, input::AnyCuArray;
     Rother = CartesianIndices((length(Rpre), length(Rpost)))
 
     # determine how many threads we can launch for the scan kernel
-    invocation = prepare(partial_scan, f, output, input, Rdim, Rpre, Rpost, Rother, neutral, init, Val(true))
-    kernel = compile(invocation; name="scan")
+    invocation = KernelInvocation(partial_scan, f, output, input, Rdim, Rpre, Rpost, Rother, neutral, init, Val(true))
+    kernel = kernel_compile(invocation; name="scan")
     kernel_config = launch_configuration(kernel.fun; shmem=(threads)->2*threads*sizeof(T))
 
     # determine the grid layout to cover the other dimensions
@@ -166,7 +166,7 @@ function scan!(f::Function, output::AnyCuArray{T}, input::AnyCuArray;
     # does that suffice to scan the array in one go?
     full = nextpow(2, length(Rdim))
     if full <= kernel_config.threads
-        launch(kernel, invocation;
+        kernel_launch(kernel, invocation;
                threads=full, blocks=(1, blocks_other...), shmem=2*full*sizeof(T))
     else
         # perform partial scans across the scanning dimension

--- a/CUDACore/src/accumulate.jl
+++ b/CUDACore/src/accumulate.jl
@@ -149,8 +149,8 @@ function scan!(f::Function, output::AnyCuArray{T}, input::AnyCuArray;
     Rother = CartesianIndices((length(Rpre), length(Rpost)))
 
     # determine how many threads we can launch for the scan kernel
-    invocation = KernelInvocation(partial_scan, f, output, input, Rdim, Rpre, Rpost, Rother, neutral, init, Val(true))
-    kernel = kernel_compile(invocation; name="scan")
+    call = KernelCall(partial_scan, f, output, input, Rdim, Rpre, Rpost, Rother, neutral, init, Val(true))
+    kernel = kernel_compile(call; name="scan")
     kernel_config = launch_configuration(kernel.fun; shmem=(threads)->2*threads*sizeof(T))
 
     # determine the grid layout to cover the other dimensions
@@ -166,7 +166,7 @@ function scan!(f::Function, output::AnyCuArray{T}, input::AnyCuArray;
     # does that suffice to scan the array in one go?
     full = nextpow(2, length(Rdim))
     if full <= kernel_config.threads
-        kernel_launch(kernel, invocation;
+        kernel_launch(kernel, call;
                threads=full, blocks=(1, blocks_other...), shmem=2*full*sizeof(T))
     else
         # perform partial scans across the scanning dimension

--- a/CUDACore/src/accumulate.jl
+++ b/CUDACore/src/accumulate.jl
@@ -149,20 +149,18 @@ function scan!(f::Function, output::AnyCuArray{T}, input::AnyCuArray;
     Rother = CartesianIndices((length(Rpre), length(Rpost)))
 
     # determine how many threads we can launch for the scan kernel
-    invocation = prepare(partial_scan, f, output, input, Rdim, Rpre, Rpost, Rother,
-                         neutral, init, Val(true))
+    invocation = prepare(partial_scan, f, output, input, Rdim, Rpre, Rpost, Rother, neutral, init, Val(true))
     kernel = compile(invocation; name="scan")
-    kernel_config = launch_configuration(kernel.fun;
-                                         shmem=threads -> 2*threads*sizeof(T))
+    kernel_config = launch_configuration(kernel.fun; shmem=(threads)->2*threads*sizeof(T))
 
     # determine the grid layout to cover the other dimensions
-    blocks_other = if length(Rother) > 1
+    if length(Rother) > 1
         dev = device()
         max_other_blocks = attribute(dev, DEVICE_ATTRIBUTE_MAX_GRID_DIM_Y)
-        (min(length(Rother), max_other_blocks),
-         cld(length(Rother), max_other_blocks))
+        blocks_other = (min(length(Rother), max_other_blocks),
+                        cld(length(Rother), max_other_blocks))
     else
-        (1, 1)
+        blocks_other = (1, 1)
     end
 
     # does that suffice to scan the array in one go?
@@ -170,33 +168,32 @@ function scan!(f::Function, output::AnyCuArray{T}, input::AnyCuArray;
     if full <= kernel_config.threads
         launch(kernel, invocation;
                threads=full, blocks=(1, blocks_other...), shmem=2*full*sizeof(T))
-        return output
+    else
+        # perform partial scans across the scanning dimension
+        # NOTE: don't set init here to avoid applying the value multiple times
+        partial = prevpow(2, kernel_config.threads)
+        blocks_dim = cld(length(Rdim), partial)
+        @cuda(threads=partial, blocks=(blocks_dim, blocks_other...), shmem=2*partial*sizeof(T),
+              partial_scan(f, output, input, Rdim, Rpre, Rpost, Rother, neutral, nothing, Val(true)))
+
+        # get the total of each thread block (except the first) of the partial scans
+        aggregates = fill(neutral, Base.setindex(size(input), blocks_dim, dims))
+        partials = selectdim(output, dims, partial:partial:length(Rdim))
+        indices = CartesianIndices(partials)
+        copyto!(aggregates, indices, partials, indices)
+
+        # scan these totals to get totals for the entire partial scan
+        accumulate!(f, aggregates, aggregates; dims=dims)
+
+        # add those totals to the partial scan result
+        # NOTE: we assume that this kernel requires fewer resources than the scan kernel.
+        #       if that does not hold, launch with fewer threads and calculate
+        #       the aggregate block index within the kernel itself.
+        @cuda(threads=partial, blocks=(blocks_dim, blocks_other...),
+              aggregate_partial_scan(f, output, aggregates, Rdim, Rpre, Rpost, Rother, init))
+
+        unsafe_free!(aggregates)
     end
-
-    # perform partial scans across the scanning dimension
-    # NOTE: don't set init here to avoid applying the value multiple times
-    partial = prevpow(2, kernel_config.threads)
-    blocks_dim = cld(length(Rdim), partial)
-    @cuda(threads=partial, blocks=(blocks_dim, blocks_other...), shmem=2*partial*sizeof(T),
-          partial_scan(f, output, input, Rdim, Rpre, Rpost, Rother, neutral, nothing, Val(true)))
-
-    # get the total of each thread block (except the first) of the partial scans
-    aggregates = fill(neutral, Base.setindex(size(input), blocks_dim, dims))
-    partials = selectdim(output, dims, partial:partial:length(Rdim))
-    indices = CartesianIndices(partials)
-    copyto!(aggregates, indices, partials, indices)
-
-    # scan these totals to get totals for the entire partial scan
-    accumulate!(f, aggregates, aggregates; dims=dims)
-
-    # add those totals to the partial scan result
-    # NOTE: we assume that this kernel requires fewer resources than the scan kernel.
-    #       if that does not hold, launch with fewer threads and calculate
-    #       the aggregate block index within the kernel itself.
-    @cuda(threads=partial, blocks=(blocks_dim, blocks_other...),
-          aggregate_partial_scan(f, output, aggregates, Rdim, Rpre, Rpost, Rother, init))
-
-    unsafe_free!(aggregates)
 
     return output
 end

--- a/CUDACore/src/compiler/execution.jl
+++ b/CUDACore/src/compiler/execution.jl
@@ -127,13 +127,13 @@ with different compiler options.
 end
 
 """
-    rebind(call::KernelCall, i, value)
+    rebind(call::KernelCall, value, i)
 
 Return a call with host argument `i` rebound and converted for the same backend. The
 new converted argument may have a different type; [`kernel_launch`](@ref) coerces arguments
 to the compiled kernel signature.
 """
-@inline rebind(call::KernelCall, i::Integer, value) = rebind_argument(call, value, Val(i))
+@inline rebind(call::KernelCall, value, i::Integer) = rebind_argument(call, value, Val(i))
 
 @inline @generated function rebind_argument(call::KernelCall{B,F,A,S}, value,
                                             ::Val{I}) where {B,F,A,S,I}

--- a/CUDACore/src/compiler/execution.jl
+++ b/CUDACore/src/compiler/execution.jl
@@ -2,7 +2,8 @@
 
 export @cuda, cudaconvert, cufunction, dynamic_cufunction, nextwarp, prevwarp
 @public maxthreads, registers, memory, version, KernelAdaptor
-@public AbstractBackend, LLVMBackend, DefaultBackend, kernel_convert, kernel_compile
+@public AbstractBackend, LLVMBackend, DefaultBackend, kernel_convert, kernel_compile, kernel_launch
+@public PreparedLaunch, prepare_launch, replace_arguments
 @public AbstractKernel, HostKernel, DeviceKernel
 
 
@@ -59,6 +60,86 @@ default implementation for [`LLVMBackend`](@ref) is [`cufunction`](@ref).
 """
 kernel_compile(::LLVMBackend, f::F, tt::TT=Tuple{}; kwargs...) where {F,TT} =
     cufunction(f, tt; kwargs...)
+
+"""
+    kernel_launch(backend, kernel, arguments::Tuple; kwargs...)
+
+Launch `kernel` with arguments already converted for `backend`. Backends with a
+different low-level kernel calling convention should override this method.
+"""
+@inline kernel_launch(::AbstractBackend, kernel, arguments::Tuple; kwargs...) =
+    kernel(arguments...; kwargs..., convert=Val(false))
+
+
+## prepared launches
+
+"""
+    PreparedLaunch
+
+A compiled kernel together with its converted arguments and the host objects that own them.
+Create one with [`prepare_launch`](@ref), and call it without positional arguments to launch.
+"""
+struct PreparedLaunch{B,K,R,A}
+    backend::B
+    kernel::K
+    roots::R
+    arguments::A
+end
+
+@inline function (launch::PreparedLaunch)(; kwargs...)
+    roots = launch.roots
+    GC.@preserve roots begin
+        kernel_launch(launch.backend, launch.kernel, launch.arguments; kwargs...)
+    end
+end
+
+"""
+    prepare_launch(f, args...; backend=LLVMBackend(), compiler_kwargs...) do launch
+        # inspect launch.kernel, then launch(; launch_kwargs...)
+    end
+
+Convert `f` and `args` once, compile the resulting signature, and pass a
+[`PreparedLaunch`](@ref) to the callback. The prepared launch is scoped to the callback and
+must not escape it or be used after changing the active CUDA device, context, task, or stream.
+"""
+@inline function prepare_launch(callback, f, args...;
+                                backend=LLVMBackend(), compiler_kwargs...)
+    backend = backend isa AbstractBackend ? backend : backend.DefaultBackend()
+    roots = (f=f, arguments=args)
+    GC.@preserve roots begin
+        kernel_f = kernel_convert(backend, f)
+        arguments = map(args) do arg
+            kernel_convert(backend, arg)
+        end
+        tt = Tuple{map(Core.Typeof, arguments)...}
+        kernel = kernel_compile(backend, kernel_f, tt; compiler_kwargs...)
+        callback(PreparedLaunch(backend, kernel, roots, arguments))
+    end
+end
+
+"""
+    replace_arguments(launch::PreparedLaunch, replacements::Pair...)
+
+Return a prepared launch with selected host arguments replaced and converted. Replacement
+indices are one-based. The converted tuple type must still match the compiled signature.
+"""
+@inline function replace_arguments(launch::PreparedLaunch{B,K,R,A},
+                                   replacements::Pair...) where {B,K,R,A}
+    host_arguments = launch.roots.arguments
+    arguments = launch.arguments
+    for (index, value) in replacements
+        index isa Integer || throw(ArgumentError("replacement indices must be integers"))
+        host_arguments = Base.setindex(host_arguments, value, index)
+        GC.@preserve host_arguments begin
+            converted = kernel_convert(launch.backend, value)
+            arguments = Base.setindex(arguments, converted, index)
+        end
+    end
+    typeof(arguments) === A ||
+        throw(ArgumentError("replacement changes the compiled argument types; prepare a new launch"))
+    roots = (f=launch.roots.f, arguments=host_arguments)
+    PreparedLaunch(launch.backend, launch.kernel, roots, arguments)
+end
 
 
 ## high-level @cuda interface

--- a/CUDACore/src/compiler/execution.jl
+++ b/CUDACore/src/compiler/execution.jl
@@ -3,7 +3,8 @@
 export @cuda, cudaconvert, cufunction, dynamic_cufunction, nextwarp, prevwarp
 @public maxthreads, registers, memory, version, KernelAdaptor
 @public AbstractBackend, LLVMBackend, DefaultBackend
-@public KernelInvocation, prepare, compile, rebind
+@public kernel_convert, kernel_compile, kernel_launch
+@public KernelInvocation, rebind
 @public AbstractKernel, HostKernel, DeviceKernel, backend
 
 
@@ -15,8 +16,8 @@ export @cuda, cudaconvert, cufunction, dynamic_cufunction, nextwarp, prevwarp
 Abstract supertype for `@cuda` backend dispatch. The default backend is
 [`LLVMBackend`](@ref), which compiles SIMT/PTX kernels via
 [`cufunction`](@ref). Other backends (e.g. Tile IR via cuTile.jl) register
-a subtype and define backend methods for [`prepare`](@ref), [`compile`](@ref),
-and [`launch`](@ref); `@cuda backend=...` then routes through them.
+a subtype and define methods for [`kernel_convert`](@ref), [`kernel_compile`](@ref),
+and [`kernel_launch`](@ref); `@cuda backend=...` then routes through them.
 
 `@cuda backend=...` accepts either an `AbstractBackend` instance or a
 module that defines `DefaultBackend()` returning one (e.g.
@@ -43,22 +44,22 @@ packages (e.g. `@cuda backend=cuTile ...` resolves to `cuTile.DefaultBackend()`)
 DefaultBackend() = LLVMBackend()
 
 """
-    prepare(backend, x)
+    kernel_convert(backend, x)
 
 Convert a host-side launch argument to its kernel-side form. The default
 implementation for [`LLVMBackend`](@ref) forwards to [`cudaconvert`](@ref);
 other backends override to produce backend-specific argument types.
 """
-prepare(::LLVMBackend, x) = cudaconvert(x)
+kernel_convert(::LLVMBackend, x) = cudaconvert(x)
 
 """
-    compile(backend, f, tt::Type{<:Tuple}; kwargs...) -> AbstractKernel
+    kernel_compile(backend, f, tt::Type{<:Tuple}; kwargs...) -> AbstractKernel
 
 Compile a function for the given backend. Returns an [`AbstractKernel`](@ref)
 callable as `kernel(args...; launch_kwargs...)` to launch on the GPU. The
 default implementation for [`LLVMBackend`](@ref) is [`cufunction`](@ref).
 """
-compile(::LLVMBackend, f::F, tt::TT=Tuple{}; kwargs...) where {F,TT} =
+kernel_compile(::LLVMBackend, f::F, tt::TT=Tuple{}; kwargs...) where {F,TT} =
     cufunction(f, tt; kwargs...)
 
 ## kernel invocations
@@ -66,44 +67,50 @@ compile(::LLVMBackend, f::F, tt::TT=Tuple{}; kwargs...) where {F,TT} =
 """
     KernelInvocation
 
-An immutable, self-rooting kernel invocation created by [`prepare`](@ref). It contains a
+An immutable, self-rooting kernel invocation. It contains a
 backend-specific converted function and arguments, together with the host objects that own
 them. Cache compiled kernels rather than invocations, because an invocation pins its host
-arguments and is tied to the device, context, and task that were current when it was prepared.
+arguments and is tied to the device, context, and task that were current when it was created.
 """
 struct KernelInvocation{B,F,A,R}
     backend::B
     f::F
     arguments::A
     roots::R
+
+    KernelInvocation{B,F,A,R}(backend::B, f::F, arguments::A, roots::R) where {B,F,A,R} =
+        new(backend, f, arguments, roots)
 end
 
+@inline _kernel_invocation(backend::B, f::F, arguments::A, roots::R) where {B,F,A,R} =
+    KernelInvocation{B,F,A,R}(backend, f, arguments, roots)
+
 """
-    prepare(f, args...; backend=LLVMBackend()) -> KernelInvocation
+    KernelInvocation(f, args...; backend=LLVMBackend())
 
 Convert `f` and `args` once and retain the host objects that own the converted values. Use
-[`compile`](@ref) to compile the invocation and [`launch`](@ref) to launch the resulting
-kernel without converting the arguments again.
+[`kernel_compile`](@ref) to compile the invocation and [`kernel_launch`](@ref) to launch the
+resulting kernel without converting the arguments again.
 """
-@inline function prepare(f, args...; backend=LLVMBackend())
+@inline function KernelInvocation(f, args...; backend=LLVMBackend())
     backend = backend isa AbstractBackend ? backend : backend.DefaultBackend()
     roots = (f=f, arguments=args)
     GC.@preserve roots begin
-        kernel_f = prepare(backend, f)
-        arguments = map(arg -> prepare(backend, arg), args)
-        KernelInvocation(backend, kernel_f, arguments, roots)
+        kernel_f = kernel_convert(backend, f)
+        arguments = map(arg -> kernel_convert(backend, arg), args)
+        _kernel_invocation(backend, kernel_f, arguments, roots)
     end
 end
 
 """
-    compile(invocation::KernelInvocation; compiler_kwargs...) -> AbstractKernel
+    kernel_compile(invocation::KernelInvocation; compiler_kwargs...) -> AbstractKernel
 
-Compile a prepared invocation for its backend. An invocation may be compiled more than once
+Compile an invocation for its backend. An invocation may be compiled more than once
 with different compiler options.
 """
-@inline function compile(invocation::KernelInvocation; kwargs...)
+@inline function kernel_compile(invocation::KernelInvocation; kwargs...)
     tt = Tuple{map(Core.Typeof, invocation.arguments)...}
-    compile(invocation.backend, invocation.f, tt; kwargs...)
+    kernel_compile(invocation.backend, invocation.f, tt; kwargs...)
 end
 
 """
@@ -117,8 +124,8 @@ Return host argument `i` from a [`KernelInvocation`](@ref).
     rebind(invocation::KernelInvocation, i => value)
 
 Return an invocation with host argument `i` rebound and converted for the same backend. The
-new converted argument may have a different type; [`launch`](@ref) coerces arguments to the
-compiled kernel signature.
+new converted argument may have a different type; [`kernel_launch`](@ref) coerces arguments
+to the compiled kernel signature.
 """
 @inline rebind(invocation::KernelInvocation, binding::Pair{<:Integer}) =
     rebind_argument(invocation, binding.second, Val(binding.first))
@@ -135,12 +142,12 @@ compiled kernel signature.
                               for i in 1:fieldcount(A)]...)
     quote
         GC.@preserve value begin
-            converted = prepare(invocation.backend, value)
+            converted = kernel_convert(invocation.backend, value)
         end
         host_arguments = $host_arguments
         roots = (f=invocation.roots.f, arguments=host_arguments)
         arguments = $arguments
-        KernelInvocation(invocation.backend, invocation.f, arguments, roots)
+        _kernel_invocation(invocation.backend, invocation.f, arguments, roots)
     end
 end
 
@@ -161,9 +168,9 @@ a CUDA function upon first use, and to a certain extent arguments will be conver
 managed automatically using `cudaconvert`. Finally, a call to `cudacall` is
 performed, scheduling a kernel launch on the current CUDA context.
 
-A direct launch converts each argument once. Use [`prepare`](@ref), [`compile`](@ref), and
-[`launch`](@ref) directly when compilation and launch need to be separated by occupancy
-queries or other configuration work.
+A direct launch converts each argument once. Use [`KernelInvocation`](@ref),
+[`kernel_compile`](@ref), and [`kernel_launch`](@ref) directly when compilation and launch
+need to be separated by occupancy queries or other configuration work.
 
 Several keyword arguments are supported that influence the behavior of `@cuda`.
 - `launch`: whether to launch this kernel, defaults to `true`. If `false` the returned
@@ -173,7 +180,7 @@ Several keyword arguments are supported that influence the behavior of `@cuda`.
 - `backend`: which compiler backend to use, defaults to [`LLVMBackend`](@ref). Either an
   [`AbstractBackend`](@ref) instance or a module that defines `DefaultBackend()` (e.g.
   `backend=CUDA` resolves to `CUDA.DefaultBackend()`). Backend-specific compiler kwargs
-  not recognized by `@cuda` itself are forwarded to [`compile`](@ref).
+  not recognized by `@cuda` itself are forwarded to [`kernel_compile`](@ref).
 - arguments that influence kernel compilation: see [`cufunction`](@ref) and
   [`dynamic_cufunction`](@ref)
 - arguments that influence kernel launch: see [`CUDACore.HostKernel`](@ref) and
@@ -201,7 +208,7 @@ macro cuda(ex...)
     vars, var_exprs = assign_args!(code, args)
 
     # group keyword argument. Backend-specific compiler kwargs land in
-    # `other_kwargs` and are forwarded to `compile`; the backend
+    # `other_kwargs` and are forwarded to `kernel_compile`; the backend
     # validates them.
     macro_kwargs, compiler_kwargs, call_kwargs, other_kwargs =
         split_kwargs(kwargs, MACRO_KWARGS, COMPILER_KWARGS, LAUNCH_KWARGS)
@@ -262,10 +269,10 @@ macro cuda(ex...)
                     $backend_raw isa $AbstractBackend ? $backend_raw : $backend_raw.DefaultBackend()
                 end
                 $f_var = $f
-                $invocation = $prepare($f_var, $(var_exprs...); backend=$backend)
-                $kernel = $compile($invocation; $(compiler_kwargs...), $(other_kwargs...))
+                $invocation = $KernelInvocation($f_var, $(var_exprs...); backend=$backend)
+                $kernel = $kernel_compile($invocation; $(compiler_kwargs...), $(other_kwargs...))
                 if $should_launch
-                    $launch($kernel, $invocation; $(call_kwargs...))
+                    $kernel_launch($kernel, $invocation; $(call_kwargs...))
                 end
                 $kernel
              end)
@@ -366,7 +373,8 @@ abstract type AbstractKernel{F,TT} end
 
 Low-level interface to call a compiled kernel. A `HostKernel` converts the supplied host
 arguments before launching; a `DeviceKernel` accepts GPU-compatible arguments directly. To
-reuse values already converted by [`prepare`](@ref), call [`launch`](@ref) instead.
+reuse values already converted by [`KernelInvocation`](@ref), call
+[`kernel_launch`](@ref) instead.
 
 A `HostKernel` is callable on the host, and a `DeviceKernel` is callable on the
 device (created by `@cuda` with `dynamic=true`).
@@ -404,38 +412,38 @@ end
     backend(kernel::AbstractKernel)
 
 Return the backend that compiled `kernel`. Backend kernel types define this trait so an
-existing kernel can be rebound with [`prepare(kernel, args...)`](@ref).
+invocation can be constructed for an existing kernel.
 """
 function backend end
 
 """
-    prepare(kernel::AbstractKernel, args...) -> KernelInvocation
+    KernelInvocation(kernel::AbstractKernel, args...)
 
-Prepare a new invocation for an existing kernel's function and backend.
+Construct a new invocation for an existing kernel's function and backend.
 """
-@inline prepare(kernel::AbstractKernel, args...) =
-    prepare(kernel.f, args...; backend=backend(kernel))
+@inline KernelInvocation(kernel::AbstractKernel, args...) =
+    KernelInvocation(kernel.f, args...; backend=backend(kernel))
 
 """
-    launch(kernel::AbstractKernel, invocation::KernelInvocation; launch_kwargs...)
+    kernel_launch(kernel::AbstractKernel, invocation::KernelInvocation; launch_kwargs...)
 
-Launch a compiled kernel with prepared arguments. The invocation retains the host roots for
+Launch a compiled kernel with converted arguments. The invocation retains the host roots for
 the duration of the backend launch. Converted values are coerced to the kernel's compiled
 signature at the calling boundary.
 """
-@generated function launch(kernel::AbstractKernel,
-                           invocation::KernelInvocation{B,F,A,R}; kwargs...) where {B,F,A,R}
+@generated function kernel_launch(kernel::AbstractKernel,
+                                  invocation::KernelInvocation{B,F,A,R}; kwargs...) where {B,F,A,R}
     root_vars = [gensym(:root) for _ in 1:fieldcount(A)+1]
     assignments = Any[:($(root_vars[1]) = invocation.roots.f)]
     append!(assignments,
             [:($(root_vars[i+1]) = @inbounds invocation.roots.arguments[$i])
              for i in 1:fieldcount(A)])
-    call = :(launch(invocation.backend, kernel, invocation.arguments; kwargs...))
+    call = :(kernel_launch(invocation.backend, kernel, invocation.arguments; kwargs...))
     preserve = Expr(:gc_preserve, call, root_vars...)
     Expr(:block, assignments..., preserve)
 end
 
-@inline launch(::AbstractBackend, kernel, arguments::Tuple; kwargs...) =
+@inline kernel_launch(::AbstractBackend, kernel, arguments::Tuple; kwargs...) =
     kernel(arguments...; kwargs...)
 
 @inline @generated function launch_converted(kernel::AbstractKernel{F,TT},
@@ -484,11 +492,11 @@ end
 backend(::HostKernel) = LLVMBackend()
 
 @inline function (kernel::HostKernel)(args...; kwargs...)
-    invocation = prepare(kernel, args...)
-    launch(kernel, invocation; kwargs...)
+    invocation = KernelInvocation(kernel, args...)
+    kernel_launch(kernel, invocation; kwargs...)
 end
 
-@inline launch(::LLVMBackend, kernel::HostKernel, arguments::Tuple; kwargs...) =
+@inline kernel_launch(::LLVMBackend, kernel::HostKernel, arguments::Tuple; kwargs...) =
     launch_converted(kernel, arguments; kwargs...)
 
 """

--- a/CUDACore/src/compiler/execution.jl
+++ b/CUDACore/src/compiler/execution.jl
@@ -3,7 +3,7 @@
 export @cuda, cudaconvert, cufunction, dynamic_cufunction, nextwarp, prevwarp
 @public maxthreads, registers, memory, version, KernelAdaptor
 @public AbstractBackend, LLVMBackend, DefaultBackend
-@public KernelInvocation, prepare, compile
+@public KernelInvocation, prepare, compile, rebind
 @public AbstractKernel, HostKernel, DeviceKernel, backend
 
 
@@ -114,17 +114,17 @@ Return host argument `i` from a [`KernelInvocation`](@ref).
 @inline Base.getindex(invocation::KernelInvocation, i::Integer) = invocation.roots.arguments[i]
 
 """
-    Base.setindex(invocation::KernelInvocation, value, i)
+    rebind(invocation::KernelInvocation, i => value)
 
-Return an invocation with host argument `i` replaced and converted for the same backend. The
+Return an invocation with host argument `i` rebound and converted for the same backend. The
 new converted argument may have a different type; [`launch`](@ref) coerces arguments to the
 compiled kernel signature.
 """
-@inline Base.setindex(invocation::KernelInvocation, value, i::Integer) =
-    setindex_invocation(invocation, value, Val(i))
+@inline rebind(invocation::KernelInvocation, binding::Pair{<:Integer}) =
+    rebind_argument(invocation, binding.second, Val(binding.first))
 
-@generated function setindex_invocation(invocation::KernelInvocation{B,F,A,R}, value,
-                                        ::Val{I}) where {B,F,A,R,I}
+@generated function rebind_argument(invocation::KernelInvocation{B,F,A,R}, value,
+                                    ::Val{I}) where {B,F,A,R,I}
     if !(1 <= I <= fieldcount(A))
         return :(throw(BoundsError(invocation, $I)))
     end

--- a/CUDACore/src/compiler/execution.jl
+++ b/CUDACore/src/compiler/execution.jl
@@ -117,6 +117,26 @@ must not escape it or be used after changing the active CUDA device, context, ta
     end
 end
 
+@inline function prepared_launch(f, args...;
+                                 backend=LLVMBackend(), compiler_kwargs...)
+    backend = backend isa AbstractBackend ? backend : backend.DefaultBackend()
+    prepared_launch(backend, f, args, (; compiler_kwargs...))
+end
+
+@inline function prepared_launch(backend::AbstractBackend, f, args::Tuple,
+                                 compiler_kwargs::NamedTuple)
+    roots = (f=f, arguments=args)
+    GC.@preserve roots begin
+        kernel_f = kernel_convert(backend, f)
+        arguments = map(args) do arg
+            kernel_convert(backend, arg)
+        end
+        tt = Tuple{map(Core.Typeof, arguments)...}
+        kernel = kernel_compile(backend, kernel_f, tt; compiler_kwargs...)
+        PreparedLaunch(backend, kernel, roots, arguments)
+    end
+end
+
 """
     replace_arguments(launch::PreparedLaunch, replacements::Pair...)
 
@@ -139,6 +159,18 @@ indices are one-based. The converted tuple type must still match the compiled si
         throw(ArgumentError("replacement changes the compiled argument types; prepare a new launch"))
     roots = (f=launch.roots.f, arguments=host_arguments)
     PreparedLaunch(launch.backend, launch.kernel, roots, arguments)
+end
+
+@inline function launch_replacing(launch::PreparedLaunch{B,K,R,A},
+                                  ::Val{I}, value; threads, blocks) where {B,K,R,A,I}
+    roots = launch.roots
+    GC.@preserve roots value begin
+        converted = kernel_convert(launch.backend, value)
+        arguments = Base.setindex(launch.arguments, converted, I)
+        typeof(arguments) === A ||
+            throw(ArgumentError("replacement changes the compiled argument types; prepare a new launch"))
+        kernel_launch(launch.backend, launch.kernel, arguments; threads, blocks)
+    end
 end
 
 

--- a/CUDACore/src/compiler/execution.jl
+++ b/CUDACore/src/compiler/execution.jl
@@ -62,43 +62,45 @@ default implementation for [`LLVMBackend`](@ref) is [`cufunction`](@ref).
 kernel_compile(::LLVMBackend, f::F, tt::TT=Tuple{}; kwargs...) where {F,TT} =
     cufunction(f, tt; kwargs...)
 
+
 ## kernel calls
 
 """
     KernelCall
 
-An immutable, self-rooting description of a kernel call. It contains a backend-specific
-converted function and arguments, together with the host objects that own them. Cache compiled
-kernels rather than calls, because a call pins its host arguments and is tied to the device,
-context, and task that were current when it was created.
+An description of a kernel call. It contains a backend-specific converted
+function and arguments, together with the source objects that own them. Cache
+compiled kernels rather than calls, because a call pins its host arguments and
+is tied to the device, context, and task that were current when it was created.
 """
-struct KernelCall{B,F,A,R}
+struct KernelCall{B,F,A,S}
     backend::B
     f::F
     arguments::A
-    roots::R
+    source::S
 
-    KernelCall{B,F,A,R}(backend::B, f::F, arguments::A, roots::R) where {B,F,A,R} =
-        new(backend, f, arguments, roots)
+    KernelCall{B,F,A,S}(backend::B, f::F, arguments::A, source::S) where {B,F,A,S} =
+        new(backend, f, arguments, source)
 end
 
-@inline _kernel_call(backend::B, f::F, arguments::A, roots::R) where {B,F,A,R} =
-    KernelCall{B,F,A,R}(backend, f, arguments, roots)
+@inline kernel_call(backend::B, f::F, arguments::A, source::S) where {B,F,A,S} =
+    KernelCall{B,F,A,S}(backend, f, arguments, source)
 
 """
     KernelCall(f, args...; backend=LLVMBackend())
 
-Convert `f` and `args` once and retain the host objects that own the converted values. Use
-[`kernel_compile`](@ref) to compile the call and [`kernel_launch`](@ref) to launch the
-resulting kernel without converting the arguments again.
+Convert `f` and `args` once and retain the host objects that own the converted
+values. Use [`kernel_compile`](@ref) to compile the call and
+[`kernel_launch`](@ref) to launch the resulting kernel without converting the
+arguments again.
 """
 @inline function KernelCall(f, args...; backend=LLVMBackend())
     backend = backend isa AbstractBackend ? backend : backend.DefaultBackend()
-    roots = (f=f, arguments=args)
-    GC.@preserve roots begin
+    source = (f=f, arguments=args)
+    GC.@preserve source begin
         kernel_f = kernel_convert(backend, f)
         arguments = map(arg -> kernel_convert(backend, arg), args)
-        _kernel_call(backend, kernel_f, arguments, roots)
+        kernel_call(backend, kernel_f, arguments, source)
     end
 end
 
@@ -114,13 +116,6 @@ with different compiler options.
 end
 
 """
-    call[i]
-
-Return host argument `i` from a [`KernelCall`](@ref).
-"""
-@inline Base.getindex(call::KernelCall, i::Integer) = call.roots.arguments[i]
-
-"""
     rebind(call::KernelCall, i => value)
 
 Return a call with host argument `i` rebound and converted for the same backend. The
@@ -130,13 +125,13 @@ to the compiled kernel signature.
 @inline rebind(call::KernelCall, binding::Pair{<:Integer}) =
     rebind_argument(call, binding.second, Val(binding.first))
 
-@generated function rebind_argument(call::KernelCall{B,F,A,R}, value,
-                                    ::Val{I}) where {B,F,A,R,I}
+@generated function rebind_argument(call::KernelCall{B,F,A,S}, value,
+                                    ::Val{I}) where {B,F,A,S,I}
     if !(1 <= I <= fieldcount(A))
         return :(throw(BoundsError(call, $I)))
     end
 
-    host_arguments = Expr(:tuple, [i == I ? :value : :(@inbounds call.roots.arguments[$i])
+    host_arguments = Expr(:tuple, [i == I ? :value : :(@inbounds call.source.arguments[$i])
                                    for i in 1:fieldcount(A)]...)
     arguments = Expr(:tuple, [i == I ? :converted : :(@inbounds call.arguments[$i])
                               for i in 1:fieldcount(A)]...)
@@ -145,9 +140,9 @@ to the compiled kernel signature.
             converted = kernel_convert(call.backend, value)
         end
         host_arguments = $host_arguments
-        roots = (f=call.roots.f, arguments=host_arguments)
+        source = (f=call.source.f, arguments=host_arguments)
         arguments = $arguments
-        _kernel_call(call.backend, call.f, arguments, roots)
+        kernel_call(call.backend, call.f, arguments, source)
     end
 end
 
@@ -416,11 +411,11 @@ the duration of the backend launch. Converted values are coerced to the kernel's
 signature at the calling boundary.
 """
 @generated function kernel_launch(kernel::AbstractKernel,
-                                  call::KernelCall{B,F,A,R}; kwargs...) where {B,F,A,R}
+                                  call::KernelCall{B,F,A,S}; kwargs...) where {B,F,A,S}
     root_vars = [gensym(:root) for _ in 1:fieldcount(A)+1]
-    assignments = Any[:($(root_vars[1]) = call.roots.f)]
+    assignments = Any[:($(root_vars[1]) = call.source.f)]
     append!(assignments,
-            [:($(root_vars[i+1]) = @inbounds call.roots.arguments[$i])
+            [:($(root_vars[i+1]) = @inbounds call.source.arguments[$i])
              for i in 1:fieldcount(A)])
     launch = :(kernel_launch(call.backend, kernel, call.arguments; kwargs...))
     preserve = Expr(:gc_preserve, launch, root_vars...)

--- a/CUDACore/src/compiler/execution.jl
+++ b/CUDACore/src/compiler/execution.jl
@@ -5,7 +5,7 @@ export @cuda, cudaconvert, cufunction, dynamic_cufunction, nextwarp, prevwarp
 @public AbstractBackend, LLVMBackend, DefaultBackend
 @public kernel_convert, kernel_compile, kernel_launch
 @public KernelInvocation, rebind
-@public AbstractKernel, HostKernel, DeviceKernel, backend
+@public AbstractKernel, HostKernel, DeviceKernel
 
 
 ## backend dispatch
@@ -16,8 +16,8 @@ export @cuda, cudaconvert, cufunction, dynamic_cufunction, nextwarp, prevwarp
 Abstract supertype for `@cuda` backend dispatch. The default backend is
 [`LLVMBackend`](@ref), which compiles SIMT/PTX kernels via
 [`cufunction`](@ref). Other backends (e.g. Tile IR via cuTile.jl) register
-a subtype and define methods for [`kernel_convert`](@ref), [`kernel_compile`](@ref),
-and [`kernel_launch`](@ref); `@cuda backend=...` then routes through them.
+a subtype and define methods for [`kernel_convert`](@ref) and
+[`kernel_compile`](@ref); `@cuda backend=...` then routes through them.
 
 `@cuda backend=...` accepts either an `AbstractBackend` instance or a
 module that defines `DefaultBackend()` returning one (e.g.
@@ -409,22 +409,6 @@ function Base.show(io::IO, ::MIME"text/plain", k::AbstractKernel{F,TT}) where {F
 end
 
 """
-    backend(kernel::AbstractKernel)
-
-Return the backend that compiled `kernel`. Backend kernel types define this trait so an
-invocation can be constructed for an existing kernel.
-"""
-function backend end
-
-"""
-    KernelInvocation(kernel::AbstractKernel, args...)
-
-Construct a new invocation for an existing kernel's function and backend.
-"""
-@inline KernelInvocation(kernel::AbstractKernel, args...) =
-    KernelInvocation(kernel.f, args...; backend=backend(kernel))
-
-"""
     kernel_launch(kernel::AbstractKernel, invocation::KernelInvocation; launch_kwargs...)
 
 Launch a compiled kernel with converted arguments. The invocation retains the host roots for
@@ -489,10 +473,8 @@ end
 
 @doc (@doc AbstractKernel) HostKernel
 
-backend(::HostKernel) = LLVMBackend()
-
 @inline function (kernel::HostKernel)(args...; kwargs...)
-    invocation = KernelInvocation(kernel, args...)
+    invocation = KernelInvocation(kernel.f, args...; backend=LLVMBackend())
     kernel_launch(kernel, invocation; kwargs...)
 end
 

--- a/CUDACore/src/compiler/execution.jl
+++ b/CUDACore/src/compiler/execution.jl
@@ -158,9 +158,13 @@ a CUDA function upon first use, and to a certain extent arguments will be conver
 managed automatically using `cudaconvert`. Finally, a call to `cudacall` is
 performed, scheduling a kernel launch on the current CUDA context.
 
+A direct launch converts each argument once. Use [`prepare_launch`](@ref) when compilation
+and launch need to be separated by occupancy queries or other configuration work.
+
 Several keyword arguments are supported that influence the behavior of `@cuda`.
 - `launch`: whether to launch this kernel, defaults to `true`. If `false` the returned
-  kernel object should be launched by calling it and passing arguments again.
+  kernel object should be launched by calling it and passing arguments again. That later
+  call converts the supplied host arguments independently.
 - `dynamic`: use dynamic parallelism to launch device-side kernels, defaults to `false`.
 - `backend`: which compiler backend to use, defaults to [`LLVMBackend`](@ref). Either an
   [`AbstractBackend`](@ref) instance or a module that defines `DefaultBackend()` (e.g.

--- a/CUDACore/src/compiler/execution.jl
+++ b/CUDACore/src/compiler/execution.jl
@@ -222,7 +222,7 @@ macro cuda(ex...)
 
     # FIXME: macro hygiene wrt. escaping kwarg values (this broke with 1.5)
     #        we esc() the whole thing now, necessitating gensyms...
-    @gensym f_var kernel_f kernel_args kernel_tt kernel backend backend_raw
+    @gensym f_var kernel_args kernel_tt kernel backend backend_raw prepared
     if dynamic
         # FIXME: we could probably somehow support kwargs with constant values by either
         #        saving them in a global Dict here, or trying to pick them up from the Julia
@@ -245,9 +245,6 @@ macro cuda(ex...)
              end)
     else
         # regular, host-side kernel launch
-        #
-        # convert the function, its arguments, call the compiler and launch the kernel
-        # while keeping the original arguments alive
         push!(code.args,
             quote
                 # Accept either an `AbstractBackend` instance or a module
@@ -257,16 +254,12 @@ macro cuda(ex...)
                     $backend_raw isa $AbstractBackend ? $backend_raw : $backend_raw.DefaultBackend()
                 end
                 $f_var = $f
-                GC.@preserve $(vars...) $f_var begin
-                    $kernel_f = $kernel_convert($backend, $f_var)
-                    $kernel_args = map(x -> $kernel_convert($backend, x), ($(var_exprs...),))
-                    $kernel_tt = Tuple{map(Core.Typeof, $kernel_args)...}
-                    $kernel = $kernel_compile($backend, $kernel_f, $kernel_tt;
-                                              $(compiler_kwargs...), $(other_kwargs...))
+                $prepare_launch($f_var, $(var_exprs...); backend=$backend,
+                                $(compiler_kwargs...), $(other_kwargs...)) do $prepared
                     if $launch
-                        $kernel($kernel_args...; $(call_kwargs...), convert=Val(false))
+                        $prepared(; $(call_kwargs...))
                     end
-                    $kernel
+                    $prepared.kernel
                 end
              end)
     end

--- a/CUDACore/src/compiler/execution.jl
+++ b/CUDACore/src/compiler/execution.jl
@@ -86,6 +86,18 @@ end
 @inline kernel_call(backend::B, f::F, arguments::A, source::S) where {B,F,A,S} =
     KernelCall{B,F,A,S}(backend, f, arguments, source)
 
+@inline @generated function kernel_call(backend::B, f::F, args::A) where {B,F,A<:Tuple}
+    converted = [:(kernel_convert(backend, args[$i])) for i in 1:fieldcount(A)]
+    quote
+        source = (f=f, arguments=args)
+        GC.@preserve source begin
+            kernel_f = kernel_convert(backend, f)
+            arguments = ($(converted...),)
+            kernel_call(backend, kernel_f, arguments, source)
+        end
+    end
+end
+
 """
     KernelCall(f, args...; backend=LLVMBackend())
 
@@ -95,13 +107,12 @@ values. Use [`kernel_compile`](@ref) to compile the call and
 arguments again.
 """
 @inline function KernelCall(f, args...; backend=LLVMBackend())
+    kernel_call(f, args, backend)
+end
+
+@inline function kernel_call(f, args::Tuple, backend=LLVMBackend())
     backend = backend isa AbstractBackend ? backend : backend.DefaultBackend()
-    source = (f=f, arguments=args)
-    GC.@preserve source begin
-        kernel_f = kernel_convert(backend, f)
-        arguments = map(arg -> kernel_convert(backend, arg), args)
-        kernel_call(backend, kernel_f, arguments, source)
-    end
+    kernel_call(backend, f, args)
 end
 
 """
@@ -116,17 +127,16 @@ with different compiler options.
 end
 
 """
-    rebind(call::KernelCall, i => value)
+    rebind(call::KernelCall, i, value)
 
 Return a call with host argument `i` rebound and converted for the same backend. The
 new converted argument may have a different type; [`kernel_launch`](@ref) coerces arguments
 to the compiled kernel signature.
 """
-@inline rebind(call::KernelCall, binding::Pair{<:Integer}) =
-    rebind_argument(call, binding.second, Val(binding.first))
+@inline rebind(call::KernelCall, i::Integer, value) = rebind_argument(call, value, Val(i))
 
-@generated function rebind_argument(call::KernelCall{B,F,A,S}, value,
-                                    ::Val{I}) where {B,F,A,S,I}
+@inline @generated function rebind_argument(call::KernelCall{B,F,A,S}, value,
+                                            ::Val{I}) where {B,F,A,S,I}
     if !(1 <= I <= fieldcount(A))
         return :(throw(BoundsError(call, $I)))
     end
@@ -410,8 +420,8 @@ Launch a compiled kernel with converted arguments. The call retains the host roo
 the duration of the backend launch. Converted values are coerced to the kernel's compiled
 signature at the calling boundary.
 """
-@generated function kernel_launch(kernel::AbstractKernel,
-                                  call::KernelCall{B,F,A,S}; kwargs...) where {B,F,A,S}
+@inline @generated function kernel_launch(kernel::AbstractKernel,
+                                          call::KernelCall{B,F,A,S}; kwargs...) where {B,F,A,S}
     root_vars = [gensym(:root) for _ in 1:fieldcount(A)+1]
     assignments = Any[:($(root_vars[1]) = call.source.f)]
     append!(assignments,

--- a/CUDACore/src/compiler/execution.jl
+++ b/CUDACore/src/compiler/execution.jl
@@ -4,7 +4,7 @@ export @cuda, cudaconvert, cufunction, dynamic_cufunction, nextwarp, prevwarp
 @public maxthreads, registers, memory, version, KernelAdaptor
 @public AbstractBackend, LLVMBackend, DefaultBackend
 @public kernel_convert, kernel_compile, kernel_launch
-@public KernelInvocation, rebind
+@public KernelCall, rebind
 @public AbstractKernel, HostKernel, DeviceKernel
 
 
@@ -62,92 +62,92 @@ default implementation for [`LLVMBackend`](@ref) is [`cufunction`](@ref).
 kernel_compile(::LLVMBackend, f::F, tt::TT=Tuple{}; kwargs...) where {F,TT} =
     cufunction(f, tt; kwargs...)
 
-## kernel invocations
+## kernel calls
 
 """
-    KernelInvocation
+    KernelCall
 
-An immutable, self-rooting kernel invocation. It contains a
-backend-specific converted function and arguments, together with the host objects that own
-them. Cache compiled kernels rather than invocations, because an invocation pins its host
-arguments and is tied to the device, context, and task that were current when it was created.
+An immutable, self-rooting description of a kernel call. It contains a backend-specific
+converted function and arguments, together with the host objects that own them. Cache compiled
+kernels rather than calls, because a call pins its host arguments and is tied to the device,
+context, and task that were current when it was created.
 """
-struct KernelInvocation{B,F,A,R}
+struct KernelCall{B,F,A,R}
     backend::B
     f::F
     arguments::A
     roots::R
 
-    KernelInvocation{B,F,A,R}(backend::B, f::F, arguments::A, roots::R) where {B,F,A,R} =
+    KernelCall{B,F,A,R}(backend::B, f::F, arguments::A, roots::R) where {B,F,A,R} =
         new(backend, f, arguments, roots)
 end
 
-@inline _kernel_invocation(backend::B, f::F, arguments::A, roots::R) where {B,F,A,R} =
-    KernelInvocation{B,F,A,R}(backend, f, arguments, roots)
+@inline _kernel_call(backend::B, f::F, arguments::A, roots::R) where {B,F,A,R} =
+    KernelCall{B,F,A,R}(backend, f, arguments, roots)
 
 """
-    KernelInvocation(f, args...; backend=LLVMBackend())
+    KernelCall(f, args...; backend=LLVMBackend())
 
 Convert `f` and `args` once and retain the host objects that own the converted values. Use
-[`kernel_compile`](@ref) to compile the invocation and [`kernel_launch`](@ref) to launch the
+[`kernel_compile`](@ref) to compile the call and [`kernel_launch`](@ref) to launch the
 resulting kernel without converting the arguments again.
 """
-@inline function KernelInvocation(f, args...; backend=LLVMBackend())
+@inline function KernelCall(f, args...; backend=LLVMBackend())
     backend = backend isa AbstractBackend ? backend : backend.DefaultBackend()
     roots = (f=f, arguments=args)
     GC.@preserve roots begin
         kernel_f = kernel_convert(backend, f)
         arguments = map(arg -> kernel_convert(backend, arg), args)
-        _kernel_invocation(backend, kernel_f, arguments, roots)
+        _kernel_call(backend, kernel_f, arguments, roots)
     end
 end
 
 """
-    kernel_compile(invocation::KernelInvocation; compiler_kwargs...) -> AbstractKernel
+    kernel_compile(call::KernelCall; compiler_kwargs...) -> AbstractKernel
 
-Compile an invocation for its backend. An invocation may be compiled more than once
+Compile a call for its backend. A call may be compiled more than once
 with different compiler options.
 """
-@inline function kernel_compile(invocation::KernelInvocation; kwargs...)
-    tt = Tuple{map(Core.Typeof, invocation.arguments)...}
-    kernel_compile(invocation.backend, invocation.f, tt; kwargs...)
+@inline function kernel_compile(call::KernelCall; kwargs...)
+    tt = Tuple{map(Core.Typeof, call.arguments)...}
+    kernel_compile(call.backend, call.f, tt; kwargs...)
 end
 
 """
-    invocation[i]
+    call[i]
 
-Return host argument `i` from a [`KernelInvocation`](@ref).
+Return host argument `i` from a [`KernelCall`](@ref).
 """
-@inline Base.getindex(invocation::KernelInvocation, i::Integer) = invocation.roots.arguments[i]
+@inline Base.getindex(call::KernelCall, i::Integer) = call.roots.arguments[i]
 
 """
-    rebind(invocation::KernelInvocation, i => value)
+    rebind(call::KernelCall, i => value)
 
-Return an invocation with host argument `i` rebound and converted for the same backend. The
+Return a call with host argument `i` rebound and converted for the same backend. The
 new converted argument may have a different type; [`kernel_launch`](@ref) coerces arguments
 to the compiled kernel signature.
 """
-@inline rebind(invocation::KernelInvocation, binding::Pair{<:Integer}) =
-    rebind_argument(invocation, binding.second, Val(binding.first))
+@inline rebind(call::KernelCall, binding::Pair{<:Integer}) =
+    rebind_argument(call, binding.second, Val(binding.first))
 
-@generated function rebind_argument(invocation::KernelInvocation{B,F,A,R}, value,
+@generated function rebind_argument(call::KernelCall{B,F,A,R}, value,
                                     ::Val{I}) where {B,F,A,R,I}
     if !(1 <= I <= fieldcount(A))
-        return :(throw(BoundsError(invocation, $I)))
+        return :(throw(BoundsError(call, $I)))
     end
 
-    host_arguments = Expr(:tuple, [i == I ? :value : :(@inbounds invocation.roots.arguments[$i])
+    host_arguments = Expr(:tuple, [i == I ? :value : :(@inbounds call.roots.arguments[$i])
                                    for i in 1:fieldcount(A)]...)
-    arguments = Expr(:tuple, [i == I ? :converted : :(@inbounds invocation.arguments[$i])
+    arguments = Expr(:tuple, [i == I ? :converted : :(@inbounds call.arguments[$i])
                               for i in 1:fieldcount(A)]...)
     quote
         GC.@preserve value begin
-            converted = kernel_convert(invocation.backend, value)
+            converted = kernel_convert(call.backend, value)
         end
         host_arguments = $host_arguments
-        roots = (f=invocation.roots.f, arguments=host_arguments)
+        roots = (f=call.roots.f, arguments=host_arguments)
         arguments = $arguments
-        _kernel_invocation(invocation.backend, invocation.f, arguments, roots)
+        _kernel_call(call.backend, call.f, arguments, roots)
     end
 end
 
@@ -168,7 +168,7 @@ a CUDA function upon first use, and to a certain extent arguments will be conver
 managed automatically using `cudaconvert`. Finally, a call to `cudacall` is
 performed, scheduling a kernel launch on the current CUDA context.
 
-A direct launch converts each argument once. Use [`KernelInvocation`](@ref),
+A direct launch converts each argument once. Use [`KernelCall`](@ref),
 [`kernel_compile`](@ref), and [`kernel_launch`](@ref) directly when compilation and launch
 need to be separated by occupancy queries or other configuration work.
 
@@ -237,7 +237,7 @@ macro cuda(ex...)
 
     # FIXME: macro hygiene wrt. escaping kwarg values (this broke with 1.5)
     #        we esc() the whole thing now, necessitating gensyms...
-    @gensym f_var kernel_args kernel_tt kernel backend backend_raw invocation
+    @gensym f_var kernel_args kernel_tt kernel backend backend_raw call
     if dynamic
         # FIXME: we could probably somehow support kwargs with constant values by either
         #        saving them in a global Dict here, or trying to pick them up from the Julia
@@ -269,10 +269,10 @@ macro cuda(ex...)
                     $backend_raw isa $AbstractBackend ? $backend_raw : $backend_raw.DefaultBackend()
                 end
                 $f_var = $f
-                $invocation = $KernelInvocation($f_var, $(var_exprs...); backend=$backend)
-                $kernel = $kernel_compile($invocation; $(compiler_kwargs...), $(other_kwargs...))
+                $call = $KernelCall($f_var, $(var_exprs...); backend=$backend)
+                $kernel = $kernel_compile($call; $(compiler_kwargs...), $(other_kwargs...))
                 if $should_launch
-                    $kernel_launch($kernel, $invocation; $(call_kwargs...))
+                    $kernel_launch($kernel, $call; $(call_kwargs...))
                 end
                 $kernel
              end)
@@ -373,7 +373,7 @@ abstract type AbstractKernel{F,TT} end
 
 Low-level interface to call a compiled kernel. A `HostKernel` converts the supplied host
 arguments before launching; a `DeviceKernel` accepts GPU-compatible arguments directly. To
-reuse values already converted by [`KernelInvocation`](@ref), call
+reuse values already converted by [`KernelCall`](@ref), call
 [`kernel_launch`](@ref) instead.
 
 A `HostKernel` is callable on the host, and a `DeviceKernel` is callable on the
@@ -409,21 +409,21 @@ function Base.show(io::IO, ::MIME"text/plain", k::AbstractKernel{F,TT}) where {F
 end
 
 """
-    kernel_launch(kernel::AbstractKernel, invocation::KernelInvocation; launch_kwargs...)
+    kernel_launch(kernel::AbstractKernel, call::KernelCall; launch_kwargs...)
 
-Launch a compiled kernel with converted arguments. The invocation retains the host roots for
+Launch a compiled kernel with converted arguments. The call retains the host roots for
 the duration of the backend launch. Converted values are coerced to the kernel's compiled
 signature at the calling boundary.
 """
 @generated function kernel_launch(kernel::AbstractKernel,
-                                  invocation::KernelInvocation{B,F,A,R}; kwargs...) where {B,F,A,R}
+                                  call::KernelCall{B,F,A,R}; kwargs...) where {B,F,A,R}
     root_vars = [gensym(:root) for _ in 1:fieldcount(A)+1]
-    assignments = Any[:($(root_vars[1]) = invocation.roots.f)]
+    assignments = Any[:($(root_vars[1]) = call.roots.f)]
     append!(assignments,
-            [:($(root_vars[i+1]) = @inbounds invocation.roots.arguments[$i])
+            [:($(root_vars[i+1]) = @inbounds call.roots.arguments[$i])
              for i in 1:fieldcount(A)])
-    call = :(kernel_launch(invocation.backend, kernel, invocation.arguments; kwargs...))
-    preserve = Expr(:gc_preserve, call, root_vars...)
+    launch = :(kernel_launch(call.backend, kernel, call.arguments; kwargs...))
+    preserve = Expr(:gc_preserve, launch, root_vars...)
     Expr(:block, assignments..., preserve)
 end
 
@@ -474,8 +474,8 @@ end
 @doc (@doc AbstractKernel) HostKernel
 
 @inline function (kernel::HostKernel)(args...; kwargs...)
-    invocation = KernelInvocation(kernel.f, args...; backend=LLVMBackend())
-    kernel_launch(kernel, invocation; kwargs...)
+    call = KernelCall(kernel.f, args...; backend=LLVMBackend())
+    kernel_launch(kernel, call; kwargs...)
 end
 
 @inline kernel_launch(::LLVMBackend, kernel::HostKernel, arguments::Tuple; kwargs...) =

--- a/CUDACore/src/compiler/execution.jl
+++ b/CUDACore/src/compiler/execution.jl
@@ -2,9 +2,9 @@
 
 export @cuda, cudaconvert, cufunction, dynamic_cufunction, nextwarp, prevwarp
 @public maxthreads, registers, memory, version, KernelAdaptor
-@public AbstractBackend, LLVMBackend, DefaultBackend, kernel_convert, kernel_compile, kernel_launch
-@public PreparedLaunch, prepare_launch, replace_arguments
-@public AbstractKernel, HostKernel, DeviceKernel
+@public AbstractBackend, LLVMBackend, DefaultBackend
+@public KernelInvocation, prepare, compile
+@public AbstractKernel, HostKernel, DeviceKernel, backend
 
 
 ## backend dispatch
@@ -15,8 +15,8 @@ export @cuda, cudaconvert, cufunction, dynamic_cufunction, nextwarp, prevwarp
 Abstract supertype for `@cuda` backend dispatch. The default backend is
 [`LLVMBackend`](@ref), which compiles SIMT/PTX kernels via
 [`cufunction`](@ref). Other backends (e.g. Tile IR via cuTile.jl) register
-a subtype and define methods for [`kernel_convert`](@ref) and
-[`kernel_compile`](@ref); `@cuda backend=...` then routes through them.
+a subtype and define backend methods for [`prepare`](@ref), [`compile`](@ref),
+and [`launch`](@ref); `@cuda backend=...` then routes through them.
 
 `@cuda backend=...` accepts either an `AbstractBackend` instance or a
 module that defines `DefaultBackend()` returning one (e.g.
@@ -43,133 +43,104 @@ packages (e.g. `@cuda backend=cuTile ...` resolves to `cuTile.DefaultBackend()`)
 DefaultBackend() = LLVMBackend()
 
 """
-    kernel_convert(backend, x)
+    prepare(backend, x)
 
 Convert a host-side launch argument to its kernel-side form. The default
 implementation for [`LLVMBackend`](@ref) forwards to [`cudaconvert`](@ref);
 other backends override to produce backend-specific argument types.
 """
-kernel_convert(::LLVMBackend, x) = cudaconvert(x)
+prepare(::LLVMBackend, x) = cudaconvert(x)
 
 """
-    kernel_compile(backend, f, tt::Type{<:Tuple}; kwargs...) -> AbstractKernel
+    compile(backend, f, tt::Type{<:Tuple}; kwargs...) -> AbstractKernel
 
 Compile a function for the given backend. Returns an [`AbstractKernel`](@ref)
 callable as `kernel(args...; launch_kwargs...)` to launch on the GPU. The
 default implementation for [`LLVMBackend`](@ref) is [`cufunction`](@ref).
 """
-kernel_compile(::LLVMBackend, f::F, tt::TT=Tuple{}; kwargs...) where {F,TT} =
+compile(::LLVMBackend, f::F, tt::TT=Tuple{}; kwargs...) where {F,TT} =
     cufunction(f, tt; kwargs...)
 
-"""
-    kernel_launch(backend, kernel, arguments::Tuple; kwargs...)
-
-Launch `kernel` with arguments already converted for `backend`. Backends with a
-different low-level kernel calling convention should override this method.
-"""
-@inline kernel_launch(::AbstractBackend, kernel, arguments::Tuple; kwargs...) =
-    kernel(arguments...; kwargs..., convert=Val(false))
-
-
-## prepared launches
+## kernel invocations
 
 """
-    PreparedLaunch
+    KernelInvocation
 
-A compiled kernel together with its converted arguments and the host objects that own them.
-Create one with [`prepare_launch`](@ref), and call it without positional arguments to launch.
+An immutable, self-rooting kernel invocation created by [`prepare`](@ref). It contains a
+backend-specific converted function and arguments, together with the host objects that own
+them. Cache compiled kernels rather than invocations, because an invocation pins its host
+arguments and is tied to the device, context, and task that were current when it was prepared.
 """
-struct PreparedLaunch{B,K,R,A}
+struct KernelInvocation{B,F,A,R}
     backend::B
-    kernel::K
-    roots::R
+    f::F
     arguments::A
-end
-
-@inline function (launch::PreparedLaunch)(; kwargs...)
-    roots = launch.roots
-    GC.@preserve roots begin
-        kernel_launch(launch.backend, launch.kernel, launch.arguments; kwargs...)
-    end
+    roots::R
 end
 
 """
-    prepare_launch(f, args...; backend=LLVMBackend(), compiler_kwargs...) do launch
-        # inspect launch.kernel, then launch(; launch_kwargs...)
-    end
+    prepare(f, args...; backend=LLVMBackend()) -> KernelInvocation
 
-Convert `f` and `args` once, compile the resulting signature, and pass a
-[`PreparedLaunch`](@ref) to the callback. The prepared launch is scoped to the callback and
-must not escape it or be used after changing the active CUDA device, context, task, or stream.
+Convert `f` and `args` once and retain the host objects that own the converted values. Use
+[`compile`](@ref) to compile the invocation and [`launch`](@ref) to launch the resulting
+kernel without converting the arguments again.
 """
-@inline function prepare_launch(callback, f, args...;
-                                backend=LLVMBackend(), compiler_kwargs...)
+@inline function prepare(f, args...; backend=LLVMBackend())
     backend = backend isa AbstractBackend ? backend : backend.DefaultBackend()
     roots = (f=f, arguments=args)
     GC.@preserve roots begin
-        kernel_f = kernel_convert(backend, f)
-        arguments = map(args) do arg
-            kernel_convert(backend, arg)
-        end
-        tt = Tuple{map(Core.Typeof, arguments)...}
-        kernel = kernel_compile(backend, kernel_f, tt; compiler_kwargs...)
-        callback(PreparedLaunch(backend, kernel, roots, arguments))
-    end
-end
-
-@inline function prepared_launch(f, args...;
-                                 backend=LLVMBackend(), compiler_kwargs...)
-    backend = backend isa AbstractBackend ? backend : backend.DefaultBackend()
-    prepared_launch(backend, f, args, (; compiler_kwargs...))
-end
-
-@inline function prepared_launch(backend::AbstractBackend, f, args::Tuple,
-                                 compiler_kwargs::NamedTuple)
-    roots = (f=f, arguments=args)
-    GC.@preserve roots begin
-        kernel_f = kernel_convert(backend, f)
-        arguments = map(args) do arg
-            kernel_convert(backend, arg)
-        end
-        tt = Tuple{map(Core.Typeof, arguments)...}
-        kernel = kernel_compile(backend, kernel_f, tt; compiler_kwargs...)
-        PreparedLaunch(backend, kernel, roots, arguments)
+        kernel_f = prepare(backend, f)
+        arguments = map(arg -> prepare(backend, arg), args)
+        KernelInvocation(backend, kernel_f, arguments, roots)
     end
 end
 
 """
-    replace_arguments(launch::PreparedLaunch, replacements::Pair...)
+    compile(invocation::KernelInvocation; compiler_kwargs...) -> AbstractKernel
 
-Return a prepared launch with selected host arguments replaced and converted. Replacement
-indices are one-based. The converted tuple type must still match the compiled signature.
+Compile a prepared invocation for its backend. An invocation may be compiled more than once
+with different compiler options.
 """
-@inline function replace_arguments(launch::PreparedLaunch{B,K,R,A},
-                                   replacements::Pair...) where {B,K,R,A}
-    host_arguments = launch.roots.arguments
-    arguments = launch.arguments
-    for (index, value) in replacements
-        index isa Integer || throw(ArgumentError("replacement indices must be integers"))
-        host_arguments = Base.setindex(host_arguments, value, index)
-        GC.@preserve host_arguments begin
-            converted = kernel_convert(launch.backend, value)
-            arguments = Base.setindex(arguments, converted, index)
-        end
-    end
-    typeof(arguments) === A ||
-        throw(ArgumentError("replacement changes the compiled argument types; prepare a new launch"))
-    roots = (f=launch.roots.f, arguments=host_arguments)
-    PreparedLaunch(launch.backend, launch.kernel, roots, arguments)
+@inline function compile(invocation::KernelInvocation; kwargs...)
+    tt = Tuple{map(Core.Typeof, invocation.arguments)...}
+    compile(invocation.backend, invocation.f, tt; kwargs...)
 end
 
-@inline function launch_replacing(launch::PreparedLaunch{B,K,R,A},
-                                  ::Val{I}, value; threads, blocks) where {B,K,R,A,I}
-    roots = launch.roots
-    GC.@preserve roots value begin
-        converted = kernel_convert(launch.backend, value)
-        arguments = Base.setindex(launch.arguments, converted, I)
-        typeof(arguments) === A ||
-            throw(ArgumentError("replacement changes the compiled argument types; prepare a new launch"))
-        kernel_launch(launch.backend, launch.kernel, arguments; threads, blocks)
+"""
+    invocation[i]
+
+Return host argument `i` from a [`KernelInvocation`](@ref).
+"""
+@inline Base.getindex(invocation::KernelInvocation, i::Integer) = invocation.roots.arguments[i]
+
+"""
+    Base.setindex(invocation::KernelInvocation, value, i)
+
+Return an invocation with host argument `i` replaced and converted for the same backend. The
+new converted argument may have a different type; [`launch`](@ref) coerces arguments to the
+compiled kernel signature.
+"""
+@inline Base.setindex(invocation::KernelInvocation, value, i::Integer) =
+    setindex_invocation(invocation, value, Val(i))
+
+@generated function setindex_invocation(invocation::KernelInvocation{B,F,A,R}, value,
+                                        ::Val{I}) where {B,F,A,R,I}
+    if !(1 <= I <= fieldcount(A))
+        return :(throw(BoundsError(invocation, $I)))
+    end
+
+    host_arguments = Expr(:tuple, [i == I ? :value : :(@inbounds invocation.roots.arguments[$i])
+                                   for i in 1:fieldcount(A)]...)
+    arguments = Expr(:tuple, [i == I ? :converted : :(@inbounds invocation.arguments[$i])
+                              for i in 1:fieldcount(A)]...)
+    quote
+        GC.@preserve value begin
+            converted = prepare(invocation.backend, value)
+        end
+        host_arguments = $host_arguments
+        roots = (f=invocation.roots.f, arguments=host_arguments)
+        arguments = $arguments
+        KernelInvocation(invocation.backend, invocation.f, arguments, roots)
     end
 end
 
@@ -190,8 +161,9 @@ a CUDA function upon first use, and to a certain extent arguments will be conver
 managed automatically using `cudaconvert`. Finally, a call to `cudacall` is
 performed, scheduling a kernel launch on the current CUDA context.
 
-A direct launch converts each argument once. Use [`prepare_launch`](@ref) when compilation
-and launch need to be separated by occupancy queries or other configuration work.
+A direct launch converts each argument once. Use [`prepare`](@ref), [`compile`](@ref), and
+[`launch`](@ref) directly when compilation and launch need to be separated by occupancy
+queries or other configuration work.
 
 Several keyword arguments are supported that influence the behavior of `@cuda`.
 - `launch`: whether to launch this kernel, defaults to `true`. If `false` the returned
@@ -201,7 +173,7 @@ Several keyword arguments are supported that influence the behavior of `@cuda`.
 - `backend`: which compiler backend to use, defaults to [`LLVMBackend`](@ref). Either an
   [`AbstractBackend`](@ref) instance or a module that defines `DefaultBackend()` (e.g.
   `backend=CUDA` resolves to `CUDA.DefaultBackend()`). Backend-specific compiler kwargs
-  not recognized by `@cuda` itself are forwarded to [`kernel_compile`](@ref).
+  not recognized by `@cuda` itself are forwarded to [`compile`](@ref).
 - arguments that influence kernel compilation: see [`cufunction`](@ref) and
   [`dynamic_cufunction`](@ref)
 - arguments that influence kernel launch: see [`CUDACore.HostKernel`](@ref) and
@@ -229,14 +201,14 @@ macro cuda(ex...)
     vars, var_exprs = assign_args!(code, args)
 
     # group keyword argument. Backend-specific compiler kwargs land in
-    # `other_kwargs` and are forwarded to `kernel_compile`; the backend
+    # `other_kwargs` and are forwarded to `compile`; the backend
     # validates them.
     macro_kwargs, compiler_kwargs, call_kwargs, other_kwargs =
         split_kwargs(kwargs, MACRO_KWARGS, COMPILER_KWARGS, LAUNCH_KWARGS)
 
     # handle keyword arguments that influence the macro's behavior
     dynamic = false
-    launch = true
+    should_launch = true
     backend_expr = :($LLVMBackend())
     for kwarg in macro_kwargs
         key::Symbol, val = kwarg.args
@@ -245,20 +217,20 @@ macro cuda(ex...)
             dynamic = val::Bool
         elseif key === :launch
             isa(val, Bool) || throw(ArgumentError("`launch` keyword argument to @cuda should be a constant value"))
-            launch = val::Bool
+            should_launch = val::Bool
         elseif key === :backend
             backend_expr = val
         else
             throw(ArgumentError("Unsupported keyword argument '$key'"))
         end
     end
-    if !launch && !isempty(call_kwargs)
+    if !should_launch && !isempty(call_kwargs)
         error("@cuda with launch=false does not support launch-time keyword arguments; use them when calling the kernel")
     end
 
     # FIXME: macro hygiene wrt. escaping kwarg values (this broke with 1.5)
     #        we esc() the whole thing now, necessitating gensyms...
-    @gensym f_var kernel_args kernel_tt kernel backend backend_raw prepared
+    @gensym f_var kernel_args kernel_tt kernel backend backend_raw invocation
     if dynamic
         # FIXME: we could probably somehow support kwargs with constant values by either
         #        saving them in a global Dict here, or trying to pick them up from the Julia
@@ -274,7 +246,7 @@ macro cuda(ex...)
                 $kernel_args = ($(var_exprs...),)
                 $kernel_tt = Tuple{map(Core.Typeof, $kernel_args)...}
                 $kernel = $dynamic_cufunction($f, $kernel_tt)
-                if $launch
+                if $should_launch
                     $kernel($kernel_args...; $(call_kwargs...))
                 end
                 $kernel
@@ -290,13 +262,12 @@ macro cuda(ex...)
                     $backend_raw isa $AbstractBackend ? $backend_raw : $backend_raw.DefaultBackend()
                 end
                 $f_var = $f
-                $prepare_launch($f_var, $(var_exprs...); backend=$backend,
-                                $(compiler_kwargs...), $(other_kwargs...)) do $prepared
-                    if $launch
-                        $prepared(; $(call_kwargs...))
-                    end
-                    $prepared.kernel
+                $invocation = $prepare($f_var, $(var_exprs...); backend=$backend)
+                $kernel = $compile($invocation; $(compiler_kwargs...), $(other_kwargs...))
+                if $should_launch
+                    $launch($kernel, $invocation; $(call_kwargs...))
                 end
+                $kernel
              end)
     end
 
@@ -393,8 +364,9 @@ abstract type AbstractKernel{F,TT} end
     (::HostKernel)(args...; kwargs...)
     (::DeviceKernel)(args...; kwargs...)
 
-Low-level interface to call a compiled kernel, passing GPU-compatible arguments
-in `args`. For a higher-level interface, use [`@cuda`](@ref).
+Low-level interface to call a compiled kernel. A `HostKernel` converts the supplied host
+arguments before launching; a `DeviceKernel` accepts GPU-compatible arguments directly. To
+reuse values already converted by [`prepare`](@ref), call [`launch`](@ref) instead.
 
 A `HostKernel` is callable on the host, and a `DeviceKernel` is callable on the
 device (created by `@cuda` with `dynamic=true`).
@@ -428,19 +400,52 @@ function Base.show(io::IO, ::MIME"text/plain", k::AbstractKernel{F,TT}) where {F
     print(io, "$(parentmodule(T)).$(nameof(T)) for $(k.f)($(join(TT.parameters, ", ")))")
 end
 
-@inline @generated function (kernel::AbstractKernel{F,TT})(args::Vararg{Any,N};
-                                                           convert=Val(kernel isa HostKernel),
-                                                           call_kwargs...) where {F,TT,N}
+"""
+    backend(kernel::AbstractKernel)
+
+Return the backend that compiled `kernel`. Backend kernel types define this trait so an
+existing kernel can be rebound with [`prepare(kernel, args...)`](@ref).
+"""
+function backend end
+
+"""
+    prepare(kernel::AbstractKernel, args...) -> KernelInvocation
+
+Prepare a new invocation for an existing kernel's function and backend.
+"""
+@inline prepare(kernel::AbstractKernel, args...) =
+    prepare(kernel.f, args...; backend=backend(kernel))
+
+"""
+    launch(kernel::AbstractKernel, invocation::KernelInvocation; launch_kwargs...)
+
+Launch a compiled kernel with prepared arguments. The invocation retains the host roots for
+the duration of the backend launch. Converted values are coerced to the kernel's compiled
+signature at the calling boundary.
+"""
+@generated function launch(kernel::AbstractKernel,
+                           invocation::KernelInvocation{B,F,A,R}; kwargs...) where {B,F,A,R}
+    root_vars = [gensym(:root) for _ in 1:fieldcount(A)+1]
+    assignments = Any[:($(root_vars[1]) = invocation.roots.f)]
+    append!(assignments,
+            [:($(root_vars[i+1]) = @inbounds invocation.roots.arguments[$i])
+             for i in 1:fieldcount(A)])
+    call = :(launch(invocation.backend, kernel, invocation.arguments; kwargs...))
+    preserve = Expr(:gc_preserve, call, root_vars...)
+    Expr(:block, assignments..., preserve)
+end
+
+@inline launch(::AbstractBackend, kernel, arguments::Tuple; kwargs...) =
+    kernel(arguments...; kwargs...)
+
+@inline @generated function launch_converted(kernel::AbstractKernel{F,TT},
+                                              args::A; call_kwargs...) where {F,TT,A<:Tuple}
     sig = Tuple{F, TT.parameters...}    # Base.signature_type with a function type
 
     # determine argument expressions
     argexprs = [:(kernel.f)]
-    for i in 1:length(args)
-        if convert.parameters[1]
-            push!(argexprs, :(cudaconvert(args[$i])))
-        else
-            push!(argexprs, :(args[$i]))
-        end
+    for i in 1:length(A.parameters)
+        push!(argexprs, :(args[$i]))
     end
 
     # filter out arguments that shouldn't be passed
@@ -475,6 +480,16 @@ struct HostKernel{F,TT} <: AbstractKernel{F,TT}
 end
 
 @doc (@doc AbstractKernel) HostKernel
+
+backend(::HostKernel) = LLVMBackend()
+
+@inline function (kernel::HostKernel)(args...; kwargs...)
+    invocation = prepare(kernel, args...)
+    launch(kernel, invocation; kwargs...)
+end
+
+@inline launch(::LLVMBackend, kernel::HostKernel, arguments::Tuple; kwargs...) =
+    launch_converted(kernel, arguments; kwargs...)
 
 """
     version(k::HostKernel)
@@ -621,6 +636,9 @@ struct DeviceKernel{F,TT} <: AbstractKernel{F,TT}
 end
 
 @doc (@doc AbstractKernel) DeviceKernel
+
+@inline (kernel::DeviceKernel)(args...; kwargs...) =
+    launch_converted(kernel, args; kwargs...)
 
 
 ## device-side API

--- a/CUDACore/src/indexing.jl
+++ b/CUDACore/src/indexing.jl
@@ -45,12 +45,12 @@ function Base.findall(bools::AnyCuArray{Bool})
         end
         ## COV_EXCL_STOP
 
-        invocation = prepare(kernel, ys, bools, indices)
-        compiled = compile(invocation; name="findall")
+        invocation = KernelInvocation(kernel, ys, bools, indices)
+        compiled = kernel_compile(invocation; name="findall")
         config = launch_configuration(compiled.fun)
         threads = min(length(indices), config.threads)
         blocks = cld(length(indices), threads)
-        launch(compiled, invocation; threads, blocks)
+        kernel_launch(compiled, invocation; threads, blocks)
     end
 
     unsafe_free!(indices)

--- a/CUDACore/src/indexing.jl
+++ b/CUDACore/src/indexing.jl
@@ -45,11 +45,12 @@ function Base.findall(bools::AnyCuArray{Bool})
         end
         ## COV_EXCL_STOP
 
-        kernel = @cuda name="findall" launch=false kernel(ys, bools, indices)
-        config = launch_configuration(kernel.fun)
-        threads = min(length(indices), config.threads)
-        blocks = cld(length(indices), threads)
-        kernel(ys, bools, indices; threads, blocks)
+        prepare_launch(kernel, ys, bools, indices; name="findall") do launch
+            config = launch_configuration(launch.kernel.fun)
+            threads = min(length(indices), config.threads)
+            blocks = cld(length(indices), threads)
+            launch(; threads, blocks)
+        end
     end
 
     unsafe_free!(indices)

--- a/CUDACore/src/indexing.jl
+++ b/CUDACore/src/indexing.jl
@@ -45,12 +45,12 @@ function Base.findall(bools::AnyCuArray{Bool})
         end
         ## COV_EXCL_STOP
 
-        invocation = KernelInvocation(kernel, ys, bools, indices)
-        compiled = kernel_compile(invocation; name="findall")
+        call = KernelCall(kernel, ys, bools, indices)
+        compiled = kernel_compile(call; name="findall")
         config = launch_configuration(compiled.fun)
         threads = min(length(indices), config.threads)
         blocks = cld(length(indices), threads)
-        kernel_launch(compiled, invocation; threads, blocks)
+        kernel_launch(compiled, call; threads, blocks)
     end
 
     unsafe_free!(indices)

--- a/CUDACore/src/indexing.jl
+++ b/CUDACore/src/indexing.jl
@@ -45,12 +45,12 @@ function Base.findall(bools::AnyCuArray{Bool})
         end
         ## COV_EXCL_STOP
 
-        prepare_launch(kernel, ys, bools, indices; name="findall") do launch
-            config = launch_configuration(launch.kernel.fun)
-            threads = min(length(indices), config.threads)
-            blocks = cld(length(indices), threads)
-            launch(; threads, blocks)
-        end
+        invocation = prepare(kernel, ys, bools, indices)
+        compiled = compile(invocation; name="findall")
+        config = launch_configuration(compiled.fun)
+        threads = min(length(indices), config.threads)
+        blocks = cld(length(indices), threads)
+        launch(compiled, invocation; threads, blocks)
     end
 
     unsafe_free!(indices)

--- a/CUDACore/src/mapreduce.jl
+++ b/CUDACore/src/mapreduce.jl
@@ -201,12 +201,13 @@ function GPUArrays.mapreducedim!(f::F, op::OP, R::AnyCuArray{T},
     # If `Rother` is large enough, then a naive loop is more efficient than partial reductions.
     if length(Rother) >= serial_mapreduce_threshold(dev)
         args = (f, op, init, Rreduce, Rother, R, A)
-        kernel = @cuda launch=false serial_mapreduce_kernel(args...)
-        kernel_config = launch_configuration(kernel.fun)
-        threads = kernel_config.threads
-        blocks = cld(length(Rother), threads)
-        kernel(args...; threads, blocks)
-        return R
+        return prepare_launch(serial_mapreduce_kernel, args...) do launch
+            kernel_config = launch_configuration(launch.kernel.fun)
+            threads = kernel_config.threads
+            blocks = cld(length(Rother), threads)
+            launch(; threads, blocks)
+            R
+        end
     end
 
     # how many threads do we want?
@@ -228,65 +229,62 @@ function GPUArrays.mapreducedim!(f::F, op::OP, R::AnyCuArray{T},
     # we might not be able to launch all those threads to reduce each slice in one go.
     # that's why each threads also loops across their inputs, processing multiple values
     # so that we can span the entire reduction dimension using a single thread block.
-    kernel = @cuda launch=false partial_mapreduce_grid(f, op, init, Rreduce, Rother, Val(shuffle), R, A)
     compute_shmem(threads) = shuffle ? 0 : threads*sizeof(T)
-    kernel_config = launch_configuration(kernel.fun; shmem=compute_shmem∘compute_threads)
-    reduce_threads = compute_threads(kernel_config.threads)
-    reduce_shmem = compute_shmem(reduce_threads)
+    prepare_launch(partial_mapreduce_grid, f, op, init, Rreduce, Rother,
+                   Val(shuffle), R, A) do launch
+        kernel_config = launch_configuration(launch.kernel.fun;
+                                             shmem=compute_shmem∘compute_threads)
+        reduce_threads = compute_threads(kernel_config.threads)
+        reduce_shmem = compute_shmem(reduce_threads)
 
-    # how many blocks should we launch?
-    #
-    # even though we can always reduce each slice in a single thread block, that may not be
-    # optimal as it might not saturate the GPU. we already launch some blocks to process
-    # independent dimensions in parallel; pad that number to ensure full occupancy.
-    other_blocks = length(Rother)
-    reduce_blocks = if other_blocks >= kernel_config.blocks
-        1
-    else
-        min(cld(length(Rreduce), reduce_threads),       # how many we need at most
-            cld(kernel_config.blocks, other_blocks))    # maximize occupancy
-    end
-
-    # determine the launch configuration
-    threads = reduce_threads
-    shmem = reduce_shmem
-    blocks = reduce_blocks*other_blocks
-
-    # perform the actual reduction
-    if reduce_blocks == 1
-        # we can cover the dimensions to reduce using a single block
-        kernel(f, op, init, Rreduce, Rother, Val(shuffle), R, A; threads, blocks, shmem)
-    else
-        # TODO: provide a version that atomically reduces from different blocks
-
-        # temporary empty array whose type will match the final partial array
-	    partial = similar(R, ntuple(_ -> 0, Val(ndims(R)+1)))
-
-        # NOTE: we can't use the previously-compiled kernel, or its launch configuration,
-        #       since the type of `partial` might not match the original output container
-        #       (e.g. if that was a view).
-        partial_kernel = @cuda launch=false partial_mapreduce_grid(f, op, init, Rreduce, Rother, Val(shuffle), partial, A)
-        partial_kernel_config = launch_configuration(partial_kernel.fun; shmem=compute_shmem∘compute_threads)
-        partial_reduce_threads = compute_threads(partial_kernel_config.threads)
-        partial_reduce_shmem = compute_shmem(partial_reduce_threads)
-        partial_reduce_blocks = if other_blocks >= partial_kernel_config.blocks
+        # how many blocks should we launch?
+        #
+        # even though we can always reduce each slice in a single thread block, that may not be
+        # optimal as it might not saturate the GPU. we already launch some blocks to process
+        # independent dimensions in parallel; pad that number to ensure full occupancy.
+        other_blocks = length(Rother)
+        reduce_blocks = if other_blocks >= kernel_config.blocks
             1
         else
-            min(cld(length(Rreduce), partial_reduce_threads),
-                cld(partial_kernel_config.blocks, other_blocks))
-        end
-        partial_threads = partial_reduce_threads
-        partial_shmem = partial_reduce_shmem
-        partial_blocks = partial_reduce_blocks*other_blocks
-
-        partial = similar(R, (size(R)..., partial_reduce_blocks))
-        if init === nothing
-            # without an explicit initializer we need to copy from the output container
-            partial .= R
+            min(cld(length(Rreduce), reduce_threads),       # how many we need at most
+                cld(kernel_config.blocks, other_blocks))    # maximize occupancy
         end
 
-        partial_kernel(f, op, init, Rreduce, Rother, Val(shuffle), partial, A;
-                       threads=partial_threads, blocks=partial_blocks, shmem=partial_shmem)
+        threads = reduce_threads
+        shmem = reduce_shmem
+        blocks = reduce_blocks*other_blocks
+
+        if reduce_blocks == 1
+            launch(; threads, blocks, shmem)
+            return
+        end
+
+        # TODO: provide a version that atomically reduces from different blocks
+        placeholder = similar(R, ntuple(Returns(0), Val(ndims(R)+1)))
+        partial = prepare_launch(partial_mapreduce_grid, f, op, init, Rreduce, Rother,
+                                 Val(shuffle), placeholder, A) do partial_launch
+            partial_config = launch_configuration(partial_launch.kernel.fun;
+                                                  shmem=compute_shmem∘compute_threads)
+            partial_threads = compute_threads(partial_config.threads)
+            partial_shmem = compute_shmem(partial_threads)
+            partial_reduce_blocks = if other_blocks >= partial_config.blocks
+                1
+            else
+                min(cld(length(Rreduce), partial_threads),
+                    cld(partial_config.blocks, other_blocks))
+            end
+            partial_blocks = partial_reduce_blocks*other_blocks
+
+            final_partial = similar(R, (size(R)..., partial_reduce_blocks))
+            if init === nothing
+                final_partial .= R
+            end
+
+            partial_launch = replace_arguments(partial_launch, 7 => final_partial)
+            partial_launch(; threads=partial_threads, blocks=partial_blocks,
+                           shmem=partial_shmem)
+            final_partial
+        end
 
         GPUArrays.mapreducedim!(identity, op, R, partial; init)
     end

--- a/CUDACore/src/mapreduce.jl
+++ b/CUDACore/src/mapreduce.jl
@@ -201,12 +201,12 @@ function GPUArrays.mapreducedim!(f::F, op::OP, R::AnyCuArray{T},
     # If `Rother` is large enough, then a naive loop is more efficient than partial reductions.
     if length(Rother) >= serial_mapreduce_threshold(dev)
         args = (f, op, init, Rreduce, Rother, R, A)
-        invocation = prepare(serial_mapreduce_kernel, args...)
-        kernel = compile(invocation)
+        invocation = KernelInvocation(serial_mapreduce_kernel, args...)
+        kernel = kernel_compile(invocation)
         kernel_config = launch_configuration(kernel.fun)
         threads = kernel_config.threads
         blocks = cld(length(Rother), threads)
-        launch(kernel, invocation; threads, blocks)
+        kernel_launch(kernel, invocation; threads, blocks)
         return R
     end
 
@@ -230,8 +230,8 @@ function GPUArrays.mapreducedim!(f::F, op::OP, R::AnyCuArray{T},
     # that's why each threads also loops across their inputs, processing multiple values
     # so that we can span the entire reduction dimension using a single thread block.
     compute_shmem(threads) = shuffle ? 0 : threads*sizeof(T)
-    invocation = prepare(partial_mapreduce_grid, f, op, init, Rreduce, Rother, Val(shuffle), R, A)
-    kernel = compile(invocation)
+    invocation = KernelInvocation(partial_mapreduce_grid, f, op, init, Rreduce, Rother, Val(shuffle), R, A)
+    kernel = kernel_compile(invocation)
     kernel_config = launch_configuration(kernel.fun; shmem=compute_shmem∘compute_threads)
     reduce_threads = compute_threads(kernel_config.threads)
     reduce_shmem = compute_shmem(reduce_threads)
@@ -257,7 +257,7 @@ function GPUArrays.mapreducedim!(f::F, op::OP, R::AnyCuArray{T},
     # perform the actual reduction
     if reduce_blocks == 1
         # we can cover the dimensions to reduce using a single block
-        launch(kernel, invocation; threads, blocks, shmem)
+        kernel_launch(kernel, invocation; threads, blocks, shmem)
     else
         # TODO: provide a version that atomically reduces from different blocks
 
@@ -267,9 +267,9 @@ function GPUArrays.mapreducedim!(f::F, op::OP, R::AnyCuArray{T},
         # NOTE: we can't use the previously-compiled kernel, or its launch configuration,
         #       since the type of `partial` might not match the original output container
         #       (e.g. if that was a view).
-        partial_invocation = prepare(partial_mapreduce_grid, f, op, init, Rreduce, Rother,
+        partial_invocation = KernelInvocation(partial_mapreduce_grid, f, op, init, Rreduce, Rother,
                                      Val(shuffle), partial, A)
-        partial_kernel = compile(partial_invocation)
+        partial_kernel = kernel_compile(partial_invocation)
         partial_kernel_config = launch_configuration(partial_kernel.fun; shmem=compute_shmem∘compute_threads)
         partial_reduce_threads = compute_threads(partial_kernel_config.threads)
         partial_reduce_shmem = compute_shmem(partial_reduce_threads)
@@ -290,7 +290,7 @@ function GPUArrays.mapreducedim!(f::F, op::OP, R::AnyCuArray{T},
         end
 
         partial_invocation = rebind(partial_invocation, 7 => partial)
-        launch(partial_kernel, partial_invocation;
+        kernel_launch(partial_kernel, partial_invocation;
                threads=partial_threads, blocks=partial_blocks, shmem=partial_shmem)
 
         GPUArrays.mapreducedim!(identity, op, R, partial; init)

--- a/CUDACore/src/mapreduce.jl
+++ b/CUDACore/src/mapreduce.jl
@@ -289,7 +289,7 @@ function GPUArrays.mapreducedim!(f::F, op::OP, R::AnyCuArray{T},
             partial .= R
         end
 
-        partial_call = rebind(partial_call, 7 => partial)
+        partial_call = rebind(partial_call, 7, partial)
         kernel_launch(partial_kernel, partial_call;
                threads=partial_threads, blocks=partial_blocks, shmem=partial_shmem)
 

--- a/CUDACore/src/mapreduce.jl
+++ b/CUDACore/src/mapreduce.jl
@@ -187,12 +187,13 @@ function GPUArrays.mapreducedim!(f::F, op::OP, R::AnyCuArray{T},
         dims = Base.fill_to_length(size(R), 1, Val(ndims(A)))
         R = reshape(R, dims)
     end
+    output = R
 
     # iteration domain, split in two: one part covers the dimensions that should
     # be reduced, and the other covers the rest. combining both covers all values.
     Rall = CartesianIndices(axes(A))
-    Rother = CartesianIndices(axes(R))
-    Rreduce = CartesianIndices(ifelse.(axes(A) .== axes(R), Ref(Base.OneTo(1)), axes(A)))
+    Rother = CartesianIndices(axes(output))
+    Rreduce = CartesianIndices(ifelse.(axes(A) .== axes(output), Ref(Base.OneTo(1)), axes(A)))
     # NOTE: we hard-code `OneTo` (`first.(axes(A))` would work too) or we get a
     #       CartesianIndices object with UnitRanges that behave badly on the GPU.
     @assert length(Rall) == length(Rother) * length(Rreduce)
@@ -200,13 +201,13 @@ function GPUArrays.mapreducedim!(f::F, op::OP, R::AnyCuArray{T},
 
     # If `Rother` is large enough, then a naive loop is more efficient than partial reductions.
     if length(Rother) >= serial_mapreduce_threshold(dev)
-        args = (f, op, init, Rreduce, Rother, R, A)
+        args = (f, op, init, Rreduce, Rother, output, A)
         return prepare_launch(serial_mapreduce_kernel, args...) do launch
             kernel_config = launch_configuration(launch.kernel.fun)
             threads = kernel_config.threads
             blocks = cld(length(Rother), threads)
             launch(; threads, blocks)
-            R
+            output
         end
     end
 
@@ -230,8 +231,9 @@ function GPUArrays.mapreducedim!(f::F, op::OP, R::AnyCuArray{T},
     # that's why each threads also loops across their inputs, processing multiple values
     # so that we can span the entire reduction dimension using a single thread block.
     compute_shmem(threads) = shuffle ? 0 : threads*sizeof(T)
-    prepare_launch(partial_mapreduce_grid, f, op, init, Rreduce, Rother,
-                   Val(shuffle), R, A) do launch
+    other_blocks = length(Rother)
+    complete = prepare_launch(partial_mapreduce_grid, f, op, init, Rreduce, Rother,
+                              Val(shuffle), output, A) do launch
         kernel_config = launch_configuration(launch.kernel.fun;
                                              shmem=compute_shmem∘compute_threads)
         reduce_threads = compute_threads(kernel_config.threads)
@@ -242,7 +244,6 @@ function GPUArrays.mapreducedim!(f::F, op::OP, R::AnyCuArray{T},
         # even though we can always reduce each slice in a single thread block, that may not be
         # optimal as it might not saturate the GPU. we already launch some blocks to process
         # independent dimensions in parallel; pad that number to ensure full occupancy.
-        other_blocks = length(Rother)
         reduce_blocks = if other_blocks >= kernel_config.blocks
             1
         else
@@ -256,38 +257,41 @@ function GPUArrays.mapreducedim!(f::F, op::OP, R::AnyCuArray{T},
 
         if reduce_blocks == 1
             launch(; threads, blocks, shmem)
-            return
+            true
+        else
+            false
+        end
+    end
+    complete && return output
+
+    # TODO: provide a version that atomically reduces from different blocks
+    placeholder = similar(output, ntuple(Returns(0), Val(ndims(output)+1)))
+    partial = prepare_launch(partial_mapreduce_grid, f, op, init, Rreduce, Rother,
+                             Val(shuffle), placeholder, A) do partial_launch
+        partial_config = launch_configuration(partial_launch.kernel.fun;
+                                              shmem=compute_shmem∘compute_threads)
+        partial_threads = compute_threads(partial_config.threads)
+        partial_shmem = compute_shmem(partial_threads)
+        partial_reduce_blocks = if other_blocks >= partial_config.blocks
+            1
+        else
+            min(cld(length(Rreduce), partial_threads),
+                cld(partial_config.blocks, other_blocks))
+        end
+        partial_blocks = partial_reduce_blocks*other_blocks
+
+        final_partial = similar(output, (size(output)..., partial_reduce_blocks))
+        if init === nothing
+            final_partial .= output
         end
 
-        # TODO: provide a version that atomically reduces from different blocks
-        placeholder = similar(R, ntuple(Returns(0), Val(ndims(R)+1)))
-        partial = prepare_launch(partial_mapreduce_grid, f, op, init, Rreduce, Rother,
-                                 Val(shuffle), placeholder, A) do partial_launch
-            partial_config = launch_configuration(partial_launch.kernel.fun;
-                                                  shmem=compute_shmem∘compute_threads)
-            partial_threads = compute_threads(partial_config.threads)
-            partial_shmem = compute_shmem(partial_threads)
-            partial_reduce_blocks = if other_blocks >= partial_config.blocks
-                1
-            else
-                min(cld(length(Rreduce), partial_threads),
-                    cld(partial_config.blocks, other_blocks))
-            end
-            partial_blocks = partial_reduce_blocks*other_blocks
-
-            final_partial = similar(R, (size(R)..., partial_reduce_blocks))
-            if init === nothing
-                final_partial .= R
-            end
-
-            partial_launch = replace_arguments(partial_launch, 7 => final_partial)
-            partial_launch(; threads=partial_threads, blocks=partial_blocks,
-                           shmem=partial_shmem)
-            final_partial
-        end
-
-        GPUArrays.mapreducedim!(identity, op, R, partial; init)
+        partial_launch = replace_arguments(partial_launch, 7 => final_partial)
+        partial_launch(; threads=partial_threads, blocks=partial_blocks,
+                       shmem=partial_shmem)
+        final_partial
     end
 
-    return R
+    GPUArrays.mapreducedim!(identity, op, output, partial; init)
+
+    return output
 end

--- a/CUDACore/src/mapreduce.jl
+++ b/CUDACore/src/mapreduce.jl
@@ -187,13 +187,11 @@ function GPUArrays.mapreducedim!(f::F, op::OP, R::AnyCuArray{T},
         dims = Base.fill_to_length(size(R), 1, Val(ndims(A)))
         R = reshape(R, dims)
     end
-    output = R
-
     # iteration domain, split in two: one part covers the dimensions that should
     # be reduced, and the other covers the rest. combining both covers all values.
     Rall = CartesianIndices(axes(A))
-    Rother = CartesianIndices(axes(output))
-    Rreduce = CartesianIndices(ifelse.(axes(A) .== axes(output), Ref(Base.OneTo(1)), axes(A)))
+    Rother = CartesianIndices(axes(R))
+    Rreduce = CartesianIndices(ifelse.(axes(A) .== axes(R), Ref(Base.OneTo(1)), axes(A)))
     # NOTE: we hard-code `OneTo` (`first.(axes(A))` would work too) or we get a
     #       CartesianIndices object with UnitRanges that behave badly on the GPU.
     @assert length(Rall) == length(Rother) * length(Rreduce)
@@ -201,14 +199,13 @@ function GPUArrays.mapreducedim!(f::F, op::OP, R::AnyCuArray{T},
 
     # If `Rother` is large enough, then a naive loop is more efficient than partial reductions.
     if length(Rother) >= serial_mapreduce_threshold(dev)
-        args = (f, op, init, Rreduce, Rother, output, A)
-        return prepare_launch(serial_mapreduce_kernel, args...) do launch
-            kernel_config = launch_configuration(launch.kernel.fun)
-            threads = kernel_config.threads
-            blocks = cld(length(Rother), threads)
-            launch(; threads, blocks)
-            output
-        end
+        invocation = prepare(serial_mapreduce_kernel, f, op, init, Rreduce, Rother, R, A)
+        kernel = compile(invocation)
+        kernel_config = launch_configuration(kernel.fun)
+        threads = kernel_config.threads
+        blocks = cld(length(Rother), threads)
+        launch(kernel, invocation; threads, blocks)
+        return R
     end
 
     # how many threads do we want?
@@ -231,67 +228,63 @@ function GPUArrays.mapreducedim!(f::F, op::OP, R::AnyCuArray{T},
     # that's why each threads also loops across their inputs, processing multiple values
     # so that we can span the entire reduction dimension using a single thread block.
     compute_shmem(threads) = shuffle ? 0 : threads*sizeof(T)
+    invocation = prepare(partial_mapreduce_grid, f, op, init, Rreduce, Rother,
+                         Val(shuffle), R, A)
+    kernel = compile(invocation)
+    kernel_config = launch_configuration(kernel.fun;
+                                         shmem=compute_shmem∘compute_threads)
+    reduce_threads = compute_threads(kernel_config.threads)
+    reduce_shmem = compute_shmem(reduce_threads)
+
+    # how many blocks should we launch?
+    #
+    # even though we can always reduce each slice in a single thread block, that may not be
+    # optimal as it might not saturate the GPU. we already launch some blocks to process
+    # independent dimensions in parallel; pad that number to ensure full occupancy.
     other_blocks = length(Rother)
-    complete = prepare_launch(partial_mapreduce_grid, f, op, init, Rreduce, Rother,
-                              Val(shuffle), output, A) do launch
-        kernel_config = launch_configuration(launch.kernel.fun;
-                                             shmem=compute_shmem∘compute_threads)
-        reduce_threads = compute_threads(kernel_config.threads)
-        reduce_shmem = compute_shmem(reduce_threads)
-
-        # how many blocks should we launch?
-        #
-        # even though we can always reduce each slice in a single thread block, that may not be
-        # optimal as it might not saturate the GPU. we already launch some blocks to process
-        # independent dimensions in parallel; pad that number to ensure full occupancy.
-        reduce_blocks = if other_blocks >= kernel_config.blocks
-            1
-        else
-            min(cld(length(Rreduce), reduce_threads),       # how many we need at most
-                cld(kernel_config.blocks, other_blocks))    # maximize occupancy
-        end
-
-        threads = reduce_threads
-        shmem = reduce_shmem
-        blocks = reduce_blocks*other_blocks
-
-        if reduce_blocks == 1
-            launch(; threads, blocks, shmem)
-            true
-        else
-            false
-        end
+    reduce_blocks = if other_blocks >= kernel_config.blocks
+        1
+    else
+        min(cld(length(Rreduce), reduce_threads),       # how many we need at most
+            cld(kernel_config.blocks, other_blocks))    # maximize occupancy
     end
-    complete && return output
+
+    threads = reduce_threads
+    shmem = reduce_shmem
+    blocks = reduce_blocks*other_blocks
+
+    if reduce_blocks == 1
+        launch(kernel, invocation; threads, blocks, shmem)
+        return R
+    end
 
     # TODO: provide a version that atomically reduces from different blocks
-    placeholder = similar(output, ntuple(Returns(0), Val(ndims(output)+1)))
-    partial = prepare_launch(partial_mapreduce_grid, f, op, init, Rreduce, Rother,
-                             Val(shuffle), placeholder, A) do partial_launch
-        partial_config = launch_configuration(partial_launch.kernel.fun;
-                                              shmem=compute_shmem∘compute_threads)
-        partial_threads = compute_threads(partial_config.threads)
-        partial_shmem = compute_shmem(partial_threads)
-        partial_reduce_blocks = if other_blocks >= partial_config.blocks
-            1
-        else
-            min(cld(length(Rreduce), partial_threads),
-                cld(partial_config.blocks, other_blocks))
-        end
-        partial_blocks = partial_reduce_blocks*other_blocks
+    placeholder = similar(R, ntuple(Returns(0), Val(ndims(R)+1)))
+    partial_invocation = prepare(partial_mapreduce_grid, f, op, init, Rreduce, Rother,
+                                 Val(shuffle), placeholder, A)
+    partial_kernel = compile(partial_invocation)
+    partial_config = launch_configuration(partial_kernel.fun;
+                                          shmem=compute_shmem∘compute_threads)
+    partial_threads = compute_threads(partial_config.threads)
+    partial_shmem = compute_shmem(partial_threads)
+    partial_reduce_blocks = if other_blocks >= partial_config.blocks
+        1
+    else
+        min(cld(length(Rreduce), partial_threads),
+            cld(partial_config.blocks, other_blocks))
+    end
+    partial_blocks = partial_reduce_blocks*other_blocks
 
-        final_partial = similar(output, (size(output)..., partial_reduce_blocks))
-        if init === nothing
-            final_partial .= output
-        end
-
-        partial_launch = replace_arguments(partial_launch, 7 => final_partial)
-        partial_launch(; threads=partial_threads, blocks=partial_blocks,
-                       shmem=partial_shmem)
-        final_partial
+    partial = similar(R, (size(R)..., partial_reduce_blocks))
+    if init === nothing
+        partial .= R
     end
 
-    GPUArrays.mapreducedim!(identity, op, output, partial; init)
+    partial_invocation = Base.setindex(partial_invocation, partial, 7)
+    launch(partial_kernel, partial_invocation;
+           threads=partial_threads, blocks=partial_blocks, shmem=partial_shmem)
 
-    return output
+    GPUArrays.mapreducedim!(identity, op, R, partial; init)
+
+    return R
 end

--- a/CUDACore/src/mapreduce.jl
+++ b/CUDACore/src/mapreduce.jl
@@ -201,12 +201,12 @@ function GPUArrays.mapreducedim!(f::F, op::OP, R::AnyCuArray{T},
     # If `Rother` is large enough, then a naive loop is more efficient than partial reductions.
     if length(Rother) >= serial_mapreduce_threshold(dev)
         args = (f, op, init, Rreduce, Rother, R, A)
-        invocation = KernelInvocation(serial_mapreduce_kernel, args...)
-        kernel = kernel_compile(invocation)
+        call = KernelCall(serial_mapreduce_kernel, args...)
+        kernel = kernel_compile(call)
         kernel_config = launch_configuration(kernel.fun)
         threads = kernel_config.threads
         blocks = cld(length(Rother), threads)
-        kernel_launch(kernel, invocation; threads, blocks)
+        kernel_launch(kernel, call; threads, blocks)
         return R
     end
 
@@ -230,8 +230,8 @@ function GPUArrays.mapreducedim!(f::F, op::OP, R::AnyCuArray{T},
     # that's why each threads also loops across their inputs, processing multiple values
     # so that we can span the entire reduction dimension using a single thread block.
     compute_shmem(threads) = shuffle ? 0 : threads*sizeof(T)
-    invocation = KernelInvocation(partial_mapreduce_grid, f, op, init, Rreduce, Rother, Val(shuffle), R, A)
-    kernel = kernel_compile(invocation)
+    call = KernelCall(partial_mapreduce_grid, f, op, init, Rreduce, Rother, Val(shuffle), R, A)
+    kernel = kernel_compile(call)
     kernel_config = launch_configuration(kernel.fun; shmem=compute_shmem∘compute_threads)
     reduce_threads = compute_threads(kernel_config.threads)
     reduce_shmem = compute_shmem(reduce_threads)
@@ -257,7 +257,7 @@ function GPUArrays.mapreducedim!(f::F, op::OP, R::AnyCuArray{T},
     # perform the actual reduction
     if reduce_blocks == 1
         # we can cover the dimensions to reduce using a single block
-        kernel_launch(kernel, invocation; threads, blocks, shmem)
+        kernel_launch(kernel, call; threads, blocks, shmem)
     else
         # TODO: provide a version that atomically reduces from different blocks
 
@@ -267,9 +267,9 @@ function GPUArrays.mapreducedim!(f::F, op::OP, R::AnyCuArray{T},
         # NOTE: we can't use the previously-compiled kernel, or its launch configuration,
         #       since the type of `partial` might not match the original output container
         #       (e.g. if that was a view).
-        partial_invocation = KernelInvocation(partial_mapreduce_grid, f, op, init, Rreduce, Rother,
-                                     Val(shuffle), partial, A)
-        partial_kernel = kernel_compile(partial_invocation)
+        partial_call = KernelCall(partial_mapreduce_grid, f, op, init, Rreduce, Rother,
+                                  Val(shuffle), partial, A)
+        partial_kernel = kernel_compile(partial_call)
         partial_kernel_config = launch_configuration(partial_kernel.fun; shmem=compute_shmem∘compute_threads)
         partial_reduce_threads = compute_threads(partial_kernel_config.threads)
         partial_reduce_shmem = compute_shmem(partial_reduce_threads)
@@ -289,8 +289,8 @@ function GPUArrays.mapreducedim!(f::F, op::OP, R::AnyCuArray{T},
             partial .= R
         end
 
-        partial_invocation = rebind(partial_invocation, 7 => partial)
-        kernel_launch(partial_kernel, partial_invocation;
+        partial_call = rebind(partial_call, 7 => partial)
+        kernel_launch(partial_kernel, partial_call;
                threads=partial_threads, blocks=partial_blocks, shmem=partial_shmem)
 
         GPUArrays.mapreducedim!(identity, op, R, partial; init)

--- a/CUDACore/src/mapreduce.jl
+++ b/CUDACore/src/mapreduce.jl
@@ -289,7 +289,7 @@ function GPUArrays.mapreducedim!(f::F, op::OP, R::AnyCuArray{T},
             partial .= R
         end
 
-        partial_invocation = Base.setindex(partial_invocation, partial, 7)
+        partial_invocation = rebind(partial_invocation, 7 => partial)
         launch(partial_kernel, partial_invocation;
                threads=partial_threads, blocks=partial_blocks, shmem=partial_shmem)
 

--- a/CUDACore/src/mapreduce.jl
+++ b/CUDACore/src/mapreduce.jl
@@ -289,7 +289,7 @@ function GPUArrays.mapreducedim!(f::F, op::OP, R::AnyCuArray{T},
             partial .= R
         end
 
-        partial_call = rebind(partial_call, 7, partial)
+        partial_call = rebind(partial_call, partial, 7)
         kernel_launch(partial_kernel, partial_call;
                threads=partial_threads, blocks=partial_blocks, shmem=partial_shmem)
 

--- a/CUDACore/src/mapreduce.jl
+++ b/CUDACore/src/mapreduce.jl
@@ -187,6 +187,7 @@ function GPUArrays.mapreducedim!(f::F, op::OP, R::AnyCuArray{T},
         dims = Base.fill_to_length(size(R), 1, Val(ndims(A)))
         R = reshape(R, dims)
     end
+
     # iteration domain, split in two: one part covers the dimensions that should
     # be reduced, and the other covers the rest. combining both covers all values.
     Rall = CartesianIndices(axes(A))
@@ -199,7 +200,8 @@ function GPUArrays.mapreducedim!(f::F, op::OP, R::AnyCuArray{T},
 
     # If `Rother` is large enough, then a naive loop is more efficient than partial reductions.
     if length(Rother) >= serial_mapreduce_threshold(dev)
-        invocation = prepare(serial_mapreduce_kernel, f, op, init, Rreduce, Rother, R, A)
+        args = (f, op, init, Rreduce, Rother, R, A)
+        invocation = prepare(serial_mapreduce_kernel, args...)
         kernel = compile(invocation)
         kernel_config = launch_configuration(kernel.fun)
         threads = kernel_config.threads
@@ -228,11 +230,9 @@ function GPUArrays.mapreducedim!(f::F, op::OP, R::AnyCuArray{T},
     # that's why each threads also loops across their inputs, processing multiple values
     # so that we can span the entire reduction dimension using a single thread block.
     compute_shmem(threads) = shuffle ? 0 : threads*sizeof(T)
-    invocation = prepare(partial_mapreduce_grid, f, op, init, Rreduce, Rother,
-                         Val(shuffle), R, A)
+    invocation = prepare(partial_mapreduce_grid, f, op, init, Rreduce, Rother, Val(shuffle), R, A)
     kernel = compile(invocation)
-    kernel_config = launch_configuration(kernel.fun;
-                                         shmem=compute_shmem∘compute_threads)
+    kernel_config = launch_configuration(kernel.fun; shmem=compute_shmem∘compute_threads)
     reduce_threads = compute_threads(kernel_config.threads)
     reduce_shmem = compute_shmem(reduce_threads)
 
@@ -249,42 +249,52 @@ function GPUArrays.mapreducedim!(f::F, op::OP, R::AnyCuArray{T},
             cld(kernel_config.blocks, other_blocks))    # maximize occupancy
     end
 
+    # determine the launch configuration
     threads = reduce_threads
     shmem = reduce_shmem
     blocks = reduce_blocks*other_blocks
 
+    # perform the actual reduction
     if reduce_blocks == 1
+        # we can cover the dimensions to reduce using a single block
         launch(kernel, invocation; threads, blocks, shmem)
-        return R
-    end
-
-    # TODO: provide a version that atomically reduces from different blocks
-    placeholder = similar(R, ntuple(Returns(0), Val(ndims(R)+1)))
-    partial_invocation = prepare(partial_mapreduce_grid, f, op, init, Rreduce, Rother,
-                                 Val(shuffle), placeholder, A)
-    partial_kernel = compile(partial_invocation)
-    partial_config = launch_configuration(partial_kernel.fun;
-                                          shmem=compute_shmem∘compute_threads)
-    partial_threads = compute_threads(partial_config.threads)
-    partial_shmem = compute_shmem(partial_threads)
-    partial_reduce_blocks = if other_blocks >= partial_config.blocks
-        1
     else
-        min(cld(length(Rreduce), partial_threads),
-            cld(partial_config.blocks, other_blocks))
+        # TODO: provide a version that atomically reduces from different blocks
+
+        # temporary empty array whose type will match the final partial array
+        partial = similar(R, ntuple(_ -> 0, Val(ndims(R)+1)))
+
+        # NOTE: we can't use the previously-compiled kernel, or its launch configuration,
+        #       since the type of `partial` might not match the original output container
+        #       (e.g. if that was a view).
+        partial_invocation = prepare(partial_mapreduce_grid, f, op, init, Rreduce, Rother,
+                                     Val(shuffle), partial, A)
+        partial_kernel = compile(partial_invocation)
+        partial_kernel_config = launch_configuration(partial_kernel.fun; shmem=compute_shmem∘compute_threads)
+        partial_reduce_threads = compute_threads(partial_kernel_config.threads)
+        partial_reduce_shmem = compute_shmem(partial_reduce_threads)
+        partial_reduce_blocks = if other_blocks >= partial_kernel_config.blocks
+            1
+        else
+            min(cld(length(Rreduce), partial_reduce_threads),
+                cld(partial_kernel_config.blocks, other_blocks))
+        end
+        partial_threads = partial_reduce_threads
+        partial_shmem = partial_reduce_shmem
+        partial_blocks = partial_reduce_blocks*other_blocks
+
+        partial = similar(R, (size(R)..., partial_reduce_blocks))
+        if init === nothing
+            # without an explicit initializer we need to copy from the output container
+            partial .= R
+        end
+
+        partial_invocation = Base.setindex(partial_invocation, partial, 7)
+        launch(partial_kernel, partial_invocation;
+               threads=partial_threads, blocks=partial_blocks, shmem=partial_shmem)
+
+        GPUArrays.mapreducedim!(identity, op, R, partial; init)
     end
-    partial_blocks = partial_reduce_blocks*other_blocks
-
-    partial = similar(R, (size(R)..., partial_reduce_blocks))
-    if init === nothing
-        partial .= R
-    end
-
-    partial_invocation = Base.setindex(partial_invocation, partial, 7)
-    launch(partial_kernel, partial_invocation;
-           threads=partial_threads, blocks=partial_blocks, shmem=partial_shmem)
-
-    GPUArrays.mapreducedim!(identity, op, R, partial; init)
 
     return R
 end

--- a/CUDACore/src/sorting.jl
+++ b/CUDACore/src/sorting.jl
@@ -954,17 +954,17 @@ function bitonic_sort!(c; by = identity, lt = isless, rev = false, dims=1)
                 # grid dimensions
                 N_blocks = max(1, N_pseudo_blocks ÷ pseudo_blocks_per_block), other_block_dims...
                 block_size = pseudo_block_length, threads1 ÷ pseudo_block_length
-                current = CUDACore.rebind(call1, 3 => I(k))
-                current = CUDACore.rebind(current, 4 => I(j))
-                current = CUDACore.rebind(current, 5 => I(j_final))
+                current = CUDACore.rebind(call1, 3, I(k))
+                current = CUDACore.rebind(current, 4, I(j))
+                current = CUDACore.rebind(current, 5, I(j_final))
                 CUDACore.kernel_launch(kernel1, current;
                                 blocks=N_blocks, threads=block_size,
                                 shmem=bitonic_shmem(c, block_size))
                 break
             else
                 N_blocks = cld(c_len, threads2), other_block_dims...
-                current = CUDACore.rebind(call2, 3 => I(k))
-                current = CUDACore.rebind(current, 4 => I(j))
+                current = CUDACore.rebind(call2, 3, I(k))
+                current = CUDACore.rebind(current, 4, I(j))
                 CUDACore.kernel_launch(kernel2, current; blocks=N_blocks, threads=threads2)
             end
         end

--- a/CUDACore/src/sorting.jl
+++ b/CUDACore/src/sorting.jl
@@ -486,8 +486,10 @@ function quicksort!(c::AbstractArray{T,N}; lt::F1, by::F2, dims::Int, partial_k=
     get_shmem(threads) = threads * (sizeof(Int) + sizeof(T))
     invocation = CUDACore.prepare(qsort_kernel, my_sort_args...)
     kernel = CUDACore.compile(invocation)
-    config = launch_configuration(kernel.fun, shmem=get_shmem)
-    threads = prevpow(2, config.threads) >> block_size_shift
+    config = launch_configuration(kernel.fun, shmem=threads->get_shmem(threads))
+    threads = prevpow(2, config.threads)
+    threads = threads >> block_size_shift   # for testing purposes
+
     CUDACore.launch(kernel, invocation;
                     blocks=prod(otherdims), threads, shmem=get_shmem(threads))
 
@@ -915,19 +917,17 @@ function bitonic_sort!(c; by = identity, lt = isless, rev = false, dims=1)
     I = c_len <= typemax(Int32) ? Int32 : Int
 
     args1 = (c, I(c_len), one(I), one(I), one(I), by, lt, Val(rev), Val(dims))
-    args2 = (c, I(c_len), one(I), one(I), by, lt, Val(rev), Val(dims))
     invocation1 = CUDACore.prepare(comparator_small_kernel, args1...)
     kernel1 = CUDACore.compile(invocation1)
-    config1 = launch_configuration(kernel1.fun,
-                                   shmem=threads -> bitonic_shmem(c, threads))
+    config1 = launch_configuration(kernel1.fun, shmem = threads -> bitonic_shmem(c, threads))
     # blocksize for kernel1 MUST be a power of 2
     threads1 = prevpow(2, config1.threads)
 
+    args2 = (c, I(c_len), one(I), one(I), by, lt, Val(rev), Val(dims))
     invocation2 = CUDACore.prepare(comparator_kernel, args2...)
     kernel2 = CUDACore.compile(invocation2)
-    config2 = launch_configuration(kernel2.fun,
-                                   shmem=threads -> bitonic_shmem(c, threads))
-    threads2 = config2.threads
+    config2 = launch_configuration(kernel2.fun, shmem = threads -> bitonic_shmem(c, threads))
+    threads2 =  config2.threads
 
     # determines cutoff for when to use kernel1 vs kernel2
     log_threads = threads1 |> log2 |> Int
@@ -938,9 +938,9 @@ function bitonic_sort!(c; by = identity, lt = isless, rev = false, dims=1)
     k0 = ceil(Int, log2(c_len))
     for k = k0:-1:1
         j_final = 1 + k0 - k
+
         # non-sorting dims are put into blocks along grid y/z. Using sqrt minimizes wasted blocks
-        other_block_dims = (Int(ceil(sqrt(otherdims_len))),
-                            Int(ceil(sqrt(otherdims_len))))
+        other_block_dims = Int(ceil(sqrt(otherdims_len))), Int(ceil(sqrt(otherdims_len)))
 
         for j = 1:j_final
             if k0 - k - j + 2 <= log_threads
@@ -952,10 +952,8 @@ function bitonic_sort!(c; by = identity, lt = isless, rev = false, dims=1)
                 pseudo_blocks_per_block = threads1 ÷ pseudo_block_length
 
                 # grid dimensions
-                N_blocks = (max(1, N_pseudo_blocks ÷ pseudo_blocks_per_block),
-                            other_block_dims...)
-                block_size = (pseudo_block_length,
-                              threads1 ÷ pseudo_block_length)
+                N_blocks = max(1, N_pseudo_blocks ÷ pseudo_blocks_per_block), other_block_dims...
+                block_size = pseudo_block_length, threads1 ÷ pseudo_block_length
                 current = Base.setindex(invocation1, I(k), 3)
                 current = Base.setindex(current, I(j), 4)
                 current = Base.setindex(current, I(j_final), 5)
@@ -964,7 +962,7 @@ function bitonic_sort!(c; by = identity, lt = isless, rev = false, dims=1)
                                 shmem=bitonic_shmem(c, block_size))
                 break
             else
-                N_blocks = (cld(c_len, threads2), other_block_dims...)
+                N_blocks = cld(c_len, threads2), other_block_dims...
                 current = Base.setindex(invocation2, I(k), 3)
                 current = Base.setindex(current, I(j), 4)
                 CUDACore.launch(kernel2, current; blocks=N_blocks, threads=threads2)

--- a/CUDACore/src/sorting.jl
+++ b/CUDACore/src/sorting.jl
@@ -954,17 +954,17 @@ function bitonic_sort!(c; by = identity, lt = isless, rev = false, dims=1)
                 # grid dimensions
                 N_blocks = max(1, N_pseudo_blocks ÷ pseudo_blocks_per_block), other_block_dims...
                 block_size = pseudo_block_length, threads1 ÷ pseudo_block_length
-                current = CUDACore.rebind(call1, 3, I(k))
-                current = CUDACore.rebind(current, 4, I(j))
-                current = CUDACore.rebind(current, 5, I(j_final))
+                current = CUDACore.rebind(call1, I(k), 3)
+                current = CUDACore.rebind(current, I(j), 4)
+                current = CUDACore.rebind(current, I(j_final), 5)
                 CUDACore.kernel_launch(kernel1, current;
                                 blocks=N_blocks, threads=block_size,
                                 shmem=bitonic_shmem(c, block_size))
                 break
             else
                 N_blocks = cld(c_len, threads2), other_block_dims...
-                current = CUDACore.rebind(call2, 3, I(k))
-                current = CUDACore.rebind(current, 4, I(j))
+                current = CUDACore.rebind(call2, I(k), 3)
+                current = CUDACore.rebind(current, I(j), 4)
                 CUDACore.kernel_launch(kernel2, current; blocks=N_blocks, threads=threads2)
             end
         end

--- a/CUDACore/src/sorting.jl
+++ b/CUDACore/src/sorting.jl
@@ -954,17 +954,17 @@ function bitonic_sort!(c; by = identity, lt = isless, rev = false, dims=1)
                 # grid dimensions
                 N_blocks = max(1, N_pseudo_blocks ÷ pseudo_blocks_per_block), other_block_dims...
                 block_size = pseudo_block_length, threads1 ÷ pseudo_block_length
-                current = Base.setindex(invocation1, I(k), 3)
-                current = Base.setindex(current, I(j), 4)
-                current = Base.setindex(current, I(j_final), 5)
+                current = rebind(invocation1, 3 => I(k))
+                current = rebind(current, 4 => I(j))
+                current = rebind(current, 5 => I(j_final))
                 CUDACore.launch(kernel1, current;
                                 blocks=N_blocks, threads=block_size,
                                 shmem=bitonic_shmem(c, block_size))
                 break
             else
                 N_blocks = cld(c_len, threads2), other_block_dims...
-                current = Base.setindex(invocation2, I(k), 3)
-                current = Base.setindex(current, I(j), 4)
+                current = rebind(invocation2, 3 => I(k))
+                current = rebind(current, 4 => I(j))
                 CUDACore.launch(kernel2, current; blocks=N_blocks, threads=threads2)
             end
         end

--- a/CUDACore/src/sorting.jl
+++ b/CUDACore/src/sorting.jl
@@ -484,13 +484,13 @@ function quicksort!(c::AbstractArray{T,N}; lt::F1, by::F2, dims::Int, partial_k=
              max_depth, nothing, lt, by, Val(dims)), partial_k)
 
     get_shmem(threads) = threads * (sizeof(Int) + sizeof(T))
-    invocation = CUDACore.KernelInvocation(qsort_kernel, my_sort_args...)
-    kernel = CUDACore.kernel_compile(invocation)
+    call = CUDACore.KernelCall(qsort_kernel, my_sort_args...)
+    kernel = CUDACore.kernel_compile(call)
     config = launch_configuration(kernel.fun, shmem=threads->get_shmem(threads))
     threads = prevpow(2, config.threads)
     threads = threads >> block_size_shift   # for testing purposes
 
-    CUDACore.kernel_launch(kernel, invocation;
+    CUDACore.kernel_launch(kernel, call;
                     blocks=prod(otherdims), threads, shmem=get_shmem(threads))
 
     return c
@@ -917,15 +917,15 @@ function bitonic_sort!(c; by = identity, lt = isless, rev = false, dims=1)
     I = c_len <= typemax(Int32) ? Int32 : Int
 
     args1 = (c, I(c_len), one(I), one(I), one(I), by, lt, Val(rev), Val(dims))
-    invocation1 = CUDACore.KernelInvocation(comparator_small_kernel, args1...)
-    kernel1 = CUDACore.kernel_compile(invocation1)
+    call1 = CUDACore.KernelCall(comparator_small_kernel, args1...)
+    kernel1 = CUDACore.kernel_compile(call1)
     config1 = launch_configuration(kernel1.fun, shmem = threads -> bitonic_shmem(c, threads))
     # blocksize for kernel1 MUST be a power of 2
     threads1 = prevpow(2, config1.threads)
 
     args2 = (c, I(c_len), one(I), one(I), by, lt, Val(rev), Val(dims))
-    invocation2 = CUDACore.KernelInvocation(comparator_kernel, args2...)
-    kernel2 = CUDACore.kernel_compile(invocation2)
+    call2 = CUDACore.KernelCall(comparator_kernel, args2...)
+    kernel2 = CUDACore.kernel_compile(call2)
     config2 = launch_configuration(kernel2.fun, shmem = threads -> bitonic_shmem(c, threads))
     threads2 =  config2.threads
 
@@ -954,7 +954,7 @@ function bitonic_sort!(c; by = identity, lt = isless, rev = false, dims=1)
                 # grid dimensions
                 N_blocks = max(1, N_pseudo_blocks ÷ pseudo_blocks_per_block), other_block_dims...
                 block_size = pseudo_block_length, threads1 ÷ pseudo_block_length
-                current = rebind(invocation1, 3 => I(k))
+                current = rebind(call1, 3 => I(k))
                 current = rebind(current, 4 => I(j))
                 current = rebind(current, 5 => I(j_final))
                 CUDACore.kernel_launch(kernel1, current;
@@ -963,7 +963,7 @@ function bitonic_sort!(c; by = identity, lt = isless, rev = false, dims=1)
                 break
             else
                 N_blocks = cld(c_len, threads2), other_block_dims...
-                current = rebind(invocation2, 3 => I(k))
+                current = rebind(call2, 3 => I(k))
                 current = rebind(current, 4 => I(j))
                 CUDACore.kernel_launch(kernel2, current; blocks=N_blocks, threads=threads2)
             end

--- a/CUDACore/src/sorting.jl
+++ b/CUDACore/src/sorting.jl
@@ -484,13 +484,13 @@ function quicksort!(c::AbstractArray{T,N}; lt::F1, by::F2, dims::Int, partial_k=
              max_depth, nothing, lt, by, Val(dims)), partial_k)
 
     get_shmem(threads) = threads * (sizeof(Int) + sizeof(T))
-    invocation = CUDACore.prepare(qsort_kernel, my_sort_args...)
-    kernel = CUDACore.compile(invocation)
+    invocation = CUDACore.KernelInvocation(qsort_kernel, my_sort_args...)
+    kernel = CUDACore.kernel_compile(invocation)
     config = launch_configuration(kernel.fun, shmem=threads->get_shmem(threads))
     threads = prevpow(2, config.threads)
     threads = threads >> block_size_shift   # for testing purposes
 
-    CUDACore.launch(kernel, invocation;
+    CUDACore.kernel_launch(kernel, invocation;
                     blocks=prod(otherdims), threads, shmem=get_shmem(threads))
 
     return c
@@ -917,15 +917,15 @@ function bitonic_sort!(c; by = identity, lt = isless, rev = false, dims=1)
     I = c_len <= typemax(Int32) ? Int32 : Int
 
     args1 = (c, I(c_len), one(I), one(I), one(I), by, lt, Val(rev), Val(dims))
-    invocation1 = CUDACore.prepare(comparator_small_kernel, args1...)
-    kernel1 = CUDACore.compile(invocation1)
+    invocation1 = CUDACore.KernelInvocation(comparator_small_kernel, args1...)
+    kernel1 = CUDACore.kernel_compile(invocation1)
     config1 = launch_configuration(kernel1.fun, shmem = threads -> bitonic_shmem(c, threads))
     # blocksize for kernel1 MUST be a power of 2
     threads1 = prevpow(2, config1.threads)
 
     args2 = (c, I(c_len), one(I), one(I), by, lt, Val(rev), Val(dims))
-    invocation2 = CUDACore.prepare(comparator_kernel, args2...)
-    kernel2 = CUDACore.compile(invocation2)
+    invocation2 = CUDACore.KernelInvocation(comparator_kernel, args2...)
+    kernel2 = CUDACore.kernel_compile(invocation2)
     config2 = launch_configuration(kernel2.fun, shmem = threads -> bitonic_shmem(c, threads))
     threads2 =  config2.threads
 
@@ -957,7 +957,7 @@ function bitonic_sort!(c; by = identity, lt = isless, rev = false, dims=1)
                 current = rebind(invocation1, 3 => I(k))
                 current = rebind(current, 4 => I(j))
                 current = rebind(current, 5 => I(j_final))
-                CUDACore.launch(kernel1, current;
+                CUDACore.kernel_launch(kernel1, current;
                                 blocks=N_blocks, threads=block_size,
                                 shmem=bitonic_shmem(c, block_size))
                 break
@@ -965,7 +965,7 @@ function bitonic_sort!(c; by = identity, lt = isless, rev = false, dims=1)
                 N_blocks = cld(c_len, threads2), other_block_dims...
                 current = rebind(invocation2, 3 => I(k))
                 current = rebind(current, 4 => I(j))
-                CUDACore.launch(kernel2, current; blocks=N_blocks, threads=threads2)
+                CUDACore.kernel_launch(kernel2, current; blocks=N_blocks, threads=threads2)
             end
         end
     end

--- a/CUDACore/src/sorting.jl
+++ b/CUDACore/src/sorting.jl
@@ -484,11 +484,12 @@ function quicksort!(c::AbstractArray{T,N}; lt::F1, by::F2, dims::Int, partial_k=
              max_depth, nothing, lt, by, Val(dims)), partial_k)
 
     get_shmem(threads) = threads * (sizeof(Int) + sizeof(T))
-    CUDACore.prepare_launch(qsort_kernel, my_sort_args...) do launch
-        config = launch_configuration(launch.kernel.fun, shmem=get_shmem)
-        threads = prevpow(2, config.threads) >> block_size_shift
-        launch(; blocks=prod(otherdims), threads, shmem=get_shmem(threads))
-    end
+    invocation = CUDACore.prepare(qsort_kernel, my_sort_args...)
+    kernel = CUDACore.compile(invocation)
+    config = launch_configuration(kernel.fun, shmem=get_shmem)
+    threads = prevpow(2, config.threads) >> block_size_shift
+    CUDACore.launch(kernel, invocation;
+                    blocks=prod(otherdims), threads, shmem=get_shmem(threads))
 
     return c
 end
@@ -915,56 +916,58 @@ function bitonic_sort!(c; by = identity, lt = isless, rev = false, dims=1)
 
     args1 = (c, I(c_len), one(I), one(I), one(I), by, lt, Val(rev), Val(dims))
     args2 = (c, I(c_len), one(I), one(I), by, lt, Val(rev), Val(dims))
-    CUDACore.prepare_launch(comparator_small_kernel, args1...) do launch1
-        config1 = launch_configuration(launch1.kernel.fun,
-                                       shmem=threads -> bitonic_shmem(c, threads))
-        # blocksize for kernel1 MUST be a power of 2
-        threads1 = prevpow(2, config1.threads)
+    invocation1 = CUDACore.prepare(comparator_small_kernel, args1...)
+    kernel1 = CUDACore.compile(invocation1)
+    config1 = launch_configuration(kernel1.fun,
+                                   shmem=threads -> bitonic_shmem(c, threads))
+    # blocksize for kernel1 MUST be a power of 2
+    threads1 = prevpow(2, config1.threads)
 
-        CUDACore.prepare_launch(comparator_kernel, args2...) do launch2
-            config2 = launch_configuration(launch2.kernel.fun,
-                                           shmem=threads -> bitonic_shmem(c, threads))
-            threads2 = config2.threads
+    invocation2 = CUDACore.prepare(comparator_kernel, args2...)
+    kernel2 = CUDACore.compile(invocation2)
+    config2 = launch_configuration(kernel2.fun,
+                                   shmem=threads -> bitonic_shmem(c, threads))
+    threads2 = config2.threads
 
-            # determines cutoff for when to use kernel1 vs kernel2
-            log_threads = threads1 |> log2 |> Int
+    # determines cutoff for when to use kernel1 vs kernel2
+    log_threads = threads1 |> log2 |> Int
 
-            # These two outer loops are the same as the serial version outlined here:
-            # https://en.wikipedia.org/wiki/Bitonic_sorter#Example_code
-            # Notation: our k/j are the base2 logs of k/j in Wikipedia example
-            k0 = ceil(Int, log2(c_len))
-            for k = k0:-1:1
-                j_final = 1 + k0 - k
-                # non-sorting dims are put into blocks along grid y/z. Using sqrt minimizes wasted blocks
-                other_block_dims = (Int(ceil(sqrt(otherdims_len))),
-                                    Int(ceil(sqrt(otherdims_len))))
+    # These two outer loops are the same as the serial version outlined here:
+    # https://en.wikipedia.org/wiki/Bitonic_sorter#Example_code
+    # Notation: our k/j are the base2 logs of k/j in Wikipedia example
+    k0 = ceil(Int, log2(c_len))
+    for k = k0:-1:1
+        j_final = 1 + k0 - k
+        # non-sorting dims are put into blocks along grid y/z. Using sqrt minimizes wasted blocks
+        other_block_dims = (Int(ceil(sqrt(otherdims_len))),
+                            Int(ceil(sqrt(otherdims_len))))
 
-                for j = 1:j_final
-                    if k0 - k - j + 2 <= log_threads
-                        # pseudo_block_length = max(nextpow(2, length(comparator))
-                        # for all comparators in this layer of the network)
-                        pseudo_block_length = 1 << abs(j_final + 1 - j)
-                        # N_pseudo_blocks = how many pseudo-blocks are in this layer of the network
-                        N_pseudo_blocks = nextpow(2, c_len) ÷ pseudo_block_length
-                        pseudo_blocks_per_block = threads1 ÷ pseudo_block_length
+        for j = 1:j_final
+            if k0 - k - j + 2 <= log_threads
+                # pseudo_block_length = max(nextpow(2, length(comparator))
+                # for all comparators in this layer of the network)
+                pseudo_block_length = 1 << abs(j_final + 1 - j)
+                # N_pseudo_blocks = how many pseudo-blocks are in this layer of the network
+                N_pseudo_blocks = nextpow(2, c_len) ÷ pseudo_block_length
+                pseudo_blocks_per_block = threads1 ÷ pseudo_block_length
 
-                        # grid dimensions
-                        N_blocks = (max(1, N_pseudo_blocks ÷ pseudo_blocks_per_block),
-                                    other_block_dims...)
-                        block_size = (pseudo_block_length,
-                                      threads1 ÷ pseudo_block_length)
-                        current_launch = CUDACore.replace_arguments(
-                            launch1, 3 => I(k), 4 => I(j), 5 => I(j_final))
-                        current_launch(; blocks=N_blocks, threads=block_size,
-                                       shmem=bitonic_shmem(c, block_size))
-                        break
-                    else
-                        N_blocks = (cld(c_len, threads2), other_block_dims...)
-                        current_launch = CUDACore.replace_arguments(
-                            launch2, 3 => I(k), 4 => I(j))
-                        current_launch(; blocks=N_blocks, threads=threads2)
-                    end
-                end
+                # grid dimensions
+                N_blocks = (max(1, N_pseudo_blocks ÷ pseudo_blocks_per_block),
+                            other_block_dims...)
+                block_size = (pseudo_block_length,
+                              threads1 ÷ pseudo_block_length)
+                current = Base.setindex(invocation1, I(k), 3)
+                current = Base.setindex(current, I(j), 4)
+                current = Base.setindex(current, I(j_final), 5)
+                CUDACore.launch(kernel1, current;
+                                blocks=N_blocks, threads=block_size,
+                                shmem=bitonic_shmem(c, block_size))
+                break
+            else
+                N_blocks = (cld(c_len, threads2), other_block_dims...)
+                current = Base.setindex(invocation2, I(k), 3)
+                current = Base.setindex(current, I(j), 4)
+                CUDACore.launch(kernel2, current; blocks=N_blocks, threads=threads2)
             end
         end
     end

--- a/CUDACore/src/sorting.jl
+++ b/CUDACore/src/sorting.jl
@@ -483,14 +483,12 @@ function quicksort!(c::AbstractArray{T,N}; lt::F1, by::F2, dims::Int, partial_k=
     my_sort_args = sort_args((c, 0, len, true, Val(N==1 && max_depth > 1),
              max_depth, nothing, lt, by, Val(dims)), partial_k)
 
-    kernel = @cuda launch=false qsort_kernel(my_sort_args...)
-
     get_shmem(threads) = threads * (sizeof(Int) + sizeof(T))
-    config = launch_configuration(kernel.fun, shmem=threads->get_shmem(threads))
-    threads = prevpow(2, config.threads)
-    threads = threads >> block_size_shift   # for testing purposes
-
-    kernel(my_sort_args...; blocks=prod(otherdims), threads, shmem=get_shmem(threads))
+    CUDACore.prepare_launch(qsort_kernel, my_sort_args...) do launch
+        config = launch_configuration(launch.kernel.fun, shmem=get_shmem)
+        threads = prevpow(2, config.threads) >> block_size_shift
+        launch(; blocks=prod(otherdims), threads, shmem=get_shmem(threads))
+    end
 
     return c
 end
@@ -916,49 +914,57 @@ function bitonic_sort!(c; by = identity, lt = isless, rev = false, dims=1)
     I = c_len <= typemax(Int32) ? Int32 : Int
 
     args1 = (c, I(c_len), one(I), one(I), one(I), by, lt, Val(rev), Val(dims))
-    kernel1 = @cuda launch=false comparator_small_kernel(args1...)
-    config1 = launch_configuration(kernel1.fun, shmem = threads -> bitonic_shmem(c, threads))
-    # blocksize for kernel1 MUST be a power of 2
-    threads1 = prevpow(2, config1.threads)
-
     args2 = (c, I(c_len), one(I), one(I), by, lt, Val(rev), Val(dims))
-    kernel2 = @cuda launch=false comparator_kernel(args2...)
-    config2 = launch_configuration(kernel2.fun, shmem = threads -> bitonic_shmem(c, threads))
-    threads2 =  config2.threads
+    CUDACore.prepare_launch(comparator_small_kernel, args1...) do launch1
+        config1 = launch_configuration(launch1.kernel.fun,
+                                       shmem=threads -> bitonic_shmem(c, threads))
+        # blocksize for kernel1 MUST be a power of 2
+        threads1 = prevpow(2, config1.threads)
 
-    # determines cutoff for when to use kernel1 vs kernel2
-    log_threads = threads1 |> log2 |> Int
+        CUDACore.prepare_launch(comparator_kernel, args2...) do launch2
+            config2 = launch_configuration(launch2.kernel.fun,
+                                           shmem=threads -> bitonic_shmem(c, threads))
+            threads2 = config2.threads
 
-    # These two outer loops are the same as the serial version outlined here:
-    # https://en.wikipedia.org/wiki/Bitonic_sorter#Example_code
-    # Notation: our k/j are the base2 logs of k/j in Wikipedia example
-    k0 = ceil(Int, log2(c_len))
-    for k = k0:-1:1
-        j_final = 1 + k0 - k
+            # determines cutoff for when to use kernel1 vs kernel2
+            log_threads = threads1 |> log2 |> Int
 
-        # non-sorting dims are put into blocks along grid y/z. Using sqrt minimizes wasted blocks
-        other_block_dims = Int(ceil(sqrt(otherdims_len))), Int(ceil(sqrt(otherdims_len)))
+            # These two outer loops are the same as the serial version outlined here:
+            # https://en.wikipedia.org/wiki/Bitonic_sorter#Example_code
+            # Notation: our k/j are the base2 logs of k/j in Wikipedia example
+            k0 = ceil(Int, log2(c_len))
+            for k = k0:-1:1
+                j_final = 1 + k0 - k
+                # non-sorting dims are put into blocks along grid y/z. Using sqrt minimizes wasted blocks
+                other_block_dims = (Int(ceil(sqrt(otherdims_len))),
+                                    Int(ceil(sqrt(otherdims_len))))
 
-        for j = 1:j_final
-            args1 = (c, I.((c_len, k, j, j_final))..., by, lt, Val(rev), Val(dims))
-            args2 = (c, I.((c_len, k, j))..., by, lt, Val(rev), Val(dims))
-            if k0 - k - j + 2 <= log_threads
-                # pseudo_block_length = max(nextpow(2, length(comparator))
-                # for all comparators in this layer of the network)
-                pseudo_block_length = 1 << abs(j_final + 1 - j)
-                # N_pseudo_blocks = how many pseudo-blocks are in this layer of the network
-                N_pseudo_blocks = nextpow(2, c_len) ÷ pseudo_block_length
-                pseudo_blocks_per_block = threads1 ÷ pseudo_block_length
+                for j = 1:j_final
+                    if k0 - k - j + 2 <= log_threads
+                        # pseudo_block_length = max(nextpow(2, length(comparator))
+                        # for all comparators in this layer of the network)
+                        pseudo_block_length = 1 << abs(j_final + 1 - j)
+                        # N_pseudo_blocks = how many pseudo-blocks are in this layer of the network
+                        N_pseudo_blocks = nextpow(2, c_len) ÷ pseudo_block_length
+                        pseudo_blocks_per_block = threads1 ÷ pseudo_block_length
 
-                # grid dimensions
-                N_blocks = max(1, N_pseudo_blocks ÷ pseudo_blocks_per_block), other_block_dims...
-                block_size = pseudo_block_length, threads1 ÷ pseudo_block_length
-                kernel1(args1...; blocks=N_blocks, threads=block_size,
-                        shmem=bitonic_shmem(c, block_size))
-                break
-            else
-                N_blocks = cld(c_len, threads2), other_block_dims...
-                kernel2(args2...; blocks = N_blocks, threads=threads2)
+                        # grid dimensions
+                        N_blocks = (max(1, N_pseudo_blocks ÷ pseudo_blocks_per_block),
+                                    other_block_dims...)
+                        block_size = (pseudo_block_length,
+                                      threads1 ÷ pseudo_block_length)
+                        current_launch = CUDACore.replace_arguments(
+                            launch1, 3 => I(k), 4 => I(j), 5 => I(j_final))
+                        current_launch(; blocks=N_blocks, threads=block_size,
+                                       shmem=bitonic_shmem(c, block_size))
+                        break
+                    else
+                        N_blocks = (cld(c_len, threads2), other_block_dims...)
+                        current_launch = CUDACore.replace_arguments(
+                            launch2, 3 => I(k), 4 => I(j))
+                        current_launch(; blocks=N_blocks, threads=threads2)
+                    end
+                end
             end
         end
     end

--- a/CUDACore/src/sorting.jl
+++ b/CUDACore/src/sorting.jl
@@ -954,17 +954,17 @@ function bitonic_sort!(c; by = identity, lt = isless, rev = false, dims=1)
                 # grid dimensions
                 N_blocks = max(1, N_pseudo_blocks ÷ pseudo_blocks_per_block), other_block_dims...
                 block_size = pseudo_block_length, threads1 ÷ pseudo_block_length
-                current = rebind(call1, 3 => I(k))
-                current = rebind(current, 4 => I(j))
-                current = rebind(current, 5 => I(j_final))
+                current = CUDACore.rebind(call1, 3 => I(k))
+                current = CUDACore.rebind(current, 4 => I(j))
+                current = CUDACore.rebind(current, 5 => I(j_final))
                 CUDACore.kernel_launch(kernel1, current;
                                 blocks=N_blocks, threads=block_size,
                                 shmem=bitonic_shmem(c, block_size))
                 break
             else
                 N_blocks = cld(c_len, threads2), other_block_dims...
-                current = rebind(call2, 3 => I(k))
-                current = rebind(current, 4 => I(j))
+                current = CUDACore.rebind(call2, 3 => I(k))
+                current = CUDACore.rebind(current, 4 => I(j))
                 CUDACore.kernel_launch(kernel2, current; blocks=N_blocks, threads=threads2)
             end
         end

--- a/docs/src/api/compiler.md
+++ b/docs/src/api/compiler.md
@@ -29,7 +29,7 @@ memory
 ```
 
 Launch a compiled call with `kernel_launch(kernel, call; launch_kwargs...)`. Arguments
-can be rebound immutably with `rebind(call, index, value)` before launching.
+can be rebound immutably with `rebind(call, value, index)` before launching.
 
 The PTX compilation target is identified by an `SMVersion`, constructed via the
 `sm"..."` string macro:

--- a/docs/src/api/compiler.md
+++ b/docs/src/api/compiler.md
@@ -15,9 +15,9 @@ The main entry-point to the compiler is the `@cuda` macro:
 If needed, you can use a lower-level API that lets you inspect the compiler kernel:
 
 ```@docs
-prepare_launch
-PreparedLaunch
-replace_arguments
+prepare
+KernelInvocation
+compile
 cudaconvert
 cufunction
 AbstractKernel
@@ -27,6 +27,9 @@ maxthreads
 registers
 memory
 ```
+
+Launch a compiled invocation with `launch(kernel, invocation; launch_kwargs...)`. Arguments
+can be replaced immutably with `Base.setindex(invocation, value, index)` before launching.
 
 The PTX compilation target is identified by an `SMVersion`, constructed via the
 `sm"..."` string macro:
@@ -43,9 +46,7 @@ through a small protocol:
 AbstractBackend
 LLVMBackend
 DefaultBackend
-kernel_convert
-kernel_compile
-kernel_launch
+backend
 ```
 
 

--- a/docs/src/api/compiler.md
+++ b/docs/src/api/compiler.md
@@ -15,6 +15,9 @@ The main entry-point to the compiler is the `@cuda` macro:
 If needed, you can use a lower-level API that lets you inspect the compiler kernel:
 
 ```@docs
+prepare_launch
+PreparedLaunch
+replace_arguments
 cudaconvert
 cufunction
 AbstractKernel
@@ -42,6 +45,7 @@ LLVMBackend
 DefaultBackend
 kernel_convert
 kernel_compile
+kernel_launch
 ```
 
 

--- a/docs/src/api/compiler.md
+++ b/docs/src/api/compiler.md
@@ -29,7 +29,7 @@ memory
 ```
 
 Launch a compiled call with `kernel_launch(kernel, call; launch_kwargs...)`. Arguments
-can be rebound immutably with `rebind(call, index => value)` before launching.
+can be rebound immutably with `rebind(call, index, value)` before launching.
 
 The PTX compilation target is identified by an `SMVersion`, constructed via the
 `sm"..."` string macro:

--- a/docs/src/api/compiler.md
+++ b/docs/src/api/compiler.md
@@ -15,7 +15,7 @@ The main entry-point to the compiler is the `@cuda` macro:
 If needed, you can use a lower-level API that lets you inspect the compiled kernel:
 
 ```@docs
-KernelInvocation
+KernelCall
 kernel_launch
 rebind
 cudaconvert
@@ -28,8 +28,8 @@ registers
 memory
 ```
 
-Launch a compiled invocation with `kernel_launch(kernel, invocation; launch_kwargs...)`. Arguments
-can be rebound immutably with `rebind(invocation, index => value)` before launching.
+Launch a compiled call with `kernel_launch(kernel, call; launch_kwargs...)`. Arguments
+can be rebound immutably with `rebind(call, index => value)` before launching.
 
 The PTX compilation target is identified by an `SMVersion`, constructed via the
 `sm"..."` string macro:

--- a/docs/src/api/compiler.md
+++ b/docs/src/api/compiler.md
@@ -18,6 +18,7 @@ If needed, you can use a lower-level API that lets you inspect the compiler kern
 prepare
 KernelInvocation
 compile
+rebind
 cudaconvert
 cufunction
 AbstractKernel
@@ -29,7 +30,7 @@ memory
 ```
 
 Launch a compiled invocation with `launch(kernel, invocation; launch_kwargs...)`. Arguments
-can be replaced immutably with `Base.setindex(invocation, value, index)` before launching.
+can be rebound immutably with `rebind(invocation, index => value)` before launching.
 
 The PTX compilation target is identified by an `SMVersion`, constructed via the
 `sm"..."` string macro:

--- a/docs/src/api/compiler.md
+++ b/docs/src/api/compiler.md
@@ -16,8 +16,6 @@ If needed, you can use a lower-level API that lets you inspect the compiled kern
 
 ```@docs
 KernelInvocation
-kernel_convert
-kernel_compile
 kernel_launch
 rebind
 cudaconvert
@@ -48,7 +46,8 @@ through a small protocol:
 AbstractBackend
 LLVMBackend
 DefaultBackend
-backend
+kernel_convert
+kernel_compile
 ```
 
 

--- a/docs/src/api/compiler.md
+++ b/docs/src/api/compiler.md
@@ -12,12 +12,13 @@ The main entry-point to the compiler is the `@cuda` macro:
 @cuda
 ```
 
-If needed, you can use a lower-level API that lets you inspect the compiler kernel:
+If needed, you can use a lower-level API that lets you inspect the compiled kernel:
 
 ```@docs
-prepare
 KernelInvocation
-compile
+kernel_convert
+kernel_compile
+kernel_launch
 rebind
 cudaconvert
 cufunction
@@ -29,7 +30,7 @@ registers
 memory
 ```
 
-Launch a compiled invocation with `launch(kernel, invocation; launch_kwargs...)`. Arguments
+Launch a compiled invocation with `kernel_launch(kernel, invocation; launch_kwargs...)`. Arguments
 can be rebound immutably with `rebind(invocation, index => value)` before launching.
 
 The PTX compilation target is identified by an `SMVersion`, constructed via the

--- a/docs/src/development/kernel.md
+++ b/docs/src/development/kernel.md
@@ -44,14 +44,14 @@ julia> k()
 ```
 
 Calling a `HostKernel` with positional arguments converts those host values for each call.
-For an occupancy query followed by an immediate launch, prepare the invocation explicitly so
+For an occupancy query followed by an immediate launch, construct the invocation explicitly so
 the arguments are only converted once:
 
 ```julia
-invocation = CUDA.prepare(my_kernel)
-kernel = CUDA.compile(invocation)
+invocation = CUDA.KernelInvocation(my_kernel)
+kernel = CUDA.kernel_compile(invocation)
 config = launch_configuration(kernel.fun)
-CUDA.launch(kernel, invocation; threads=config.threads)
+CUDA.kernel_launch(kernel, invocation; threads=config.threads)
 ```
 
 

--- a/docs/src/development/kernel.md
+++ b/docs/src/development/kernel.md
@@ -44,14 +44,14 @@ julia> k()
 ```
 
 Calling a `HostKernel` with positional arguments converts those host values for each call.
-For an occupancy query followed by an immediate launch, keep the converted arguments in a
-scoped prepared launch:
+For an occupancy query followed by an immediate launch, prepare the invocation explicitly so
+the arguments are only converted once:
 
 ```julia
-CUDA.prepare_launch(my_kernel) do launch
-    config = launch_configuration(launch.kernel.fun)
-    launch(; threads=config.threads)
-end
+invocation = CUDA.prepare(my_kernel)
+kernel = CUDA.compile(invocation)
+config = launch_configuration(kernel.fun)
+CUDA.launch(kernel, invocation; threads=config.threads)
 ```
 
 

--- a/docs/src/development/kernel.md
+++ b/docs/src/development/kernel.md
@@ -43,6 +43,17 @@ julia> CUDA.registers(k)
 julia> k()
 ```
 
+Calling a `HostKernel` with positional arguments converts those host values for each call.
+For an occupancy query followed by an immediate launch, keep the converted arguments in a
+scoped prepared launch:
+
+```julia
+CUDA.prepare_launch(my_kernel) do launch
+    config = launch_configuration(launch.kernel.fun)
+    launch(; threads=config.threads)
+end
+```
+
 
 ## Kernel inputs and outputs
 

--- a/docs/src/development/kernel.md
+++ b/docs/src/development/kernel.md
@@ -44,14 +44,14 @@ julia> k()
 ```
 
 Calling a `HostKernel` with positional arguments converts those host values for each call.
-For an occupancy query followed by an immediate launch, construct the invocation explicitly so
+For an occupancy query followed by an immediate launch, construct the call explicitly so
 the arguments are only converted once:
 
 ```julia
-invocation = CUDA.KernelInvocation(my_kernel)
-kernel = CUDA.kernel_compile(invocation)
+call = CUDA.KernelCall(my_kernel)
+kernel = CUDA.kernel_compile(call)
 config = launch_configuration(kernel.fun)
-CUDA.kernel_launch(kernel, invocation; threads=config.threads)
+CUDA.kernel_launch(kernel, call; threads=config.threads)
 ```
 
 

--- a/docs/src/tutorials/introduction.jl
+++ b/docs/src/tutorials/introduction.jl
@@ -338,28 +338,28 @@ CUDA.@profile trace=true bench_gpu3!(y_d, x_d)
 # threads to launch depends on your GPU as well as on the kernel. To automatically select an
 # appropriate number of threads, it is recommended to use the launch configuration API. This
 # API takes a compiled kernel and returns an upper bound on the number of threads and the
-# minimum number of blocks required to fully saturate the GPU. Preparing the invocation first
+# minimum number of blocks required to fully saturate the GPU. Constructing the call first
 # keeps the converted arguments available while we inspect and launch the kernel:
 
 fill!(y_d, 2)
-invocation = CUDA.KernelInvocation(gpu_add3!, y_d, x_d)
-kernel = CUDA.kernel_compile(invocation)
+call = CUDA.KernelCall(gpu_add3!, y_d, x_d)
+kernel = CUDA.kernel_compile(call)
 config = launch_configuration(kernel.fun)
 threads = min(N, config.threads)
 blocks = cld(N, threads)
-CUDA.kernel_launch(kernel, invocation; threads, blocks)
+CUDA.kernel_launch(kernel, call; threads, blocks)
 @test all(Array(y_d) .== 3.0f0)
 
 # Now let's benchmark this:
 
 function bench_gpu4!(y, x)
     CUDA.@sync begin
-        invocation = CUDA.KernelInvocation(gpu_add3!, y, x)
-        kernel = CUDA.kernel_compile(invocation)
+        call = CUDA.KernelCall(gpu_add3!, y, x)
+        kernel = CUDA.kernel_compile(call)
         config = launch_configuration(kernel.fun)
         threads = min(length(y), config.threads)
         blocks = cld(length(y), threads)
-        CUDA.kernel_launch(kernel, invocation; threads, blocks)
+        CUDA.kernel_launch(kernel, call; threads, blocks)
     end
 end
 

--- a/docs/src/tutorials/introduction.jl
+++ b/docs/src/tutorials/introduction.jl
@@ -338,28 +338,28 @@ CUDA.@profile trace=true bench_gpu3!(y_d, x_d)
 # threads to launch depends on your GPU as well as on the kernel. To automatically select an
 # appropriate number of threads, it is recommended to use the launch configuration API. This
 # API takes a compiled kernel and returns an upper bound on the number of threads and the
-# minimum number of blocks required to fully saturate the GPU. `prepare_launch` keeps the
-# converted arguments available while we inspect and launch the kernel:
+# minimum number of blocks required to fully saturate the GPU. Preparing the invocation first
+# keeps the converted arguments available while we inspect and launch the kernel:
 
 fill!(y_d, 2)
-CUDA.prepare_launch(gpu_add3!, y_d, x_d) do launch
-    config = launch_configuration(launch.kernel.fun)
-    threads = min(N, config.threads)
-    blocks = cld(N, threads)
-    launch(; threads, blocks)
-end
+invocation = CUDA.prepare(gpu_add3!, y_d, x_d)
+kernel = CUDA.compile(invocation)
+config = launch_configuration(kernel.fun)
+threads = min(N, config.threads)
+blocks = cld(N, threads)
+CUDA.launch(kernel, invocation; threads, blocks)
 @test all(Array(y_d) .== 3.0f0)
 
 # Now let's benchmark this:
 
 function bench_gpu4!(y, x)
     CUDA.@sync begin
-        CUDA.prepare_launch(gpu_add3!, y, x) do launch
-            config = launch_configuration(launch.kernel.fun)
-            threads = min(length(y), config.threads)
-            blocks = cld(length(y), threads)
-            launch(; threads, blocks)
-        end
+        invocation = CUDA.prepare(gpu_add3!, y, x)
+        kernel = CUDA.compile(invocation)
+        config = launch_configuration(kernel.fun)
+        threads = min(length(y), config.threads)
+        blocks = cld(length(y), threads)
+        CUDA.launch(kernel, invocation; threads, blocks)
     end
 end
 

--- a/docs/src/tutorials/introduction.jl
+++ b/docs/src/tutorials/introduction.jl
@@ -337,32 +337,29 @@ CUDA.@profile trace=true bench_gpu3!(y_d, x_d)
 # as using more threads generally improves performance, but the maximum number of allowed
 # threads to launch depends on your GPU as well as on the kernel. To automatically select an
 # appropriate number of threads, it is recommended to use the launch configuration API. This
-# API takes a compiled (but not launched) kernel, returns a tuple with an upper bound on the
-# number of threads, and the minimum number of blocks that are required to fully saturate
-# the GPU:
-
-kernel = @cuda launch=false gpu_add3!(y_d, x_d)
-config = launch_configuration(kernel.fun)
-threads = min(N, config.threads)
-blocks = cld(N, threads)
-
-# The compiled kernel is callable, and we can pass the computed launch configuration as
-# keyword arguments:
+# API takes a compiled kernel and returns an upper bound on the number of threads and the
+# minimum number of blocks required to fully saturate the GPU. `prepare_launch` keeps the
+# converted arguments available while we inspect and launch the kernel:
 
 fill!(y_d, 2)
-kernel(y_d, x_d; threads, blocks)
+CUDA.prepare_launch(gpu_add3!, y_d, x_d) do launch
+    config = launch_configuration(launch.kernel.fun)
+    threads = min(N, config.threads)
+    blocks = cld(N, threads)
+    launch(; threads, blocks)
+end
 @test all(Array(y_d) .== 3.0f0)
 
 # Now let's benchmark this:
 
 function bench_gpu4!(y, x)
-    kernel = @cuda launch=false gpu_add3!(y, x)
-    config = launch_configuration(kernel.fun)
-    threads = min(length(y), config.threads)
-    blocks = cld(length(y), threads)
-
     CUDA.@sync begin
-        kernel(y, x; threads, blocks)
+        CUDA.prepare_launch(gpu_add3!, y, x) do launch
+            config = launch_configuration(launch.kernel.fun)
+            threads = min(length(y), config.threads)
+            blocks = cld(length(y), threads)
+            launch(; threads, blocks)
+        end
     end
 end
 

--- a/docs/src/tutorials/introduction.jl
+++ b/docs/src/tutorials/introduction.jl
@@ -342,24 +342,24 @@ CUDA.@profile trace=true bench_gpu3!(y_d, x_d)
 # keeps the converted arguments available while we inspect and launch the kernel:
 
 fill!(y_d, 2)
-invocation = CUDA.prepare(gpu_add3!, y_d, x_d)
-kernel = CUDA.compile(invocation)
+invocation = CUDA.KernelInvocation(gpu_add3!, y_d, x_d)
+kernel = CUDA.kernel_compile(invocation)
 config = launch_configuration(kernel.fun)
 threads = min(N, config.threads)
 blocks = cld(N, threads)
-CUDA.launch(kernel, invocation; threads, blocks)
+CUDA.kernel_launch(kernel, invocation; threads, blocks)
 @test all(Array(y_d) .== 3.0f0)
 
 # Now let's benchmark this:
 
 function bench_gpu4!(y, x)
     CUDA.@sync begin
-        invocation = CUDA.prepare(gpu_add3!, y, x)
-        kernel = CUDA.compile(invocation)
+        invocation = CUDA.KernelInvocation(gpu_add3!, y, x)
+        kernel = CUDA.kernel_compile(invocation)
         config = launch_configuration(kernel.fun)
         threads = min(length(y), config.threads)
         blocks = cld(length(y), threads)
-        CUDA.launch(kernel, invocation; threads, blocks)
+        CUDA.kernel_launch(kernel, invocation; threads, blocks)
     end
 end
 

--- a/docs/src/tutorials/performance.jl
+++ b/docs/src/tutorials/performance.jl
@@ -173,23 +173,23 @@ end
 
 function bench_gpu4!(y, x)
     CUDA.@sync begin
-        invocation = CUDA.prepare(gpu_add4!, y, x)
-        kernel = CUDA.compile(invocation)
+        invocation = CUDA.KernelInvocation(gpu_add4!, y, x)
+        kernel = CUDA.kernel_compile(invocation)
         config = launch_configuration(kernel.fun)
         threads = min(length(y), config.threads)
         blocks = cld(length(y), threads)
-        CUDA.launch(kernel, invocation; threads, blocks)
+        CUDA.kernel_launch(kernel, invocation; threads, blocks)
     end
 end
 
 function bench_gpu5!(y, x)
     CUDA.@sync begin
-        invocation = CUDA.prepare(gpu_add5!, y, x)
-        kernel = CUDA.compile(invocation)
+        invocation = CUDA.KernelInvocation(gpu_add5!, y, x)
+        kernel = CUDA.kernel_compile(invocation)
         config = launch_configuration(kernel.fun)
         threads = min(length(y), config.threads)
         blocks = cld(length(y), threads)
-        CUDA.launch(kernel, invocation; threads, blocks)
+        CUDA.kernel_launch(kernel, invocation; threads, blocks)
     end
 end
 

--- a/docs/src/tutorials/performance.jl
+++ b/docs/src/tutorials/performance.jl
@@ -172,21 +172,25 @@ end
 # The benchmark[^1]:
 
 function bench_gpu4!(y, x)
-    kernel = @cuda launch=false gpu_add4!(y, x)
-    config = launch_configuration(kernel.fun)
-    threads = min(length(y), config.threads)
-    blocks = cld(length(y), threads)
-
-    CUDA.@sync kernel(y, x; threads, blocks)
+    CUDA.@sync begin
+        CUDA.prepare_launch(gpu_add4!, y, x) do launch
+            config = launch_configuration(launch.kernel.fun)
+            threads = min(length(y), config.threads)
+            blocks = cld(length(y), threads)
+            launch(; threads, blocks)
+        end
+    end
 end
 
 function bench_gpu5!(y, x)
-    kernel = @cuda launch=false gpu_add5!(y, x)
-    config = launch_configuration(kernel.fun)
-    threads = min(length(y), config.threads)
-    blocks = cld(length(y), threads)
-
-    CUDA.@sync kernel(y, x; threads, blocks)
+    CUDA.@sync begin
+        CUDA.prepare_launch(gpu_add5!, y, x) do launch
+            config = launch_configuration(launch.kernel.fun)
+            threads = min(length(y), config.threads)
+            blocks = cld(length(y), threads)
+            launch(; threads, blocks)
+        end
+    end
 end
 
 

--- a/docs/src/tutorials/performance.jl
+++ b/docs/src/tutorials/performance.jl
@@ -173,23 +173,23 @@ end
 
 function bench_gpu4!(y, x)
     CUDA.@sync begin
-        CUDA.prepare_launch(gpu_add4!, y, x) do launch
-            config = launch_configuration(launch.kernel.fun)
-            threads = min(length(y), config.threads)
-            blocks = cld(length(y), threads)
-            launch(; threads, blocks)
-        end
+        invocation = CUDA.prepare(gpu_add4!, y, x)
+        kernel = CUDA.compile(invocation)
+        config = launch_configuration(kernel.fun)
+        threads = min(length(y), config.threads)
+        blocks = cld(length(y), threads)
+        CUDA.launch(kernel, invocation; threads, blocks)
     end
 end
 
 function bench_gpu5!(y, x)
     CUDA.@sync begin
-        CUDA.prepare_launch(gpu_add5!, y, x) do launch
-            config = launch_configuration(launch.kernel.fun)
-            threads = min(length(y), config.threads)
-            blocks = cld(length(y), threads)
-            launch(; threads, blocks)
-        end
+        invocation = CUDA.prepare(gpu_add5!, y, x)
+        kernel = CUDA.compile(invocation)
+        config = launch_configuration(kernel.fun)
+        threads = min(length(y), config.threads)
+        blocks = cld(length(y), threads)
+        CUDA.launch(kernel, invocation; threads, blocks)
     end
 end
 

--- a/docs/src/tutorials/performance.jl
+++ b/docs/src/tutorials/performance.jl
@@ -173,23 +173,23 @@ end
 
 function bench_gpu4!(y, x)
     CUDA.@sync begin
-        invocation = CUDA.KernelInvocation(gpu_add4!, y, x)
-        kernel = CUDA.kernel_compile(invocation)
+        call = CUDA.KernelCall(gpu_add4!, y, x)
+        kernel = CUDA.kernel_compile(call)
         config = launch_configuration(kernel.fun)
         threads = min(length(y), config.threads)
         blocks = cld(length(y), threads)
-        CUDA.kernel_launch(kernel, invocation; threads, blocks)
+        CUDA.kernel_launch(kernel, call; threads, blocks)
     end
 end
 
 function bench_gpu5!(y, x)
     CUDA.@sync begin
-        invocation = CUDA.KernelInvocation(gpu_add5!, y, x)
-        kernel = CUDA.kernel_compile(invocation)
+        call = CUDA.KernelCall(gpu_add5!, y, x)
+        kernel = CUDA.kernel_compile(call)
         config = launch_configuration(kernel.fun)
         threads = min(length(y), config.threads)
         blocks = cld(length(y), threads)
-        CUDA.kernel_launch(kernel, invocation; threads, blocks)
+        CUDA.kernel_launch(kernel, call; threads, blocks)
     end
 end
 

--- a/lib/cublas/src/linalg.jl
+++ b/lib/cublas/src/linalg.jl
@@ -103,14 +103,14 @@ function LinearAlgebra.dot(x::AnyCuArray{T1}, y::AnyCuArray{T2}) where {T1,T2}
         end
 
         compute_shmem(threads) = shuffle ? 0 : threads*sizeof(T)
-        CUDACore.prepare_launch(kernel, x, y, res, Val(shuffle)) do launch
-            config = launch_configuration(launch.kernel.fun;
-                                          shmem=compute_shmem∘compute_threads)
-            threads = compute_threads(config.threads)
-            blocks = min(config.blocks, cld(n, config.blocks))
-            shmem = compute_shmem(threads)
-            launch(; threads, blocks, shmem)
-        end
+        invocation = CUDACore.prepare(kernel, x, y, res, Val(shuffle))
+        compiled = CUDACore.compile(invocation)
+        config = launch_configuration(compiled.fun;
+                                      shmem=compute_shmem∘compute_threads)
+        threads = compute_threads(config.threads)
+        blocks = min(config.blocks, cld(n, config.blocks))
+        shmem = compute_shmem(threads)
+        CUDACore.launch(compiled, invocation; threads, blocks, shmem)
 
         CUDACore.@allowscalar res[]
     end
@@ -190,14 +190,14 @@ function LinearAlgebra.dot(x::AnyCuArray{T1}, A::AnyCuArray{T2}, y::AnyCuArray{T
         end
 
         compute_shmem(threads) = shuffle ? 0 : threads*sizeof(T)
-        CUDACore.prepare_launch(kernel, x, A, y, res, Val(shuffle)) do launch
-            config = launch_configuration(launch.kernel.fun;
-                                          shmem=compute_shmem∘compute_threads)
-            threads = compute_threads(config.threads)
-            blocks = min(config.blocks, cld(mA, config.blocks))
-            shmem = compute_shmem(threads)
-            launch(; threads, blocks, shmem)
-        end
+        invocation = CUDACore.prepare(kernel, x, A, y, res, Val(shuffle))
+        compiled = CUDACore.compile(invocation)
+        config = launch_configuration(compiled.fun;
+                                      shmem=compute_shmem∘compute_threads)
+        threads = compute_threads(config.threads)
+        blocks = min(config.blocks, cld(mA, config.blocks))
+        shmem = compute_shmem(threads)
+        CUDACore.launch(compiled, invocation; threads, blocks, shmem)
 
         CUDACore.@allowscalar res[]
     end

--- a/lib/cublas/src/linalg.jl
+++ b/lib/cublas/src/linalg.jl
@@ -102,11 +102,11 @@ function LinearAlgebra.dot(x::AnyCuArray{T1}, y::AnyCuArray{T2}) where {T1,T2}
             end
         end
 
+        # how many threads can we launch?
         compute_shmem(threads) = shuffle ? 0 : threads*sizeof(T)
         invocation = CUDACore.prepare(kernel, x, y, res, Val(shuffle))
         compiled = CUDACore.compile(invocation)
-        config = launch_configuration(compiled.fun;
-                                      shmem=compute_shmem∘compute_threads)
+        config = launch_configuration(compiled.fun; shmem=compute_shmem∘compute_threads)
         threads = compute_threads(config.threads)
         blocks = min(config.blocks, cld(n, config.blocks))
         shmem = compute_shmem(threads)
@@ -189,11 +189,11 @@ function LinearAlgebra.dot(x::AnyCuArray{T1}, A::AnyCuArray{T2}, y::AnyCuArray{T
             end
         end
 
+        # how many threads can we launch?
         compute_shmem(threads) = shuffle ? 0 : threads*sizeof(T)
         invocation = CUDACore.prepare(kernel, x, A, y, res, Val(shuffle))
         compiled = CUDACore.compile(invocation)
-        config = launch_configuration(compiled.fun;
-                                      shmem=compute_shmem∘compute_threads)
+        config = launch_configuration(compiled.fun; shmem=compute_shmem∘compute_threads)
         threads = compute_threads(config.threads)
         blocks = min(config.blocks, cld(mA, config.blocks))
         shmem = compute_shmem(threads)

--- a/lib/cublas/src/linalg.jl
+++ b/lib/cublas/src/linalg.jl
@@ -104,13 +104,13 @@ function LinearAlgebra.dot(x::AnyCuArray{T1}, y::AnyCuArray{T2}) where {T1,T2}
 
         # how many threads can we launch?
         compute_shmem(threads) = shuffle ? 0 : threads*sizeof(T)
-        invocation = CUDACore.prepare(kernel, x, y, res, Val(shuffle))
-        compiled = CUDACore.compile(invocation)
+        invocation = CUDACore.KernelInvocation(kernel, x, y, res, Val(shuffle))
+        compiled = CUDACore.kernel_compile(invocation)
         config = launch_configuration(compiled.fun; shmem=compute_shmem∘compute_threads)
         threads = compute_threads(config.threads)
         blocks = min(config.blocks, cld(n, config.blocks))
         shmem = compute_shmem(threads)
-        CUDACore.launch(compiled, invocation; threads, blocks, shmem)
+        CUDACore.kernel_launch(compiled, invocation; threads, blocks, shmem)
 
         CUDACore.@allowscalar res[]
     end
@@ -191,13 +191,13 @@ function LinearAlgebra.dot(x::AnyCuArray{T1}, A::AnyCuArray{T2}, y::AnyCuArray{T
 
         # how many threads can we launch?
         compute_shmem(threads) = shuffle ? 0 : threads*sizeof(T)
-        invocation = CUDACore.prepare(kernel, x, A, y, res, Val(shuffle))
-        compiled = CUDACore.compile(invocation)
+        invocation = CUDACore.KernelInvocation(kernel, x, A, y, res, Val(shuffle))
+        compiled = CUDACore.kernel_compile(invocation)
         config = launch_configuration(compiled.fun; shmem=compute_shmem∘compute_threads)
         threads = compute_threads(config.threads)
         blocks = min(config.blocks, cld(mA, config.blocks))
         shmem = compute_shmem(threads)
-        CUDACore.launch(compiled, invocation; threads, blocks, shmem)
+        CUDACore.kernel_launch(compiled, invocation; threads, blocks, shmem)
 
         CUDACore.@allowscalar res[]
     end

--- a/lib/cublas/src/linalg.jl
+++ b/lib/cublas/src/linalg.jl
@@ -104,13 +104,13 @@ function LinearAlgebra.dot(x::AnyCuArray{T1}, y::AnyCuArray{T2}) where {T1,T2}
 
         # how many threads can we launch?
         compute_shmem(threads) = shuffle ? 0 : threads*sizeof(T)
-        invocation = CUDACore.KernelInvocation(kernel, x, y, res, Val(shuffle))
-        compiled = CUDACore.kernel_compile(invocation)
+        call = CUDACore.KernelCall(kernel, x, y, res, Val(shuffle))
+        compiled = CUDACore.kernel_compile(call)
         config = launch_configuration(compiled.fun; shmem=compute_shmem∘compute_threads)
         threads = compute_threads(config.threads)
         blocks = min(config.blocks, cld(n, config.blocks))
         shmem = compute_shmem(threads)
-        CUDACore.kernel_launch(compiled, invocation; threads, blocks, shmem)
+        CUDACore.kernel_launch(compiled, call; threads, blocks, shmem)
 
         CUDACore.@allowscalar res[]
     end
@@ -191,13 +191,13 @@ function LinearAlgebra.dot(x::AnyCuArray{T1}, A::AnyCuArray{T2}, y::AnyCuArray{T
 
         # how many threads can we launch?
         compute_shmem(threads) = shuffle ? 0 : threads*sizeof(T)
-        invocation = CUDACore.KernelInvocation(kernel, x, A, y, res, Val(shuffle))
-        compiled = CUDACore.kernel_compile(invocation)
+        call = CUDACore.KernelCall(kernel, x, A, y, res, Val(shuffle))
+        compiled = CUDACore.kernel_compile(call)
         config = launch_configuration(compiled.fun; shmem=compute_shmem∘compute_threads)
         threads = compute_threads(config.threads)
         blocks = min(config.blocks, cld(mA, config.blocks))
         shmem = compute_shmem(threads)
-        CUDACore.kernel_launch(compiled, invocation; threads, blocks, shmem)
+        CUDACore.kernel_launch(compiled, call; threads, blocks, shmem)
 
         CUDACore.@allowscalar res[]
     end

--- a/lib/cublas/src/linalg.jl
+++ b/lib/cublas/src/linalg.jl
@@ -102,14 +102,15 @@ function LinearAlgebra.dot(x::AnyCuArray{T1}, y::AnyCuArray{T2}) where {T1,T2}
             end
         end
 
-        # how many threads can we launch?
-        kernel = @cuda launch=false kernel(x, y, res, Val(shuffle))
         compute_shmem(threads) = shuffle ? 0 : threads*sizeof(T)
-        config = launch_configuration(kernel.fun; shmem=compute_shmem∘compute_threads)
-        threads = compute_threads(config.threads)
-        blocks = min(config.blocks, cld(n, config.blocks))
-        shmem = compute_shmem(threads)
-        kernel(x, y, res, Val(shuffle); threads, blocks, shmem)
+        CUDACore.prepare_launch(kernel, x, y, res, Val(shuffle)) do launch
+            config = launch_configuration(launch.kernel.fun;
+                                          shmem=compute_shmem∘compute_threads)
+            threads = compute_threads(config.threads)
+            blocks = min(config.blocks, cld(n, config.blocks))
+            shmem = compute_shmem(threads)
+            launch(; threads, blocks, shmem)
+        end
 
         CUDACore.@allowscalar res[]
     end
@@ -188,14 +189,15 @@ function LinearAlgebra.dot(x::AnyCuArray{T1}, A::AnyCuArray{T2}, y::AnyCuArray{T
             end
         end
 
-        # how many threads can we launch?
-        kernel_func = @cuda launch=false kernel(x, A, y, res, Val(shuffle))
         compute_shmem(threads) = shuffle ? 0 : threads*sizeof(T)
-        config = launch_configuration(kernel_func.fun; shmem=compute_shmem∘compute_threads)
-        threads = compute_threads(config.threads)
-        blocks = min(config.blocks, cld(mA, config.blocks))
-        shmem = compute_shmem(threads)
-        kernel_func(x, A, y, res, Val(shuffle); threads, blocks, shmem)
+        CUDACore.prepare_launch(kernel, x, A, y, res, Val(shuffle)) do launch
+            config = launch_configuration(launch.kernel.fun;
+                                          shmem=compute_shmem∘compute_threads)
+            threads = compute_threads(config.threads)
+            blocks = min(config.blocks, cld(mA, config.blocks))
+            shmem = compute_shmem(threads)
+            launch(; threads, blocks, shmem)
+        end
 
         CUDACore.@allowscalar res[]
     end

--- a/lib/cusparse/src/conversions.jl
+++ b/lib/cusparse/src/conversions.jl
@@ -70,12 +70,12 @@ function SparseArrays.sparse(I::CuVector{Cint}, J::CuVector{Cint}, V::CuVector{T
         return
     end
     # COV_EXCL_STOP
-    CUDACore.prepare_launch(find_groups, groups, coo.rowInd, coo.colInd) do launch
-        config = launch_configuration(launch.kernel.fun)
-        threads = min(length(groups), config.threads)
-        blocks = cld(length(groups), threads)
-        launch(; threads, blocks)
-    end
+    invocation = CUDACore.prepare(find_groups, groups, coo.rowInd, coo.colInd)
+    kernel = CUDACore.compile(invocation)
+    config = launch_configuration(kernel.fun)
+    threads = min(length(groups), config.threads)
+    blocks = cld(length(groups), threads)
+    CUDACore.launch(kernel, invocation; threads, blocks)
 
     # if we got any group of more than one element, we need to combine them.
     # this may actually not be required, as some CUSPARSE functions can handle
@@ -126,13 +126,13 @@ function SparseArrays.sparse(I::CuVector{Cint}, J::CuVector{Cint}, V::CuVector{T
             return
         end
         # COV_EXCL_STOP
-        CUDACore.prepare_launch(combine_groups, groups, indices, coo.rowInd, coo.colInd,
-                                coo.nzVal, I, J, V, combine) do launch
-            config = launch_configuration(launch.kernel.fun)
-            threads = min(length(groups), config.threads)
-            blocks = cld(length(groups), threads)
-            launch(; threads, blocks)
-        end
+        invocation = CUDACore.prepare(combine_groups, groups, indices, coo.rowInd, coo.colInd,
+                                      coo.nzVal, I, J, V, combine)
+        kernel = CUDACore.compile(invocation)
+        config = launch_configuration(kernel.fun)
+        threads = min(length(groups), config.threads)
+        blocks = cld(length(groups), threads)
+        CUDACore.launch(kernel, invocation; threads, blocks)
         synchronize()
         coo = CuSparseMatrixCOO{Tv}(I, J, V, (m, n))
     end

--- a/lib/cusparse/src/conversions.jl
+++ b/lib/cusparse/src/conversions.jl
@@ -70,12 +70,12 @@ function SparseArrays.sparse(I::CuVector{Cint}, J::CuVector{Cint}, V::CuVector{T
         return
     end
     # COV_EXCL_STOP
-    invocation = CUDACore.prepare(find_groups, groups, coo.rowInd, coo.colInd)
-    kernel = CUDACore.compile(invocation)
+    invocation = CUDACore.KernelInvocation(find_groups, groups, coo.rowInd, coo.colInd)
+    kernel = CUDACore.kernel_compile(invocation)
     config = launch_configuration(kernel.fun)
     threads = min(length(groups), config.threads)
     blocks = cld(length(groups), threads)
-    CUDACore.launch(kernel, invocation; threads, blocks)
+    CUDACore.kernel_launch(kernel, invocation; threads, blocks)
 
     # if we got any group of more than one element, we need to combine them.
     # this may actually not be required, as some CUSPARSE functions can handle
@@ -126,13 +126,13 @@ function SparseArrays.sparse(I::CuVector{Cint}, J::CuVector{Cint}, V::CuVector{T
             return
         end
         # COV_EXCL_STOP
-        invocation = CUDACore.prepare(combine_groups, groups, indices, coo.rowInd, coo.colInd,
+        invocation = CUDACore.KernelInvocation(combine_groups, groups, indices, coo.rowInd, coo.colInd,
                                       coo.nzVal, I, J, V, combine)
-        kernel = CUDACore.compile(invocation)
+        kernel = CUDACore.kernel_compile(invocation)
         config = launch_configuration(kernel.fun)
         threads = min(length(groups), config.threads)
         blocks = cld(length(groups), threads)
-        CUDACore.launch(kernel, invocation; threads, blocks)
+        CUDACore.kernel_launch(kernel, invocation; threads, blocks)
         synchronize()
         coo = CuSparseMatrixCOO{Tv}(I, J, V, (m, n))
     end

--- a/lib/cusparse/src/conversions.jl
+++ b/lib/cusparse/src/conversions.jl
@@ -70,11 +70,12 @@ function SparseArrays.sparse(I::CuVector{Cint}, J::CuVector{Cint}, V::CuVector{T
         return
     end
     # COV_EXCL_STOP
-    kernel = @cuda launch=false find_groups(groups, coo.rowInd, coo.colInd)
-    config = launch_configuration(kernel.fun)
-    threads = min(length(groups), config.threads)
-    blocks = cld(length(groups), threads)
-    kernel(groups, coo.rowInd, coo.colInd; threads, blocks)
+    CUDACore.prepare_launch(find_groups, groups, coo.rowInd, coo.colInd) do launch
+        config = launch_configuration(launch.kernel.fun)
+        threads = min(length(groups), config.threads)
+        blocks = cld(length(groups), threads)
+        launch(; threads, blocks)
+    end
 
     # if we got any group of more than one element, we need to combine them.
     # this may actually not be required, as some CUSPARSE functions can handle
@@ -125,11 +126,13 @@ function SparseArrays.sparse(I::CuVector{Cint}, J::CuVector{Cint}, V::CuVector{T
             return
         end
         # COV_EXCL_STOP
-        kernel = @cuda launch=false combine_groups(groups, indices, coo.rowInd, coo.colInd, coo.nzVal, I, J, V, combine)
-        config = launch_configuration(kernel.fun)
-        threads = min(length(groups), config.threads)
-        blocks = cld(length(groups), threads)
-        kernel(groups, indices, coo.rowInd, coo.colInd, coo.nzVal, I, J, V, combine; threads, blocks)
+        CUDACore.prepare_launch(combine_groups, groups, indices, coo.rowInd, coo.colInd,
+                                coo.nzVal, I, J, V, combine) do launch
+            config = launch_configuration(launch.kernel.fun)
+            threads = min(length(groups), config.threads)
+            blocks = cld(length(groups), threads)
+            launch(; threads, blocks)
+        end
         synchronize()
         coo = CuSparseMatrixCOO{Tv}(I, J, V, (m, n))
     end

--- a/lib/cusparse/src/conversions.jl
+++ b/lib/cusparse/src/conversions.jl
@@ -70,12 +70,12 @@ function SparseArrays.sparse(I::CuVector{Cint}, J::CuVector{Cint}, V::CuVector{T
         return
     end
     # COV_EXCL_STOP
-    invocation = CUDACore.KernelInvocation(find_groups, groups, coo.rowInd, coo.colInd)
-    kernel = CUDACore.kernel_compile(invocation)
+    call = CUDACore.KernelCall(find_groups, groups, coo.rowInd, coo.colInd)
+    kernel = CUDACore.kernel_compile(call)
     config = launch_configuration(kernel.fun)
     threads = min(length(groups), config.threads)
     blocks = cld(length(groups), threads)
-    CUDACore.kernel_launch(kernel, invocation; threads, blocks)
+    CUDACore.kernel_launch(kernel, call; threads, blocks)
 
     # if we got any group of more than one element, we need to combine them.
     # this may actually not be required, as some CUSPARSE functions can handle
@@ -126,13 +126,13 @@ function SparseArrays.sparse(I::CuVector{Cint}, J::CuVector{Cint}, V::CuVector{T
             return
         end
         # COV_EXCL_STOP
-        invocation = CUDACore.KernelInvocation(combine_groups, groups, indices, coo.rowInd, coo.colInd,
-                                      coo.nzVal, I, J, V, combine)
-        kernel = CUDACore.kernel_compile(invocation)
+        call = CUDACore.KernelCall(combine_groups, groups, indices, coo.rowInd, coo.colInd,
+                                   coo.nzVal, I, J, V, combine)
+        kernel = CUDACore.kernel_compile(call)
         config = launch_configuration(kernel.fun)
         threads = min(length(groups), config.threads)
         blocks = cld(length(groups), threads)
-        CUDACore.kernel_launch(kernel, invocation; threads, blocks)
+        CUDACore.kernel_launch(kernel, call; threads, blocks)
         synchronize()
         coo = CuSparseMatrixCOO{Tv}(I, J, V, (m, n))
     end

--- a/lib/cusparse/src/linalg.jl
+++ b/lib/cusparse/src/linalg.jl
@@ -152,9 +152,9 @@ function LinearAlgebra.dot(y::CuVector{T}, A::CuSparseMatrixCSC{T}, x::CuVector{
 
     shuffle = true
 
-    placeholder = CuArray{T}(undef, 1)
+    result = CuArray{T}(undef, 1)
     invocation = CUDACore.prepare(kernel, y, A.colPtr, A.rowVal, A.nzVal, x,
-                                  placeholder, n, Val(shuffle))
+                                  result, n, Val(shuffle))
     compiled = CUDACore.compile(invocation)
     config = launch_configuration(compiled.fun)
     threads = compute_threads(config.threads, n, shuffle, device())
@@ -165,6 +165,7 @@ function LinearAlgebra.dot(y::CuVector{T}, A::CuSparseMatrixCSC{T}, x::CuVector{
 
     return sum(result)
 end
+
 
 function LinearAlgebra.dot(y::CuVector{T}, A::CuSparseMatrixCSR{T}, x::CuVector{T}) where {T<:Union{BlasInt, BlasFloat}}
     if length(y) != size(A, 1) || length(x) != size(A, 2)
@@ -210,9 +211,9 @@ function LinearAlgebra.dot(y::CuVector{T}, A::CuSparseMatrixCSR{T}, x::CuVector{
 
     shuffle = true
 
-    placeholder = CuArray{T}(undef, 1)
+    result = CuArray{T}(undef, 1)
     invocation = CUDACore.prepare(kernel, y, A.rowPtr, A.colVal, A.nzVal, x,
-                                  placeholder, n, Val(shuffle))
+                                  result, n, Val(shuffle))
     compiled = CUDACore.compile(invocation)
     config = launch_configuration(compiled.fun)
     threads = compute_threads(config.threads, n, shuffle, device())

--- a/lib/cusparse/src/linalg.jl
+++ b/lib/cusparse/src/linalg.jl
@@ -153,15 +153,15 @@ function LinearAlgebra.dot(y::CuVector{T}, A::CuSparseMatrixCSC{T}, x::CuVector{
     shuffle = true
 
     result = CuArray{T}(undef, 1)
-    invocation = CUDACore.prepare(kernel, y, A.colPtr, A.rowVal, A.nzVal, x,
+    invocation = CUDACore.KernelInvocation(kernel, y, A.colPtr, A.rowVal, A.nzVal, x,
                                   result, n, Val(shuffle))
-    compiled = CUDACore.compile(invocation)
+    compiled = CUDACore.kernel_compile(invocation)
     config = launch_configuration(compiled.fun)
     threads = compute_threads(config.threads, n, shuffle, device())
     blocks = min(config.blocks, cld(n, threads))
     result = CuArray{T}(undef, blocks)
     invocation = CUDACore.rebind(invocation, 6 => result)
-    CUDACore.launch(compiled, invocation; threads, blocks)
+    CUDACore.kernel_launch(compiled, invocation; threads, blocks)
 
     return sum(result)
 end
@@ -212,15 +212,15 @@ function LinearAlgebra.dot(y::CuVector{T}, A::CuSparseMatrixCSR{T}, x::CuVector{
     shuffle = true
 
     result = CuArray{T}(undef, 1)
-    invocation = CUDACore.prepare(kernel, y, A.rowPtr, A.colVal, A.nzVal, x,
+    invocation = CUDACore.KernelInvocation(kernel, y, A.rowPtr, A.colVal, A.nzVal, x,
                                   result, n, Val(shuffle))
-    compiled = CUDACore.compile(invocation)
+    compiled = CUDACore.kernel_compile(invocation)
     config = launch_configuration(compiled.fun)
     threads = compute_threads(config.threads, n, shuffle, device())
     blocks = min(config.blocks, cld(n, threads))
     result = CuArray{T}(undef, blocks)
     invocation = CUDACore.rebind(invocation, 6 => result)
-    CUDACore.launch(compiled, invocation; threads, blocks)
+    CUDACore.kernel_launch(compiled, invocation; threads, blocks)
 
     return sum(result)
 end

--- a/lib/cusparse/src/linalg.jl
+++ b/lib/cusparse/src/linalg.jl
@@ -152,13 +152,17 @@ function LinearAlgebra.dot(y::CuVector{T}, A::CuSparseMatrixCSC{T}, x::CuVector{
 
     shuffle = true
 
-    result = CuArray{T}(undef, 1)
-    kernel = @cuda launch=false kernel(y, A.colPtr, A.rowVal, A.nzVal, x, result, n, Val(shuffle))
-    config = launch_configuration(kernel.fun)
-    threads = compute_threads(config.threads, n, shuffle, device())
-    blocks = min(config.blocks, cld(n, threads))
-    result = CuArray{T}(undef, blocks)
-    kernel(y, A.colPtr, A.rowVal, A.nzVal, x, result, n, Val(shuffle); threads, blocks)
+    placeholder = CuArray{T}(undef, 1)
+    result = CUDACore.prepare_launch(kernel, y, A.colPtr, A.rowVal, A.nzVal, x,
+                                     placeholder, n, Val(shuffle)) do launch
+        config = launch_configuration(launch.kernel.fun)
+        threads = compute_threads(config.threads, n, shuffle, device())
+        blocks = min(config.blocks, cld(n, threads))
+        result = CuArray{T}(undef, blocks)
+        launch = CUDACore.replace_arguments(launch, 6 => result)
+        launch(; threads, blocks)
+        result
+    end
 
     return sum(result)
 end
@@ -207,14 +211,17 @@ function LinearAlgebra.dot(y::CuVector{T}, A::CuSparseMatrixCSR{T}, x::CuVector{
 
     shuffle = true
 
-    result = CuArray{T}(undef, 1)
-    kernel = @cuda launch=false kernel(y, A.rowPtr, A.colVal, A.nzVal, x, result, n, Val(shuffle))
-    config = launch_configuration(kernel.fun)
-    threads = compute_threads(config.threads, n, shuffle, device())
-    blocks = min(config.blocks, cld(n, threads))
-    result = CuArray{T}(undef, blocks)
-    kernel(y, A.rowPtr, A.colVal, A.nzVal, x, result, n, Val(shuffle); threads, blocks)
+    placeholder = CuArray{T}(undef, 1)
+    result = CUDACore.prepare_launch(kernel, y, A.rowPtr, A.colVal, A.nzVal, x,
+                                     placeholder, n, Val(shuffle)) do launch
+        config = launch_configuration(launch.kernel.fun)
+        threads = compute_threads(config.threads, n, shuffle, device())
+        blocks = min(config.blocks, cld(n, threads))
+        result = CuArray{T}(undef, blocks)
+        launch = CUDACore.replace_arguments(launch, 6 => result)
+        launch(; threads, blocks)
+        result
+    end
 
     return sum(result)
 end
-

--- a/lib/cusparse/src/linalg.jl
+++ b/lib/cusparse/src/linalg.jl
@@ -160,7 +160,7 @@ function LinearAlgebra.dot(y::CuVector{T}, A::CuSparseMatrixCSC{T}, x::CuVector{
     threads = compute_threads(config.threads, n, shuffle, device())
     blocks = min(config.blocks, cld(n, threads))
     result = CuArray{T}(undef, blocks)
-    invocation = Base.setindex(invocation, result, 6)
+    invocation = CUDACore.rebind(invocation, 6 => result)
     CUDACore.launch(compiled, invocation; threads, blocks)
 
     return sum(result)
@@ -219,7 +219,7 @@ function LinearAlgebra.dot(y::CuVector{T}, A::CuSparseMatrixCSR{T}, x::CuVector{
     threads = compute_threads(config.threads, n, shuffle, device())
     blocks = min(config.blocks, cld(n, threads))
     result = CuArray{T}(undef, blocks)
-    invocation = Base.setindex(invocation, result, 6)
+    invocation = CUDACore.rebind(invocation, 6 => result)
     CUDACore.launch(compiled, invocation; threads, blocks)
 
     return sum(result)

--- a/lib/cusparse/src/linalg.jl
+++ b/lib/cusparse/src/linalg.jl
@@ -160,7 +160,7 @@ function LinearAlgebra.dot(y::CuVector{T}, A::CuSparseMatrixCSC{T}, x::CuVector{
     threads = compute_threads(config.threads, n, shuffle, device())
     blocks = min(config.blocks, cld(n, threads))
     result = CuArray{T}(undef, blocks)
-    call = CUDACore.rebind(call, 6 => result)
+    call = CUDACore.rebind(call, result, 6)
     CUDACore.kernel_launch(compiled, call; threads, blocks)
 
     return sum(result)
@@ -219,7 +219,7 @@ function LinearAlgebra.dot(y::CuVector{T}, A::CuSparseMatrixCSR{T}, x::CuVector{
     threads = compute_threads(config.threads, n, shuffle, device())
     blocks = min(config.blocks, cld(n, threads))
     result = CuArray{T}(undef, blocks)
-    call = CUDACore.rebind(call, 6 => result)
+    call = CUDACore.rebind(call, result, 6)
     CUDACore.kernel_launch(compiled, call; threads, blocks)
 
     return sum(result)

--- a/lib/cusparse/src/linalg.jl
+++ b/lib/cusparse/src/linalg.jl
@@ -153,15 +153,15 @@ function LinearAlgebra.dot(y::CuVector{T}, A::CuSparseMatrixCSC{T}, x::CuVector{
     shuffle = true
 
     result = CuArray{T}(undef, 1)
-    invocation = CUDACore.KernelInvocation(kernel, y, A.colPtr, A.rowVal, A.nzVal, x,
-                                  result, n, Val(shuffle))
-    compiled = CUDACore.kernel_compile(invocation)
+    call = CUDACore.KernelCall(kernel, y, A.colPtr, A.rowVal, A.nzVal, x,
+                               result, n, Val(shuffle))
+    compiled = CUDACore.kernel_compile(call)
     config = launch_configuration(compiled.fun)
     threads = compute_threads(config.threads, n, shuffle, device())
     blocks = min(config.blocks, cld(n, threads))
     result = CuArray{T}(undef, blocks)
-    invocation = CUDACore.rebind(invocation, 6 => result)
-    CUDACore.kernel_launch(compiled, invocation; threads, blocks)
+    call = CUDACore.rebind(call, 6 => result)
+    CUDACore.kernel_launch(compiled, call; threads, blocks)
 
     return sum(result)
 end
@@ -212,15 +212,15 @@ function LinearAlgebra.dot(y::CuVector{T}, A::CuSparseMatrixCSR{T}, x::CuVector{
     shuffle = true
 
     result = CuArray{T}(undef, 1)
-    invocation = CUDACore.KernelInvocation(kernel, y, A.rowPtr, A.colVal, A.nzVal, x,
-                                  result, n, Val(shuffle))
-    compiled = CUDACore.kernel_compile(invocation)
+    call = CUDACore.KernelCall(kernel, y, A.rowPtr, A.colVal, A.nzVal, x,
+                               result, n, Val(shuffle))
+    compiled = CUDACore.kernel_compile(call)
     config = launch_configuration(compiled.fun)
     threads = compute_threads(config.threads, n, shuffle, device())
     blocks = min(config.blocks, cld(n, threads))
     result = CuArray{T}(undef, blocks)
-    invocation = CUDACore.rebind(invocation, 6 => result)
-    CUDACore.kernel_launch(compiled, invocation; threads, blocks)
+    call = CUDACore.rebind(call, 6 => result)
+    CUDACore.kernel_launch(compiled, call; threads, blocks)
 
     return sum(result)
 end

--- a/lib/cusparse/src/linalg.jl
+++ b/lib/cusparse/src/linalg.jl
@@ -153,16 +153,15 @@ function LinearAlgebra.dot(y::CuVector{T}, A::CuSparseMatrixCSC{T}, x::CuVector{
     shuffle = true
 
     placeholder = CuArray{T}(undef, 1)
-    result = CUDACore.prepare_launch(kernel, y, A.colPtr, A.rowVal, A.nzVal, x,
-                                     placeholder, n, Val(shuffle)) do launch
-        config = launch_configuration(launch.kernel.fun)
-        threads = compute_threads(config.threads, n, shuffle, device())
-        blocks = min(config.blocks, cld(n, threads))
-        result = CuArray{T}(undef, blocks)
-        launch = CUDACore.replace_arguments(launch, 6 => result)
-        launch(; threads, blocks)
-        result
-    end
+    invocation = CUDACore.prepare(kernel, y, A.colPtr, A.rowVal, A.nzVal, x,
+                                  placeholder, n, Val(shuffle))
+    compiled = CUDACore.compile(invocation)
+    config = launch_configuration(compiled.fun)
+    threads = compute_threads(config.threads, n, shuffle, device())
+    blocks = min(config.blocks, cld(n, threads))
+    result = CuArray{T}(undef, blocks)
+    invocation = Base.setindex(invocation, result, 6)
+    CUDACore.launch(compiled, invocation; threads, blocks)
 
     return sum(result)
 end
@@ -212,16 +211,15 @@ function LinearAlgebra.dot(y::CuVector{T}, A::CuSparseMatrixCSR{T}, x::CuVector{
     shuffle = true
 
     placeholder = CuArray{T}(undef, 1)
-    result = CUDACore.prepare_launch(kernel, y, A.rowPtr, A.colVal, A.nzVal, x,
-                                     placeholder, n, Val(shuffle)) do launch
-        config = launch_configuration(launch.kernel.fun)
-        threads = compute_threads(config.threads, n, shuffle, device())
-        blocks = min(config.blocks, cld(n, threads))
-        result = CuArray{T}(undef, blocks)
-        launch = CUDACore.replace_arguments(launch, 6 => result)
-        launch(; threads, blocks)
-        result
-    end
+    invocation = CUDACore.prepare(kernel, y, A.rowPtr, A.colVal, A.nzVal, x,
+                                  placeholder, n, Val(shuffle))
+    compiled = CUDACore.compile(invocation)
+    config = launch_configuration(compiled.fun)
+    threads = compute_threads(config.threads, n, shuffle, device())
+    blocks = min(config.blocks, cld(n, threads))
+    result = CuArray{T}(undef, blocks)
+    invocation = Base.setindex(invocation, result, 6)
+    CUDACore.launch(compiled, invocation; threads, blocks)
 
     return sum(result)
 end

--- a/perf/array.jl
+++ b/perf/array.jl
@@ -64,6 +64,10 @@ end
 
 group["broadcast"] = @async_benchmarkable $gpu_mat .= 0f0
 
+broadcast_src = CUDA.fill(1f0, 257)
+broadcast_dest = similar(broadcast_src)
+group["broadcast launch"] = @async_benchmarkable $broadcast_dest .= $broadcast_src .+ 2f0
+
 # no need to test inplace version, which performs the same operation (but with an alloc)
 let group = addgroup!(group, "accumulate")
     let group = addgroup!(group, "Float32")

--- a/test/core/array.jl
+++ b/test/core/array.jl
@@ -621,6 +621,12 @@ end
   @test vec(Array(sum!(view(CUDA.zeros(1,1,1), 1, :, :), CUDA.ones(1,4096)))) == [4096f0]
 end
 
+@testset "mapreduce inference" begin
+  input = CUDA.ones(512)
+  output = similar(input, 1)
+  @test @inferred(GPUArrays.mapreducedim!(identity, +, output, input; init=0f0)) === output
+end
+
 @testset "issue 1202" begin
   # test that deepcopying a struct with a CuArray field gets properly deepcopied
   a = (x = CUDA.zeros(2),)

--- a/test/core/execution.jl
+++ b/test/core/execution.jl
@@ -1,5 +1,24 @@
 dummy() = return
 
+struct CountedHost{T}
+    value::T
+    counter::Base.RefValue{Int}
+end
+
+struct CountedDevice{T}
+    value::T
+end
+
+function Adapt.adapt_structure(to::CUDA.KernelAdaptor, arg::CountedHost)
+    arg.counter[] += 1
+    CountedDevice(Adapt.adapt(to, arg.value))
+end
+
+function copy_counted(arg, output)
+    output[] = arg.value[]
+    return
+end
+
 @testset "@cuda" begin
 
 @test_throws UndefVarError @cuda undefined()
@@ -38,6 +57,63 @@ end
     CUDA.memory(k)
     CUDA.registers(k)
     CUDA.maxthreads(k)
+end
+
+
+@testset "prepared launch" begin
+    input = CuArray([11])
+    output = CuArray([0])
+
+    counter = Ref(0)
+    arg = CountedHost(input, counter)
+    @cuda copy_counted(arg, output)
+    @test counter[] == 1
+    @test Array(output) == [11]
+
+    counter[] = 0
+    kernel = CUDA.prepare_launch(copy_counted, arg, output) do launch
+        @test launch.kernel isa CUDACore.HostKernel
+        @test CUDACore.launch_configuration(launch.kernel.fun).threads > 0
+        @test_throws MethodError launch(arg, output)
+        launch()
+        launch()
+        launch.kernel
+    end
+    @test kernel isa CUDACore.HostKernel
+    @test counter[] == 1
+    @test Array(output) == [11]
+
+    counter[] = 0
+    kernel = @cuda launch=false copy_counted(arg, output)
+    @test counter[] == 1
+    kernel(arg, output)
+    @test counter[] == 2
+
+    replacement_counter = Ref(0)
+    CUDA.prepare_launch(copy_counted, arg, output) do launch
+        replacement = CountedHost(CuArray([12]), replacement_counter)
+        launch = CUDA.replace_arguments(launch, 1 => replacement)
+        @test counter[] == 3
+        @test replacement_counter[] == 1
+        GC.gc(true)
+        launch()
+        @test_throws ArgumentError CUDA.replace_arguments(
+            launch, 1 => CountedHost(CuArray(Float32[13]), Ref(0)))
+    end
+    @test replacement_counter[] == 1
+    @test Array(output) == [12]
+
+    ephemeral_counter = Ref(0)
+    CUDA.prepare_launch(copy_counted, CountedHost(CuArray([14]), ephemeral_counter), output) do launch
+        GC.gc(true)
+        launch()
+    end
+    @test ephemeral_counter[] == 1
+    @test Array(output) == [14]
+
+    CUDA.prepare_launch(dummy) do launch
+        launch()
+    end
 end
 
 
@@ -240,7 +316,9 @@ end
         using CUDA
         const compile_calls = Ref(0)
         const convert_calls = Ref(0)
+        const launch_calls = Ref(0)
         const last_kwargs = Ref{Any}(nothing)
+        const last_launch_kwargs = Ref{Any}(nothing)
 
         struct Backend <: CUDACore.AbstractBackend end
         DefaultBackend() = Backend()
@@ -256,6 +334,11 @@ end
             compile_calls[] += 1
             last_kwargs[] = (; kwargs...)
             Kernel{F}(f)
+        end
+        function CUDACore.kernel_launch(::Backend, kernel, args::Tuple; kwargs...)
+            launch_calls[] += 1
+            last_launch_kwargs[] = (; kwargs...)
+            kernel(args...; kwargs...)
         end
     end
 
@@ -275,6 +358,26 @@ end
     @cuda backend=BackendStub.Backend() opt_level=2 dummy()
     @test haskey(BackendStub.last_kwargs[], :opt_level)
     @test BackendStub.last_kwargs[][:opt_level] == 2
+
+    BackendStub.compile_calls[] = 0
+    BackendStub.convert_calls[] = 0
+    BackendStub.launch_calls[] = 0
+    result = CUDA.prepare_launch(dummy, 1, 2;
+                                 backend=BackendStub, opt_level=3) do launch
+        @test launch isa CUDA.PreparedLaunch
+        @test launch.kernel isa BackendStub.Kernel
+        launch(; threads=4)
+        launch = CUDA.replace_arguments(launch, 1 => 3)
+        launch(; threads=8)
+        @test_throws ArgumentError CUDA.replace_arguments(launch, 2 => 4.0)
+        :prepared
+    end
+    @test result === :prepared
+    @test BackendStub.compile_calls[] == 1
+    @test BackendStub.convert_calls[] == 5 # function, two arguments, and two replacements
+    @test BackendStub.launch_calls[] == 2
+    @test BackendStub.last_kwargs[] == (opt_level=3,)
+    @test BackendStub.last_launch_kwargs[] == (threads=8,)
 
     # dynamic + backend kwargs are rejected (errors at macro-expansion time,
     # so wrap in @macroexpand to defer)

--- a/test/core/execution.jl
+++ b/test/core/execution.jl
@@ -71,17 +71,17 @@ end
     @test Array(output) == [11]
 
     counter[] = 0
-    invocation = CUDA.prepare(copy_counted, arg, output)
+    invocation = CUDA.KernelInvocation(copy_counted, arg, output)
     @test invocation isa CUDA.KernelInvocation
     @test invocation[1] === arg
-    kernel = CUDA.compile(invocation)
+    kernel = CUDA.kernel_compile(invocation)
     @test kernel isa CUDACore.HostKernel
     @test CUDACore.launch_configuration(kernel.fun).threads > 0
-    CUDA.launch(kernel, invocation)
-    CUDA.launch(kernel, invocation)
+    CUDA.kernel_launch(kernel, invocation)
+    CUDA.kernel_launch(kernel, invocation)
     @test counter[] == 1
     @test Array(output) == [11]
-    rebound = CUDA.prepare(kernel, arg, output)
+    rebound = CUDA.KernelInvocation(kernel, arg, output)
     @test rebound.backend isa CUDA.LLVMBackend
     @test counter[] == 2
 
@@ -98,27 +98,27 @@ end
     @test replacement_invocation[1] === replacement
     @test replacement_counter[] == 1
     GC.gc(true)
-    CUDA.launch(kernel, replacement_invocation)
+    CUDA.kernel_launch(kernel, replacement_invocation)
     @test replacement_counter[] == 1
     @test Array(output) == [12]
 
     ephemeral_counter = Ref(0)
     function escaping_invocation()
-        CUDA.prepare(copy_counted,
+        CUDA.KernelInvocation(copy_counted,
                      CountedHost(CuArray([14]), ephemeral_counter), output)
     end
     escaped = escaping_invocation()
     GC.gc(true)
-    escaped_kernel = CUDA.compile(escaped)
-    CUDA.launch(escaped_kernel, escaped)
+    escaped_kernel = CUDA.kernel_compile(escaped)
+    CUDA.kernel_launch(escaped_kernel, escaped)
     @test ephemeral_counter[] == 1
     @test Array(output) == [14]
 
-    empty_invocation = CUDA.prepare(dummy)
-    CUDA.launch(CUDA.compile(empty_invocation), empty_invocation)
+    empty_invocation = CUDA.KernelInvocation(dummy)
+    CUDA.kernel_launch(CUDA.kernel_compile(empty_invocation), empty_invocation)
 
     rebind_int(inv, value) = CUDA.rebind(inv, 1 => value)
-    int_invocation = CUDA.prepare(identity, Int32(1))
+    int_invocation = CUDA.KernelInvocation(identity, Int32(1))
     @test @inferred(rebind_int(int_invocation, Int32(2))) isa CUDA.KernelInvocation
     rebind_int(int_invocation, Int32(2))
     @test @allocated(rebind_int(int_invocation, Int32(2))) == 0
@@ -130,12 +130,12 @@ end
         return
     end
     scalar_output = CuArray(Int32[0])
-    scalar_invocation = CUDA.prepare(write_scalar, Int32(1), scalar_output)
-    scalar_kernel = CUDA.compile(scalar_invocation)
+    scalar_invocation = CUDA.KernelInvocation(write_scalar, Int32(1), scalar_output)
+    scalar_kernel = CUDA.kernel_compile(scalar_invocation)
     widened_invocation = CUDA.rebind(scalar_invocation, 1 => Int64(2))
-    CUDA.launch(scalar_kernel, widened_invocation)
+    CUDA.kernel_launch(scalar_kernel, widened_invocation)
     @test Array(scalar_output) == Int32[2]
-    @test_throws InexactError CUDA.launch(
+    @test_throws InexactError CUDA.kernel_launch(
         scalar_kernel, CUDA.rebind(scalar_invocation, 1 => typemax(Int64)))
 
     scalar_kernel(Int64(3), scalar_output)
@@ -146,9 +146,9 @@ end
         output[] = input[]
         return
     end
-    array_invocation = CUDA.prepare(copy_first, input, output)
-    array_kernel = CUDA.compile(array_invocation)
-    @test_throws MethodError CUDA.launch(
+    array_invocation = CUDA.KernelInvocation(copy_first, input, output)
+    array_kernel = CUDA.kernel_compile(array_invocation)
+    @test_throws MethodError CUDA.kernel_launch(
         array_kernel, CUDA.rebind(array_invocation, 1 => float_input))
 end
 
@@ -355,7 +355,7 @@ end
     @cuda backend=CUDA dummy()
     @cuda backend=CUDACore dummy()
 
-    # custom backend stub: assert prepare/compile/launch are called
+    # custom backend stub: assert conversion, compilation, and launch hooks are called
     # and that unknown kwargs are forwarded
     @eval module BackendStub
         using CUDA
@@ -373,14 +373,14 @@ end
         end
 
         CUDACore.backend(::Kernel) = Backend()
-        CUDACore.prepare(::Backend, x) = (convert_calls[] += 1; x)
-        function CUDACore.compile(::Backend, f::F, tt::Type{<:Tuple};
-                                  kwargs...) where {F}
+        CUDACore.kernel_convert(::Backend, x) = (convert_calls[] += 1; x)
+        function CUDACore.kernel_compile(::Backend, f::F, tt::Type{<:Tuple};
+                                         kwargs...) where {F}
             compile_calls[] += 1
             last_kwargs[] = (; kwargs...)
             Kernel{F,tt}(f)
         end
-        function (kernel::Kernel)(args...; kwargs...)
+        function CUDACore.kernel_launch(::Backend, kernel::Kernel, args::Tuple; kwargs...)
             launch_calls[] += 1
             last_launch_kwargs[] = (; kwargs...)
             nothing
@@ -392,7 +392,7 @@ end
     BackendStub.last_kwargs[] = nothing
     @cuda backend=BackendStub.Backend() dummy()
     @test BackendStub.compile_calls[] == 1
-    # f + 0 args, all routed through prepare
+    # f + 0 args, all routed through kernel_convert
     @test BackendStub.convert_calls[] == 1
     @test BackendStub.launch_calls[] == 1
 
@@ -412,14 +412,14 @@ end
     BackendStub.compile_calls[] = 0
     BackendStub.convert_calls[] = 0
     BackendStub.launch_calls[] = 0
-    invocation = CUDA.prepare(dummy, 1, 2; backend=BackendStub)
+    invocation = CUDA.KernelInvocation(dummy, 1, 2; backend=BackendStub)
     @test invocation isa CUDA.KernelInvocation
     @test invocation[1] == 1
-    kernel = CUDA.compile(invocation; opt_level=3)
+    kernel = CUDA.kernel_compile(invocation; opt_level=3)
     @test kernel isa BackendStub.Kernel
-    CUDA.launch(kernel, invocation; threads=4)
+    CUDA.kernel_launch(kernel, invocation; threads=4)
     invocation = CUDA.rebind(invocation, 1 => 3)
-    CUDA.launch(kernel, invocation; threads=8)
+    CUDA.kernel_launch(kernel, invocation; threads=8)
     drifted = CUDA.rebind(invocation, 2 => 4.0)
     @test drifted[2] == 4.0
     @test BackendStub.compile_calls[] == 1

--- a/test/core/execution.jl
+++ b/test/core/execution.jl
@@ -60,7 +60,7 @@ end
 end
 
 
-@testset "kernel invocation" begin
+@testset "kernel call" begin
     input = CuArray([11])
     output = CuArray([0])
 
@@ -71,14 +71,14 @@ end
     @test Array(output) == [11]
 
     counter[] = 0
-    invocation = CUDA.KernelInvocation(copy_counted, arg, output)
-    @test invocation isa CUDA.KernelInvocation
-    @test invocation[1] === arg
-    kernel = CUDA.kernel_compile(invocation)
+    call = CUDA.KernelCall(copy_counted, arg, output)
+    @test call isa CUDA.KernelCall
+    @test call[1] === arg
+    kernel = CUDA.kernel_compile(call)
     @test kernel isa CUDACore.HostKernel
     @test CUDACore.launch_configuration(kernel.fun).threads > 0
-    CUDA.kernel_launch(kernel, invocation)
-    CUDA.kernel_launch(kernel, invocation)
+    CUDA.kernel_launch(kernel, call)
+    CUDA.kernel_launch(kernel, call)
     @test counter[] == 1
     @test Array(output) == [11]
     counter[] = 0
@@ -89,50 +89,50 @@ end
 
     replacement_counter = Ref(0)
     replacement = CountedHost(CuArray([12]), replacement_counter)
-    replacement_invocation = CUDA.rebind(invocation, 1 => replacement)
-    @test invocation[1] === arg
-    @test replacement_invocation[1] === replacement
+    replacement_call = CUDA.rebind(call, 1 => replacement)
+    @test call[1] === arg
+    @test replacement_call[1] === replacement
     @test replacement_counter[] == 1
     GC.gc(true)
-    CUDA.kernel_launch(kernel, replacement_invocation)
+    CUDA.kernel_launch(kernel, replacement_call)
     @test replacement_counter[] == 1
     @test Array(output) == [12]
 
     ephemeral_counter = Ref(0)
-    function escaping_invocation()
-        CUDA.KernelInvocation(copy_counted,
-                     CountedHost(CuArray([14]), ephemeral_counter), output)
+    function escaping_call()
+        CUDA.KernelCall(copy_counted,
+                        CountedHost(CuArray([14]), ephemeral_counter), output)
     end
-    escaped = escaping_invocation()
+    escaped = escaping_call()
     GC.gc(true)
     escaped_kernel = CUDA.kernel_compile(escaped)
     CUDA.kernel_launch(escaped_kernel, escaped)
     @test ephemeral_counter[] == 1
     @test Array(output) == [14]
 
-    empty_invocation = CUDA.KernelInvocation(dummy)
-    CUDA.kernel_launch(CUDA.kernel_compile(empty_invocation), empty_invocation)
+    empty_call = CUDA.KernelCall(dummy)
+    CUDA.kernel_launch(CUDA.kernel_compile(empty_call), empty_call)
 
     rebind_int(inv, value) = CUDA.rebind(inv, 1 => value)
-    int_invocation = CUDA.KernelInvocation(identity, Int32(1))
-    @test @inferred(rebind_int(int_invocation, Int32(2))) isa CUDA.KernelInvocation
-    rebind_int(int_invocation, Int32(2))
-    @test @allocated(rebind_int(int_invocation, Int32(2))) == 0
+    int_call = CUDA.KernelCall(identity, Int32(1))
+    @test @inferred(rebind_int(int_call, Int32(2))) isa CUDA.KernelCall
+    rebind_int(int_call, Int32(2))
+    @test @allocated(rebind_int(int_call, Int32(2))) == 0
     runtime_index = Ref(1)[]
-    @test CUDA.rebind(int_invocation, runtime_index => Int64(3))[1] == 3
+    @test CUDA.rebind(int_call, runtime_index => Int64(3))[1] == 3
 
     function write_scalar(value, output)
         output[] = value
         return
     end
     scalar_output = CuArray(Int32[0])
-    scalar_invocation = CUDA.KernelInvocation(write_scalar, Int32(1), scalar_output)
-    scalar_kernel = CUDA.kernel_compile(scalar_invocation)
-    widened_invocation = CUDA.rebind(scalar_invocation, 1 => Int64(2))
-    CUDA.kernel_launch(scalar_kernel, widened_invocation)
+    scalar_call = CUDA.KernelCall(write_scalar, Int32(1), scalar_output)
+    scalar_kernel = CUDA.kernel_compile(scalar_call)
+    widened_call = CUDA.rebind(scalar_call, 1 => Int64(2))
+    CUDA.kernel_launch(scalar_kernel, widened_call)
     @test Array(scalar_output) == Int32[2]
     @test_throws InexactError CUDA.kernel_launch(
-        scalar_kernel, CUDA.rebind(scalar_invocation, 1 => typemax(Int64)))
+        scalar_kernel, CUDA.rebind(scalar_call, 1 => typemax(Int64)))
 
     scalar_kernel(Int64(3), scalar_output)
     @test Array(scalar_output) == Int32[3]
@@ -142,10 +142,10 @@ end
         output[] = input[]
         return
     end
-    array_invocation = CUDA.KernelInvocation(copy_first, input, output)
-    array_kernel = CUDA.kernel_compile(array_invocation)
+    array_call = CUDA.KernelCall(copy_first, input, output)
+    array_kernel = CUDA.kernel_compile(array_call)
     @test_throws MethodError CUDA.kernel_launch(
-        array_kernel, CUDA.rebind(array_invocation, 1 => float_input))
+        array_kernel, CUDA.rebind(array_call, 1 => float_input))
 end
 
 
@@ -407,15 +407,15 @@ end
     BackendStub.compile_calls[] = 0
     BackendStub.convert_calls[] = 0
     BackendStub.launch_calls[] = 0
-    invocation = CUDA.KernelInvocation(dummy, 1, 2; backend=BackendStub)
-    @test invocation isa CUDA.KernelInvocation
-    @test invocation[1] == 1
-    kernel = CUDA.kernel_compile(invocation; opt_level=3)
+    call = CUDA.KernelCall(dummy, 1, 2; backend=BackendStub)
+    @test call isa CUDA.KernelCall
+    @test call[1] == 1
+    kernel = CUDA.kernel_compile(call; opt_level=3)
     @test kernel isa BackendStub.Kernel
-    CUDA.kernel_launch(kernel, invocation; threads=4)
-    invocation = CUDA.rebind(invocation, 1 => 3)
-    CUDA.kernel_launch(kernel, invocation; threads=8)
-    drifted = CUDA.rebind(invocation, 2 => 4.0)
+    CUDA.kernel_launch(kernel, call; threads=4)
+    call = CUDA.rebind(call, 1 => 3)
+    CUDA.kernel_launch(kernel, call; threads=8)
+    drifted = CUDA.rebind(call, 2 => 4.0)
     @test drifted[2] == 4.0
     @test BackendStub.compile_calls[] == 1
     @test BackendStub.convert_calls[] == 5 # function, two arguments, and two rebindings

--- a/test/core/execution.jl
+++ b/test/core/execution.jl
@@ -73,7 +73,7 @@ end
     counter[] = 0
     call = CUDA.KernelCall(copy_counted, arg, output)
     @test call isa CUDA.KernelCall
-    @test call[1] === arg
+    @test call.source.arguments[1] === arg
     kernel = CUDA.kernel_compile(call)
     @test kernel isa CUDACore.HostKernel
     @test CUDACore.launch_configuration(kernel.fun).threads > 0
@@ -90,8 +90,8 @@ end
     replacement_counter = Ref(0)
     replacement = CountedHost(CuArray([12]), replacement_counter)
     replacement_call = CUDA.rebind(call, 1 => replacement)
-    @test call[1] === arg
-    @test replacement_call[1] === replacement
+    @test call.source.arguments[1] === arg
+    @test replacement_call.source.arguments[1] === replacement
     @test replacement_counter[] == 1
     GC.gc(true)
     CUDA.kernel_launch(kernel, replacement_call)
@@ -117,7 +117,7 @@ end
     int_call = CUDA.KernelCall(identity, Int32(1))
     @test @inferred(rebind_int(int_call, Int32(2))) isa CUDA.KernelCall
     runtime_index = Ref(1)[]
-    @test CUDA.rebind(int_call, runtime_index => Int64(3))[1] == 3
+    @test CUDA.rebind(int_call, runtime_index => Int64(3)).source.arguments[1] == 3
 
     function write_scalar(value, output)
         output[] = value
@@ -407,14 +407,14 @@ end
     BackendStub.launch_calls[] = 0
     call = CUDA.KernelCall(dummy, 1, 2; backend=BackendStub)
     @test call isa CUDA.KernelCall
-    @test call[1] == 1
+    @test call.source.arguments[1] == 1
     kernel = CUDA.kernel_compile(call; opt_level=3)
     @test kernel isa BackendStub.Kernel
     CUDA.kernel_launch(kernel, call; threads=4)
     call = CUDA.rebind(call, 1 => 3)
     CUDA.kernel_launch(kernel, call; threads=8)
     drifted = CUDA.rebind(call, 2 => 4.0)
-    @test drifted[2] == 4.0
+    @test drifted.source.arguments[2] == 4.0
     @test BackendStub.compile_calls[] == 1
     @test BackendStub.convert_calls[] == 5 # function, two arguments, and two rebindings
     @test BackendStub.launch_calls[] == 2

--- a/test/core/execution.jl
+++ b/test/core/execution.jl
@@ -60,7 +60,7 @@ end
 end
 
 
-@testset "prepared launch" begin
+@testset "kernel invocation" begin
     input = CuArray([11])
     output = CuArray([0])
 
@@ -71,17 +71,19 @@ end
     @test Array(output) == [11]
 
     counter[] = 0
-    kernel = CUDA.prepare_launch(copy_counted, arg, output) do launch
-        @test launch.kernel isa CUDACore.HostKernel
-        @test CUDACore.launch_configuration(launch.kernel.fun).threads > 0
-        @test_throws MethodError launch(arg, output)
-        launch()
-        launch()
-        launch.kernel
-    end
+    invocation = CUDA.prepare(copy_counted, arg, output)
+    @test invocation isa CUDA.KernelInvocation
+    @test invocation[1] === arg
+    kernel = CUDA.compile(invocation)
     @test kernel isa CUDACore.HostKernel
+    @test CUDACore.launch_configuration(kernel.fun).threads > 0
+    CUDA.launch(kernel, invocation)
+    CUDA.launch(kernel, invocation)
     @test counter[] == 1
     @test Array(output) == [11]
+    rebound = CUDA.prepare(kernel, arg, output)
+    @test rebound.backend isa CUDA.LLVMBackend
+    @test counter[] == 2
 
     counter[] = 0
     kernel = @cuda launch=false copy_counted(arg, output)
@@ -90,30 +92,64 @@ end
     @test counter[] == 2
 
     replacement_counter = Ref(0)
-    CUDA.prepare_launch(copy_counted, arg, output) do launch
-        replacement = CountedHost(CuArray([12]), replacement_counter)
-        launch = CUDA.replace_arguments(launch, 1 => replacement)
-        @test counter[] == 3
-        @test replacement_counter[] == 1
-        GC.gc(true)
-        launch()
-        @test_throws ArgumentError CUDA.replace_arguments(
-            launch, 1 => CountedHost(CuArray(Float32[13]), Ref(0)))
-    end
+    replacement = CountedHost(CuArray([12]), replacement_counter)
+    replacement_invocation = Base.setindex(invocation, replacement, 1)
+    @test invocation[1] === arg
+    @test replacement_invocation[1] === replacement
+    @test replacement_counter[] == 1
+    GC.gc(true)
+    CUDA.launch(kernel, replacement_invocation)
     @test replacement_counter[] == 1
     @test Array(output) == [12]
 
     ephemeral_counter = Ref(0)
-    CUDA.prepare_launch(copy_counted, CountedHost(CuArray([14]), ephemeral_counter), output) do launch
-        GC.gc(true)
-        launch()
+    function escaping_invocation()
+        CUDA.prepare(copy_counted,
+                     CountedHost(CuArray([14]), ephemeral_counter), output)
     end
+    escaped = escaping_invocation()
+    GC.gc(true)
+    escaped_kernel = CUDA.compile(escaped)
+    CUDA.launch(escaped_kernel, escaped)
     @test ephemeral_counter[] == 1
     @test Array(output) == [14]
 
-    CUDA.prepare_launch(dummy) do launch
-        launch()
+    empty_invocation = CUDA.prepare(dummy)
+    CUDA.launch(CUDA.compile(empty_invocation), empty_invocation)
+
+    replace_int(inv, value) = Base.setindex(inv, value, 1)
+    int_invocation = CUDA.prepare(identity, Int32(1))
+    @test @inferred(replace_int(int_invocation, Int32(2))) isa CUDA.KernelInvocation
+    replace_int(int_invocation, Int32(2))
+    @test @allocated(replace_int(int_invocation, Int32(2))) == 0
+    runtime_index = Ref(1)[]
+    @test Base.setindex(int_invocation, Int64(3), runtime_index)[1] == 3
+
+    function write_scalar(value, output)
+        output[] = value
+        return
     end
+    scalar_output = CuArray(Int32[0])
+    scalar_invocation = CUDA.prepare(write_scalar, Int32(1), scalar_output)
+    scalar_kernel = CUDA.compile(scalar_invocation)
+    widened_invocation = Base.setindex(scalar_invocation, Int64(2), 1)
+    CUDA.launch(scalar_kernel, widened_invocation)
+    @test Array(scalar_output) == Int32[2]
+    @test_throws InexactError CUDA.launch(
+        scalar_kernel, Base.setindex(scalar_invocation, typemax(Int64), 1))
+
+    scalar_kernel(Int64(3), scalar_output)
+    @test Array(scalar_output) == Int32[3]
+
+    float_input = CuArray(Float32[1])
+    function copy_first(input, output)
+        output[] = input[]
+        return
+    end
+    array_invocation = CUDA.prepare(copy_first, input, output)
+    array_kernel = CUDA.compile(array_invocation)
+    @test_throws MethodError CUDA.launch(
+        array_kernel, Base.setindex(array_invocation, float_input, 1))
 end
 
 
@@ -288,6 +324,15 @@ end
     kernel(a) = return
     bar(a) = @cuda kernel(a)
     @inferred bar(CuArray([1]))
+
+    function reassigned_launch_kwarg()
+        threads = 1
+        @cuda threads=threads dummy()
+        threads = 2
+        return threads
+    end
+    lowered = only(code_lowered(reassigned_launch_kwarg, Tuple{}))
+    @test !occursin("Core.Box", sprint(show, lowered))
 end
 
 
@@ -310,7 +355,7 @@ end
     @cuda backend=CUDA dummy()
     @cuda backend=CUDACore dummy()
 
-    # custom backend stub: assert kernel_convert/kernel_compile are called
+    # custom backend stub: assert prepare/compile/launch are called
     # and that unknown kwargs are forwarded
     @eval module BackendStub
         using CUDA
@@ -323,22 +368,22 @@ end
         struct Backend <: CUDACore.AbstractBackend end
         DefaultBackend() = Backend()
 
-        struct Kernel{F}
+        struct Kernel{F,TT} <: CUDACore.AbstractKernel{F,TT}
             f::F
         end
-        (::Kernel)(args...; kwargs...) = nothing
 
-        CUDACore.kernel_convert(::Backend, x) = (convert_calls[] += 1; x)
-        function CUDACore.kernel_compile(::Backend, f::F, tt::Type{<:Tuple};
-                                         kwargs...) where {F}
+        CUDACore.backend(::Kernel) = Backend()
+        CUDACore.prepare(::Backend, x) = (convert_calls[] += 1; x)
+        function CUDACore.compile(::Backend, f::F, tt::Type{<:Tuple};
+                                  kwargs...) where {F}
             compile_calls[] += 1
             last_kwargs[] = (; kwargs...)
-            Kernel{F}(f)
+            Kernel{F,tt}(f)
         end
-        function CUDACore.kernel_launch(::Backend, kernel, args::Tuple; kwargs...)
+        function (kernel::Kernel)(args...; kwargs...)
             launch_calls[] += 1
             last_launch_kwargs[] = (; kwargs...)
-            kernel(args...; kwargs...)
+            nothing
         end
     end
 
@@ -347,7 +392,7 @@ end
     BackendStub.last_kwargs[] = nothing
     @cuda backend=BackendStub.Backend() dummy()
     @test BackendStub.compile_calls[] == 1
-    # f + 0 args, all routed through kernel_convert
+    # f + 0 args, all routed through prepare
     @test BackendStub.convert_calls[] == 1
     @test BackendStub.launch_calls[] == 1
 
@@ -355,7 +400,7 @@ end
     @cuda backend=BackendStub dummy()
     @test BackendStub.compile_calls[] == 2
 
-    # other_kwargs forwarding to kernel_compile
+    # other_kwargs forwarding to compile
     @cuda backend=BackendStub.Backend() opt_level=2 dummy()
     @test haskey(BackendStub.last_kwargs[], :opt_level)
     @test BackendStub.last_kwargs[][:opt_level] == 2
@@ -367,17 +412,16 @@ end
     BackendStub.compile_calls[] = 0
     BackendStub.convert_calls[] = 0
     BackendStub.launch_calls[] = 0
-    result = CUDA.prepare_launch(dummy, 1, 2;
-                                 backend=BackendStub, opt_level=3) do launch
-        @test launch isa CUDA.PreparedLaunch
-        @test launch.kernel isa BackendStub.Kernel
-        launch(; threads=4)
-        launch = CUDA.replace_arguments(launch, 1 => 3)
-        launch(; threads=8)
-        @test_throws ArgumentError CUDA.replace_arguments(launch, 2 => 4.0)
-        :prepared
-    end
-    @test result === :prepared
+    invocation = CUDA.prepare(dummy, 1, 2; backend=BackendStub)
+    @test invocation isa CUDA.KernelInvocation
+    @test invocation[1] == 1
+    kernel = CUDA.compile(invocation; opt_level=3)
+    @test kernel isa BackendStub.Kernel
+    CUDA.launch(kernel, invocation; threads=4)
+    invocation = Base.setindex(invocation, 3, 1)
+    CUDA.launch(kernel, invocation; threads=8)
+    drifted = Base.setindex(invocation, 4.0, 2)
+    @test drifted[2] == 4.0
     @test BackendStub.compile_calls[] == 1
     @test BackendStub.convert_calls[] == 5 # function, two arguments, and two replacements
     @test BackendStub.launch_calls[] == 2

--- a/test/core/execution.jl
+++ b/test/core/execution.jl
@@ -89,7 +89,7 @@ end
 
     replacement_counter = Ref(0)
     replacement = CountedHost(CuArray([12]), replacement_counter)
-    replacement_call = CUDA.rebind(call, 1, replacement)
+    replacement_call = CUDA.rebind(call, replacement, 1)
     @test call.source.arguments[1] === arg
     @test replacement_call.source.arguments[1] === replacement
     @test replacement_counter[] == 1
@@ -113,11 +113,11 @@ end
     empty_call = CUDA.KernelCall(dummy)
     CUDA.kernel_launch(CUDA.kernel_compile(empty_call), empty_call)
 
-    rebind_int(inv, value) = CUDA.rebind(inv, 1, value)
+    rebind_int(inv, value) = CUDA.rebind(inv, value, 1)
     int_call = CUDA.KernelCall(identity, Int32(1))
     @test @inferred(rebind_int(int_call, Int32(2))) isa CUDA.KernelCall
     runtime_index = Ref(1)[]
-    @test CUDA.rebind(int_call, runtime_index, Int64(3)).source.arguments[1] == 3
+    @test CUDA.rebind(int_call, Int64(3), runtime_index).source.arguments[1] == 3
 
     function write_scalar(value, output)
         output[] = value
@@ -126,11 +126,11 @@ end
     scalar_output = CuArray(Int32[0])
     scalar_call = CUDA.KernelCall(write_scalar, Int32(1), scalar_output)
     scalar_kernel = CUDA.kernel_compile(scalar_call)
-    widened_call = CUDA.rebind(scalar_call, 1, Int64(2))
+    widened_call = CUDA.rebind(scalar_call, Int64(2), 1)
     CUDA.kernel_launch(scalar_kernel, widened_call)
     @test Array(scalar_output) == Int32[2]
     @test_throws InexactError CUDA.kernel_launch(
-        scalar_kernel, CUDA.rebind(scalar_call, 1, typemax(Int64)))
+        scalar_kernel, CUDA.rebind(scalar_call, typemax(Int64), 1))
 
     scalar_kernel(Int64(3), scalar_output)
     @test Array(scalar_output) == Int32[3]
@@ -143,7 +143,7 @@ end
     array_call = CUDA.KernelCall(copy_first, input, output)
     array_kernel = CUDA.kernel_compile(array_call)
     @test_throws MethodError CUDA.kernel_launch(
-        array_kernel, CUDA.rebind(array_call, 1, float_input))
+        array_kernel, CUDA.rebind(array_call, float_input, 1))
 end
 
 
@@ -411,9 +411,9 @@ end
     kernel = CUDA.kernel_compile(call; opt_level=3)
     @test kernel isa BackendStub.Kernel
     CUDA.kernel_launch(kernel, call; threads=4)
-    call = CUDA.rebind(call, 1, 3)
+    call = CUDA.rebind(call, 3, 1)
     CUDA.kernel_launch(kernel, call; threads=8)
-    drifted = CUDA.rebind(call, 2, 4.0)
+    drifted = CUDA.rebind(call, 4.0, 2)
     @test drifted.source.arguments[2] == 4.0
     @test BackendStub.compile_calls[] == 1
     @test BackendStub.convert_calls[] == 5 # function, two arguments, and two rebindings

--- a/test/core/execution.jl
+++ b/test/core/execution.jl
@@ -349,6 +349,7 @@ end
     @test BackendStub.compile_calls[] == 1
     # f + 0 args, all routed through kernel_convert
     @test BackendStub.convert_calls[] == 1
+    @test BackendStub.launch_calls[] == 1
 
     # module-as-backend resolution for the custom backend
     @cuda backend=BackendStub dummy()
@@ -358,6 +359,10 @@ end
     @cuda backend=BackendStub.Backend() opt_level=2 dummy()
     @test haskey(BackendStub.last_kwargs[], :opt_level)
     @test BackendStub.last_kwargs[][:opt_level] == 2
+
+    @cuda backend=BackendStub.Backend() opt_level=3 threads=16 dummy()
+    @test BackendStub.last_kwargs[] == (opt_level=3,)
+    @test BackendStub.last_launch_kwargs[] == (threads=16,)
 
     BackendStub.compile_calls[] = 0
     BackendStub.convert_calls[] = 0

--- a/test/core/execution.jl
+++ b/test/core/execution.jl
@@ -93,7 +93,7 @@ end
 
     replacement_counter = Ref(0)
     replacement = CountedHost(CuArray([12]), replacement_counter)
-    replacement_invocation = Base.setindex(invocation, replacement, 1)
+    replacement_invocation = CUDA.rebind(invocation, 1 => replacement)
     @test invocation[1] === arg
     @test replacement_invocation[1] === replacement
     @test replacement_counter[] == 1
@@ -117,13 +117,13 @@ end
     empty_invocation = CUDA.prepare(dummy)
     CUDA.launch(CUDA.compile(empty_invocation), empty_invocation)
 
-    replace_int(inv, value) = Base.setindex(inv, value, 1)
+    rebind_int(inv, value) = CUDA.rebind(inv, 1 => value)
     int_invocation = CUDA.prepare(identity, Int32(1))
-    @test @inferred(replace_int(int_invocation, Int32(2))) isa CUDA.KernelInvocation
-    replace_int(int_invocation, Int32(2))
-    @test @allocated(replace_int(int_invocation, Int32(2))) == 0
+    @test @inferred(rebind_int(int_invocation, Int32(2))) isa CUDA.KernelInvocation
+    rebind_int(int_invocation, Int32(2))
+    @test @allocated(rebind_int(int_invocation, Int32(2))) == 0
     runtime_index = Ref(1)[]
-    @test Base.setindex(int_invocation, Int64(3), runtime_index)[1] == 3
+    @test CUDA.rebind(int_invocation, runtime_index => Int64(3))[1] == 3
 
     function write_scalar(value, output)
         output[] = value
@@ -132,11 +132,11 @@ end
     scalar_output = CuArray(Int32[0])
     scalar_invocation = CUDA.prepare(write_scalar, Int32(1), scalar_output)
     scalar_kernel = CUDA.compile(scalar_invocation)
-    widened_invocation = Base.setindex(scalar_invocation, Int64(2), 1)
+    widened_invocation = CUDA.rebind(scalar_invocation, 1 => Int64(2))
     CUDA.launch(scalar_kernel, widened_invocation)
     @test Array(scalar_output) == Int32[2]
     @test_throws InexactError CUDA.launch(
-        scalar_kernel, Base.setindex(scalar_invocation, typemax(Int64), 1))
+        scalar_kernel, CUDA.rebind(scalar_invocation, 1 => typemax(Int64)))
 
     scalar_kernel(Int64(3), scalar_output)
     @test Array(scalar_output) == Int32[3]
@@ -149,7 +149,7 @@ end
     array_invocation = CUDA.prepare(copy_first, input, output)
     array_kernel = CUDA.compile(array_invocation)
     @test_throws MethodError CUDA.launch(
-        array_kernel, Base.setindex(array_invocation, float_input, 1))
+        array_kernel, CUDA.rebind(array_invocation, 1 => float_input))
 end
 
 
@@ -418,12 +418,12 @@ end
     kernel = CUDA.compile(invocation; opt_level=3)
     @test kernel isa BackendStub.Kernel
     CUDA.launch(kernel, invocation; threads=4)
-    invocation = Base.setindex(invocation, 3, 1)
+    invocation = CUDA.rebind(invocation, 1 => 3)
     CUDA.launch(kernel, invocation; threads=8)
-    drifted = Base.setindex(invocation, 4.0, 2)
+    drifted = CUDA.rebind(invocation, 2 => 4.0)
     @test drifted[2] == 4.0
     @test BackendStub.compile_calls[] == 1
-    @test BackendStub.convert_calls[] == 5 # function, two arguments, and two replacements
+    @test BackendStub.convert_calls[] == 5 # function, two arguments, and two rebindings
     @test BackendStub.launch_calls[] == 2
     @test BackendStub.last_kwargs[] == (opt_level=3,)
     @test BackendStub.last_launch_kwargs[] == (threads=8,)

--- a/test/core/execution.jl
+++ b/test/core/execution.jl
@@ -89,7 +89,7 @@ end
 
     replacement_counter = Ref(0)
     replacement = CountedHost(CuArray([12]), replacement_counter)
-    replacement_call = CUDA.rebind(call, 1 => replacement)
+    replacement_call = CUDA.rebind(call, 1, replacement)
     @test call.source.arguments[1] === arg
     @test replacement_call.source.arguments[1] === replacement
     @test replacement_counter[] == 1
@@ -113,11 +113,11 @@ end
     empty_call = CUDA.KernelCall(dummy)
     CUDA.kernel_launch(CUDA.kernel_compile(empty_call), empty_call)
 
-    rebind_int(inv, value) = CUDA.rebind(inv, 1 => value)
+    rebind_int(inv, value) = CUDA.rebind(inv, 1, value)
     int_call = CUDA.KernelCall(identity, Int32(1))
     @test @inferred(rebind_int(int_call, Int32(2))) isa CUDA.KernelCall
     runtime_index = Ref(1)[]
-    @test CUDA.rebind(int_call, runtime_index => Int64(3)).source.arguments[1] == 3
+    @test CUDA.rebind(int_call, runtime_index, Int64(3)).source.arguments[1] == 3
 
     function write_scalar(value, output)
         output[] = value
@@ -126,11 +126,11 @@ end
     scalar_output = CuArray(Int32[0])
     scalar_call = CUDA.KernelCall(write_scalar, Int32(1), scalar_output)
     scalar_kernel = CUDA.kernel_compile(scalar_call)
-    widened_call = CUDA.rebind(scalar_call, 1 => Int64(2))
+    widened_call = CUDA.rebind(scalar_call, 1, Int64(2))
     CUDA.kernel_launch(scalar_kernel, widened_call)
     @test Array(scalar_output) == Int32[2]
     @test_throws InexactError CUDA.kernel_launch(
-        scalar_kernel, CUDA.rebind(scalar_call, 1 => typemax(Int64)))
+        scalar_kernel, CUDA.rebind(scalar_call, 1, typemax(Int64)))
 
     scalar_kernel(Int64(3), scalar_output)
     @test Array(scalar_output) == Int32[3]
@@ -143,7 +143,7 @@ end
     array_call = CUDA.KernelCall(copy_first, input, output)
     array_kernel = CUDA.kernel_compile(array_call)
     @test_throws MethodError CUDA.kernel_launch(
-        array_kernel, CUDA.rebind(array_call, 1 => float_input))
+        array_kernel, CUDA.rebind(array_call, 1, float_input))
 end
 
 
@@ -411,9 +411,9 @@ end
     kernel = CUDA.kernel_compile(call; opt_level=3)
     @test kernel isa BackendStub.Kernel
     CUDA.kernel_launch(kernel, call; threads=4)
-    call = CUDA.rebind(call, 1 => 3)
+    call = CUDA.rebind(call, 1, 3)
     CUDA.kernel_launch(kernel, call; threads=8)
-    drifted = CUDA.rebind(call, 2 => 4.0)
+    drifted = CUDA.rebind(call, 2, 4.0)
     @test drifted.source.arguments[2] == 4.0
     @test BackendStub.compile_calls[] == 1
     @test BackendStub.convert_calls[] == 5 # function, two arguments, and two rebindings

--- a/test/core/execution.jl
+++ b/test/core/execution.jl
@@ -81,10 +81,6 @@ end
     CUDA.kernel_launch(kernel, invocation)
     @test counter[] == 1
     @test Array(output) == [11]
-    rebound = CUDA.KernelInvocation(kernel, arg, output)
-    @test rebound.backend isa CUDA.LLVMBackend
-    @test counter[] == 2
-
     counter[] = 0
     kernel = @cuda launch=false copy_counted(arg, output)
     @test counter[] == 1
@@ -372,7 +368,6 @@ end
             f::F
         end
 
-        CUDACore.backend(::Kernel) = Backend()
         CUDACore.kernel_convert(::Backend, x) = (convert_calls[] += 1; x)
         function CUDACore.kernel_compile(::Backend, f::F, tt::Type{<:Tuple};
                                          kwargs...) where {F}

--- a/test/core/execution.jl
+++ b/test/core/execution.jl
@@ -116,8 +116,6 @@ end
     rebind_int(inv, value) = CUDA.rebind(inv, 1 => value)
     int_call = CUDA.KernelCall(identity, Int32(1))
     @test @inferred(rebind_int(int_call, Int32(2))) isa CUDA.KernelCall
-    rebind_int(int_call, Int32(2))
-    @test @allocated(rebind_int(int_call, Int32(2))) == 0
     runtime_index = Ref(1)[]
     @test CUDA.rebind(int_call, runtime_index => Int64(3))[1] == 3
 

--- a/test/core/kernelabstractions.jl
+++ b/test/core/kernelabstractions.jl
@@ -1,6 +1,26 @@
 import KernelAbstractions
 import KernelAbstractions as KA
 
+struct KAConversionHost{T}
+    value::T
+    counter::Base.RefValue{Int}
+end
+
+struct KAConversionDevice{T}
+    value::T
+end
+
+
+function Adapt.adapt_structure(to::CUDA.KernelAdaptor, arg::KAConversionHost)
+    arg.counter[] += 1
+    KAConversionDevice(Adapt.adapt(to, arg.value))
+end
+
+KA.@kernel function copy_converted!(output, arg)
+    index = KA.@index(Global)
+    @inbounds output[index] = arg.wrapper.value[index]
+end
+
 include(joinpath(dirname(pathof(KernelAbstractions)), "..", "test", "testsuite.jl"))
 
 ka_skip_tests = Set{String}(["sparse"])
@@ -13,4 +33,23 @@ end
 
 @testset "KA.functional" begin
     @test KA.functional(CUDABackend()) == CUDA.functional()
+end
+
+@testset "argument conversion" begin
+    backend = CUDABackend()
+    kernel = copy_converted!(backend)
+    input = CuArray(collect(1:257))
+    output = similar(input)
+    counter = Ref(0)
+    arg = (wrapper=KAConversionHost(input, counter),)
+
+    kernel(output, arg; ndrange=length(output))
+    synchronize()
+
+    counter[] = 0
+    kernel(output, arg; ndrange=length(output))
+    synchronize()
+
+    @test counter[] == 1
+    @test Array(output) == collect(1:257)
 end

--- a/test/core/kernelabstractions.jl
+++ b/test/core/kernelabstractions.jl
@@ -10,6 +10,8 @@ struct KAConversionDevice{T}
     value::T
 end
 
+Base.broadcastable(arg::KAConversionHost) = Ref(arg)
+Base.:+(x::Float32, arg::KAConversionDevice{Float32}) = x + arg.value
 
 function Adapt.adapt_structure(to::CUDA.KernelAdaptor, arg::KAConversionHost)
     arg.counter[] += 1
@@ -52,4 +54,13 @@ end
 
     @test counter[] == 1
     @test Array(output) == collect(1:257)
+
+    counter[] = 0
+    broadcast_input = CUDA.fill(1f0, 257)
+    broadcast_output = similar(broadcast_input)
+    broadcast_output .= broadcast_input .+ KAConversionHost(2f0, counter)
+    synchronize()
+
+    @test counter[] == 1
+    @test Array(broadcast_output) == fill(3f0, 257)
 end


### PR DESCRIPTION
Adds a prepared-launch API that converts kernel arguments once and reuses them after launch configuration.

CUDAKernels now uses this API when selecting a workgroup size, avoiding a second conversion during launch. This affects common operations such as GPU broadcasts. Existing delayed-launch users in CUDACore, cuBLAS, and cuSPARSE are migrated as well.

Before:

```julia-repl
julia> using CUDA, BenchmarkTools

julia> x = CUDA.fill(1f0, 257);

julia> y = similar(x);

julia> y .= x .+ 2f0;

julia> @benchmark $y .= $x .+ 2f0 teardown=(CUDA.synchronize())
BenchmarkTools.Trial: 10000 samples with 9 evaluations per sample.
 Range (min … max):  2.590 μs … 112.070 μs  ┊ GC (min … max): 0.00% … 95.44%
 Time  (median):     2.678 μs               ┊ GC (median):    0.00%
 Time  (mean ± σ):   2.735 μs ±   2.105 μs  ┊ GC (mean ± σ):  1.51% ±  1.92%

           ▁▆▆▇▆▅█▆▇▆▄▅▃▃▁▁
  ▁▁▁▁▁▂▂▃▆████████████████▇▅▅▃▃▃▂▂▂▂▁▂▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁ ▃
  2.59 μs         Histogram: frequency by time        2.89 μs <

 Memory estimate: 1.41 KiB, allocs estimate: 37.
```

After:

```julia-repl

julia> @benchmark $y .= $x .+ 2f0 teardown=(CUDA.synchronize())
BenchmarkTools.Trial: 10000 samples with 9 evaluations per sample.
 Range (min … max):  2.175 μs … 293.035 μs  ┊ GC (min … max): 0.00% … 98.32%
 Time  (median):     2.262 μs               ┊ GC (median):    0.00%
 Time  (mean ± σ):   2.368 μs ±   4.209 μs  ┊ GC (mean ± σ):  3.37% ±  2.16%

         ▃▅▇█▆▆▅▂▁
  ▁▁▁▂▂▄▇██████████▆▆▅▄▄▃▃▃▃▃▂▂▂▂▂▂▁▁▁▂▂▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁ ▃
  2.18 μs         Histogram: frequency by time        2.58 μs <

 Memory estimate: 1.31 KiB, allocs estimate: 36.
```

cc @vchuravy 