### PR TITLE
Reduce kernel launch and first-use latency

### DIFF
--- a/CUDACore/lib/cudadrv/state.jl
+++ b/CUDACore/lib/cudadrv/state.jl
@@ -177,29 +177,34 @@ end
 function context(dev::CuDevice)
     devidx = deviceid(dev)+1
 
+    # Keep device-dependent work in a named function so it can be precompiled.
     @memoize index=devidx begin
-        # check if the device isn't too old
-        if capability(dev) < v"5.0"
-            @error("""Your $(name(dev)) GPU (compute capability $(capability(dev).major).$(capability(dev).minor)) is not supported by CUDA.jl.
-                      Please use a device with at least capability 5.0, or downgrade CUDA.jl (see the README for compatibility details).""",
-                   maxlog=1, _id=devidx)
-        elseif runtime_version() >= v"13" && capability(dev) < v"7.5"
-            @error("""Your $(name(dev)) GPU (compute capability $(capability(dev).major).$(capability(dev).minor)) is not supported by CUDA toolkit 13+.
-                      Please use a device with at least capability 7.5, or use an older CUDA toolkit (see `CUDA.set_runtime_version!`).""",
-                   maxlog=1, _id=devidx)
-        end
-        # or not among the capabilities ptxas can target.
-        if !in(capability(dev), ptxas_compat().cap)
-            @warn("""Your $(name(dev)) GPU (compute capability $(capability(dev).major).$(capability(dev).minor)) is not fully supported by CUDA $(compiler_version().major).$(compiler_version().minor).
-                     Some functionality may be broken. Ensure you are using the latest version of CUDA.jl in combination with an up-to-date NVIDIA driver.
-                     If that does not help, please file an issue to add support for the latest CUDA toolkit.""",
-                  maxlog=1, _id=devidx)
-        end
-
-        # configure the primary context
-        pctx = CuPrimaryContext(dev)
-        CuContext(pctx)
+        create_context(dev, devidx)
     end::CuContext
+end
+
+function create_context(dev::CuDevice, devidx::Int)
+    # check if the device isn't too old
+    if capability(dev) < v"5.0"
+        @error("""Your $(name(dev)) GPU (compute capability $(capability(dev).major).$(capability(dev).minor)) is not supported by CUDA.jl.
+                  Please use a device with at least capability 5.0, or downgrade CUDA.jl (see the README for compatibility details).""",
+               maxlog=1, _id=devidx)
+    elseif runtime_version() >= v"13" && capability(dev) < v"7.5"
+        @error("""Your $(name(dev)) GPU (compute capability $(capability(dev).major).$(capability(dev).minor)) is not supported by CUDA toolkit 13+.
+                  Please use a device with at least capability 7.5, or use an older CUDA toolkit (see `CUDA.set_runtime_version!`).""",
+               maxlog=1, _id=devidx)
+    end
+    # or not among the capabilities ptxas can target.
+    if !in(capability(dev), ptxas_compat().cap)
+        @warn("""Your $(name(dev)) GPU (compute capability $(capability(dev).major).$(capability(dev).minor)) is not fully supported by CUDA $(compiler_version().major).$(compiler_version().minor).
+                 Some functionality may be broken. Ensure you are using the latest version of CUDA.jl in combination with an up-to-date NVIDIA driver.
+                 If that does not help, please file an issue to add support for the latest CUDA toolkit.""",
+              maxlog=1, _id=devidx)
+    end
+
+    # configure the primary context
+    pctx = CuPrimaryContext(dev)
+    CuContext(pctx)
 end
 
 """

--- a/CUDACore/src/compiler/execution.jl
+++ b/CUDACore/src/compiler/execution.jl
@@ -198,6 +198,19 @@ to the compiled kernel signature.
 end
 
 
+# Keep the pipeline behind one function barrier for type-unstable argument tuples.
+@inline function compile_and_launch(backend, f::F, args::Tuple, ::Val{launch};
+                                    launch_kwargs::NamedTuple=(;),
+                                    compiler_kwargs...) where {F,launch}
+    call = kernel_call(backend, f, args)
+    kernel = kernel_compile(call; compiler_kwargs...)
+    if launch
+        kernel_launch(kernel, call; launch_kwargs...)
+    end
+    return kernel
+end
+
+
 ## high-level @cuda interface
 
 const MACRO_KWARGS = [:dynamic, :launch, :backend]
@@ -316,11 +329,10 @@ macro cuda(ex...)
                     $backend_raw isa $AbstractBackend ? $backend_raw : $backend_raw.DefaultBackend()
                 end
                 $f_var = $f
-                $call = $KernelCall($f_var, $(var_exprs...); backend=$backend)
-                $kernel = $kernel_compile($call; $(compiler_kwargs...), $(other_kwargs...))
-                if $should_launch
-                    $kernel_launch($kernel, $call; $(call_kwargs...))
-                end
+                $kernel = $compile_and_launch($backend, $f_var, ($(var_exprs...),),
+                                              Val($should_launch);
+                                              launch_kwargs=(; $(call_kwargs...)),
+                                              $(compiler_kwargs...), $(other_kwargs...))
                 $kernel
              end)
     end

--- a/CUDACore/src/compiler/execution.jl
+++ b/CUDACore/src/compiler/execution.jl
@@ -347,8 +347,17 @@ function Adapt.adapt_storage(to::KernelAdaptor, managed::Managed)
 end
 
 function lock_managed(managed::AbstractVector{<:Managed})
-    locked = unique(managed)
-    sort!(locked; by=memory -> objectid(memory.lock))
+    # Sort globally to avoid deadlocks and make duplicates adjacent.
+    locked = sort(managed; by=memory -> objectid(memory.lock))
+    n = 0
+    prev = nothing
+    for memory in locked
+        memory === prev && continue
+        n += 1
+        @inbounds locked[n] = memory
+        prev = memory
+    end
+    resize!(locked, n)
     for memory in locked
         lock(memory.lock)
     end
@@ -364,11 +373,22 @@ end
 
 function with_managed(f::F, managed::AbstractVector{<:Managed};
                       stream::CuStream=stream()) where {F}
+    state = active_state()
+    capturing = is_capturing(stream)
+    if length(managed) == 1
+        memory = @inbounds managed[1]
+        lock(memory.lock)
+        try
+            take_ownership!(memory; state, stream, capturing)
+            return f()
+        finally
+            unlock(memory.lock)
+        end
+    end
     locked = lock_managed(managed)
     try
-        state = active_state()
         for memory in locked
-            take_ownership!(memory; state, stream)
+            take_ownership!(memory; state, stream, capturing)
         end
         return f()
     finally

--- a/CUDACore/src/memory.jl
+++ b/CUDACore/src/memory.jl
@@ -595,11 +595,12 @@ end
 # device-side operation. The caller must hold `managed.lock` until that operation has been
 # submitted to `stream`, so the recorded owner cannot become visible before its submission.
 function take_ownership!(managed::Managed{M}; state=active_state(),
-                         stream::CuStream=state.stream) where {M}
+                         stream::CuStream=state.stream,
+                         capturing::Bool=is_capturing(stream)) where {M}
   sizeof(managed) == 0 && return managed
 
   # accessing memory during stream capture: taint the memory so that we always synchronize
-  if is_capturing(stream)
+  if capturing
     managed.captured = true
   end
 
@@ -634,7 +635,7 @@ function take_ownership!(managed::Managed{M}; state=active_state(),
 
   # prefetch unified memory as we're likely to use it on the GPU
   if M == UnifiedMemory
-    can_prefetch = !is_capturing(stream)
+    can_prefetch = !capturing
     can_prefetch &= !__pinned(convert(Ptr{Cvoid}, managed.mem), managed.mem.ctx)
     can_prefetch &= attribute(state.device,
                               DEVICE_ATTRIBUTE_CONCURRENT_MANAGED_ACCESS) == 1

--- a/CUDACore/src/precompile.jl
+++ b/CUDACore/src/precompile.jl
@@ -52,6 +52,14 @@ let CUDACompilerJob = CompilerJob{PTXCompilerTarget, CUDACompilerParams}
     precompile(Tuple{typeof(GPUCompiler.cached_results), Type{CUDACompilerResults}, CUDACompilerJob})
 end
 
+# GPU-dependent paths cannot be reached by the device-free workload above.
+precompile(Tuple{typeof(context), CuDevice})
+precompile(Tuple{typeof(create_context), CuDevice, Int})
+precompile(Tuple{typeof(active_state)})
+precompile(Tuple{typeof(compiler_config), CuDevice})
+precompile(Tuple{typeof(Core.kwcall), @NamedTuple{kernel::Bool}, typeof(compiler_config),
+                 CuDevice})
+
 # scalar reference (used by cuBLAS for alpha/beta parameters)
 precompile(Tuple{Type{CuRefValue{Float32}}, Float32})
 precompile(Tuple{typeof(pool_free), Managed{DeviceMemory}})

--- a/CUDATools/src/precompile.jl
+++ b/CUDATools/src/precompile.jl
@@ -3,6 +3,16 @@ precompile(Tuple{typeof(Profile.detect_cupti)})
 precompile(Tuple{typeof(Profile.profile_internally), Function})
 precompile(Tuple{typeof(Profile.capture), CUPTI.ActivityConfig})
 
+# Reflection depends on a GPU; `func` and `types` are deliberately unspecialized.
+for io in (Base.TTY, Base.DevNull)
+    precompile(Tuple{typeof(code_native), io, Any, Any})
+    precompile(Tuple{typeof(Core.kwcall), @NamedTuple{kernel::Bool}, typeof(code_native),
+                     io, Any, Any})
+    precompile(Tuple{typeof(code_llvm), io, Any, Any})
+    precompile(Tuple{typeof(Core.kwcall), @NamedTuple{kernel::Bool}, typeof(code_llvm),
+                     io, Any, Any})
+end
+
 using PrecompileTools
 
 @compile_workload begin

--- a/perf/runbenchmarks.jl
+++ b/perf/runbenchmarks.jl
@@ -2,6 +2,9 @@
 
 using CUDA
 
+# Record the environment alongside benchmark results.
+CUDA.versioninfo()
+
 using BenchmarkTools
 
 using Random, StableRNGs

--- a/test/core/execution.jl
+++ b/test/core/execution.jl
@@ -753,13 +753,17 @@ end
     @cuda kernel(out_dev, 1, 2)
     @test Array(out_dev)[1] == 3
 
-    all_splat = (out_dev, 3, 4)
-    @cuda kernel(all_splat...)
+    tuple_splat = (out_dev, 3, 4)
+    @cuda kernel(tuple_splat...)
     @test Array(out_dev)[1] == 7
 
     partial_splat = (5, 6)
     @cuda kernel(out_dev, partial_splat...)
     @test Array(out_dev)[1] == 11
+
+    vector_splat = Any[out_dev, 7, 8]
+    @cuda kernel(vector_splat...)
+    @test Array(out_dev)[1] == 15
 end
 
 @testset "object invoke" begin


### PR DESCRIPTION
Reduce overhead in common kernel compilation and launch paths:

  - avoid redundant allocation and stream-capture queries when tracking managed memory;
  - use a function barrier for launches with runtime-length argument splats;
  - precompile GPU-dependent initialization and reflection paths;
  - record the CUDA environment in benchmark logs.

Locally, type-unstable launch overhead dropped from 2625 ns and 21 allocations to 1653 ns and 6 allocations. First-kernel latency improved by roughly 150 ms, while package import time remained unchanged.