### PR TITLE
Restore best-effort CUDA 10.2 and 11 support

### DIFF
--- a/CUDACore/lib/cudadrv/context.jl
+++ b/CUDACore/lib/cudadrv/context.jl
@@ -214,7 +214,11 @@ Lower the refcount of a context, possibly freeing up all resources associated wi
 does not respect any users of the context, and might make other objects unusable.
 """
 function unsafe_release!(pctx::CuPrimaryContext)
-    cuDevicePrimaryCtxRelease_v2(pctx.dev)
+    if driver_version() >= v"11"
+        cuDevicePrimaryCtxRelease_v2(pctx.dev)
+    else
+        cuDevicePrimaryCtxRelease(pctx.dev)
+    end
     return
 end
 
@@ -226,7 +230,11 @@ in the current process. Note that this forcibly invalidates all contexts derived
 primary context, and as a result outstanding resources might become invalid.
 """
 function unsafe_reset!(pctx::CuPrimaryContext)
-    cuDevicePrimaryCtxReset_v2(pctx.dev)
+    if driver_version() >= v"11"
+        cuDevicePrimaryCtxReset_v2(pctx.dev)
+    else
+        cuDevicePrimaryCtxReset(pctx.dev)
+    end
     return
 end
 
@@ -257,7 +265,11 @@ flags(pctx::CuPrimaryContext) = state(pctx)[1]
 Set the flags of a primary context.
 """
 function setflags!(pctx::CuPrimaryContext, flags)
-    cuDevicePrimaryCtxSetFlags_v2(pctx.dev, flags)
+    if driver_version() >= v"11"
+        cuDevicePrimaryCtxSetFlags_v2(pctx.dev, flags)
+    else
+        cuDevicePrimaryCtxSetFlags(pctx.dev, flags)
+    end
 end
 
 

--- a/CUDACore/lib/cudadrv/devices.jl
+++ b/CUDACore/lib/cudadrv/devices.jl
@@ -79,6 +79,8 @@ corresponding to the device ID as known to CUDA.
 deviceid(dev::CuDevice) = Int(convert(CUdevice, dev))
 
 function uuid(dev::CuDevice)
+    driver_version() < v"11.4" && return parent_uuid(dev)
+
     # returns the MIG UUID if this is a compute instance
     uuid_ref = Ref{CUuuid}()
     cuDeviceGetUuid_v2(uuid_ref, dev)
@@ -183,7 +185,9 @@ function capability(dev::CuDevice)
                          attribute(dev, DEVICE_ATTRIBUTE_COMPUTE_CAPABILITY_MINOR))
 end
 
-memory_pools_supported(dev::CuDevice) = attribute(dev, DEVICE_ATTRIBUTE_MEMORY_POOLS_SUPPORTED) == 1
+memory_pools_supported(dev::CuDevice) =
+    driver_version() >= v"11.2" &&
+    attribute(dev, DEVICE_ATTRIBUTE_MEMORY_POOLS_SUPPORTED) == 1
 @deprecate has_stream_ordered(dev::CuDevice) memory_pools_supported(dev)
 
 unified_addressing(dev::CuDevice) =

--- a/CUDACore/lib/cudadrv/execution.jl
+++ b/CUDACore/lib/cudadrv/execution.jl
@@ -54,8 +54,36 @@ function launch(f::CuFunction, args::Vararg{Any,N}; blocks::CuDim=1, threads::Cu
     threaddim = CuDim3(threads)
     clusterdim = CuDim3(clustersize)
 
-    if dependent && capability(device()) < v"9.0"
-        error("Programmatic dependent launch requires compute capability 9.0 or higher")
+    if dependent
+        driver_version() >= v"11.8" ||
+            error("Programmatic dependent launch requires CUDA 11.8 or higher")
+        capability(device()) >= v"9.0" ||
+            error("Programmatic dependent launch requires compute capability 9.0 or higher")
+    end
+
+    if driver_version() < v"11.8"
+        # cuLaunchKernelEx and its launch attributes require CUDA 11.8.
+        if clusterdim.x != 1 || clusterdim.y != 1 || clusterdim.z != 1
+            error("Thread block clusters require CUDA 11.8 or higher")
+        end
+        try
+            pack_arguments(args...) do kernelParams
+                if cooperative
+                    cuLaunchCooperativeKernel(f,
+                                              blockdim.x, blockdim.y, blockdim.z,
+                                              threaddim.x, threaddim.y, threaddim.z,
+                                              shmem, stream, kernelParams)
+                else
+                    cuLaunchKernel(f,
+                                   blockdim.x, blockdim.y, blockdim.z,
+                                   threaddim.x, threaddim.y, threaddim.z,
+                                   shmem, stream, kernelParams, C_NULL)
+                end
+            end
+        catch err
+            diagnose_launch_failure(f, err; blockdim, threaddim, clusterdim, shmem)
+        end
+        return
     end
 
     attributes = Ref{NTuple{3,CUlaunchAttribute}}()

--- a/CUDACore/lib/cudadrv/graph.jl
+++ b/CUDACore/lib/cudadrv/graph.jl
@@ -89,7 +89,22 @@ mutable struct CuGraphExec
     global function instantiate(graph::CuGraph, flags=0)
         handle_ref = Ref{CUgraphExec}()
 
-        cuGraphInstantiateWithFlags(handle_ref, graph, flags)
+        if driver_version() >= v"11.4"
+            cuGraphInstantiateWithFlags(handle_ref, graph, flags)
+        else
+            flags == 0 || error("Graph instantiation flags require CUDA 11.4 or higher")
+
+            error_node = Ref{CUgraphNode}()
+            buflen = 256
+            buf = Vector{UInt8}(undef, buflen)
+            GC.@preserve buf begin
+                if driver_version() >= v"11"
+                    cuGraphInstantiate_v2(handle_ref, graph, error_node, pointer(buf), buflen)
+                else
+                    cuGraphInstantiate(handle_ref, graph, error_node, pointer(buf), buflen)
+                end
+            end
+        end
 
         ctx = current_context()
         obj = new(handle_ref[], graph, ctx)

--- a/CUDACore/lib/cudadrv/memory.jl
+++ b/CUDACore/lib/cudadrv/memory.jl
@@ -583,8 +583,15 @@ function unsafe_copy3d!(dst::Union{Ptr{T},CuPtr{T},CuArrayPtr{T}}, dstTyp::Type{
     srcPos = CuDim3(srcPos)
     dstPos = CuDim3(dstPos)
 
-    srcOffset = 0
-    dstOffset = 0
+    # Work around JuliaGPU/CUDA.jl#863. Checking which allocator produced the
+    # pointer would cost more than applying the offset correction unconditionally.
+    if v"11.2" <= driver_version() <= v"11.3"
+        srcOffset = (srcPos.x-1)*aligned_sizeof(T) + srcPitch*((srcPos.y-1) + srcHeight*(srcPos.z-1))
+        dstOffset = (dstPos.x-1)*aligned_sizeof(T) + dstPitch*((dstPos.y-1) + dstHeight*(dstPos.z-1))
+    else
+        srcOffset = 0
+        dstOffset = 0
+    end
 
     srcMemoryType, srcHost, srcDevice, srcArray = if srcTyp == HostMemory
         CU_MEMORYTYPE_HOST,

--- a/CUDACore/lib/cudadrv/version.jl
+++ b/CUDACore/lib/cudadrv/version.jl
@@ -148,6 +148,11 @@ Derived by parsing `ptxas --version`.
 """
 function compiler_version()
     @memoize begin
+        CUDA_Compiler.is_available() ||
+            error("""No CUDA compiler is available for the selected CUDA version and platform.
+                     Select a version with matching artifacts using `CUDA.set_runtime_version!`,
+                     or install a local toolkit and call
+                     `CUDA.set_runtime_version!(local_toolkit=true)`.""")
         output = readchomp(`$(CUDA_Compiler.ptxas()) --version`)
         m = match(r"release (\d+)\.(\d+),\s*V(\d+)\.(\d+)\.(\d+)", output)
         m === nothing && error("Could not parse `ptxas --version` output: $output")

--- a/CUDACore/src/compatibility.jl
+++ b/CUDACore/src/compatibility.jl
@@ -42,9 +42,10 @@ Base.intersect(v::VersionNumber, r::VersionRange) =
 # - https://en.wikipedia.org/wiki/CUDA#GPUs_supported
 # - ptxas |& grep -A 10 '\--gpu-name'
 #
-# The bounds across every supported toolkit (12.0 through 13.4) were measured rather than
-# inferred, by pinning `CUDA_SDK_jll` to each release in a temporary environment and
-# reading the `--gpu-name` list off that toolkit's ptxas; do the same when adding entries.
+# The bounds from CUDA 12.0 through 13.4 were measured rather than inferred, by pinning
+# `CUDA_SDK_jll` to each release in a temporary environment and reading the `--gpu-name`
+# list off that toolkit's ptxas; older entries are retained from the historical support
+# table. Use the same measurement when adding entries.
 # What that pins down: sm_100/sm_101/sm_120 arrive in 12.8, sm_103/sm_121 and the `f`
 # variants in 12.9, sm_88/sm_110 in 13.0 -- which is also where sm_50-sm_72 and sm_101 are
 # dropped -- and sm_107 in 13.4.
@@ -98,8 +99,9 @@ end
 
 # Source: PTX ISA document, Release History table
 #
-# Verified from 12.0 onwards by feeding a pinned `CUDA_SDK_jll`'s ptxas a stub module at
-# each `.version` and taking the highest it accepts. The one gap is 8.6: no CUDA 12.7
+# Verified from CUDA 12.0 onwards by feeding a pinned `CUDA_SDK_jll`'s ptxas a stub module
+# at each `.version` and taking the highest it accepts. Older entries are retained from the
+# historical support table. The one gap is 8.6: no CUDA 12.7
 # exists in the JLL set to test against (12.6 tops out at 8.5, 12.8 already accepts 8.7).
 const ptxas_ptx_db = Dict(
     v"1.0" => between(v"1.0", highest),
@@ -366,4 +368,3 @@ function ptxas_compat(version=compiler_version())
     return (cap=ptxas_cap_support(version),
             ptx=ptxas_ptx_support(version))
 end
-

--- a/CUDACore/src/compiler/compilation.jl
+++ b/CUDACore/src/compiler/compilation.jl
@@ -17,8 +17,8 @@ end
 const CUDACompilerConfig = CompilerConfig{PTXCompilerTarget, CUDACompilerParams}
 const AnyCUDAJob = CompilerJob{PTXCompilerTarget, <:AbstractCUDACompilerParams}
 
-# CUDA 12.0 is the oldest supported toolkit, and Maxwell is the oldest supported GPU.
-const minreq = (; ptx=v"8.0", sm=sm"50")
+# CUDA 10.2 is the oldest supported toolkit, and Maxwell is the oldest supported GPU.
+const minreq = (; ptx=v"6.5", sm=sm"50")
 
 GPUCompiler.runtime_module(@nospecialize(job::AnyCUDAJob)) = CUDACore
 # keep host references symbolic and emit them as patchable globals; `link_kernel`

--- a/CUDACore/src/initialization.jl
+++ b/CUDACore/src/initialization.jl
@@ -89,8 +89,8 @@ function __init__()
         return
     end
 
-    if driver < v"12"
-        @error "This version of CUDA.jl requires an NVIDIA driver for CUDA 12.x or higher (yours only supports up to CUDA $driver)"
+    if driver < v"10.2"
+        @error "This version of CUDA.jl requires an NVIDIA driver for CUDA 10.2 or higher (yours only supports up to CUDA $driver)"
         _initialization_error[] = "NVIDIA driver too old"
         return
     end
@@ -117,6 +117,10 @@ function __init__()
                or in a container. In that case, you need to specify which CUDA
                version to use at run time by calling `CUDA.set_runtime_version!`
                or provisioning the preference it sets at compile time.
+
+               If no runtime and compiler artifacts exist for that CUDA version and
+               platform, install a local toolkit and call
+               `CUDA.set_runtime_version!(local_toolkit=true)` instead.
 
                If you are not running in a container or on an HPC log-in node,
                try re-compiling the CUDA runtime JLL and re-loading CUDA.jl:
@@ -153,8 +157,8 @@ function __init__()
     # ensure the loaded runtime is supported. done after cuInit so that runtime_version()
     # (on Linux, a ccall into libcudart) doesn't have to deal with ERROR_NO_DEVICE.
     runtime = runtime_version()
-    if runtime < v"12"
-        @error "This version of CUDA.jl only supports CUDA 12 or higher (your toolkit provides CUDA $runtime)"
+    if runtime < v"10.2"
+        @error "This version of CUDA.jl only supports CUDA 10.2 or higher (your toolkit provides CUDA $runtime)"
         _initialization_error[] = "CUDA runtime too old"
         return
     end

--- a/CUDATools/src/profile.jl
+++ b/CUDATools/src/profile.jl
@@ -388,15 +388,21 @@ function profile_internally(@nospecialize(f); concurrent=true, kwargs...)
         CUPTI.CUPTI_ACTIVITY_KIND_RUNTIME,
         # kernel execution
         concurrent ? CUPTI.CUPTI_ACTIVITY_KIND_CONCURRENT_KERNEL : CUPTI.CUPTI_ACTIVITY_KIND_KERNEL,
-        CUPTI.CUPTI_ACTIVITY_KIND_INTERNAL_LAUNCH_API,
         # memory operations
         CUPTI.CUPTI_ACTIVITY_KIND_MEMCPY,
         CUPTI.CUPTI_ACTIVITY_KIND_MEMSET,
-        CUPTI.CUPTI_ACTIVITY_KIND_MEMORY2,
         # NVTX markers
         CUPTI.CUPTI_ACTIVITY_KIND_MARKER,
         CUPTI.CUPTI_ACTIVITY_KIND_MARKER_DATA,
     ]
+    if CUDACore.runtime_version() >= v"11"
+        # internal launch API records require CUDA 11 or later
+        push!(activity_kinds, CUPTI.CUPTI_ACTIVITY_KIND_INTERNAL_LAUNCH_API)
+    end
+    if CUDACore.runtime_version() >= v"11.2"
+        # memory allocation records require CUDA 11.2
+        push!(activity_kinds, CUPTI.CUPTI_ACTIVITY_KIND_MEMORY2)
+    end
     cfg = CUPTI.ActivityConfig(activity_kinds)
 
     # wait for the device to become idle

--- a/README.md
+++ b/README.md
@@ -125,16 +125,36 @@ package manager:
 - Host platform: only 64-bit Linux and Windows are supported;
 - Device hardware: only NVIDIA GPUs with **compute capability 5.0** (Maxwell) or higher are
   supported;
-- NVIDIA driver: a driver for **CUDA 12** or newer is required;
-- CUDA toolkit (in case you need to use your own): only **CUDA toolkit 12.0** or newer are
+- NVIDIA driver: a driver for **CUDA 10.2** or newer is required;
+- CUDA toolkit (in case you need to use your own): only **CUDA toolkit 10.2** or newer are
   supported.
+
+### Platform support
+
+| Host platform | CUDA 12.x–13.x | CUDA 11.x | CUDA 10.2 |
+|---|:---:|:---:|:---:|
+| Linux x86-64 | 🔵 | 🟡 | 🟡 |
+| Linux ARM64/SBSA | 🟢 | 🟡 | — |
+| Linux ARM64/Tegra | 🟢 | 🟡 | 🟡 |
+| Windows x86-64 | 🟢 | 🟡 | 🟡 |
+
+- 🔵 **CI tested** — supported and regularly exercised by functional GPU CI.
+- 🟢 **Supported** — expected to work; regressions are considered bugs, but the
+  configuration is not tracked by functional GPU CI.
+- 🟡 **Best effort** — may be untested or only partially functional. Artifacts or
+  individual features may be unavailable, and fixes are accepted when reasonably scoped.
+- **— Not applicable** — no corresponding NVIDIA platform/toolkit combination.
+
+Best-effort support does not imply complete feature or artifact availability. Some
+configurations may require a local CUDA toolkit, and toolkit components or CUDA.jl
+functionality may be unavailable. Compatibility fixes are welcome when they remain
+reasonably scoped and do not complicate support for current toolkits. See
+[Selecting a CUDA Toolkit](#selecting-a-cuda-toolkit) for configuration details.
 
 If you cannot meet these requirements, you may need to install an older version of CUDA.jl:
 
-* CUDA.jl v5.8 is the last version with support for CUDA 11, and consequently Kepler GPUs (removed in v5.9)
+* CUDA.jl v5.8 is the last version with support for Kepler GPUs (removed in v5.9)
 * CUDA.jl v5.3 is the last version with support for PowerPC (removed in v5.4)
-* CUDA.jl v4.4 is the last version with support for CUDA 11.0-11.3 (deprecated in v5.0)
-* CUDA.jl v4.0 is the last version to work with CUDA 10.2 (removed in v4.1)
 * CUDA.jl v3.8 is the last version to work with CUDA 10.1 (removed in v3.9)
 * CUDA.jl v1.3 is the last version to work with CUDA 9-10.0 (removed in v2.0)
 
@@ -151,7 +171,8 @@ two cases where you may want to select a different version:
   In that case, call e.g. `CUDA.set_runtime_version!(v"12.9")` to
   use a specific toolkit which still supports the device in question.
 - **You want to use a CUDA Toolkit that is already installed on your system**.
-  This is not recommended, but if you want to do it anyway, call
+  This may be necessary on older systems for which matching runtime and compiler
+  artifacts are unavailable. Call
   `CUDA.set_runtime_version!(local_toolkit=true)`.
 
 Both these options will be remembered across sessions via a local preference,

--- a/README.md
+++ b/README.md
@@ -111,52 +111,68 @@ numbers that move in lockstep.
 
 ## Requirements
 
-The latest development version of CUDA.jl requires **Julia 1.10** or higher. If you are
-using an older version of Julia, you need to use a previous version of CUDA.jl. This will
-happen automatically when you install the package using Julia's package manager.
+The latest development version of CUDA.jl requires **Julia 1.10** or higher. If
+you are using an older version of Julia, you need to use a previous version of
+CUDA.jl. This will happen automatically when you install the package using
+Julia's package manager.
 
-Note that CUDA.jl may not work with a custom build of Julia; it is recommended that you
-install Julia using the [official binaries](https://julialang.org/downloads/) or
+Note that CUDA.jl may not work with a custom build of Julia; it is recommended
+that you install Julia using the [official
+binaries](https://julialang.org/downloads/) or
 [juliaup](https://github.com/JuliaLang/juliaup).
 
-The latest version of CUDA.jl also has certain requirements that cannot be enforced by the
-package manager:
+| Julia version | Status |
+|---|:---:|
+| ≤ 1.9 | 🔴 |
+| 1.10–1.12 | 🔵 |
+| 1.13 | 🟢 |
+| master | 🟡 |
 
-- Host platform: only 64-bit Linux and Windows are supported;
-- Device hardware: only NVIDIA GPUs with **compute capability 5.0** (Maxwell) or higher are
-  supported;
-- NVIDIA driver: a driver for **CUDA 10.2** or newer is required;
-- CUDA toolkit (in case you need to use your own): only **CUDA toolkit 10.2** or newer are
-  supported.
+CUDA.jl supports many CUDA toolkit versions, and we generally support those
+toolkits that NVIDIA still supports for their other vendor libraries (like
+cuDNN). Beyond that, we will try to keep some level of support for older
+toolkits such that CUDA.jl can be run on embedded devices that are still
+supported by NVIDIA.
 
-### Platform support
+| Host platform | CUDA 12.0–13.3 | CUDA 11.x | CUDA 10.x | CUDA ≤ 9.x |
+|---|:---:|:---:|:---:|:---:|
+| Linux x86-64 | 🔵 | 🟡 | 🟡 | 🔴 |
+| Linux ARM64/SBSA | 🟢 | 🟡 | — | — |
+| Linux ARM64/Tegra | 🟢 | 🟡 | 🟡 | 🔴 |
+| Windows x86-64 | 🟢 | 🟡 | 🟡 | 🔴 |
 
-| Host platform | CUDA 12.x–13.x | CUDA 11.x | CUDA 10.2 |
-|---|:---:|:---:|:---:|
-| Linux x86-64 | 🔵 | 🟡 | 🟡 |
-| Linux ARM64/SBSA | 🟢 | 🟡 | — |
-| Linux ARM64/Tegra | 🟢 | 🟡 | 🟡 |
-| Windows x86-64 | 🟢 | 🟡 | 🟡 |
+Toolkit support directly impact the devices we support:
 
-- 🔵 **CI tested** — supported and regularly exercised by functional GPU CI.
-- 🟢 **Supported** — expected to work; regressions are considered bugs, but the
-  configuration is not tracked by functional GPU CI.
-- 🟡 **Best effort** — may be untested or only partially functional. Artifacts or
-  individual features may be unavailable, and fixes are accepted when reasonably scoped.
-- **— Not applicable** — no corresponding NVIDIA platform/toolkit combination.
+| Architecture | Compute capability | Status |
+|---|:---:|:---:|
+| Kepler and older | ≤ 3.7 | 🔴 |
+| Maxwell | 5.0, 5.2 | 🟢 |
+| Pascal | 6.0, 6.1 | 🟢 |
+| Volta | 7.0 | 🟢 |
+| Turing | 7.5 | 🟢 |
+| Ampere | 8.0, 8.6 | 🔵 |
+| Ada Lovelace | 8.9 | 🟢 |
+| Hopper | 9.0 | 🟢 |
+| Blackwell | 10.0, 10.3, 12.0, 12.1 | 🟢 |
 
-Best-effort support does not imply complete feature or artifact availability. Some
-configurations may require a local CUDA toolkit, and toolkit components or CUDA.jl
-functionality may be unavailable. Compatibility fixes are welcome when they remain
-reasonably scoped and do not complicate support for current toolkits. See
-[Selecting a CUDA Toolkit](#selecting-a-cuda-toolkit) for configuration details.
+Tegra devices are supported as well, although additionally limited by the CUDA
+toolkit shipped with the last JetPack release for that device:
 
-If you cannot meet these requirements, you may need to install an older version of CUDA.jl:
+| Platform | Architecture | Compute capability | Status |
+|---|---|:---:|:---:|
+| Jetson TK1 | Kepler | 3.2 | 🔴 |
+| Jetson Nano, TX1 | Maxwell | 5.3 | 🟡 |
+| Jetson TX2 | Pascal | 6.2 | 🟡 |
+| Jetson Xavier | Volta | 7.2 | 🟡 |
+| Jetson Orin | Ampere | 8.7 | 🟢 |
+| Jetson Thor | Blackwell | 11.0 | 🟢 |
 
-* CUDA.jl v5.8 is the last version with support for Kepler GPUs (removed in v5.9)
-* CUDA.jl v5.3 is the last version with support for PowerPC (removed in v5.4)
-* CUDA.jl v3.8 is the last version to work with CUDA 10.1 (removed in v3.9)
-* CUDA.jl v1.3 is the last version to work with CUDA 9-10.0 (removed in v2.0)
+### Support legend
+
+- 🔵 **CI tested**: supported and regularly exercised by CI.
+- 🟢 **Supported**: expected to work, but not covered by CI.
+- 🟡 **Best effort**: untested and not supporting all functionality.
+- 🔴 **Not supported**.
 
 
 ## Selecting a CUDA Toolkit
@@ -165,7 +181,7 @@ CUDA.jl will automatically download and use a CUDA Toolkit that's supported
 by your NVIDIA driver as well as most of the devices in your system. There are
 two cases where you may want to select a different version:
 
-- **You have a GPU that is not supported by the latest CUDA Toolkit**.
+- **You have a GPU that is not supported by the current CUDA Toolkit**.
   Although CUDA.jl tries to select a runtime that supports most of your GPUs,
   specific devices may end up being unsupported by the active toolkit.
   In that case, call e.g. `CUDA.set_runtime_version!(v"12.9")` to
@@ -187,13 +203,6 @@ funding in the future. If you use our software as part of your research, teachin
 activities, we would be grateful if you could cite our work. The
 [CITATION.bib](https://github.com/JuliaGPU/CUDA.jl/blob/main/CITATION.bib) file in the
 root of this repository lists the relevant papers.
-
-
-## Project Status
-
-The package is tested against, and being developed for, Julia 1.10 and above. Main
-development and testing happens on x86 Linux, but the package is expected to work on
-Windows and ARM and as well.
 
 
 ## Questions and Contributions

--- a/docs/src/installation/overview.md
+++ b/docs/src/installation/overview.md
@@ -150,9 +150,13 @@ releases while keeping the runtime fixed. Keep them within the same CUDA major b
 runtime libraries may link against compiler libraries with a major-versioned soname.
 CUDA.jl configures them together by default.
 
+CUDA 10.2 and 11 are supported on a best-effort basis. Matching runtime and compiler
+artifacts are not available for every older CUDA version and platform. If artifact
+selection cannot provide both, use a local toolkit as described below.
+
 ### Using a local CUDA
 
-To use a local installation, you set the `local_toolkit` keyword argument to
+To use a local installation, set the `local_toolkit` keyword argument to
 `CUDA.set_runtime_version!`:
 
 ```

--- a/lib/cublas/src/cuBLAS.jl
+++ b/lib/cublas/src/cuBLAS.jl
@@ -50,12 +50,17 @@ function math_mode!(handle, mode, precision=CUDACore.math_precision())
     flags = 0
 
     # https://github.com/facebookresearch/faiss/issues/1385
-    flags = CUBLAS_MATH_DISALLOW_REDUCED_PRECISION_REDUCTION
+    if version() > v"11"
+        flags = CUBLAS_MATH_DISALLOW_REDUCED_PRECISION_REDUCTION
+    end
 
     flags |= if mode == CUDACore.PEDANTIC_MATH
-        # prevent use of tensor cores
-        CUBLAS_PEDANTIC_MATH
+        # Prevent use of tensor cores. On cuBLAS 10 they are opt-in,
+        # so the default math mode already accomplishes this.
+        version() < v"11" ? CUBLAS_DEFAULT_MATH : CUBLAS_PEDANTIC_MATH
     elseif mode == CUDACore.DEFAULT_MATH
+        # On cuBLAS 10, tensor-op math may convert FP32 inputs to FP16. Keep the
+        # default mode's guarantee of using at least the requested precision.
         CUBLAS_DEFAULT_MATH
     elseif mode == CUDACore.FAST_MATH
         # downcast to a reduced-precision compute mode whenever possible; the
@@ -65,6 +70,8 @@ function math_mode!(handle, mode, precision=CUDACore.math_precision())
             CUBLAS_FP32_EMULATED_BF16X9_MATH
         elseif precision === :FixedPoint && version() >= v"13.1"
             CUBLAS_FP64_EMULATED_FIXEDPOINT_MATH
+        elseif version() < v"11"
+            CUBLAS_TENSOR_OP_MATH
         else
             CUBLAS_TF32_TENSOR_OP_MATH
         end

--- a/lib/cublas/src/libcublas_deprecated.jl
+++ b/lib/cublas/src/libcublas_deprecated.jl
@@ -3,12 +3,54 @@
 @checked function cublasGemmEx_old(handle, transa, transb, m, n, k, alpha, A, Atype, lda, B,
                                    Btype, ldb, beta, C, Ctype, ldc, computeType, algo)
     initialize_context()
-    @ccall libcublas.cublasGemmEx(handle::cublasHandle_t, transa::cublasOperation_t,
-                                  transb::cublasOperation_t, m::Cint, n::Cint, k::Cint,
-                                  alpha::PtrOrCuPtr{Cvoid}, A::CuPtr{Cvoid},
-                                  Atype::cudaDataType, lda::Cint, B::CuPtr{Cvoid},
-                                  Btype::cudaDataType, ldb::Cint, beta::PtrOrCuPtr{Cvoid},
-                                  C::CuPtr{Cvoid}, Ctype::cudaDataType, ldc::Cint,
-                                  computeType::cudaDataType,
-                                  algo::cublasGemmAlgo_t)::cublasStatus_t
+    @gcsafe_ccall libcublas.cublasGemmEx(handle::cublasHandle_t, transa::cublasOperation_t,
+                                         transb::cublasOperation_t, m::Cint, n::Cint,
+                                         k::Cint, alpha::PtrOrCuPtr{Cvoid},
+                                         A::CuPtr{Cvoid}, Atype::cudaDataType, lda::Cint,
+                                         B::CuPtr{Cvoid}, Btype::cudaDataType, ldb::Cint,
+                                         beta::PtrOrCuPtr{Cvoid}, C::CuPtr{Cvoid},
+                                         Ctype::cudaDataType, ldc::Cint,
+                                         computeType::cudaDataType,
+                                         algo::cublasGemmAlgo_t)::cublasStatus_t
+end
+
+@checked function cublasGemmBatchedEx_old(handle, transa, transb, m, n, k, alpha, Aarray,
+                                          Atype, lda, Barray, Btype, ldb, beta, Carray,
+                                          Ctype, ldc, batchCount, computeType, algo)
+    initialize_context()
+    @gcsafe_ccall libcublas.cublasGemmBatchedEx(handle::cublasHandle_t,
+                                                transa::cublasOperation_t,
+                                                transb::cublasOperation_t, m::Cint, n::Cint,
+                                                k::Cint, alpha::PtrOrCuPtr{Cvoid},
+                                                Aarray::CuPtr{Ptr{Cvoid}},
+                                                Atype::cudaDataType, lda::Cint,
+                                                Barray::CuPtr{Ptr{Cvoid}},
+                                                Btype::cudaDataType, ldb::Cint,
+                                                beta::PtrOrCuPtr{Cvoid},
+                                                Carray::CuPtr{Ptr{Cvoid}},
+                                                Ctype::cudaDataType, ldc::Cint,
+                                                batchCount::Cint, computeType::cudaDataType,
+                                                algo::cublasGemmAlgo_t)::cublasStatus_t
+end
+
+@checked function cublasGemmStridedBatchedEx_old(handle, transa, transb, m, n, k, alpha, A,
+                                                 Atype, lda, strideA, B, Btype, ldb,
+                                                 strideB, beta, C, Ctype, ldc, strideC,
+                                                 batchCount, computeType, algo)
+    initialize_context()
+    @gcsafe_ccall libcublas.cublasGemmStridedBatchedEx(handle::cublasHandle_t,
+                                                       transa::cublasOperation_t,
+                                                       transb::cublasOperation_t, m::Cint,
+                                                       n::Cint, k::Cint,
+                                                       alpha::PtrOrCuPtr{Cvoid},
+                                                       A::CuPtr{Cvoid}, Atype::cudaDataType,
+                                                       lda::Cint, strideA::Clonglong,
+                                                       B::CuPtr{Cvoid}, Btype::cudaDataType,
+                                                       ldb::Cint, strideB::Clonglong,
+                                                       beta::PtrOrCuPtr{Cvoid},
+                                                       C::CuPtr{Cvoid}, Ctype::cudaDataType,
+                                                       ldc::Cint, strideC::Clonglong,
+                                                       batchCount::Cint,
+                                                       computeType::cudaDataType,
+                                                       algo::cublasGemmAlgo_t)::cublasStatus_t
 end

--- a/lib/cublas/src/wrappers.jl
+++ b/lib/cublas/src/wrappers.jl
@@ -1235,6 +1235,7 @@ function gemmExComputeType(TA, TB, TC, m, k, n)
         return math_mode==CUDACore.PEDANTIC_MATH ? CUBLAS_COMPUTE_64F_PEDANTIC : CUBLAS_COMPUTE_64F
     end
     if sig === (BFloat16, BFloat16) || sig === (BFloat16, Float32)
+        version() >= v"11" || return nothing
         return math_mode==CUDACore.PEDANTIC_MATH ? CUBLAS_COMPUTE_32F_PEDANTIC : CUBLAS_COMPUTE_32F
     end
 
@@ -1262,10 +1263,17 @@ function gemmEx!(transA::Char, transB::Char,
         throw(ArgumentError("gemmEx does not support $(eltype(C))=$(eltype(A))*$(eltype(B))"))
     computeT = juliaStorageType(eltype(C), computeType)
     
-    cublasGemmEx(
-        handle(), transA, transB, m, n, k, CuRef{computeT}(alpha), A, eltype(A), lda, B,
-        eltype(B), ldb, CuRef{computeT}(beta), C, eltype(C), ldc, computeType, algo
-    )
+    if version() >= v"11"
+        cublasGemmEx(
+            handle(), transA, transB, m, n, k, CuRef{computeT}(alpha), A, eltype(A), lda, B,
+            eltype(B), ldb, CuRef{computeT}(beta), C, eltype(C), ldc, computeType, algo)
+    else
+        # Before CUDA 11, the compute type used cudaDataType instead.
+        old_compute_type = convert(cudaDataType, computeT)
+        cublasGemmEx_old(
+            handle(), transA, transB, m, n, k, CuRef{computeT}(alpha), A, eltype(A), lda, B,
+            eltype(B), ldb, CuRef{computeT}(beta), C, eltype(C), ldc, old_compute_type, algo)
+    end
     C
 end
 
@@ -1301,10 +1309,16 @@ function gemmBatchedEx!(transA::Char, transB::Char,
     Bptrs = unsafe_batch(B)
     Cptrs = unsafe_batch(C)
 
-    cublasGemmBatchedEx(
-        handle(), transA, transB, m, n, k, CuRef{computeT}(alpha), Aptrs, eltype(A[1]), lda, Bptrs,
-        eltype(B[1]), ldb, CuRef{computeT}(beta), Cptrs, eltype(C[1]), ldc, length(A), computeType, algo
-    )
+    if version() >= v"11"
+        cublasGemmBatchedEx(
+            handle(), transA, transB, m, n, k, CuRef{computeT}(alpha), Aptrs, eltype(A[1]), lda, Bptrs,
+            eltype(B[1]), ldb, CuRef{computeT}(beta), Cptrs, eltype(C[1]), ldc, length(A), computeType, algo)
+    else
+        old_compute_type = convert(cudaDataType, computeT)
+        cublasGemmBatchedEx_old(
+            handle(), transA, transB, m, n, k, CuRef{computeT}(alpha), Aptrs, eltype(A[1]), lda, Bptrs,
+            eltype(B[1]), ldb, CuRef{computeT}(beta), Cptrs, eltype(C[1]), ldc, length(A), old_compute_type, algo)
+    end
     unsafe_free!(Cptrs)
     unsafe_free!(Bptrs)
     unsafe_free!(Aptrs)
@@ -1341,10 +1355,18 @@ function gemmStridedBatchedEx!(
     isnothing(computeType) &&
     throw(ArgumentError("gemmEx does not support $(eltype(C))=$(eltype(A))*$(eltype(B))"))
     computeT = juliaStorageType(eltype(C), computeType)
-    cublasGemmStridedBatchedEx(
-        handle(), transA, transB, m, n, k, CuRef{computeT}(alpha), A, eltype(A), lda, strideA,
-        B, eltype(B), ldb, strideB, CuRef{computeT}(beta), C, eltype(C), ldc, strideC,
-        batchCount, computeType, algo)
+    if version() >= v"11"
+        cublasGemmStridedBatchedEx(
+            handle(), transA, transB, m, n, k, CuRef{computeT}(alpha), A, eltype(A), lda, strideA,
+            B, eltype(B), ldb, strideB, CuRef{computeT}(beta), C, eltype(C), ldc, strideC,
+            batchCount, computeType, algo)
+    else
+        old_compute_type = convert(cudaDataType, computeT)
+        cublasGemmStridedBatchedEx_old(
+            handle(), transA, transB, m, n, k, CuRef{computeT}(alpha), A, eltype(A), lda, strideA,
+            B, eltype(B), ldb, strideB, CuRef{computeT}(beta), C, eltype(C), ldc, strideC,
+            batchCount, old_compute_type, algo)
+    end
     C
 end
 

--- a/lib/cupti/src/wrappers.jl
+++ b/lib/cupti/src/wrappers.jl
@@ -352,8 +352,18 @@ function process(f, cfg::ActivityConfig)
             CUpti_ActivityKernel11
         elseif cuda >= v"13.0"
             CUpti_ActivityKernel10
-        else
+        elseif cuda >= v"12.0"
             CUpti_ActivityKernel9
+        elseif cuda >= v"11.8"
+            CUpti_ActivityKernel8
+        elseif cuda >= v"11.6"
+            CUpti_ActivityKernel7
+        elseif cuda >= v"11.2"
+            CUpti_ActivityKernel6
+        elseif cuda >= v"11.1"
+            CUpti_ActivityKernel5
+        else # oldest supported record layout
+            CUpti_ActivityKernel4
         end
     activity_types[CUPTI_ACTIVITY_KIND_CONCURRENT_KERNEL] =
         activity_types[CUPTI_ACTIVITY_KIND_KERNEL]
@@ -363,20 +373,36 @@ function process(f, cfg::ActivityConfig)
             CUpti_ActivityMemcpy7
         elseif cuda >= v"12.8"
             CUpti_ActivityMemcpy6
-        else
+        elseif cuda >= v"11.6"
             CUpti_ActivityMemcpy5
+        elseif cuda >= v"11.1"
+            CUpti_ActivityMemcpy4
+        elseif cuda >= v"11.0"
+            CUpti_ActivityMemcpy3
+        else # oldest supported record layout
+            CUpti_ActivityMemcpy
         end
     activity_types[CUPTI_ACTIVITY_KIND_MEMSET] =
         if cuda >= v"13.4"
             CUpti_ActivityMemset5
-        else
+        elseif cuda >= v"11.6"
             CUpti_ActivityMemset4
+        elseif cuda >= v"11.1"
+            CUpti_ActivityMemset3
+        elseif cuda >= v"11.0"
+            CUpti_ActivityMemset2
+        else # oldest supported record layout
+            CUpti_ActivityMemset
         end
     activity_types[CUPTI_ACTIVITY_KIND_MEMORY2] =
         if cuda >= v"12.6"
             CUpti_ActivityMemory4
-        else
+        elseif cuda >= v"11.6"
             CUpti_ActivityMemory3
+        elseif cuda >= v"11.2"
+            CUpti_ActivityMemory2
+        else # oldest supported record layout
+            CUpti_ActivityMemory
         end
 
     # extract typed activity records

--- a/lib/cusolver/src/dense_generic.jl
+++ b/lib/cusolver/src/dense_generic.jl
@@ -386,6 +386,10 @@ end
 
 # Xsyevd
 function Xsyevd!(jobz::Char, uplo::Char, A::StridedCuMatrix{T}) where {T <: BlasFloat}
+    if version() < v"11"
+        # The 64-bit generic API is only available in cuSOLVER 11 or later.
+        return T <: Complex ? heevd!(jobz, uplo, A) : syevd!(jobz, uplo, A)
+    end
     chkuplo(uplo)
     n = checksquare(A)
     R = real(T)

--- a/lib/cusparse/src/cuSPARSE.jl
+++ b/lib/cusparse/src/cuSPARSE.jl
@@ -33,6 +33,7 @@ functional() = _initialized[]
 
 # core library
 include("libcusparse.jl")
+include("libcusparse_deprecated.jl")
 
 include("error.jl")
 include("array.jl")

--- a/lib/cusparse/src/generic.jl
+++ b/lib/cusparse/src/generic.jl
@@ -31,6 +31,7 @@ for (elty, felty) in ((:Int16, :Float16),
                       (:Int128, :ComplexF64))
     @eval begin
         function sparsetodense(coo::CuSparseMatrixCOO{$elty}, index::SparseChar, algo::cusparseSparseToDenseAlg_t=CUSPARSE_SPARSETODENSE_ALG_DEFAULT)
+            version() < v"11.3" && throw(ErrorException("This operation is not supported by the current CUDA version."))
             m,n = size(coo)
             coo_compat = CuSparseMatrixCOO(
                 coo.rowInd,
@@ -53,6 +54,7 @@ for (elty, felty) in ((:Int16, :Float16),
             return reinterpret($elty, B)
         end
         function sparsetodense(bsr::CuSparseMatrixBSR{$elty}, index::SparseChar, algo::cusparseSparseToDenseAlg_t=CUSPARSE_SPARSETODENSE_ALG_DEFAULT)
+            version() < v"11.3" && throw(ErrorException("This operation is not supported by the current CUDA version."))
             m,n = size(bsr)
             bsr_compat = CuSparseMatrixBSR(
                 bsr.rowPtr,
@@ -78,6 +80,7 @@ for (elty, felty) in ((:Int16, :Float16),
             return reinterpret($elty, B)
         end
         function sparsetodense(csr::CuSparseMatrixCSR{$elty}, index::SparseChar, algo::cusparseSparseToDenseAlg_t=CUSPARSE_SPARSETODENSE_ALG_DEFAULT)
+            version() < v"11.3" && throw(ErrorException("This operation is not supported by the current CUDA version."))
             m,n = size(csr)
             csr_compat = CuSparseMatrixCSR(
                 csr.rowPtr,
@@ -103,6 +106,13 @@ for (elty, felty) in ((:Int16, :Float16),
 end
 
 function sparsetodense(A::Union{CuSparseMatrixCSC{T},CuSparseMatrixCSR{T},CuSparseMatrixCOO{T}}, index::SparseChar, algo::cusparseSparseToDenseAlg_t=CUSPARSE_SPARSETODENSE_ALG_DEFAULT) where {T}
+    if version() < v"11.3"
+        # These generic conversions were introduced in cuSPARSE 11.3. Fall back to
+        # legacy per-type routines, which only handle BLAS types and 32-bit indices.
+        isa(A, Union{CuSparseMatrixCSR{T,Cint},CuSparseMatrixCSC{T,Cint}}) && T <: BlasFloat ||
+            throw(ErrorException("This operation is not supported by the current CUDA version."))
+        return sparsetodense_old(A, index)
+    end
     m,n = size(A)
     B = CuMatrix{T}(undef, m, n)
     desc_sparse = CuSparseMatrixDescriptor(A, index)
@@ -120,6 +130,13 @@ function sparsetodense(A::Union{CuSparseMatrixCSC{T},CuSparseMatrixCSR{T},CuSpar
 end
 
 function densetosparse(A::CuMatrix{T}, fmt::Symbol, index::SparseChar, algo::cusparseDenseToSparseAlg_t=CUSPARSE_DENSETOSPARSE_ALG_DEFAULT) where {T}
+    if version() < v"11.3"
+        # These generic conversions were introduced in cuSPARSE 11.3. Fall back to
+        # legacy per-type routines, which only handle BLAS types.
+        T <: BlasFloat && fmt in (:csr, :csc) ||
+            throw(ErrorException("This operation is not supported by the current CUDA version."))
+        return densetosparse_old(A, fmt, index)
+    end
     m,n = size(A)
     local rowPtr, colPtr, desc_sparse, B
     if fmt == :coo
@@ -179,6 +196,7 @@ end
 Sets the nonzero elements of `X` equal to the nonzero elements of `Y` at the same indices.
 """
 function gather!(X::CuSparseVector, Y::CuVector, index::SparseChar)
+    version() < v"11" && throw(ErrorException("This operation is not supported by the current CUDA version."))
     descX = CuSparseVectorDescriptor(X, index)
     descY = CuDenseVectorDescriptor(Y)
     cusparseGather(handle(), descY, descX)
@@ -191,6 +209,7 @@ end
 Set `Y[:] = X[:]` for dense `Y` and sparse `X`.
 """
 function scatter!(Y::CuVector, X::CuSparseVector, index::SparseChar)
+    version() < v"11" && throw(ErrorException("This operation is not supported by the current CUDA version."))
     descX = CuSparseVectorDescriptor(X, index)
     descY = CuDenseVectorDescriptor(Y)
     cusparseScatter(handle(), descX, descY)
@@ -203,6 +222,7 @@ end
 Computes `alpha * X + beta * Y` for sparse `X` and dense `Y`.
 """
 function axpby!(alpha::Number, X::CuSparseVector{T}, beta::Number, Y::CuVector{T}, index::SparseChar) where {T}
+    version() < v"11" && throw(ErrorException("This operation is not supported by the current CUDA version."))
     descX = CuSparseVectorDescriptor(X, index)
     descY = CuDenseVectorDescriptor(Y)
     cusparseAxpby(handle(), Ref{T}(alpha), descX, Ref{T}(beta), descY)
@@ -215,6 +235,7 @@ end
 Performs the Givens rotation specified by `c` and `s` to sparse `X` and dense `Y`.
 """
 function rot!(X::CuSparseVector{T}, Y::CuVector{T}, c::Number, s::Number, index::SparseChar) where {T}
+    version() < v"11" && throw(ErrorException("This operation is not supported by the current CUDA version."))
     descX = CuSparseVectorDescriptor(X, index)
     descY = CuDenseVectorDescriptor(Y)
     cusparseRot(handle(), Ref{T}(c), Ref{T}(s), descX, descY)
@@ -245,8 +266,20 @@ function mv!(transa::SparseChar, alpha::Number, A::CuSparseMatrix{TA}, X::DenseC
     # Support transa = 'C' for real matrices
     transa = T <: Real && transa == 'C' ? 'T' : transa
 
-    descA = CuSparseMatrixDescriptor(A, index)
-    m,n = size(A)
+    if cuSPARSE.version() < v"12.0" && isa(A, CuSparseMatrixCSC) && transa == 'C' && TA <: Complex
+        throw(ArgumentError("Matrix-vector multiplication with the adjoint of a complex CSC matrix" *
+                            " is not supported by the current CUDA version. Use a CSR or COO matrix instead."))
+    end
+
+    if cuSPARSE.version() < v"12.0" && isa(A, CuSparseMatrixCSC)
+        # Before cuSPARSE 12, model CSC input as its transposed CSR representation.
+        descA = CuSparseMatrixDescriptor(A, index, transposed=true)
+        n,m = size(A)
+        transa = transa == 'N' ? 'T' : 'N'
+    else
+        descA = CuSparseMatrixDescriptor(A, index)
+        m,n = size(A)
+    end
 
     if transa == 'N'
         chkmvdims(X,n,Y,m)
@@ -260,9 +293,9 @@ function mv!(transa::SparseChar, alpha::Number, A::CuSparseMatrix{TA}, X::DenseC
     # operations with 16-bit numbers always imply mixed-precision computation
     # TODO: we should better model the supported combinations here,
     #       and error if using an unsupported one (like with gemmEx!)
-    compute_type = if T == Float16
+    compute_type = if cuSPARSE.version() >= v"11.4" && T == Float16
         Float32
-    elseif T == ComplexF16
+    elseif cuSPARSE.version() >= v"11.7.2" && T == ComplexF16
         ComplexF32
     else
         T
@@ -290,8 +323,20 @@ function mm!(transa::SparseChar, transb::SparseChar, alpha::Number, A::CuSparseM
     transa = T <: Real && transa == 'C' ? 'T' : transa
     transb = T <: Real && transb == 'C' ? 'T' : transb
 
-    descA = CuSparseMatrixDescriptor(A, index)
-    m,k = size(A)
+    if cuSPARSE.version() < v"12.0" && isa(A, CuSparseMatrixCSC) && transa == 'C' && T <: Complex
+        throw(ArgumentError("Matrix-matrix multiplication with the adjoint of a complex CSC matrix" *
+                            " is not supported by the current CUDA version. Use a CSR or COO matrix instead."))
+    end
+
+    if cuSPARSE.version() < v"12.0" && isa(A, CuSparseMatrixCSC)
+        # Before cuSPARSE 12, model CSC input as its transposed CSR representation.
+        descA = CuSparseMatrixDescriptor(A, index, transposed=true)
+        k,m = size(A)
+        transa = transa == 'N' ? 'T' : 'N'
+    else
+        descA = CuSparseMatrixDescriptor(A, index)
+        m,k = size(A)
+    end
     n = size(C)[2]
 
     if transa == 'N' && transb == 'N'
@@ -362,6 +407,10 @@ end
 function bmm!(transa::SparseChar, transb::SparseChar, alpha::Number, A::CuSparseArrayCSR{T,Ti,3},
               B::DenseCuArray{T,3}, beta::Number, C::DenseCuArray{T,3}, index::SparseChar, algo::cusparseSpMMAlg_t=CUSPARSE_SPMM_ALG_DEFAULT) where {T,Ti}
 
+    if cuSPARSE.version() < v"11.7.2"
+        throw(ErrorException("Batched sparse-matrix times batched dense-matrix (bmm!) requires a CUSPARSE version ≥ 11.7.2 (yours: $(cuSPARSE.version()))."))
+    end
+
     # Support transa = 'C' and `transb = 'C' for real matrices
     transa = T <: Real && transa == 'C' ? 'T' : transa
     transb = T <: Real && transb == 'C' ? 'T' : transb
@@ -422,6 +471,7 @@ end
 # AB and C must have the same sparsity pattern if β ≠ 0.
 function gemm!(transa::SparseChar, transb::SparseChar, alpha::Number, A::CuSparseMatrixCSR{T}, B::CuSparseMatrixCSR{T},
                beta::Number, C::CuSparseMatrixCSR{T}, index::SparseChar, algo::cusparseSpGEMMAlg_t=CUSPARSE_SPGEMM_DEFAULT) where {T}
+    version() < v"11" && throw(ErrorException("This operation is not supported by the current CUDA version."))
 
     m,k = size(A)
     n = size(C)[2]
@@ -553,6 +603,7 @@ end
 
 function gemm(transa::SparseChar, transb::SparseChar, alpha::Number, A::CuSparseMatrixCSR{T},
               B::CuSparseMatrixCSR{T}, index::SparseChar, algo::cusparseSpGEMMAlg_t=CUSPARSE_SPGEMM_DEFAULT) where {T}
+    version() < v"11" && throw(ErrorException("This operation is not supported by the current CUDA version."))
 
     m, k = size(A)
     l, n = size(B)
@@ -721,6 +772,7 @@ end
 function sv!(transa::SparseChar, uplo::SparseChar, diag::SparseChar,
              alpha::Number, A::Union{CuSparseMatrixCSC{T},CuSparseMatrixCSR{T},CuSparseMatrixCOO{T}}, X::DenseCuVector{T},
              Y::DenseCuVector{T}, index::SparseChar, algo::cusparseSpSVAlg_t=CUSPARSE_SPSV_ALG_DEFAULT) where {T}
+    version() < v"11.5" && throw(ErrorException("This operation is not supported by the current CUDA version."))
 
     # Support transa = 'C' for real matrices
     transa = T <: Real && transa == 'C' ? 'T' : transa
@@ -773,6 +825,7 @@ end
 function sm!(transa::SparseChar, transb::SparseChar, uplo::SparseChar, diag::SparseChar,
              alpha::Number, A::Union{CuSparseMatrixCSC{T},CuSparseMatrixCSR{T},CuSparseMatrixCOO{T}}, B::DenseCuMatrix{T},
              C::DenseCuMatrix{T}, index::SparseChar, algo::cusparseSpSMAlg_t=CUSPARSE_SPSM_ALG_DEFAULT) where {T}
+    version() < v"11.6" && throw(ErrorException("This operation is not supported by the current CUDA version."))
 
     # Support transa = 'C' and `transb = 'C' for real matrices
     transa = T <: Real && transa == 'C' ? 'T' : transa
@@ -833,6 +886,7 @@ end
 function sddmm!(transa::SparseChar, transb::SparseChar, alpha::Number, A::DenseCuMatrix{T}, B::DenseCuMatrix{T},
                 beta::Number, C::Union{CuSparseMatrixCSR{T},CuSparseMatrixBSR{T}}, index::SparseChar, algo::cusparseSDDMMAlg_t=CUSPARSE_SDDMM_ALG_DEFAULT) where {T}
 
+    cuSPARSE.version() < v"11.4.1" && throw(ErrorException("This operation is not supported by the current CUDA version."))
     (C isa CuSparseMatrixBSR) && (cuSPARSE.version() < v"12.1.0") && throw(ErrorException("This operation is not supported by the current CUDA version."))
 
     # Support transa = 'C' and `transb = 'C' for real matrices
@@ -867,4 +921,54 @@ function sddmm!(transa::SparseChar, transb::SparseChar, alpha::Number, A::DenseC
         cusparseSDDMM(handle(), transa, transb, Ref{T}(alpha), descA, descB, Ref{T}(beta), descC, T, algo, buffer)
     end
     return C
+end
+
+## legacy dense <-> sparse conversions, for cuSPARSE before 11.3
+
+for (nname, d2rname, d2cname, r2dname, c2dname, elty) in
+        ((:cusparseSnnz, :cusparseSdense2csr, :cusparseSdense2csc, :cusparseScsr2dense, :cusparseScsc2dense, :Float32),
+         (:cusparseDnnz, :cusparseDdense2csr, :cusparseDdense2csc, :cusparseDcsr2dense, :cusparseDcsc2dense, :Float64),
+         (:cusparseCnnz, :cusparseCdense2csr, :cusparseCdense2csc, :cusparseCcsr2dense, :cusparseCcsc2dense, :ComplexF32),
+         (:cusparseZnnz, :cusparseZdense2csr, :cusparseZdense2csc, :cusparseZcsr2dense, :cusparseZcsc2dense, :ComplexF64))
+    @eval begin
+        function sparsetodense_old(csr::CuSparseMatrixCSR{$elty,Cint}, index::SparseChar)
+            m,n = size(csr)
+            A = CuMatrix{$elty}(undef, m, n)
+            descr = CuMatrixDescriptor('G', 'L', 'N', index)
+            $r2dname(handle(), m, n, descr, nonzeros(csr), csr.rowPtr, csr.colVal,
+                     A, max(1, stride(A, 2)))
+            return A
+        end
+        function sparsetodense_old(csc::CuSparseMatrixCSC{$elty,Cint}, index::SparseChar)
+            m,n = size(csc)
+            A = CuMatrix{$elty}(undef, m, n)
+            descr = CuMatrixDescriptor('G', 'L', 'N', index)
+            $c2dname(handle(), m, n, descr, nonzeros(csc), rowvals(csc), csc.colPtr,
+                     A, max(1, stride(A, 2)))
+            return A
+        end
+        function densetosparse_old(A::CuMatrix{$elty}, fmt::Symbol, index::SparseChar)
+            m,n = size(A)
+            lda = max(1, stride(A, 2))
+            descr = CuMatrixDescriptor('G', 'L', 'N', index)
+            nnzTotal = Ref{Cint}()
+            if fmt == :csr
+                nnzPerRow = CuVector{Cint}(undef, m)
+                $nname(handle(), 'R', m, n, descr, A, lda, nnzPerRow, nnzTotal)
+                rowPtr = CuVector{Cint}(undef, m+1)
+                colVal = CuVector{Cint}(undef, nnzTotal[])
+                nzVal = CuVector{$elty}(undef, nnzTotal[])
+                $d2rname(handle(), m, n, descr, A, lda, nnzPerRow, nzVal, rowPtr, colVal)
+                return CuSparseMatrixCSR{$elty, Cint}(rowPtr, colVal, nzVal, (m, n))
+            else
+                nnzPerCol = CuVector{Cint}(undef, n)
+                $nname(handle(), 'C', m, n, descr, A, lda, nnzPerCol, nnzTotal)
+                colPtr = CuVector{Cint}(undef, n+1)
+                rowVal = CuVector{Cint}(undef, nnzTotal[])
+                nzVal = CuVector{$elty}(undef, nnzTotal[])
+                $d2cname(handle(), m, n, descr, A, lda, nnzPerCol, nzVal, rowVal, colPtr)
+                return CuSparseMatrixCSC{$elty, Cint}(colPtr, rowVal, nzVal, (m, n))
+            end
+        end
+    end
 end

--- a/lib/cusparse/src/libcusparse_deprecated.jl
+++ b/lib/cusparse/src/libcusparse_deprecated.jl
@@ -1,0 +1,66 @@
+# Wrappers for legacy cuSPARSE conversions that are absent from current headers but
+# required by toolkits predating the generic conversion API.
+
+for (fname, elty) in ((:cusparseSdense2csr, :Float32),
+                      (:cusparseDdense2csr, :Float64),
+                      (:cusparseCdense2csr, :ComplexF32),
+                      (:cusparseZdense2csr, :ComplexF64))
+    @eval @checked function $fname(handle, m, n, descrA, A, lda, nnzPerRow,
+                                   csrSortedValA, csrSortedRowPtrA, csrSortedColIndA)
+        initialize_context()
+        @gcsafe_ccall libcusparse.$fname(handle::cusparseHandle_t, m::Cint, n::Cint,
+                                         descrA::cusparseMatDescr_t, A::CuPtr{$elty},
+                                         lda::Cint, nnzPerRow::CuPtr{Cint},
+                                         csrSortedValA::CuPtr{$elty},
+                                         csrSortedRowPtrA::CuPtr{Cint},
+                                         csrSortedColIndA::CuPtr{Cint})::cusparseStatus_t
+    end
+end
+
+for (fname, elty) in ((:cusparseSdense2csc, :Float32),
+                      (:cusparseDdense2csc, :Float64),
+                      (:cusparseCdense2csc, :ComplexF32),
+                      (:cusparseZdense2csc, :ComplexF64))
+    @eval @checked function $fname(handle, m, n, descrA, A, lda, nnzPerCol,
+                                   cscSortedValA, cscSortedRowIndA, cscSortedColPtrA)
+        initialize_context()
+        @gcsafe_ccall libcusparse.$fname(handle::cusparseHandle_t, m::Cint, n::Cint,
+                                         descrA::cusparseMatDescr_t, A::CuPtr{$elty},
+                                         lda::Cint, nnzPerCol::CuPtr{Cint},
+                                         cscSortedValA::CuPtr{$elty},
+                                         cscSortedRowIndA::CuPtr{Cint},
+                                         cscSortedColPtrA::CuPtr{Cint})::cusparseStatus_t
+    end
+end
+
+for (fname, elty) in ((:cusparseScsr2dense, :Float32),
+                      (:cusparseDcsr2dense, :Float64),
+                      (:cusparseCcsr2dense, :ComplexF32),
+                      (:cusparseZcsr2dense, :ComplexF64))
+    @eval @checked function $fname(handle, m, n, descrA, csrSortedValA, csrSortedRowPtrA,
+                                   csrSortedColIndA, A, lda)
+        initialize_context()
+        @gcsafe_ccall libcusparse.$fname(handle::cusparseHandle_t, m::Cint, n::Cint,
+                                         descrA::cusparseMatDescr_t,
+                                         csrSortedValA::CuPtr{$elty},
+                                         csrSortedRowPtrA::CuPtr{Cint},
+                                         csrSortedColIndA::CuPtr{Cint}, A::CuPtr{$elty},
+                                         lda::Cint)::cusparseStatus_t
+    end
+end
+
+for (fname, elty) in ((:cusparseScsc2dense, :Float32),
+                      (:cusparseDcsc2dense, :Float64),
+                      (:cusparseCcsc2dense, :ComplexF32),
+                      (:cusparseZcsc2dense, :ComplexF64))
+    @eval @checked function $fname(handle, m, n, descrA, cscSortedValA, cscSortedRowIndA,
+                                   cscSortedColPtrA, A, lda)
+        initialize_context()
+        @gcsafe_ccall libcusparse.$fname(handle::cusparseHandle_t, m::Cint, n::Cint,
+                                         descrA::cusparseMatDescr_t,
+                                         cscSortedValA::CuPtr{$elty},
+                                         cscSortedRowIndA::CuPtr{Cint},
+                                         cscSortedColPtrA::CuPtr{Cint}, A::CuPtr{$elty},
+                                         lda::Cint)::cusparseStatus_t
+    end
+end

--- a/test/core/codegen.jl
+++ b/test/core/codegen.jl
@@ -207,18 +207,27 @@ end
     asm_post = CUDACore.rewrite_ptx_header(asm_pre, v"8.0", sm"90")
     @test occursin(".target sm_90", asm_post)
 
-    @test success(run_ptxas(asm_post, "sm_90"))
+    # Assembling the rewritten headers requires support for both the requested
+    # PTX ISA and target (CUDA 12+ for PTX 8.0, CUDA 12.9+ for `f` variants).
+    ptxas_support = CUDACore.ptxas_compat()
+    if v"8.0" in ptxas_support.ptx && v"9.0" in ptxas_support.cap
+        @test success(run_ptxas(asm_post, "sm_90"))
+    end
 
     # Architecture-specific feature set appends an `a` suffix to the .target directive (and the same
     # string is what `compile()` passes to --gpu-name, since ptxas requires exact match for `a`-mode).
     asm_arch = CUDACore.rewrite_ptx_header(asm_pre, v"8.0", sm"90a")
     @test occursin(".target sm_90a", asm_arch)
-    @test success(run_ptxas(asm_arch, "sm_90a"))
+    if v"8.0" in ptxas_support.ptx && v"9.0" in ptxas_support.cap
+        @test success(run_ptxas(asm_arch, "sm_90a"))
+    end
 
     # Family-specific appends `f`. Requires PTX 8.8+ at the `.target` line.
     asm_family = CUDACore.rewrite_ptx_header(asm_pre, v"8.8", sm"100f")
     @test occursin(".target sm_100f", asm_family)
-    @test success(run_ptxas(asm_family, "sm_100f"))
+    if v"8.8" in ptxas_support.ptx
+        @test success(run_ptxas(asm_family, "sm_100f"))
+    end
 end
 
 @testset "SMVersion and sm\"...\" macro" begin

--- a/test/core/cudadrv.jl
+++ b/test/core/cudadrv.jl
@@ -6,7 +6,9 @@ synchronize()
 
 ctx = current_context()
 @test CUDACore.isvalid(ctx)
-@test unique_id(ctx) > 0
+if CUDA.driver_version() >= v"12"
+    @test unique_id(ctx) > 0
+end
 
 dev = current_device()
 exclusive = attribute(dev, CUDA.DEVICE_ATTRIBUTE_COMPUTE_MODE) == CUDA.COMPUTEMODE_EXCLUSIVE_PROCESS
@@ -45,6 +47,9 @@ end
 end
 
 
+# context-handle reuse detection (needed by the validity tests below) requires
+# the unique context IDs introduced in CUDA 12
+if CUDA.driver_version() >= v"12"
 @testset "primary context" begin
 
 script = """
@@ -107,6 +112,7 @@ script = """
 proc, out, err = julia_exec(`-e $script`)
 @test success(proc)
 
+end
 end
 
 
@@ -847,7 +853,7 @@ end
 @testset "pool" begin
 
 dev = device()
-if attribute(dev, CUDA.DEVICE_ATTRIBUTE_MEMORY_POOLS_SUPPORTED) == 1
+if CUDA.driver_version() >= v"11.2" && attribute(dev, CUDA.DEVICE_ATTRIBUTE_MEMORY_POOLS_SUPPORTED) == 1
 
 pool = memory_pool(dev)
 
@@ -877,7 +883,9 @@ end
 s = CuStream()
 synchronize(s)
 @test CUDA.isdone(s)
-@test unique_id(s) > 0
+if CUDA.driver_version() >= v"12"
+    @test unique_id(s) > 0
+end
 
 let s2 = CuStream()
     @test s != s2

--- a/test/core/device/intrinsics.jl
+++ b/test/core/device/intrinsics.jl
@@ -227,11 +227,14 @@ end
 
 @testset "parallel synchronization and communication" begin
 
-@test @filecheck CUDA.code_llvm(Tuple{}; arch=sm"90", raw=true) do
-    @check "asm sideeffect \"griddepcontrol.launch_dependents;\", \"\""
-    @check "asm sideeffect \"griddepcontrol.wait;\", \"~{memory}\""
-    trigger_programmatic_launch_completion()
-    grid_dependency_synchronize()
+# compiling for sm_90 requires a toolchain that supports it (CUDA 11.8+)
+if v"9.0" in CUDACore.ptxas_compat().cap
+    @test @filecheck CUDA.code_llvm(Tuple{}; arch=sm"90", raw=true) do
+        @check "asm sideeffect \"griddepcontrol.launch_dependents;\", \"\""
+        @check "asm sideeffect \"griddepcontrol.wait;\", \"~{memory}\""
+        trigger_programmatic_launch_completion()
+        grid_dependency_synchronize()
+    end
 end
 
 @on_device sync_threads()

--- a/test/core/execution.jl
+++ b/test/core/execution.jl
@@ -192,11 +192,13 @@ end
     # explicit `ptx=` is taken as an exact request (codegen-test affordance), so the
     # `.version` line should match what was asked for, independently of what LLVM and
     # ptxas would natively pick.
-    @test @filecheck CUDA.code_ptx((); ptx=v"8.0") do
-        @check ".version 8.0"
-        dummy()
+    if v"8.0" in CUDACore.ptxas_compat().ptx
+        @test @filecheck CUDA.code_ptx((); ptx=v"8.0") do
+            @check ".version 8.0"
+            dummy()
+        end
     end
-    @test_throws "requires PTX ISA 8.0" @cuda launch=false ptx=v"7.8" dummy()
+    @test_throws "requires PTX ISA $(CUDACore.minreq.ptx)" @cuda launch=false ptx=v"6.4" dummy()
 
     # explicit `ptx=` is validated against BOTH LLVM and ptxas (not just LLVM as it
     # used to be); a clearly out-of-range value must error at config time.
@@ -448,12 +450,17 @@ end
             @cuda cooperative=true threads=64 blocks=2 clustersize=2 dummy()
         end
     else
-        @test_throws CuError @cuda threads=64 blocks=2 clustersize=2 dummy()
+        # on drivers without cuLaunchKernelEx (CUDA < 11.8), the launch fails
+        # eagerly with an ErrorException instead of a driver CuError
+        expected = CUDACore.driver_version() >= v"11.8" ? CuError : ErrorException
+        @test_throws expected @cuda threads=64 blocks=2 clustersize=2 dummy()
     end
 end
 
 @testset "programmatic dependent launch" begin
-    if CUDA.capability(device()) >= v"9.0"
+    if CUDA.driver_version() < v"11.8"
+        @test_throws "requires CUDA 11.8" @cuda dependent=true dummy()
+    elseif CUDA.capability(device()) >= v"9.0"
         function producer!(output)
             i = (blockIdx().x - 1i32) * blockDim().x + threadIdx().x
             trigger_programmatic_launch_completion()


### PR DESCRIPTION
Restore best-effort support for CUDA 10.2 and CUDA 11 while retaining CUDA 12 and 13 as the primary supported configurations.

- Lower the driver, runtime, and PTX compatibility floors to CUDA 10.2.
- Use legacy driver APIs when newer context, graph, launch, UUID, and memory-pool entry points are unavailable.
- Restore versioned compatibility paths for cuBLAS, cuSOLVER, cuSPARSE, and CUPTI.
- Avoid unsafe unprivileged CUPTI activity probing with CUDA 10 on Tegra.
- Add a support matrix distinguishing CI-tested, supported, and best-effort configurations.
- Direct older platforms to local CUDA toolkits when matching JLL artifacts are unavailable.

The idea here is that with LLMs it's reasonably simple to keep support for older versions, once in a while checking on an actual device I have laying around. However, I won't hesitate to cut functionality or make it slow on older toolkits; the focus is still CUDA 12.x and 13.x.