### PR TITLE
Fix bad typing in Enzyme ext

### DIFF
--- a/CUDACore/ext/EnzymeCoreExt.jl
+++ b/CUDACore/ext/EnzymeCoreExt.jl
@@ -96,12 +96,19 @@ function EnzymeCore.EnzymeRules.augmented_primal(config, ofn::Const{typeof(cudac
     end
     
     shadow = if EnzymeRules.needs_shadow(config)
-        if EnzymeRules.width(config) == 1
+        if EnzymeRules.width(config) == 1 && !(IT <: Const)
             ofn.val(x.dval)
-        else
+        elseif EnzymeRules.width(config) == 1 && IT <: Const
+            ofn.val(EnzymeCore.make_zero(x.val))
+        elseif !(IT <: Const)
           ntuple(Val(EnzymeRules.width(config))) do i
               Base.@_inline_meta
               ofn.val(x.dval[i])
+          end
+        else
+          ntuple(Val(EnzymeRules.width(config))) do i
+              Base.@_inline_meta
+              ofn.val(EnzymeCore.make_zero(x.val[i]))
           end
         end
     else


### PR DESCRIPTION
Tested that this fixes https://github.com/JuliaGPU/CUDA.jl/issues/2947 locally

However, because CUDACore is currently on GPUCompiler 2.x, which Enzyme doesn't yet support, we might need to back port this for most users to benefit.