### PR TITLE
Add support for CUDA programmatic dependent launch (PDL).

### DIFF
--- a/CUDACore/lib/cudadrv/execution.jl
+++ b/CUDACore/lib/cudadrv/execution.jl
@@ -26,7 +26,8 @@ end
 
 """
     launch(f::CuFunction; args...; blocks::CuDim=1, threads::CuDim=1,
-           clustersize::CuDim=1, cooperative=false, shmem=0, stream=stream())
+           clustersize::CuDim=1, cooperative=false, dependent=false,
+           shmem=0, stream=stream())
 
 Low-level call to launch a CUDA function `f` on the GPU, using `blocks` and `threads` as
 respectively the grid and block configuration. Dynamic shared memory is allocated according
@@ -35,19 +36,29 @@ capability is `>= 9.0`, [thread block clusters](https://docs.nvidia.com/cuda/cud
 are launched. If `clustersize > 1` and compute capability is `< 9.0`, an error is thrown, as
 thread block clusters are not supported.
 
+Setting `dependent=true` marks this as a programmatically dependent launch, allowing it to
+overlap with the preceding kernel in `stream`. The preceding kernel should call
+[`trigger_programmatic_launch_completion`](@ref), and this kernel must call
+[`grid_dependency_synchronize`](@ref) before accessing its results. This feature requires
+compute capability 9.0 or higher.
+
 Arguments to a kernel should either be bitstype, in which case they will be copied to the
 internal kernel parameter buffer, or a pointer to device memory.
 
 This is a low-level call, prefer to use [`cudacall`](@ref) instead.
 """
 function launch(f::CuFunction, args::Vararg{Any,N}; blocks::CuDim=1, threads::CuDim=1,
-                clustersize::CuDim=1, cooperative::Bool=false, shmem::Integer=0,
-                stream::CuStream=stream()) where {N}
+                clustersize::CuDim=1, cooperative::Bool=false, dependent::Bool=false,
+                shmem::Integer=0, stream::CuStream=stream()) where {N}
     blockdim = CuDim3(blocks)
     threaddim = CuDim3(threads)
     clusterdim = CuDim3(clustersize)
 
-    attributes = Ref{NTuple{2,CUlaunchAttribute}}()
+    if dependent && capability(device()) < v"9.0"
+        error("Programmatic dependent launch requires compute capability 9.0 or higher")
+    end
+
+    attributes = Ref{NTuple{3,CUlaunchAttribute}}()
     GC.@preserve attributes stream begin
         attributes_ptr = Base.unsafe_convert(Ptr{CUlaunchAttribute}, attributes)
         num_attributes = 0
@@ -65,6 +76,12 @@ function launch(f::CuFunction, args::Vararg{Any,N}; blocks::CuDim=1, threads::Cu
             attribute.value.clusterDim.z = clusterdim.z
             num_attributes += 1
         end
+        if dependent
+            attribute = attributes_ptr + num_attributes * sizeof(CUlaunchAttribute)
+            attribute.id = CU_LAUNCH_ATTRIBUTE_PROGRAMMATIC_STREAM_SERIALIZATION
+            attribute.value.programmaticStreamSerializationAllowed = 1
+            num_attributes += 1
+        end
 
         config_attrs = num_attributes == 0 ? Ptr{CUlaunchAttribute}(C_NULL) : attributes_ptr
         config = CUlaunchConfig(blockdim.x, blockdim.y, blockdim.z,
@@ -80,7 +97,8 @@ function launch(f::CuFunction, args::Vararg{Any,N}; blocks::CuDim=1, threads::Cu
     end
 end
 
-@noinline function diagnose_launch_failure(f::CuFunction, err; blockdim, threaddim, clusterdim, shmem)
+@noinline function diagnose_launch_failure(f::CuFunction, err; blockdim, threaddim,
+                                           clusterdim, shmem)
     if !isa(err, CuError) || !in(err.code, [ERROR_INVALID_VALUE,
                                             ERROR_LAUNCH_OUT_OF_RESOURCES])
         rethrow()
@@ -189,7 +207,7 @@ end
 
 """
     cudacall(f, types, values...; blocks::CuDim, threads::CuDim,
-             cooperative=false, shmem=0, stream=stream())
+             cooperative=false, dependent=false, shmem=0, stream=stream())
 
 `ccall`-like interface for launching a CUDA function `f` on a GPU.
 

--- a/CUDACore/src/compiler/execution.jl
+++ b/CUDACore/src/compiler/execution.jl
@@ -161,7 +161,8 @@ end
 
 const MACRO_KWARGS = [:dynamic, :launch, :backend]
 const COMPILER_KWARGS = [:kernel, :name, :always_inline, :minthreads, :maxthreads, :blocks_per_sm, :maxregs, :fastmath, :arch, :cap, :ptx]
-const LAUNCH_KWARGS = [:cooperative, :blocks, :threads, :clustersize, :shmem, :stream]
+const LAUNCH_KWARGS = [:cooperative, :dependent, :blocks, :threads, :clustersize, :shmem,
+                       :stream]
 
 
 """
@@ -401,6 +402,11 @@ The following keyword arguments are supported:
 - `cooperative` (default: `false`): whether to launch a cooperative kernel that supports
   grid synchronization (see [`CG.this_grid`](@ref) and [`CG.sync`](@ref)).
   Note that this requires care wrt. the number of blocks launched.
+- `dependent` (default: `false`): whether this kernel is programmatically dependent on the
+  preceding kernel in the same stream. This can enable overlap between the two kernels on
+  devices with compute capability 9.0 or higher; see
+  [`trigger_programmatic_launch_completion`](@ref) and
+  [`grid_dependency_synchronize`](@ref).
 """
 AbstractKernel
 

--- a/CUDACore/src/device/intrinsics/synchronization.jl
+++ b/CUDACore/src/device/intrinsics/synchronization.jl
@@ -63,6 +63,47 @@ the warp.
 end # @device_functions
 
 
+## grid dependency control
+
+export trigger_programmatic_launch_completion, grid_dependency_synchronize
+
+@device_functions begin
+
+"""
+    trigger_programmatic_launch_completion()
+
+Allow programmatically dependent kernels later in the same stream to start executing. At
+least one thread in every block must call this function; blocks that exit without calling it
+trigger completion implicitly. Calling this function does not make the current kernel's
+writes visible to a dependent kernel, which must call
+[`grid_dependency_synchronize`](@ref) before accessing them.
+
+Requires compute capability 9.0 or higher.
+"""
+@inline function trigger_programmatic_launch_completion()
+    require_sm_90()
+    @asmcall("griddepcontrol.launch_dependents;", "", true, Cvoid, Tuple{})
+    return
+end
+
+"""
+    grid_dependency_synchronize()
+
+Wait for prerequisite kernels to complete and make their global-memory writes visible to
+the current kernel. A kernel using this function should be launched with `dependent=true`.
+All accesses to results from the prerequisite kernels must occur after this call.
+
+Requires compute capability 9.0 or higher.
+"""
+@inline function grid_dependency_synchronize()
+    require_sm_90()
+    @asmcall("griddepcontrol.wait;", "~{memory}", true, Cvoid, Tuple{})
+    return
+end
+
+end # @device_functions
+
+
 ## generalized synchronization (barrier)
 
 export barrier_sync

--- a/docs/src/api/kernel.md
+++ b/docs/src/api/kernel.md
@@ -74,6 +74,8 @@ sync_warp
 threadfence_block
 threadfence
 threadfence_system
+trigger_programmatic_launch_completion
+grid_dependency_synchronize
 ```
 
 

--- a/docs/src/development/kernel.md
+++ b/docs/src/development/kernel.md
@@ -452,6 +452,45 @@ Within a kernel, only a very limited subset of the CUDA API is available:
   these streams can be passed to `@cuda` using the `stream` keyword argument
 
 
+## Programmatic dependent launch
+
+[Programmatic dependent launch](https://docs.nvidia.com/cuda/cuda-programming-guide/04-special-topics/programmatic-dependent-launch.html)
+can overlap the tail of one kernel with the independent preamble of the next kernel in the
+same stream. The producer signals when its dependent can start, and the consumer waits
+before reading the producer's results:
+
+```julia
+function producer!(output)
+    trigger_programmatic_launch_completion()
+
+    # This work may overlap with the consumer's preamble.
+    output[threadIdx().x] = threadIdx().x
+    return
+end
+
+function consumer!(output, input)
+    i = threadIdx().x # Independent work can run before the wait.
+
+    grid_dependency_synchronize()
+    output[i] = input[i]
+    return
+end
+
+@cuda threads=32 producer!(input)
+@cuda threads=32 dependent=true consumer!(output, input)
+```
+
+The `dependent=true` attribute belongs on the consumer launch. Every producer block should
+call `trigger_programmatic_launch_completion`; a block that exits without calling it
+triggers completion implicitly. The consumer must call `grid_dependency_synchronize` before
+accessing any producer results, even when the trigger has already run, because the trigger
+does not make the producer's writes visible.
+
+Overlap is opportunistic. Correctness must not require the two kernels to run concurrently,
+as doing so can deadlock. Programmatic dependent launch requires compute capability 9.0 or
+higher.
+
+
 ## Cooperative groups
 
 With cooperative groups, it is possible to write parallel kernels that are not tied to a

--- a/test/core/device/intrinsics.jl
+++ b/test/core/device/intrinsics.jl
@@ -98,6 +98,11 @@ end
     cluster_kernel() = cluster_arrive()
     @test_throws "requires compute capability 9.0" @cuda launch=false arch=sm"80" cluster_kernel()
 
+    dependent_launch_kernel() = trigger_programmatic_launch_completion()
+    @test_throws "requires compute capability 9.0" begin
+        @cuda launch=false arch=sm"80" dependent_launch_kernel()
+    end
+
     function distributed_shared_kernel()
         CuDistributedSharedArray(CuStaticSharedArray(UInt32, 1), 1)
         return
@@ -178,6 +183,13 @@ end
 end
 
 @testset "parallel synchronization and communication" begin
+
+@test @filecheck CUDA.code_llvm(Tuple{}; arch=sm"90", raw=true) do
+    @check "asm sideeffect \"griddepcontrol.launch_dependents;\", \"\""
+    @check "asm sideeffect \"griddepcontrol.wait;\", \"~{memory}\""
+    trigger_programmatic_launch_completion()
+    grid_dependency_synchronize()
+end
 
 @on_device sync_threads()
 @on_device sync_threads_count(Int32(1))

--- a/test/core/execution.jl
+++ b/test/core/execution.jl
@@ -452,6 +452,47 @@ end
     end
 end
 
+@testset "programmatic dependent launch" begin
+    if CUDA.capability(device()) >= v"9.0"
+        function producer!(output)
+            i = (blockIdx().x - 1i32) * blockDim().x + threadIdx().x
+            trigger_programmatic_launch_completion()
+            if i <= length(output)
+                @inbounds output[i] = i
+            end
+            return
+        end
+
+        function consumer!(output, input)
+            i = (blockIdx().x - 1i32) * blockDim().x + threadIdx().x
+            independent = i + 1i32
+            grid_dependency_synchronize()
+            if i <= length(output)
+                @inbounds output[i] = input[i] + independent
+            end
+            return
+        end
+
+        input = CUDA.zeros(Int32, 128)
+        output = similar(input)
+        @cuda threads=64 blocks=2 producer!(input)
+        @cuda dependent=true threads=64 blocks=2 consumer!(output, input)
+        @test Array(output) == Int32[2i + 1 for i in 1:length(output)]
+
+        # Exercise the maximum attribute count used by launch().
+        cooperative = CUDA.attribute(device(), CUDA.DEVICE_ATTRIBUTE_COOPERATIVE_LAUNCH) == 1
+        if cooperative
+            kernel = @cuda launch=false consumer!(output, input)
+            @cuda dummy()
+            kernel(output, input; cooperative=true, dependent=true,
+                   threads=64, blocks=2, clustersize=2)
+            synchronize()
+        end
+    else
+        @test_throws "requires compute capability 9.0" @cuda dependent=true dummy()
+    end
+end
+
 @testset "external kernels" begin
     @eval module KernelModule
         export external_dummy


### PR DESCRIPTION
A dependent consumer kernel can now be launched with:

```julia
@cuda dependent=true consumer(args...)
```

This sets `CU_LAUNCH_ATTRIBUTE_PROGRAMMATIC_STREAM_SERIALIZATION` on the launch.

Also add the device-side operations:

- `trigger_programmatic_launch_completion()`
- `grid_dependency_synchronize()`

The inline PTX uses memory clobbers to prevent memory accesses from moving across the trigger or wait. Both operations require compute capability 9.0 or newer.