### PR TITLE
cuDNN: set default pointwise alpha2 to 1

### DIFF
--- a/lib/cudnn/src/backend.jl
+++ b/lib/cudnn/src/backend.jl
@@ -345,7 +345,7 @@ function pointwise_operation(pwdesc::BackendDescriptor, x::BackendDescriptor,
                              y::BackendDescriptor;
                              b::Union{Nothing,BackendDescriptor}=nothing,
                              t::Union{Nothing,BackendDescriptor}=nothing,
-                             alpha1::Real=1, alpha2::Real=0)
+                             alpha1::Real=1, alpha2::Real=1)
     make_descriptor(:operation_pointwise) do op
         op[:pw_descriptor] = pwdesc
         op[:xdesc] = x

--- a/lib/cudnn/src/graph/ops.jl
+++ b/lib/cudnn/src/graph/ops.jl
@@ -364,7 +364,7 @@ function pointwise!(g::Graph, mode, x::Tensor, inputs::Tensor...;
                     relu_lower_clip_slope::Real=0, elu_alpha::Real=1,
                     softplus_beta::Real=1, swish_beta::Real=1,
                     axis::Union{Nothing,Integer}=nothing,
-                    alpha1::Real=1, alpha2::Real=0, name::String="Y")
+                    alpha1::Real=1, alpha2::Real=1, name::String="Y")
     length(inputs) <= 2 || throw(ArgumentError("pointwise! accepts at most three inputs"))
     b = length(inputs) >= 1 ? inputs[1] : nothing
     t = length(inputs) == 2 ? inputs[2] : nothing

--- a/lib/cudnn/test/graph_ops.jl
+++ b/lib/cudnn/test/graph_ops.jl
@@ -9,6 +9,7 @@ using cuDNN:
     is_supported,
     matmul!,
     output!,
+    pointwise!,
     resample_bwd!,
     resample_fwd!,
     tensor!,
@@ -156,6 +157,27 @@ let K=16, M=16, N=16, B=2
     if is_supported(g)
         execute!(g, ta=>a, tb=>b, ty=>y)
         @test Float32.(Array(y)) ≈ matmul_ref(a, b) rtol=2f-3 atol=2f-3
+    else
+        @test_skip is_supported(g)
+    end
+end
+
+# binary pointwise: alpha2 must default to 1 — the scaling constants mean
+# y = op(alpha1·x, alpha2·b), so a zero default drops the second operand
+let M=16, N=16
+    x = CuArray(reshape(Float16.(sin.(1:M*N)), M, N, 1))
+    b = CuArray(reshape(Float16.(cos.(1:M*N)), M, N, 1))
+    y = CUDACore.zeros(Float16, M, N, 1)
+
+    g = Graph(io_dtype=Float16, intermediate_dtype=Float32, compute_dtype=Float32)
+    tx = tensor!(g, x; name="X")
+    tb = tensor!(g, b; name="B")
+    ty = tensor!(g, y; name="Y", output=true)
+    pointwise!(g, :add, tx, tb; y=ty)
+
+    if is_supported(g)
+        execute!(g, tx=>x, tb=>b, ty=>y)
+        @test Float32.(Array(y)) ≈ Float32.(Array(x)) .+ Float32.(Array(b)) rtol=1f-3 atol=1f-3
     else
         @test_skip is_supported(g)
     end


### PR DESCRIPTION
The pointwise scaling constants mean `y = op(alpha1·x, alpha2·b)`, and cuDNN documents both `CUDNN_ATTR_OPERATION_POINTWISE_ALPHA1/ALPHA2` as optional with default 1.0. Since #3191, `pointwise!` defaulted `alpha2 = 0`, turning every defaulted binary pointwise op into `op(x, 0·b)`. Engine heuristics return zero candidate configs for the degenerate graph, so even a plain bias-add fusion reported unsupported (and on any engine that did accept it, the second operand would have been silently dropped). This PR adds a binary pointwise execution test; there was previously no pointwise coverage.