### PR TITLE
Separate PTX and cubin target compatibility

### DIFF
--- a/CUDACore/src/compatibility.jl
+++ b/CUDACore/src/compatibility.jl
@@ -8,10 +8,11 @@ const highest = v"999"
 # selected via the suffix on the `.target` directive (and the matching `--gpu-name`
 # to ptxas):
 #
-#   - Baseline (no suffix, e.g. sm_90): the forward-compatible feature set. Code compiled
-#     for sm_X runs on any sm_Y with Y >= X (onion model).
-#   - Family (`f` suffix, e.g. sm_100f): a superset of Baseline. Same-major-family-portable;
-#     code compiled for sm_100f runs on sm_100, sm_103, etc., but not across families.
+#   - Baseline (no suffix, e.g. sm_90): the forward-compatible feature set. PTX compiled
+#     for sm_X runs on any sm_Y with Y >= X (onion model); cubins only within a major.
+#   - Family (`f` suffix, e.g. sm_100f): a superset of Baseline. Forward-compatible with
+#     later targets in the same architecture family, i.e. the same major version (with
+#     sm_101f belonging to the sm_11x family).
 #   - Architecture (`a` suffix, e.g. sm_90a): a superset of Family. Locked to one
 #     exact CC; code compiled for sm_103a runs only on CC 10.3 devices.
 #

--- a/CUDACore/src/compiler/compilation.jl
+++ b/CUDACore/src/compiler/compilation.jl
@@ -239,6 +239,34 @@ function default_ptx_versions(llvm_support, ptxas_support)
     return maximum(common_ptxs), maximum(ptxas_ptxs)
 end
 
+# Prefer a target whose cubin can execute on the device. If the toolchain cannot produce
+# one, retain the best PTX-compatible target for PTX-level reflection; execution rejects it.
+function select_ptxas_sm(ptx_sms, dev_cap)
+    supported = filter(sm -> base_version(sm) >= base_version(minreq.sm), ptx_sms)
+    candidates = filter(sm -> cubin_compatible(sm, dev_cap), supported)
+    if isempty(candidates)
+        candidates = filter(sm -> ptx_compatible(sm, dev_cap), supported)
+    end
+    isempty(candidates) && return nothing
+
+    fs_rank(fs::Symbol) = fs === :arch ? 2 : fs === :family ? 1 : 0
+    sm_key(sm::SMVersion) = (base_version(sm), fs_rank(sm.feature_set))
+    return argmax(sm_key, candidates)
+end
+
+function select_llvm_sm(llvm_sms, ptxas_sm)
+    ptxas_sm in llvm_sms && return ptxas_sm
+
+    # Arch/family features do not carry across versions. Use the newest baseline
+    # LLVM supports at or below the target that ptxas will assemble for.
+    candidates = filter(llvm_sms) do sm
+        sm.feature_set === :baseline &&
+            base_version(minreq.sm) <= base_version(sm) <= base_version(ptxas_sm)
+    end
+    isempty(candidates) && return nothing
+    return argmax(base_version, candidates)
+end
+
 @noinline function _compiler_config(dev; kernel=true, name=nothing, always_inline=false,
                                          arch=nothing, cap=nothing, ptx=nothing, kwargs...)
     # `cap=` is the deprecated old name for `arch=` (matches nvcc/ptxas `-arch`).
@@ -274,9 +302,6 @@ end
 
     # when selecting compute capabilities, we prefer the most recent one, as
     # well as prefer to use architecture-accelerated features when available.
-    fs_rank(fs::Symbol) = fs === :arch ? 2 : fs === :family ? 1 : 0
-    sm_key(sm::SMVersion) = (base_version(sm), fs_rank(sm.feature_set))
-
     # determine the compute capability to use.
     ## ptxas
     ptx_sms = ptx_sm_support(ptxas_ptx)
@@ -288,31 +313,15 @@ end
             error("$(cpu_name(arch)) is not supported by PTX ISA $(ptxas_ptx)")
         ptxas_sm = arch
     else
-        # pick the most specific capability the selected PTX ISA supports whose cubin
-        # would actually load on the current device. For baseline that's the onion model;
-        # `:arch` requires an exact CC match, `:family` a same-family match.
-        ptxas_candidates = filter(ptx_sms) do sm
-            base_version(sm) >= base_version(minreq.sm) && runs_on(sm, capability(dev))
-        end
-        isempty(ptxas_candidates) &&
+        ptxas_sm = select_ptxas_sm(ptx_sms, capability(dev))
+        ptxas_sm === nothing &&
             error("Compute capability $(capability(dev)) is not supported by ptxas " *
                   "$(compiler_version()) at PTX ISA $(ptxas_ptx)")
-        ptxas_sm = argmax(sm_key, ptxas_candidates)
     end
     ## LLVM
-    if ptxas_sm in llvm_support.sm
-        llvm_sm = ptxas_sm
-    else
-        # Exact `ptxas_sm` unavailable in LLVM. Fall back to baseline LLVM at a
-        # lower base, since arch/family features don't carry across versions.
-        baseline_candidates = filter(llvm_support.sm) do sm
-            sm.feature_set === :baseline &&
-                base_version(minreq.sm) <= base_version(sm) <= base_version(ptxas_sm)
-        end
-        isempty(baseline_candidates) &&
-            error("Compute capability $(cpu_name(ptxas_sm)) is not supported by LLVM $(nvptx_llvm_version)")
-        llvm_sm = argmax(sm_key, baseline_candidates)
-    end
+    llvm_sm = select_llvm_sm(llvm_support.sm, ptxas_sm)
+    llvm_sm === nothing &&
+        error("Compute capability $(cpu_name(ptxas_sm)) is not supported by LLVM $(nvptx_llvm_version)")
 
     # create GPUCompiler objects
     target = PTXCompilerTarget(; cap=base_version(llvm_sm), ptx=llvm_ptx,

--- a/CUDACore/src/compiler/execution.jl
+++ b/CUDACore/src/compiler/execution.jl
@@ -679,6 +679,14 @@ function cufunction(f::F, tt::TT=Tuple{}; kwargs...) where {F,TT}
         # look up (or generate) the compilation artifacts for this function
         source = methodinstance(F, tt)
         config = compiler_config(cuda.device; kwargs...)::CUDACompilerConfig
+        # Target selection may retain a PTX-compatible target for reflection, but
+        # executing a kernel requires a cubin that loads on this device.
+        sm = config.params.sm
+        cubin_compatible(sm, capability(cuda.device)) ||
+            error("Cannot execute code compiled for $(cpu_name(sm)) on $(cuda.device): " *
+                  "the cubin would not load on compute capability " *
+                  "$(capability(cuda.device)). Use a CUDA toolkit that supports " *
+                  "this device, or select a compatible target with `arch=`.")
         job = CompilerJob(source, config)
         res = compile_or_lookup(job)::CUDACompilerResults
 

--- a/CUDACore/src/compiler/sm.jl
+++ b/CUDACore/src/compiler/sm.jl
@@ -28,9 +28,10 @@ an already-constructed `SMVersion` interchangeably.
 
 - `:baseline` (no suffix, e.g. `sm_90`) — forward-compatible (the "onion model"):
   PTX compiled for `sm_X` runs on any `sm_Y` with `Y >= X`.
-- `:family` (`f` suffix, e.g. `sm_100f`) — same-major-family-portable: PTX runs on
-  any device in the same architecture family (currently == same major version) at
-  or above this CC.
+- `:family` (`f` suffix, e.g. `sm_100f`) — forward-compatible with later targets
+  in the same architecture family, which NVIDIA defines as a major compute-capability
+  version (sm_10x, sm_11x, sm_12x); the sole exception is `sm_101f`, which belongs to
+  the sm_11x family.
 - `:arch` (`a` suffix, e.g. `sm_90a`) — locked to one exact CC: PTX runs only on
   devices with exactly this compute capability, but in exchange gets access to
   architecture-accelerated features.
@@ -104,22 +105,35 @@ cpu_name(sm::SMVersion) = "sm_$(sm.major)$(sm.minor)$(suffix(sm))"
 # usable against the version-keyed compatibility databases.
 base_version(sm::SMVersion) = VersionNumber(sm.major, sm.minor)
 
-# Would a cubin compiled for `sm` actually load and run on a device with capability
-# `dev_cap`? Per NVIDIA's PTX ISA reference (.target directive):
-#   - baseline: forward-compatible (onion model) -- any sm_X runs on sm_Y for Y >= X.
-#   - family:   same architecture family (currently == same major) and forward-portable
-#               within the family.
-#   - arch:     locked to one exact CC; cubin only loads on devices with that exact cap.
-function runs_on(sm::SMVersion, dev_cap::VersionNumber)
+# CUDA 12.x called Thor sm_101; CUDA 13 renamed the same architecture to sm_110.
+canonical_capability(cap::VersionNumber) = cap == v"10.1" ? v"11.0" : cap
+
+# Whether PTX targeted at `sm` can be JIT-compiled for `dev_cap`.
+function ptx_compatible(sm::SMVersion, dev_cap::VersionNumber)
+    cap = base_version(sm)
     if sm.feature_set === :arch
-        return base_version(sm) == dev_cap
+        return canonical_capability(cap) == canonical_capability(dev_cap)
     elseif sm.feature_set === :family
-        return sm.major == dev_cap.major && base_version(sm) <= dev_cap
+        cap = canonical_capability(cap)
+        dev_cap = canonical_capability(dev_cap)
+        return cap.major == dev_cap.major && cap <= dev_cap
     else  # :baseline
-        return base_version(sm) <= dev_cap
+        return cap <= dev_cap
     end
 end
 
+# Whether a cubin compiled for `sm` can load and run on `dev_cap`. Family- and
+# architecture-specific targets retain their PTX restrictions; baseline cubins add a
+# same-major bound. NVIDIA does not guarantee binary compatibility on Tegra, which
+# cannot be distinguished from `dev_cap` alone.
+function cubin_compatible(sm::SMVersion, dev_cap::VersionNumber)
+    ptx_compatible(sm, dev_cap) || return false
+    sm.feature_set === :baseline || return true
+
+    cap = base_version(sm)
+    cap.major == dev_cap.major && return true
+    return canonical_capability(cap).major == canonical_capability(dev_cap).major
+end
 
 Base.show(io::IO, sm::SMVersion) = print(io, "sm\"", sm.major, sm.minor, suffix(sm), "\"")
 

--- a/test/core/codegen.jl
+++ b/test/core/codegen.jl
@@ -260,6 +260,69 @@ end
     @test sm"103a"                     == SMVersion("103a")
 end
 
+@testset "target compatibility" begin
+    ptx_compatible = CUDACore.ptx_compatible
+    cubin_compatible = CUDACore.cubin_compatible
+
+    # Baseline cubins are forward-compatible only within a major version.
+    @test cubin_compatible(sm"80", v"8.0")
+    @test cubin_compatible(sm"80", v"8.6")
+    @test !cubin_compatible(sm"86", v"8.0")
+    @test !cubin_compatible(sm"90", v"12.0")
+    @test !cubin_compatible(sm"75", v"8.0")
+    @test cubin_compatible(sm"100", v"10.1")
+    @test !cubin_compatible(sm"103", v"10.1")
+    @test cubin_compatible(sm"101", v"11.0")
+
+    # Family compatibility follows NVIDIA's architecture families. sm_101f is the
+    # pre-CUDA-13 spelling of sm_110f.
+    @test cubin_compatible(sm"100f", v"10.0")
+    @test cubin_compatible(sm"100f", v"10.3")
+    @test cubin_compatible(sm"103f", v"10.7")
+    @test !cubin_compatible(sm"100f", v"10.1")
+    @test !cubin_compatible(sm"101f", v"10.3")
+    @test cubin_compatible(sm"101f", v"10.1")
+    @test cubin_compatible(sm"101f", v"11.0")
+    @test cubin_compatible(sm"120f", v"12.1")
+    @test !cubin_compatible(sm"121f", v"12.0")
+    @test !cubin_compatible(sm"100f", v"12.0")
+
+    # Architecture-specific code requires an exact capability.
+    @test cubin_compatible(sm"90a", v"9.0")
+    @test !cubin_compatible(sm"90a", v"9.1")
+    @test !cubin_compatible(sm"90a", v"12.0")
+    @test cubin_compatible(sm"101a", v"11.0")
+
+    # Baseline PTX follows the onion model across major versions.
+    @test ptx_compatible(sm"90", v"12.0")
+    @test !ptx_compatible(sm"120", v"9.0")
+end
+
+@testset "target selection" begin
+    select_ptxas_sm = CUDACore.select_ptxas_sm
+
+    # Prefer the most capable target whose cubin can load.
+    @test select_ptxas_sm([sm"90", sm"120", sm"120f", sm"120a"],
+                          v"12.0") == sm"120a"
+    @test select_ptxas_sm([sm"100", sm"100f", sm"103", sm"103f"],
+                          v"10.3") == sm"103f"
+    @test select_ptxas_sm(CUDACore.ptx_sm_support(v"8.0"), v"9.0") == sm"90a"
+
+    # If no cubin can load, retain only a PTX-compatible target for reflection.
+    @test select_ptxas_sm([sm"80", sm"80a", sm"90", sm"90a"], v"12.0") == sm"90"
+    @test select_ptxas_sm([sm"120"], v"9.0") === nothing
+end
+
+@testset "LLVM target selection" begin
+    select_llvm_sm = CUDACore.select_llvm_sm
+
+    @test select_llvm_sm([sm"90", sm"90a"], sm"90a") == sm"90a"
+    @test select_llvm_sm([sm"90", sm"100", sm"100f"], sm"100f") == sm"100f"
+    @test select_llvm_sm([sm"80", sm"90"], sm"90a") == sm"90"
+    @test select_llvm_sm([sm"80", sm"90", sm"90a"], sm"120a") == sm"90"
+    @test select_llvm_sm([sm"90a", sm"100"], sm"90") === nothing
+end
+
 end
 
 ############################################################################################

--- a/test/core/device/intrinsics.jl
+++ b/test/core/device/intrinsics.jl
@@ -53,16 +53,28 @@ end
 end
 
 @testset "target requirements" begin
+    # Compile and validate without loading a cubin: targets need not match the test GPU.
+    # PTX reflection disables validation, including the static assertions tested here.
+    function compile_kernel(f, tt; kwargs...)
+        source = CUDACore.methodinstance(typeof(f), tt)
+        config = CUDACore.compiler_config(device(); kwargs...)
+        CUDACore.compile(CUDACore.CompilerJob(source, config))
+    end
+
     out = CUDA.zeros(UInt32, 1)
 
     function dp4a_kernel(out)
         @inbounds out[] = CUDA.dp4a(Int32(1), Int32(2), Int32(3))
         return
     end
-    @test_throws "requires compute capability 6.1" @cuda launch=false arch=sm"60" dp4a_kernel(out)
+    @test_throws "requires compute capability 6.1" compile_kernel(
+        dp4a_kernel, Tuple{typeof(CUDA.cudaconvert(out))};
+        arch=sm"60")
 
     nanosleep_kernel() = nanosleep(UInt32(1))
-    @test_throws "requires compute capability 7.0" @cuda launch=false arch=sm"61" nanosleep_kernel()
+    @test_throws "requires compute capability 7.0" compile_kernel(
+        nanosleep_kernel, Tuple{};
+        arch=sm"61")
 
     @test @filecheck CUDA.code_ptx((Core.LLVMPtr{UInt16,AS.Global},); arch=sm"61") do ptr
         @check "{{atom(\\.sys)?\\.global\\.cas\\.b32}}"
@@ -82,7 +94,8 @@ end
     end
     local_ptr_t = Core.LLVMPtr{UInt32,AS.Local}
     @test_throws "atomics require a generic, global, or shared address space" begin
-        CUDA.cufunction(invalid_atomic_address_space_kernel, Tuple{local_ptr_t}; arch=sm"80")
+        compile_kernel(invalid_atomic_address_space_kernel, Tuple{local_ptr_t};
+                      arch=sm"80")
     end
 
     outf16 = CUDA.zeros(Float16, 16 * 16)
@@ -91,7 +104,9 @@ end
             pointer(out), Int32(16))
         return
     end
-    @test_throws "requires compute capability 7.0" @cuda launch=false arch=sm"61" wmma_kernel(outf16)
+    @test_throws "requires compute capability 7.0" compile_kernel(
+        wmma_kernel, Tuple{typeof(CUDA.cudaconvert(outf16))};
+        arch=sm"61")
 
     outi8 = CUDA.zeros(Int8, 16 * 16)
     function wmma_int_kernel(out)
@@ -99,7 +114,9 @@ end
             pointer(out), Int32(16))
         return
     end
-    @test_throws "requires compute capability 7.2" @cuda launch=false arch=sm"70" wmma_int_kernel(outi8)
+    @test_throws "requires compute capability 7.2" compile_kernel(
+        wmma_int_kernel, Tuple{typeof(CUDA.cudaconvert(outi8))};
+        arch=sm"70")
 
     outbf16 = CUDA.zeros(CUDACore.BFloat16, 16 * 16)
     function wmma_bf16_kernel(out)
@@ -107,21 +124,27 @@ end
             pointer(out), Int32(16))
         return
     end
-    @test_throws "requires compute capability 8.0" @cuda launch=false arch=sm"72" wmma_bf16_kernel(outbf16)
+    @test_throws "requires compute capability 8.0" compile_kernel(
+        wmma_bf16_kernel, Tuple{typeof(CUDA.cudaconvert(outbf16))};
+        arch=sm"72")
 
     cluster_kernel() = cluster_arrive()
-    @test_throws "requires compute capability 9.0" @cuda launch=false arch=sm"80" cluster_kernel()
+    @test_throws "requires compute capability 9.0" compile_kernel(
+        cluster_kernel, Tuple{};
+        arch=sm"80")
 
     dependent_launch_kernel() = trigger_programmatic_launch_completion()
     @test_throws "requires compute capability 9.0" begin
-        @cuda launch=false arch=sm"80" dependent_launch_kernel()
+        compile_kernel(dependent_launch_kernel, Tuple{}; arch=sm"80")
     end
 
     function distributed_shared_kernel()
         CuDistributedSharedArray(CuStaticSharedArray(UInt32, 1), 1)
         return
     end
-    @test_throws "requires compute capability 9.0" @cuda launch=false arch=sm"80" distributed_shared_kernel()
+    @test_throws "requires compute capability 9.0" compile_kernel(
+        distributed_shared_kernel, Tuple{};
+        arch=sm"80")
 
     # `cp.async.wait_group` takes an immediate operand, so the number of stages needs to
     # be materialized as a constant, capping it at 8 like CUDA's `__pipeline_wait_prior`
@@ -149,7 +172,8 @@ end
     dst_t = CUDACore.Aligned{Core.LLVMPtr{UInt32,AS.Shared},3}
     src_t = CUDACore.Aligned{Core.LLVMPtr{UInt32,AS.Global},3}
     @test_throws "memcpy_async alignment must be a power of 2" begin
-        CUDA.cufunction(invalid_memcpy_alignment_kernel, Tuple{dst_t,src_t}; arch=sm"80")
+        compile_kernel(invalid_memcpy_alignment_kernel, Tuple{dst_t,src_t};
+                      arch=sm"80")
     end
 end
 

--- a/test/core/execution.jl
+++ b/test/core/execution.jl
@@ -188,6 +188,9 @@ end
         @check ".target sm_50"
         dummy()
     end
+    if dev_cap.major != 5
+        @test_throws "would not load" @cuda launch=false arch=sm"50" dummy()
+    end
 
     # explicit `ptx=` is taken as an exact request (codegen-test affordance), so the
     # `.version` line should match what was asked for, independently of what LLVM and
@@ -196,6 +199,20 @@ end
         @test @filecheck CUDA.code_ptx((); ptx=v"8.0") do
             @check ".version 8.0"
             dummy()
+        end
+
+        # Reflection may stop at PTX for an older virtual architecture, but executable
+        # compilation must not silently produce a cubin that cannot load on this device.
+        ptx_sms = filter(sm -> CUDACore.base_version(sm) >=
+                               CUDACore.base_version(CUDACore.minreq.sm),
+                          CUDACore.ptx_sm_support(v"8.0"))
+        if !any(sm -> CUDACore.cubin_compatible(sm, dev_cap), ptx_sms)
+            # Only the cross-generation fallback must avoid architecture/family targets.
+            @test @filecheck CUDA.code_ptx((); ptx=v"8.0") do
+                @check_not "{{\\.target sm_[0-9]+[af]}}"
+                dummy()
+            end
+            @test_throws "would not load" @cuda launch=false ptx=v"8.0" dummy()
         end
     end
     @test_throws "requires PTX ISA $(CUDACore.minreq.ptx)" @cuda launch=false ptx=v"6.4" dummy()


### PR DESCRIPTION
CUDA.jl loads the cubin produced by `ptxas`, so PTX forward compatibility alone does not make a compilation target executable. For example, PTX targeting `sm_90` can be inspected on an `sm_120` GPU, but its `sm_90` cubin cannot load there.

Model PTX and cubin compatibility separately. Prefer the most capable target whose cubin can load, falling back to a PTX-compatible target for reflection. Kernel construction rejects incompatible cubins before compilation, including explicit `arch=` requests. Family and architecture targets retain their narrower compatibility rules, including Thor's `sm_101`/`sm_110` naming change. LLVM can still fall back to a supported baseline target when it lacks the requested variant.

Test target compatibility and selection independently of the installed GPU. Intrinsic requirement tests compile and validate without loading a cubin, so cross-generation targets reach the intended static assertions. The PTX reflection test only excludes architecture/family targets when using the cross-generation fallback.