### PR TITLE
Fix 3-arg QR `ldiv!` for multi-column right-hand sides

### DIFF
--- a/lib/cusolver/src/linalg.jl
+++ b/lib/cusolver/src/linalg.jl
@@ -298,7 +298,7 @@ end
 
 function LinearAlgebra.ldiv!(x::CuArray, _qr::QR, b::CuArray)
     _x = ldiv!(_qr, b)
-    x .= vec(_x)
+    copyto!(x, _x)
     unsafe_free!(_x)
     return x
 end

--- a/lib/cusolver/test/dense/qr.jl
+++ b/lib/cusolver/test/dense/qr.jl
@@ -129,4 +129,15 @@ end
         ldiv!(y, qr(A), x)
         y
     end
+
+    # multi-column rhs, e.g. inverting a matrix via `A \ I`
+    @test testf(rand(elty, m, m), rand(elty, m, l)) do A, X
+        ldiv!(qr(A), X)
+        X
+    end
+
+    @test testf(rand(elty, m, m), rand(elty, m, l), rand(elty, m, l)) do A, X, Y
+        ldiv!(Y, qr(A), X)
+        Y
+    end
 end


### PR DESCRIPTION
`ldiv!(x, ::QR, b)` in `lib/cusolver/src/linalg.jl` assumed a vector rhs:

```julia
_x = ldiv!(_qr, b)
x .= vec(_x)          # <- flattens an n×k result
```

The 2-arg `ldiv!(::QR, ::CuMatrix)` right above it already handles matrix rhs, but
the 3-arg form never got the same treatment. With a k>1 column rhs, `_x` is n×k and
`vec(_x)` is length n·k, so broadcasting into the n×k destination `x` throws
`DimensionMismatch: array could not be broadcast to match destination`.

`lib/cusolver/test/dense/qr.jl` only exercised `ldiv!` with vector rhs. Added
matrix-rhs cases for the 2-arg and 3-arg forms. The 3-arg one fails on master for
all four eltypes with the `DimensionMismatch` above; both pass with the fix.
