### PR TITLE
Fix cuDNN tests importing CUDA instead of CUDACore

### DIFF
--- a/lib/cudnn/test/convolution.jl
+++ b/lib/cudnn/test/convolution.jl
@@ -1,4 +1,3 @@
-using CUDACore
 using cuDNN: convolution!, convolution_data_gradient!, convolution_filter_gradient!
 
 CUDACore.allowscalar(false)

--- a/lib/cudnn/test/convolution.jl
+++ b/lib/cudnn/test/convolution.jl
@@ -1,7 +1,7 @@
-using CUDA
+using CUDACore
 using cuDNN: convolution!, convolution_data_gradient!, convolution_filter_gradient!
 
-CUDA.allowscalar(false)
+CUDACore.allowscalar(false)
 
 conv_ref_type(::Type{Float64}) = Float64
 conv_ref_type(::Type) = Float32

--- a/lib/cudnn/test/graph_ops.jl
+++ b/lib/cudnn/test/graph_ops.jl
@@ -1,4 +1,4 @@
-using CUDA
+using CUDACore
 
 using cuDNN:
     conv_dgrad!,
@@ -12,7 +12,7 @@ using cuDNN:
     resample_fwd!,
     tensor!
 
-CUDA.allowscalar(false)
+CUDACore.allowscalar(false)
 
 function matmul_ref(a, b)
     M, K, B = size(a)
@@ -141,7 +141,7 @@ end
 let K=16, M=16, N=16, B=2
     a = CuArray(reshape(Float16.(sin.(1:M*K*B)), M, K, B))
     b = CuArray(reshape(Float16.(cos.(1:K*N*B)), K, N, B))
-    y = CUDA.zeros(Float16, M, N, B)
+    y = CUDACore.zeros(Float16, M, N, B)
 
     g = Graph(io_dtype=Float16, intermediate_dtype=Float32, compute_dtype=Float32)
     ta = tensor!(g, a; name="A")
@@ -165,7 +165,7 @@ let W=8, H=7, C=3, N=2, K=5
     stride = (2, 1)
     dilation = (1, 2)
     ref = conv2d_ref(x, w; pre_padding, post_padding, stride, dilation)
-    y = CUDA.zeros(Float16, size(ref)...)
+    y = CUDACore.zeros(Float16, size(ref)...)
 
     g = Graph(io_dtype=Float16, intermediate_dtype=Float32, compute_dtype=Float32)
     tx = tensor!(g, x; name="X")
@@ -182,7 +182,7 @@ let W=8, H=7, C=3, N=2, K=5
 
     dy = CuArray(reshape(Float16.(sin.(1:length(ref))), size(ref)) ./ 64)
 
-    dx = CUDA.zeros(Float16, size(x))
+    dx = CUDACore.zeros(Float16, size(x))
     dgrad_ref = conv2d_dgrad_ref(dy, w, size(x); pre_padding, stride, dilation)
     gd = Graph(io_dtype=Float16, intermediate_dtype=Float32, compute_dtype=Float32)
     tdy = tensor!(gd, dy; name="dY")
@@ -196,7 +196,7 @@ let W=8, H=7, C=3, N=2, K=5
         @test_skip is_supported(gd)
     end
 
-    dw = CUDA.zeros(Float16, size(w))
+    dw = CUDACore.zeros(Float16, size(w))
     wgrad_ref = conv2d_wgrad_ref(dy, x, size(w); pre_padding, stride, dilation)
     gw = Graph(io_dtype=Float16, intermediate_dtype=Float32, compute_dtype=Float32)
     tyw = tensor!(gw, dy; name="dY")
@@ -217,7 +217,7 @@ let W=7, H=6, C=2, N=2
     padding = (1, 1)
     stride = (2, 2)
     ref = avgpool2d_ref(x; window, pre_padding=padding, stride, include_pad=true)
-    y = CUDA.zeros(Float32, size(ref))
+    y = CUDACore.zeros(Float32, size(ref))
 
     g = Graph(io_dtype=Float32, intermediate_dtype=Float32, compute_dtype=Float32)
     tx = tensor!(g, x; name="X")
@@ -232,7 +232,7 @@ let W=7, H=6, C=2, N=2
     end
 
     dy = CuArray(reshape(Float32.(sin.(1:length(ref))), size(ref)))
-    dx = CUDA.zeros(Float32, size(x))
+    dx = CUDACore.zeros(Float32, size(x))
     bwd_ref = avgpool2d_bwd_ref(dy, size(x); window, pre_padding=padding, stride,
                                 include_pad=true)
     gb = Graph(io_dtype=Float32, intermediate_dtype=Float32, compute_dtype=Float32)

--- a/lib/cudnn/test/graph_ops.jl
+++ b/lib/cudnn/test/graph_ops.jl
@@ -1,5 +1,3 @@
-using CUDACore
-
 using cuDNN:
     conv_dgrad!,
     conv_fprop!,

--- a/lib/cudnn/test/normalization.jl
+++ b/lib/cudnn/test/normalization.jl
@@ -1,4 +1,3 @@
-using CUDACore
 using cuDNN: batchnorm_gradient!, batchnorm_gradient_supported,
              batchnorm_inference!, batchnorm_inference_supported,
              batchnorm_training!, batchnorm_training_supported, graph_unsupported

--- a/lib/cudnn/test/normalization.jl
+++ b/lib/cudnn/test/normalization.jl
@@ -1,14 +1,14 @@
-using CUDA
+using CUDACore
 using cuDNN: batchnorm_gradient!, batchnorm_gradient_supported,
              batchnorm_inference!, batchnorm_inference_supported,
              batchnorm_training!, batchnorm_training_supported, graph_unsupported
 
-CUDA.allowscalar(false)
+CUDACore.allowscalar(false)
 
 let
-    x = CUDA.zeros(Float32, 4, 4, 2, 0)
+    x = CUDACore.zeros(Float32, 4, 4, 2, 0)
     y = similar(x)
-    param = CUDA.zeros(Float32, 1, 1, 2, 1)
+    param = CUDACore.zeros(Float32, 1, 1, 2, 1)
     @test batchnorm_inference_supported(y, x, param, param, param, param)
     @test batchnorm_inference!(y, x, param, param, param, param) === y
 end

--- a/lib/cudnn/test/pooling.jl
+++ b/lib/cudnn/test/pooling.jl
@@ -1,7 +1,7 @@
-using CUDA
+using CUDACore
 using cuDNN: maxpool!, meanpool!, ∇maxpool!, ∇meanpool!, UnsupportedGraphError
 
-CUDA.allowscalar(false)
+CUDACore.allowscalar(false)
 
 function pool_output_dims(x_size; window, pre_padding, post_padding, stride)
     (fld(x_size[1] + pre_padding[1] + post_padding[1] - window[1], stride[1]) + 1,
@@ -159,7 +159,7 @@ let W=7, H=6, C=2, N=2
     bwd_padding = padding
     max_ref = maxpool2d_ref(x; window, pre_padding=bwd_pre_padding,
                             post_padding=bwd_post_padding, stride)
-    y = CUDA.zeros(Float32, size(max_ref))
+    y = CUDACore.zeros(Float32, size(max_ref))
     maxpool!(y, x; window, padding=bwd_padding, stride)
     dy = CuArray(reshape(Float32.(cos.(1:length(max_ref))), size(max_ref)))
     dx0 = CuArray(reshape(Float32.(sin.(1:length(x))), size(x)) ./ 8)

--- a/lib/cudnn/test/pooling.jl
+++ b/lib/cudnn/test/pooling.jl
@@ -1,4 +1,3 @@
-using CUDACore
 using cuDNN: maxpool!, meanpool!, ∇maxpool!, ∇meanpool!, UnsupportedGraphError
 
 CUDACore.allowscalar(false)

--- a/lib/cudnn/test/sdpa.jl
+++ b/lib/cudnn/test/sdpa.jl
@@ -1,6 +1,4 @@
 using BFloat16s: BFloat16
-import CUDACore
-import cuDNN
 using cuDNN: attention, attention!, attention_backward, attention_backward!, build!, execute!,
              Graph, scalar!, sdpa_fwd!, tensor!
 using cuRAND

--- a/lib/cudnn/test/sdpa.jl
+++ b/lib/cudnn/test/sdpa.jl
@@ -1,5 +1,5 @@
 using BFloat16s: BFloat16
-import CUDA
+import CUDACore
 import cuDNN
 using cuDNN: attention, attention!, attention_backward, attention_backward!, build!, execute!,
              Graph, scalar!, sdpa_fwd!, tensor!
@@ -111,7 +111,7 @@ function sdpa_stats_test(T; d=64, sq=32, skv=32, h=4, hk=h, b=2,
 
     ref, refstats = sdpa_ref(q, k, v; scale, causal, stats=true)
     out = similar(q)
-    stats = CUDA.zeros(Float32, 1, h, sq, b)
+    stats = CUDACore.zeros(Float32, 1, h, sq, b)
     attention!(out, q, k, v; scale, causal, stats)
     @test Array(out) ≈ ref rtol=2e-2
     @test Array(stats) ≈ refstats rtol=rtol
@@ -124,7 +124,7 @@ function sdpa_backward_test(T; d=64, sq=32, skv=32, h=4, hk=h, b=2,
     v = cuRAND.randn(T, d, hk, skv, b) ./ 4
     dO = cuRAND.randn(T, d, h, sq, b) ./ 4
     o = similar(q)
-    stats = CUDA.zeros(Float32, 1, h, sq, b)
+    stats = CUDACore.zeros(Float32, 1, h, sq, b)
     attention!(o, q, k, v; scale, causal, stats)
 
     refdq, refdk, refdv = sdpa_bwd_ref(q, k, v, dO; scale, causal)
@@ -154,7 +154,7 @@ function sdpa_padding_test(T; d=64, sq=64, skv=64, h=4, hk=2, b=2,
 
     ref = sdpa_ref(q, k, v; scale, seq_len_q, seq_len_kv)
     out = similar(q)
-    stats = CUDA.zeros(Float32, 1, h, sq, b)
+    stats = CUDACore.zeros(Float32, 1, h, sq, b)
     if !cuDNN.attention_supported(out, q, k, v; stats, seq_len_q, seq_len_kv)
         @test_skip "SDPA sequence-length engine is unsupported on this device"
         return


### PR DESCRIPTION
cuDNN tests were still importing CUDA after #3191 while the test environment only had CUDACore, so some tests were erroring when testing cuDNN independently (e.g. through `Pkg.test("cuDNN")`).