### PR TITLE
Fix profiling and cuDNN tests on Tegra

### DIFF
--- a/CUDATools/src/profile.jl
+++ b/CUDATools/src/profile.jl
@@ -171,6 +171,9 @@ function detect_cupti()
         return _cupti_active[]
     end
 
+    # Some CUPTI versions crash while probing Tegra without profiling permissions.
+    CUPTI.can_profile() || return false
+
     if !_nvtx_activated[]
         # If we're not running under an external profiler, let CUPTI handle NVTX events
         # We cannot run this unconditionally during initialization to avoid interfering
@@ -371,6 +374,14 @@ Base.@kwdef struct ProfileResults
 end
 
 function profile_internally(@nospecialize(f); concurrent=true, kwargs...)
+    if !CUPTI.can_profile()
+        error("""The integrated profiler relies on CUPTI, which requires additional permissions on Tegra devices.
+                 With CUDA 13 and later, grant read/write access to `/dev/nvgpu/*/prof`
+                 (typically by joining its owning group) and enable non-admin profiling with
+                 `NVreg_RestrictProfilingToAdminUsers=0`. With older CUDA toolkits, run Julia
+                 as root. Alternatively, use an external profiler such as Nsight Systems.""")
+    end
+
     activity_kinds = [
         # API calls
         CUPTI.CUPTI_ACTIVITY_KIND_DRIVER,

--- a/CUDATools/src/reflection.jl
+++ b/CUDATools/src/reflection.jl
@@ -44,6 +44,17 @@ end
 code_sass(@nospecialize(func), @nospecialize(types); kwargs...) =
     code_sass(stdout, func, types; kwargs...)
 
+function _check_cupti_profiling()
+    CUPTI.can_profile() && return true
+
+    @error """SASS code generation relies on CUPTI, which requires additional permissions on Tegra devices.
+              With CUDA 13 and later, grant read/write access to `/dev/nvgpu/*/prof`
+              (typically by joining its owning group) and enable non-admin profiling with
+              `NVreg_RestrictProfilingToAdminUsers=0`. With older CUDA toolkits, run Julia
+              as root."""
+    return false
+end
+
 function code_sass(io::IO, job::CompilerJob; raw::Bool=false)
     if !job.config.kernel
         error("Can only generate SASS code for kernel functions")
@@ -55,6 +66,8 @@ function code_sass(io::IO, job::CompilerJob; raw::Bool=false)
                   Please use a more recent device."""
         return
     end
+
+    _check_cupti_profiling() || return
 
     # NVIDIA bug #4604961: CUPTI in CUDA 12.4 Update 1 does not capture profiled events
     # unless the activity API is first activated. This is fixed in 12.5 Update 1.
@@ -89,6 +102,8 @@ function code_sass(f::Base.Callable, io::IO=stdout; raw::Bool=false)
                   Please use a more recent device."""
         return
     end
+
+    _check_cupti_profiling() || return
 
     # NVIDIA bug #4604961: CUPTI in CUDA 12.4 Update 1 does not capture profiled events
     # unless the activity API is first activated. This is fixed in 12.5 Update 1.

--- a/docs/src/development/profiling.md
+++ b/docs/src/development/profiling.md
@@ -132,6 +132,24 @@ Here, every call is prefixed with an ID, which can be used to correlate host and
 events. For example, here we can see that the host-side `cuLaunchKernel` call with ID 6
 corresponds to the device-side `broadcast` kernel.
 
+#### Profiling on Tegra
+
+The integrated profiler relies on CUPTI, which needs additional permissions on Tegra
+devices (such as the Jetson series). What exactly is required depends on the CUDA version:
+
+- with CUDA 13 and later (typically JetPack 7+), non-root users need read/write access to
+  the GPU profiling device nodes `/dev/nvgpu/*/prof*`. These are commonly owned by the
+  `debug` group on Jetson systems, in which case run `sudo usermod -aG debug $USER` and
+  log in again. The driver also needs to allow non-admin profiling by loading `nvidia` with
+  `NVreg_RestrictProfilingToAdminUsers=0` (see [Troubleshooting Nsight Compute](@ref)
+  below). Without the device node access, CUPTI crashes the process outright instead
+  of reporting an error;
+- with CUDA 10 through 12 (typically JetPack 4 through 6), profiling requires running as
+  root. This was verified with CUDA 10.2 and 11.4; CUDA 12 uses the same conservative gate.
+
+The same requirements apply to other CUPTI-based functionality, such as
+`@device_code_sass`.
+
 ### External profilers
 
 If you want more details, or a graphical representation, we recommend using external
@@ -368,6 +386,8 @@ Nsight Compute does not support the GPU you have. Run `ncu --list-chips` to veri
 ##### `==ERROR== ERR_NVGPUCTRPERM`
 
 Run the terminal as administrator. Refer to [the NVIDIA documentation issue webpage](https://developer.nvidia.com/ERR_NVGPUCTRPERM) for more details.
+On Tegra devices, also see [Profiling on Tegra](@ref) for the additional device node
+permissions required there.
 
 ##### `==ERROR== Cuda driver is not compatible with Nsight Compute`
 

--- a/lib/cudnn/test/rnn.jl
+++ b/lib/cudnn/test/rnn.jl
@@ -118,8 +118,9 @@ rnntest(layout=CUDNN_RNN_DATA_LAYOUT_BATCH_MAJOR_UNPACKED)
 rnntest(seqLengthArray=Cint[1,2,1,2])
 rnntest(fwdMode=CUDNN_FWD_MODE_TRAINING)
 rnntest(hiddenSize=16)
-# XXX: it's unclear which devices support this algorithm
-if capability(device()) >= v"6.1"
+# Persistent-static RNNs are not supported on integrated GPUs (observed on Orin, sm_87).
+if capability(device()) >= v"6.1" &&
+   CUDACore.attribute(device(), CUDACore.DEVICE_ATTRIBUTE_INTEGRATED) != 1
     rnntest(algo=CUDNN_RNN_ALGO_PERSIST_STATIC)
 end
 #rnntest(algo=CUDNN_RNN_ALGO_PERSIST_DYNAMIC) # causes segfault

--- a/lib/cupti/src/wrappers.jl
+++ b/lib/cupti/src/wrappers.jl
@@ -65,6 +65,39 @@ function library_version()
                   parse(Int, m.captures[3]))
 end
 
+"""
+    can_profile() -> Bool
+
+Whether CUDA.jl should attempt to use CUPTI in the current process.
+
+On Tegra, CUDA 10 through 12 require root, while CUDA 13 and later require read/write
+access to a profiling device node. This check is intentionally conservative because some
+CUPTI versions crash in `cuptiSubscribe` when that access is missing. On other systems,
+CUPTI reports permission errors normally, so this function returns `true` and lets CUPTI
+handle them.
+"""
+function can_profile()
+    CUDACore.is_tegra() || return true
+
+    # The legacy Tegra driver does not support non-root CUPTI profiling. This was verified
+    # with CUDA 10.2 and 11.4; conservatively apply the same restriction to CUDA 12.
+    if CUDACore.runtime_version() < v"13"
+        return Libc.geteuid() == 0
+    end
+
+    # CUDA 13 and later use per-GPU profiler nodes under /dev/nvgpu. Keep checking the
+    # legacy node as well because the exact device layout is a property of the driver.
+    if isdir("/dev/nvgpu")
+        for dev in readdir("/dev/nvgpu"; join=true)
+            _has_profiling_access(joinpath(dev, "prof")) && return true
+        end
+    end
+    return _has_profiling_access("/dev/nvhost-prof-gpu")
+end
+
+_has_profiling_access(path) =
+    ccall(:access, Cint, (Cstring, Cint), path, #=R_OK | W_OK=# 0x6) == 0
+
 
 #
 # callback API

--- a/test/setup.jl
+++ b/test/setup.jl
@@ -1,6 +1,7 @@
 using Test
 using CUDA
 using CUDACore
+using CUPTI
 using FileCheck
 using GPUArrays
 using NVML: has_nvml, NVML
@@ -42,8 +43,9 @@ const sanitize = any(contains("NV_SANITIZER"), keys(ENV))
 function can_use_cupti()
     sanitize && return false
 
-    # Tegra requires running as root and modifying the device tree
-    if CUDA.is_tegra()
+    # Tegra has platform-specific profiling requirements, and some CUPTI versions crash
+    # instead of reporting insufficient permissions.
+    if !CUPTI.can_profile()
         return false
     end
 


### PR DESCRIPTION
CUPTI profiling permissions behave differently across Tegra generations.

With CUDA 10 through 12, profiling requires running as root. With CUDA 13,
non-root profiling works when the process can access the GPU profiling device
nodes and non-admin profiling is enabled. Without device-node access, the
CUDA 13 CUPTI library may segfault in `cuptiSubscribe` instead of returning a
permission error.

Checking this before entering CUPTI gives users an actionable error instead of
crashing the Julia process. Non-Tegra systems retain the existing behavior and
continue to let CUPTI report permission failures itself.

Separately, the persistent-static cuDNN RNN algorithm is unsupported on the
integrated Orin GPU. The test now uses the CUDA integrated-device attribute to
skip that algorithm without tying the workaround to a specific Jetson model or
compute capability.