### PR TITLE
cuDNN: support block-scaled (MXFP8/NVFP4) graph ops

### DIFF
--- a/lib/cudnn/src/backend.jl
+++ b/lib/cudnn/src/backend.jl
@@ -77,6 +77,7 @@ backend_attribute_type(::Type{cudnnBackendNormFwdPhase_t}) = CUDNN_TYPE_NORM_FWD
 backend_attribute_type(::Type{cudnnRngDistribution_t}) = CUDNN_TYPE_RNG_DISTRIBUTION
 backend_attribute_type(::Type{cudnnMoeGroupedMatmulMode_t}) = CUDNN_TYPE_MOE_GROUPED_MATMUL_MODE
 backend_attribute_type(::Type{cudnnBackendOperationGraphMode_t}) = CUDNN_TYPE_OPERATIONGRAPH_MODE
+backend_attribute_type(::Type{cudnnBackendTensorReordering_t}) = CUDNN_TYPE_TENSOR_REORDERING_MODE
 backend_attribute_type(::Type{cudnnFraction_t}) = CUDNN_TYPE_FRACTION
 
 setattr!(d, name, v::cudnnFraction_t) =
@@ -227,7 +228,8 @@ make_descriptor(f, type::Symbol) = make_descriptor(f, descriptor_types[type])
 ## Constructors
 
 function backend_tensor(; uid::Integer, dims, strides, dtype::cudnnDataType_t,
-                        is_virtual::Bool=false, by_value::Bool=false, alignment::Integer=16)
+                        is_virtual::Bool=false, by_value::Bool=false, alignment::Integer=16,
+                        reordering::cudnnBackendTensorReordering_t=CUDNN_TENSOR_REORDERING_NONE)
     make_descriptor(:tensor) do d
         d[:unique_id] = Int64(uid)
         d[:data_type] = dtype
@@ -236,6 +238,7 @@ function backend_tensor(; uid::Integer, dims, strides, dtype::cudnnDataType_t,
         d[:byte_alignment] = Int64(alignment)
         is_virtual && (d[:is_virtual] = true)
         by_value && (d[:is_by_value] = true)
+        reordering == CUDNN_TENSOR_REORDERING_NONE || (d[:reordering_mode] = reordering)
     end
 end
 
@@ -370,6 +373,35 @@ function reduction_operation(reddesc::BackendDescriptor, x::BackendDescriptor,
         op[:desc] = reddesc
         op[:xdesc] = x
         op[:ydesc] = y
+    end
+end
+
+function block_scale_dequantize_operation(x::BackendDescriptor, scale::BackendDescriptor,
+                                          y::BackendDescriptor;
+                                          math_prec::cudnnDataType_t=CUDNN_DATA_FLOAT,
+                                          block_size::Integer)
+    make_descriptor(:operation_block_scale_dequantize) do op
+        op[:xdesc] = x
+        op[:scale_desc] = scale
+        op[:ydesc] = y
+        op[:math_prec] = math_prec
+        setattr!(op, attribute(op, :block_size), CUDNN_TYPE_INT32, 1, Int32[block_size])
+    end
+end
+
+# quantize accepts plain scale output tensors at ranks 2 and 4 (the norm-fused
+# recipe), but at rank 3 demands an F8_128x4-reordered one; without it,
+# finalization fails with the misleading CUDNN_STATUS_BAD_PARAM_ATTRIBUTE_TYPE
+function block_scale_quantize_operation(x::BackendDescriptor, y::BackendDescriptor,
+                                        scale::BackendDescriptor;
+                                        math_prec::cudnnDataType_t=CUDNN_DATA_FLOAT,
+                                        block_size::Integer)
+    make_descriptor(:operation_block_scale_quantize) do op
+        op[:xdesc] = x
+        op[:ydesc] = y
+        op[:scale_desc] = scale
+        op[:math_prec] = math_prec
+        setattr!(op, attribute(op, :block_size), CUDNN_TYPE_INT32, 1, Int32[block_size])
     end
 end
 
@@ -561,7 +593,9 @@ end
 
 is_unsupported(e::CUDNNError) = 3000 <= Int(e.code) < 4000
 
-# Unsupported configurations are expected while searching for a plan.
+# A candidate config can fail plan finalization for reasons beyond NOT_SUPPORTED
+# (kernel compilation failures, say); like cudnn-frontend's build_plans, skip it
+# and try the next one.
 function try_execution_plan(enginecfg::BackendDescriptor;
                             deviceprop::Union{Nothing,BackendDescriptor}=nothing)
     try
@@ -572,7 +606,6 @@ function try_execution_plan(enginecfg::BackendDescriptor;
         end
     catch e
         e isa CUDNNError || rethrow()
-        is_unsupported(e) || rethrow()
         return nothing
     end
 end

--- a/lib/cudnn/src/graph/execute.jl
+++ b/lib/cudnn/src/graph/execute.jl
@@ -1,15 +1,30 @@
+checked_array_pointer(t::Tensor, value) = throw(ArgumentError(
+    "binding for $(t.name) must be a DenseCuArray, or a type with its own " *
+    "checked_array_pointer method; got $(typeof(value))"))
+
+# Public for array types whose memory layout the dense comparison cannot express.
+# Implementations must validate whatever consistency their storage admits and
+# return a device pointer.
+@public checked_array_pointer
+
 function checked_array_pointer(t::Tensor, a::DenseCuArray)
-    size(a) == Tuple(t.dims) ||
-        throw(DimensionMismatch("binding for $(t.name) has size $(size(a)), expected $(Tuple(t.dims))"))
-    canonical_strides(t.dims, strides(a)) == t.strides ||
-        throw(DimensionMismatch("binding for $(t.name) has strides $(strides(a)), expected $(Tuple(t.strides))"))
     cudnnDataType(eltype(a)) == t.dtype ||
-        throw(ArgumentError("binding for $(t.name) has eltype $(eltype(a)), expected $(juliaDataType(t.dtype))"))
+        throw(ArgumentError("binding for $(t.name) has eltype $(eltype(a)), expected $(t.dtype)"))
+    memory_layout(dims, strides) =
+        sort!([(Int64(d), Int64(s)) for (d, s) in zip(dims, strides) if d != 1]; by=last)
+    if t.reordering == CUDNN_TENSOR_REORDERING_NONE
+        memory_layout(size(a), strides(a)) == memory_layout(t.dims, t.strides) ||
+            throw(DimensionMismatch(
+                "binding for $(t.name) has size $(size(a)) with strides $(strides(a)), " *
+                "which does not lay out the tensor's $(Tuple(t.dims)) with strides $(Tuple(t.strides))"))
+    else
+        length(a) == prod(t.dims) || throw(DimensionMismatch(
+            "binding for $(t.name) has $(length(a)) elements, expected $(prod(t.dims))"))
+    end
     return pointer(a)
 end
 
 function checked_scalar_pointer(t::Tensor, value, refs)
-    t.by_value || throw(ArgumentError("binding for $(t.name) must be a DenseCuArray"))
     T = juliaDataType(t.dtype)
     ref = value isa Ref ? value : Ref{T}(convert(T, value))
     push!(refs, ref)
@@ -25,11 +40,11 @@ function execute!(g::Graph, bindings::AbstractDict)
     for t in g.variant_tensors
         haskey(bindings, t) || throw(ArgumentError("missing binding for cuDNN graph tensor $(t.name)"))
         value = bindings[t]
-        if value isa DenseCuArray
+        if t.by_value
+            push!(pointers, checked_scalar_pointer(t, value, refs))
+        else
             push!(arrays, value)
             push!(pointers, checked_array_pointer(t, value))
-        else
-            push!(pointers, checked_scalar_pointer(t, value, refs))
         end
     end
 

--- a/lib/cudnn/src/graph/graph.jl
+++ b/lib/cudnn/src/graph/graph.jl
@@ -11,6 +11,7 @@ mutable struct Tensor
     by_value::Bool
     output::Bool
     alignment::Int
+    reordering::cudnnBackendTensorReordering_t
 end
 
 mutable struct Graph
@@ -54,14 +55,15 @@ end
 function tensor!(g::Graph; dims, strides=dense_strides(dims), dtype=nothing,
                  virtual::Bool=false, by_value::Bool=false, name::String="",
                  uid::Integer=0, alignment::Integer=16, output::Bool=false,
-                 backend_order=nothing)
+                 backend_order=nothing,
+                 reordering::cudnnBackendTensorReordering_t=CUDNN_TENSOR_REORDERING_NONE)
     dims_v = collect(Int64, dims)
     order = backend_order === nothing ? collect(length(dims_v):-1:1) : collect(Int, backend_order)
     sort(order) == collect(1:length(dims_v)) ||
         throw(ArgumentError("backend_order must be a permutation of tensor dimensions"))
     t = Tensor(name, Int64(uid), dims_v, canonical_strides(dims_v, strides), order,
                dtype === nothing ? nothing : graph_dtype(dtype), virtual, by_value, output,
-               Int(alignment))
+               Int(alignment), reordering)
     push!(g.tensors, t)
     return t
 end

--- a/lib/cudnn/src/graph/lower.jl
+++ b/lib/cudnn/src/graph/lower.jl
@@ -14,7 +14,7 @@ function lower_tensor!(ctx::LoweringContext, t::Tensor)
     d = track!(ctx, backend_tensor(uid=t.uid, dims=cudnn_order(t, t.dims),
                                    strides=cudnn_order(t, t.strides), dtype=t.dtype,
                                    is_virtual=t.virtual, by_value=t.by_value,
-                                   alignment=t.alignment))
+                                   alignment=t.alignment, reordering=t.reordering))
     ctx.tensor_descs[t] = d
     return d
 end

--- a/lib/cudnn/src/graph/ops.jl
+++ b/lib/cudnn/src/graph/ops.jl
@@ -66,6 +66,22 @@ struct ReductionOp <: Operation
     deterministic::Bool
 end
 
+struct BlockScaleDequantizeOp <: Operation
+    x::Tensor
+    scale::Tensor
+    y::Tensor
+    block_size::Int
+    math_prec::cudnnDataType_t
+end
+
+struct BlockScaleQuantizeOp <: Operation
+    x::Tensor
+    y::Tensor
+    scale::Tensor
+    block_size::Int
+    math_prec::cudnnDataType_t
+end
+
 struct ConvFpropOp <: Operation
     x::Tensor
     w::Tensor
@@ -764,6 +780,115 @@ function matmul!(g::Graph, a::Tensor, b::Tensor;
     return c
 end
 
+function swizzled_scale_dims(xdims, block_size, order)
+    dims = copy(collect(Int64, xdims))
+    isempty(order) && return dims
+    round_up(x::Integer, m::Integer) = cld(x, m) * m
+    dims[order[1]] = round_up(cld(dims[order[1]], block_size), 4)
+    length(order) >= 2 && (dims[order[2]] = round_up(dims[order[2]], 128))
+    return dims
+end
+
+# engines address whole tiles regardless of the declared extents; cuDNN accepts
+# unpadded declarations at build time but crashes the context at execution
+function check_swizzled_scale_dims(fname, x::Tensor, scale::Tensor, block_size)
+    order = [i for i in sortperm(scale.strides) if scale.dims[i] != 1]
+    expected = swizzled_scale_dims(x.dims, block_size, order)
+    scale.dims == expected || throw(DimensionMismatch(
+        "$fname F8_128x4 scale dimensions $(Tuple(scale.dims)) do not tile data " *
+        "dimensions $(Tuple(x.dims)) with block_size=$block_size; the swizzled layout " *
+        "needs whole 128×4 tiles: cld(extent, block_size) scales rounded up to a " *
+        "multiple of 4 along the packed dimension and the next dimension rounded up " *
+        "to a multiple of 128, i.e. $(Tuple(expected))"))
+    return nothing
+end
+
+function check_block_scale_dims(fname, x::Tensor, scale::Tensor, block_size)
+    length(x.dims) == length(scale.dims) ||
+        throw(DimensionMismatch("$fname data and scale tensors must have the same rank"))
+    scale.reordering == CUDNN_TENSOR_REORDERING_F8_128x4 &&
+        return check_swizzled_scale_dims(fname, x, scale, block_size)
+    blocked = 0
+    for (dx, ds) in zip(x.dims, scale.dims)
+        if dx == ds * block_size
+            blocked += 1
+        elseif dx != ds
+            throw(DimensionMismatch(
+                "$fname scale dimensions $(Tuple(scale.dims)) must match data dimensions " *
+                "$(Tuple(x.dims)) except along one dimension divided by block_size=$block_size"))
+        end
+    end
+    blocked == 1 || throw(DimensionMismatch(
+        "$fname expects exactly one dimension blocked by block_size=$block_size; " *
+        "got data $(Tuple(x.dims)) and scale $(Tuple(scale.dims))"))
+    return nothing
+end
+
+function block_scale_dequantize!(g::Graph, x::Tensor, scale::Tensor;
+                                 block_size::Integer, math_prec=Float32,
+                                 y::Union{Nothing,Tensor}=nothing, name::String="Y")
+    version() >= v"9.7" || throw(ArgumentError(
+        "block_scale_dequantize! requires cuDNN 9.7, got $(version())"))
+    block_size > 1 ||
+        throw(ArgumentError("block_scale_dequantize! block_size must be > 1, got $block_size"))
+    check_block_scale_dims("block_scale_dequantize!", x, scale, block_size)
+    if y === nothing
+        y = tensor!(g; dims=x.dims, dtype=nothing, virtual=true, name)
+    else
+        y.dims == x.dims || throw(DimensionMismatch(
+            "block_scale_dequantize! output dimensions must be $(Tuple(x.dims))"))
+    end
+    push!(g.ops, BlockScaleDequantizeOp(x, scale, y, Int(block_size), graph_dtype(math_prec)))
+    return y
+end
+
+# dense strides assigning stride 1 to `order`'s first dimension, with dimensions
+# absent from `order` (singletons) outermost
+function ordered_strides(dims, order)
+    strides = similar(dims)
+    s = one(eltype(dims))
+    for i in [order; [i for i in eachindex(dims) if !(i in order)]]
+        strides[i] = s
+        s *= dims[i]
+    end
+    return strides
+end
+
+function block_scale_quantize!(g::Graph, x::Tensor;
+                               block_size::Integer, block_dim::Integer=1,
+                               dtype=nothing, scale_dtype=nothing, math_prec=Float32,
+                               y::Union{Nothing,Tensor}=nothing,
+                               scale::Union{Nothing,Tensor}=nothing, name::String="Q")
+    version() >= v"9.7" || throw(ArgumentError(
+        "block_scale_quantize! requires cuDNN 9.7, got $(version())"))
+    block_size > 1 ||
+        throw(ArgumentError("block_scale_quantize! block_size must be > 1, got $block_size"))
+    if y === nothing
+        dtype === nothing &&
+            throw(ArgumentError("block_scale_quantize! needs dtype to create the quantized output"))
+        y = tensor!(g; dims=x.dims, dtype, output=true, name)
+    else
+        y.dims == x.dims || throw(DimensionMismatch(
+            "block_scale_quantize! output dimensions must be $(Tuple(x.dims))"))
+    end
+    if scale === nothing
+        scale_dtype === nothing &&
+            throw(ArgumentError("block_scale_quantize! needs scale_dtype to create the scale output"))
+        1 <= block_dim <= length(x.dims) ||
+            throw(ArgumentError("block_scale_quantize! block_dim must index a dimension of x"))
+        x.dims[block_dim] % block_size == 0 || throw(DimensionMismatch(
+            "block_scale_quantize! dimension $block_dim of x must be divisible by block_size=$block_size"))
+        order = [block_dim; [i for i in sortperm(x.strides) if i != block_dim && x.dims[i] != 1]]
+        sdims = swizzled_scale_dims(x.dims, block_size, order)
+        scale = tensor!(g; dims=sdims, strides=ordered_strides(sdims, order),
+                        dtype=scale_dtype, output=true, name=name * ".scale",
+                        reordering=CUDNN_TENSOR_REORDERING_F8_128x4)
+    end
+    check_block_scale_dims("block_scale_quantize!", x, scale, block_size)
+    push!(g.ops, BlockScaleQuantizeOp(x, y, scale, Int(block_size), graph_dtype(math_prec)))
+    return y, scale
+end
+
 function reduction!(g::Graph, mode, x::Tensor;
                     y::Union{Nothing,Tensor}=nothing, dims,
                     compute_dtype=g.compute_dtype, deterministic::Bool=false,
@@ -901,6 +1026,16 @@ end
 function lower(op::MatmulOp, ctx::LoweringContext)
     matdesc = track!(ctx, matmul_descriptor(compute_type=op.compute_dtype))
     matmul_operation(matdesc, desc(ctx, op.b), desc(ctx, op.a), desc(ctx, op.c))
+end
+
+function lower(op::BlockScaleDequantizeOp, ctx::LoweringContext)
+    block_scale_dequantize_operation(desc(ctx, op.x), desc(ctx, op.scale), desc(ctx, op.y);
+                                     math_prec=op.math_prec, block_size=op.block_size)
+end
+
+function lower(op::BlockScaleQuantizeOp, ctx::LoweringContext)
+    block_scale_quantize_operation(desc(ctx, op.x), desc(ctx, op.y), desc(ctx, op.scale);
+                                   math_prec=op.math_prec, block_size=op.block_size)
 end
 
 function lower(op::ReductionOp, ctx::LoweringContext)
@@ -1049,4 +1184,5 @@ function lower(op::SDPABwdOp, ctx::LoweringContext)
 end
 
 @public pointwise!, matmul!, reduction!, conv_fprop!, conv_dgrad!, conv_wgrad!,
-        resample_fwd!, resample_bwd!, norm_fwd!, norm_bwd!, sdpa_fwd!, sdpa_bwd!
+        resample_fwd!, resample_bwd!, norm_fwd!, norm_bwd!, sdpa_fwd!, sdpa_bwd!,
+        block_scale_dequantize!, block_scale_quantize!

--- a/lib/cudnn/test/graph_ops.jl
+++ b/lib/cudnn/test/graph_ops.jl
@@ -1,4 +1,6 @@
 using cuDNN:
+    block_scale_dequantize!,
+    block_scale_quantize!,
     conv_dgrad!,
     conv_fprop!,
     conv_wgrad!,
@@ -6,9 +8,13 @@ using cuDNN:
     execute!,
     is_supported,
     matmul!,
+    output!,
     resample_bwd!,
     resample_fwd!,
-    tensor!
+    tensor!,
+    CUDNN_DATA_FP8_E4M3,
+    CUDNN_DATA_FP8_E8M0,
+    CUDNN_TENSOR_REORDERING_F8_128x4
 
 CUDACore.allowscalar(false)
 
@@ -246,4 +252,88 @@ let W=7, H=6, C=2, N=2
     else
         @test_skip is_supported(gb)
     end
+end
+
+# block-scale requires Blackwell
+blockscale_claimed = CUDACore.capability(CUDACore.device()) >= v"10.0"
+
+# helper: MXFP8 operand pair, dequantized and multiplied. F8_128x4 scale
+# dimensions are padded to whole 128×4 tiles
+function blockscale_matmul!(g; K, M, N)
+    MP, KS = cld(M, 128) * 128, cld(cld(K, 32), 4) * 4
+    NP = cld(N, 128) * 128
+    a = tensor!(g; dims=(M, K, 1), strides=(K, 1, M * K), dtype=CUDNN_DATA_FP8_E4M3,
+                name="A")
+    as = tensor!(g; dims=(MP, KS, 1), strides=(KS, 1, MP * KS),
+                 dtype=CUDNN_DATA_FP8_E8M0, name="A.scale",
+                 reordering=CUDNN_TENSOR_REORDERING_F8_128x4)
+    da = block_scale_dequantize!(g, a, as; block_size=32)
+    b = tensor!(g; dims=(K, N, 1), dtype=CUDNN_DATA_FP8_E4M3, name="B")
+    bs = tensor!(g; dims=(KS, NP, 1), dtype=CUDNN_DATA_FP8_E8M0, name="B.scale",
+                 reordering=CUDNN_TENSOR_REORDERING_F8_128x4)
+    db = block_scale_dequantize!(g, b, bs; block_size=32)
+    return matmul!(g, da, db)
+end
+
+let K=128, M=128, N=128
+    g = Graph(intermediate_dtype=Float32, compute_dtype=Float32)
+    output!(blockscale_matmul!(g; K, M, N))
+    @test is_supported(g) == blockscale_claimed
+end
+
+let K=128, M=128, N=64
+    g = Graph(intermediate_dtype=Float32, compute_dtype=Float32)
+    output!(blockscale_matmul!(g; K, M, N))
+    @test is_supported(g) == blockscale_claimed
+
+    g2 = Graph()
+    b = tensor!(g2; dims=(K, N, 1), dtype=CUDNN_DATA_FP8_E4M3)
+    unpadded = tensor!(g2; dims=(K ÷ 32, N, 1), dtype=CUDNN_DATA_FP8_E8M0,
+                       reordering=CUDNN_TENSOR_REORDERING_F8_128x4)
+    @test_throws DimensionMismatch block_scale_dequantize!(g2, b, unpadded; block_size=32)
+end
+
+let K=160, M=128, N=128
+    g = Graph(intermediate_dtype=Float32, compute_dtype=Float32)
+    output!(blockscale_matmul!(g; K, M, N))
+    @test is_supported(g) == blockscale_claimed
+end
+
+let K=128, M=128, N=128
+    g = Graph(intermediate_dtype=Float32, compute_dtype=Float32)
+    c = blockscale_matmul!(g; K, M, N)
+    y, scale = block_scale_quantize!(g, c; block_size=32, block_dim=1,
+                                     dtype=CUDNN_DATA_FP8_E4M3,
+                                     scale_dtype=CUDNN_DATA_FP8_E8M0)
+    @test y.dims == [M, N, 1]
+    @test scale.dims == [M ÷ 32, N, 1]
+    @test scale.reordering == CUDNN_TENSOR_REORDERING_F8_128x4
+    @test is_supported(g) == blockscale_claimed
+end
+
+let
+    g = Graph()
+    x = tensor!(g; dims=(64, 200, 1), dtype=Float32)
+    y, scale = block_scale_quantize!(g, x; block_size=32, block_dim=1,
+                                     dtype=CUDNN_DATA_FP8_E4M3,
+                                     scale_dtype=CUDNN_DATA_FP8_E8M0)
+    @test scale.dims == [4, 256, 1]     # cld(64, 32) = 2 → 4; 200 → 256
+    @test scale.strides == [1, 4, 1024]
+end
+
+let
+    g = Graph()
+    x = tensor!(g; dims=(128, 64, 1), dtype=CUDNN_DATA_FP8_E4M3)
+    bad_scale = tensor!(g; dims=(128, 3, 1), dtype=CUDNN_DATA_FP8_E8M0)
+    @test_throws DimensionMismatch block_scale_dequantize!(g, x, bad_scale; block_size=32)
+    bad_rank = tensor!(g; dims=(128, 2), dtype=CUDNN_DATA_FP8_E8M0)
+    @test_throws DimensionMismatch block_scale_dequantize!(g, x, bad_rank; block_size=32)
+    unblocked = tensor!(g; dims=(128, 64, 1), dtype=CUDNN_DATA_FP8_E8M0)
+    @test_throws DimensionMismatch block_scale_dequantize!(g, x, unblocked; block_size=32)
+    @test_throws ArgumentError block_scale_dequantize!(g, x, bad_scale; block_size=1)
+    hi = tensor!(g; dims=(128, 64, 1), dtype=Float32)
+    @test_throws ArgumentError block_scale_quantize!(g, hi; block_size=32)
+    @test_throws DimensionMismatch block_scale_quantize!(g, hi; block_size=32, block_dim=3,
+                                                         dtype=CUDNN_DATA_FP8_E4M3,
+                                                         scale_dtype=CUDNN_DATA_FP8_E8M0)
 end


### PR DESCRIPTION
Adds block-scale quantize/dequantize support to the cuDNN graph API (cuDNN ≥ 9.7), enabling narrow-precision matmuls with block-scaled operands.

- New graph ops `block_scale_dequantize!` and `block_scale_quantize!`.
- Tensors gain a `reordering` attribute. `F8_128x4`-reordered scale tensors must be tile-padded (blocked dim to a multiple of 4 blocks, the next dim in stride order to a multiple of 128); cuDNN accepts unpadded dims at build time but crashes the CUDA context at execution, so dims are validated up front. `block_scale_quantize!` creates its scale output with the padded shape automatically.
- `execute!` binding checks are refactored into the now public `checked_array_pointer` hook, so packages can bind array types whose memory layout the dense stride comparison can't express (e.g. [sub-byte packed elements](https://github.com/MurrellGroup/BitPacking.jl/blob/92dc7927e4bb876fbc3cb7f5b07caafd90524793/src/NarrowArray.jl), [swizzled scale storage](https://github.com/jool-space/Microscaling.jl/blob/0dda13885b55dd30052c31bdd553a3d52619b9cd/src/sm1xx.jl)).
- Plan search now skips a candidate engine on any `CUDNNError`, matching [cudnn-frontend](https://github.com/NVIDIA/cudnn-frontend)'s `build_plans` (previously only 3000–3999 were caught, letting e.g. `INTERNAL_ERROR_COMPILATION_FAILED` escape from `is_supported`).

Tested on GB10 (sm_121).