### PR TITLE
cuDNN: accept F8_128x4 scale tiles on any blocked dimension

### DIFF
--- a/lib/cudnn/src/graph/ops.jl
+++ b/lib/cudnn/src/graph/ops.jl
@@ -846,17 +846,24 @@ function swizzled_scale_dims(xdims, block_size, order)
 end
 
 # engines address whole tiles regardless of the declared extents; cuDNN accepts
-# unpadded declarations at build time but crashes the context at execution
+# unpadded declarations at build time but crashes the context at execution.
+# Tile roles follow the quantization semantics, not storage order: the blocked
+# axis's scale count pads to a multiple of 4, its partner axis to 128.
 function check_swizzled_scale_dims(fname, x::Tensor, scale::Tensor, block_size)
-    order = [i for i in sortperm(scale.strides) if scale.dims[i] != 1]
-    expected = swizzled_scale_dims(x.dims, block_size, order)
-    scale.dims == expected || throw(DimensionMismatch(
+    round_up(v, m) = cld(v, m) * m
+    for p in eachindex(x.dims), q in eachindex(x.dims)
+        p == q && continue
+        expected = collect(Int64, x.dims)
+        expected[p] = round_up(cld(expected[p], block_size), 4)
+        expected[q] = round_up(expected[q], 128)
+        scale.dims == expected && return nothing
+    end
+    throw(DimensionMismatch(
         "$fname F8_128x4 scale dimensions $(Tuple(scale.dims)) do not tile data " *
-        "dimensions $(Tuple(x.dims)) with block_size=$block_size; the swizzled layout " *
-        "needs whole 128×4 tiles: cld(extent, block_size) scales rounded up to a " *
-        "multiple of 4 along the packed dimension and the next dimension rounded up " *
-        "to a multiple of 128, i.e. $(Tuple(expected))"))
-    return nothing
+        "dimensions $(Tuple(x.dims)) with block_size=$block_size along any dimension; " *
+        "the swizzled layout needs whole 128×4 tiles: one dimension divided into " *
+        "cld(extent, block_size) blocks and rounded up to a multiple of 4, with a " *
+        "partner dimension rounded up to a multiple of 128"))
 end
 
 function check_block_scale_dims(fname, x::Tensor, scale::Tensor, block_size)

--- a/lib/cudnn/test/graph_ops.jl
+++ b/lib/cudnn/test/graph_ops.jl
@@ -1,6 +1,7 @@
 using cuDNN:
     block_scale_dequantize!,
     block_scale_quantize!,
+    build!,
     conv_dgrad!,
     conv_fprop!,
     conv_wgrad!,
@@ -316,6 +317,77 @@ let K=128, M=128, N=64
     unpadded = tensor!(g2; dims=(K ÷ 32, N, 1), dtype=CUDNN_DATA_FP8_E8M0,
                        reordering=CUDNN_TENSOR_REORDERING_F8_128x4)
     @test_throws DimensionMismatch block_scale_dequantize!(g2, b, unpadded; block_size=32)
+end
+
+# the MXFP8-attention V orientation (cudnn-frontend's mxfp8 sample): blocked
+# along the sequence dim, head dim innermost
+let s=288, dh=64
+    g = Graph()
+    v = tensor!(g; dims=(dh, s, 1), dtype=CUDNN_DATA_FP8_E4M3)
+    vs = tensor!(g; dims=(128, 12, 1), dtype=CUDNN_DATA_FP8_E8M0,
+                 reordering=CUDNN_TENSOR_REORDERING_F8_128x4)
+    @test block_scale_dequantize!(g, v, vs; block_size=32).dims == [dh, s, 1]
+    # the same orientation without the whole-tile padding: rejected
+    bad = tensor!(g; dims=(dh, cld(s, 32), 1), dtype=CUDNN_DATA_FP8_E8M0,
+                  reordering=CUDNN_TENSOR_REORDERING_F8_128x4)
+    @test_throws DimensionMismatch block_scale_dequantize!(g, v, bad; block_size=32)
+end
+
+# a transposed (1, k) NVFP4 vector operand: the unit partner axis still
+# pads to a whole tile
+let k=32
+    g = Graph()
+    w = tensor!(g; dims=(1, k, 1), strides=(1, 1, k), dtype=CUDNN_DATA_FP8_E4M3)
+    ws = tensor!(g; dims=(128, 4, 1), dtype=CUDNN_DATA_FP8_E4M3,
+                 reordering=CUDNN_TENSOR_REORDERING_F8_128x4)
+    @test block_scale_dequantize!(g, w, ws; block_size=16).dims == [1, k, 1]
+    bad = tensor!(g; dims=(1, cld(k, 16), 1), dtype=CUDNN_DATA_FP8_E4M3,
+                  reordering=CUDNN_TENSOR_REORDERING_F8_128x4)
+    @test_throws DimensionMismatch block_scale_dequantize!(g, w, bad; block_size=16)
+end
+
+# fp8 buffers have no Julia array type; bind raw bytes through the
+# checked_array_pointer seam
+struct RawBytes{A}
+    a::A
+end
+cuDNN.checked_array_pointer(t::cuDNN.Tensor, r::RawBytes) = pointer(r.a)
+
+# execute the V orientation. Uniform scales are swizzle-invariant, so bytes
+# bind without the tile layout; doubling both scales must quadruple the
+# product. E4M3: 1.0 = 0x38, 1.5 = 0x3c; E8M0: 0x7f = 2^0.
+if blockscale_claimed
+    let M=128, K=128, N=64, MP=128, KS=4, NP=128
+        g = Graph(intermediate_dtype=Float32, compute_dtype=Float32)
+        a = tensor!(g; dims=(M, K, 1), strides=(K, 1, M * K),
+                    dtype=CUDNN_DATA_FP8_E4M3, name="A")
+        as = tensor!(g; dims=(MP, KS, 1), strides=(KS, 1, MP * KS),
+                     dtype=CUDNN_DATA_FP8_E8M0, name="A.scale",
+                     reordering=CUDNN_TENSOR_REORDERING_F8_128x4)
+        da = block_scale_dequantize!(g, a, as; block_size=32)
+        b = tensor!(g; dims=(K, N, 1), strides=(N, 1, K * N),
+                    dtype=CUDNN_DATA_FP8_E4M3, name="B")
+        bs = tensor!(g; dims=(KS, NP, 1), dtype=CUDNN_DATA_FP8_E8M0, name="B.scale",
+                     reordering=CUDNN_TENSOR_REORDERING_F8_128x4)
+        db = block_scale_dequantize!(g, b, bs; block_size=32)
+        c = matmul!(g, da, db)
+        output!(c)
+        build!(g)
+
+        abuf = CUDACore.fill(0x38, K, M, 1)
+        bbuf = CuArray([iseven(k + n) ? 0x38 : 0x3c for n in 1:N, k in 1:K, _ in 1:1])
+        Bref = [iseven(k + n) ? 1.0f0 : 1.5f0 for k in 1:K, n in 1:N]
+        refC = ones(Float32, M, K) * Bref
+        for (scale_byte, factor) in ((0x7f, 1.0f0), (0x80, 2.0f0))
+            asbuf = CUDACore.fill(scale_byte, MP * KS)
+            bsbuf = CUDACore.fill(scale_byte, KS * NP)
+            cbuf = CUDACore.zeros(Float32, M, N, 1)
+            execute!(g, Dict{cuDNN.Tensor,Any}(a => RawBytes(abuf), as => RawBytes(asbuf),
+                                               b => RawBytes(bbuf), bs => RawBytes(bsbuf),
+                                               c => cbuf))
+            @test Array(cbuf)[:, :, 1] ≈ factor^2 .* refC
+        end
+    end
 end
 
 let K=160, M=128, N=128


### PR DESCRIPTION
In #3230, `check_swizzled_scale_dims` validated F8_128x4 swizzled scale tensors positionally: innermost scale dimension padded to a multiple of 4, its partner to a multiple of 128. That happens to describe every ordinary matmul operand, where the blocked contraction dim is storage-innermost. The blocked axis's scale count pads to 4 and the partner axis to 128, whatever the storage order. The two readings diverge once an operand is blocked along a non-innermost axis, which is exactly what the MXFP8 attention recipe does to V (block-scaled along the sequence axis, head dim innermost). [cudnn-frontend's mxfp8 sample](https://github.com/NVIDIA/cudnn-frontend/blob/c2f4357/samples/cpp/sdpa/mxfp8_fwd.cpp#L112-L123) declares SF_V as `{b, h, round4(⌈s/32⌉), round128(d)}` and notes the declared inner stride "is not load-bearing". The kernel reads scales through the F8_128x4 reordering, so the old check would have rejected NVIDIA's own shapes.

- `check_swizzled_scale_dims` now tries (blocked, partner) dimension pairs; scale strides are no longer consulted.
- Unit extents participate: a `(1, k)` vector operand's partner axis has extent 1 and still pads to a whole 128-tile. Matching is exact equality against the declared dims, so admitting unit-extent pairs cannot false-accept — it only stops false-rejecting vector operands (a transposed NVFP4 gemv operand is the practical case).
- Whole-tile padding stays enforced: engines address whole 128×4 tiles regardless of declared extents, and unpadded declarations build fine but crash the context at execution (measured).

Tested with construction accept/reject cases for the frontend sample's V shape and the vector orientation, plus an execution test gated on engine availability: a pair-dequant matmul with the B operand's blocked axis not innermost, crafted E4M3/E8M0 bytes bound through the `checked_array_pointer` seam, checked against an exact reference. Uniform scales are invariant under the swizzle, so the bytes bind without reproducing the tile layout, and doubling both operands' scales must exactly quadruple the product — it does, to the bit, on sm_121 (GB10, cuDNN 9.24), where engines exist for both storage orientations.

Made with Claude Code

If this could be squeezed in before v6.3 I would be happy, as it's the last fix of my recent spree, but since it is a minor fix that only enables MXFP8 attention (which I have yet to test due to B200 availability), it's not too urgent. 😊

[only subpackages]