### PR TITLE
don't return reshaped array from `mapreducedim!`

### DIFF
--- a/CUDACore/src/mapreduce.jl
+++ b/CUDACore/src/mapreduce.jl
@@ -208,7 +208,7 @@ function GPUArrays.mapreducedim!(f::F, op::OP, R::AnyCuArray{T},
         threads = kernel_config.threads
         blocks = cld(length(Rother), threads)
         kernel_launch(kernel, call; threads, blocks)
-        return R
+        return R_old
     end
 
     # how many threads do we want?

--- a/CUDACore/src/mapreduce.jl
+++ b/CUDACore/src/mapreduce.jl
@@ -182,6 +182,7 @@ function GPUArrays.mapreducedim!(f::F, op::OP, R::AnyCuArray{T},
                          Float16, Float32, Float64,
                          ComplexF16, ComplexF32, ComplexF64}
 
+    R_old = R
     # add singleton dimensions to the output container, if needed
     if ndims(R) < ndims(A)
         dims = Base.fill_to_length(size(R), 1, Val(ndims(A)))
@@ -296,5 +297,5 @@ function GPUArrays.mapreducedim!(f::F, op::OP, R::AnyCuArray{T},
         GPUArrays.mapreducedim!(identity, op, R, partial; init)
     end
 
-    return R
+    return R_old
 end

--- a/docs/src/usage/array.md
+++ b/docs/src/usage/array.md
@@ -119,7 +119,7 @@ julia> b = CUDA.zeros(1)
  0.0
 
 julia> Base.mapreducedim!(identity, +, b, a)
-1×1 CuArray{Float32, 2, CUDACore.DeviceMemory}:
+1-element CuArray{Float32, 1, CUDACore.DeviceMemory}:
  6.0
 ```
 

--- a/test/core/array.jl
+++ b/test/core/array.jl
@@ -1022,3 +1022,9 @@ end
   sum!(a, b)
   @test Array(a) == [2f0]
 end
+
+@testset "mapreducedim! returning same type" begin
+    R = transpose(CUDA.zeros(Float32, 2, 3))
+    A = CUDA.rand(Float32, 3, 2, 10)
+    @test @inferred(GPUArrays.mapreducedim!(identity, +, R, A)) === R
+end


### PR DESCRIPTION
Discovered in https://github.com/JuliaGPU/GPUArrays.jl/pull/754. Once this is approved, I will open PRs for all the other backends as well.
