### PR TITLE
cuSOLVER: Materialize QR's Q with orgqr

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -190,6 +190,11 @@ Julia 1.10 the cache stays session-local
 - Materializing the `Q` factor of a QR decomposition now uses `orgqr` directly,
   avoiding an overflow in `ormqr`'s 32-bit workspace size for tall matrices
   ([#3234](https://github.com/JuliaGPU/CUDA.jl/issues/3234)).
+- Applying the `Q` factor of a QR decomposition (`Q * B`, `Q' * b`, `F \ b`) and
+  `orgqr!` on very tall matrices now apply the reflectors in blocks, keeping
+  cuSOLVER's workspace size within 32-bit range instead of failing with
+  `CUSOLVER_STATUS_INVALID_VALUE`
+  ([#3234](https://github.com/JuliaGPU/CUDA.jl/issues/3234)).
 
 
 ## v6.2 (June 2026)

--- a/NEWS.md
+++ b/NEWS.md
@@ -187,6 +187,9 @@ Julia 1.10 the cache stays session-local
 - Narrowed the data operand of the `trsm` wrappers to CUDA arrays, resolving a
   dispatch ambiguity with GPUArrays' generic triangular solves
   ([#3240](https://github.com/JuliaGPU/CUDA.jl/pull/3240)).
+- Materializing the `Q` factor of a QR decomposition now uses `orgqr` directly,
+  avoiding an overflow in `ormqr`'s 32-bit workspace size for tall matrices
+  ([#3234](https://github.com/JuliaGPU/CUDA.jl/issues/3234)).
 
 
 ## v6.2 (June 2026)

--- a/lib/cusolver/src/dense.jl
+++ b/lib/cusolver/src/dense.jl
@@ -283,6 +283,42 @@ for (fname,elty) in ((:cusolverDnSgetrs, :Float32),
 end
 
 #ormqr
+
+# cuSOLVER's ormqr workspace grows with the number of rows of the reflectors times the
+# number of reflectors, and its 32-bit size query fails once that product gets large
+# (JuliaGPU/CUDA.jl#3234). Applying the reflectors in blocks bounds the workspace.
+const ORMQR_MAX_ELEMENTS = 2^30
+function ormqr_blocksize(mA, k)
+    mA * k <= ORMQR_MAX_ELEMENTS && return k
+    nb = ORMQR_MAX_ELEMENTS ÷ mA
+    return max(32, nb - nb % 32)
+end
+
+# Apply the `k` reflectors stored in `A` to `C` in blocks of `nb`.
+#
+# Reflector `i` only touches rows `i:mA`, so the reflectors `j:jend` can be applied through
+# the trailing submatrices `A[j:mA, j:jend]` and `C[j:mA, :]` (or `C[:, j:mA]` from the
+# right). `Q*C` and `C*Q'` apply the last reflector first; `Q'*C` and `C*Q` the first.
+function ormqr_blocked!(side::Char, trans::Char, A::StridedCuMatrix, tau::CuVector,
+                        C::StridedCuVecOrMat, nb::Integer)
+    mA = size(A, 1)
+    k = length(tau)
+    blocks = 1:nb:k
+    forward = (side == 'L') != (trans == 'N')
+    for j in (forward ? blocks : reverse(blocks))
+        jend = min(j + nb - 1, k)
+        Ab = view(A, j:mA, j:jend)
+        τb = tau[j:jend]
+        Cb = if side == 'L'
+            C isa AbstractVector ? view(C, j:mA) : view(C, j:mA, :)
+        else
+            view(C, :, j:mA)
+        end
+        ormqr!(side, trans, Ab, τb, Cb; blocksize=length(τb))
+    end
+    return C
+end
+
 for (bname, fname, elty) in ((:cusolverDnSormqr_bufferSize, :cusolverDnSormqr, :Float32),
                              (:cusolverDnDormqr_bufferSize, :cusolverDnDormqr, :Float64),
                              (:cusolverDnCunmqr_bufferSize, :cusolverDnCunmqr, :ComplexF32),
@@ -292,7 +328,8 @@ for (bname, fname, elty) in ((:cusolverDnSormqr_bufferSize, :cusolverDnSormqr, :
                         trans::Char,
                         A::StridedCuMatrix{$elty},
                         tau::CuVector{$elty},
-                        C::StridedCuVecOrMat{$elty})
+                        C::StridedCuVecOrMat{$elty};
+                        blocksize::Union{Nothing,Integer}=nothing)
 
             # Support transa = 'C' for real matrices
             trans = $elty <: Real && trans == 'C' ? 'T' : trans
@@ -315,6 +352,11 @@ for (bname, fname, elty) in ((:cusolverDnSormqr_bufferSize, :cusolverDnSormqr, :
             if side == 'R' && k > n
                 throw(DimensionMismatch("invalid number of reflectors: k = $k should be <= n = $n"))
             end
+            nb = blocksize === nothing ? ormqr_blocksize(mA, k) : Int(blocksize)
+            if nb < k
+                return ormqr_blocked!(side, trans, A, tau, C, nb)
+            end
+
             lda = max(1, stride(A, 2))
             ldc = max(1, stride(C, 2))
             dh = dense_handle()
@@ -357,13 +399,22 @@ for (bname, fname, elty) in ((:cusolverDnSorgqr_bufferSize, :cusolverDnSorgqr, :
                 return out[] * sizeof($elty)
             end
 
-            with_workspace(dh.workspace_gpu, bufferSize) do buffer
-                $fname(dh, m, n, k, A, lda, tau,
-                       buffer, sizeof(buffer) ÷ sizeof($elty), dh.info)
-            end
+            if bufferSize() < 0
+                # the 32-bit workspace size overflowed for this very tall matrix;
+                # apply the reflectors to an identity matrix in blocks instead
+                Q = CuMatrix{$elty}(I, m, n)
+                ormqr!('L', 'N', A, tau, Q)
+                copyto!(view(A, :, 1:n), Q)
+                unsafe_free!(Q)
+            else
+                with_workspace(dh.workspace_gpu, bufferSize) do buffer
+                    $fname(dh, m, n, k, A, lda, tau,
+                           buffer, sizeof(buffer) ÷ sizeof($elty), dh.info)
+                end
 
-            info = @allowscalar dh.info[1]
-            chkargsok(BlasInt(info))
+                info = @allowscalar dh.info[1]
+                chkargsok(BlasInt(info))
+            end
 
             if n < size(A, 2)
                 A[:, 1:n]

--- a/lib/cusolver/src/linalg.jl
+++ b/lib/cusolver/src/linalg.jl
@@ -309,6 +309,14 @@ end
 CUDACore.CuArray(Q::AbstractQ) = CuMatrix(Q)
 CUDACore.CuArray{T}(Q::AbstractQ) where {T} = CuMatrix{T}(Q)
 CUDACore.CuMatrix(Q::AbstractQ{T}) where {T} = CuMatrix{T}(Q)
+# Generate the compact Q directly. Applying the reflectors to an identity matrix
+# with `ormqr` can overflow cuSOLVER's 32-bit workspace size for tall matrices (#3234).
+function CUDACore.CuMatrix{T}(Q::QRPackedQ{S,<:CuArray,<:CuArray}) where {T,S}
+    factors = Q.factors
+    k = min(size(factors)...)
+    Qk = orgqr!(factors[:, 1:k], Q.τ)
+    T === S ? Qk : CuMatrix{T}(Qk)
+end
 CUDACore.CuMatrix{T}(Q::QRPackedQ{S}) where {T,S} =
     CuMatrix{T}(lmul!(Q, CuMatrix{S}(I, size(Q, 1), min(size(Q.factors)...))))
 CUDACore.CuMatrix{T, B}(Q::QRPackedQ{S}) where {T, B, S} = CuMatrix{T}(Q)

--- a/lib/cusolver/src/linalg.jl
+++ b/lib/cusolver/src/linalg.jl
@@ -356,7 +356,7 @@ LinearAlgebra.rmul!(A::CuVecOrMat{T},
     ormqr!('R', 'C', parent(adjB).factors, parent(adjB).τ, A)
 LinearAlgebra.rmul!(A::CuVecOrMat{T},
                     trA::Transpose{<:Any,<:QRPackedQ{T,<:CuArray,<:CuArray}}) where {T<:BlasFloat} =
-    ormqr!('R', 'T', parent(trA).factors, parent(adjB).τ, A)
+    ormqr!('R', 'T', parent(trA).factors, parent(trA).τ, A)
 
 
 ## SVD

--- a/lib/cusolver/test/dense/factorizations.jl
+++ b/lib/cusolver/test/dense/factorizations.jl
@@ -40,6 +40,18 @@ end
 
             cuSOLVER.ormqr!(side, trans, dA, dτ, dC)
             @test dC ≈ dD
+
+            # blocked application of the reflectors (used for very tall matrices)
+            for blocksize in (1, 3, 4)
+                dC = CuArray(C)
+                cuSOLVER.ormqr!(side, trans, dA, dτ, dC; blocksize)
+                @test dC ≈ dD
+                dc = CuArray(C[:, 1])
+                if side == 'L'
+                    cuSOLVER.ormqr!(side, trans, dA, dτ, dc; blocksize)
+                    @test dc ≈ dD[:, 1]
+                end
+            end
         end
     end
 end

--- a/lib/cusolver/test/dense/qr.jl
+++ b/lib/cusolver/test/dense/qr.jl
@@ -65,6 +65,11 @@ l = 13
     @test collect(CuArray(d_q)) ≈ Array(q)
     @test Array(d_r) ≈ Array(r)
     @test CuArray(d_q) ≈ convert(typeof(d_A), d_q)
+    other_elty = elty <: Complex ? (elty == ComplexF32 ? ComplexF64 : ComplexF32) :
+                                   (elty == Float32 ? Float64 : Float32)
+    d_q_other = CuMatrix{other_elty}(d_q)
+    @test eltype(d_q_other) === other_elty
+    @test collect(d_q_other) ≈ Array(q)
 
     A              = rand(elty, n, m)
     d_A            = CuArray(A)


### PR DESCRIPTION
CuMatrix(F.Q) applied the Householder reflectors to an identity matrix with ormqr. For the tall matrix reported in #3234, cuSOLVER's 32-bit workspace query overflows and returns CUSOLVER_STATUS_INVALID_VALUE.

Generate the compact Q directly with orgqr! instead, which is also what cupy, PyTorch, scikit-cuda and Paddle do. This avoids the failing workspace path and identity initialization while preserving compact shapes and requested element-type conversion.

The ormqr workspace scales with rows × reflectors regardless of the width of the right-hand side, so `Q' * b` and `F \ b` failed on the same inputs. Apply the reflectors in blocks of trailing submatrices once that product gets large, bounding the workspace of every call. The same blocked application on an identity matrix serves as a fallback in orgqr!, whose workspace query silently goes negative beyond ~16M rows.

Fixes https://github.com/JuliaGPU/CUDA.jl/issues/3234
