### PR TITLE
Restrict Crayons to 4.1.x to unblock CI

### DIFF
--- a/CUDATools/Project.toml
+++ b/CUDATools/Project.toml
@@ -27,7 +27,7 @@ NVML = {path = "../lib/nvml"}
 CUDACore = "=6.2.1"
 CUDA_Compiler_jll = "0.3, 0.4"
 CUPTI = "=6.2.1"
-Crayons = "4.1"
+Crayons = "~4.1"
 GPUCompiler = "2"
 LLVM = "9.3.1"
 NVML = "=6.2.1"

--- a/CUDATools/Project.toml
+++ b/CUDATools/Project.toml
@@ -27,7 +27,7 @@ NVML = {path = "../lib/nvml"}
 CUDACore = "=6.2.1"
 CUDA_Compiler_jll = "0.3, 0.4"
 CUPTI = "=6.2.1"
-Crayons = "4"
+Crayons = "4.1"
 GPUCompiler = "2"
 LLVM = "9.3.1"
 NVML = "=6.2.1"


### PR DESCRIPTION
Temporary stupid fix to unblock CI while we adjust to the new version 4.2.0