### PR TITLE
Add UE5M3 to cudaDataType enum

### DIFF
--- a/CUDACore/src/library_types.jl
+++ b/CUDACore/src/library_types.jl
@@ -39,6 +39,7 @@ end
     R_6F_E2M3  = 31 # real as a nv_fp6_e2m3
     R_6F_E3M2  = 32 # real as a nv_fp6_e3m2
     R_4F_E2M1  = 33 # real as a nv_fp4_e2m1
+    R_8F_UE5M3 = 34 # real as an unsigned nv_fp8_ue5m3
 end
 
 const R_8F_UE4M3 = R_8F_E4M3 # real as an unsigned nv_fp8_e4m3

--- a/test/core/utils.jl
+++ b/test/core/utils.jl
@@ -33,7 +33,8 @@ end
     # narrow-precision floats: enum members exist,
     # but no Julia type maps to them in CUDACore.
     for c_type in (CUDACore.R_8F_E4M3, CUDACore.R_8F_E5M2, CUDACore.R_8F_UE8M0,
-                   CUDACore.R_6F_E2M3, CUDACore.R_6F_E3M2, CUDACore.R_4F_E2M1)
+                   CUDACore.R_6F_E2M3, CUDACore.R_6F_E3M2, CUDACore.R_4F_E2M1,
+                   CUDACore.R_8F_UE5M3)
         @test_throws ArgumentError Type(c_type)
     end
 end


### PR DESCRIPTION
Adds `R_8F_UE5M3 = 34`, introduced in the CUDA 13.4 Developer Preview and retained in the CUDA 13.4.1 GA release.

Similar to #3180