### PR TITLE
Extend Enzyme rules for SVectors

### DIFF
--- a/CUDACore/ext/EnzymeCoreExt.jl
+++ b/CUDACore/ext/EnzymeCoreExt.jl
@@ -132,13 +132,13 @@ function EnzymeCore.EnzymeRules.forward(config, ofn::Const{Type{CT}},
     if EnzymeRules.needs_primal(config) && EnzymeRules.needs_shadow(config)
         if EnzymeRules.width(config) == 1
             shadow = ofn.val(uval.val, primargs...)::CT
-            fill!(shadow, 0)
+            fill!(shadow, zero(eltype(shadow)))
             Duplicated(ofn.val(uval.val, primargs...), shadow)
         else
             tup = ntuple(Val(EnzymeRules.width(config))) do i
                 Base.@_inline_meta
                 shadow = ofn.val(uval.val, primargs...)::CT
-                fill!(shadow, 0)
+                fill!(shadow, zero(eltype(shadow)))
                 shadow::CT
             end
             BatchDuplicated(ofn.val(uval.val, primargs...), tup)
@@ -146,13 +146,13 @@ function EnzymeCore.EnzymeRules.forward(config, ofn::Const{Type{CT}},
     elseif EnzymeRules.needs_shadow(config)
         if EnzymeRules.width(config) == 1
             shadow = ofn.val(uval.val, primargs...)::CT
-            fill!(shadow, 0)
+            fill!(shadow, zero(eltype(shadow)))
 	    shadow::shadow_type(config, RT)
         else
             tup = ntuple(Val(EnzymeRules.width(config))) do i
                 Base.@_inline_meta
                 shadow = ofn.val(uval.val, primargs...)::CT
-                fill!(shadow, 0)
+                fill!(shadow, zero(eltype(shadow)))
                 shadow::CT
             end
 	    tup::shadow_type(config, RT)
@@ -505,13 +505,13 @@ function EnzymeCore.EnzymeRules.augmented_primal(config, ofn::Const{Type{CT}}, :
     shadow = if EnzymeRules.needs_shadow(config)
         if EnzymeRules.width(config) == 1
             subshadow = ofn.val(uval.val, primargs...)::CT
-            fill!(subshadow, 0)
+            fill!(subshadow, zero(eltype(subshadow)))
             subshadow
         else
           ntuple(Val(EnzymeRules.width(config))) do i
               Base.@_inline_meta
               subshadow = ofn.val(uval.val, primargs...)::CT
-              fill!(subshadow, 0)
+              fill!(subshadow, zero(eltype(subshadow)))
               subshadow
           end
         end
@@ -566,14 +566,24 @@ function EnzymeCore.EnzymeRules.noalias(::Type{CT}, ::UndefInitializer, args...)
     return nothing
 end
 
+# `make_zero`/`make_zero!` are defined element-wise, which would require scalar
+# indexing on a `CuArray`, so zero the array in bulk instead. That is only
+# equivalent to the element-wise definition when every part of the element type is
+# a float, which covers `Float32`, `ComplexF64`, `SVector{3,Float64}`, ...  Other
+# element types are left to the generic implementation, as before.
+@inline float_only(::Type{FT}) where {FT <: AbstractFloat} = true
+@inline float_only(::Type{Complex{FT}}) where {FT <: AbstractFloat} = true
+@inline float_only(::Type{FT}) where {FT} =
+    isbitstype(FT) && fieldcount(FT) > 0 && all(float_only, fieldtypes(FT))
+@inline bulk_zeroable(::Type{FT}) where {FT} =
+    float_only(FT) && hasmethod(Base.zero, Tuple{Type{FT}})
+
 @inline function EnzymeCore.make_zero(
     x::DenseCuArray{FT},
-) where {FT<:AbstractFloat}
-    return Base.zero(x)
-end
-@inline function EnzymeCore.make_zero(
-    x::DenseCuArray{Complex{FT}},
-) where {FT<:AbstractFloat}
+) where {FT}
+    if !bulk_zeroable(FT)
+        return EnzymeCore.make_zero(Core.Typeof(x), IdDict(), x, Val(false))
+    end
     return Base.zero(x)
 end
 
@@ -582,7 +592,10 @@ end
     seen::IdDict,
     prev::CT,
     ::Val{copy_if_inactive} = Val(false),
-)::CT where {copy_if_inactive, FT<:AbstractFloat, CT <: Union{DenseCuArray{FT},DenseCuArray{Complex{FT}}}}
+)::CT where {copy_if_inactive, FT, CT <: DenseCuArray{FT}}
+    if !bulk_zeroable(FT)
+        return copy_if_inactive ? copy(prev) : prev
+    end
     if haskey(seen, prev)
         return seen[prev]
     end
@@ -594,7 +607,8 @@ end
 @inline function EnzymeCore.make_zero!(
     prev::DenseCuArray{FT},
     seen::ST,
-)::Nothing where {FT<:AbstractFloat,ST}
+)::Nothing where {FT,ST}
+    bulk_zeroable(FT) || return nothing
     if !isnothing(seen)
         if prev in seen
             return nothing
@@ -602,20 +616,6 @@ end
         push!(seen, prev)
     end
     fill!(prev, zero(FT))
-    return nothing
-end
-
-@inline function EnzymeCore.make_zero!(
-    prev::DenseCuArray{Complex{FT}},
-    seen::ST,
-)::Nothing where {FT<:AbstractFloat,ST}
-    if !isnothing(seen)
-        if prev in seen
-            return nothing
-        end
-        push!(seen, prev)
-    end
-    fill!(prev, zero(Complex{FT}))
     return nothing
 end
 
@@ -662,7 +662,7 @@ function EnzymeCore.EnzymeRules.augmented_primal(config, ofn::Const{typeof(GPUAr
                                         ::Type{RT},
                                         f::EnzymeCore.Const{typeof(Base.identity)},
                                         op::EnzymeCore.Const{typeof(Base.add_sum)},
-                                        R::EnzymeCore.Annotation{<:AnyCuArray{T}}, A; init) where {RT, T<:AbstractFloat}
+                                        R::EnzymeCore.Annotation{<:AnyCuArray{T}}, A; init) where {RT, T}
     if A isa Const || A isa Duplicated || A isa BatchDuplicated
         ofn.val(f.val, op.val, R.val, A.val)
     end
@@ -686,7 +686,7 @@ function EnzymeCore.EnzymeRules.reverse(config, ofn::Const{typeof(GPUArrays.mapr
                                         tape,
                                         f::EnzymeCore.Const{typeof(Base.identity)},
                                         op::EnzymeCore.Const{typeof(Base.add_sum)},
-                                        R::EnzymeCore.Annotation{<:AnyCuArray{T}}, A; init) where {RT, T<:AbstractFloat}
+                                        R::EnzymeCore.Annotation{<:AnyCuArray{T}}, A; init) where {RT, T}
 
     if !(A isa Const) && !(R isa Const)
         if A isa Duplicated || A isa DuplicatedNoNeed
@@ -742,7 +742,7 @@ function EnzymeCore.EnzymeRules.augmented_primal(config, ofn::Const{typeof(GPUAr
                                                 ::Type{Active{RT}},
                                         f::EnzymeCore.Const{typeof(Base.identity)},
                                         op::EnzymeCore.Const{typeof(Base.add_sum)},
-                                        A::EnzymeCore.Annotation{<:AnyCuArray{T}}; dims::D, init) where {RT, T<:AbstractFloat, D}
+                                        A::EnzymeCore.Annotation{<:AnyCuArray{T}}; dims::D, init) where {RT, T, D}
     primal = if EnzymeRules.needs_primal(config)
         ofn.val(f.val, op.val, A.val; dims, init)
     else
@@ -762,14 +762,16 @@ function EnzymeCore.EnzymeRules.reverse(config, ofn::Const{typeof(GPUArrays._map
                                         tape,
                                         f::EnzymeCore.Const{typeof(Base.identity)},
                                         op::EnzymeCore.Const{typeof(Base.add_sum)},
-                                        A::EnzymeCore.Annotation{<:AnyCuArray{T}}; dims::D, init) where {RT, T<:AbstractFloat, D}
+                                        A::EnzymeCore.Annotation{<:AnyCuArray{T}}; dims::D, init) where {RT, T, D}
 
+    # `Ref` so that the cotangent is broadcast as a scalar; for a non-scalar
+    # element type like `SVector` it would otherwise broadcast over its own axes
     if A isa Duplicated || A isa DuplicatedNoNeed
-        A.dval .+= dres.val
+        A.dval .+= Ref(dres.val)
     elseif A isa BatchDuplicated || A isa BatchDuplicatedNoNeed
         ntuple(Val(EnzymeRules.batch_width(A))) do i
             Base.@_inline_meta
-            A.dval[i] .+= dres.val
+            A.dval[i] .+= Ref(dres.val)
             nothing
         end
     end

--- a/CUDACore/ext/EnzymeCoreExt.jl
+++ b/CUDACore/ext/EnzymeCoreExt.jl
@@ -569,8 +569,8 @@ end
 # `make_zero`/`make_zero!` are defined element-wise, which would require scalar
 # indexing on a `CuArray`, so zero the array in bulk instead. That is only
 # equivalent to the element-wise definition when every part of the element type is
-# a float, which covers `Float32`, `ComplexF64`, `SVector{3,Float64}`, ...  Other
-# element types are left to the generic implementation, as before.
+# a float, which covers `Float32`, `ComplexF64`, `SVector{3,Float64}` etc.
+# For other element types the element-wise definition is run on a host copy instead.
 @inline float_only(::Type{FT}) where {FT <: AbstractFloat} = true
 @inline float_only(::Type{Complex{FT}}) where {FT <: AbstractFloat} = true
 @inline float_only(::Type{FT}) where {FT} =
@@ -578,11 +578,23 @@ end
 @inline bulk_zeroable(::Type{FT}) where {FT} =
     float_only(FT) && hasmethod(Base.zero, Tuple{Type{FT}})
 
+# An element type that is not `bulk_zeroable` can still have float content that has to be
+# zeroed, e.g. any struct mixing floats with flags or indices
+@inline function make_zero_via_host(prev::CT,
+                                    ::Val{copy_if_inactive}) where {copy_if_inactive, CT <: DenseCuArray}
+    zeroed = map(Array(prev)) do x
+        EnzymeCore.make_zero(Core.Typeof(x), IdDict(), x, Val(copy_if_inactive))
+    end
+    newa = similar(prev)
+    copyto!(newa, zeroed)
+    return newa::CT
+end
+
 @inline function EnzymeCore.make_zero(
     x::DenseCuArray{FT},
 ) where {FT}
     if !bulk_zeroable(FT)
-        return EnzymeCore.make_zero(Core.Typeof(x), IdDict(), x, Val(false))
+        return make_zero_via_host(x, Val(false))
     end
     return Base.zero(x)
 end
@@ -593,13 +605,10 @@ end
     prev::CT,
     ::Val{copy_if_inactive} = Val(false),
 )::CT where {copy_if_inactive, FT, CT <: DenseCuArray{FT}}
-    if !bulk_zeroable(FT)
-        return copy_if_inactive ? copy(prev) : prev
-    end
     if haskey(seen, prev)
         return seen[prev]
     end
-    newa = Base.zero(prev)
+    newa = bulk_zeroable(FT) ? Base.zero(prev) : make_zero_via_host(prev, Val(copy_if_inactive))
     seen[prev] = newa
     return newa
 end
@@ -608,14 +617,17 @@ end
     prev::DenseCuArray{FT},
     seen::ST,
 )::Nothing where {FT,ST}
-    bulk_zeroable(FT) || return nothing
     if !isnothing(seen)
         if prev in seen
             return nothing
         end
         push!(seen, prev)
     end
-    fill!(prev, zero(FT))
+    if bulk_zeroable(FT)
+        fill!(prev, zero(FT))
+    else
+        copyto!(prev, map(EnzymeCore.make_zero, Array(prev)))
+    end
     return nothing
 end
 

--- a/test/extensions/enzyme.jl
+++ b/test/extensions/enzyme.jl
@@ -1,5 +1,6 @@
 using Enzyme, EnzymeCore
 using GPUCompiler
+using StaticArrays
 using Test
 using CUDA
 
@@ -14,6 +15,22 @@ end
    dA = CUDA.ones(64)
    Enzyme.make_zero!(dA)
    @test all(dA .≈ 0)
+
+   # element types that are made up of floats are zeroed like floats are
+   A = CuArray(fill(SVector{3, Float64}(1, 2, 3), 8))
+   dA = Enzyme.make_zero(A)
+   @test dA isa CuArray{SVector{3, Float64}}
+   @test pointer(dA) != pointer(A)
+   @test all(iszero, Array(dA))
+   Enzyme.make_zero!(A)
+   @test all(iszero, Array(A))
+
+   # element types that hold no float at all are inactive and left alone,
+   # as they are on the CPU
+   B = CuArray(Int32[1, 2, 3])
+   @test Enzyme.make_zero(B) === B
+   Enzyme.make_zero!(B)
+   @test Array(B) == Int32[1, 2, 3]
 end
 
 function square_kernel!(x)
@@ -100,6 +117,17 @@ end
     @test all(shad .≈ 0.0)
 end
 
+svalloc(x) = CuArray{SVector{3, Float64}, 1, CUDA.DeviceMemory}(undef, (x,))
+
+@testset "Allocate SVector" begin
+    dup = Enzyme.autodiff(ForwardWithPrimal, svalloc, Duplicated, Const(10))
+    @test all(iszero, Array(dup[1]))
+
+    fwd, rev = Enzyme.autodiff_thunk(ReverseSplitWithPrimal, Const{typeof(svalloc)}, Duplicated, Const{Int})
+    tape, prim, shad = fwd(Const(svalloc), Const(10))
+    @test all(iszero, Array(shad))
+end
+
 firstsum(x, y) = first(x .+ y)
 @testset "Forward broadcast" begin
     x = CuArray(5*ones(5))
@@ -153,6 +181,24 @@ end
     res = Enzyme.autodiff(Reverse, setadd, Duplicated(out, dout), Duplicated(x, dx), Duplicated(y, dy))
     @test all(dx .≈ 1)
     @test all(dy .≈ 1)
+end
+
+sumsvabs2(x) = sum(sum.(abs2, x))
+
+@testset "Reverse sum abs2 SVector" begin
+    x = CuArray([SVector{3, Float64}(1, 2, 3), SVector{3, Float64}(4, 5, 6)])
+    dx = CUDA.fill(zero(SVector{3, Float64}), 2)
+    Enzyme.autodiff(Reverse, sumsvabs2, Active, Duplicated(x, dx))
+    @test Array(dx) ≈ 2 .* Array(x)
+end
+
+sumsv(x) = sum(abs2, sum(x))
+
+@testset "Reverse sum of SVectors" begin
+    x = CuArray([SVector{3, Float64}(1, 2, 3), SVector{3, Float64}(4, 5, 6)])
+    dx = CUDA.fill(zero(SVector{3, Float64}), 2)
+    Enzyme.autodiff(Reverse, sumsv, Active, Duplicated(x, dx))
+    @test Array(dx) ≈ fill(2 .* SVector{3, Float64}(5, 7, 9), 2)
 end
 
 sumabs2(x) = sum(abs2.(x))


### PR DESCRIPTION
The Enzyme rules are currently written for arrays of floats or complex floats, but other isbits types like SVectors are also valid in CuArrays. This is an attempt to broaden the rules to work there.

Since Enzyme depends on GPUCompiler 1.6.2 and CUDACore on GPUCompiler 2.2, this might require some other changes before it gets run on CI.

Tagging @wsmoses for review. Initially coded by me, refined by Claude.