### PR TITLE
Delete unnecessary `axes()` method

### DIFF
--- a/CUDACore/src/device/array.jl
+++ b/CUDACore/src/device/array.jl
@@ -213,7 +213,6 @@ Base.Experimental.Const(A::CuDeviceArray) = Const(A)
 
 Base.IndexStyle(::Type{<:Const}) = IndexLinear()
 Base.size(C::Const) = size(C.a)
-Base.axes(C::Const) = axes(C.a)
 Base.@propagate_inbounds Base.getindex(A::Const, i1::Integer) = const_arrayref(A.a, i1)
 
 # deprecated


### PR DESCRIPTION
It already has a Base definition implemented in terms of `size()`.

Fixes these invalidations on 1.13:
```julia
 inserting axes(C::CUDACore.Const) @ CUDACore ~/.julia/packages/CUDACore/NlVPI/src/device/array.jl:216 invalidated:                                                                                                                            
   backedges: 1: superseding axes(A) @ Base abstractarray.jl:100 with MethodInstance for axes(::DenseVector{UInt8}) (180 children)
```