### PR TITLE
Don't let `^` accuracy depend on the exponent's width.

### DIFF
--- a/CUDACore/src/device/intrinsics/math.jl
+++ b/CUDACore/src/device/intrinsics/math.jl
@@ -391,7 +391,7 @@ end
     y == 1 && return x
     y == 2 && return x*x
     y == 3 && return x*x*x
-    x ^ y  # no fast variant for Float64; uses __nv_powi
+    x ^ y  # no fast variant for Float64; uses __nv_pow
 end
 @device_override @assume_effects :foldable @inline function FastMath.pow_fast(x::Float32, y::Integer)
     y == -1 && return inv(x)
@@ -409,9 +409,15 @@ end
     y == 3 && return x*x*x
     Float16(FastMath.pow_fast(Float32(x), Float32(y)))
 end
-@device_override Base.:(^)(x::Float64, y::Int32) = ccall("extern __nv_powi", llvmcall, Cdouble, (Cdouble, Int32), x, y)
-@device_override Base.:(^)(x::Float32, y::Int32) = ccall("extern __nv_powif", llvmcall, Cfloat, (Cfloat, Int32), x, y)
-@device_override @assume_effects :foldable @inline function Base.:(^)(x::Float32, y::Int64)
+
+# stay with Base's semantics and avoid the drift of libdevice's integer powers,
+# which square at the working precision.
+@device_function powi(x::Float64, y::Int32) = ccall("extern __nv_powi", llvmcall, Cdouble, (Cdouble, Int32), x, y)
+@device_function powi(x::Float32, y::Int32) = ccall("extern __nv_powif", llvmcall, Cfloat, (Cfloat, Int32), x, y)
+
+# Base's `^(::Float, ::Integer)` calls `power_by_squaring`, whose
+# `trailing_zeros` loop emits `cttz_int`, so convert and defer to `__nv_pow`.
+@device_override @assume_effects :foldable @inline function Base.:(^)(x::Float32, y::Integer)
     y == -1 && return inv(x)
     y == 0 && return one(x)
     y == 1 && return x
@@ -419,7 +425,7 @@ end
     y == 3 && return x*x*x
     x ^ Float32(y)
 end
-@device_override @assume_effects :foldable @inline function Base.:(^)(x::Float64, y::Int64)
+@device_override @assume_effects :foldable @inline function Base.:(^)(x::Float64, y::Integer)
     y == -1 && return inv(x)
     y == 0 && return one(x)
     y == 1 && return x

--- a/test/core/device/intrinsics/math.jl
+++ b/test/core/device/intrinsics/math.jl
@@ -13,6 +13,23 @@ using SpecialFunctions
             @test testf((x,y)->x.^y, rand(Float32, 1), rand(range, 1))
             @test testf((x,y)->x.^y, rand(Float32, 1), -rand(range, 1))
         end
+
+        # Integer exponents: accuracy must not depend on the exponent's width.
+        # __nv_powi/__nv_powif used to back the Int32 methods and drifted by
+        # ~1500 ulp on the cases below, while Int64 went via __nv_pow.
+        @testset "integer exponent ($T, $I)" for T in (Float32, Float64),
+                                                 I in (Int32, Int64)
+            x = T[1.001, 0.9, 1.1, 1.0001, 2, 0.5]
+            n = I[500, 200, 30, 5000, 7, -3]
+            @test Array(CuArray(x) .^ CuArray(n)) ≈ x .^ n rtol=8*eps(T)
+        end
+
+        # Both widths have to agree with each other, not just with the CPU
+        @testset "integer exponent width agreement ($T)" for T in (Float32, Float64)
+            x = CuArray(T[1.001, 0.9, 1.1, 1.0001])
+            n = Int64[500, 200, 30, 5000]
+            @test Array(x .^ CuArray(Int32.(n))) == Array(x .^ CuArray(n))
+        end
     end
     
     @testset "min/max" begin


### PR DESCRIPTION
`^(::Float32, ::Int32)` mapped to __nv_powif and `^(::Float32, ::Int64)` converted and used __nv_powf, so the exponent's width decided the result: libdevice squares at the working precision and drifts to ~1500 ulp on 1.0001f0^5000, where the Int64 path stays within an ulp. Base draws no such distinction, and the split dated to the 2021 mechanical libdevice mapping rather than a deliberate tradeoff. Route every integer width through the accurate path and keep the libdevice functions as `powi` for callers that want the cheaper op. Costs @fastmath Float64 integer powers __nv_powi; pow_fast is the right place to recover that if it matters.