### PR TITLE
Unify CUDA driver and library logging

### DIFF
--- a/CUDACore/lib/cudadrv/libcuda.jl
+++ b/CUDACore/lib/cudadrv/libcuda.jl
@@ -7007,31 +7007,26 @@ const CUlogsCallback = Ptr{Cvoid}
 const CUlogIterator = Cuint
 
 @checked function cuLogsRegisterCallback(callbackFunc, userData, callback_out)
-    initialize_context()
     @gcsafe_ccall libcuda.cuLogsRegisterCallback(callbackFunc::CUlogsCallback,
                                                  userData::Ptr{Cvoid},
                                                  callback_out::Ptr{CUlogsCallbackHandle})::CUresult
 end
 
 @checked function cuLogsUnregisterCallback(callback)
-    initialize_context()
     @gcsafe_ccall libcuda.cuLogsUnregisterCallback(callback::CUlogsCallbackHandle)::CUresult
 end
 
 @checked function cuLogsCurrent(iterator_out, flags)
-    initialize_context()
     @gcsafe_ccall libcuda.cuLogsCurrent(iterator_out::Ptr{CUlogIterator},
                                         flags::Cuint)::CUresult
 end
 
 @checked function cuLogsDumpToFile(iterator, pathToFile, flags)
-    initialize_context()
     @gcsafe_ccall libcuda.cuLogsDumpToFile(iterator::Ptr{CUlogIterator},
                                            pathToFile::Cstring, flags::Cuint)::CUresult
 end
 
 @checked function cuLogsDumpToMemory(iterator, buffer, size, flags)
-    initialize_context()
     @gcsafe_ccall libcuda.cuLogsDumpToMemory(iterator::Ptr{CUlogIterator}, buffer::Cstring,
                                              size::Ptr{Csize_t}, flags::Cuint)::CUresult
 end

--- a/CUDACore/lib/cudadrv/module.jl
+++ b/CUDACore/lib/cudadrv/module.jl
@@ -53,7 +53,7 @@ mutable struct CuModule
         handle_ref = Ref{CUmodule}()
 
         options[JIT_ERROR_LOG_BUFFER] = Vector{UInt8}(undef, 1024*1024)
-        if isdebug(:CuModule)
+        if isdebug()
             options[JIT_INFO_LOG_BUFFER] = Vector{UInt8}(undef, 1024*1024)
             options[JIT_LOG_VERBOSE] = true
         end
@@ -80,11 +80,11 @@ mutable struct CuModule
             end
         end
 
-        if isdebug(:CuModule)
+        if isdebug()
             options = decode(optionKeys, optionVals)
             if !isempty(options[JIT_INFO_LOG_BUFFER])
                 @debug """JIT info log:
-                          $(options[JIT_INFO_LOG_BUFFER])"""
+                          $(options[JIT_INFO_LOG_BUFFER])""" _group=:CUDA
             end
         end
 

--- a/CUDACore/lib/cudadrv/module/linker.jl
+++ b/CUDACore/lib/cudadrv/module/linker.jl
@@ -22,10 +22,9 @@ mutable struct CuLink
         handle_ref = Ref{CUlinkState}()
 
         options[JIT_ERROR_LOG_BUFFER] = Vector{UInt8}(undef, 1024*1024)
-        @debug begin
+        if isdebug()
             options[JIT_INFO_LOG_BUFFER] = Vector{UInt8}(undef, 1024*1024)
             options[JIT_LOG_VERBOSE] = true
-            "JIT compiling code" # FIXME: remove this useless message
         end
         if Base.JLOptions().debug_level == 1
             # XXX: does not apply to the linker
@@ -152,11 +151,11 @@ function complete(link::CuLink)
         end
     end
 
-    if isdebug(:CuLink)
+    if isdebug()
         options = decode(link.optionKeys, link.optionVals)
         if !isempty(options[JIT_INFO_LOG_BUFFER])
             @debug """JIT info log:
-                      $(options[JIT_INFO_LOG_BUFFER])"""
+                      $(options[JIT_INFO_LOG_BUFFER])""" _group=:CUDA
         end
     end
 

--- a/CUDACore/src/CUDACore.jl
+++ b/CUDACore/src/CUDACore.jl
@@ -84,7 +84,7 @@ include("../lib/cudadrv/CUDAdrv.jl")
 include("initialization.jl")
 include("compiler/sm.jl")
 include("compatibility.jl")
-include("debug.jl")
+include("logging.jl")
 
 # device functionality (needs to be loaded first, because of generated functions)
 include("device/utils.jl")

--- a/CUDACore/src/CUDAKernels.jl
+++ b/CUDACore/src/CUDAKernels.jl
@@ -247,7 +247,7 @@ function KA.priority!(::CUDABackend, prio::Symbol)
     event = CuEvent(CUDACore.EVENT_DISABLE_TIMING)
     record(event, old_stream)
 
-    @debug "Switching default stream" flags priority
+    @debug "Switching default stream" flags priority _group=:CUDA
     new_stream = CuStream(; flags, priority)
     CUDACore.wait(event, new_stream)
     stream!(new_stream)

--- a/CUDACore/src/compiler/compilation.jl
+++ b/CUDACore/src/compiler/compilation.jl
@@ -509,7 +509,7 @@ function compile(@nospecialize(job::CompilerJob))
         end
         error(msg)
     elseif !isempty(log)
-        @debug "PTX compiler log:\n" * log
+        @debug "PTX compiler log:\n" * log _group=:CUDA
     end
     rm(ptx_input)
 
@@ -542,7 +542,7 @@ function compile(@nospecialize(job::CompilerJob))
             msg *= "\nIf you think this is a bug, please file an issue and attach $(ptxas_output)"
             error(msg)
         elseif !isempty(log)
-            @debug "PTX linker info log:\n" * log
+            @debug "PTX linker info log:\n" * log _group=:CUDA
         end
         rm(ptxas_output)
 

--- a/CUDACore/src/debug.jl
+++ b/CUDACore/src/debug.jl
@@ -1,4 +1,0 @@
-# debug functionality
-
-isdebug(group, mod=CUDACore) =
-    Base.CoreLogging.current_logger_for_env(Base.CoreLogging.Debug, group, mod) !== nothing

--- a/CUDACore/src/initialization.jl
+++ b/CUDACore/src/initialization.jl
@@ -69,7 +69,7 @@ function __init__()
     driver = try
         set_driver_version()
     catch err
-        @debug "CUDA driver failed to report a version" exception=(err, catch_backtrace())
+        @debug "CUDA driver failed to report a version" exception=(err, catch_backtrace()) _group=:CUDA
         _initialization_error[] = "CUDA driver not functional"
         return
     end
@@ -137,6 +137,11 @@ function __init__()
     catch err
         _initialization_error[] = "CUDA initialization failed: " * sprint(showerror, err)
         return
+    end
+
+    # forward the driver's log messages when debugging
+    if !precompiling && driver >= v"12.9" && isdebug()
+        enable_logging(true)
     end
 
     # ensure the loaded runtime is supported. done after cuInit so that runtime_version()

--- a/CUDACore/src/logging.jl
+++ b/CUDACore/src/logging.jl
@@ -1,0 +1,212 @@
+# logging functionality: forwarding messages from the driver and libraries to Julia
+
+using Base.CoreLogging: LogLevel, Debug, Info, Warn, Error, @logmsg
+
+@public enable_logging, flush_logs
+
+
+## debug helpers
+
+# A shared group makes JULIA_DEBUG=CUDA cover the stack while preserving module filters.
+isdebug(mod=CUDACore; group=:CUDA) =
+    Base.CoreLogging.current_logger_for_env(Debug, group, mod) !== nothing
+
+
+## message queue
+#
+# Callbacks can run on NVIDIA worker threads while the calling thread waits in the library.
+# They must not yield, perform I/O, re-enter the library, or throw through its C frames.
+# Queue messages under a spin lock; a Julia task delivers them to the logger.
+
+struct LibraryLogMessage
+    mod::Module
+    level::LogLevel
+    message::String
+    # the logging state of the task that triggered the message, so that e.g. `with_logger`
+    # around a library call captures its messages (for foreign threads: the global logger)
+    logstate::Base.CoreLogging.LogState
+end
+
+const log_queue = LibraryLogMessage[]
+const log_queue_lock = Threads.SpinLock()    # a spin lock, so that taking it can't yield
+const log_condition = Ref{Base.AsyncCondition}()
+const log_condition_lock = ReentrantLock()
+const log_flush_lock = ReentrantLock()
+
+# set up the queue. must be called before registering any callback with the driver or a
+# library, and creates a task, so cannot be called during precompilation.
+function init_logging()
+    Base.@lock log_condition_lock begin
+        if !isassigned(log_condition) || !isopen(log_condition[])
+            log_condition[] = Base.AsyncCondition() do _
+                flush_logs()
+            end
+            # messages that are still queued at exit would otherwise be lost
+            atexit(flush_logs)
+        end
+    end
+    return
+end
+
+# queue a message. safe to call from a log callback.
+function enqueue_log(mod::Module, level::LogLevel, message::AbstractString)
+    msg = LibraryLogMessage(mod, level, String(message),
+                            Base.CoreLogging.current_logstate())
+    Base.@lock log_queue_lock push!(log_queue, msg)
+    # NOTE: uv_async_send is thread-safe, but coalesces wake-ups, so the handler drains the
+    #       entire queue rather than processing a single message.
+    if isassigned(log_condition)
+        ccall(:uv_async_send, Cint, (Ptr{Cvoid},), log_condition[].handle)
+    end
+    return
+end
+
+"""
+    CUDA.flush_logs()
+
+Deliver queued driver and library messages to Julia's logging system, waiting for any
+ongoing delivery to finish. Call this before inspecting captured messages or closing a
+logger's output stream. This does not synchronize GPU work or enable logging.
+"""
+function flush_logs()
+    # Only delivery takes this lock; callbacks must remain able to enqueue while a logger
+    # yields or calls a CUDA library itself.
+    Base.@lock log_flush_lock begin
+        messages = Base.@lock log_queue_lock begin
+            isempty(log_queue) && return
+            queued = copy(log_queue)
+            empty!(log_queue)
+            queued
+        end
+        for msg in messages
+            try
+                Base.CoreLogging.with_logstate(() -> emit_log(msg), msg.logstate)
+            catch err
+                # A closed stream or failing custom logger must not kill the delivery task
+                # and leave all subsequent messages accumulating in the queue.
+                try
+                    Base.display_error(stderr, err, catch_backtrace())
+                catch
+                end
+            end
+        end
+    end
+    return
+end
+
+function emit_log(msg::LibraryLogMessage)
+    @logmsg msg.level msg.message _module=msg.mod _group=:CUDA _file=nothing _line=nothing
+    return
+end
+
+# run the body of a log callback, guarding against things that are invalid in a callback:
+# - throwing, which would unwind through the driver's or library's frames;
+# - running finalizers, which could call back into the library that invoked the callback,
+#   while it is still holding internal locks.
+function guarded_callback(f)
+    # don't use `GC.enable_finalizers(true)` to re-enable, as that immediately runs any
+    # pending finalizers; they will be run at the next safe opportunity instead.
+    ccall(:jl_gc_disable_finalizers_internal, Cvoid, ())
+    try
+        f()
+    catch err
+        # report through the queue, since regular error reporting involves I/O
+        try
+            enqueue_log(CUDACore, Error,
+                        "Error in log callback: " * sprint(showerror, err, catch_backtrace()))
+        catch
+        end
+    finally
+        ccall(:jl_gc_enable_finalizers_internal, Cvoid, ())
+    end
+    return
+end
+
+
+## library messages
+#
+# cuBLASLt, cuSPARSE, cuSOLVER, cuTENSOR and the cuQuantum libraries share a logging design,
+# with a callback that receives a numeric level, the name of the API function, and a message:
+#   1: errors, 2: trace (kernel launches), 3: performance hints, 4: info, 5: API trace
+
+function library_log_callback(mod::Module, level::Integer, function_name::Cstring,
+                              message::Cstring)
+    guarded_callback() do
+        level = if level <= 1
+            Error
+        elseif level == 3
+            Info
+        else
+            Debug
+        end
+
+        function_name = unsafe_string(function_name)
+        message = unsafe_string(message)
+        output = if isempty(message)
+            "$function_name(...)"
+        else
+            "$function_name: $message"
+        end
+
+        enqueue_log(mod, level, output)
+    end
+    return
+end
+
+# libraries also write to stdout when logging is enabled, unless a log file is set
+const devnull_path = Sys.iswindows() ? "NUL" : "/dev/null"
+
+
+## driver messages
+#
+# CuError captures the driver's ring buffer independently (see error.jl). Forward failures
+# at Debug because they include handled errors as well as explanations already in CuError.
+
+const driver_log_handle = Ref{CUlogsCallbackHandle}(C_NULL)
+const driver_log_callback_lock = ReentrantLock()
+
+function driver_log_callback(data::Ptr{Cvoid}, level::CUlogLevel, message::Ptr{UInt8},
+                             length::Csize_t)
+    guarded_callback() do
+        jl_level = level == CU_LOG_LEVEL_WARNING ? Warn : Debug
+        enqueue_log(CUDACore, jl_level, unsafe_string(message, length))
+    end
+    return
+end
+
+"""
+    CUDA.enable_logging(enable::Bool=true)
+
+Forward the CUDA driver's log messages to Julia's logging system. Failure explanations
+are reported at `Debug` level and warnings at `Warn` level. This includes failures handled
+internally by CUDA.jl or a library. Requires a driver supporting CUDA 12.9 or newer.
+
+Starting Julia with `JULIA_DEBUG=CUDA` enables this automatically and shows debug messages
+from all CUDA.jl packages. Calling this function only toggles driver log forwarding; it
+does not change Julia's log level or enable library logging. Use [`flush_logs`](@ref) to
+finish delivery before inspecting captured messages.
+
+Driver explanations in `CuError` exceptions are available independently of this setting.
+For crash diagnostics, set `CUDA_LOG_FILE` before starting Julia to write logs directly.
+"""
+function enable_logging(enable::Bool=true)
+    if driver_version() < v"12.9"
+        enable && @warn "Forwarding the driver log requires CUDA 12.9 or newer (found CUDA $(driver_version()))" maxlog=1
+        return
+    end
+
+    Base.@lock driver_log_callback_lock begin
+        if enable
+            init_logging()
+            if driver_log_handle[] == C_NULL
+                callback = @cfunction(driver_log_callback, Nothing,
+                                      (Ptr{Cvoid}, CUlogLevel, Ptr{UInt8}, Csize_t))
+                cuLogsRegisterCallback(callback, C_NULL, driver_log_handle)
+            end
+        elseif driver_log_handle[] != C_NULL
+            cuLogsUnregisterCallback(driver_log_handle[])
+            driver_log_handle[] = C_NULL
+        end
+    end
+    return
+end

--- a/NEWS.md
+++ b/NEWS.md
@@ -59,6 +59,13 @@ CUDA_Runtime_jll 0.24.4 and CUDA_Compiler_jll 0.6.2.
   precompiling there produces a usable image.
 - `CuError` now includes the driver's own error log, when the driver provides
   one ([#3259](https://github.com/JuliaGPU/CUDA.jl/pull/3259)).
+- `JULIA_DEBUG=CUDA` now enables diagnostics across CUDA.jl and its libraries.
+  Individual packages also provide `enable_logging()` to toggle forwarding to Julia's
+  logger. cuBLASLt, cuSPARSE, and the driver gain log forwarding; driver failures are
+  reported at `Debug`, while library warnings and errors retain their severity.
+  Deferred delivery avoids callback I/O hangs with cuBLASXt. Use `CUDA.flush_logs()`
+  before inspecting captured messages or closing a log file. Julia's `-g2` flag no
+  longer enables library logging.
 - LinearAlgebra's storage-specific `mul!` methods are implemented, keeping
   CUDA.jl working with the dispatch rework in Julia 1.13
   ([#3257](https://github.com/JuliaGPU/CUDA.jl/pull/3257)).

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -87,6 +87,7 @@ function main()
                 "development/kernel.md",
                 "development/troubleshooting.md",
                 "development/debugging.md",
+                "development/logging.md",
             ],
             "Hacking" => Any[
                 "hacking/exposing_new_intrinsics.md",

--- a/docs/src/development/logging.md
+++ b/docs/src/development/logging.md
@@ -1,0 +1,131 @@
+# Logging
+
+CUDA.jl can forward diagnostics from the CUDA driver and NVIDIA libraries to Julia's
+logging system. Use these messages to inspect API calls, investigate failures, and find
+performance hints.
+
+## Enabling logging
+
+Start Julia with `JULIA_DEBUG=CUDA` to enable debug output across CUDA.jl and its libraries,
+including packages loaded separately, such as cuDNN and cuTENSOR:
+
+```sh
+JULIA_DEBUG=CUDA julia
+```
+
+For less output, name individual packages. For example, `JULIA_DEBUG=cuDNN` enables cuDNN
+logging, and `JULIA_DEBUG=CUDACore,cuBLAS` enables CUDA.jl's core diagnostics, the driver
+log, and cuBLAS logging.
+
+You can also toggle forwarding at run time:
+
+```julia
+cuDNN.enable_logging()
+# ... calls to cuDNN ...
+cuDNN.enable_logging(false)
+```
+
+This setting applies process-wide. It does not change Julia's log level: the default
+logger only shows `Info` and above. To see traces, include the package in `JULIA_DEBUG`
+or use a logger that accepts `Debug` messages. Library logging can be expensive even when
+Julia filters out the messages, so disable forwarding in performance-sensitive code.
+
+| Message                                  | Level   |
+|:-----------------------------------------|:--------|
+| Library errors and failure explanations   | `Error` |
+| Warnings                                 | `Warn`  |
+| Performance hints                        | `Info`  |
+| API traces and kernel launches            | `Debug` |
+| Driver failure explanations               | `Debug` |
+
+The following packages provide `enable_logging`: `CUDA` (driver messages; requires a
+driver supporting CUDA 12.9 or newer), `cuBLAS` (including cuBLASLt), `cuDNN`, `cuSPARSE`,
+`cuTENSOR`, `cuStateVec`, and `cuTensorNet`. On Windows, cuBLAS forwarding covers cuBLASLt
+only. `CUDA.enable_logging()` controls the driver; it does not enable library logging.
+
+`cuSOLVER.enable_logging()` requires a shared library that exports NVIDIA's logging API.
+If unavailable, it warns; use `CUSOLVERDN_LOG_LEVEL` as described below instead.
+cuFFT, cuRAND, CUPTI, and NVML have no equivalent library log forwarding.
+
+## Diagnosing errors
+
+On drivers supporting CUDA 12.9 or newer, `CuError` exceptions include available driver
+explanations without enabling logging:
+
+```
+CUDA error: operation not supported (code 801, ERROR_NOT_SUPPORTED)
+Driver log:
+  [12:34:56.789][1234][CUDA][E] ...
+  [12:34:56.789][1234][CUDA][E] Returning 801 (CUDA_ERROR_NOT_SUPPORTED) from cuModuleLoadDataEx
+```
+
+`JULIA_DEBUG=CUDA` also shows driver diagnostics for failures handled internally, such as
+an allocation retried after freeing memory or a driver failure inside a library. These
+messages do not necessarily mean your operation failed; check its return value or exception.
+
+## Capturing messages
+
+Messages use the logger of the Julia task that triggered them. Messages from NVIDIA worker
+threads use the global logger. Delivery is asynchronous: call `CUDA.flush_logs()` before
+inspecting captured messages or closing a logger's output stream.
+
+For example, to save cuBLAS diagnostics:
+
+```julia
+using CUDA, Logging
+
+cuBLAS.enable_logging()
+try
+    open("cublas.log", "w") do io
+        with_logger(SimpleLogger(io, Logging.Debug)) do
+            try
+                A = CUDA.rand(Float32, 16, 16)
+                A * A
+            finally
+                CUDA.flush_logs()
+            end
+        end
+    end
+finally
+    cuBLAS.enable_logging(false)
+end
+```
+
+To capture NVIDIA worker-thread messages too, install a global logger with
+`Logging.global_logger`. Custom loggers can select all CUDA diagnostics by their `:CUDA`
+group, or individual packages by the `_module` argument of `handle_message`.
+
+## Crash diagnostics
+
+A crash can lose messages before Julia delivers them. For these cases, configure NVIDIA's
+own output before starting Julia. Leave Julia log forwarding disabled for those libraries,
+so it does not override their output settings.
+
+| Library     | Environment variables                                  |
+|:------------|:-------------------------------------------------------|
+| CUDA driver | `CUDA_LOG_FILE=stderr`                                  |
+| cuBLAS      | `CUBLAS_LOGINFO_DBG=1 CUBLAS_LOGDEST_DBG=stderr`           |
+| cuBLASLt    | `CUBLASLT_LOG_LEVEL=5 CUBLASLT_LOG_FILE=/dev/stderr`       |
+| cuDNN       | `CUDNN_LOGLEVEL_DBG=3 CUDNN_LOGDEST_DBG=stderr`            |
+| cuSPARSE    | `CUSPARSE_LOG_LEVEL=5 CUSPARSE_LOG_FILE=/dev/stderr`       |
+| cuSOLVER    | `CUSOLVERDN_LOG_LEVEL=5 CUSOLVERDN_LOG_FILE=/dev/stderr`   |
+| cuTENSOR    | `CUTENSOR_LOG_LEVEL=5 CUTENSOR_LOG_FILE=/dev/stderr`       |
+| cuQuantum   | `CUSTATEVEC_LOG_LEVEL=5`, `CUTENSORNET_LOG_LEVEL=5`        |
+
+Replace `/dev/stderr` with a file path on systems without that device. cuQuantum's settings
+above write to standard output. These messages bypass Julia's logging filters and loggers.
+Log levels differ between libraries; consult NVIDIA's documentation for other settings.
+
+## API reference
+
+```@docs
+CUDACore.enable_logging
+CUDACore.flush_logs
+cuBLAS.enable_logging
+cuDNN.enable_logging
+cuSPARSE.enable_logging
+cuSOLVER.enable_logging
+cuTENSOR.enable_logging
+cuStateVec.enable_logging
+cuTensorNet.enable_logging
+```

--- a/docs/src/installation/troubleshooting.md
+++ b/docs/src/installation/troubleshooting.md
@@ -15,9 +15,9 @@ Driver log:
   [12:34:56.789][1234][CUDA][E] Returning 801 (CUDA_ERROR_NOT_SUPPORTED) from cuModuleLoadDataEx
 ```
 
-The same log can be written out by the driver directly, which is useful when an error is
-swallowed by another library or when the process crashes: set the `CUDA_LOG_FILE`
-environment variable to `stdout`, `stderr`, or a path before starting Julia.
+Start Julia with `JULIA_DEBUG=CUDA` to also see diagnostics for failures handled internally
+by CUDA.jl or a library, together with library API traces. Refer to [Logging](@ref) for
+selecting individual libraries and collecting logs when the process crashes.
 
 
 ## UndefVarError: libcuda not defined

--- a/docs/src/lib/cudnn.md
+++ b/docs/src/lib/cudnn.md
@@ -51,8 +51,9 @@ outside `legacy`.
 
 ## Debugging
 
-Set `CUDNN_LOGLEVEL_DBG=3` or start Julia with `JULIA_DEBUG=cuDNN` to report cuDNN
-diagnostics through Julia logging.
+Start Julia with `JULIA_DEBUG=cuDNN`, or call `cuDNN.enable_logging()`, to report cuDNN's
+API traces and failure explanations through Julia's logging system. Refer to the
+[Logging](@ref) section for details.
 
 ## Public
 

--- a/lib/cublas/src/cuBLAS.jl
+++ b/lib/cublas/src/cuBLAS.jl
@@ -26,7 +26,7 @@ else
 end
 
 
-@public functional
+@public functional, enable_logging
 
 const _initialized = Ref{Bool}(false)
 functional() = _initialized[]
@@ -246,45 +246,106 @@ end
 
 ## logging
 
-# CUBLAS calls the log callback multiple times for each message, so we need to buffer them
-const log_buffer = IOBuffer()
+# cuBLAS invokes the callback once per line of a message, from the calling thread, which
+# for cuBLASXt can be a worker thread. Lines are assembled per thread into complete messages.
+const log_lock = Threads.SpinLock()
+const log_buffers = Dict{Int,IOBuffer}()
+const log_atexit = Ref(false)
 
-function log_message(ptr)
-    global log_buffer
-    str = unsafe_string(ptr)
-
-    # flush if we've started a new log message
-    if startswith(str, r"[A-Z]!")
-        flush_log_messages()
+function log_message(ptr::Cstring)
+    CUDACore.guarded_callback() do
+        line = unsafe_string(ptr)
+        Base.@lock log_lock begin
+            buf = get!(IOBuffer, log_buffers, Threads.threadid())
+            # a message starts with a line marked by an uppercase severity code (e.g. `I!`),
+            # and ends with a chunk of several lines (the time, process and compiler details)
+            if buf.size > 0 && ncodeunits(line) >= 2 && 'A' <= Char(codeunit(line, 1)) <= 'Z' &&
+               codeunit(line, 2) == UInt8('!')
+                flush_log_buffer(buf)
+            end
+            println(buf, line)
+            if occursin('\n', chop(line))
+                flush_log_buffer(buf)
+            end
+        end
     end
-
-    # append the lines to the buffer
-    println(log_buffer, str)
-
     return
 end
 
-function flush_log_messages()
-    global log_buffer
-    message = String(take!(log_buffer))
+# NOTE: must be called with the log lock held
+function flush_log_buffer(buf::IOBuffer)
+    message = String(take!(buf))
     isempty(message) && return
 
-    # the message format isn't documented, but it looks like a message starts with a capital
-    # and the severity (e.g. `I!`), and subsequent lines start with a lowercase mark (`!i`)
+    # the first line is marked with the severity (e.g. `I!`), subsequent ones with a
+    # lowercase code (`i!`), optionally followed by a space
     code = message[1]
-    lines = split(message[3:end], r"\n+[a-z]!")
-    message = join(strip.(lines), '\n')
-    if code == 'I'
-        @debug message
-    elseif code == 'W'
-        @warn message
-    elseif code == 'E'
-        @error message
-    elseif code == 'F'
-        error(message)
-    else
-        @info "Unknown log message, please file an issue.\n$message"
+    lines = map(eachline(IOBuffer(message))) do line
+        strip(ncodeunits(line) >= 2 && codeunit(line, 2) == UInt8('!') ? line[3:end] : line)
     end
+    filter!(!isempty, lines)
+    message = join(lines, '\n')
+
+    level = if code == 'I'
+        CUDACore.Debug
+    elseif code == 'W'
+        CUDACore.Warn
+    elseif code == 'E'
+        CUDACore.Error
+    elseif code == 'F'
+        CUDACore.Error
+    else
+        CUDACore.Info
+    end
+    CUDACore.enqueue_log(cuBLAS, level, message)
+    return
+end
+
+# report incomplete messages, e.g. at exit
+function flush_log_buffers()
+    Base.@lock log_lock begin
+        for buf in values(log_buffers)
+            flush_log_buffer(buf)
+        end
+    end
+    return
+end
+
+# cuBLASLt uses the logging design shared by other libraries
+function lt_log_message(level::Int32, function_name::Cstring, message::Cstring)
+    CUDACore.library_log_callback(cuBLAS, level, function_name, message)
+    return
+end
+
+"""
+    cuBLAS.enable_logging(enable::Bool=true)
+
+Forward log messages from cuBLAS and cuBLASLt to Julia's logging system. API traces are
+reported at `Debug` level, performance hints at `Info` level, and problems at `Warn` or
+`Error` level. Starting Julia with `JULIA_DEBUG=cuBLAS` enables this automatically, and also
+shows the `Debug`-level messages.
+"""
+function enable_logging(enable::Bool=true)
+    if enable
+        CUDACore.init_logging()
+        # the cuBLAS logging callback crashes on Windows (NVIDIA bug #3321130)
+        if !Sys.iswindows()
+            callback = @cfunction(log_message, Nothing, (Cstring,))
+            cublasSetLoggerCallback(callback)
+            if !log_atexit[]
+                atexit(flush_log_buffers)
+                log_atexit[] = true
+            end
+        end
+        callback = @cfunction(lt_log_message, Nothing, (Int32, Cstring, Cstring))
+        cublasLtLoggerSetCallback(callback)
+        cublasLtLoggerOpenFile(CUDACore.devnull_path)
+        cublasLtLoggerSetLevel(5)
+    else
+        Sys.iswindows() || cublasLoggerConfigure(0, 0, 0, C_NULL)
+        cublasLtLoggerSetLevel(0)
+    end
+    return
 end
 
 function __init__()
@@ -311,12 +372,9 @@ function __init__()
         libcublasLt = CUDA_Runtime_jll.libcublasLt
     end
 
-    # register a log callback
-    if !Sys.iswindows() && # NVIDIA bug #3321130 &&
-       !precompiling && (isdebug(:init, cuBLAS) || Base.JLOptions().debug_level >= 2)
-        callback = @cfunction(log_message, Nothing, (Cstring,))
-        cublasSetLoggerCallback(callback)
-        atexit(flush_log_messages)
+    # forward the library's log messages when debugging
+    if !precompiling && isdebug(cuBLAS)
+        enable_logging(true)
     end
 
     # wire up reclaim (precompile-captured constructors can't push into

--- a/lib/cublas/src/libcublas.jl
+++ b/lib/cublas/src/libcublas.jl
@@ -3211,7 +3211,6 @@ function cublasGetStatusString(status)
 end
 
 @checked function cublasLoggerConfigure(logIsOn, logToStdOut, logToStdErr, logFileName)
-    initialize_context()
     @gcsafe_ccall libcublas.cublasLoggerConfigure(logIsOn::Cint, logToStdOut::Cint,
                                                   logToStdErr::Cint,
                                                   logFileName::Cstring)::cublasStatus_t

--- a/lib/cublas/src/libcublasLt.jl
+++ b/lib/cublas/src/libcublasLt.jl
@@ -1473,33 +1473,27 @@ end
 const cublasLtLoggerCallback_t = Ptr{Cvoid}
 
 @checked function cublasLtLoggerSetCallback(callback)
-    initialize_context()
     @gcsafe_ccall libcublasLt.cublasLtLoggerSetCallback(callback::cublasLtLoggerCallback_t)::cublasStatus_t
 end
 
 @checked function cublasLtLoggerSetFile(file)
-    initialize_context()
     @gcsafe_ccall libcublasLt.cublasLtLoggerSetFile(file::Ptr{Libc.FILE})::cublasStatus_t
 end
 
 @checked function cublasLtLoggerOpenFile(logFile)
-    initialize_context()
     @gcsafe_ccall libcublasLt.cublasLtLoggerOpenFile(logFile::Cstring)::cublasStatus_t
 end
 
 @checked function cublasLtLoggerSetLevel(level)
-    initialize_context()
     @gcsafe_ccall libcublasLt.cublasLtLoggerSetLevel(level::Cint)::cublasStatus_t
 end
 
 @checked function cublasLtLoggerSetMask(mask)
-    initialize_context()
     @gcsafe_ccall libcublasLt.cublasLtLoggerSetMask(mask::Cint)::cublasStatus_t
 end
 
 # no prototype is found for this function at cublasLt.h:2882:29, please use with caution
 @checked function cublasLtLoggerForceDisable()
-    initialize_context()
     @gcsafe_ccall libcublasLt.cublasLtLoggerForceDisable()::cublasStatus_t
 end
 

--- a/lib/cublas/test/logging.jl
+++ b/lib/cublas/test/logging.jl
@@ -1,0 +1,70 @@
+using Base.CoreLogging: Debug
+using Test: TestLogger, collect_test_logs
+
+@testset "logging" begin
+    cuBLAS.enable_logging()
+    try
+        A = CuArray(rand(Float32, 8, 8))
+
+        # API calls are traced at debug level, as a single message per call
+        logs, _ = collect_test_logs(min_level=Debug) do
+            A * A
+            CUDACore.flush_logs()
+        end
+        @test all(log -> log._module === cuBLAS, logs)
+        if !Sys.iswindows()
+            gemm = filter(log -> occursin(r"cublas[SD]?[Gg]emm", log.message), logs)
+            @test !isempty(gemm)
+            @test occursin("transa", first(gemm).message)
+        end
+        # cuBLASLt messages are forwarded too
+        @test any(log -> occursin("cublasLt", log.message), logs)
+
+        # Check severity mapping without depending on toolkit-specific performance hints.
+        @test_logs (:info, "matmul: consider padding") begin
+            ccall(@cfunction(cuBLAS.lt_log_message, Nothing, (Int32, Cstring, Cstring)),
+                  Nothing, (Int32, Cstring, Cstring), 3, "matmul", "consider padding")
+            CUDACore.flush_logs()
+        end
+
+        # cuBLASXt logs from worker threads, whose messages go to the global logger
+        if !Sys.iswindows()
+            logger = TestLogger(min_level=Debug)
+            old_logger = Base.CoreLogging.global_logger(logger)
+            try
+                Base.CoreLogging.with_logger(logger) do
+                    n = 256
+                    C = zeros(Float32, n, n)
+                    cuBLAS.xt_gemm!('N', 'N', 1f0, rand(Float32, n, n), rand(Float32, n, n), 0f0, C)
+                    CUDACore.flush_logs()
+                end
+            finally
+                Base.CoreLogging.global_logger(old_logger)
+            end
+            @test any(log -> occursin("cublasXtSgemm", log.message), logger.logs)
+            @test any(log -> occursin("cublasSgemm_v2", log.message), logger.logs)
+        end
+
+        cuBLAS.enable_logging(false)
+        @test_logs min_level=Debug begin
+            A * A
+            CUDACore.flush_logs()
+        end
+    finally
+        cuBLAS.enable_logging(false)
+    end
+end
+
+@testset "message assembly" begin
+    CUDACore.init_logging()
+    cuBLAS.flush_log_buffers()
+    CUDA.flush_logs()
+    @test_logs (:warn, "example\nα parameter\nTime: now\nProcess: test") begin
+        callback = @cfunction(cuBLAS.log_message, Nothing, (Cstring,))
+        # Some chunks have no newline; unmarked lines may start with Unicode.
+        for line in ("W! example", "α parameter", "Time: now\nProcess: test\n")
+            ccall(callback, Nothing, (Cstring,), line)
+        end
+        CUDA.flush_logs()
+    end
+end

--- a/lib/cudnn/src/cuDNN.jl
+++ b/lib/cudnn/src/cuDNN.jl
@@ -20,7 +20,7 @@ else
 end
 
 
-@public functional
+@public functional, enable_logging
 
 const _initialized = Ref{Bool}(false)
 functional() = _initialized[]
@@ -153,32 +153,55 @@ end
 
 ## logging
 
-function log_message(sev, udata, dbg_ptr, ptr)
-    dbg = unsafe_load(dbg_ptr)
-
-    # find the length of the message, as denoted by two null terminators
-    len = 0
-    while true && len < 10000
-        if unsafe_load(ptr, len+1) == 0 && unsafe_load(ptr, len+2) == 0
-            break
+function log_message(sev::cudnnSeverity_t, udata::Ptr{Cvoid}, dbg::Ptr{cudnnDebug_t},
+                     msg::Ptr{UInt8})
+    CUDACore.guarded_callback() do
+        # each line of the message is NUL-terminated, and the message ends with two NULs
+        len = 0
+        while len < 1 << 20
+            if unsafe_load(msg, len + 1) == 0 && unsafe_load(msg, len + 2) == 0
+                break
+            end
+            len += 1
         end
-        len += 1
-    end
-    str = unsafe_string(ptr, len)
+        lines = split(unsafe_string(msg, len), '\0')
+        message = join(rstrip.(lines), '\n')
 
-    # split into lines and report
-    lines = split(str, '\0')
-    msg = join(strip.(lines), '\n')
-    if sev == CUDNN_SEV_INFO
-        @debug msg
-    elseif sev == CUDNN_SEV_WARNING
-        @warn msg
-    elseif sev == CUDNN_SEV_ERROR
-        @error msg
-    elseif sev == CUDNN_SEV_FATAL
-        error(msg)
+        level = if sev == CUDNN_SEV_INFO
+            CUDACore.Debug
+        elseif sev == CUDNN_SEV_WARNING
+            CUDACore.Warn
+        elseif sev == CUDNN_SEV_ERROR
+            CUDACore.Error
+        else
+            CUDACore.Error
+        end
+        CUDACore.enqueue_log(cuDNN, level, message)
     end
+    return
+end
 
+"""
+    cuDNN.enable_logging(enable::Bool=true)
+
+Forward log messages from cuDNN to Julia's logging system. API traces are reported at
+`Debug` level, and problems (including the library's explanation of why a call failed) at
+`Warn` or `Error` level. Starting Julia with `JULIA_DEBUG=cuDNN` enables this
+automatically, and also shows the `Debug`-level messages.
+"""
+function enable_logging(enable::Bool=true)
+    if enable
+        CUDACore.init_logging()
+        callback = @cfunction(log_message, Nothing,
+                              (cudnnSeverity_t, Ptr{Cvoid}, Ptr{cudnnDebug_t}, Ptr{UInt8}))
+        mask = UInt32(1) << UInt32(CUDNN_SEV_INFO) |
+               UInt32(1) << UInt32(CUDNN_SEV_WARNING) |
+               UInt32(1) << UInt32(CUDNN_SEV_ERROR)
+        cudnnSetCallback(mask, C_NULL, callback)
+    else
+        # restores the built-in callback, which respects the CUDNN_LOG* environment variables
+        cudnnSetCallback(0, C_NULL, C_NULL)
+    end
     return
 end
 
@@ -205,11 +228,9 @@ function __init__()
         libcudnn = CUDNN_jll.libcudnn
     end
 
-    # register a log callback
-    if !precompiling && (isdebug(:init, cuDNN) || Base.JLOptions().debug_level >= 2)
-        callback = @cfunction(log_message, Nothing,
-                              (cudnnSeverity_t, Ptr{Cvoid}, Ptr{cudnnDebug_t}, Ptr{UInt8}))
-        cudnnSetCallback(typemax(UInt32), C_NULL, callback)
+    # forward the library's log messages when debugging
+    if !precompiling && isdebug(cuDNN)
+        enable_logging(true)
     end
 
     CUDACore.register_reclaimable!(idle_handles)

--- a/lib/cudnn/test/logging.jl
+++ b/lib/cudnn/test/logging.jl
@@ -1,0 +1,35 @@
+using Base.CoreLogging: Debug
+
+@testset "logging" begin
+    cuDNN.enable_logging()
+    try
+        desc = Ref{cuDNN.cudnnTensorDescriptor_t}()
+
+        # API calls are traced at debug level
+        @test_logs (:debug, r"cudnnCreateTensorDescriptor") min_level=Debug match_mode=:any begin
+            cuDNN.cudnnCreateTensorDescriptor(desc)
+            CUDACore.flush_logs()
+        end
+
+        # failures are explained at error level
+        logs, _ = Test.collect_test_logs(min_level=Debug) do
+            cuDNN.unchecked_cudnnSetTensor4dDescriptor(desc[], cuDNN.CUDNN_TENSOR_NCHW,
+                                                        cuDNN.CUDNN_DATA_FLOAT, -1, 1, 1, 1)
+            CUDACore.flush_logs()
+        end
+        @test all(log -> log._module === cuDNN, logs)
+        errors = filter(log -> log.level == Base.CoreLogging.Error, logs)
+        @test !isempty(errors)
+        @test occursin("CUDNN_STATUS_BAD_PARAM", first(errors).message)
+        # lines of a message are joined
+        @test occursin(r"cudnnSetTensor4dDescriptor.*\n.*Traceback"s, first(errors).message)
+
+        cuDNN.enable_logging(false)
+        @test_logs min_level=Debug begin
+            cuDNN.cudnnDestroyTensorDescriptor(desc[])
+            CUDACore.flush_logs()
+        end
+    finally
+        cuDNN.enable_logging(false)
+    end
+end

--- a/lib/cupti/src/wrappers.jl
+++ b/lib/cupti/src/wrappers.jl
@@ -276,7 +276,7 @@ macro enable!(cfg, expr)
                         catch err
                             if isa(err, $mod.CUPTIError) &&
                                err.code == $mod.CUPTI_ERROR_NOT_COMPATIBLE
-                                @debug "CUPTI does not support $activity_kind; not profiling it"
+                                @debug "CUPTI does not support $activity_kind; not profiling it" _group=:CUDA
                                 continue
                             end
                             rethrow()

--- a/lib/cusolver/src/cuSOLVER.jl
+++ b/lib/cusolver/src/cuSOLVER.jl
@@ -4,7 +4,7 @@ using CUDACore
 using GPUToolbox
 
 using CUDACore: CUstream, cuComplex, cuDoubleComplex, libraryPropertyType, cudaDataType, cudaEmulationStrategy_t, cudaEmulationMantissaControl_t, cudaEmulationSpecialValuesSupport_t
-using CUDACore: @allowscalar, assertscalar, unsafe_free!, retry_reclaim, initialize_context
+using CUDACore: @allowscalar, assertscalar, unsafe_free!, retry_reclaim, initialize_context, isdebug
 
 using cuBLAS
 using cuBLAS: cublasFillMode_t, cublasOperation_t, cublasSideMode_t, cublasDiagType_t
@@ -23,7 +23,7 @@ else
 end
 
 
-@public functional, has_cusolvermg
+@public functional, has_cusolvermg, enable_logging
 
 const _initialized = Ref{Bool}(false)
 functional() = _initialized[]
@@ -261,6 +261,53 @@ function mg_handle()
 end
 
 
+## logging
+
+# the logging API is documented and defined in the static library, but the shared library
+# does not export it (checked from CUDA 11 through 13.4; NVIDIA bug #6738440)
+function has_logging_api()
+    lib = CUDACore.Libdl.dlopen(libcusolver)
+    try
+        CUDACore.Libdl.dlsym(lib, :cusolverDnLoggerSetCallback; throw_error=false) !== nothing
+    finally
+        CUDACore.Libdl.dlclose(lib)
+    end
+end
+
+function log_message(level::Int32, function_name::Cstring, message::Cstring)
+    CUDACore.library_log_callback(cuSOLVER, level, function_name, message)
+    return
+end
+
+"""
+    cuSOLVER.enable_logging(enable::Bool=true)
+
+Forward log messages from cuSOLVER to Julia's logging system. API and kernel traces are
+reported at `Debug` level, performance hints at `Info` level, and problems at `Error`
+level. Starting Julia with `JULIA_DEBUG=cuSOLVER` enables this automatically, and also shows
+the `Debug`-level messages.
+
+If the installed shared library does not export the logging API, enabling emits a warning.
+Set `CUSOLVERDN_LOG_LEVEL` before starting Julia to use cuSOLVER's own output instead.
+"""
+function enable_logging(enable::Bool=true)
+    if !has_logging_api()
+        enable && @warn "The cuSOLVER $(version()) shared library does not export the logging callback API; set the CUSOLVERDN_LOG_LEVEL environment variable to have the library print its log to stdout instead" maxlog=1
+        return
+    end
+    if enable
+        CUDACore.init_logging()
+        callback = @cfunction(log_message, Nothing, (Int32, Cstring, Cstring))
+        cusolverDnLoggerSetCallback(callback)
+        # the library also writes to stdout, unless a log file is set
+        cusolverDnLoggerOpenFile(CUDACore.devnull_path)
+        cusolverDnLoggerSetLevel(5)
+    else
+        cusolverDnLoggerSetLevel(0)
+    end
+    return
+end
+
 function __init__()
     precompiling = ccall(:jl_generating_output, Cint, ()) != 0
 
@@ -285,6 +332,13 @@ function __init__()
         if hasproperty(CUDA_Runtime_jll, :libcusolverMg)
             libcusolverMg = CUDA_Runtime_jll.libcusolverMg
         end
+    end
+
+    # forward the library's log messages when debugging. only complain about the missing
+    # API when cuSOLVER was named explicitly, not when implied by `JULIA_DEBUG=CUDA`.
+    if !precompiling && isdebug(cuSOLVER) &&
+       (has_logging_api() || isdebug(cuSOLVER; group=:init))
+        enable_logging(true)
     end
 
     CUDACore.register_reclaimable!(idle_dense_handles)

--- a/lib/cusolver/src/libcusolver.jl
+++ b/lib/cusolver/src/libcusolver.jl
@@ -5094,33 +5094,27 @@ end
 const cusolverDnLoggerCallback_t = Ptr{Cvoid}
 
 @checked function cusolverDnLoggerSetCallback(callback)
-    initialize_context()
     @gcsafe_ccall libcusolver.cusolverDnLoggerSetCallback(callback::cusolverDnLoggerCallback_t)::cusolverStatus_t
 end
 
 @checked function cusolverDnLoggerSetFile(file)
-    initialize_context()
     @gcsafe_ccall libcusolver.cusolverDnLoggerSetFile(file::Ptr{Libc.FILE})::cusolverStatus_t
 end
 
 @checked function cusolverDnLoggerOpenFile(logFile)
-    initialize_context()
     @gcsafe_ccall libcusolver.cusolverDnLoggerOpenFile(logFile::Cstring)::cusolverStatus_t
 end
 
 @checked function cusolverDnLoggerSetLevel(level)
-    initialize_context()
     @gcsafe_ccall libcusolver.cusolverDnLoggerSetLevel(level::Cint)::cusolverStatus_t
 end
 
 @checked function cusolverDnLoggerSetMask(mask)
-    initialize_context()
     @gcsafe_ccall libcusolver.cusolverDnLoggerSetMask(mask::Cint)::cusolverStatus_t
 end
 
 # no prototype is found for this function at cusolverDn.h:5036:32, please use with caution
 @checked function cusolverDnLoggerForceDisable()
-    initialize_context()
     @gcsafe_ccall libcusolver.cusolverDnLoggerForceDisable()::cusolverStatus_t
 end
 

--- a/lib/cusolver/test/logging.jl
+++ b/lib/cusolver/test/logging.jl
@@ -1,0 +1,25 @@
+using Base.CoreLogging: Debug
+
+@testset "logging" begin
+    if !cuSOLVER.has_logging_api()
+        # the shared library does not export the logging API (only the static one defines it)
+        @test_logs (:warn, r"does not export the logging callback API") cuSOLVER.enable_logging()
+    else
+        cuSOLVER.enable_logging()
+        try
+            A = CuArray(rand(Float32, 8, 8))
+            @test_logs (:debug, r"cusolverDn\w*getrf") min_level=Debug match_mode=:any begin
+                lu(A)
+                CUDACore.flush_logs()
+            end
+
+            cuSOLVER.enable_logging(false)
+            @test_logs min_level=Debug begin
+                lu(A)
+                CUDACore.flush_logs()
+            end
+        finally
+            cuSOLVER.enable_logging(false)
+        end
+    end
+end

--- a/lib/cusparse/src/cuSPARSE.jl
+++ b/lib/cusparse/src/cuSPARSE.jl
@@ -4,7 +4,7 @@ using CUDACore
 using GPUToolbox
 
 using CUDACore: CUstream, cuComplex, cuDoubleComplex, libraryPropertyType, cudaDataType
-using CUDACore: unsafe_free!, retry_reclaim, initialize_context, @allowscalar
+using CUDACore: unsafe_free!, retry_reclaim, initialize_context, @allowscalar, isdebug
 
 using GPUArrays
 
@@ -26,7 +26,7 @@ end
 const SparseChar = Char
 
 
-@public functional
+@public functional, enable_logging
 
 const _initialized = Ref{Bool}(false)
 functional() = _initialized[]
@@ -122,6 +122,35 @@ function handle()
 end
 
 
+## logging
+
+function log_message(level::Int32, function_name::Cstring, message::Cstring)
+    CUDACore.library_log_callback(cuSPARSE, level, function_name, message)
+    return
+end
+
+"""
+    cuSPARSE.enable_logging(enable::Bool=true)
+
+Forward log messages from cuSPARSE to Julia's logging system. API and kernel traces are
+reported at `Debug` level, performance hints at `Info` level, and problems at `Error`
+level. Starting Julia with `JULIA_DEBUG=cuSPARSE` enables this automatically, and also shows
+the `Debug`-level messages.
+"""
+function enable_logging(enable::Bool=true)
+    if enable
+        CUDACore.init_logging()
+        callback = @cfunction(log_message, Nothing, (Int32, Cstring, Cstring))
+        cusparseLoggerSetCallback(callback)
+        # the library also writes to stdout, unless a log file is set
+        cusparseLoggerOpenFile(CUDACore.devnull_path)
+        cusparseLoggerSetLevel(5)
+    else
+        cusparseLoggerSetLevel(0)
+    end
+    return
+end
+
 function __init__()
     precompiling = ccall(:jl_generating_output, Cint, ()) != 0
 
@@ -139,6 +168,11 @@ function __init__()
         libcusparse = path
     else
         libcusparse = CUDA_Runtime_jll.libcusparse
+    end
+
+    # forward the library's log messages when debugging
+    if !precompiling && isdebug(cuSPARSE)
+        enable_logging(true)
     end
 
     CUDACore.register_reclaimable!(idle_handles)

--- a/lib/cusparse/src/libcusparse.jl
+++ b/lib/cusparse/src/libcusparse.jl
@@ -194,32 +194,26 @@ end
 const cusparseLoggerCallback_t = Ptr{Cvoid}
 
 @checked function cusparseLoggerSetCallback(callback)
-    initialize_context()
     @gcsafe_ccall libcusparse.cusparseLoggerSetCallback(callback::cusparseLoggerCallback_t)::cusparseStatus_t
 end
 
 @checked function cusparseLoggerSetFile(file)
-    initialize_context()
     @gcsafe_ccall libcusparse.cusparseLoggerSetFile(file::Ptr{Libc.FILE})::cusparseStatus_t
 end
 
 @checked function cusparseLoggerOpenFile(logFile)
-    initialize_context()
     @gcsafe_ccall libcusparse.cusparseLoggerOpenFile(logFile::Cstring)::cusparseStatus_t
 end
 
 @checked function cusparseLoggerSetLevel(level)
-    initialize_context()
     @gcsafe_ccall libcusparse.cusparseLoggerSetLevel(level::Cint)::cusparseStatus_t
 end
 
 @checked function cusparseLoggerSetMask(mask)
-    initialize_context()
     @gcsafe_ccall libcusparse.cusparseLoggerSetMask(mask::Cint)::cusparseStatus_t
 end
 
 @checked function cusparseLoggerForceDisable()
-    initialize_context()
     @gcsafe_ccall libcusparse.cusparseLoggerForceDisable()::cusparseStatus_t
 end
 

--- a/lib/cusparse/test/logging.jl
+++ b/lib/cusparse/test/logging.jl
@@ -1,0 +1,25 @@
+using Base.CoreLogging: Debug
+
+@testset "logging" begin
+    cuSPARSE.enable_logging()
+    try
+        A = CuSparseMatrixCSR(sprand(Float32, 16, 16, 0.5))
+        x = CuArray(rand(Float32, 16))
+
+        # API calls and kernel launches are traced at debug level
+        logs, _ = Test.collect_test_logs(min_level=Debug) do
+            A * x
+            CUDACore.flush_logs()
+        end
+        @test all(log -> log._module === cuSPARSE, logs)
+        @test any(log -> occursin(r"^cusparseSpMV", log.message), logs)
+
+        cuSPARSE.enable_logging(false)
+        @test_logs min_level=Debug begin
+            A * x
+            CUDACore.flush_logs()
+        end
+    finally
+        cuSPARSE.enable_logging(false)
+    end
+end

--- a/lib/custatevec/src/cuStateVec.jl
+++ b/lib/custatevec/src/cuStateVec.jl
@@ -14,7 +14,7 @@ else
 end
 
 
-@public functional
+@public functional, enable_logging
 
 const _initialized = Ref{Bool}(false)
 functional() = _initialized[]
@@ -102,19 +102,29 @@ end
 
 ## logging
 
-function log_message(log_level, function_name, message)
-    function_name = unsafe_string(function_name)
-    message = unsafe_string(message)
-    output = if isempty(message)
-        "$function_name(...)"
+function log_message(level::Int32, function_name::Cstring, message::Cstring)
+    CUDACore.library_log_callback(cuStateVec, level, function_name, message)
+    return
+end
+
+"""
+    cuStateVec.enable_logging(enable::Bool=true)
+
+Forward log messages from cuStateVec to Julia's logging system. API and kernel traces are
+reported at `Debug` level, performance hints at `Info` level, and problems at `Error`
+level. Starting Julia with `JULIA_DEBUG=cuStateVec` enables this automatically, and also shows
+the `Debug`-level messages.
+"""
+function enable_logging(enable::Bool=true)
+    if enable
+        CUDACore.init_logging()
+        callback = @cfunction(log_message, Nothing, (Int32, Cstring, Cstring))
+        custatevecLoggerSetCallback(callback)
+        # the library also writes to stdout, unless a log file is set
+        custatevecLoggerOpenFile(CUDACore.devnull_path)
+        custatevecLoggerSetLevel(5)
     else
-        "$function_name: $message"
-    end
-    if log_level <= 1
-        @error output
-    else
-        # the other log levels are different levels of tracing and hints
-        @debug output
+        custatevecLoggerSetLevel(0)
     end
     return
 end
@@ -142,12 +152,9 @@ function __init__()
         libcustatevec = cuQuantum_jll.libcustatevec
     end
 
-    # register a log callback
-    if !precompiling && (isdebug(:init, cuStateVec) || Base.JLOptions().debug_level >= 2)
-        callback = @cfunction(log_message, Nothing, (Int32, Cstring, Cstring))
-        custatevecLoggerSetCallback(callback)
-        custatevecLoggerOpenFile(Sys.iswindows() ? "NUL" : "/dev/null")
-        custatevecLoggerSetLevel(5)
+    # forward the library's log messages when debugging
+    if !precompiling && isdebug(cuStateVec)
+        enable_logging(true)
     end
 
     CUDACore.register_reclaimable!(idle_handles)

--- a/lib/custatevec/src/libcustatevec.jl
+++ b/lib/custatevec/src/libcustatevec.jl
@@ -200,7 +200,6 @@ end
 end
 
 @checked function custatevecLoggerSetCallbackData(callback, userData)
-    initialize_context()
     @gcsafe_ccall libcustatevec.custatevecLoggerSetCallbackData(callback::custatevecLoggerCallbackData_t,
                                                                 userData::Ptr{Cvoid})::custatevecStatus_t
 end
@@ -214,7 +213,6 @@ end
 end
 
 @checked function custatevecLoggerSetLevel(level)
-    initialize_context()
     @gcsafe_ccall libcustatevec.custatevecLoggerSetLevel(level::Int32)::custatevecStatus_t
 end
 

--- a/lib/custatevec/test/logging.jl
+++ b/lib/custatevec/test/logging.jl
@@ -1,0 +1,24 @@
+using Base.CoreLogging: Debug
+
+@testset "logging" begin
+    cuStateVec.enable_logging()
+    try
+        sv = CuStateVec(ComplexF32, 2)
+        X = ComplexF32[0 1; 1 0]
+
+        @test_logs (:debug, r"custatevecApplyMatrix") min_level=Debug match_mode=:any begin
+            applyMatrix!(sv, X, false, Int32[0], Int32[])
+            synchronize()
+            CUDACore.flush_logs()
+        end
+
+        cuStateVec.enable_logging(false)
+        @test_logs min_level=Debug begin
+            applyMatrix!(sv, X, false, Int32[0], Int32[])
+            synchronize()
+            CUDACore.flush_logs()
+        end
+    finally
+        cuStateVec.enable_logging(false)
+    end
+end

--- a/lib/cutensor/src/cuTENSOR.jl
+++ b/lib/cutensor/src/cuTENSOR.jl
@@ -17,7 +17,7 @@ else
 end
 
 
-@public functional
+@public functional, enable_logging
 
 const _initialized = Ref{Bool}(false)
 functional() = _initialized[]
@@ -98,19 +98,29 @@ end
 
 ## logging
 
-function log_message(log_level, function_name, message)
-    function_name = unsafe_string(function_name)
-    message = unsafe_string(message)
-    output = if isempty(message)
-        "$function_name(...)"
+function log_message(level::Int32, function_name::Cstring, message::Cstring)
+    CUDACore.library_log_callback(cuTENSOR, level, function_name, message)
+    return
+end
+
+"""
+    cuTENSOR.enable_logging(enable::Bool=true)
+
+Forward log messages from cuTENSOR to Julia's logging system. API and kernel traces are
+reported at `Debug` level, performance hints at `Info` level, and problems at `Error`
+level. Starting Julia with `JULIA_DEBUG=cuTENSOR` enables this automatically, and also shows
+the `Debug`-level messages.
+"""
+function enable_logging(enable::Bool=true)
+    if enable
+        CUDACore.init_logging()
+        callback = @cfunction(log_message, Nothing, (Int32, Cstring, Cstring))
+        cutensorLoggerSetCallback(callback)
+        # the library also writes to stdout, unless a log file is set
+        cutensorLoggerOpenFile(CUDACore.devnull_path)
+        cutensorLoggerSetLevel(5)
     else
-        "$function_name: $message"
-    end
-    if log_level <= 1
-        @error output
-    else
-        # the other log levels are different levels of tracing and hints
-        @debug output
+        cutensorLoggerSetLevel(0)
     end
     return
 end
@@ -138,12 +148,9 @@ function __init__()
         libcutensor = CUTENSOR_jll.libcutensor
     end
 
-    # register a log callback
-    if !precompiling && (isdebug(:init, cuTENSOR) || Base.JLOptions().debug_level >= 2)
-        callback = @cfunction(log_message, Nothing, (Int32, Cstring, Cstring))
-        cutensorLoggerSetCallback(callback)
-        cutensorLoggerOpenFile(Sys.iswindows() ? "NUL" : "/dev/null")
-        cutensorLoggerSetLevel(5)
+    # forward the library's log messages when debugging
+    if !precompiling && isdebug(cuTENSOR)
+        enable_logging(true)
     end
 
     CUDACore.register_reclaimable!(idle_handles)

--- a/lib/cutensor/src/libcutensor.jl
+++ b/lib/cutensor/src/libcutensor.jl
@@ -572,33 +572,27 @@ function cutensorGetCudartVersion()
 end
 
 @checked function cutensorLoggerSetCallback(callback)
-    initialize_context()
     @gcsafe_ccall libcutensor.cutensorLoggerSetCallback(callback::cutensorLoggerCallback_t)::cutensorStatus_t
 end
 
 @checked function cutensorLoggerSetFile(file)
-    initialize_context()
     @gcsafe_ccall libcutensor.cutensorLoggerSetFile(file::Ptr{Libc.FILE})::cutensorStatus_t
 end
 
 @checked function cutensorLoggerOpenFile(logFile)
-    initialize_context()
     @gcsafe_ccall libcutensor.cutensorLoggerOpenFile(logFile::Cstring)::cutensorStatus_t
 end
 
 @checked function cutensorLoggerSetLevel(level)
-    initialize_context()
     @gcsafe_ccall libcutensor.cutensorLoggerSetLevel(level::Int32)::cutensorStatus_t
 end
 
 @checked function cutensorLoggerSetMask(mask)
-    initialize_context()
     @gcsafe_ccall libcutensor.cutensorLoggerSetMask(mask::Int32)::cutensorStatus_t
 end
 
 # no prototype is found for this function at cutensor.h:1513:18, please use with caution
 @checked function cutensorLoggerForceDisable()
-    initialize_context()
     @gcsafe_ccall libcutensor.cutensorLoggerForceDisable()::cutensorStatus_t
 end
 

--- a/lib/cutensor/test/logging.jl
+++ b/lib/cutensor/test/logging.jl
@@ -1,0 +1,25 @@
+using Base.CoreLogging: Debug
+using cuTENSOR: permute!
+
+@testset "logging" begin
+    cuTENSOR.enable_logging()
+    try
+        A = CuArray(rand(Float32, 4, 8))
+        C = similar(A, 8, 4)
+
+        @test_logs (:debug, r"cutensorPermute") min_level=Debug match_mode=:any begin
+            permute!(1f0, A, ['a', 'b'], cuTENSOR.OP_IDENTITY, C, ['b', 'a'])
+            synchronize()
+            CUDACore.flush_logs()
+        end
+
+        cuTENSOR.enable_logging(false)
+        @test_logs min_level=Debug begin
+            permute!(1f0, A, ['a', 'b'], cuTENSOR.OP_IDENTITY, C, ['b', 'a'])
+            synchronize()
+            CUDACore.flush_logs()
+        end
+    finally
+        cuTENSOR.enable_logging(false)
+    end
+end

--- a/lib/cutensornet/src/cuTensorNet.jl
+++ b/lib/cutensornet/src/cuTensorNet.jl
@@ -18,7 +18,7 @@ else
 end
 
 
-@public functional
+@public functional, enable_logging
 
 const _initialized = Ref{Bool}(false)
 functional() = _initialized[]
@@ -90,19 +90,29 @@ end
 
 ## logging
 
-function log_message(log_level, function_name, message)
-    function_name = unsafe_string(function_name)
-    message = unsafe_string(message)
-    output = if isempty(message)
-        "$function_name(...)"
+function log_message(level::Int32, function_name::Cstring, message::Cstring)
+    CUDACore.library_log_callback(cuTensorNet, level, function_name, message)
+    return
+end
+
+"""
+    cuTensorNet.enable_logging(enable::Bool=true)
+
+Forward log messages from cuTensorNet to Julia's logging system. API and kernel traces are
+reported at `Debug` level, performance hints at `Info` level, and problems at `Error`
+level. Starting Julia with `JULIA_DEBUG=cuTensorNet` enables this automatically, and also shows
+the `Debug`-level messages.
+"""
+function enable_logging(enable::Bool=true)
+    if enable
+        CUDACore.init_logging()
+        callback = @cfunction(log_message, Nothing, (Int32, Cstring, Cstring))
+        cutensornetLoggerSetCallback(callback)
+        # the library also writes to stdout, unless a log file is set
+        cutensornetLoggerOpenFile(CUDACore.devnull_path)
+        cutensornetLoggerSetLevel(5)
     else
-        "$function_name: $message"
-    end
-    if log_level <= 1
-        @error output
-    else
-        # the other log levels are different levels of tracing and hints
-        @debug output
+        cutensornetLoggerSetLevel(0)
     end
     return
 end
@@ -130,12 +140,9 @@ function __init__()
         libcutensornet = cuQuantum_jll.libcutensornet
     end
 
-    # register a log callback
-    if isdebug(:init, cuTensorNet) || Base.JLOptions().debug_level >= 2
-        callback = @cfunction(log_message, Nothing, (Int32, Cstring, Cstring))
-        cutensornetLoggerSetCallback(callback)
-        cutensornetLoggerOpenFile(Sys.iswindows() ? "NUL" : "/dev/null")
-        cutensornetLoggerSetLevel(5)
+    # forward the library's log messages when debugging
+    if !precompiling && isdebug(cuTensorNet)
+        enable_logging(true)
     end
 
     CUDACore.register_reclaimable!(idle_handles)

--- a/lib/cutensornet/src/libcutensornet.jl
+++ b/lib/cutensornet/src/libcutensornet.jl
@@ -1163,7 +1163,6 @@ end
 end
 
 @checked function cutensornetLoggerSetCallbackData(callback, userData)
-    initialize_context()
     @gcsafe_ccall libcutensornet.cutensornetLoggerSetCallbackData(callback::cutensornetLoggerCallbackData_t,
                                                                   userData::Ptr{Cvoid})::cutensornetStatus_t
 end
@@ -1177,7 +1176,6 @@ end
 end
 
 @checked function cutensornetLoggerSetLevel(level)
-    initialize_context()
     @gcsafe_ccall libcutensornet.cutensornetLoggerSetLevel(level::Int32)::cutensornetStatus_t
 end
 

--- a/lib/cutensornet/test/logging.jl
+++ b/lib/cutensornet/test/logging.jl
@@ -1,0 +1,34 @@
+using Base.CoreLogging: Debug
+
+@testset "logging" begin
+    cuTensorNet.enable_logging()
+    try
+        # contract A[a,b] * B[b,c] -> C[a,c]
+        n = 8
+        A = CuArray(rand(Float32, n, n))
+        B = CuArray(rand(Float32, n, n))
+        ctn = CuTensorNetwork(Float32, [Int32['a', 'b'], Int32['b', 'c']], [[n, n], [n, n]],
+                              [C_NULL, C_NULL], Int32[0, 0], Int32['a', 'c'], [n, n], C_NULL)
+        ctn.input_arrs = [A, B]
+
+        logs, _ = Test.collect_test_logs(min_level=Debug) do
+            info = rehearse_contraction(ctn, 2^28)
+            ctn.output_arr = CUDACore.zeros(Float32, n, n)
+            perform_contraction!(ctn, info, NoAutoTune())
+            synchronize()
+            CUDACore.flush_logs()
+        end
+        @test all(log -> log._module === cuTensorNet, logs)
+        @test any(log -> occursin("cutensornetContractSlices", log.message), logs)
+
+        cuTensorNet.enable_logging(false)
+        @test_logs min_level=Debug begin
+            info = rehearse_contraction(ctn, 2^28)
+            perform_contraction!(ctn, info, NoAutoTune())
+            synchronize()
+            CUDACore.flush_logs()
+        end
+    finally
+        cuTensorNet.enable_logging(false)
+    end
+end

--- a/res/wrap/cublas.toml
+++ b/res/wrap/cublas.toml
@@ -781,3 +781,6 @@ needs_context = false
 8 = "CuPtr{Ptr{T}}"
 10 = "CuPtr{Ptr{T}}"
 13 = "CuPtr{Ptr{T}}"
+
+[api.cublasLoggerConfigure]
+needs_context = false

--- a/res/wrap/cublasLt.toml
+++ b/res/wrap/cublasLt.toml
@@ -29,3 +29,21 @@ checked_rettypes = [ "cublasStatus_t" ]
 
 [api.cublasLtMatmulDescSetAttribute.argtypes]
 3 = "PtrOrCuPtr{Cvoid}"
+
+[api.cublasLtLoggerSetCallback]
+needs_context = false
+
+[api.cublasLtLoggerSetFile]
+needs_context = false
+
+[api.cublasLtLoggerOpenFile]
+needs_context = false
+
+[api.cublasLtLoggerSetLevel]
+needs_context = false
+
+[api.cublasLtLoggerSetMask]
+needs_context = false
+
+[api.cublasLtLoggerForceDisable]
+needs_context = false

--- a/res/wrap/cuda.toml
+++ b/res/wrap/cuda.toml
@@ -116,3 +116,18 @@ needs_context = false
 
 [api.cuDeviceGetUuid_v2]
 needs_context = false
+
+[api.cuLogsRegisterCallback]
+needs_context = false
+
+[api.cuLogsUnregisterCallback]
+needs_context = false
+
+[api.cuLogsCurrent]
+needs_context = false
+
+[api.cuLogsDumpToFile]
+needs_context = false
+
+[api.cuLogsDumpToMemory]
+needs_context = false

--- a/res/wrap/cusolver.toml
+++ b/res/wrap/cusolver.toml
@@ -1278,3 +1278,21 @@ needs_context = false
 15 = "CuPtr{Cvoid}"
 18 = "CuPtr{Cvoid}"
 22 = "CuPtr{Cint}"
+
+[api.cusolverDnLoggerSetCallback]
+needs_context = false
+
+[api.cusolverDnLoggerSetFile]
+needs_context = false
+
+[api.cusolverDnLoggerOpenFile]
+needs_context = false
+
+[api.cusolverDnLoggerSetLevel]
+needs_context = false
+
+[api.cusolverDnLoggerSetMask]
+needs_context = false
+
+[api.cusolverDnLoggerForceDisable]
+needs_context = false

--- a/res/wrap/cusparse.toml
+++ b/res/wrap/cusparse.toml
@@ -1075,3 +1075,21 @@ needs_context = false
 
 [api.cusparseConstBlockedEllGet.argtypes]
 4 = "Ref{Int64}"
+
+[api.cusparseLoggerSetCallback]
+needs_context = false
+
+[api.cusparseLoggerSetFile]
+needs_context = false
+
+[api.cusparseLoggerOpenFile]
+needs_context = false
+
+[api.cusparseLoggerSetLevel]
+needs_context = false
+
+[api.cusparseLoggerSetMask]
+needs_context = false
+
+[api.cusparseLoggerForceDisable]
+needs_context = false

--- a/res/wrap/custatevec.toml
+++ b/res/wrap/custatevec.toml
@@ -154,3 +154,9 @@ needs_context = false
 
 [api.custatevecInitializeStateVector.argtypes]
 2 = "PtrOrCuPtr{Cvoid}"
+
+[api.custatevecLoggerSetCallbackData]
+needs_context = false
+
+[api.custatevecLoggerSetLevel]
+needs_context = false

--- a/res/wrap/cutensor.toml
+++ b/res/wrap/cutensor.toml
@@ -64,3 +64,21 @@ needs_context = false
 7 = "Ptr{CuPtr{Cvoid}}"
 8 = "Ptr{CuPtr{Cvoid}}"
 9 = "CuPtr{Cvoid}"
+
+[api.cutensorLoggerSetCallback]
+needs_context = false
+
+[api.cutensorLoggerSetFile]
+needs_context = false
+
+[api.cutensorLoggerOpenFile]
+needs_context = false
+
+[api.cutensorLoggerSetLevel]
+needs_context = false
+
+[api.cutensorLoggerSetMask]
+needs_context = false
+
+[api.cutensorLoggerForceDisable]
+needs_context = false

--- a/res/wrap/cutensornet.toml
+++ b/res/wrap/cutensornet.toml
@@ -77,3 +77,9 @@ needs_context = false
 9 = "CuPtr{Cvoid}"
 10 = "CuPtr{Cvoid}"
 12 = "CuPtr{Cvoid}"
+
+[api.cutensornetLoggerSetCallbackData]
+needs_context = false
+
+[api.cutensornetLoggerSetLevel]
+needs_context = false

--- a/test/core/logging.jl
+++ b/test/core/logging.jl
@@ -1,0 +1,148 @@
+using Base.CoreLogging: Debug
+
+@testset "driver log" begin
+    if CUDA.driver_version() >= v"12.9"
+        CUDA.enable_logging()
+        try
+            # the driver explains failures, including ones that never surface as an exception
+            @test_logs (:debug, r"CUDA_ERROR_INVALID_VALUE") min_level=Debug match_mode=:any begin
+                CUDACore.unchecked_cuMemAlloc_v2(Ref{CUDACore.CUdeviceptr}(), 0)
+                CUDACore.flush_logs()
+            end
+
+            # messages are attributed to the package
+            logs, _ = Test.collect_test_logs(min_level=Debug) do
+                CUDACore.unchecked_cuMemAlloc_v2(Ref{CUDACore.CUdeviceptr}(), 0)
+                CUDACore.flush_logs()
+            end
+            @test !isempty(logs)
+            @test all(log -> log._module === CUDACore, logs)
+
+            # exceptions still carry the driver's explanation, independent of forwarding
+            err = try
+                CUDACore.cuMemAlloc_v2(Ref{CUDACore.CUdeviceptr}(), 0)
+                nothing
+            catch err
+                err
+            end
+            @test err isa CuError
+            @test err.log[] !== nothing
+            @test occursin("CUDA_ERROR_INVALID_VALUE", err.log[])
+            @test occursin("Driver log:", sprint(showerror, err))
+
+            # messages from other tasks are delivered to that task's logger
+            logs, _ = Test.collect_test_logs(min_level=Debug) do
+                fetch(Threads.@spawn begin
+                    CUDACore.unchecked_cuMemAlloc_v2(Ref{CUDACore.CUdeviceptr}(), 0)
+                    CUDACore.flush_logs()
+                end)
+            end
+            @test any(log -> occursin("CUDA_ERROR_INVALID_VALUE", log.message), logs)
+
+            CUDA.enable_logging(false)
+            @test_logs min_level=Debug begin
+                CUDACore.unchecked_cuMemAlloc_v2(Ref{CUDACore.CUdeviceptr}(), 0)
+                CUDACore.flush_logs()
+            end
+        finally
+            CUDA.enable_logging(false)
+        end
+    else
+        @test_logs (:warn, r"requires CUDA 12.9") CUDA.enable_logging()
+    end
+end
+
+@testset "JULIA_DEBUG=CUDA" begin
+    for (debug, core, blas) in (("CUDA", true, true),
+                               ("CUDACore", true, false),
+                               ("cuBLAS", false, true),
+                               ("", false, false),
+                               ("CUDA,!cuBLAS", true, false),
+                               ("all,!CUDA", false, false))
+        withenv("JULIA_DEBUG" => debug) do
+            @test CUDACore.isdebug() == core
+            @test CUDACore.isdebug(CUDA.cuBLAS) == blas
+            io = IOBuffer()
+            Base.CoreLogging.with_logger(Base.CoreLogging.SimpleLogger(io)) do
+                CUDACore.enqueue_log(CUDACore, Debug, "core message")
+                CUDACore.enqueue_log(CUDA.cuBLAS, Debug, "BLAS message")
+                CUDA.flush_logs()
+            end
+            output = String(take!(io))
+            @test occursin("core message", output) == core
+            @test occursin("BLAS message", output) == blas
+            @test ENV["JULIA_DEBUG"] == debug
+        end
+    end
+end
+
+@testset "callback safety" begin
+    # log callbacks must never throw
+    CUDACore.init_logging()
+    @test_logs (:error, r"Error in log callback.*boom"s) begin
+        CUDACore.guarded_callback() do
+            error("boom")
+        end
+        CUDACore.flush_logs()
+    end
+end
+
+struct BlockingLibraryLogger <: Base.CoreLogging.AbstractLogger
+    entered::Channel{Nothing}
+    release::Channel{Nothing}
+end
+Base.CoreLogging.min_enabled_level(::BlockingLibraryLogger) = Debug
+Base.CoreLogging.shouldlog(::BlockingLibraryLogger, args...) = true
+function Base.CoreLogging.handle_message(logger::BlockingLibraryLogger, args...; kwargs...)
+    put!(logger.entered, nothing)
+    take!(logger.release)
+end
+
+struct FailingLibraryLogger <: Base.CoreLogging.AbstractLogger end
+Base.CoreLogging.min_enabled_level(::FailingLibraryLogger) = Debug
+Base.CoreLogging.shouldlog(::FailingLibraryLogger, args...) = true
+Base.CoreLogging.catch_exceptions(::FailingLibraryLogger) = false
+Base.CoreLogging.handle_message(::FailingLibraryLogger, args...; kwargs...) = error("logger failed")
+
+@testset "log delivery" begin
+    CUDACore.init_logging()
+    CUDA.flush_logs()
+
+    # Delivery keeps the originating logger even after with_logger returns.
+    logger = Test.TestLogger(min_level=Debug)
+    Base.CoreLogging.with_logger(logger) do
+        CUDACore.enqueue_log(CUDACore, Debug, "captured")
+    end
+    CUDA.flush_logs()
+    @test only(logger.logs).message == "captured"
+
+    # A manual flush must wait for a background delivery that has already taken the queue.
+    blocking = BlockingLibraryLogger(Channel{Nothing}(1), Channel{Nothing}(1))
+    Base.CoreLogging.with_logger(blocking) do
+        CUDACore.enqueue_log(CUDACore, Debug, "blocking")
+    end
+    take!(blocking.entered)
+    flushing = @async CUDA.flush_logs()
+    try
+        yield()
+        @test !istaskdone(flushing)
+    finally
+        put!(blocking.release, nothing)
+        wait(flushing)
+    end
+
+    # A bad logger must not discard the rest of a batch or stop background delivery.
+    redirect_stderr(devnull) do
+        Base.CoreLogging.with_logger(FailingLibraryLogger()) do
+            CUDACore.enqueue_log(CUDACore, Debug, "failure")
+        end
+        Base.CoreLogging.with_logger(logger) do
+            CUDACore.enqueue_log(CUDACore, Debug, "after failure")
+        end
+        @test timedwait(() -> length(logger.logs) == 2, 10) == :ok
+    end
+    Base.CoreLogging.with_logger(logger) do
+        CUDACore.enqueue_log(CUDACore, Debug, "next batch")
+    end
+    @test timedwait(() -> length(logger.logs) == 3, 10) == :ok
+end


### PR DESCRIPTION
Forward NVIDIA diagnostics through Julia logging, with a shared CUDA log group and per-package enable_logging() controls. JULIA_DEBUG=CUDA covers the stack without changing ENV; module filters still select individual packages. Keep driver failures at Debug because they include handled errors, and preserve library warning and error levels.

Queue callbacks without yielding or running finalizers, avoiding cuBLASXt callback I/O deadlocks. Serialize delivery, retain the originating logger, and contain logger failures. Expose flush_logs() for reliable capture.

Add cuBLASLt and cuSPARSE forwarding and diagnose unavailable cuSOLVER logging APIs. Document filtering, capture, and direct crash diagnostics; stop enabling library logging with -g2.