### PR TITLE
Widen ldg indices to Int before reaching the intrinsic.

### DIFF
--- a/CUDACore/src/device/pointer.jl
+++ b/CUDACore/src/device/pointer.jl
@@ -31,10 +31,10 @@ const LDGTypes = (UInt8, UInt16, UInt32, UInt64, Int8, Int16, Int32, Int64,
     # method covers both scalar and vector element types, since `convert(LLVMType, T)`
     # already maps `NTuple{N, VecElement{T}}` to `<N x T>`.
     @device_function @inline @generated function pointerref_ldg(ptr::LLVMPtr{T,AS.Global},
-                                                                i::I, ::Val{align}) where {T, I, align}
+                                                                i::Int, ::Val{align}) where {T, align}
         @dispose ctx=Context() begin
             eltyp = convert(LLVMType, T)
-            T_idx = convert(LLVMType, I)
+            T_idx = convert(LLVMType, Int)
             T_ptr = convert(LLVMType, ptr)
 
             llvm_f, _ = create_function(eltyp, [T_ptr, T_idx])
@@ -51,13 +51,13 @@ const LDGTypes = (UInt8, UInt16, UInt32, UInt64, Int8, Int16, Int32, Int64,
                 ret!(builder, ld)
             end
 
-            call_function(llvm_f, T, Tuple{LLVMPtr{T,AS.Global}, I}, :ptr, :(i-one(I)))
+            call_function(llvm_f, T, Tuple{LLVMPtr{T,AS.Global}, Int}, :ptr, :(i - 1))
         end
     end
 
     for (N, T) in ((4, Float32), (2, Float64), (4, Int8), (4, Int16), (4, Int32), (2, Int64))
-        @eval unsafe_cached_load(p::LLVMPtr{NTuple{$N, Base.VecElement{$T}},AS.Global}, i::Integer=1, align::Val=Val(1)) =
-            pointerref_ldg(p, i, align)
+        @eval @inline unsafe_cached_load(p::LLVMPtr{NTuple{$N, Base.VecElement{$T}},AS.Global}, i::Integer=1, align::Val=Val(1)) =
+            pointerref_ldg(p, Int(i), align)
     end
 else
     for T in LDGTypes
@@ -71,10 +71,10 @@ else
         typ = Symbol(class, width)
 
         intr = "llvm.nvvm.ldg.global.$class.$typ.p1$typ"
-        @eval @device_function @inline function pointerref_ldg(base_ptr::LLVMPtr{$T,AS.Global}, i::I,
-                                              ::Val{align}) where {I <: Integer, align}
-            offset = i-one(i) # in elements
-            ptr = base_ptr + offset*I(sizeof($T))
+        @eval @device_function @inline function pointerref_ldg(base_ptr::LLVMPtr{$T,AS.Global}, i::Int,
+                                              ::Val{align}) where {align}
+            offset = i - 1 # in elements
+            ptr = base_ptr + offset*sizeof($T)
             @typed_ccall($intr, llvmcall, $T, (LLVMPtr{$T,AS.Global}, Int32), ptr, Val(align))
         end
     end
@@ -90,14 +90,14 @@ else
         typ = Symbol(class, width)
 
         intr = "llvm.nvvm.ldg.global.$class.v$N$typ.p1v$N$typ"
-        @eval @device_function @inline function pointerref_ldg(base_ptr::LLVMPtr{NTuple{$N, Base.VecElement{$T}},AS.Global}, i::I,
-                                              ::Val{align}) where {I <: Integer, align}
-            offset = i-one(i) # in elements
-            ptr = base_ptr + offset*I($N*sizeof($T))
+        @eval @device_function @inline function pointerref_ldg(base_ptr::LLVMPtr{NTuple{$N, Base.VecElement{$T}},AS.Global}, i::Int,
+                                              ::Val{align}) where {align}
+            offset = i - 1 # in elements
+            ptr = base_ptr + offset*($N*sizeof($T))
             @typed_ccall($intr, llvmcall, $NTuple{$N, Base.VecElement{$T}}, (LLVMPtr{NTuple{$N, Base.VecElement{$T}},AS.Global}, Int32), ptr, Val(align))
         end
-        @eval unsafe_cached_load(p::LLVMPtr{NTuple{$N, Base.VecElement{$T}},AS.Global}, i::Integer=1, align::Val=Val(1)) =
-            pointerref_ldg(p, i, align)
+        @eval @inline unsafe_cached_load(p::LLVMPtr{NTuple{$N, Base.VecElement{$T}},AS.Global}, i::Integer=1, align::Val=Val(1)) =
+            pointerref_ldg(p, Int(i), align)
     end
 end
 
@@ -105,8 +105,10 @@ end
 
 export unsafe_cached_load
 
-unsafe_cached_load(p::LLVMPtr{<:Union{LDGTypes...},AS.Global}, i::Integer=1, align::Val=Val(1)) =
-    pointerref_ldg(p, i, align)
+# Like `unsafe_load`, the index is widened to `Int` before reaching the intrinsic so that
+# an unsigned index is zero-extended in Julia, rather than sign-extended by `getelementptr`.
+@inline unsafe_cached_load(p::LLVMPtr{<:Union{LDGTypes...},AS.Global}, i::Integer=1, align::Val=Val(1)) =
+    pointerref_ldg(p, Int(i), align)
 # NOTE: fall back to normal unsafe_load for unsupported types. we could be smarter here,
 #       e.g. destruct/load/reconstruct, but that's too complicated for what it's worth.
 unsafe_cached_load(p::LLVMPtr, i::Integer=1, align::Val=Val(1)) =

--- a/test/core/device/ldg.jl
+++ b/test/core/device/ldg.jl
@@ -45,6 +45,27 @@ end
     @test Array(d_a) == Array(d_b)
 end
 
+@testset "unsigned index" begin
+    # `getelementptr` treats its index as signed, so an unsigned index whose high bit is
+    # set must be zero-extended rather than sign-extended (cfr. JuliaLLVM/LLVM.jl#583).
+    # the pointer sits at the midpoint so a sign-extended offset would stay in bounds
+    # (and read the wrong element) instead of faulting.
+    for I in (UInt8, UInt16)
+        half = 1 << (8*sizeof(I) - 1)
+        a = CUDA.zeros(Int8, 2half + 2)
+        b = CUDA.zeros(Int8, 1)
+        CUDA.@allowscalar a[1] = 9
+        CUDA.@allowscalar a[2half + 1] = 3
+
+        ptr_a = reinterpret(Core.LLVMPtr{Int8,AS.Global}, pointer(a) + half)
+        ptr_b = reinterpret(Core.LLVMPtr{Int8,AS.Global}, pointer(b))
+        let ptr_a=ptr_a, ptr_b=ptr_b, i=I(half + 1)
+            @on_device unsafe_store!(ptr_b, unsafe_cached_load(ptr_a, i))
+        end
+        @test Array(b) == [3]
+    end
+end
+
 @testset "Const" begin
     function kernel(a, b, i)
         @inbounds b[i] = Base.Experimental.Const(a)[i]


### PR DESCRIPTION
Mirror JuliaLLVM/LLVM.jl#583 (and Base's `unsafe_load` for `Ptr`) in `unsafe_cached_load`: `pointerref_ldg` now takes `i::Int`, with the conversion done via `Int(i)` in the inlined wrappers. Previously the offset was computed at the width of the index type and then sign-extended by `getelementptr` (or by `+(::LLVMPtr, ::Integer)`), sending unsigned indices above typemax(signed(I)) to an address below the buffer, and making `unsafe_cached_load` disagree with `unsafe_load` for such indices.

Dropping the index type parameter also means the LLVM 20+ generator runs once per pointer type instead of once per index type.