### PR TITLE
Annotate CuErrors with the driver error log

### DIFF
--- a/CUDACore/lib/cudadrv/error.jl
+++ b/CUDACore/lib/cudadrv/error.jl
@@ -27,15 +27,20 @@ Base.convert(::Type{Optional{T}}, x::Optional) where T = convert(Optional{T}, x[
 """
     CuError(code)
 
-Create a CUDA error object with error code `code`.
+Create a CUDA error object with error code `code`. Internally, errors thrown by API calls
+are annotated with the driver's explanation of the failure, if the driver provides one.
 """
 struct CuError <: Exception
     code::CUresult
+    log::Optional{String}
+
+    CuError(code, log=nothing) = new(code, log)
 end
 
 Base.convert(::Type{CUresult}, err::CuError) = err.code
 
-Base.:(==)(x::CuError,y::CuError) = x.code == y.code
+Base.:(==)(x::CuError, y::CuError) = x.code == y.code
+Base.hash(err::CuError, h::UInt) = hash(err.code, h)
 
 """
     name(err::CuError)
@@ -78,8 +83,76 @@ function Base.showerror(io::IO, err::CuError)
     else
         print(io, "CUDA error: $(description(err)) (code $(reinterpret(Int32, err.code)), $(name(err)))")
     end
+    if err.log[] !== nothing
+        print(io, "\nDriver log:")
+        for line in eachline(IOBuffer(err.log[]))
+            print(io, "\n  ", line)
+        end
+    end
 end
 
 Base.show(io::IO, ::MIME"text/plain", err::CuError) = print(io, "CuError($(err.code))")
 
 @enum_without_prefix visibility=:public cudaError_enum CUDA_
+
+
+## driver error log
+
+# CUDA 12.9 introduced an error log: a ring buffer of up to 100 entries in which the driver
+# explains, in plain English, why API calls failed. We dump it incrementally whenever we
+# throw a CuError, so that the error message can include the driver's explanation. The log
+# is process-wide, so messages from concurrent failures may be grouped in a single CuError.
+#
+# The same log can be written to a file by setting the `CUDA_LOG_FILE` environment variable.
+
+const driver_log_lock = ReentrantLock()
+const driver_log_iterator = Ref{CUlogIterator}(0)
+const driver_log_initialized = Ref(false)
+
+# return the entries the driver added to its log since the previous call (or since start-up,
+# for the first call), or `nothing` if there are none or if the driver does not support this.
+#
+# NOTE: this consumes the log, so it should only be called when throwing a CuError, or to
+#       discard entries from failures that were handled (see `discard_driver_log`).
+function driver_log()
+    # the log API was introduced in CUDA 12.9
+    if !isassigned(_driver_version) || driver_version() < v"12.9"
+        return nothing
+    end
+
+    # this function is called while throwing errors, so avoid our checked wrappers
+    # (which might initialize state, or throw again).
+    Base.@lock driver_log_lock begin
+        buf = Vector{UInt8}(undef, 25_600)   # documented maximum
+        sz = Ref{Csize_t}(length(buf))
+        if driver_log_initialized[]
+            res = @gcsafe_ccall libcuda.cuLogsDumpToMemory(
+                driver_log_iterator::Ptr{CUlogIterator}, buf::Ptr{UInt8}, sz::Ptr{Csize_t},
+                0::Cuint)::CUresult
+        else
+            # first call: dump everything, and remember where the log currently ends
+            res = @gcsafe_ccall libcuda.cuLogsDumpToMemory(C_NULL::Ptr{CUlogIterator},
+                                                           buf::Ptr{UInt8}, sz::Ptr{Csize_t},
+                                                           0::Cuint)::CUresult
+            res == SUCCESS || return nothing
+            res = @gcsafe_ccall libcuda.cuLogsCurrent(
+                driver_log_iterator::Ptr{CUlogIterator}, 0::Cuint)::CUresult
+            if res == SUCCESS
+                driver_log_initialized[] = true
+            end
+        end
+        res == SUCCESS || return nothing
+
+        # the reported size excludes the NUL terminator; tolerate drivers that include it
+        n = Int(sz[])
+        while n > 0 && buf[n] == 0
+            n -= 1
+        end
+        log = rstrip(String(resize!(buf, n)))
+        return isempty(log) ? nothing : log
+    end
+end
+
+# discard log entries from API failures that were handled, so that they do not get
+# attributed to the next error that is thrown.
+discard_driver_log() = (driver_log(); nothing)

--- a/CUDACore/lib/cudadrv/libcuda.jl
+++ b/CUDACore/lib/cudadrv/libcuda.jl
@@ -25,9 +25,11 @@ end
 # outlined functionality to avoid GC frame allocation
 @noinline function throw_api_error(res)
     if res == ERROR_OUT_OF_MEMORY
+        # do not attribute this handled, self-explanatory failure to a later CuError
+        discard_driver_log()
         throw(OutOfGPUMemoryError())
     else
-        throw(CuError(res))
+        throw(CuError(res, driver_log()))
     end
 end
 

--- a/CUDACore/lib/cudadrv/module.jl
+++ b/CUDACore/lib/cudadrv/module.jl
@@ -21,10 +21,15 @@ function checked_cuModuleLoadDataEx(_module, image, numOptions, options, optionV
     #        that would require a redesign of the memory pool,
     #        so maybe do so when we replace it with CUDA 11.2's pool.
     res = retry_reclaim(isequal(ERROR_OUT_OF_MEMORY)) do
-        unchecked_cuModuleLoadDataEx(_module, image, numOptions, options, optionValues)
+        res = unchecked_cuModuleLoadDataEx(_module, image, numOptions, options, optionValues)
+        if res == ERROR_OUT_OF_MEMORY
+            # OOM is self-explanatory, whether retried here or returned below.
+            discard_driver_log()
+        end
+        res
     end
     if res != SUCCESS
-        throw(CuError(res))
+        throw(CuError(res, driver_log()))
     end
 
     return
@@ -65,7 +70,11 @@ mutable struct CuModule
                                                  ERROR_INVALID_IMAGE,
                                                  ERROR_INVALID_PTX)
                 options = decode(optionKeys, optionVals)
-                error(GC.@preserve options unsafe_string(pointer(options[JIT_ERROR_LOG_BUFFER])))
+                log = GC.@preserve options unsafe_string(pointer(options[JIT_ERROR_LOG_BUFFER]))
+                # the JIT log is only populated when compiling or linking; if the driver
+                # rejected the image outright, the CuError (and its driver log) is all we have
+                isempty(log) && rethrow()
+                error(log)
             else
                 rethrow()
             end

--- a/docs/src/installation/troubleshooting.md
+++ b/docs/src/installation/troubleshooting.md
@@ -1,6 +1,25 @@
 # Troubleshooting
 
 
+## Getting more details about CUDA errors
+
+Many CUDA API errors are generic (e.g. `ERROR_INVALID_VALUE` or `ERROR_NOT_SUPPORTED`) and
+do not explain what went wrong. With CUDA 12.9 or newer, the driver keeps an error log with
+plain-English explanations of failed API calls, and CUDA.jl includes these messages when it
+reports a `CuError`:
+
+```
+CUDA error: operation not supported (code 801, ERROR_NOT_SUPPORTED)
+Driver log:
+  [12:34:56.789][1234][CUDA][E] ...
+  [12:34:56.789][1234][CUDA][E] Returning 801 (CUDA_ERROR_NOT_SUPPORTED) from cuModuleLoadDataEx
+```
+
+The same log can be written out by the driver directly, which is useful when an error is
+swallowed by another library or when the process crashes: set the `CUDA_LOG_FILE`
+environment variable to `stdout`, `stderr`, or a path before starting Julia.
+
+
 ## UndefVarError: libcuda not defined
 
 This means that CUDA.jl could not find a suitable CUDA driver. For more information,

--- a/res/wrap/libcuda_prologue.jl
+++ b/res/wrap/libcuda_prologue.jl
@@ -20,9 +20,11 @@ end
 # outlined functionality to avoid GC frame allocation
 @noinline function throw_api_error(res)
     if res == ERROR_OUT_OF_MEMORY
+        # do not attribute this handled, self-explanatory failure to a later CuError
+        discard_driver_log()
         throw(OutOfGPUMemoryError())
     else
-        throw(CuError(res))
+        throw(CuError(res, driver_log()))
     end
 end
 

--- a/test/core/cudadrv.jl
+++ b/test/core/cudadrv.jl
@@ -196,6 +196,46 @@ let
 
     @test occursin("0", str)
     @test occursin("no error", str)
+    @test !occursin("Driver log", str)
+
+    # errors can be annotated with the driver's log
+    ex = CuError(CUDA.ERROR_INVALID_VALUE, "explanation")
+    @test ex == CuError(CUDA.ERROR_INVALID_VALUE)
+    @test hash(ex) == hash(CuError(CUDA.ERROR_INVALID_VALUE))
+    @test ex.log[] == "explanation"
+    io = IOBuffer()
+    showerror(io, ex)
+    str = String(take!(io))
+    @test occursin("invalid argument", str)
+    @test occursin("Driver log:", str)
+    @test occursin("explanation", str)
+end
+
+if CUDA.driver_version() >= v"12.9"
+    # the driver explains failed API calls (CUDA 12.9+)
+    let
+        # exercise the initial full-buffer dump even if an earlier test initialized the cursor
+        CUDACore.driver_log_initialized[] = false
+        ex = try
+            CUDACore.cuDeviceGet(Ref{CUDACore.CUdevice}(), typemax(Cint))
+            nothing
+        catch err
+            err
+        end
+        @test ex isa CuError
+        @test ex.code == CUDA.ERROR_INVALID_DEVICE
+        @test ex.log[] !== nothing
+        @test occursin("cuDeviceGet", ex.log[])
+
+        # the log is dumped incrementally, so nothing should be left
+        @test CUDACore.driver_log() === nothing
+
+        # handled out-of-memory errors should not leak preceding log entries
+        res = CUDACore.unchecked_cuDeviceGet(Ref{CUDACore.CUdevice}(), typemax(Cint))
+        @test res == CUDA.ERROR_INVALID_DEVICE
+        @test_throws OutOfGPUMemoryError CUDACore.throw_api_error(CUDA.ERROR_OUT_OF_MEMORY)
+        @test CUDACore.driver_log() === nothing
+    end
 end
 
 end


### PR DESCRIPTION
CUDA 12.9 introduced an error log in which the driver explains, in plain English, why API calls failed. Dump it incrementally whenever a CuError is thrown and include the entries in the error message, so generic errors such as ERROR_NOT_SUPPORTED carry the driver's reason. Because the log is process-wide, concurrent failures may be grouped in one exception.

Discard entries for handled failures, including allocation retries and out-of-memory errors, so they are not attributed to a later error. CuModule now rethrows the CuError when its JIT log is empty instead of replacing it with an empty ErrorException.

Document CUDA_LOG_FILE for cases where errors are swallowed or the process crashes.