### PR TITLE
[release-6.2] Backports for 6.2

### DIFF
--- a/CUDACore/ext/EnzymeCoreExt.jl
+++ b/CUDACore/ext/EnzymeCoreExt.jl
@@ -37,6 +37,13 @@ function metaf(config, fn, args::Vararg{Any, N}) where N
 end
 
 function EnzymeCore.EnzymeRules.forward(config, ofn::Const{typeof(cufunction)},
+                                        ::Type{<:Const}, f::Const{F},
+                                        tt::Const{TT}; kwargs...) where {F,TT}
+    res = ofn.val(f.val, tt.val; kwargs...)
+    return res
+end
+
+function EnzymeCore.EnzymeRules.forward(config, ofn::Const{typeof(cufunction)},
                                         ::Type{<:Duplicated}, f::Const{F},
                                         tt::Const{TT}; kwargs...) where {F,TT}
     res = ofn.val(f.val, tt.val; kwargs...)

--- a/CUDACore/ext/EnzymeCoreExt.jl
+++ b/CUDACore/ext/EnzymeCoreExt.jl
@@ -89,12 +89,19 @@ function EnzymeCore.EnzymeRules.augmented_primal(config, ofn::Const{typeof(cudac
     end
     
     shadow = if EnzymeRules.needs_shadow(config)
-        if EnzymeRules.width(config) == 1
+        if EnzymeRules.width(config) == 1 && !(IT <: Const)
             ofn.val(x.dval)
-        else
+        elseif EnzymeRules.width(config) == 1 && IT <: Const
+            ofn.val(EnzymeCore.make_zero(x.val))
+        elseif !(IT <: Const)
           ntuple(Val(EnzymeRules.width(config))) do i
               Base.@_inline_meta
               ofn.val(x.dval[i])
+          end
+        else
+          ntuple(Val(EnzymeRules.width(config))) do i
+              Base.@_inline_meta
+              ofn.val(EnzymeCore.make_zero(x.val[i]))
           end
         end
     else

--- a/CUDACore/src/device/intrinsics/math.jl
+++ b/CUDACore/src/device/intrinsics/math.jl
@@ -375,7 +375,7 @@ end
     y == 1 && return x
     y == 2 && return x*x
     y == 3 && return x*x*x
-    x ^ y  # no fast variant for Float64; uses __nv_powi
+    x ^ y  # no fast variant for Float64; uses __nv_pow
 end
 @device_override @assume_effects :foldable @inline function FastMath.pow_fast(x::Float32, y::Integer)
     y == -1 && return inv(x)
@@ -393,9 +393,15 @@ end
     y == 3 && return x*x*x
     Float16(FastMath.pow_fast(Float32(x), Float32(y)))
 end
-@device_override Base.:(^)(x::Float64, y::Int32) = ccall("extern __nv_powi", llvmcall, Cdouble, (Cdouble, Int32), x, y)
-@device_override Base.:(^)(x::Float32, y::Int32) = ccall("extern __nv_powif", llvmcall, Cfloat, (Cfloat, Int32), x, y)
-@device_override @assume_effects :foldable @inline function Base.:(^)(x::Float32, y::Int64)
+
+# stay with Base's semantics and avoid the drift of libdevice's integer powers,
+# which square at the working precision.
+@device_function powi(x::Float64, y::Int32) = ccall("extern __nv_powi", llvmcall, Cdouble, (Cdouble, Int32), x, y)
+@device_function powi(x::Float32, y::Int32) = ccall("extern __nv_powif", llvmcall, Cfloat, (Cfloat, Int32), x, y)
+
+# Base's `^(::Float, ::Integer)` calls `power_by_squaring`, whose
+# `trailing_zeros` loop emits `cttz_int`, so convert and defer to `__nv_pow`.
+@device_override @assume_effects :foldable @inline function Base.:(^)(x::Float32, y::Integer)
     y == -1 && return inv(x)
     y == 0 && return one(x)
     y == 1 && return x
@@ -403,7 +409,7 @@ end
     y == 3 && return x*x*x
     x ^ Float32(y)
 end
-@device_override @assume_effects :foldable @inline function Base.:(^)(x::Float64, y::Int64)
+@device_override @assume_effects :foldable @inline function Base.:(^)(x::Float64, y::Integer)
     y == -1 && return inv(x)
     y == 0 && return one(x)
     y == 1 && return x

--- a/CUDACore/src/mapreduce.jl
+++ b/CUDACore/src/mapreduce.jl
@@ -182,6 +182,7 @@ function GPUArrays.mapreducedim!(f::F, op::OP, R::AnyCuArray{T},
                          Float16, Float32, Float64,
                          ComplexF16, ComplexF32, ComplexF64}
 
+    R_old = R
     # add singleton dimensions to the output container, if needed
     if ndims(R) < ndims(A)
         dims = Base.fill_to_length(size(R), 1, Val(ndims(A)))
@@ -206,7 +207,7 @@ function GPUArrays.mapreducedim!(f::F, op::OP, R::AnyCuArray{T},
         threads = kernel_config.threads
         blocks = cld(length(Rother), threads)
         kernel(args...; threads, blocks)
-        return R
+        return R_old
     end
 
     # how many threads do we want?
@@ -291,5 +292,5 @@ function GPUArrays.mapreducedim!(f::F, op::OP, R::AnyCuArray{T},
         GPUArrays.mapreducedim!(identity, op, R, partial; init)
     end
 
-    return R
+    return R_old
 end

--- a/CUDATools/src/profile.jl
+++ b/CUDATools/src/profile.jl
@@ -144,6 +144,9 @@ function filtermask(t::NamedTuple, mask::AbstractVector{Bool})
     NamedTuple{keys(t)}(Tuple(col[mask] for col in t))
 end
 
+# NVTX colors are ARGB, while Crayons expects RGB.
+nvtx_crayon(color::UInt32) = Crayon(; foreground=color & 0x00ffffff)
+
 #
 # external profiler
 #
@@ -1072,7 +1075,7 @@ function Base.show(io::IO, results::ProfileResults)
             for color in unique(df.color)
                 if color !== nothing
                     ids = Set(df.id[isequal.(df.color, color)])
-                    highlighter = TextHighlighter(Crayon(; foreground=color)) do data, i, j
+                    highlighter = TextHighlighter(nvtx_crayon(color)) do data, i, j
                         keys(data)[j] in (:name, :domain) && data.id[i] in ids
                     end
                     push!(color_highlighters, highlighter)

--- a/docs/src/usage/array.md
+++ b/docs/src/usage/array.md
@@ -119,7 +119,7 @@ julia> b = CUDA.zeros(1)
  0.0
 
 julia> Base.mapreducedim!(identity, +, b, a)
-1×1 CuArray{Float32, 2, CUDACore.DeviceMemory}:
+1-element CuArray{Float32, 1, CUDACore.DeviceMemory}:
  6.0
 ```
 

--- a/lib/cublas/src/linalg.jl
+++ b/lib/cublas/src/linalg.jl
@@ -437,9 +437,9 @@ function LinearAlgebra.generic_trimatmul!(C::StridedCuMatrix{T}, uplocA, isunitc
     return C
 end
 
-LinearAlgebra.generic_trimatdiv!(C::StridedCuMatrix{T}, uploc, isunitc, tfun::Function, A::StridedCuMatrix{T}, B::AbstractMatrix{T}) where {T<:CublasFloat} =
+LinearAlgebra.generic_trimatdiv!(C::StridedCuMatrix{T}, uploc, isunitc, tfun::Function, A::StridedCuMatrix{T}, B::AdjOrTransOrCuMatrix{T}) where {T<:CublasFloat} =
     trsm!('L', uploc, tfun === identity ? 'N' : tfun === transpose ? 'T' : 'C', isunitc, one(T), A, C === B ? C : copyto!(C, B))
-LinearAlgebra.generic_mattridiv!(C::StridedCuMatrix{T}, uploc, isunitc, tfun::Function, A::AbstractMatrix{T}, B::StridedCuMatrix{T}) where {T<:CublasFloat} =
+LinearAlgebra.generic_mattridiv!(C::StridedCuMatrix{T}, uploc, isunitc, tfun::Function, A::AdjOrTransOrCuMatrix{T}, B::StridedCuMatrix{T}) where {T<:CublasFloat} =
     trsm!('R', uploc, tfun === identity ? 'N' : tfun === transpose ? 'T' : 'C', isunitc, one(T), B, C === A ? C : copyto!(C, A))
 
 # Matrix inverse

--- a/lib/cusolver/src/linalg.jl
+++ b/lib/cusolver/src/linalg.jl
@@ -298,7 +298,7 @@ end
 
 function LinearAlgebra.ldiv!(x::CuArray, _qr::QR, b::CuArray)
     _x = ldiv!(_qr, b)
-    x .= vec(_x)
+    copyto!(x, _x)
     unsafe_free!(_x)
     return x
 end

--- a/lib/cusolver/test/dense/qr.jl
+++ b/lib/cusolver/test/dense/qr.jl
@@ -129,4 +129,15 @@ end
         ldiv!(y, qr(A), x)
         y
     end
+
+    # multi-column rhs, e.g. inverting a matrix via `A \ I`
+    @test testf(rand(elty, m, m), rand(elty, m, l)) do A, X
+        ldiv!(qr(A), X)
+        X
+    end
+
+    @test testf(rand(elty, m, m), rand(elty, m, l), rand(elty, m, l)) do A, X, Y
+        ldiv!(Y, qr(A), X)
+        Y
+    end
 end

--- a/lib/cusparse/src/array.jl
+++ b/lib/cusparse/src/array.jl
@@ -818,6 +818,7 @@ CuSparseVector{T}(Mat::SparseMatrixCSC) where {T} =
 CuSparseMatrixCSC{T}(Vec::SparseVector) where {T} =
     CuSparseMatrixCSC{T}(CuVector{Cint}([1]), CuVector{Cint}(Vec.nzind),
                          CuVector{T}(Vec.nzval), (length(Vec), 1))
+CuSparseMatrixCSR{T}(Vec::SparseVector) where {T} = CuSparseMatrixCSR(CuSparseMatrixCSC{T}(Vec))
 CuSparseMatrixCSC{T}(Mat::SparseMatrixCSC) where {T} =
     CuSparseMatrixCSC{T}(CuVector{Cint}(Mat.colptr), CuVector{Cint}(Mat.rowval),
                          CuVector{T}(Mat.nzval), size(Mat))

--- a/test/core/array.jl
+++ b/test/core/array.jl
@@ -1016,3 +1016,9 @@ end
   sum!(a, b)
   @test Array(a) == [2f0]
 end
+
+@testset "mapreducedim! returning same type" begin
+    R = transpose(CUDA.zeros(Float32, 2, 3))
+    A = CUDA.rand(Float32, 3, 2, 10)
+    @test @inferred(GPUArrays.mapreducedim!(identity, +, R, A)) === R
+end

--- a/test/core/device/intrinsics/math.jl
+++ b/test/core/device/intrinsics/math.jl
@@ -13,6 +13,23 @@ using SpecialFunctions
             @test testf((x,y)->x.^y, rand(Float32, 1), rand(range, 1))
             @test testf((x,y)->x.^y, rand(Float32, 1), -rand(range, 1))
         end
+
+        # Integer exponents: accuracy must not depend on the exponent's width.
+        # __nv_powi/__nv_powif used to back the Int32 methods and drifted by
+        # ~1500 ulp on the cases below, while Int64 went via __nv_pow.
+        @testset "integer exponent ($T, $I)" for T in (Float32, Float64),
+                                                 I in (Int32, Int64)
+            x = T[1.001, 0.9, 1.1, 1.0001, 2, 0.5]
+            n = I[500, 200, 30, 5000, 7, -3]
+            @test Array(CuArray(x) .^ CuArray(n)) ≈ x .^ n rtol=8*eps(T)
+        end
+
+        # Both widths have to agree with each other, not just with the CPU
+        @testset "integer exponent width agreement ($T)" for T in (Float32, Float64)
+            x = CuArray(T[1.001, 0.9, 1.1, 1.0001])
+            n = Int64[500, 200, 30, 5000]
+            @test Array(x .^ CuArray(Int32.(n))) == Array(x .^ CuArray(n))
+        end
     end
     
     @testset "min/max" begin

--- a/test/extensions/enzyme.jl
+++ b/test/extensions/enzyme.jl
@@ -34,7 +34,7 @@ end
     dA = CUDA.ones(64)
     A .= (1:1:64)
     dA .= 1
-    Enzyme.autodiff(Forward, square!, Duplicated(A, dA))
+    Enzyme.autodiff(Forward, square!, Const, Duplicated(A, dA))
     @test all(dA .≈ (2:2:128))
 
     A = CuArray(rand(Float32, 32))
@@ -43,7 +43,7 @@ end
     A .= (1:1:32)
     dA .= 1
     dA2 .= 3
-    Enzyme.autodiff(Forward, square!, BatchDuplicated(A, (dA, dA2)))
+    Enzyme.autodiff(Forward, square!, Const, BatchDuplicated(A, (dA, dA2)))
     @test all(dA .≈ (2:2:64))
     @test all(dA2 .≈ 3*(2:2:64))
 end
@@ -84,7 +84,7 @@ end
     @test all(dA .≈ 0)
 end
 
-alloc(x) = CuArray{Float32, 1, CUDA.Mem.DeviceBuffer}(undef, (x,))
+alloc(x) = CuArray{Float32, 1, CUDA.DeviceMemory}(undef, (x,))
 
 @testset "Forward allocate" begin
     dup = Enzyme.autodiff(ForwardWithPrimal, alloc, Duplicated, Const(10))

--- a/test/setup.jl
+++ b/test/setup.jl
@@ -19,6 +19,16 @@ let gpuarrays = pathof(GPUArrays),
     gpuarrays_root = dirname(dirname(gpuarrays))
     include(joinpath(gpuarrays_root, "test", "testsuite.jl"))
 end
+TestSuite.sparse_types(::Type{<:CuArray}) =
+    (CUDA.CuSparseVector, CUDA.CuSparseMatrixCSC, CUDA.CuSparseMatrixCSR)
+
+function TestSuite.supported_eltypes(::Type{<:CuArray}, test)
+    typs = [TestSuite.supported_eltypes(CuArray)...]
+    if startswith(string(test), "test_sparse")
+        filter!(ET -> !(ET <: Integer || ET <: Complex{<:Integer}), typs)
+    end
+    return typs
+end
 
 if VERSION >= v"1.13.0-DEV.1044"
     using Base.ScopedValues


### PR DESCRIPTION
`AbstractMatrix{T}` in the copied operand made these wider than GPUArrays' generic triangular solves in one slot and narrower in the others, so with JuliaGPU/GPUArrays.jl#763 dispatch is ambiguous.

(cherry picked from commit afa2910940a3b73bcec6a4865b49787978a9224b)