### PR TITLE
cuDNN: support layer and RMS norm modes

### DIFF
--- a/lib/cudnn/src/backend.jl
+++ b/lib/cudnn/src/backend.jl
@@ -530,22 +530,22 @@ end
 
 function norm_backward_operation(; mode::cudnnBackendNormMode_t,
                                  x::BackendDescriptor,
-                                 mean::BackendDescriptor,
+                                 mean::Union{Nothing,BackendDescriptor}=nothing,
                                  inv_variance::BackendDescriptor,
                                  dy::BackendDescriptor,
                                  scale::BackendDescriptor,
                                  dscale::BackendDescriptor,
-                                 dbias::BackendDescriptor,
+                                 dbias::Union{Nothing,BackendDescriptor}=nothing,
                                  dx::BackendDescriptor)
     make_descriptor(:operation_norm_backward) do op
         op[:mode] = mode
         op[:xdesc] = x
-        op[:mean_desc] = mean
+        mean === nothing || (op[:mean_desc] = mean)
         op[:inv_variance_desc] = inv_variance
         op[:dydesc] = dy
         op[:scale_desc] = scale
         op[:dscale_desc] = dscale
-        op[:dbias_desc] = dbias
+        dbias === nothing || (op[:dbias_desc] = dbias)
         op[:dxdesc] = dx
     end
 end

--- a/lib/cudnn/src/backend.jl
+++ b/lib/cudnn/src/backend.jl
@@ -502,7 +502,7 @@ function norm_forward_operation(; mode::cudnnBackendNormMode_t,
                                 mean::Union{Nothing,BackendDescriptor}=nothing,
                                 inv_variance::Union{Nothing,BackendDescriptor}=nothing,
                                 scale::BackendDescriptor,
-                                bias::BackendDescriptor,
+                                bias::Union{Nothing,BackendDescriptor}=nothing,
                                 epsilon::Union{Nothing,BackendDescriptor}=nothing,
                                 momentum::Union{Nothing,BackendDescriptor}=nothing,
                                 input_running_mean::Union{Nothing,BackendDescriptor}=nothing,
@@ -517,7 +517,7 @@ function norm_forward_operation(; mode::cudnnBackendNormMode_t,
         mean === nothing || (op[:mean_desc] = mean)
         inv_variance === nothing || (op[:inv_variance_desc] = inv_variance)
         op[:scale_desc] = scale
-        op[:bias_desc] = bias
+        bias === nothing || (op[:bias_desc] = bias)
         epsilon === nothing || (op[:epsilon_desc] = epsilon)
         momentum === nothing || (op[:exp_avg_factor_desc] = momentum)
         input_running_mean === nothing || (op[:input_running_mean_desc] = input_running_mean)

--- a/lib/cudnn/src/graph/ops.jl
+++ b/lib/cudnn/src/graph/ops.jl
@@ -179,11 +179,11 @@ struct NormBwdOp <: Operation
     dy::Tensor
     x::Tensor
     scale::Tensor
-    mean::Tensor
+    mean::Union{Nothing,Tensor}
     inv_variance::Tensor
     dx::Tensor
     dscale::Tensor
-    dbias::Tensor
+    dbias::Union{Nothing,Tensor}
     mode::cudnnBackendNormMode_t
 end
 
@@ -776,24 +776,37 @@ function norm_fwd!(g::Graph, x::Tensor, scale::Tensor, bias::Union{Nothing,Tenso
     return training ? (y, mean, inv_variance, output_running_mean, output_running_var) : y
 end
 
-function norm_bwd!(g::Graph, dy::Tensor, x::Tensor, scale::Tensor, mean::Tensor,
-                   inv_variance::Tensor; dx::Union{Nothing,Tensor}=nothing,
+function norm_bwd!(g::Graph, dy::Tensor, x::Tensor, scale::Tensor,
+                   mean::Union{Nothing,Tensor}, inv_variance::Tensor;
+                   dx::Union{Nothing,Tensor}=nothing,
                    dscale::Union{Nothing,Tensor}=nothing,
                    dbias::Union{Nothing,Tensor}=nothing, mode=:batchnorm,
                    name::String="dX")
-    norm_mode(mode) == CUDNN_BATCH_NORM ||
-        throw(ArgumentError("norm_bwd! currently supports only batch normalization"))
+    nmode = norm_mode(mode)
     dy.dims == x.dims || throw(DimensionMismatch("norm dY dimensions must match input"))
     xdtype = something(x.dtype, g.io_dtype)
     check_norm_dtype("norm input", x, xdtype)
     stat_dtype = norm_stat_dtype(xdtype)
     check_norm_dtype("norm dY", dy, xdtype)
-    pdims = norm_channel_dims(x)
+    # scale and its gradient take the parameter shape; the statistics saved
+    # by training take the complement
+    if nmode == CUDNN_BATCH_NORM
+        pdims = norm_channel_dims(x)
+        sdims = pdims
+    else
+        pdims = norm_layer_param_dims(x, scale)
+        sdims = norm_stat_dims(x, pdims)
+    end
     check_norm_param("norm scale", scale, pdims)
-    check_norm_param("norm mean", mean, pdims)
-    check_norm_param("norm inv_variance", inv_variance, pdims)
     check_norm_dtype("norm scale", scale, stat_dtype)
-    check_norm_dtype("norm mean", mean, stat_dtype)
+    if nmode == CUDNN_RMS_NORM
+        mean === nothing || throw(ArgumentError("RMS norm has no mean statistic"))
+    else
+        mean === nothing && throw(ArgumentError("norm_bwd! requires the saved mean"))
+        check_norm_param("norm mean", mean, sdims)
+        check_norm_dtype("norm mean", mean, stat_dtype)
+    end
+    check_norm_param("norm inv_variance", inv_variance, sdims)
     check_norm_dtype("norm inv_variance", inv_variance, stat_dtype)
     dx === nothing && (dx = tensor!(g; dims=x.dims, dtype=x.dtype, virtual=true, name,
                                     backend_order=x.backend_order))
@@ -802,15 +815,17 @@ function norm_bwd!(g::Graph, dy::Tensor, x::Tensor, scale::Tensor, mean::Tensor,
     dscale === nothing &&
         (dscale = tensor!(g; dims=pdims, dtype=scale.dtype, virtual=true,
                           name="dScale", backend_order=x.backend_order))
-    dbias === nothing &&
+    check_norm_param("norm dscale", dscale, pdims)
+    check_norm_dtype("norm dscale", dscale, stat_dtype)
+    # RMS norm's bias is optional, so its gradient is created on request only
+    dbias === nothing && nmode != CUDNN_RMS_NORM &&
         (dbias = tensor!(g; dims=pdims, dtype=scale.dtype, virtual=true,
                          name="dBias", backend_order=x.backend_order))
-    check_norm_param("norm dscale", dscale, pdims)
-    check_norm_param("norm dbias", dbias, pdims)
-    check_norm_dtype("norm dscale", dscale, stat_dtype)
-    check_norm_dtype("norm dbias", dbias, stat_dtype)
-    push!(g.ops, NormBwdOp(dy, x, scale, mean, inv_variance, dx, dscale, dbias,
-                           norm_mode(mode)))
+    if dbias !== nothing
+        check_norm_param("norm dbias", dbias, pdims)
+        check_norm_dtype("norm dbias", dbias, stat_dtype)
+    end
+    push!(g.ops, NormBwdOp(dy, x, scale, mean, inv_variance, dx, dscale, dbias, nmode))
     return dx, dscale, dbias
 end
 
@@ -1190,10 +1205,12 @@ function lower(op::NormFwdOp, ctx::LoweringContext)
 end
 
 function lower(op::NormBwdOp, ctx::LoweringContext)
-    norm_backward_operation(mode=op.mode, x=desc(ctx, op.x), mean=desc(ctx, op.mean),
+    norm_backward_operation(mode=op.mode, x=desc(ctx, op.x),
+                            mean=op.mean === nothing ? nothing : desc(ctx, op.mean),
                             inv_variance=desc(ctx, op.inv_variance),
                             dy=desc(ctx, op.dy), scale=desc(ctx, op.scale),
-                            dscale=desc(ctx, op.dscale), dbias=desc(ctx, op.dbias),
+                            dscale=desc(ctx, op.dscale),
+                            dbias=op.dbias === nothing ? nothing : desc(ctx, op.dbias),
                             dx=desc(ctx, op.dx))
 end
 

--- a/lib/cudnn/src/graph/ops.jl
+++ b/lib/cudnn/src/graph/ops.jl
@@ -163,7 +163,7 @@ struct NormFwdOp <: Operation
     mean::Union{Nothing,Tensor}
     inv_variance::Union{Nothing,Tensor}
     scale::Tensor
-    bias::Tensor
+    bias::Union{Nothing,Tensor}
     epsilon::Union{Nothing,Tensor}
     momentum::Union{Nothing,Tensor}
     input_running_mean::Union{Nothing,Tensor}
@@ -291,12 +291,14 @@ graph_padding_mode(mode::Symbol) =
     throw(ArgumentError("unknown cuDNN padding mode $mode"))
 
 function norm_mode(mode::cudnnBackendNormMode_t)
-    mode == CUDNN_BATCH_NORM ||
-        throw(ArgumentError("only batch normalization is supported"))
+    mode in (CUDNN_BATCH_NORM, CUDNN_LAYER_NORM, CUDNN_RMS_NORM) ||
+        throw(ArgumentError("unsupported cuDNN norm mode $mode"))
     return mode
 end
 norm_mode(mode::Symbol) =
     mode === :batchnorm ? CUDNN_BATCH_NORM :
+    mode === :layernorm ? CUDNN_LAYER_NORM :
+    mode === :rmsnorm ? CUDNN_RMS_NORM :
     throw(ArgumentError("unsupported cuDNN norm mode $mode"))
 
 norm_phase(phase::cudnnBackendNormFwdPhase_t) = phase
@@ -340,6 +342,21 @@ function norm_channel_dims(x::Tensor)
     dims[end-1] = x.dims[end-1]
     return dims
 end
+
+function norm_layer_param_dims(x::Tensor, scale::Tensor)
+    length(scale.dims) == length(x.dims) ||
+        throw(DimensionMismatch("norm scale rank must match the input rank"))
+    all(i -> scale.dims[i] == 1 || scale.dims[i] == x.dims[i], eachindex(x.dims)) ||
+        throw(DimensionMismatch(
+            "norm scale dimensions must be 1 or match the input; " *
+            "got $(Tuple(scale.dims)) for input $(Tuple(x.dims))"))
+    any(i -> scale.dims[i] != 1, eachindex(x.dims)) ||
+        throw(ArgumentError("norm scale must span at least one normalized dimension"))
+    return collect(scale.dims)
+end
+
+norm_stat_dims(x::Tensor, pdims) =
+    Int64[p == 1 ? d : Int64(1) for (p, d) in zip(pdims, x.dims)]
 
 function check_norm_param(name, t::Tensor, dims)
     t.dims == dims || throw(DimensionMismatch("$name dimensions must be $(Tuple(dims))"))
@@ -634,7 +651,7 @@ function conv_wgrad!(g::Graph, dy::Tensor, x::Tensor;
     return dw
 end
 
-function norm_fwd!(g::Graph, x::Tensor, scale::Tensor, bias::Tensor;
+function norm_fwd!(g::Graph, x::Tensor, scale::Tensor, bias::Union{Nothing,Tensor};
                    y::Union{Nothing,Tensor}=nothing,
                    mean::Union{Nothing,Tensor}=nothing,
                    inv_variance::Union{Nothing,Tensor}=nothing,
@@ -646,16 +663,22 @@ function norm_fwd!(g::Graph, x::Tensor, scale::Tensor, bias::Tensor;
                    output_running_mean::Union{Nothing,Tensor}=nothing,
                    output_running_var::Union{Nothing,Tensor}=nothing,
                    name::String="Y")
-    pdims = norm_channel_dims(x)
+    nphase = norm_phase(phase)
+    nmode = norm_mode(mode)
+    pdims = nmode == CUDNN_BATCH_NORM ? norm_channel_dims(x) :
+                                        norm_layer_param_dims(x, scale)
     check_norm_param("norm scale", scale, pdims)
-    check_norm_param("norm bias", bias, pdims)
     xdtype = something(x.dtype, g.io_dtype)
     check_norm_dtype("norm input", x, xdtype)
     stat_dtype = norm_stat_dtype(xdtype)
     check_norm_dtype("norm scale", scale, stat_dtype)
-    check_norm_dtype("norm bias", bias, stat_dtype)
-    nphase = norm_phase(phase)
-    nmode = norm_mode(mode)
+    if bias === nothing
+        nmode == CUDNN_RMS_NORM ||
+            throw(ArgumentError("only RMS norm allows omitting the bias"))
+    else
+        check_norm_param("norm bias", bias, pdims)
+        check_norm_dtype("norm bias", bias, stat_dtype)
+    end
 
     if y === nothing
         y = tensor!(g; dims=x.dims, dtype=xdtype, virtual=true, name,
@@ -665,7 +688,8 @@ function norm_fwd!(g::Graph, x::Tensor, scale::Tensor, bias::Tensor;
         check_norm_dtype("norm output", y, xdtype)
     end
 
-    if nphase == CUDNN_NORM_FWD_TRAINING
+    training = nphase == CUDNN_NORM_FWD_TRAINING
+    if nmode == CUDNN_BATCH_NORM && training
         mean === nothing &&
             (mean = tensor!(g; dims=pdims, dtype=stat_dtype, virtual=true, name="Mean",
                             backend_order=x.backend_order))
@@ -697,7 +721,7 @@ function norm_fwd!(g::Graph, x::Tensor, scale::Tensor, bias::Tensor;
             check_norm_dtype("output_running_var", output_running_var, stat_dtype)
             check_norm_dtype("norm momentum", momentum, graph_dtype(norm_scalar_type(g)))
         end
-    else
+    elseif nmode == CUDNN_BATCH_NORM
         mean === nothing && throw(ArgumentError("norm inference requires mean"))
         inv_variance === nothing &&
             throw(ArgumentError("norm inference requires inv_variance"))
@@ -711,13 +735,45 @@ function norm_fwd!(g::Graph, x::Tensor, scale::Tensor, bias::Tensor;
         input_running_mean === nothing && input_running_var === nothing &&
             output_running_mean === nothing && output_running_var === nothing ||
             throw(ArgumentError("norm inference does not take running statistics"))
+    else
+        # layer/RMS norm: statistics are per sample and computed on the fly
+        momentum === nothing ||
+            throw(ArgumentError("per-sample norms do not take momentum"))
+        input_running_mean === nothing && input_running_var === nothing &&
+            output_running_mean === nothing && output_running_var === nothing ||
+            throw(ArgumentError("per-sample norms do not take running statistics"))
+        epsilon === nothing &&
+            (epsilon = scalar!(g, norm_scalar_type(g); rank=length(x.dims), name="Epsilon"))
+        check_norm_dtype("norm epsilon", epsilon, graph_dtype(norm_scalar_type(g)))
+        sdims = norm_stat_dims(x, pdims)
+        if training
+            if nmode == CUDNN_RMS_NORM
+                mean === nothing ||
+                    throw(ArgumentError("RMS norm has no mean statistic"))
+            else
+                mean === nothing &&
+                    (mean = tensor!(g; dims=sdims, dtype=stat_dtype, virtual=true,
+                                    name="Mean", backend_order=x.backend_order))
+                check_norm_param("norm mean", mean, sdims)
+                check_norm_dtype("norm mean", mean, stat_dtype)
+            end
+            inv_variance === nothing &&
+                (inv_variance = tensor!(g; dims=sdims, dtype=stat_dtype, virtual=true,
+                                        name="InvVariance", backend_order=x.backend_order))
+            check_norm_param("norm inv_variance", inv_variance, sdims)
+            check_norm_dtype("norm inv_variance", inv_variance, stat_dtype)
+        else
+            mean === nothing ||
+                throw(ArgumentError("per-sample norm inference does not take mean"))
+            inv_variance === nothing ||
+                throw(ArgumentError("per-sample norm inference does not take inv_variance"))
+        end
     end
 
     push!(g.ops, NormFwdOp(x, mean, inv_variance, scale, bias, epsilon, momentum,
                            input_running_mean, input_running_var, output_running_mean,
                            output_running_var, y, nmode, nphase))
-    return nphase == CUDNN_NORM_FWD_TRAINING ?
-           (y, mean, inv_variance, output_running_mean, output_running_var) : y
+    return training ? (y, mean, inv_variance, output_running_mean, output_running_var) : y
 end
 
 function norm_bwd!(g::Graph, dy::Tensor, x::Tensor, scale::Tensor, mean::Tensor,
@@ -725,6 +781,8 @@ function norm_bwd!(g::Graph, dy::Tensor, x::Tensor, scale::Tensor, mean::Tensor,
                    dscale::Union{Nothing,Tensor}=nothing,
                    dbias::Union{Nothing,Tensor}=nothing, mode=:batchnorm,
                    name::String="dX")
+    norm_mode(mode) == CUDNN_BATCH_NORM ||
+        throw(ArgumentError("norm_bwd! currently supports only batch normalization"))
     dy.dims == x.dims || throw(DimensionMismatch("norm dY dimensions must match input"))
     xdtype = something(x.dtype, g.io_dtype)
     check_norm_dtype("norm input", x, xdtype)
@@ -1116,7 +1174,8 @@ function lower(op::NormFwdOp, ctx::LoweringContext)
                            mean=op.mean === nothing ? nothing : desc(ctx, op.mean),
                            inv_variance=op.inv_variance === nothing ? nothing :
                                         desc(ctx, op.inv_variance),
-                           scale=desc(ctx, op.scale), bias=desc(ctx, op.bias),
+                           scale=desc(ctx, op.scale),
+                           bias=op.bias === nothing ? nothing : desc(ctx, op.bias),
                            epsilon=op.epsilon === nothing ? nothing : desc(ctx, op.epsilon),
                            momentum=op.momentum === nothing ? nothing : desc(ctx, op.momentum),
                            input_running_mean=op.input_running_mean === nothing ? nothing :

--- a/lib/cudnn/test/graph.jl
+++ b/lib/cudnn/test/graph.jl
@@ -142,6 +142,15 @@ rny, rnmean, rninv, _, _ = norm_fwd!(g, nx, lscale, nothing; mode=:rmsnorm)
 @test rnmean === nothing
 @test rninv.dims == [1, 6, 3, 2]
 @test norm_fwd!(g, nx, lscale, nothing; mode=:rmsnorm, phase=:inference).dims == nx.dims
+lbdx, lbdscale, lbdbias = norm_bwd!(g, lny, nx, lscale, lnmean, lninv; mode=:layernorm)
+@test lbdx.dims == nx.dims
+@test lbdscale.dims == [7, 1, 1, 1]
+@test lbdbias.dims == [7, 1, 1, 1]
+rbdx, rbdscale, rbdbias = norm_bwd!(g, rny, nx, lscale, nothing, rninv; mode=:rmsnorm)
+@test rbdscale.dims == [7, 1, 1, 1]
+@test rbdbias === nothing
+@test_throws ArgumentError norm_bwd!(g, rny, nx, lscale, lnmean, rninv; mode=:rmsnorm)
+@test_throws ArgumentError norm_bwd!(g, lny, nx, lscale, nothing, lninv; mode=:layernorm)
 @test_throws ArgumentError norm_fwd!(g, nx, lscale, nothing; mode=:layernorm)
 @test_throws ArgumentError norm_fwd!(g, nx, lscale, lbias; mode=:rmsnorm, mean=lnmean)
 @test_throws ArgumentError norm_fwd!(g, nx, nscale, nbias;

--- a/lib/cudnn/test/graph.jl
+++ b/lib/cudnn/test/graph.jl
@@ -131,9 +131,21 @@ ndx, ndscale, ndbias = norm_bwd!(g, ny, nx, nscale, nmean, ninv)
 @test ndbias.dims == nbias.dims
 badscale = tensor!(g; dims=(1, 1, 4, 1), dtype=Float32, name="BadScale")
 @test_throws DimensionMismatch norm_fwd!(g, nx, badscale, nbias; epsilon=neps)
-@test_throws ArgumentError norm_fwd!(g, nx, nscale, nbias; mode=:layernorm)
+# layer/RMS norm: scale spans the normalized dims, stats span the complement
+lscale = tensor!(g; dims=(7, 1, 1, 1), dtype=Float32, name="LayerScale")
+lbias = tensor!(g; dims=(7, 1, 1, 1), dtype=Float32, name="LayerBias")
+lny, lnmean, lninv, _, _ = norm_fwd!(g, nx, lscale, lbias; mode=:layernorm)
+@test lny.dims == nx.dims
+@test lnmean.dims == [1, 6, 3, 2]
+@test lninv.dims == [1, 6, 3, 2]
+rny, rnmean, rninv, _, _ = norm_fwd!(g, nx, lscale, nothing; mode=:rmsnorm)
+@test rnmean === nothing
+@test rninv.dims == [1, 6, 3, 2]
+@test norm_fwd!(g, nx, lscale, nothing; mode=:rmsnorm, phase=:inference).dims == nx.dims
+@test_throws ArgumentError norm_fwd!(g, nx, lscale, nothing; mode=:layernorm)
+@test_throws ArgumentError norm_fwd!(g, nx, lscale, lbias; mode=:rmsnorm, mean=lnmean)
 @test_throws ArgumentError norm_fwd!(g, nx, nscale, nbias;
-                                     mode=cuDNN.CUDNN_LAYER_NORM)
+                                     mode=cuDNN.CUDNN_GROUP_NORM)
 @test_throws ArgumentError norm_fwd!(g, nx, nscale, nbias; phase=:inference,
                                      mean=nmean, inv_variance=ninv, epsilon=neps)
 @test_throws ArgumentError norm_fwd!(g, nx, nscale, nbias; phase=:inference,

--- a/lib/cudnn/test/graph_ops.jl
+++ b/lib/cudnn/test/graph_ops.jl
@@ -8,10 +8,12 @@ using cuDNN:
     execute!,
     is_supported,
     matmul!,
+    norm_fwd!,
     output!,
     pointwise!,
     resample_bwd!,
     resample_fwd!,
+    tensor,
     tensor!,
     CUDNN_DATA_FP8_E4M3,
     CUDNN_DATA_FP8_E8M0,
@@ -358,4 +360,53 @@ let
     @test_throws DimensionMismatch block_scale_quantize!(g, hi; block_size=32, block_dim=3,
                                                          dtype=CUDNN_DATA_FP8_E4M3,
                                                          scale_dtype=CUDNN_DATA_FP8_E8M0)
+end
+
+# layer and RMS norm normalize over the dimensions the scale spans; the
+# statistics span the complement and, at inference, are computed on the fly
+function layernorm_ref(x, scale, bias; epsilon)
+    mean = sum(x; dims=1) ./ size(x, 1)
+    var = sum(abs2, x .- mean; dims=1) ./ size(x, 1)
+    return @. scale * (x - mean) / sqrt(var + epsilon) + bias
+end
+
+function rmsnorm_ref(x, scale; epsilon)
+    ms = sum(abs2, x; dims=1) ./ size(x, 1)
+    return @. scale * x / sqrt(ms + epsilon)
+end
+
+let H=64, S=8, B=2
+    epsilon = 1f-4
+    x_ref = reshape(Float32.(sin.(1:H*S*B)), H, S, B)
+    scale_ref = reshape(1f0 .+ Float32.(cos.(1:H)) ./ 2, H, 1, 1)
+    bias_ref = reshape(Float32.(sin.(1:H)) ./ 4, H, 1, 1)
+    x, scale, bias = CuArray(x_ref), CuArray(scale_ref), CuArray(bias_ref)
+
+    y = CUDACore.zeros(Float32, H, S, B)
+    g = Graph()
+    tx = tensor!(g, x; name="X")
+    tscale = tensor!(g, scale; name="Scale")
+    tbias = tensor!(g, bias; name="Bias")
+    ty = tensor!(g, y; name="Y", output=true)
+    norm_fwd!(g, tx, tscale, tbias; y=ty, mode=:layernorm, phase=:inference)
+    if is_supported(g)
+        execute!(g, tx=>x, tscale=>scale, tbias=>bias, ty=>y,
+                 tensor(g, "Epsilon")=>epsilon)
+        @test Array(y) ≈ layernorm_ref(x_ref, scale_ref, bias_ref; epsilon) rtol=1f-4 atol=1f-4
+    else
+        @test_skip is_supported(g)
+    end
+
+    yr = CUDACore.zeros(Float32, H, S, B)
+    gr = Graph()
+    rx = tensor!(gr, x; name="X")
+    rscale = tensor!(gr, scale; name="Scale")
+    ry = tensor!(gr, yr; name="Y", output=true)
+    norm_fwd!(gr, rx, rscale, nothing; y=ry, mode=:rmsnorm, phase=:inference)
+    if is_supported(gr)
+        execute!(gr, rx=>x, rscale=>scale, ry=>yr, tensor(gr, "Epsilon")=>epsilon)
+        @test Array(yr) ≈ rmsnorm_ref(x_ref, scale_ref; epsilon) rtol=1f-4 atol=1f-4
+    else
+        @test_skip is_supported(gr)
+    end
 end

--- a/lib/cudnn/test/graph_ops.jl
+++ b/lib/cudnn/test/graph_ops.jl
@@ -8,6 +8,7 @@ using cuDNN:
     execute!,
     is_supported,
     matmul!,
+    norm_bwd!,
     norm_fwd!,
     output!,
     pointwise!,
@@ -408,5 +409,104 @@ let H=64, S=8, B=2
         @test Array(yr) ≈ rmsnorm_ref(x_ref, scale_ref; epsilon) rtol=1f-4 atol=1f-4
     else
         @test_skip is_supported(gr)
+    end
+end
+
+# backward references, normalized over dimension 1 with statistics saved by
+# the training forward
+function layernorm_bwd_ref(dy, x, scale; epsilon)
+    H = size(x, 1)
+    mean = sum(x; dims=1) ./ H
+    var = sum(abs2, x .- mean; dims=1) ./ H
+    iv = @. 1 / sqrt(var + epsilon)
+    xhat = @. (x - mean) * iv
+    dxhat = @. dy * scale
+    dx = iv .* (dxhat .- sum(dxhat; dims=1) ./ H .-
+                xhat .* (sum(dxhat .* xhat; dims=1) ./ H))
+    return dx, sum(dy .* xhat; dims=(2, 3)), sum(dy; dims=(2, 3))
+end
+
+function rmsnorm_bwd_ref(dy, x, scale; epsilon)
+    H = size(x, 1)
+    iv = @. 1 / sqrt($(sum(abs2, x; dims=1)) / H + epsilon)
+    xhat = @. x * iv
+    dxhat = @. dy * scale
+    dx = iv .* (dxhat .- xhat .* (sum(dxhat .* xhat; dims=1) ./ H))
+    return dx, sum(dy .* xhat; dims=(2, 3))
+end
+
+# training forward to backward round trip: the forward saves the per-sample
+# statistics, the backward consumes them; returns nothing when unsupported
+function norm_roundtrip(mode, x, scale, bias, dy; epsilon)
+    (H, S, B) = size(x)
+    y, dx = CUDACore.zeros(Float32, H, S, B), CUDACore.zeros(Float32, H, S, B)
+    sinv = CUDACore.zeros(Float32, 1, S, B)
+    smean = mode === :rmsnorm ? nothing : CUDACore.zeros(Float32, 1, S, B)
+    dscale = CUDACore.zeros(Float32, H, 1, 1)
+    dbias = mode === :rmsnorm ? nothing : CUDACore.zeros(Float32, H, 1, 1)
+    inout(g, a; kws...) = a === nothing ? nothing : tensor!(g, a; kws...)
+    bind!(binds, t, a) = t === nothing ? binds : push!(binds, t => a)
+
+    g = Graph()
+    tx, tscale, tbias = tensor!(g, x; name="X"), tensor!(g, scale; name="S"),
+                        inout(g, bias; name="B")
+    ty = tensor!(g, y; name="Y", output=true)
+    tinv = tensor!(g, sinv; name="IV", output=true)
+    tmean = inout(g, smean; name="M", output=true)
+    norm_fwd!(g, tx, tscale, tbias; y=ty, mean=tmean, inv_variance=tinv,
+              mode, phase=:training)
+    is_supported(g) || return nothing
+    binds = Any[tx => x, tscale => scale, ty => y, tinv => sinv,
+                tensor(g, "Epsilon") => epsilon]
+    bind!(bind!(binds, tbias, bias), tmean, smean)
+    execute!(g, binds...)
+
+    gb = Graph()
+    bdy, bx, bscale = tensor!(gb, dy; name="dY"), tensor!(gb, x; name="X"),
+                      tensor!(gb, scale; name="S")
+    binv, bmean = tensor!(gb, sinv; name="IV"), inout(gb, smean; name="M")
+    bdx = tensor!(gb, dx; name="dX", output=true)
+    bdscale = tensor!(gb, dscale; name="dS", output=true)
+    bdbias = inout(gb, dbias; name="dB", output=true)
+    norm_bwd!(gb, bdy, bx, bscale, bmean, binv;
+              dx=bdx, dscale=bdscale, dbias=bdbias, mode)
+    is_supported(gb) || return nothing
+    binds = Any[bdy => dy, bx => x, bscale => scale, binv => sinv,
+                bdx => dx, bdscale => dscale]
+    bind!(bind!(binds, bmean, smean), bdbias, dbias)
+    execute!(gb, binds...)
+    return y, dx, dscale, dbias
+end
+
+let H=64, S=8, B=2
+    epsilon = 1f-4
+    x_ref = reshape(Float32.(sin.(1:H*S*B)), H, S, B)
+    scale_ref = reshape(1f0 .+ Float32.(cos.(1:H)) ./ 2, H, 1, 1)
+    bias_ref = reshape(Float32.(sin.(1:H)) ./ 4, H, 1, 1)
+    dy_ref = reshape(Float32.(cos.(1:H*S*B)), H, S, B) ./ 2
+    x, scale, bias, dy = CuArray.((x_ref, scale_ref, bias_ref, dy_ref))
+
+    r = norm_roundtrip(:layernorm, x, scale, bias, dy; epsilon)
+    if r === nothing
+        @test_skip false
+    else
+        y, dx, dscale, dbias = r
+        dx_ref, dscale_ref, dbias_ref = layernorm_bwd_ref(dy_ref, x_ref, scale_ref; epsilon)
+        @test Array(y) ≈ layernorm_ref(x_ref, scale_ref, bias_ref; epsilon) rtol=1f-3 atol=1f-3
+        @test Array(dx) ≈ dx_ref rtol=1f-3 atol=1f-3
+        @test Array(dscale) ≈ dscale_ref rtol=1f-3 atol=1f-3
+        @test Array(dbias) ≈ dbias_ref rtol=1f-3 atol=1f-3
+    end
+
+    r = norm_roundtrip(:rmsnorm, x, scale, nothing, dy; epsilon)
+    if r === nothing
+        @test_skip false
+    else
+        y, dx, dscale, dbias = r
+        dx_ref, dscale_ref = rmsnorm_bwd_ref(dy_ref, x_ref, scale_ref; epsilon)
+        @test dbias === nothing
+        @test Array(y) ≈ rmsnorm_ref(x_ref, scale_ref; epsilon) rtol=1f-3 atol=1f-3
+        @test Array(dx) ≈ dx_ref rtol=1f-3 atol=1f-3
+        @test Array(dscale) ≈ dscale_ref rtol=1f-3 atol=1f-3
     end
 end


### PR DESCRIPTION
The norm operations are single backend descriptors with a mode enum, but the wrappers only modeled batch normalization's contract and rejected every other mode. That contract varies per mode along three axes:

- **parameter shapes**: batch norm is per-channel; layer/RMS norm scale and bias span the normalized dimensions, with statistics on the complement;
- **which statistics exist**: layer norm saves the mean and inverse variance; RMS norm never centers, so it has no mean statistic;
- **phase rules**: batch norm inference takes precomputed statistics and no epsilon (the caller folds it), while per-sample norms compute statistics on the fly, take none at inference, and take epsilon in both phases.

Accept `:layernorm` and `:rmsnorm` in norm_mode, derive layer/RMS parameter and statistic shapes from the scale tensor, restructure `norm_fwd!`'s  phase logic per mode, and make the bias optional (RMS norm allows omitting it; `CUDNN_ATTR_OPERATION_NORM_FWD_BIAS_DESC` is set only when present). `norm_bwd!` is extended the same way: per-mode gradient and statistic shapes, the saved mean omitted for RMS norm, and the bias gradient created on request only there.

Matches cudnn-frontend's `rmsnorm`/`layernorm` nodes, which lower to these same descriptors. Instance norm slots into the same structure (batch-norm-shaped parameters, per-sample phase rules, statistics over the trailing two dimensions) and can follow when there's a consumer; group norm has no backend support per the header's own table.

Tested on GB10 (sm_121): inference executes against reference numerics for both modes, and training-forward-to-backward round trips verify `dX`/`dScale`/`dBias` against the reference formulas (RMS with and without bias).