### PR TITLE
Default CUDA atomics to device scope and expose explicit scopes

### DIFF
--- a/CUDACore/src/device/intrinsics/atomics.jl
+++ b/CUDACore/src/device/intrinsics/atomics.jl
@@ -4,9 +4,17 @@
 # Low-level intrinsics
 #
 
-# TODO:
-# - scoped atomics: _system and _block versions (see CUDA programming guide, sm_60+)
-#   https://github.com/Microsoft/clang/blob/86d4513d3e0daa4d5a29b0b1de7c854ca15f9fe5/test/CodeGen/builtins-nvptx.c#L293
+# Memory scopes, named as LLVM's NVPTX sync scopes. Default is device scope, like CUDA C's
+# atomic*() (the _system/_block variants are explicit there too). LLVM's own default is
+# system scope, which Pascal cannot provide under Windows (#3187).
+const atomic_scopes = (:block, :device, :system)
+const AtomicScope = Union{Val{:block}, Val{:device}, Val{:system}}
+llvm_syncscope(::Val{S}) where {S} = SyncScope(String(S))
+
+# the PTX spelling of a scope, for inline assembly
+ptx_scope(::Val{:block}) = ".cta"
+ptx_scope(::Val{:device}) = ".gpu"
+ptx_scope(::Val{:system}) = ".sys"
 
 ## LLVM
 
@@ -25,7 +33,8 @@ const atomic_acquire_release = LLVM.API.LLVMAtomicOrderingAcquireRelease
 # >
 # > - The pointer must be either a global pointer, a shared pointer, or a generic pointer
 # >   that points to either the global address space or the shared address space.
-@generated function llvm_atomic_op(::Val{binop}, ptr::LLVMPtr{T,A}, val::T) where {binop, T, A}
+@generated function llvm_atomic_op(::Val{binop}, ptr::LLVMPtr{T,A}, val::T,
+                                   scope::Val{S}) where {binop, T, A, S}
     @dispose ctx=Context() begin
         T_val = convert(LLVMType, T)
         T_ptr = convert(LLVMType, ptr)
@@ -42,7 +51,7 @@ const atomic_acquire_release = LLVM.API.LLVMAtomicOrderingAcquireRelease
 
             rv = atomic_rmw!(builder, binop,
                             typed_ptr, parameters(llvm_f)[2],
-                            atomic_acquire_release, #=single_threaded=# false)
+                            atomic_acquire_release, llvm_syncscope(scope()))
 
             ret!(builder, rv)
         end
@@ -80,8 +89,9 @@ for T in (Int32, Int64, UInt32, UInt64)
         fn = Symbol("atomic_$(op)!")
         @eval @inline $fn(ptr::Union{LLVMPtr{$T,AS.Generic},
                                      LLVMPtr{$T,AS.Global},
-                                     LLVMPtr{$T,AS.Shared}}, val::$T) =
-            llvm_atomic_op($(Val(binops[rmw])), ptr, val)
+                                     LLVMPtr{$T,AS.Shared}}, val::$T,
+                          scope::AtomicScope=Val(:device)) =
+            llvm_atomic_op($(Val(binops[rmw])), ptr, val, scope)
     end
 end
 
@@ -95,15 +105,17 @@ for T in (:Float16, :Float32, :Float64)
         fn = Symbol("atomic_$(op)!")
         @eval @inline $fn(ptr::Union{LLVMPtr{$T,AS.Generic},
                                      LLVMPtr{$T,AS.Global},
-                                     LLVMPtr{$T,AS.Shared}}, val::$T) =
-           llvm_atomic_op($(Val(binops[rmw])), ptr, val)
+                                     LLVMPtr{$T,AS.Shared}}, val::$T,
+                          scope::AtomicScope=Val(:device)) =
+           llvm_atomic_op($(Val(binops[rmw])), ptr, val, scope)
     end
 
     # there's no specific NNVM intrinsic for fsub, resulting in a selection error.
     @eval @inline atomic_sub!(ptr::Union{LLVMPtr{$T,AS.Generic},
                                          LLVMPtr{$T,AS.Global},
-                                         LLVMPtr{$T,AS.Shared}}, val::$T) =
-        atomic_add!(ptr, -val)
+                                         LLVMPtr{$T,AS.Shared}}, val::$T,
+                              scope::AtomicScope=Val(:device)) =
+        atomic_add!(ptr, -val, scope)
 end
 
 # BFloat16 requires Julia 1.11 for bfloat codegen support; on older versions (and older
@@ -111,16 +123,19 @@ end
 @static if VERSION >= v"1.11"
     @eval @inline atomic_add!(ptr::Union{LLVMPtr{BFloat16,AS.Generic},
                                          LLVMPtr{BFloat16,AS.Global},
-                                         LLVMPtr{BFloat16,AS.Shared}}, val::BFloat16) =
-        llvm_atomic_op($(Val(binops[:fadd])), ptr, val)
+                                         LLVMPtr{BFloat16,AS.Shared}}, val::BFloat16,
+                              scope::AtomicScope=Val(:device)) =
+        llvm_atomic_op($(Val(binops[:fadd])), ptr, val, scope)
     @eval @inline atomic_sub!(ptr::Union{LLVMPtr{BFloat16,AS.Generic},
                                          LLVMPtr{BFloat16,AS.Global},
-                                         LLVMPtr{BFloat16,AS.Shared}}, val::BFloat16) =
-        atomic_add!(ptr, -val)
+                                         LLVMPtr{BFloat16,AS.Shared}}, val::BFloat16,
+                              scope::AtomicScope=Val(:device)) =
+        atomic_add!(ptr, -val, scope)
 end
 
 # cmpxchg is subject to the same address space restrictions as atomicrmw, above
-@generated function llvm_atomic_cas(ptr::LLVMPtr{T,A}, cmp::T, val::T) where {T, A}
+@generated function llvm_atomic_cas(ptr::LLVMPtr{T,A}, cmp::T, val::T,
+                                    scope::Val{S}) where {T, A, S}
     @dispose ctx=Context() begin
         T_val = convert(LLVMType, T)
         T_ptr = convert(LLVMType, ptr)
@@ -137,7 +152,7 @@ end
 
             res = atomic_cmpxchg!(builder, typed_ptr, parameters(llvm_f)[2],
                                 parameters(llvm_f)[3], atomic_acquire_release, atomic_acquire,
-                                #=single threaded=# false)
+                                llvm_syncscope(scope()))
 
             rv = extract_value!(builder, res, 0)
 
@@ -150,39 +165,45 @@ end
 
 for T in (:Int32, :Int64, :UInt32, :UInt64)
     @eval @device_function @inline function atomic_cas!(ptr::LLVMPtr{$T,A}, cmp::$T,
-                                                        val::$T) where {A}
+                                                        val::$T,
+                                                        scope::AtomicScope=Val(:device)) where {A}
         GPUCompiler.@static_assert(
             A == AS.Generic || A == AS.Global || A == AS.Shared,
             "atomics require a generic, global, or shared address space")
-        llvm_atomic_cas(ptr, cmp, val)
+        llvm_atomic_cas(ptr, cmp, val, scope)
     end
 end
 
 # LLVM expands i16 cmpxchg to a 32-bit CAS loop; use native PTX where available.
-for A in (AS.Generic, AS.Global, AS.Shared), T in (:Int16, :UInt16)
+for A in (AS.Generic, AS.Global, AS.Shared), T in (:Int16, :UInt16), S in atomic_scopes
     if A == AS.Global
-        scope = ".global"
+        space = ".global"
     elseif A == AS.Shared
-        scope = ".shared"
+        space = ".shared"
     else
-        scope = ""
+        space = ""
     end
 
-    intr = "atom$scope.cas.b16 \$0, [\$1], \$2, \$3;"
-    @eval @device_function @inline function atomic_cas!(ptr::LLVMPtr{$T,$A}, cmp::$T, val::$T)
+    # mirror what LLVM emits for the wider types: acquire/release semantics, which PTX
+    # only spells out from sm_70 (the same hardware that has the 16-bit instruction).
+    intr = "atom.acq_rel$(ptx_scope(Val(S)))$space.cas.b16 \$0, [\$1], \$2, \$3;"
+    @eval @device_function @inline function atomic_cas!(ptr::LLVMPtr{$T,$A}, cmp::$T, val::$T,
+                                                        scope::Val{$(QuoteNode(S))})
         if compute_capability() >= sv"7.0"
             @asmcall($intr, "=h,l,h,h", true, $T,
                      Tuple{Core.LLVMPtr{$T,$A},$T,$T}, ptr, cmp, val)
         else
-            llvm_atomic_cas(ptr, cmp, val)
+            llvm_atomic_cas(ptr, cmp, val, scope)
         end
     end
+end
+for T in (:Int16, :UInt16)
+    @eval @inline atomic_cas!(ptr::LLVMPtr{$T,A}, cmp::$T, val::$T) where {A} =
+        atomic_cas!(ptr, cmp, val, Val(:device))
 end
 
 
 ## NVVM
-
-# floating-point operations using NVVM intrinsics
 
 for A in (AS.Generic, AS.Global, AS.Shared)
     # declare i32 @llvm.nvvm.atomic.load.inc.32.p0i32(i32* address, i32 val)
@@ -196,10 +217,24 @@ for A in (AS.Generic, AS.Global, AS.Shared)
         nb = sizeof(T)*8
         fn = Symbol("atomic_$(op)!")
         intr = "llvm.nvvm.atomic.load.$op.$nb.p$(convert(Int, A))i$nb"
-        @eval @device_function @inline $fn(ptr::LLVMPtr{$T,$A}, val::$T) =
+        @eval @device_function @inline $fn(ptr::LLVMPtr{$T,$A}, val::$T,
+                                           ::Val{:device}=Val(:device)) =
             @typed_ccall($intr, llvmcall, $T, (LLVMPtr{$T,$A}, $T), ptr, val)
     end
 end
+
+# the intrinsics have no scope operand, so other scopes use a compare-and-swap loop.
+# the comparisons are unsigned, like the PTX instructions (and CUDA C's atomicInc).
+@inline function inc_op(old::Int32, val::Int32)
+    reinterpret(UInt32, old) >= reinterpret(UInt32, val) ? Int32(0) : old + Int32(1)
+end
+@inline function dec_op(old::Int32, val::Int32)
+    (old == Int32(0) || reinterpret(UInt32, old) > reinterpret(UInt32, val)) ? val : old - Int32(1)
+end
+@inline atomic_inc!(ptr::LLVMPtr{Int32}, val::Int32, scope::Union{Val{:block},Val{:system}}) =
+    first(atomic_modify!(ptr, inc_op, val, scope))
+@inline atomic_dec!(ptr::LLVMPtr{Int32}, val::Int32, scope::Union{Val{:block},Val{:system}}) =
+    first(atomic_modify!(ptr, dec_op, val, scope))
 
 
 ## Julia
@@ -213,11 +248,12 @@ inttype(::Type{Float64}) = Int64
 inttype(::Type{BFloat16}) = Int16
 
 for T in [:Float16, :Float32, :Float64, :BFloat16]
-    @eval @inline function atomic_cas!(ptr::LLVMPtr{$T,A}, cmp::$T, new::$T) where {A}
+    @eval @inline function atomic_cas!(ptr::LLVMPtr{$T,A}, cmp::$T, new::$T,
+                                       scope::AtomicScope=Val(:device)) where {A}
         IT = inttype($T)
         cmp_i = reinterpret(IT, cmp)
         new_i = reinterpret(IT, new)
-        old_i = atomic_cas!(reinterpret(LLVMPtr{IT,A}, ptr), cmp_i, new_i)
+        old_i = atomic_cas!(reinterpret(LLVMPtr{IT,A}, ptr), cmp_i, new_i, scope)
         return reinterpret($T, old_i)
     end
 end
@@ -225,21 +261,25 @@ end
 
 # generic atomic support using compare-and-swap
 
-@inline function atomic_op!(ptr::LLVMPtr{T}, op::Function, val) where {T}
+@inline function atomic_modify!(ptr::LLVMPtr{T}, op::Function, val,
+                                scope::AtomicScope=Val(:device)) where {T}
     old = Base.unsafe_load(ptr)
     while true
         cmp = old
         new = convert(T, op(old, val))
-        old = atomic_cas!(ptr, cmp, new)
-        isequal(old, cmp) && return new
+        old = atomic_cas!(ptr, cmp, new, scope)
+        isequal(old, cmp) && return (old, new)
     end
 end
+
+@inline atomic_op!(ptr::LLVMPtr, op::Function, val, scope::AtomicScope=Val(:device)) =
+    last(atomic_modify!(ptr, op, val, scope))
 
 
 ## documentation
 
 """
-    atomic_cas!(ptr::LLVMPtr{T}, cmp::T, val::T)
+    atomic_cas!(ptr::LLVMPtr{T}, cmp::T, val::T, [scope::Val])
 
 Reads the value `old` located at address `ptr` and compare with `cmp`. If `old` equals to
 `cmp`, stores `val` at the same address. Otherwise, doesn't change the value `old`. These
@@ -248,21 +288,28 @@ operations are performed in one atomic transaction. The function returns `old`.
 This operation is supported for values of type Int16, Int32, Int64, UInt16, UInt32,
 UInt64, Float16, Float32, Float64, and BFloat16. 16-bit operations use a native
 instruction on GPU hardware with compute capability 7.0+, and are emulated otherwise.
+
+`scope` selects the set of threads the operation is atomic with respect to: `Val(:block)`,
+`Val(:device)` (default, matching CUDA C's `atomicX`), or `Val(:system)` (matching
+`atomicX_system`; requires compute capability 6.0, or 7.2 on Tegra, and is not available on
+Pascal GPUs under Windows).
 """
 atomic_cas!
 
 """
-    atomic_xchg!(ptr::LLVMPtr{T}, val::T)
+    atomic_xchg!(ptr::LLVMPtr{T}, val::T, [scope::Val])
 
 Reads the value `old` located at address `ptr` and stores `val` at the same address. These
 operations are performed in one atomic transaction. The function returns `old`.
 
 This operation is supported for values of type Int32, Int64, UInt32 and UInt64.
+
+For memory scopes and platform restrictions, see [`atomic_cas!`](@ref).
 """
 atomic_xchg!
 
 """
-    atomic_add!(ptr::LLVMPtr{T}, val::T)
+    atomic_add!(ptr::LLVMPtr{T}, val::T, [scope::Val])
 
 Reads the value `old` located at address `ptr`, computes `old + val`, and stores the result
 back to memory at the same address. These operations are performed in one atomic
@@ -271,94 +318,112 @@ transaction. The function returns `old`.
 This operation is supported for values of type Int32, Int64, UInt32, UInt64, Float16,
 Float32, and Float64. BFloat16 is supported on Julia 1.11+. The back-end uses a native
 instruction where available and emulates the operation otherwise.
+
+For memory scopes and platform restrictions, see [`atomic_cas!`](@ref).
 """
 atomic_add!
 
 """
-    atomic_sub!(ptr::LLVMPtr{T}, val::T)
+    atomic_sub!(ptr::LLVMPtr{T}, val::T, [scope::Val])
 
 Reads the value `old` located at address `ptr`, computes `old - val`, and stores the result
 back to memory at the same address. These operations are performed in one atomic
 transaction. The function returns `old`.
 
 This operation is supported for values of type Int32, Int64, UInt32 and UInt64.
+
+For memory scopes and platform restrictions, see [`atomic_cas!`](@ref).
 """
 atomic_sub!
 
 """
-    atomic_and!(ptr::LLVMPtr{T}, val::T)
+    atomic_and!(ptr::LLVMPtr{T}, val::T, [scope::Val])
 
 Reads the value `old` located at address `ptr`, computes `old & val`, and stores the result
 back to memory at the same address. These operations are performed in one atomic
 transaction. The function returns `old`.
 
 This operation is supported for values of type Int32, Int64, UInt32 and UInt64.
+
+For memory scopes and platform restrictions, see [`atomic_cas!`](@ref).
 """
 atomic_and!
 
 """
-    atomic_or!(ptr::LLVMPtr{T}, val::T)
+    atomic_or!(ptr::LLVMPtr{T}, val::T, [scope::Val])
 
 Reads the value `old` located at address `ptr`, computes `old | val`, and stores the result
 back to memory at the same address. These operations are performed in one atomic
 transaction. The function returns `old`.
 
 This operation is supported for values of type Int32, Int64, UInt32 and UInt64.
+
+For memory scopes and platform restrictions, see [`atomic_cas!`](@ref).
 """
 atomic_or!
 
 """
-    atomic_xor!(ptr::LLVMPtr{T}, val::T)
+    atomic_xor!(ptr::LLVMPtr{T}, val::T, [scope::Val])
 
 Reads the value `old` located at address `ptr`, computes `old ⊻ val`, and stores the result
 back to memory at the same address. These operations are performed in one atomic
 transaction. The function returns `old`.
 
 This operation is supported for values of type Int32, Int64, UInt32 and UInt64.
+
+For memory scopes and platform restrictions, see [`atomic_cas!`](@ref).
 """
 atomic_xor!
 
 """
-    atomic_min!(ptr::LLVMPtr{T}, val::T)
+    atomic_min!(ptr::LLVMPtr{T}, val::T, [scope::Val])
 
 Reads the value `old` located at address `ptr`, computes `min(old, val)`, and stores the
 result back to memory at the same address. These operations are performed in one atomic
 transaction. The function returns `old`.
 
 This operation is supported for values of type Int32, Int64, UInt32 and UInt64.
+
+For memory scopes and platform restrictions, see [`atomic_cas!`](@ref).
 """
 atomic_min!
 
 """
-    atomic_max!(ptr::LLVMPtr{T}, val::T)
+    atomic_max!(ptr::LLVMPtr{T}, val::T, [scope::Val])
 
 Reads the value `old` located at address `ptr`, computes `max(old, val)`, and stores the
 result back to memory at the same address. These operations are performed in one atomic
 transaction. The function returns `old`.
 
 This operation is supported for values of type Int32, Int64, UInt32 and UInt64.
+
+For memory scopes and platform restrictions, see [`atomic_cas!`](@ref).
 """
 atomic_max!
 
 """
-    atomic_inc!(ptr::LLVMPtr{T}, val::T)
+    atomic_inc!(ptr::LLVMPtr{T}, val::T, [scope::Val])
 
 Reads the value `old` located at address `ptr`, computes `((old >= val) ? 0 : (old+1))`, and
 stores the result back to memory at the same address. These three operations are performed
 in one atomic transaction. The function returns `old`.
 
-This operation is only supported for values of type Int32.
+This operation accepts Int32 values, interpreted as unsigned 32-bit integers.
+
+For memory scopes and platform restrictions, see [`atomic_cas!`](@ref).
 """
 atomic_inc!
 
 """
-    atomic_dec!(ptr::LLVMPtr{T}, val::T)
+    atomic_dec!(ptr::LLVMPtr{T}, val::T, [scope::Val])
 
 Reads the value `old` located at address `ptr`, computes `(((old == 0) | (old > val)) ? val
 : (old-1) )`, and stores the result back to memory at the same address. These three
 operations are performed in one atomic transaction. The function returns `old`.
 
-This operation is only supported for values of type Int32.
+This operation accepts Int32 values, interpreted as unsigned 32-bit integers.
+
+For memory scopes and platform restrictions, see [`atomic_cas!`](@ref).
 """
 atomic_dec!
 

--- a/CUDACore/src/device/intrinsics/atomics.jl
+++ b/CUDACore/src/device/intrinsics/atomics.jl
@@ -16,6 +16,19 @@ ptx_scope(::Val{:block}) = ".cta"
 ptx_scope(::Val{:device}) = ".gpu"
 ptx_scope(::Val{:system}) = ".sys"
 
+# Shared memory is confined to a block, regardless of the requested scope.
+@inline function check_atomic_scope(::LLVMPtr{T,A}, ::Val{S}) where {T,A,S}
+    if S === :system && A != AS.Shared
+        GPUCompiler.@static_assert(compute_capability() >= sv"6.0",
+            "system-scope atomics require compute capability 6.0; use device scope")
+        @static if Sys.iswindows()
+            GPUCompiler.@static_assert(compute_capability() >= sv"7.0",
+                "system-scope atomics are not supported on Pascal GPUs under Windows; use device scope")
+        end
+    end
+    return
+end
+
 ## LLVM
 
 # all atomic operations have acquire and/or release semantics,
@@ -56,7 +69,10 @@ const atomic_acquire_release = LLVM.API.LLVMAtomicOrderingAcquireRelease
             ret!(builder, rv)
         end
 
-        call_function(llvm_f, T, Tuple{LLVMPtr{T,A}, T}, :ptr, :val)
+        quote
+            check_atomic_scope(ptr, scope)
+            $(call_function(llvm_f, T, Tuple{LLVMPtr{T,A}, T}, :ptr, :val))
+        end
     end
 end
 
@@ -159,7 +175,10 @@ end
             ret!(builder, rv)
         end
 
-        call_function(llvm_f, T, Tuple{LLVMPtr{T,A}, T, T}, :ptr, :cmp, :val)
+        quote
+            check_atomic_scope(ptr, scope)
+            $(call_function(llvm_f, T, Tuple{LLVMPtr{T,A}, T, T}, :ptr, :cmp, :val))
+        end
     end
 end
 
@@ -189,6 +208,7 @@ for A in (AS.Generic, AS.Global, AS.Shared), T in (:Int16, :UInt16), S in atomic
     intr = "atom.acq_rel$(ptx_scope(Val(S)))$space.cas.b16 \$0, [\$1], \$2, \$3;"
     @eval @device_function @inline function atomic_cas!(ptr::LLVMPtr{$T,$A}, cmp::$T, val::$T,
                                                         scope::Val{$(QuoteNode(S))})
+        check_atomic_scope(ptr, scope)
         if compute_capability() >= sv"7.0"
             @asmcall($intr, "=h,l,h,h", true, $T,
                      Tuple{Core.LLVMPtr{$T,$A},$T,$T}, ptr, cmp, val)

--- a/CUDACore/src/device/runtime.jl
+++ b/CUDACore/src/device/runtime.jl
@@ -126,7 +126,8 @@ end
 # it's not useful to have several threads report exceptions (interleaved output, can crash
 # CUDA), so use an output lock to only have a single thread write an exception message
 @inline function lock_output!(info::ExceptionInfo)
-    # atomic operations on host-pinned memory are iffy, but are fine from the POV of one GPU
+    # the lock lives in host-pinned memory, but only this GPU's threads contend for it, so
+    # the default device scope is what we want (system scope is unavailable on some platforms)
     if atomic_cas!(info.output_lock_ptr, Int32(0), Int32(1)) == Int32(0)
         # we just took the lock, note our index
         info.threadIdx, info.blockIdx = threadIdx(), blockIdx()

--- a/NEWS.md
+++ b/NEWS.md
@@ -39,6 +39,16 @@ unreliable in Pkg's artifact-selection subprocess and meant every toolkit
 addition needed a driver release. Requires CUDA_Driver_jll 13.3.4,
 CUDA_Runtime_jll 0.24.4 and CUDA_Compiler_jll 0.6.2.
 
+*Technically breaking changes*:
+
+- CUDA.jl atomic operations now default to device scope, matching the scope of
+  CUDA C's `atomicX` functions. LLVM 22 began honoring system scope for CAS,
+  causing the Windows driver to reject Pascal kernels containing these
+  instructions with error 801, including bounds-checking exception paths
+  ([#3187](https://github.com/JuliaGPU/CUDA.jl/issues/3187)). The low-level
+  `atomic_*!` functions accept a trailing `Val(:block)`, `Val(:device)`, or
+  `Val(:system)`; `CUDA.@atomic` uses device scope.
+
 *New features*:
 
 - Forward-compatibility drivers are keyed by a `tegra` platform tag computed

--- a/NEWS.md
+++ b/NEWS.md
@@ -47,7 +47,10 @@ CUDA_Runtime_jll 0.24.4 and CUDA_Compiler_jll 0.6.2.
   instructions with error 801, including bounds-checking exception paths
   ([#3187](https://github.com/JuliaGPU/CUDA.jl/issues/3187)). The low-level
   `atomic_*!` functions accept a trailing `Val(:block)`, `Val(:device)`, or
-  `Val(:system)`; `CUDA.@atomic` uses device scope.
+  `Val(:system)`; `CUDA.@atomic` uses device scope. These functions report a
+  compile-time error for system scope below compute capability 6.0 or on
+  Pascal under Windows. This check does not cover Julia field atomics or
+  atomics emitted directly through LLVM.
 
 *New features*:
 

--- a/docs/src/api/kernel.md
+++ b/docs/src/api/kernel.md
@@ -140,7 +140,29 @@ CUDACore.@atomic
 ```
 
 If your expression is not recognized, or you need more control, use the underlying
-functions:
+functions.
+
+### Memory scopes
+
+Each low-level function takes an optional trailing `scope` argument selecting the set of
+threads the operation is atomic with respect to, mirroring CUDA C's scoped variants:
+
+| CUDA.jl                             | CUDA C              | Atomic with respect to          |
+|:------------------------------------|:--------------------|:--------------------------------|
+| `atomic_add!(ptr, val, Val(:block))`  | `atomicAdd_block`   | threads in the same block       |
+| `atomic_add!(ptr, val)`               | `atomicAdd`         | all threads on the device       |
+| `atomic_add!(ptr, val, Val(:system))` | `atomicAdd_system`  | the device, other devices and the host |
+
+Device scope is the default, and what `CUDA.@atomic` uses. System scope is needed only when
+the CPU or another GPU concurrently accesses the same memory, requires compute capability
+6.0 (7.2 on Tegra), and is not available on Pascal GPUs under Windows.
+Memory allocation and platform support must also permit system-wide atomicity.
+
+These scope choices match CUDA C, but the memory ordering is not identical: most CUDA.jl
+operations use acquire/release ordering, whereas CUDA C's legacy `atomicX` functions use
+relaxed ordering. The device-scope `atomic_inc!` and `atomic_dec!` intrinsics are relaxed.
+Ordering guarantees also depend on the target's support (compute capability 7.0+ for
+acquire/release instructions).
 
 ```@docs
 CUDACore.atomic_cas!

--- a/docs/src/api/kernel.md
+++ b/docs/src/api/kernel.md
@@ -155,8 +155,9 @@ threads the operation is atomic with respect to, mirroring CUDA C's scoped varia
 
 Device scope is the default, and what `CUDA.@atomic` uses. System scope is needed only when
 the CPU or another GPU concurrently accesses the same memory, requires compute capability
-6.0 (7.2 on Tegra), and is not available on Pascal GPUs under Windows.
-Memory allocation and platform support must also permit system-wide atomicity.
+6.0 (7.2 on Tegra), and is not available on Pascal GPUs under Windows. The low-level
+functions reject system scope at compile time on targets below 6.0 and on Pascal under
+Windows. Memory allocation and platform support must also permit system-wide atomicity.
 
 These scope choices match CUDA C, but the memory ordering is not identical: most CUDA.jl
 operations use acquire/release ordering, whereas CUDA C's legacy `atomicX` functions use

--- a/test/core/device/intrinsics.jl
+++ b/test/core/device/intrinsics.jl
@@ -77,13 +77,13 @@ end
         arch=sm"61")
 
     @test @filecheck CUDA.code_ptx((Core.LLVMPtr{UInt16,AS.Global},); arch=sm"61") do ptr
-        @check "{{atom(\\.sys)?\\.global\\.cas\\.b32}}"
+        @check "atom.gpu.global.cas.b32"
         @check_not "cas.b16"
         CUDA.atomic_cas!(ptr, UInt16(0), UInt16(1))
         return
     end
     @test @filecheck CUDA.code_ptx((Core.LLVMPtr{UInt16,AS.Global},); arch=sm"70") do ptr
-        @check "atom.global.cas.b16"
+        @check "atom.acq_rel.gpu.global.cas.b16"
         CUDA.atomic_cas!(ptr, UInt16(0), UInt16(1))
         return
     end

--- a/test/core/device/intrinsics/atomics.jl
+++ b/test/core/device/intrinsics/atomics.jl
@@ -677,4 +677,82 @@ end
     end
 end
 
+@testset "validation" begin
+    # compile up to PTX, where validation runs, without invoking ptxas: the targets
+    # tested here need not be supported by the toolkit or match the test GPU.
+    function validate_kernel(f, tt; kwargs...)
+        source = CUDACore.methodinstance(typeof(f), tt)
+        config = CUDACore.compiler_config(device(); kwargs...)
+        job = CUDACore.CompilerJob(source, config)
+        CUDACore.GPUCompiler.JuliaContext() do ctx
+            CUDACore.GPUCompiler.compile(:asm, job)
+        end
+        return
+    end
+
+    function system_kernel(a)
+        CUDA.atomic_cas!(pointer(a), Int32(0), Int32(1), Val(:system))
+        return
+    end
+    function device_kernel(a)
+        CUDA.atomic_cas!(pointer(a), Int32(0), Int32(1))
+        return
+    end
+    function shared_kernel(a)
+        b = CuStaticSharedArray(Int32, 1)
+        CUDA.atomic_add!(pointer(b), Int32(1), Val(:system))
+        a[] = b[]
+        return
+    end
+    T = Tuple{CuDeviceVector{Int32,1}}
+
+    # system scope requires sm_60; LLVM would silently emit device scope on sm_5x
+    err = try
+        validate_kernel(system_kernel, T; arch=sm"50")
+        nothing
+    catch err
+        err
+    end
+    @test err isa CUDA.InvalidIRError
+    @test occursin("system-scope atomics require compute capability 6.0",
+                   sprint(showerror, err))
+    @test any(frame -> frame.func == :system_kernel,
+              Iterators.flatten(e[2] for e in err.errors))
+
+    # RMW, 16-bit CAS emulation, and the inc/dec fallbacks must check the scope too.
+    function rmw_kernel(a)
+        CUDA.atomic_add!(pointer(a), Int32(1), Val(:system))
+        return
+    end
+    function cas16_kernel(a)
+        CUDA.atomic_cas!(pointer(a), Int16(0), Int16(1), Val(:system))
+        return
+    end
+    function inc_kernel(a)
+        CUDA.atomic_inc!(pointer(a), Int32(7), Val(:system))
+        return
+    end
+    function dec_kernel(a)
+        CUDA.atomic_dec!(pointer(a), Int32(7), Val(:system))
+        return
+    end
+    for (f, tt) in ((rmw_kernel, T), (cas16_kernel, Tuple{CuDeviceVector{Int16,1}}),
+                    (inc_kernel, T), (dec_kernel, T))
+        @test_throws CUDA.InvalidIRError validate_kernel(f, tt; arch=sm"50")
+        validate_kernel(f, tt; arch=sm"70")
+    end
+
+    # the default scope, and shared memory, are fine everywhere
+    validate_kernel(device_kernel, T; arch=sm"50")
+    validate_kernel(shared_kernel, T; arch=sm"50")
+
+    # Windows rejects Pascal modules containing system-scope atomics (#3187).
+    if Sys.iswindows()
+        @test_throws CUDA.InvalidIRError validate_kernel(system_kernel, T; arch=sm"61")
+    else
+        validate_kernel(system_kernel, T; arch=sm"61")
+    end
+    validate_kernel(system_kernel, T; arch=sm"70")
+end
+
 end

--- a/test/core/device/intrinsics/atomics.jl
+++ b/test/core/device/intrinsics/atomics.jl
@@ -483,3 +483,198 @@ end
 end
 
 end
+
+
+@testset "memory scopes" begin
+
+dev_cap = capability(device())
+system_scope_supported = dev_cap >= v"6.0" &&
+                         (!Sys.iswindows() || dev_cap >= v"7.0") &&
+                         (!CUDA.is_tegra() || dev_cap >= v"7.2")
+
+@testset "reflection" begin
+    # what LLVM spells out depends on the target: sm_5x has no scope qualifiers at all,
+    # sm_6x adds them, and sm_70+ also adds acquire/release semantics.
+    function cas_pattern(cap, scope)
+        sem = cap >= v"7.0" ? ".acq_rel" : ""
+        qual = cap >= v"6.0" ? ".$scope" : ""
+        "atom$sem$qual.global.cas.b32"
+    end
+
+    # atomicrmw carries the scope in the IR; whether the back-end spells it out in PTX
+    # depends on the LLVM version, so check the IR rather than the PTX.
+    @test @filecheck CUDA.code_llvm(Tuple{CuDeviceVector{Int32,1}}) do a
+        @check "atomicrmw add {{.*}} syncscope(\"device\")"
+        CUDA.atomic_add!(pointer(a), Int32(1))
+        return
+    end
+    @test @filecheck CUDA.code_llvm(Tuple{CuDeviceVector{Int32,1}}) do a
+        @check "atomicrmw add {{.*}} syncscope(\"block\")"
+        CUDA.atomic_add!(pointer(a), Int32(1), Val(:block))
+        return
+    end
+    @test @filecheck CUDA.code_llvm(Tuple{CuDeviceVector{Int32,1}}) do a
+        @check "atomicrmw add"
+        @check_not "syncscope"
+        CUDA.atomic_add!(pointer(a), Int32(1), Val(:system))
+        return
+    end
+
+    for (arch, cap) in ((nothing, dev_cap), (sm"61", v"6.1"), (sm"50", v"5.0"))
+        kwargs = arch === nothing ? (;) : (; arch)
+        @test @filecheck CUDA.code_ptx(Tuple{CuDeviceVector{Int32,1}}; kwargs...) do a
+            @check cas_pattern(cap, "gpu")
+            CUDA.atomic_cas!(pointer(a), Int32(0), Int32(1))
+            return
+        end
+        @test @filecheck CUDA.code_ptx(Tuple{CuDeviceVector{Int32,1}}; kwargs...) do a
+            @check cas_pattern(cap, "cta")
+            CUDA.atomic_cas!(pointer(a), Int32(0), Int32(1), Val(:block))
+            return
+        end
+        if cap >= v"6.0"
+            @test @filecheck CUDA.code_ptx(Tuple{CuDeviceVector{Int32,1}}; kwargs...) do a
+                @check cas_pattern(cap, "sys")
+                CUDA.atomic_cas!(pointer(a), Int32(0), Int32(1), Val(:system))
+                return
+            end
+        end
+    end
+
+    # Bounds-checking exception paths must not introduce system atomics (#3187).
+    function checked_store(a)
+        a[1] = Int32(42)
+        return
+    end
+    ptx = sprint(io -> CUDA.code_ptx(io, checked_store, Tuple{CuDeviceVector{Int32,1}};
+                                    arch=sm"61", ptx=v"8.8", kernel=true, dump_module=true))
+    @test occursin("atom.gpu", ptx)
+    @test !occursin(r"(?:atom|red)\.sys", ptx)
+
+    if dev_cap >= v"7.0"
+        # 16-bit CAS uses inline assembly, which spells out the scope too
+        @test @filecheck CUDA.code_ptx(Tuple{CuDeviceVector{Int16,1}}) do a
+            @check "atom.acq_rel.gpu.global.cas.b16"
+            CUDA.atomic_cas!(pointer(a), Int16(0), Int16(1))
+            return
+        end
+        @test @filecheck CUDA.code_ptx(Tuple{CuDeviceVector{Int16,1}}) do a
+            @check "atom.acq_rel.cta.global.cas.b16"
+            CUDA.atomic_cas!(pointer(a), Int16(0), Int16(1), Val(:block))
+            return
+        end
+    end
+end
+
+@testset "block scope" begin
+    a = CuArray(Int32[0])
+
+    function add_kernel(a, scope)
+        CUDA.atomic_add!(pointer(a), Int32(1), scope)
+        return
+    end
+    @cuda threads=1024 add_kernel(a, Val(:block))
+    @test Array(a)[1] == 1024
+
+    function cas_kernel(a, scope)
+        CUDA.atomic_cas!(pointer(a), Int32(1024), Int32(1), scope)
+        return
+    end
+    @cuda threads=1024 cas_kernel(a, Val(:block))
+    @test Array(a)[1] == 1
+
+    function incdec_kernel(a, scope)
+        CUDA.atomic_inc!(pointer(a), Int32(2047), scope)
+        CUDA.atomic_dec!(pointer(a, 2), Int32(2047), scope)
+        return
+    end
+    a = CuArray(Int32[0, 0])
+    @cuda threads=1024 incdec_kernel(a, Val(:block))
+    @test Array(a) == [1024, 2048 - 1024]
+end
+
+# system-scope atomics require sm_60, and are not available on Pascal under Windows
+if system_scope_supported
+@testset "system scope" begin
+    function add_kernel(a, scope)
+        CUDA.atomic_add!(pointer(a), Int32(1), scope)
+        return
+    end
+    function cas_kernel(a, scope)
+        CUDA.atomic_cas!(pointer(a), Int32(1024), Int32(1), scope)
+        return
+    end
+    function incdec_kernel(a, scope)
+        CUDA.atomic_inc!(pointer(a), Int32(2047), scope)
+        CUDA.atomic_dec!(pointer(a, 2), Int32(2047), scope)
+        return
+    end
+
+    a = CuArray(Int32[0])
+    @cuda threads=1024 add_kernel(a, Val(:system))
+    @test Array(a)[1] == 1024
+    @cuda threads=1024 cas_kernel(a, Val(:system))
+    @test Array(a)[1] == 1
+
+    a = CuArray(Int32[0, 0])
+    @cuda threads=1024 incdec_kernel(a, Val(:system))
+    @test Array(a) == [1024, 2048 - 1024]
+
+    # Smoke-test host-pinned memory. Synchronization precedes the host read; this
+    # does not test concurrent CPU/GPU atomicity.
+    counter = Int32[0]
+    a = unsafe_wrap(CuArray{Int32,1,CUDA.HostMemory}, counter)
+    @cuda threads=1024 add_kernel(a, Val(:system))
+    synchronize()
+    @test counter[1] == 1024
+end
+end
+
+@testset "floating-point scopes" begin
+    types = [Float32, Float64]
+    dev_cap >= v"7.0" && push!(types, Float16)
+    for scope in (Val(:block), Val(:device), Val(:system))
+        if scope === Val(:system) && !system_scope_supported
+            continue
+        end
+        for T in types
+            a = CuArray(T[0])
+            function kernel(a, scope)
+                CUDA.atomic_add!(pointer(a), one(eltype(a)), scope)
+                return
+            end
+            @cuda threads=128 kernel(a, scope)
+            @test Array(a) == T[128]
+        end
+    end
+end
+
+@testset "inc/dec return values and unsigned limits" begin
+    scopes = (Val(:device), Val(:block), Val(:system))
+    for scope in scopes
+        if scope === Val(:system) && !system_scope_supported
+            continue
+        end
+        for op in (CUDA.atomic_inc!, CUDA.atomic_dec!),
+            initial in Int32[0, 1, 7, 8, -1, typemin(Int32)],
+            limit in Int32[0, 7, -1, typemin(Int32)]
+            a = CuArray(Int32[initial])
+            result = similar(a)
+            function kernel(a, result, op, limit, scope)
+                @inbounds result[1] = op(pointer(a), limit, scope)
+                return
+            end
+            @cuda kernel(a, result, op, limit, scope)
+            old, bound = reinterpret(UInt32, initial), reinterpret(UInt32, limit)
+            expected = if op === CUDA.atomic_inc!
+                old >= bound ? UInt32(0) : old + UInt32(1)
+            else
+                old == 0 || old > bound ? bound : old - UInt32(1)
+            end
+            @test Array(result) == [initial]
+            @test Array(a) == [reinterpret(Int32, expected)]
+        end
+    end
+end
+
+end


### PR DESCRIPTION
The Windows driver rejects Pascal kernels containing system-scope atomic instructions with `CUDA_ERROR_NOT_SUPPORTED` (801). This can affect ordinary array accesses: bounds-checking exception paths contain an atomic lock for exception reporting, so even a kernel that never throws can fail to load.

CUDA.jl previously emitted atomics with LLVM's default system scope. LLVM 22 began honoring that scope for compare-and-swap instructions, exposing this platform restriction. This PR defaults CUDA.jl atomics to device scope, matching CUDA C's ordinary `atomicAdd`, `atomicCAS`, etc. For example, the generated Pascal instruction for `CUDA.atomic_cas!(ptr, old, new)` changes from:

```ptx
// Before
atom.sys.global.cas.b32

// After
atom.gpu.global.cas.b32
```

Device scope provides atomicity among threads on the same GPU, including those contending for the exception-reporting lock. Callers that need a different scope can pass an optional trailing argument to the low-level atomic functions:

```julia
CUDA.atomic_add!(ptr, value)               # device scope (default)
CUDA.atomic_add!(ptr, value, Val(:block))  # threads in the same block
CUDA.atomic_add!(ptr, value, Val(:system)) # GPU, other GPUs, and CPU
```

`CUDA.@atomic` also uses device scope. Code that relied on the previous system scope must request it explicitly. The scope choices match CUDA C's ordinary, `_block`, and `_system` variants; memory ordering remains different, with most CUDA.jl operations retaining acquire/release ordering rather than CUDA C's relaxed ordering.

The atomic methods use `GPUCompiler.@static_assert` to reject system scope below compute capability 6.0 and on Pascal under Windows, reporting the calling location instead of an opaque module-load error. Shared-memory operations are exempt because shared memory is confined to a block. These checks cover CUDA.jl's atomic APIs; allocation and platform requirements still apply, and Julia field atomics or directly emitted LLVM atomics are outside their scope.

Fixes https://github.com/JuliaGPU/CUDA.jl/issues/3187.