### PR TITLE
Adapt to the library-based NVPTX_LLVM_Backend_jll 23

### DIFF
--- a/CUDACore/Project.toml
+++ b/CUDACore/Project.toml
@@ -41,6 +41,9 @@ ChainRulesCoreExt = "ChainRulesCore"
 EnzymeCoreExt = "EnzymeCore"
 SpecialFunctionsExt = "SpecialFunctions"
 
+[sources]
+GPUCompiler = {url = "https://github.com/JuliaGPU/GPUCompiler.jl", rev = "tb/jll-libraries"}
+
 [compat]
 Adapt = "4.4"
 BFloat16s = "0.5, 0.6"
@@ -54,7 +57,7 @@ ChainRulesCore = "1"
 EnzymeCore = "0.8.2"
 ExprTools = "0.1"
 GPUArrays = "11.5.14"
-GPUCompiler = "2.4"
+GPUCompiler = "2.7"
 GPUToolbox = "3"
 KernelAbstractions = "0.9.38"
 LLVM = "9.6"
@@ -63,7 +66,7 @@ LazyArtifacts = "1"
 Libdl = "1"
 LinearAlgebra = "1"
 Logging = "1"
-NVPTX_LLVM_Backend_jll = "22"
+NVPTX_LLVM_Backend_jll = "23"
 PrecompileTools = "1"
 Preferences = "1"
 Printf = "1"

--- a/CUDACore/Project.toml
+++ b/CUDACore/Project.toml
@@ -41,9 +41,6 @@ ChainRulesCoreExt = "ChainRulesCore"
 EnzymeCoreExt = "EnzymeCore"
 SpecialFunctionsExt = "SpecialFunctions"
 
-[sources]
-GPUCompiler = {url = "https://github.com/JuliaGPU/GPUCompiler.jl", rev = "tb/jll-libraries"}
-
 [compat]
 Adapt = "4.4"
 BFloat16s = "0.5, 0.6"

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -43,7 +43,6 @@ cuTENSOR = "011b41b2-24ef-40a8-b3eb-fa098493e9e1"
 cuTensorNet = "448d79b3-4b49-4e06-a5ea-00c62c0dc3db"
 
 [sources]
-GPUCompiler = {url = "https://github.com/JuliaGPU/GPUCompiler.jl", rev = "tb/jll-libraries"}
 CUDA = {path = ".."}
 CUDACore = {path = "../CUDACore"}
 CUDATools = {path = "../CUDATools"}

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -43,6 +43,7 @@ cuTENSOR = "011b41b2-24ef-40a8-b3eb-fa098493e9e1"
 cuTensorNet = "448d79b3-4b49-4e06-a5ea-00c62c0dc3db"
 
 [sources]
+GPUCompiler = {url = "https://github.com/JuliaGPU/GPUCompiler.jl", rev = "tb/jll-libraries"}
 CUDA = {path = ".."}
 CUDACore = {path = "../CUDACore"}
 CUDATools = {path = "../CUDATools"}

--- a/test/core/device/intrinsics/math.jl
+++ b/test/core/device/intrinsics/math.jl
@@ -568,13 +568,15 @@ using SpecialFunctions
                 abs(x)
             end
         end
+        # PTX `abs.s` is undefined for INT_MIN, so since LLVM 23 only `llvm.abs` with
+        # the poison flag lowers to it; Julia's `abs` becomes `neg` + `max` instead.
         @test @filecheck CUDA.code_ptx(Tuple{Int32}) do x
-            @check "abs.s32"
+            @check "{{abs|max}}.s32"
             @check_not "__nv_"
             abs(x)
         end
         @test @filecheck CUDA.code_ptx(Tuple{Int64}) do x
-            @check "abs.s64"
+            @check "{{abs|max}}.s64"
             @check_not "__nv_"
             abs(x)
         end


### PR DESCRIPTION
JuliaPackaging/Yggdrasil#14727 replaced the `llc`, `lld` and `llvm-downgrade` executables in the GPU LLVM JLLs with shared libraries exposing a small C API, moving the back-ends to LLVM 23 at the same time. JuliaGPU/GPUCompiler.jl#930 makes GPUCompiler call those libraries in-process, and bumps its compat to the new JLL majors. Since this package pins the same JLL, it needs its compat bumped in lockstep, which is what this PR does.

Changes:

- `CUDACore`: `NVPTX_LLVM_Backend_jll` compat 22 → 23, `GPUCompiler` compat → 2.7 (the library API needs the new GPUCompiler). No code references the JLL's products; the compatibility tables already know LLVM 23.
- The integer `abs` PTX test now accepts `max.s32`/`max.s64`: since LLVM 23 (llvm/llvm-project#183851) only `llvm.abs` with the poison flag lowers to PTX `abs.s`, which is undefined for INT_MIN, and Julia's `abs` must map INT_MIN to itself, so it becomes `neg` + `max`.

Note that NVPTX_LLVM_Backend_jll 23.1.1+0 had a bug in its FMA contraction option (fused in LLVM instead of leaving pairs contractible for ptxas); 23.1.1+1 fixes it, and compat cannot exclude the +0 build.