### PR TITLE
Gate CUPTI MARKER_DATA activity records on CUDA 11

### DIFF
--- a/CUDATools/src/profile.jl
+++ b/CUDATools/src/profile.jl
@@ -393,11 +393,13 @@ function profile_internally(@nospecialize(f); concurrent=true, kwargs...)
         CUPTI.CUPTI_ACTIVITY_KIND_MEMSET,
         # NVTX markers
         CUPTI.CUPTI_ACTIVITY_KIND_MARKER,
-        CUPTI.CUPTI_ACTIVITY_KIND_MARKER_DATA,
     ]
     if CUDACore.runtime_version() >= v"11"
         # internal launch API records require CUDA 11 or later
         push!(activity_kinds, CUPTI.CUPTI_ACTIVITY_KIND_INTERNAL_LAUNCH_API)
+        # NVTX marker data (payload, color, category) is optional, and CUPTI 10.2 rejects
+        # enabling it with CUPTI_ERROR_NOT_COMPATIBLE (observed on Jetson)
+        push!(activity_kinds, CUPTI.CUPTI_ACTIVITY_KIND_MARKER_DATA)
     end
     if CUDACore.runtime_version() >= v"11.2"
         # memory allocation records require CUDA 11.2


### PR DESCRIPTION
CUPTI 10.2 rejects enabling CUPTI_ACTIVITY_KIND_MARKER_DATA with CUPTI_ERROR_NOT_COMPATIBLE (observed on a Jetson Nano, JetPack 4.6, running as root), which made `CUDA.@profile` fail outright on CUDA 10.2. The marker data records only add optional payload, color and category columns to the NVTX table, so enable them on CUDA 11 and later only, like the other version-gated activity kinds.