### PR TITLE
cuDNN: implement the composite SDPA backward

### DIFF
--- a/lib/cudnn/src/backend.jl
+++ b/lib/cudnn/src/backend.jl
@@ -358,12 +358,18 @@ function pointwise_operation(pwdesc::BackendDescriptor, x::BackendDescriptor,
 end
 
 function matmul_operation(matdesc::BackendDescriptor, a::BackendDescriptor,
-                          b::BackendDescriptor, c::BackendDescriptor)
+                          b::BackendDescriptor, c::BackendDescriptor;
+                          m_override::Union{Nothing,BackendDescriptor}=nothing,
+                          n_override::Union{Nothing,BackendDescriptor}=nothing,
+                          k_override::Union{Nothing,BackendDescriptor}=nothing)
     make_descriptor(:operation_matmul) do op
         op[:adesc] = a
         op[:bdesc] = b
         op[:cdesc] = c
         op[:desc] = matdesc
+        m_override === nothing || (op[:gemm_m_override_desc] = m_override)
+        n_override === nothing || (op[:gemm_n_override_desc] = n_override)
+        k_override === nothing || (op[:gemm_k_override_desc] = k_override)
     end
 end
 

--- a/lib/cudnn/src/graph/engines.jl
+++ b/lib/cudnn/src/graph/engines.jl
@@ -66,12 +66,14 @@ function select_plan(g::Graph, opgraph::BackendDescriptor;
     end
 end
 
-function build!(g::Graph; kwargs...)
+function build!(g::Graph;
+                mode::cudnnBackendOperationGraphMode_t=CUDNN_OPERATIONGRAPH_MODE_AUTO,
+                kwargs...)
     g.plan === nothing || unsafe_destroy!(g)
     validate!(g)
     assign_uids!(g)
     try
-        opgraph, intermediates = lower_graph(g)
+        opgraph, intermediates = lower_graph(g; mode)
         try
             plan, workspace_size = select_plan(g, opgraph; kwargs...)
             g.plan = plan

--- a/lib/cudnn/src/graph/lower.jl
+++ b/lib/cudnn/src/graph/lower.jl
@@ -21,20 +21,11 @@ end
 
 desc(ctx::LoweringContext, t::Tensor) = ctx.tensor_descs[t]
 
-operation_graph_mode(::Operation) = CUDNN_OPERATIONGRAPH_MODE_AUTO
-
-function operation_graph_mode(g::Graph)
-    length(g.ops) == 1 && return operation_graph_mode(only(g.ops))
-    any(op -> op isa ConvFpropOp || op isa ConvDgradOp || op isa ConvWgradOp, g.ops) &&
-        return CUDNN_OPERATIONGRAPH_MODE_GENERIC_CONV_FUSION
-    any(op -> op isa MatmulOp, g.ops) &&
-        return CUDNN_OPERATIONGRAPH_MODE_GENERIC_MATMUL_FUSION
-    all(op -> op isa PointwiseOp || op isa ReductionOp, g.ops) &&
-        return CUDNN_OPERATIONGRAPH_MODE_GENERIC_POINTWISE_FUSION
-    return CUDNN_OPERATIONGRAPH_MODE_AUTO
-end
-
-function lower_graph(g::Graph)
+# AUTO leaves the mode attribute unset so the backend detects the pattern
+# family itself; an explicit mode scopes matching to one family and can only
+# remove engines from consideration, so it is opt-in via build!'s mode kwarg
+function lower_graph(g::Graph;
+                     mode::cudnnBackendOperationGraphMode_t=CUDNN_OPERATIONGRAPH_MODE_AUTO)
     ctx = LoweringContext(IdDict{Tensor,BackendDescriptor}(),
                           BackendDescriptor[])
     for t in g.tensors
@@ -44,6 +35,6 @@ function lower_graph(g::Graph)
     for op in g.ops
         push!(op_descs, track!(ctx, lower(op, ctx)))
     end
-    graph = track!(ctx, operation_graph(op_descs; mode=operation_graph_mode(g)))
+    graph = track!(ctx, operation_graph(op_descs; mode))
     return graph, ctx.intermediates
 end

--- a/lib/cudnn/src/graph/ops.jl
+++ b/lib/cudnn/src/graph/ops.jl
@@ -16,20 +16,9 @@ struct SDPAFwdOp <: Operation
     mask_subgraph::Union{Nothing,SDPAMaskSubgraph}
 end
 
-struct SDPABwdOp <: Operation
-    q::Tensor
-    k::Tensor
-    v::Tensor
-    o::Tensor
-    dO::Tensor
-    stats::Tensor
-    scale::Tensor
-    dQ::Tensor
-    dK::Tensor
-    dV::Tensor
-    seq_len_q::Union{Nothing,Tensor}
-    seq_len_kv::Union{Nothing,Tensor}
-    mask_subgraph::Union{Nothing,SDPAMaskSubgraph}
+struct ReshapeOp <: Operation
+    x::Tensor
+    y::Tensor
 end
 
 struct PointwiseOp <: Operation
@@ -56,7 +45,13 @@ struct MatmulOp <: Operation
     b::Tensor
     c::Tensor
     compute_dtype::cudnnDataType_t
+    m_override::Union{Nothing,Tensor}
+    n_override::Union{Nothing,Tensor}
+    k_override::Union{Nothing,Tensor}
 end
+
+MatmulOp(a, b, c, compute_dtype) = MatmulOp(a, b, c, compute_dtype,
+                                            nothing, nothing, nothing)
 
 struct ReductionOp <: Operation
     mode::cudnnReduceTensorOp_t
@@ -221,18 +216,6 @@ function sdpa_causal_subgraph!(g::Graph, skv, sq, hq, b)
     output = tensor!(g; dims=score_dims, dtype=Float32, virtual=true, name="MaskedScore")
     return SDPAMaskSubgraph(input, fill, output)
 end
-
-operation_graph_mode(::SDPAFwdOp) = CUDNN_OPERATIONGRAPH_MODE_UNIFIED_SDPA_FWD
-operation_graph_mode(::SDPABwdOp) = CUDNN_OPERATIONGRAPH_MODE_UNIFIED_SDPA_BWD
-operation_graph_mode(::ConvFpropOp) = CUDNN_OPERATIONGRAPH_MODE_CONV_FORWARD
-operation_graph_mode(::ConvDgradOp) = CUDNN_OPERATIONGRAPH_MODE_CONV_BWD_DATA
-operation_graph_mode(::ConvWgradOp) = CUDNN_OPERATIONGRAPH_MODE_CONV_BWD_FILTER
-operation_graph_mode(::ResampleFwdOp) = CUDNN_OPERATIONGRAPH_MODE_RESAMPLE_FWD
-operation_graph_mode(::ResampleBwdOp) = CUDNN_OPERATIONGRAPH_MODE_RESAMPLE_BWD
-operation_graph_mode(op::NormFwdOp) =
-    op.phase == CUDNN_NORM_FWD_TRAINING ? CUDNN_OPERATIONGRAPH_MODE_NORM_FWD_TRAIN :
-    CUDNN_OPERATIONGRAPH_MODE_NORM_FWD_INFER
-operation_graph_mode(::NormBwdOp) = CUDNN_OPERATIONGRAPH_MODE_NORM_BWD
 
 alphabeta_type(dtype::cudnnDataType_t) =
     dtype == CUDNN_DATA_DOUBLE ? CUDNN_TYPE_DOUBLE : CUDNN_TYPE_FLOAT
@@ -1027,11 +1010,72 @@ function sdpa_fwd!(g::Graph, q::Tensor, k::Tensor, v::Tensor;
     return stats === nothing ? o : (o, stats)
 end
 
+# re-presents x with new dims/strides/dtype: the virtual-transpose mechanism
+# of pattern-matched graphs
+function reshape!(g::Graph, x::Tensor; dims, strides=dense_strides(dims),
+                  dtype=nothing, virtual::Bool=true, name::String="Y")
+    prod(dims) == prod(x.dims) ||
+        throw(DimensionMismatch(
+            "reshape! element count must match: $(Tuple(x.dims)) -> $(Tuple(dims))"))
+    y = tensor!(g; dims, strides, dtype, virtual, name)
+    push!(g.ops, ReshapeOp(x, y))
+    return y
+end
+
+function check_sdpa_bwd_shape(name, t::Tensor, dims)
+    length(t.dims) == 4 || throw(ArgumentError("$name must be rank 4"))
+    t.backend_order == [4, 3, 2, 1] ||
+        throw(ArgumentError("$name must use the default dimension order"))
+    t.dims == collect(Int64, dims) ||
+        throw(DimensionMismatch(
+            "$name dimensions must be $(Tuple(dims)), got $(Tuple(t.dims))"))
+    t.virtual && throw(ArgumentError("$name must not be virtual"))
+    return t
+end
+
+# io strides are engine-parameterized; only head-dim-innermost is required
+function check_sdpa_bwd_io(name, t::Tensor, dims)
+    check_sdpa_bwd_shape(name, t, dims)
+    t.strides[1] == 1 ||
+        throw(ArgumentError("$name must have the head dimension innermost (stride 1)"))
+    return t
+end
+
+# engine spill buffers assume this packing; other strides are accepted at
+# build time and corrupt gradients silently
+function check_sdpa_bwd_workspace(name, t::Tensor, dims)
+    check_sdpa_bwd_shape(name, t, dims)
+    t.strides == dense_strides(t.dims) ||
+        throw(ArgumentError(
+            "$name must be densely packed as $(Tuple(dims)); the fMHA backward " *
+            "engines silently corrupt gradients for other layouts"))
+    return t
+end
+
+function check_sdpa_bwd_dtype(name, t::Tensor, dtype)
+    t.dtype === nothing && (t.dtype = dtype)
+    t.dtype == dtype ||
+        throw(ArgumentError("$name must have $(juliaDataType(dtype)) dtype"))
+    return t
+end
+
+# in-place transpose of the leading two dims: the pattern consumes K^T/V^T
+function sdpa_bwd_transpose!(t::Tensor)
+    t.dims = Int64[t.dims[2], t.dims[1], t.dims[3], t.dims[4]]
+    t.strides = Int64[t.strides[2], t.strides[1], t.strides[3], t.strides[4]]
+    return t
+end
+
+# the composite spelling the fMHA backward engines pattern-match (the unified
+# SDPA_BWD op has no engines anywhere); dims are (d, s, h, b), unlike sdpa_fwd!.
+# Mutates k/v into their transposes; grouped queries add fullhead workspaces.
 function sdpa_bwd!(g::Graph, q::Tensor, k::Tensor, v::Tensor, o::Tensor, dO::Tensor,
                    stats::Tensor;
                    dQ::Union{Nothing,Tensor}=nothing,
                    dK::Union{Nothing,Tensor}=nothing,
                    dV::Union{Nothing,Tensor}=nothing,
+                   softmax_sum::Union{Nothing,Tensor}=nothing,
+                   dQ_accum::Union{Nothing,Tensor}=nothing,
                    scale::Union{Nothing,Tensor}=nothing,
                    seq_len_q::Union{Nothing,Tensor}=nothing,
                    seq_len_kv::Union{Nothing,Tensor}=nothing,
@@ -1042,42 +1086,165 @@ function sdpa_bwd!(g::Graph, q::Tensor, k::Tensor, v::Tensor, o::Tensor, dO::Ten
     length(q.dims) == 4 || throw(ArgumentError("q must be rank 4"))
     length(k.dims) == 4 || throw(ArgumentError("k must be rank 4"))
     length(v.dims) == 4 || throw(ArgumentError("v must be rank 4"))
-    d, hq, sq, b = q.dims
-    dk, hk, skv, bk = k.dims
-    dv, hv, skvv, bv = v.dims
-    dk == d || throw(DimensionMismatch("q and k head dimensions must match"))
-    dv == d || throw(DimensionMismatch("q and v head dimensions must match"))
-    hk == hv || throw(DimensionMismatch("k and v head counts must match"))
-    skv == skvv || throw(DimensionMismatch("k and v sequence lengths must match"))
-    bk == b && bv == b || throw(DimensionMismatch("q, k, and v batch sizes must match"))
-    hq % hk == 0 || throw(DimensionMismatch("q head count must be a multiple of k/v heads"))
-    o.dims == q.dims || throw(DimensionMismatch("o dimensions must match q"))
-    dO.dims == q.dims || throw(DimensionMismatch("dO dimensions must match q"))
-    stats.dims == [1, hq, sq, b] ||
-        throw(DimensionMismatch("stats dimensions must be $((1, hq, sq, b))"))
-    (stats.dtype === nothing || stats.dtype == CUDNN_DATA_FLOAT) ||
-        throw(ArgumentError("stats must have Float32 dtype"))
+    d, sq, h, b = q.dims
+    hk = k.dims[3]
+    h % hk == 0 ||
+        throw(DimensionMismatch("q head count must be a multiple of k/v heads"))
+    skv = k.dims[2]
+
+    iodt = q.dtype === nothing ? g.io_dtype : q.dtype
+    for (name, t, dims) in (("q", q, (d, sq, h, b)), ("k", k, (d, skv, hk, b)),
+                            ("v", v, (d, skv, hk, b)), ("o", o, (d, sq, h, b)),
+                            ("dO", dO, (d, sq, h, b)))
+        check_sdpa_bwd_io(name, t, dims)
+        check_sdpa_bwd_dtype(name, t, iodt)
+    end
+    check_sdpa_bwd_workspace("stats", stats, (1, sq, h, b))
+    check_sdpa_bwd_dtype("stats", stats, CUDNN_DATA_FLOAT)
     check_sdpa_sequence_lengths(seq_len_q, seq_len_kv, b)
 
-    dQ === nothing && (dQ = tensor!(g; dims=q.dims, dtype=q.dtype, virtual=true,
+    dQ === nothing && (dQ = tensor!(g; dims=(d, sq, h, b), dtype=iodt, output=true,
                                     name="dQ"))
-    dK === nothing && (dK = tensor!(g; dims=k.dims, dtype=k.dtype, virtual=true,
+    dK === nothing && (dK = tensor!(g; dims=(d, skv, hk, b), dtype=iodt, output=true,
                                     name="dK"))
-    dV === nothing && (dV = tensor!(g; dims=v.dims, dtype=v.dtype, virtual=true,
+    dV === nothing && (dV = tensor!(g; dims=(d, skv, hk, b), dtype=iodt, output=true,
                                     name="dV"))
-    dQ.dims == q.dims || throw(DimensionMismatch("dQ dimensions must match q"))
-    dK.dims == k.dims || throw(DimensionMismatch("dK dimensions must match k"))
-    dV.dims == v.dims || throw(DimensionMismatch("dV dimensions must match v"))
+    softmax_sum === nothing &&
+        (softmax_sum = tensor!(g; dims=(1, sq, h, b), dtype=Float32, output=true,
+                               name="SoftmaxSum"))
+    dQ_accum === nothing &&
+        (dQ_accum = tensor!(g; dims=(d, sq, h, b), dtype=Float32, output=true,
+                            name="dQAccum"))
+    for (name, t, dims) in (("dQ", dQ, (d, sq, h, b)), ("dK", dK, (d, skv, hk, b)),
+                            ("dV", dV, (d, skv, hk, b)))
+        check_sdpa_bwd_io(name, t, dims)
+        check_sdpa_bwd_dtype(name, t, iodt)
+    end
+    check_sdpa_bwd_workspace("softmax_sum", softmax_sum, (1, sq, h, b))
+    check_sdpa_bwd_dtype("softmax_sum", softmax_sum, CUDNN_DATA_FLOAT)
+    check_sdpa_bwd_workspace("dQ_accum", dQ_accum, (d, sq, h, b))
+    check_sdpa_bwd_dtype("dQ_accum", dQ_accum, CUDNN_DATA_FLOAT)
     scale === nothing && (scale = scalar!(g, Float32; rank=4, name="Scale"))
+    one_t = scalar!(g, Float32; rank=4, name="One")
 
-    foreach(sdpa_tensor!, (q, k, v, o, dO, stats, scale, dQ, dK, dV))
-    seq_len_q === nothing || foreach(sdpa_tensor!, (seq_len_q, seq_len_kv))
+    kstrides = Tuple(Int.(k.strides))    # Kview undoes the transpose below
+    foreach(sdpa_bwd_transpose!, (k, v))
 
-    mask_subgraph = causal ? sdpa_causal_subgraph!(g, skv, sq, hq, b) : nothing
+    # C = B×A on the trailing cuDNN dims, pushed directly: the pattern's
+    # grouped-head folding (h against hk) fails matmul!'s generic batch checks.
+    # Under padding masks each GEMM extent is overridden by the sequence lengths.
+    mm!(A, B, C; m=nothing, n=nothing, k=nothing) =
+        (push!(g.ops, MatmulOp(B, A, C, g.compute_dtype, m, n, k)); C)
+    virt(name, dims) = tensor!(g; dims, dtype=nothing, virtual=true, name)
+    # virtual transpose of the leading two dims, narrowed to the io dtype
+    transposed(x, name) = begin
+        n1, n2, n3, n4 = x.dims
+        reshape!(g, x; dims=(Int(n2), Int(n1), n3, n4),
+                 strides=(Int(n1), 1, n1 * n2, n1 * n2 * n3), dtype=iodt, name)
+    end
 
-    push!(g.ops, SDPABwdOp(q, k, v, o, dO, stats, scale, dQ, dK, dV,
-                           seq_len_q, seq_len_kv, mask_subgraph))
-    return dQ, dK, dV
+    # softmax_sum = rowsum(dO ∘ O) × 1  (the ×1 is the pattern's dropout-scale slot)
+    doo = pointwise!(g, CUDNN_POINTWISE_MUL, dO, o; name="mul_dO_O")
+    ssum = reduction!(g, :add, doo; dims=1, name="reduce_dO_o")
+    pointwise!(g, CUDNN_POINTWISE_MUL, ssum, one_t; y=softmax_sum,
+               name="scale_dropout_inv")
+
+    slq, slkv = seq_len_q, seq_len_kv
+    padded = slq !== nothing
+    ninf = causal || padded ? scalar!(g, Float32; rank=4, name="MaskValue") : nothing
+
+    # P = exp(scale · QKᵀ − stats), padding/causally masked on request
+    s = mm!(q, k, virt("S", (skv, sq, h, b)); m=slq, n=slkv)
+    ss = pointwise!(g, CUDNN_POINTWISE_MUL, s, scale; name="mul_s_attn_scale")
+    sm = pointwise!(g, CUDNN_POINTWISE_SUB, ss, stats; name="sub_s_m")
+    if padded
+        score_dims = (skv, sq, h, b)
+        row = tensor!(g; dims=score_dims, dtype=CUDNN_DATA_INT32, virtual=true,
+                      name="row_idx_padding")
+        col = tensor!(g; dims=score_dims, dtype=CUDNN_DATA_INT32, virtual=true,
+                      name="col_idx_padding")
+        pointwise!(g, CUDNN_POINTWISE_GEN_INDEX, sm; y=row, axis=2,
+                   compute_dtype=CUDNN_DATA_INT32, name="gen_row_idx_padding")
+        pointwise!(g, CUDNN_POINTWISE_GEN_INDEX, sm; y=col, axis=3,
+                   compute_dtype=CUDNN_DATA_INT32, name="gen_col_idx_padding")
+        rmask = tensor!(g; dims=score_dims, dtype=CUDNN_DATA_BOOLEAN, virtual=true,
+                        name="row_mask_padding")
+        cmask = tensor!(g; dims=score_dims, dtype=CUDNN_DATA_BOOLEAN, virtual=true,
+                        name="col_mask_padding")
+        pointwise!(g, CUDNN_POINTWISE_CMP_LT, row, slq; y=rmask,
+                   compute_dtype=CUDNN_DATA_BOOLEAN, name="lt_row_sq_padding")
+        pointwise!(g, CUDNN_POINTWISE_CMP_LT, col, slkv; y=cmask,
+                   compute_dtype=CUDNN_DATA_BOOLEAN, name="lt_col_skv_padding")
+        pmask = tensor!(g; dims=score_dims, dtype=CUDNN_DATA_BOOLEAN, virtual=true,
+                        name="padding_mask")
+        pointwise!(g, CUDNN_POINTWISE_LOGICAL_AND, rmask, cmask; y=pmask,
+                   compute_dtype=CUDNN_DATA_BOOLEAN, name="and_row_col_padding")
+        sm = pointwise!(g, CUDNN_POINTWISE_BINARY_SELECT, sm, ninf, pmask,
+                        name="select_padding")
+    end
+    if causal
+        score_dims = (skv, sq, h, b)
+        row = tensor!(g; dims=score_dims, dtype=CUDNN_DATA_INT32, virtual=true,
+                      name="row_idx")
+        col = tensor!(g; dims=score_dims, dtype=CUDNN_DATA_INT32, virtual=true,
+                      name="col_idx")
+        pointwise!(g, CUDNN_POINTWISE_GEN_INDEX, sm; y=row, axis=2,
+                   compute_dtype=CUDNN_DATA_INT32, name="gen_row_idx")
+        pointwise!(g, CUDNN_POINTWISE_GEN_INDEX, sm; y=col, axis=3,
+                   compute_dtype=CUDNN_DATA_INT32, name="gen_col_idx")
+        mask = tensor!(g; dims=score_dims, dtype=CUDNN_DATA_BOOLEAN, virtual=true,
+                       name="causal_mask")
+        pointwise!(g, CUDNN_POINTWISE_CMP_GE, row, col; y=mask,
+                   compute_dtype=CUDNN_DATA_INT32, name="row_ge_col")
+        sm = pointwise!(g, CUDNN_POINTWISE_BINARY_SELECT, sm, ninf, mask,
+                        name="select_causal")
+    end
+    p = pointwise!(g, CUDNN_POINTWISE_EXP, sm; name="exp_s")
+
+    # grouped-query gradients accumulate per query head into fullhead
+    # workspaces, then fold onto the shared k/v heads by reduction
+    dK_fullhead = dV_fullhead = nothing
+    if hk != h
+        dK_fullhead = tensor!(g; dims=(d, skv, h, b), dtype=iodt, output=true,
+                              name="dKFullhead")
+        dV_fullhead = tensor!(g; dims=(d, skv, h, b), dtype=iodt, output=true,
+                              name="dVFullhead")
+    end
+
+    # dV = Pᵀ dO
+    pt = transposed(p, "PT")
+    if hk == h
+        mm!(pt, dO, dV; m=slkv, k=slq)
+    else
+        mm!(pt, dO, dV_fullhead; m=slkv, k=slq)
+        push!(g.ops, ReductionOp(reduction_mode(:add), dV_fullhead, dV,
+                                 g.compute_dtype, false))
+    end
+
+    # dS = scale · P ∘ (dO Vᵀ − softmax_sum)
+    dp = mm!(dO, v, virt("dP", (skv, sq, h, b)); m=slq, n=slkv)
+    dps = pointwise!(g, CUDNN_POINTWISE_SUB, dp, softmax_sum;
+                     name="sub_dP_softmax_sum")
+    ds0 = pointwise!(g, CUDNN_POINTWISE_MUL, dps, p; name="mul_dP_exp_s")
+    ds = pointwise!(g, CUDNN_POINTWISE_MUL, ds0, scale; name="mul_dS_attn_scale")
+
+    # dK = dSᵀ Q
+    dst = transposed(ds, "dST")
+    if hk == h
+        mm!(dst, q, dK; m=slkv, k=slq)
+    else
+        mm!(dst, q, dK_fullhead; m=slkv, k=slq)
+        push!(g.ops, ReductionOp(reduction_mode(:add), dK_fullhead, dK,
+                                 g.compute_dtype, false))
+    end
+
+    # dQ = dS K, accumulated in Float32 and cast to the io dtype
+    kview = reshape!(g, k; dims=(d, skv, hk, b), strides=kstrides, dtype=iodt,
+                     name="Kview")
+    mm!(ds, kview, dQ_accum; m=slq, k=slkv)
+    pointwise!(g, CUDNN_POINTWISE_IDENTITY, dQ_accum; y=dQ, name="identity_dQ")
+
+    return dQ, dK, dV, softmax_sum, dQ_accum, dK_fullhead, dV_fullhead
 end
 
 function lower(op::PointwiseOp, ctx::LoweringContext)
@@ -1098,7 +1265,13 @@ end
 
 function lower(op::MatmulOp, ctx::LoweringContext)
     matdesc = track!(ctx, matmul_descriptor(compute_type=op.compute_dtype))
-    matmul_operation(matdesc, desc(ctx, op.b), desc(ctx, op.a), desc(ctx, op.c))
+    matmul_operation(matdesc, desc(ctx, op.b), desc(ctx, op.a), desc(ctx, op.c);
+                     m_override=op.m_override === nothing ? nothing :
+                                desc(ctx, op.m_override),
+                     n_override=op.n_override === nothing ? nothing :
+                                desc(ctx, op.n_override),
+                     k_override=op.k_override === nothing ? nothing :
+                                desc(ctx, op.k_override))
 end
 
 function lower(op::BlockScaleDequantizeOp, ctx::LoweringContext)
@@ -1240,25 +1413,13 @@ function lower(op::SDPAFwdOp, ctx::LoweringContext)
     end
 end
 
-function lower(op::SDPABwdOp, ctx::LoweringContext)
-    make_descriptor(:operation_sdpa_bwd) do d
-        d[:qdesc] = desc(ctx, op.q)
-        d[:kdesc] = desc(ctx, op.k)
-        d[:vdesc] = desc(ctx, op.v)
-        d[:odesc] = desc(ctx, op.o)
-        d[:doddesc] = desc(ctx, op.dO)
-        d[:statsdesc] = desc(ctx, op.stats)
-        d[:scaledesc] = desc(ctx, op.scale)
-        d[:dqdesc] = desc(ctx, op.dQ)
-        d[:dkdesc] = desc(ctx, op.dK)
-        d[:dvdesc] = desc(ctx, op.dV)
-        op.seq_len_q === nothing || (d[:seq_len_qdesc] = desc(ctx, op.seq_len_q))
-        op.seq_len_kv === nothing || (d[:seq_len_kvdesc] = desc(ctx, op.seq_len_kv))
-        op.mask_subgraph === nothing ||
-            lower_sdpa_mask_subgraph!(d, ctx, op.mask_subgraph)
+function lower(op::ReshapeOp, ctx::LoweringContext)
+    make_descriptor(:operation_reshape) do d
+        d[:xdesc] = desc(ctx, op.x)
+        d[:ydesc] = desc(ctx, op.y)
     end
 end
 
-@public pointwise!, matmul!, reduction!, conv_fprop!, conv_dgrad!, conv_wgrad!,
-        resample_fwd!, resample_bwd!, norm_fwd!, norm_bwd!, sdpa_fwd!, sdpa_bwd!,
-        block_scale_dequantize!, block_scale_quantize!
+@public pointwise!, matmul!, reduction!, reshape!, conv_fprop!, conv_dgrad!,
+        conv_wgrad!, resample_fwd!, resample_bwd!, norm_fwd!, norm_bwd!,
+        sdpa_fwd!, sdpa_bwd!, block_scale_dequantize!, block_scale_quantize!

--- a/lib/cudnn/src/ops/attention.jl
+++ b/lib/cudnn/src/ops/attention.jl
@@ -13,10 +13,12 @@ function attention_dims(q, k, v, out)
     return d, hq, sq, skv, b
 end
 
+# stats uses the (1, s, h, b) packing the backward's spill buffers require;
+# the forward writes it through strides at no cost
 function attention_stats_dims(stats, h, sq, b)
     stats === nothing && return
-    size(stats) == (1, h, sq, b) ||
-        throw(DimensionMismatch("stats must have size $((1, h, sq, b)), got $(size(stats))"))
+    size(stats) == (1, sq, h, b) ||
+        throw(DimensionMismatch("stats must have size $((1, sq, h, b)), got $(size(stats))"))
     eltype(stats) == Float32 ||
         throw(ArgumentError("stats must be a Float32 DenseCuArray"))
     return
@@ -78,8 +80,11 @@ function build_attention_graph(out, q, k, v, stats, seq_len_q, seq_len_kv, causa
     tv = tensor!(g, v; name="V")
     to = tensor!(g, out; name="O", output=true)
     ts = scalar!(g, Float32; rank=4, name="Scale")
+    # the (1, sq, h, b) stats buffer, declared on sdpa_fwd!'s (1, h, sq, b) dims
+    _, h, sq, _ = size(q)
     tstats = stats === nothing ? nothing :
-             tensor!(g, stats; name="Stats", output=true)
+             tensor!(g; dims=(1, h, sq, size(q, 4)), strides=(1, sq, 1, sq * h),
+                     dtype=Float32, name="Stats", output=true)
     tseqq = seq_len_q === nothing ? nothing :
             tensor!(g, seq_len_q; name="SeqLenQ")
     tseqkv = seq_len_kv === nothing ? nothing :
@@ -89,24 +94,28 @@ function build_attention_graph(out, q, k, v, stats, seq_len_q, seq_len_kv, causa
     build!(g; deterministic, math_mode, max_workspace)
 end
 
-function build_attention_backward_graph(dq, dk, dv, dO, q, k, v, o, stats, seq_len_q,
-                                         seq_len_kv, causal; deterministic, math_mode,
-                                         max_workspace)
-    g = Graph(io_dtype=eltype(q), intermediate_dtype=Float32, compute_dtype=Float32)
-    tq = tensor!(g, q; name="Q")
-    tk = tensor!(g, k; name="K")
-    tv = tensor!(g, v; name="V")
-    to = tensor!(g, o; name="O")
-    tdO = tensor!(g, dO; name="dO")
-    tstats = tensor!(g, stats; name="Stats")
-    tdq = tensor!(g, dq; name="dQ", output=true)
-    tdk = tensor!(g, dk; name="dK", output=true)
-    tdv = tensor!(g, dv; name="dV", output=true)
+function build_attention_backward_graph(::Type{T}, d, h, hk, sq, skv, b, causal,
+                                        padded; deterministic, math_mode,
+                                        max_workspace) where {T}
+    g = Graph(io_dtype=T, intermediate_dtype=Float32, compute_dtype=Float32)
+    # canonical (d, h, s, b) buffers bind through transposed strides for free
+    io(name, s, nh; output=false) = tensor!(g; dims=(d, s, nh, b),
+                                            strides=(1, d * nh, d, d * nh * s),
+                                            dtype=T, output, name)
+    tq = io("Q", sq, h)
+    tk = io("K", skv, hk)
+    tv = io("V", skv, hk)
+    to = io("O", sq, h)
+    tdO = io("dO", sq, h)
+    tstats = tensor!(g; dims=(1, sq, h, b), dtype=Float32, name="Stats")
+    tdq = io("dQ", sq, h; output=true)
+    tdk = io("dK", skv, hk; output=true)
+    tdv = io("dV", skv, hk; output=true)
     ts = scalar!(g, Float32; rank=4, name="Scale")
-    tseqq = seq_len_q === nothing ? nothing :
-            tensor!(g, seq_len_q; name="SeqLenQ")
-    tseqkv = seq_len_kv === nothing ? nothing :
-             tensor!(g, seq_len_kv; name="SeqLenKV")
+    tseqq = padded ? tensor!(g; dims=(1, 1, 1, b), dtype=Int32, name="SeqLenQ") :
+            nothing
+    tseqkv = padded ? tensor!(g; dims=(1, 1, 1, b), dtype=Int32, name="SeqLenKV") :
+             nothing
     sdpa_bwd!(g, tq, tk, tv, to, tdO, tstats; dQ=tdq, dK=tdk, dV=tdv, scale=ts,
               seq_len_q=tseqq, seq_len_kv=tseqkv, causal)
     build!(g; deterministic, math_mode, max_workspace)
@@ -175,6 +184,8 @@ function attention_backward!(dq::DenseCuArray{T,4}, dk::DenseCuArray{T,4},
         throw(ArgumentError("attention_backward! does not support bias"))
     isempty(dq) && isempty(dk) && isempty(dv) && return dq, dk, dv
     d, h, sq, skv, b = attention_dims(q, k, v, o)
+    hk = size(k, 2)
+    attention_lengths_dims(seq_len_q, seq_len_kv, b)
     size(dO) == size(q) ||
         throw(DimensionMismatch("dO must have size $(size(q)), got $(size(dO))"))
     size(dq) == size(q) ||
@@ -184,7 +195,6 @@ function attention_backward!(dq::DenseCuArray{T,4}, dk::DenseCuArray{T,4},
     size(dv) == size(v) ||
         throw(DimensionMismatch("dV must have size $(size(v)), got $(size(dv))"))
     attention_stats_dims(stats, h, sq, b)
-    attention_lengths_dims(seq_len_q, seq_len_kv, b)
     d % 8 == 0 || throw(ArgumentError("head dimension must be a multiple of 8, got $d"))
     d <= 256 || throw(ArgumentError("head dimension must be <= 256, got $d"))
 
@@ -192,10 +202,14 @@ function attention_backward!(dq::DenseCuArray{T,4}, dk::DenseCuArray{T,4},
                                   seq_len_kv, causal, deterministic, math_mode,
                                   max_workspace)
     g = cached_graph(key) do
-        build_attention_backward_graph(dq, dk, dv, dO, q, k, v, o, stats, seq_len_q,
-                                        seq_len_kv, causal; deterministic, math_mode,
-                                        max_workspace)
+        build_attention_backward_graph(T, d, h, hk, sq, skv, b, causal,
+                                       seq_len_q !== nothing;
+                                       deterministic, math_mode, max_workspace)
     end
+
+    # workspace outputs the composite pattern requires, scratch per call
+    softmax_sum = CUDACore.zeros(Float32, 1, sq, h, b)
+    dQ_accum = CUDACore.zeros(Float32, d, sq, h, b)
 
     bindings = IdDict{Tensor,Any}(
         tensor(g, "Q") => q,
@@ -207,11 +221,21 @@ function attention_backward!(dq::DenseCuArray{T,4}, dk::DenseCuArray{T,4},
         tensor(g, "dQ") => dq,
         tensor(g, "dK") => dk,
         tensor(g, "dV") => dv,
+        tensor(g, "SoftmaxSum") => softmax_sum,
+        tensor(g, "dQAccum") => dQ_accum,
         tensor(g, "Scale") => Float32(scale),
+        tensor(g, "One") => 1f0,
     )
-    seq_len_q === nothing || (bindings[tensor(g, "SeqLenQ")] = seq_len_q)
-    seq_len_kv === nothing || (bindings[tensor(g, "SeqLenKV")] = seq_len_kv)
-    causal && (bindings[tensor(g, "MaskValue")] = Float32(-Inf))
+    (causal || seq_len_q !== nothing) &&
+        (bindings[tensor(g, "MaskValue")] = Float32(-Inf))
+    if seq_len_q !== nothing
+        bindings[tensor(g, "SeqLenQ")] = seq_len_q
+        bindings[tensor(g, "SeqLenKV")] = seq_len_kv
+    end
+    if hk != h
+        bindings[tensor(g, "dKFullhead")] = CUDACore.zeros(T, d, skv, h, b)
+        bindings[tensor(g, "dVFullhead")] = CUDACore.zeros(T, d, skv, h, b)
+    end
     execute!(g, bindings)
     return dq, dk, dv
 end
@@ -283,9 +307,9 @@ function attention_backward_supported(dq::DenseCuArray{T,4}, dk::DenseCuArray{T,
                                  max_workspace)
     try
         cached_graph(key) do
-            build_attention_backward_graph(dq, dk, dv, dO, q, k, v, o, stats, seq_len_q,
-                                           seq_len_kv, causal; deterministic, math_mode,
-                                           max_workspace)
+            build_attention_backward_graph(T, d, h, size(k, 2), sq, skv, b, causal,
+                                           seq_len_q !== nothing;
+                                           deterministic, math_mode, max_workspace)
         end
         return true
     catch e
@@ -303,13 +327,18 @@ end
     attention_backward_supported(dQ, dK, dV, dO, q, k, v, o, stats; kwargs...) -> Bool
 
 Execute fused scaled dot-product attention with tensors shaped
-`(head_dim, heads, sequence_length, batch_size)`.
+`(head_dim, heads, sequence_length, batch_size)`, except `stats`, which is
+shaped `(1, sequence_length, heads, batch_size)`.
 
 Supported inputs are `Float16` and `BFloat16` `DenseCuArray`s. `scale` defaults to
 `1 / sqrt(head_dim)`. Forward can write the Float32 `stats` tensor needed by backward.
-Set `causal=true` for top-left causal forward masking. Dense padding masks are enabled by
-passing Int32 `seq_len_q` and `seq_len_kv` tensors shaped `(1, 1, 1, batch_size)`.
+Set `causal=true` for top-left causal masking. Dense padding masks are enabled by
+passing Int32 `seq_len_q` and `seq_len_kv` tensors shaped `(1, 1, 1, batch_size)`;
+padded backward gradients are defined inside the valid region only.
 `dropout_p` must be zero and `bias` must be `nothing`.
+
+The backward pass builds the composite graph of `sdpa_bwd!` and allocates its
+workspace buffers per call (two more under grouped-query attention).
 
 The support predicates build and cache a plan without executing it.
 """

--- a/lib/cudnn/test/graph.jl
+++ b/lib/cudnn/test/graph.jl
@@ -13,6 +13,7 @@ using cuDNN:
     reduction!,
     resample_bwd!,
     resample_fwd!,
+    reshape!,
     sdpa_bwd!,
     scalar!,
     sdpa_fwd!,
@@ -44,21 +45,100 @@ seqfloat = tensor!(g; dims=(1, 1, 1, 2), dtype=Float32, name="FloatSeqLen")
 @test_throws ArgumentError sdpa_fwd!(g, q, k, v; scale, seq_len_q=seqfloat,
                                      seq_len_kv=seqkv)
 
-dO = tensor!(g; dims=(64, 4, 32, 2), dtype=Float16, name="dO")
-stats = tensor!(g; dims=(1, 4, 32, 2), dtype=Float32, name="Stats")
-dq, dk, dv = sdpa_bwd!(g, q, k, v, o, dO, stats; scale)
-@test dq.dims == q.dims
-@test dk.dims == k.dims
-@test dv.dims == v.dims
-dqc, dkc, dvc = sdpa_bwd!(g, q, k, v, o, dO, stats; scale, causal=true)
-@test dqc.dims == q.dims
-@test dkc.dims == k.dims
-@test dvc.dims == v.dims
-dqp, dkp, dvp = sdpa_bwd!(g, q, k, v, o, dO, stats; scale, seq_len_q=seqq,
-                           seq_len_kv=seqkv)
-@test dqp.dims == q.dims
-@test dkp.dims == k.dims
-@test dvp.dims == v.dims
+# the composite backward uses (d, s, h, b) dims, unlike the forward
+gbwd = Graph(io_dtype=Float16, intermediate_dtype=Float32, compute_dtype=Float32)
+bq = tensor!(gbwd; dims=(64, 32, 4, 2), dtype=Float16, name="Q")
+bk = tensor!(gbwd; dims=(64, 48, 4, 2), dtype=Float16, name="K")
+bv = tensor!(gbwd; dims=(64, 48, 4, 2), dtype=Float16, name="V")
+bo = tensor!(gbwd; dims=(64, 32, 4, 2), dtype=Float16, name="O")
+bdO = tensor!(gbwd; dims=(64, 32, 4, 2), dtype=Float16, name="dO")
+bstats = tensor!(gbwd; dims=(1, 32, 4, 2), dtype=Float32, name="Stats")
+dq, dk, dv, ssum, dqacc = sdpa_bwd!(gbwd, bq, bk, bv, bo, bdO, bstats)
+@test dq.dims == [64, 32, 4, 2]
+@test dk.dims == [64, 48, 4, 2]
+@test dv.dims == [64, 48, 4, 2]
+@test ssum.dims == [1, 32, 4, 2]
+@test ssum.dtype == cuDNN.CUDNN_DATA_FLOAT
+@test dqacc.dims == [64, 32, 4, 2]
+@test dqacc.dtype == cuDNN.CUDNN_DATA_FLOAT
+# k and v were re-presented in place as their transposes
+@test bk.dims == [48, 64, 4, 2]
+@test bk.strides == [64, 1, 64 * 48, 64 * 48 * 4]
+
+gbwdc = Graph(io_dtype=Float16, intermediate_dtype=Float32, compute_dtype=Float32)
+cq = tensor!(gbwdc; dims=(64, 32, 4, 2), dtype=Float16, name="Q")
+ck = tensor!(gbwdc; dims=(64, 48, 4, 2), dtype=Float16, name="K")
+cv = tensor!(gbwdc; dims=(64, 48, 4, 2), dtype=Float16, name="V")
+co = tensor!(gbwdc; dims=(64, 32, 4, 2), dtype=Float16, name="O")
+cdO = tensor!(gbwdc; dims=(64, 32, 4, 2), dtype=Float16, name="dO")
+cstats = tensor!(gbwdc; dims=(1, 32, 4, 2), dtype=Float32, name="Stats")
+cdq, _ = sdpa_bwd!(gbwdc, cq, ck, cv, co, cdO, cstats; causal=true)
+@test cdq.dims == [64, 32, 4, 2]
+@test cuDNN.tensor(gbwdc, "MaskValue").by_value
+
+# grouped queries add fullhead workspaces folded onto the shared k/v heads
+ggqa = Graph(io_dtype=Float16, intermediate_dtype=Float32, compute_dtype=Float32)
+mq = tensor!(ggqa; dims=(64, 32, 4, 2), dtype=Float16, name="Q")
+mk = tensor!(ggqa; dims=(64, 48, 2, 2), dtype=Float16, name="K")
+mv = tensor!(ggqa; dims=(64, 48, 2, 2), dtype=Float16, name="V")
+mo = tensor!(ggqa; dims=(64, 32, 4, 2), dtype=Float16, name="O")
+mdO = tensor!(ggqa; dims=(64, 32, 4, 2), dtype=Float16, name="dO")
+mstats = tensor!(ggqa; dims=(1, 32, 4, 2), dtype=Float32, name="Stats")
+mdq, mdk, mdv, _, _, mdkf, mdvf = sdpa_bwd!(ggqa, mq, mk, mv, mo, mdO, mstats)
+@test mdq.dims == [64, 32, 4, 2]
+@test mdk.dims == [64, 48, 2, 2]
+@test mdv.dims == [64, 48, 2, 2]
+@test mdkf.dims == [64, 48, 4, 2]
+@test mdvf.dims == [64, 48, 4, 2]
+
+# io strides are free: a (d, h, s, b)-packed buffer binds through transposed strides
+gbshd = Graph(io_dtype=Float16, intermediate_dtype=Float32, compute_dtype=Float32)
+tq = tensor!(gbshd; dims=(64, 32, 4, 2), strides=(1, 256, 64, 8192),
+              dtype=Float16, name="Q")
+tk = tensor!(gbshd; dims=(64, 48, 4, 2), strides=(1, 256, 64, 12288),
+             dtype=Float16, name="K")
+tv = tensor!(gbshd; dims=(64, 48, 4, 2), strides=(1, 256, 64, 12288),
+             dtype=Float16, name="V")
+to = tensor!(gbshd; dims=(64, 32, 4, 2), strides=(1, 256, 64, 8192),
+             dtype=Float16, name="O")
+tdO = tensor!(gbshd; dims=(64, 32, 4, 2), strides=(1, 256, 64, 8192),
+              dtype=Float16, name="dO")
+tstats = tensor!(gbshd; dims=(1, 32, 4, 2), dtype=Float32, name="Stats")
+tdq, _ = sdpa_bwd!(gbshd, tq, tk, tv, to, tdO, tstats)
+@test tdq.dims == [64, 32, 4, 2]
+@test tk.strides == [256, 1, 64, 12288]
+
+# rejections: unpaired seq lens, indivisible heads, head dim not innermost,
+# non-packed stats/workspaces
+gbad = Graph(io_dtype=Float16, intermediate_dtype=Float32, compute_dtype=Float32)
+xq = tensor!(gbad; dims=(64, 32, 4, 2), dtype=Float16, name="Q")
+xk = tensor!(gbad; dims=(64, 48, 4, 2), dtype=Float16, name="K")
+xv = tensor!(gbad; dims=(64, 48, 4, 2), dtype=Float16, name="V")
+xo = tensor!(gbad; dims=(64, 32, 4, 2), dtype=Float16, name="O")
+xdO = tensor!(gbad; dims=(64, 32, 4, 2), dtype=Float16, name="dO")
+xstats = tensor!(gbad; dims=(1, 32, 4, 2), dtype=Float32, name="Stats")
+xseqq = tensor!(gbad; dims=(1, 1, 1, 2), dtype=Int32, name="SeqLenQ")
+@test_throws ArgumentError sdpa_bwd!(gbad, xq, xk, xv, xo, xdO, xstats;
+                                     seq_len_q=xseqq)
+kgqa = tensor!(gbad; dims=(64, 48, 3, 2), dtype=Float16, name="Kgqa")
+vgqa = tensor!(gbad; dims=(64, 48, 3, 2), dtype=Float16, name="Vgqa")
+@test_throws DimensionMismatch sdpa_bwd!(gbad, xq, kgqa, vgqa, xo, xdO, xstats)
+qbad = tensor!(gbad; dims=(64, 32, 4, 2), strides=(32, 1, 2048, 8192),
+               dtype=Float16, name="Qbad")
+@test_throws ArgumentError sdpa_bwd!(gbad, qbad, xk, xv, xo, xdO, xstats)
+badstats = tensor!(gbad; dims=(1, 32, 4, 2), strides=(1, 4, 1, 128),
+                   dtype=Float32, name="BadStats")
+@test_throws ArgumentError sdpa_bwd!(gbad, xq, xk, xv, xo, xdO, badstats)
+badsum = tensor!(gbad; dims=(1, 32, 4, 2), strides=(1, 4, 1, 128),
+                 dtype=Float32, name="BadSum")
+@test_throws ArgumentError sdpa_bwd!(gbad, xq, xk, xv, xo, xdO, xstats;
+                                     softmax_sum=badsum)
+
+rsx = tensor!(g; dims=(8, 16, 2), dtype=Float16, name="ReshapeX")
+rsy = reshape!(g, rsx; dims=(16, 8, 2), strides=(8, 1, 128), name="ReshapeY")
+@test rsy.dims == [16, 8, 2]
+@test rsy.virtual
+@test_throws DimensionMismatch reshape!(g, rsx; dims=(4, 4, 2))
 
 a = tensor!(g; dims=(8, 16, 2), dtype=Float16, name="A")
 b = tensor!(g; dims=(16, 32, 2), dtype=Float16, name="B")

--- a/lib/cudnn/test/sdpa.jl
+++ b/lib/cudnn/test/sdpa.jl
@@ -109,10 +109,10 @@ function sdpa_stats_test(T; d=64, sq=32, skv=32, h=4, hk=h, b=2,
 
     ref, refstats = sdpa_ref(q, k, v; scale, causal, stats=true)
     out = similar(q)
-    stats = CUDACore.zeros(Float32, 1, h, sq, b)
+    stats = CUDACore.zeros(Float32, 1, sq, h, b)
     attention!(out, q, k, v; scale, causal, stats)
     @test Array(out) ≈ ref rtol=2e-2
-    @test Array(stats) ≈ refstats rtol=rtol
+    @test Array(stats) ≈ permutedims(refstats, (1, 3, 2, 4)) rtol=rtol
 end
 
 function sdpa_backward_test(T; d=64, sq=32, skv=32, h=4, hk=h, b=2,
@@ -122,7 +122,7 @@ function sdpa_backward_test(T; d=64, sq=32, skv=32, h=4, hk=h, b=2,
     v = cuRAND.randn(T, d, hk, skv, b) ./ 4
     dO = cuRAND.randn(T, d, h, sq, b) ./ 4
     o = similar(q)
-    stats = CUDACore.zeros(Float32, 1, h, sq, b)
+    stats = CUDACore.zeros(Float32, 1, sq, h, b)
     attention!(o, q, k, v; scale, causal, stats)
 
     refdq, refdk, refdv = sdpa_bwd_ref(q, k, v, dO; scale, causal)
@@ -152,7 +152,7 @@ function sdpa_padding_test(T; d=64, sq=64, skv=64, h=4, hk=2, b=2,
 
     ref = sdpa_ref(q, k, v; scale, seq_len_q, seq_len_kv)
     out = similar(q)
-    stats = CUDACore.zeros(Float32, 1, h, sq, b)
+    stats = CUDACore.zeros(Float32, 1, sq, h, b)
     if !cuDNN.attention_supported(out, q, k, v; stats, seq_len_q, seq_len_kv)
         @test_skip "SDPA sequence-length engine is unsupported on this device"
         return
@@ -162,21 +162,26 @@ function sdpa_padding_test(T; d=64, sq=64, skv=64, h=4, hk=2, b=2,
     expected = zero_padded_queries!(copy(ref), seq_len_q)
     @test got ≈ expected rtol=rtol
 
+    # padded backward: gradients compare inside the valid region; out-of-range
+    # rows are clamped away by the GEMM overrides and stay zero
     dO = cuRAND.randn(T, d, h, sq, b) ./ 4
     refdq, refdk, refdv = sdpa_bwd_ref(q, k, v, dO; scale, seq_len_q, seq_len_kv)
-    dq, dk, dv = similar(q), similar(k), similar(v)
+    dq = CUDACore.zeros(T, d, h, sq, b)
+    dk = CUDACore.zeros(T, d, hk, skv, b)
+    dv = CUDACore.zeros(T, d, hk, skv, b)
     if !cuDNN.attention_backward_supported(dq, dk, dv, dO, q, k, v, out, stats;
                                            seq_len_q, seq_len_kv)
-        @test_skip "SDPA sequence-length backward engine is unsupported on this device"
+        @test_skip "SDPA padded backward engine is unsupported on this device"
         return
     end
     attention_backward!(dq, dk, dv, dO, q, k, v, out, stats; scale, seq_len_q,
                         seq_len_kv)
-    gotdq = zero_padded_queries!(Array(dq), seq_len_q)
-    refdq = zero_padded_queries!(refdq, seq_len_q)
-    @test gotdq ≈ refdq rtol=rtol
-    @test Array(dk) ≈ refdk rtol=rtol
-    @test Array(dv) ≈ refdv rtol=rtol
+    @test zero_padded_queries!(Array(dq), seq_len_q) ≈
+          zero_padded_queries!(refdq, seq_len_q) rtol=rtol
+    @test zero_padded_queries!(Array(dk), seq_len_kv) ≈
+          zero_padded_queries!(refdk, seq_len_kv) rtol=rtol
+    @test zero_padded_queries!(Array(dv), seq_len_kv) ≈
+          zero_padded_queries!(refdv, seq_len_kv) rtol=rtol
 end
 
 if capability(device()) >= v"8.0"
@@ -194,6 +199,7 @@ if capability(device()) >= v"8.0"
         sdpa_backward_test(T)
         sdpa_backward_test(T; h=4, hk=2)
         sdpa_backward_test(T; causal=true)
+        sdpa_backward_test(T; h=4, hk=2, causal=true)
         sdpa_padding_test(T)
     end
 


### PR DESCRIPTION
The unified `SDPA_BWD` descriptor has no engines on any hardware I've tested  (`sm_121` and `sm_100`, backends 9.24 and 9.26-preview). The fMHA backward engines instead pattern-match the composite graph that [cudnn-frontend](https://github.com/NVIDIA/cudnn-frontend)'s CompositeSDPABackwardNode expands to. This rewrites `sdpa_bwd!` as that spelling and makes `attention_backward!` work for the first time.

- `sdpa_bwd!` builds the composite graph: recomputation matmuls, softmax primitives, RESHAPE virtual transposes, and two non-virtual fp32 workspace outputs (`softmax_sum`, `dQ_accum`). Grouped-query attention is supported via the frontend's fullhead mechanism (per-query-head accumulation + head-folding reduction). io tensors accept any head-dim-innermost strides. Stats and the workspaces require dense packing. The engines accept other strides at build time and silently corrupt gradients (measured; cudnn-frontend hardcodes the same layouts).
- `reshape!`/`ReshapeOp`: the RESHAPE backend op, the virtual-transpose mechanism of pattern-matched graphs.
- Operation-graph mode: the type-based stamping heuristic is removed — every graph builds unstamped (AUTO), matching cudnn-frontend behavior, since an explicit mode only scopes engines out (a wrong stamp is precisely what hid the fMHA match from the composite graph). `build!` gains an opt-in `mode` kwarg. Verified outcome-identical across the suite; build-time cost of AUTO measured at noise level.
- Eager verbs are zero-copy: both passes take canonical `(head_dim, heads, seq, batch)` arrays, the backward binding them through transposed-stride declarations.

Breaking since #3191:
- `sdpa_bwd!`'s contract changes (dims `(d, s, h, b)`, 7-tuple return, in-place k/v transpose, non-virtual outputs). The previous unified emission could not execute on any known hardware.
- The eager stats layout changes from `(1, h, s, b)` to `(1, s, h, b)` — the packing the backward engines require of their spill buffers and cudnn-frontend's only dense stats format; the forward writes it through strides at no cost. The old layout only survived because nothing ever read stats back.

Grouped-query attention (frontend fullhead mechanism: per-query-head accumulation + head-folding reduction) and dense padding masks (padding score-modifier chain + GEMM extent overrides on every matmul; `MatmulOp` gains optional M/N/K override tensors) are both supported. Padded backward gradients are defined inside the valid region. Verified on sm_121 (GB10, cuDNN 9.24): dense, causal, GQA, causal-GQA, and padded-GQA backward against analytic references, Float16 and BFloat16; suite 856 pass / 2 broken with no SDPA skips.

Made with Claude Code